### PR TITLE
difftest: support --no-diff arg to emulate without difftest by nemu

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -41,7 +41,13 @@ int difftest_init() {
   for (int i = 0; i < EMU_CORES; i++) {
     difftest[i] = new Difftest(i);
   }
+  return 0;
+}
 
+int init_nemuproxy() {
+  for (int i = 0; i < EMU_CORES; i++) {
+    difftest[i]->update_nemuproxy(i);
+  }
   return 0;
 }
 
@@ -74,11 +80,14 @@ int difftest_step() {
 }
 
 Difftest::Difftest(int coreid) : id(coreid) {
-  proxy = new DIFF_PROXY(coreid);
   state = new DiffState();
   clear_step();
   // nemu_this_pc = 0x80000000;
   // pc_retire_pointer = DEBUG_GROUP_TRACE_SIZE - 1;
+}
+
+void Difftest::update_nemuproxy(int coreid) {
+  proxy = new DIFF_PROXY(coreid);
 }
 
 int Difftest::step() {

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -37,9 +37,6 @@ static const char *reg_name[DIFFTEST_NR_REG+1] = {
 Difftest **difftest = NULL;
 
 int difftest_init() {
-  // init global memory (used for consistency)
-  ref_misc_put_gmaddr(pmem);
-
   difftest = new Difftest*[EMU_CORES];
   for (int i = 0; i < EMU_CORES; i++) {
     difftest[i] = new Difftest(i);

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -53,15 +53,6 @@ int init_nemuproxy() {
 
 int difftest_state() {
   for (int i = 0; i < EMU_CORES; i++) {
-    // if (difftest[i]->step(&diff[i], i)) {
-    //     trapCode = STATE_ABORT;
-    //   }
-      // lastcommit[i] = max_cycle;
-
-      // // update instr_cnt
-      // uint64_t commit_count = (core_max_instr[i] >= diff[i].commit) ? diff[i].commit : core_max_instr[i];
-      // core_max_instr[i] -= commit_count;
-
     if (difftest[i]->get_trap_valid()) {
       return difftest[i]->get_trap_code();
     }
@@ -82,8 +73,6 @@ int difftest_step() {
 Difftest::Difftest(int coreid) : id(coreid) {
   state = new DiffState();
   clear_step();
-  // nemu_this_pc = 0x80000000;
-  // pc_retire_pointer = DEBUG_GROUP_TRACE_SIZE - 1;
 }
 
 void Difftest::update_nemuproxy(int coreid) {
@@ -156,8 +145,7 @@ int Difftest::step() {
     }
     return 1;
   }
-
-  // 
+ 
   return 0;
 }
 

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -193,10 +193,11 @@ public:
   // Its backend should be cross-platform (NEMU, Spike, ...)
   // Initialize difftest environments
   Difftest(int coreid);
-  DIFF_PROXY *proxy;
+  DIFF_PROXY *proxy = NULL;
   uint32_t num_commit = 0; // # of commits if made progress
   // Trigger a difftest checking procdure
   int step();
+  void update_nemuproxy(int);
   inline bool get_trap_valid() {
     return dut.trap.valid;
   }
@@ -253,9 +254,8 @@ private:
   uint64_t ticks = 0;
   uint64_t last_commit = 0;
 
-
   uint64_t nemu_this_pc;
-  DiffState *state;
+  DiffState *state = NULL;
 
   int check_timeout();
   void do_first_instr_commit();
@@ -275,5 +275,6 @@ extern Difftest **difftest;
 int difftest_init();
 int difftest_step();
 int difftest_state();
+int init_nemuproxy();
 
 #endif

--- a/src/test/csrc/difftest/goldenmem.cpp
+++ b/src/test/csrc/difftest/goldenmem.cpp
@@ -18,6 +18,7 @@
 #include <sys/mman.h>
 #include <time.h>
 #include "compress.h"
+#include "nemuproxy.h"
 
 uint8_t *pmem;
 
@@ -31,6 +32,7 @@ void init_goldenmem() {
   void* get_img_start();
   long get_img_size();
   nonzero_large_memcpy(pmem, get_img_start(), get_img_size());
+  ref_misc_put_gmaddr(pmem);
 }
 
 void update_goldenmem(paddr_t addr, void *data, uint64_t mask, int len) {

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -18,6 +18,8 @@
 #include "sdcard.h"
 #include "difftest.h"
 #include "nemuproxy.h"
+#include "goldenmem.h"
+#include "device.h"
 #include <getopt.h>
 #include <signal.h>
 #include <unistd.h>
@@ -229,6 +231,13 @@ inline void Emulator::single_cycle() {
 }
 
 uint64_t Emulator::execute(uint64_t max_cycle, uint64_t max_instr) {
+
+  if (args.enable_diff) {
+    init_goldenmem();
+  }
+  difftest_init();
+  init_device();
+
   uint32_t lasttime_poll = 0;
   uint32_t lasttime_snapshot = 0;
   // const int stuck_limit = 5000;

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -343,7 +343,6 @@ uint64_t Emulator::execute(uint64_t max_cycle, uint64_t max_instr) {
         break;
       }
     }
-    if (trapCode != STATE_RUNNING) break;
 
 #ifdef VM_SAVABLE
     static int snapshot_count = 0;
@@ -625,4 +624,6 @@ void Emulator::snapshot_load(const char *filename) {
   long sdcard_offset = 0;
   stream.read(&sdcard_offset, sizeof(sdcard_offset));
   if(fp)
-    fse
+    fseek(fp, sdcard_offset, SEEK_SET);
+}
+#endif

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -41,6 +41,7 @@ static inline void print_help(const char *file) {
   printf("      --load-snapshot=PATH   load snapshot from PATH\n");
   printf("      --no-snapshot          disable saving snapshots\n");
   printf("      --dump-wave            dump waveform when log is enabled\n");
+  printf("      --no-diff              disable differential testing\n");
   printf("      --diff=PATH            set the path of REF for differential testing\n");
   printf("  -h, --help                 print program help info\n");
   printf("\n");
@@ -56,6 +57,7 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
     { "no-snapshot",       0, NULL,  0  },
     { "force-dump-result", 0, NULL,  0  },
     { "diff",              1, NULL,  0  },
+    { "no-diff",           0, NULL,  0  },
     { "seed",              1, NULL, 's' },
     { "max-cycles",        1, NULL, 'C' },
     { "max-instr",         1, NULL, 'I' },
@@ -79,6 +81,7 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
           case 2: args.enable_snapshot = false; continue;
           case 3: args.force_dump_result = true; continue;
           case 4: difftest_ref_so = optarg; continue;
+          case 5: args.enable_diff = false; continue;
         }
         // fall through
       default:
@@ -334,9 +337,11 @@ uint64_t Emulator::execute(uint64_t max_cycle, uint64_t max_instr) {
     trapCode = difftest_state();
     if (trapCode != STATE_RUNNING) break;
 
-    if (difftest_step()) {
-      trapCode = STATE_ABORT;
-      break;
+    if (args.enable_diff) {
+      if (difftest_step()) {
+        trapCode = STATE_ABORT;
+        break;
+      }
     }
     if (trapCode != STATE_RUNNING) break;
 
@@ -620,6 +625,4 @@ void Emulator::snapshot_load(const char *filename) {
   long sdcard_offset = 0;
   stream.read(&sdcard_offset, sizeof(sdcard_offset));
   if(fp)
-    fseek(fp, sdcard_offset, SEEK_SET);
-}
-#endif
+    fse

--- a/src/test/csrc/verilator/emu.h
+++ b/src/test/csrc/verilator/emu.h
@@ -67,6 +67,7 @@ struct EmuArgs {
   bool enable_waveform;
   bool enable_snapshot;
   bool force_dump_result;
+  bool enable_diff;
 
   EmuArgs() {
     seed = 0;
@@ -81,6 +82,7 @@ struct EmuArgs {
     enable_waveform = false;
     enable_snapshot = true;
     force_dump_result = false;
+    enable_diff = true;
   }
 };
 

--- a/src/test/csrc/verilator/main.cpp
+++ b/src/test/csrc/verilator/main.cpp
@@ -17,9 +17,6 @@
 #include <locale.h>
 #include <csignal>
 #include "emu.h"
-#include "difftest.h"
-#include "device.h"
-#include "goldenmem.h"
 
 static char mybuf[BUFSIZ];
 
@@ -40,11 +37,6 @@ int main(int argc, const char** argv) {
   }
 
   auto emu = new Emulator(argc, argv);
-  init_goldenmem();
-  difftest_init();
-
-  // init device
-  init_device();
 
   get_sc_time_stamp = [&emu]() -> double {
     return emu->get_cycles();


### PR DESCRIPTION
Refactor is still required to resolve the conflict when --max-instr=NUM and --no-diff are enabled simultaneously