### PR TITLE
use mill -i to work around JVM options not working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,11 @@ REMOTE ?= localhost
 .DEFAULT_GOAL = verilog
 
 help:
-	mill XiangShan.test.runMain $(SIMTOP) --help
+	mill -i XiangShan.test.runMain $(SIMTOP) --help
 
 $(TOP_V): $(SCALA_FILE)
 	mkdir -p $(@D)
-	mill XiangShan.test.runMain $(FPGATOP) -td $(@D) --config $(CONFIG) --full-stacktrace --output-file $(@F) --disable-all --remove-assert --infer-rw --repl-seq-mem -c:$(FPGATOP):-o:$(@D)/$(@F).conf $(SIM_ARGS)
+	mill -i XiangShan.test.runMain $(FPGATOP) -td $(@D) --config $(CONFIG) --full-stacktrace --output-file $(@F) --disable-all --remove-assert --infer-rw --repl-seq-mem -c:$(FPGATOP):-o:$(@D)/$(@F).conf $(SIM_ARGS)
 	$(MEM_GEN) $(@D)/$(@F).conf --tsmc28 --output_file $(@D)/tsmc28_sram.v > $(@D)/tsmc28_sram.v.conf
 	$(MEM_GEN) $(@D)/$(@F).conf --output_file $(@D)/sim_sram.v
 	# sed -i -e 's/_\(aw\|ar\|w\|r\|b\)_\(\|bits_\)/_\1/g' $@
@@ -74,7 +74,7 @@ $(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
 	mkdir -p $(@D)
 	@echo "\n[mill] Generating Verilog files..." > $(TIMELOG)
 	@date -R | tee -a $(TIMELOG)
-	$(TIME_CMD) mill XiangShan.test.runMain $(SIMTOP) -td $(@D) --config $(CONFIG) --full-stacktrace --output-file $(@F) --infer-rw --repl-seq-mem -c:$(SIMTOP):-o:$(@D)/$(@F).conf $(SIM_ARGS)
+	$(TIME_CMD) mill -i XiangShan.test.runMain $(SIMTOP) -td $(@D) --config $(CONFIG) --full-stacktrace --output-file $(@F) --infer-rw --repl-seq-mem -c:$(SIMTOP):-o:$(@D)/$(@F).conf $(SIM_ARGS)
 	$(MEM_GEN) $(@D)/$(@F).conf --output_file $(@D)/$(@F).sram.v
 	@git log -n 1 >> .__head__
 	@git diff >> .__diff__

--- a/debug/Makefile
+++ b/debug/Makefile
@@ -113,16 +113,16 @@ disassemble-xv6:
 SUITE = cache.L2CacheTest
 
 unit-test:
-	cd .. && mill XiangShan.test.testOnly -o -s $(SUITE)
+	cd .. && mill -i XiangShan.test.testOnly -o -s $(SUITE)
 
 tlc-test:
-	cd .. && mill XiangShan.test.testOnly -o -s cache.TLCTest.TLCCacheTest
+	cd .. && mill -i XiangShan.test.testOnly -o -s cache.TLCTest.TLCCacheTest
 
 l1-test:
-	cd .. && mill XiangShan.test.testOnly -o -s cache.L1DTest.L1DCacheTest
+	cd .. && mill -i XiangShan.test.testOnly -o -s cache.L1DTest.L1DCacheTest
 
 unit-test-all:
-	cd .. && mill XiangShan.test.test -P$(P)
+	cd .. && mill -i XiangShan.test.test -P$(P)
 
 # ------------------------------------------------------------------
 # chore


### PR DESCRIPTION
Have a try with this, if still fails, my suggestion is using `.mill-jvm-opt` with
```
 -Xss16m
 -Xmx128G
 ```