### PR TITLE
device: add AXI4IntrGenerator to generate external interrupts

### DIFF
--- a/src/main/scala/device/AXI4IntrGenerator.scala
+++ b/src/main/scala/device/AXI4IntrGenerator.scala
@@ -1,0 +1,32 @@
+package device
+
+import chisel3._
+import chisel3.util._
+import chipsalliance.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy.AddressSet
+import utils._
+
+// we support 256 interrupt bits by default
+class IntrGenIO extends Bundle {
+  val intrVec = Output(UInt(256.W))
+}
+
+class AXI4IntrGenerator
+(
+  address: Seq[AddressSet]
+)(implicit p: Parameters)
+  extends AXI4SlaveModule(address, executable = false, _extra = new IntrGenIO)
+{
+
+  override lazy val module = new AXI4SlaveModuleImp(this){
+
+    val intrReg = RegInit(VecInit(Seq.fill(8)(0.U(32.W))))
+    io.extra.get.intrVec := Cat(intrReg.reverse)
+
+    when (in.w.fire()) {
+      intrReg(waddr(4, 2)) := in.w.bits.data(31, 0)
+    }
+
+    in.r.bits.data := intrReg(raddr)
+  }
+}

--- a/src/test/scala/top/SimMMIO.scala
+++ b/src/test/scala/top/SimMMIO.scala
@@ -18,6 +18,7 @@ class SimMMIO(edge: AXI4EdgeParameters)(implicit p: config.Parameters) extends L
     ctrlAddress = Seq(AddressSet(0x40001000L, 0x7L))
   ))
   val sd = LazyModule(new AXI4DummySD(Seq(AddressSet(0x40002000L, 0xfff))))
+  val intrGen = LazyModule(new AXI4IntrGenerator(Seq(AddressSet(0x40070000L, 0x0000ffffL))))
 
   val axiBus = AXI4Xbar()
 
@@ -25,6 +26,7 @@ class SimMMIO(edge: AXI4EdgeParameters)(implicit p: config.Parameters) extends L
   vga.node :*= axiBus
   flash.node := axiBus
   sd.node := axiBus
+  intrGen.node := axiBus
 
   axiBus := node
 
@@ -39,8 +41,10 @@ class SimMMIO(edge: AXI4EdgeParameters)(implicit p: config.Parameters) extends L
   lazy val module = new LazyModuleImp(this){
     val io = IO(new Bundle() {
       val uart = new UARTIO
+      val interrupt = new IntrGenIO
     })
     io.uart <> uart.module.io.extra.get
+    io.interrupt <> intrGen.module.io.extra.get
   }
 
 }

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -34,7 +34,7 @@ class SimTop(implicit p: Parameters) extends Module {
 
   soc.io.clock := clock.asBool()
   soc.io.reset := reset.asBool()
-  soc.io.extIntrs := 0.U
+  soc.io.extIntrs := simMMIO.io.interrupt.intrVec
 
   val io = IO(new Bundle(){
     val logCtrl = new LogCtrlIO


### PR DESCRIPTION
This commit adds a new AXI4 device to generate external interrupts.
Previously none of the simulated external devices trigger interrupts.
To test external interrupts, we add this device.