### PR TITLE
backend: wrap all RS into a larger scheduler module

### DIFF
--- a/src/main/scala/xiangshan/backend/FloatBlock.scala
+++ b/src/main/scala/xiangshan/backend/FloatBlock.scala
@@ -26,73 +26,48 @@ import xiangshan.backend.issue.ReservationStation
 import xiangshan.mem.{HasFpLoadHelper, HasLoadHelper}
 import difftest._
 
-class FpBlockToCtrlIO(implicit p: Parameters) extends XSBundle {
-  val wbRegs = Vec(NRFpWritePorts, ValidIO(new ExuOutput))
-  val numExist = Vec(exuParameters.FpExuCnt, Output(UInt(log2Ceil(IssQueSize).W)))
-}
-
-class FloatBlock
-(
-  intSlowWakeUpIn: Seq[ExuConfig],
-  memSlowWakeUpIn: Seq[ExuConfig],
-  fastWakeUpOut: Seq[ExuConfig],
-  slowWakeUpOut: Seq[ExuConfig],
-)(implicit p: Parameters) extends XSModule with HasExeBlockHelper with HasFpLoadHelper {
+class FloatBlock()(implicit p: Parameters) extends XSModule with HasExeBlockHelper with HasFpLoadHelper {
   val io = IO(new Bundle {
-    val fromCtrlBlock = Flipped(new CtrlToFpBlockIO)
-    val toCtrlBlock = new FpBlockToCtrlIO
-    val toMemBlock = new FpBlockToMemBlockIO
-
-    val intWakeUpFp = Vec(intSlowWakeUpIn.size, Flipped(DecoupledIO(new ExuOutput)))
-    val memWakeUpFp = Vec(memSlowWakeUpIn.size, Flipped(DecoupledIO(new ExuOutput)))
-    val wakeUpOut = Flipped(new WakeUpBundle(fastWakeUpOut.size, slowWakeUpOut.size))
-    val intWakeUpOut = Vec(intSlowWakeUpIn.size, DecoupledIO(new ExuOutput))
-    val fpWbOut = Vec(8, ValidIO(new ExuOutput))
-
-    // from csr
+    val redirect = Flipped(ValidIO(new Redirect))
+    val flush = Input(Bool())
+    // in
+    val issue = Vec(6, Flipped(DecoupledIO(new ExuInput)))
+    // out
+    val writeback = Vec(6, DecoupledIO(new ExuOutput))
+    // misc from csr
     val frm = Input(UInt(3.W))
   })
 
-  val redirect = io.fromCtrlBlock.redirect
-  val flush = io.fromCtrlBlock.flush
+//  val intWakeUpFpReg = Wire(Vec(intSlowWakeUpIn.size, Flipped(DecoupledIO(new ExuOutput))))
+//  for((w, r) <- io.intWakeUpFp.zip(intWakeUpFpReg)){
+//    val in = WireInit(w)
+//    w.ready := in.ready
+//    in.valid := w.valid && !w.bits.uop.roqIdx.needFlush(io.redirect, io.flush)
+//    PipelineConnect(in, r, r.fire() || r.bits.uop.roqIdx.needFlush(io.redirect, io.flush), false.B)
+//  }
+//  // to memBlock's store rs
+//  io.intWakeUpOut <> intWakeUpFpReg.map(x => WireInit(x))
+//
+//  val intRecoded = intWakeUpFpReg.map(x => {
+//    val rec = Wire(DecoupledIO(new ExuOutput))
+//    rec.valid := x.valid && x.bits.uop.ctrl.fpWen
+//    rec.bits := x.bits
+//    rec.bits.data := Mux(x.bits.uop.ctrl.fpu.typeTagOut === S,
+//      recode(x.bits.data(31, 0), S),
+//      recode(x.bits.data(63, 0), D)
+//    )
+//    rec.bits.redirectValid := false.B
+//    x.ready := rec.ready || !rec.valid
+//    rec
+//  })
 
-  val intWakeUpFpReg = Wire(Vec(intSlowWakeUpIn.size, Flipped(DecoupledIO(new ExuOutput))))
-  for((w, r) <- io.intWakeUpFp.zip(intWakeUpFpReg)){
-    val in = WireInit(w)
-    w.ready := in.ready
-    in.valid := w.valid && !w.bits.uop.roqIdx.needFlush(redirect, flush)
-    PipelineConnect(in, r, r.fire() || r.bits.uop.roqIdx.needFlush(redirect, flush), false.B)
-  }
-  // to memBlock's store rs
-  io.intWakeUpOut <> intWakeUpFpReg.map(x => WireInit(x))
-
-  val intRecoded = intWakeUpFpReg.map(x => {
-    val rec = Wire(DecoupledIO(new ExuOutput))
-    rec.valid := x.valid && x.bits.uop.ctrl.fpWen
-    rec.bits := x.bits
-    rec.bits.data := Mux(x.bits.uop.ctrl.fpu.typeTagOut === S,
-      recode(x.bits.data(31, 0), S),
-      recode(x.bits.data(63, 0), D)
-    )
-    rec.bits.redirectValid := false.B
-    x.ready := rec.ready || !rec.valid
-    rec
-  })
-
-  val memRecoded = WireInit(io.memWakeUpFp)
-  for((rec, reg) <- memRecoded.zip(io.memWakeUpFp)){
-    rec.bits.data := fpRdataHelper(reg.bits.uop, reg.bits.data)
-    rec.bits.redirectValid := false.B
-    reg.ready := true.B
-  }
-  val wakeUpInRecode = intRecoded ++ memRecoded
-
-  val fpRf = Module(new Regfile(
-    numReadPorts = NRFpReadPorts,
-    numWirtePorts = NRFpWritePorts,
-    hasZero = false,
-    len = XLEN + 1
-  ))
+//  val memRecoded = WireInit(io.memWakeUpFp)
+//  for((rec, reg) <- memRecoded.zip(io.memWakeUpFp)){
+//    rec.bits.data := fpRdataHelper(reg.bits.uop, reg.bits.data)
+//    rec.bits.redirectValid := false.B
+//    reg.ready := true.B
+//  }
+//  val wakeUpInRecode = intRecoded ++ memRecoded
 
   val fmacExeUnits = Array.tabulate(exuParameters.FmacCnt)(_ => Module(new FmacExeUnit))
   val fmiscExeUnits = Array.tabulate(exuParameters.FmiscCnt)(_ => Module(new FmiscExeUnit))
@@ -101,155 +76,28 @@ class FloatBlock
   fmiscExeUnits.foreach(_.frm := io.frm)
 
   val exeUnits = fmacExeUnits ++ fmiscExeUnits
-  val fpWbArbiter = Module(new Wb(
-    exeUnits.map(_.config) ++ intSlowWakeUpIn ++ memSlowWakeUpIn,
-    NRFpWritePorts,
-    isFp = true
-  ))
-  io.fpWbOut.zip(fpWbArbiter.io.out).map{ case (wakeup, wb) =>
-    wakeup.valid := RegNext(wb.valid && !wb.bits.uop.roqIdx.needFlush(redirect, flush))
-    wakeup.bits := RegNext(wb.bits)
-    wakeup.bits.data := ieee(RegNext(wb.bits.data))
-  }
 
-  def needWakeup(cfg: ExuConfig): Boolean =
-    (cfg.readIntRf && cfg.writeIntRf) || (cfg.readFpRf && cfg.writeFpRf)
+  for ((exu, i) <- exeUnits.zipWithIndex) {
+    exeUnits(i).io.redirect <> io.redirect
+    exeUnits(i).io.flush <> io.flush
 
-  def needData(a: ExuConfig, b: ExuConfig): Boolean =
-    (a.readIntRf && b.writeIntRf) || (a.readFpRf && b.writeFpRf)
-
-  // val readPortIndex = RegNext(io.fromCtrlBlock.readPortIndex)
-  val readPortIndex = Seq(0, 1, 2, 3, 2, 3)
-  val reservationStations = exeUnits.map(_.config).zipWithIndex.map({ case (cfg, i) =>
-    var certainLatency = -1
-    if (cfg.hasCertainLatency) {
-      certainLatency = cfg.latency.latencyVal.get
+    // in
+    exeUnits(i).io.fromFp <> io.issue(i)
+    for (j <- 0 until 3) {
+      // when one of the higher bits is zero, then it's not a legal single-precision number
+      val isLegalSingle = io.issue(i).bits.uop.ctrl.fpu.typeTagIn === S && io.issue(i).bits.src(j)(63, 32).andR
+      val single = recode(io.issue(i).bits.src(j)(31, 0), S)
+      val double = recode(io.issue(i).bits.src(j)(63, 0), D)
+      exeUnits(i).io.fromFp.bits.src(j) := Mux(isLegalSingle, single, double)
     }
 
-    val readFpRf = cfg.readFpRf
-    val wakeUpInRecodeWithCfg = intSlowWakeUpIn.zip(intRecoded) ++ memSlowWakeUpIn.zip(memRecoded)
-
-    val inBlockFastPorts = exeUnits.filter(e => e.config.hasCertainLatency).map(a => (a.config, a.io.out.bits.data))
-    val fastPortsCnt = inBlockFastPorts.length
-
-    val inBlockListenPorts = exeUnits.filter(e => e.config.hasUncertainlatency).map(a => (a.config, a.io.out))
-    val slowPorts = VecInit(fpWbArbiter.io.out.drop(4))
-    val slowPortsCnt = slowPorts.length
-
-    println(s"${i}: exu:${cfg.name} fastPortsCnt: ${fastPortsCnt} " +
-      s"slowPorts: ${slowPortsCnt} " +
-      s"delay:${certainLatency}"
+    // out
+    io.writeback(i).valid := exu.io.out.valid
+    io.writeback(i).bits := exu.io.out.bits
+    io.writeback(i).bits.data := Mux(exu.io.out.bits.uop.ctrl.fpWen,
+      ieee(exu.io.out.bits.data),
+      exu.io.out.bits.data
     )
-
-    val rs = Module(new ReservationStation(s"rs_${cfg.name}", cfg, IssQueSize, XLEN + 1,
-      inBlockFastPorts.map(_._1).length,
-      slowPorts.length,
-      fixedDelay = certainLatency,
-      fastWakeup = certainLatency >= 0,
-      feedback = false,1, 1
-    ))
-
-    rs.io.redirect <> redirect // TODO: remove it
-    rs.io.flush <> flush // TODO: remove it
-    rs.io.numExist <> io.toCtrlBlock.numExist(i)
-    rs.io.fromDispatch <> VecInit(io.fromCtrlBlock.enqIqCtrl(i))
-
-    rs.io.srcRegValue := DontCare
-    val src1Value = VecInit((0 until 4).map(i => fpRf.io.readPorts(i * 3).data))
-    val src2Value = VecInit((0 until 4).map(i => fpRf.io.readPorts(i * 3 + 1).data))
-    val src3Value = VecInit((0 until 4).map(i => fpRf.io.readPorts(i * 3 + 2).data))
-
-    rs.io.srcRegValue(0)(0) := src1Value(readPortIndex(i))
-    rs.io.srcRegValue(0)(1) := src2Value(readPortIndex(i))
-    if (cfg.fpSrcCnt > 2) rs.io.srcRegValue(0)(2) := src3Value(readPortIndex(i))
-
-    rs.io.fastDatas <> inBlockFastPorts.map(_._2)
-    rs.io.slowPorts <> slowPorts
-
-    exeUnits(i).io.redirect <> redirect
-    exeUnits(i).io.flush <> flush
-    exeUnits(i).io.fromFp <> rs.io.deq(0)
-    // rs.io.memfeedback := DontCare
-
-    rs.suggestName(s"rs_${cfg.name}")
-
-    rs
-  })
-
-  for(rs <- reservationStations){
-    val inBlockUops = reservationStations.filter(x =>
-      x.exuCfg.hasCertainLatency && x.exuCfg.writeFpRf
-    ).map(x => {
-      val raw = WireInit(x.io.fastUopOut(0))
-      raw.valid := x.io.fastUopOut(0).valid && raw.bits.ctrl.fpWen
-      raw
-    })
-    rs.io.fastUopsIn <> inBlockUops
+    exu.io.out.ready := io.writeback(i).ready
   }
-
-  // read fp rf from ctrl block
-  fpRf.io.readPorts.zipWithIndex.map{ case (r, i) => r.addr := io.fromCtrlBlock.readRf(i) }
-  (0 until exuParameters.StuCnt).foreach(i =>
-    io.toMemBlock.readFpRf(i).data := RegNext(ieee(fpRf.io.readPorts(i + 12).data))
-  )
-  // write fp rf arbiter
-  fpWbArbiter.io.in.drop(exeUnits.length).zip(wakeUpInRecode).foreach(
-    x => x._1 <> fpOutValid(x._2, connectReady = true)
-  )
-
-  for((exu, i) <- exeUnits.zipWithIndex){
-    val out, outReg = Wire(DecoupledIO(new ExuOutput))
-    out.bits := exu.io.out.bits
-    out.valid := exu.io.out.valid && !out.bits.uop.roqIdx.needFlush(redirect, flush)
-    PipelineConnect(out, outReg,
-      outReg.fire() || outReg.bits.uop.roqIdx.needFlush(redirect, flush), false.B
-    )
-    io.wakeUpOut.slow(i).valid := outReg.valid
-    io.wakeUpOut.slow(i).bits := outReg.bits
-    io.wakeUpOut.slow(i).bits.redirectValid := false.B
-    io.wakeUpOut.slow(i).bits.data := Mux(outReg.bits.uop.ctrl.fpWen,
-      ieee(outReg.bits.data),
-      outReg.bits.data
-    )
-    fpWbArbiter.io.in(i).valid := exu.io.out.valid && exu.io.out.bits.uop.ctrl.fpWen && outReg.ready
-    fpWbArbiter.io.in(i).bits := exu.io.out.bits
-    if(exu.config.writeIntRf){
-      outReg.ready := !outReg.valid || (
-        io.wakeUpOut.slow(i).ready && outReg.bits.uop.ctrl.rfWen
-        ) || outReg.bits.uop.ctrl.fpWen
-      // don't consider flush in 'intFire'
-      val intFire = exu.io.out.valid && out.ready && out.bits.uop.ctrl.rfWen
-      exu.io.out.ready := intFire || fpWbArbiter.io.in(i).fire() || !exu.io.out.valid
-    } else {
-      outReg.ready := true.B
-      exu.io.out.ready := fpWbArbiter.io.in(i).fire() || !exu.io.out.valid
-    }
-  }
-
-  XSPerfAccumulate("competition", fpWbArbiter.io.in.map(i => !i.ready && i.valid).foldRight(0.U)(_+_))
-
-  // set busytable and update roq
-  io.toCtrlBlock.wbRegs <> fpWbArbiter.io.out
-
-  fpRf.io.writePorts.zip(fpWbArbiter.io.out).foreach{
-    case (rf, wb) =>
-      rf.wen := wb.valid
-      rf.addr := wb.bits.uop.pdest
-      rf.data := wb.bits.data
-  }
-  fpRf.io.debug_rports := DontCare
-
-  if (!env.FPGAPlatform) {
-    for ((rport, rat) <- fpRf.io.debug_rports.zip(io.fromCtrlBlock.debug_rat)) {
-      rport.addr := rat
-    }
-    val difftest = Module(new DifftestArchFpRegState)
-    difftest.io.clock  := clock
-    difftest.io.coreid := hardId.U
-    difftest.io.fpr    := VecInit(fpRf.io.debug_rports.map(p => ieee(p.data)))
-  }
-
-  val rsDeqCount = PopCount(reservationStations.map(_.io.deq(0).valid))
-  XSPerfAccumulate("fp_rs_deq_count", rsDeqCount)
-  XSPerfHistogram("fp_rs_deq_count", rsDeqCount, true.B, 0, 6, 1)
 }

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -22,37 +22,13 @@ import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.tile.HasFPUParameters
 import system.L1CacheErrorInfo
 import xiangshan._
-import xiangshan.backend.roq.{RoqLsqIO, RoqPtr}
-import xiangshan.backend.exu._
+import xiangshan.backend.roq.RoqLsqIO
 import xiangshan.cache._
 import xiangshan.mem._
 import xiangshan.backend.fu.{FenceToSbuffer, HasExceptionNO}
-import xiangshan.backend.issue.ReservationStation
-import xiangshan.backend.regfile.RfReadPort
 import utils._
 
-class LsBlockToCtrlIO(implicit p: Parameters) extends XSBundle {
-  val stIn = Vec(exuParameters.StuCnt, ValidIO(new ExuInput))
-  val stOut = Vec(exuParameters.StuCnt, ValidIO(new ExuOutput))
-  val numExist = Vec(exuParameters.LsExuCnt, Output(UInt(log2Ceil(IssQueSize).W)))
-  val replay = ValidIO(new Redirect)
-}
-
-class IntBlockToMemBlockIO(implicit p: Parameters) extends XSBundle {
-  val readIntRf = Vec(NRMemReadPorts, new RfReadPort(XLEN))
-}
-
-class FpBlockToMemBlockIO(implicit p: Parameters) extends XSBundle {
-  val readFpRf = Vec(exuParameters.StuCnt, new RfReadPort(XLEN + 1))
-}
-
-class MemBlock(
-  val fastWakeUpIn: Seq[ExuConfig],
-  val slowWakeUpIn: Seq[ExuConfig],
-  val fastWakeUpOut: Seq[ExuConfig],
-  val slowWakeUpOut: Seq[ExuConfig],
-  val numIntWakeUpFp: Int
-)(implicit p: Parameters) extends LazyModule {
+class MemBlock()(implicit p: Parameters) extends LazyModule {
 
   val dcache = LazyModule(new DCacheWrapper())
   val uncache = LazyModule(new Uncache())
@@ -68,37 +44,33 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   with HasFpLoadHelper
 {
 
-  val fastWakeUpIn = outer.fastWakeUpIn
-  val slowWakeUpIn = outer.slowWakeUpIn
-  val fastWakeUpOut = outer.fastWakeUpOut
-  val slowWakeUpOut = outer.slowWakeUpOut
-  val numIntWakeUpFp = outer.numIntWakeUpFp
-
   val io = IO(new Bundle {
-    val fromCtrlBlock = Flipped(new CtrlToLsBlockIO)
-    val fromIntBlock = Flipped(new IntBlockToMemBlockIO)
-    val fromFpBlock = Flipped(new FpBlockToMemBlockIO)
-    val toCtrlBlock = new LsBlockToCtrlIO
-
-    val wakeUpIn = new WakeUpBundle(fastWakeUpIn.size, slowWakeUpIn.size)
-    val intWakeUpFp = Vec(numIntWakeUpFp, Flipped(DecoupledIO(new ExuOutput)))
-    val wakeUpOutInt = Flipped(new WakeUpBundle(fastWakeUpOut.size, slowWakeUpOut.size))
-    val wakeUpOutFp = Flipped(new WakeUpBundle(fastWakeUpOut.size, slowWakeUpOut.size))
-
-    val ldFastWakeUpInt = Flipped(new WakeUpBundle(exuParameters.LduCnt, 0))
-    val intWbOut = Vec(4, Flipped(ValidIO(new ExuOutput)))
-    val fpWbOut = Vec(8, Flipped(ValidIO(new ExuOutput)))
-
+    val redirect = Flipped(ValidIO(new Redirect))
+    val flush = Input(Bool())
+    // in
+    val issue = Vec(4, Flipped(DecoupledIO(new ExuInput)))
+    val replay = Vec(4, ValidIO(new RSFeedback))
+    val rsIdx = Vec(4, Input(UInt(log2Up(IssQueSize).W)))
+    val isFirstIssue = Vec(4, Input(Bool()))
+    val stData = Vec(2, Flipped(ValidIO(new StoreDataBundle)))
+    val stIssuePtr = Output(new SqPtr())
+    // out
+    val writeback = Vec(4, DecoupledIO(new ExuOutput))
+    val otherFastWakeup = Vec(2, ValidIO(new MicroOp))
+    // misc
+    val stIn = Vec(exuParameters.StuCnt, ValidIO(new ExuInput))
+    val stOut = Vec(exuParameters.StuCnt, ValidIO(new ExuOutput))
+    val memoryViolation = ValidIO(new Redirect)
     val ptw = new TlbPtwIO(LoadPipelineWidth + StorePipelineWidth)
     val sfence = Input(new SfenceBundle)
     val tlbCsr = Input(new TlbCsrBundle)
     val fenceToSbuffer = Flipped(new FenceToSbuffer)
-
+    val enqLsq = new LsqEnqIO
+    val memPredUpdate = Vec(StorePipelineWidth, Input(new MemPredUpdateReq))
     val lsqio = new Bundle {
       val exceptionAddr = new ExceptionAddrIO // to csr
       val roq = Flipped(new RoqLsqIO) // roq to lsq
     }
-
     val csrCtrl = Flipped(new CustomCSRCtrlIO)
     val error = new L1CacheErrorInfo
     val memInfo = new Bundle {
@@ -112,8 +84,6 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   val uncache = outer.uncache.module
 
   io.error <> RegNext(RegNext(dcache.io.error))
-
-  val redirect = io.fromCtrlBlock.redirect
 
   val loadUnits = Seq.fill(exuParameters.LduCnt)(Module(new LoadUnit))
   val storeUnits = Seq.fill(exuParameters.StuCnt)(Module(new StoreUnit))
@@ -132,96 +102,17 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   loadUnits.head.io.ldout.ready := ldOut0.ready
 
   val exeWbReqs = ldOut0 +: loadUnits.tail.map(_.io.ldout)
-  // 'wakeUpFp' is 1 cycle later than 'exeWbReqs'
-  val wakeUpFp = Wire(Vec(exuParameters.LduCnt, Decoupled(new ExuOutput)))
+  io.writeback <> exeWbReqs ++ VecInit(storeUnits.map(_.io.stout))
+  io.otherFastWakeup <> loadUnits.map(_.io.fastUop)
 
-  val readPortIndex = Seq(0, 1, 2, 4)
-  io.fromIntBlock.readIntRf.foreach(_.addr := DontCare)
-  io.fromFpBlock.readFpRf.foreach(_.addr := DontCare)
-  val reservationStations = (loadExuConfigs ++ storeExuConfigs).zipWithIndex.map({ case (cfg, i) =>
-    var certainLatency = -1
-    if (cfg.hasCertainLatency) {
-      certainLatency = cfg.latency.latencyVal.get
-    }
-
-    val readIntRf = cfg.readIntRf
-    val readFpRf = cfg.readFpRf
-
-    // load has uncertain latency, so only use external wake up data
-    val fastDatas = fastWakeUpIn.zip(io.wakeUpIn.fast)
-      .filter(x => (x._1.writeIntRf && readIntRf) || (x._1.writeFpRf && readFpRf))
-      .map(a => (a._1, a._2.bits.data)) ++
-      (if (cfg == LdExeUnitCfg && EnableLoadFastWakeUp) loadExuConfigs.zip(loadUnits.map(_.io.ldout.bits.data)) else Seq())
-
-    val fastPortsCnt = fastDatas.length
-
-    val slowPorts = if (cfg == StExeUnitCfg) io.intWbOut ++ io.fpWbOut else io.intWbOut
-    val slowPortsCnt = slowPorts.length
-
-    // if tlb miss, replay
-    val feedback = true
-
-    println(s"${i}: exu:${cfg.name} fastPortsCnt: ${fastPortsCnt} slowPorts: ${slowPortsCnt} delay:${certainLatency} feedback:${feedback}")
-
-    val rs = Module(new ReservationStation(s"rs_${cfg.name}", cfg, IssQueSize, XLEN,
-      fastDatas.map(_._1).length,
-      slowPorts.length,
-      fixedDelay = certainLatency,
-      fastWakeup = certainLatency >= 0,
-      feedback = feedback, 1, 1)
-    )
-
-    rs.io.redirect <> redirect // TODO: remove it
-    rs.io.flush    <> io.fromCtrlBlock.flush // TODO: remove it
-    rs.io.numExist <> io.toCtrlBlock.numExist(i)
-    rs.io.fromDispatch  <> VecInit(io.fromCtrlBlock.enqIqCtrl(i))
-
-    rs.io.srcRegValue(0)(0) := io.fromIntBlock.readIntRf(readPortIndex(i)).data
-    if (i >= exuParameters.LduCnt) {
-      rs.io.srcRegValue(0)(1) := io.fromIntBlock.readIntRf(readPortIndex(i) + 1).data
-      rs.io.fpRegValue := io.fromFpBlock.readFpRf(i - exuParameters.LduCnt).data
-    }
-
-    rs.io.fastDatas <> fastDatas.map(_._2)
-    rs.io.slowPorts <> slowPorts
-
-    // exeUnits(i).io.redirect <> redirect
-    // exeUnits(i).io.fromInt <> rs.io.deq
-    rs.io.memfeedback := DontCare
-
-    rs.suggestName(s"rs_${cfg.name}")
-
-    rs
-  })
-
-  for(rs <- reservationStations){
-    rs.io.fastUopsIn <> fastWakeUpIn.zip(io.wakeUpIn.fastUops)
-      .filter(x => (x._1.writeIntRf && rs.exuCfg.readIntRf) || (x._1.writeFpRf && rs.exuCfg.readFpRf))
-      .map(_._2) ++
-      (if (rs.exuCfg == LdExeUnitCfg && EnableLoadFastWakeUp) loadUnits.map(_.io.fastUop) else Seq())
-  }
-
-  wakeUpFp.zip(exeWbReqs).foreach{
-    case(w, e) =>
-      val r = RegNext(e.bits)
-      w.bits := r
-      w.valid := RegNext(e.valid && !e.bits.uop.roqIdx.needFlush(redirect, io.fromCtrlBlock.flush))
-      e.ready := true.B
-      assert(w.ready === true.B)
-  }
-
-  io.ldFastWakeUpInt.fastUops <> loadUnits.map(_.io.fastUop)
-  io.ldFastWakeUpInt.fast <> loadUnits.map(_.io.ldout).map(decoupledIOToValidIO)
-  io.wakeUpOutInt.slow <> exeWbReqs
-  io.wakeUpOutFp.slow <> wakeUpFp
-  io.wakeUpIn.slow.foreach(_.ready := true.B)
-  io.intWakeUpFp.foreach(_.ready := true.B)
+  // TODO: fast load wakeup
 
   val dtlb    = Module(new TLB(Width = DTLBWidth, isDtlb = true))
   val lsq     = Module(new LsqWrappper)
   val sbuffer = Module(new NewSbuffer)
   // if you wants to stress test dcache store, use FakeSbuffer
   // val sbuffer = Module(new FakeSbuffer)
+  io.stIssuePtr := lsq.io.issuePtrExt
 
   // dtlb
   io.ptw         <> dtlb.io.ptw
@@ -230,14 +121,14 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
 
   // LoadUnit
   for (i <- 0 until exuParameters.LduCnt) {
-    loadUnits(i).io.redirect      <> io.fromCtrlBlock.redirect
-    loadUnits(i).io.flush         <> io.fromCtrlBlock.flush
-    loadUnits(i).io.rsFeedback    <> reservationStations(i).io.memfeedback
-    loadUnits(i).io.rsIdx         := reservationStations(i).io.rsIdx // TODO: beautify it
-    loadUnits(i).io.isFirstIssue  := reservationStations(i).io.isFirstIssue // NOTE: just for dtlb's perf cnt
+    loadUnits(i).io.redirect      <> io.redirect
+    loadUnits(i).io.flush         <> io.flush
+    loadUnits(i).io.rsFeedback    <> io.replay(i)
+    loadUnits(i).io.rsIdx         := io.rsIdx(i) // TODO: beautify it
+    loadUnits(i).io.isFirstIssue  := io.isFirstIssue(i) // NOTE: just for dtlb's perf cnt
     loadUnits(i).io.dtlb          <> dtlb.io.requestor(i)
     // get input form dispatch
-    loadUnits(i).io.ldin          <> reservationStations(i).io.deq(0)
+    loadUnits(i).io.ldin          <> io.issue(i)
     // dcache access
     loadUnits(i).io.dcache        <> dcache.io.lsu.load(i)
     // forward
@@ -245,7 +136,6 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     loadUnits(i).io.sbuffer       <> sbuffer.io.forward(i)
 
     // Lsq to load unit's rs
-    reservationStations(i).io.stIssuePtr := lsq.io.issuePtrExt
 
     // passdown to lsq
     lsq.io.loadIn(i)              <> loadUnits(i).io.lsq.loadIn
@@ -254,57 +144,56 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
 
     // update waittable
     // TODO: read pc
-    io.fromCtrlBlock.memPredUpdate(i) := DontCare
+    io.memPredUpdate(i) := DontCare
     lsq.io.needReplayFromRS(i)    <> loadUnits(i).io.lsq.needReplayFromRS
   }
 
   // StoreUnit
   for (i <- 0 until exuParameters.StuCnt) {
     val stu = storeUnits(i)
-    val rs = reservationStations(exuParameters.LduCnt + i)
     val dtlbReq = dtlb.io.requestor(exuParameters.LduCnt + i)
 
-    stu.io.redirect    <> io.fromCtrlBlock.redirect
-    stu.io.flush       <> io.fromCtrlBlock.flush
-    stu.io.rsFeedback <> rs.io.memfeedback
-    stu.io.rsIdx       <> rs.io.rsIdx
-    stu.io.isFirstIssue <> rs.io.isFirstIssue // NOTE: just for dtlb's perf cnt
+    stu.io.redirect    <> io.redirect
+    stu.io.flush       <> io.flush
+    stu.io.rsFeedback <> io.replay(exuParameters.LduCnt + i)
+    stu.io.rsIdx       <> io.rsIdx(exuParameters.LduCnt + i)
+    // NOTE: just for dtlb's perf cnt
+    stu.io.isFirstIssue <> io.isFirstIssue(exuParameters.LduCnt + i)
     stu.io.dtlb        <> dtlbReq
-    stu.io.stin        <> rs.io.deq(0)
+    stu.io.stin        <> io.issue(exuParameters.LduCnt + i)
     stu.io.lsq         <> lsq.io.storeIn(i)
 
     // Lsq to load unit's rs
-    rs.io.stIssuePtr := lsq.io.issuePtrExt
     // rs.io.storeData <> lsq.io.storeDataIn(i)
-    lsq.io.storeDataIn(i) := rs.io.stData
+    lsq.io.storeDataIn(i) := io.stData(i)
 
     // sync issue info to rs
-    lsq.io.storeIssue(i).valid := rs.io.deq(0).valid
-    lsq.io.storeIssue(i).bits := rs.io.deq(0).bits
+    lsq.io.storeIssue(i).valid := io.issue(exuParameters.LduCnt + i).valid
+    lsq.io.storeIssue(i).bits := io.issue(exuParameters.LduCnt + i).bits
 
     // sync issue info to store set LFST
-    io.toCtrlBlock.stIn(i).valid := rs.io.deq(0).valid
-    io.toCtrlBlock.stIn(i).bits := rs.io.deq(0).bits
+    io.stIn(i).valid := io.issue(exuParameters.LduCnt + i).valid
+    io.stIn(i).bits := io.issue(exuParameters.LduCnt + i).bits
 
-    io.toCtrlBlock.stOut(i).valid := stu.io.stout.valid
-    io.toCtrlBlock.stOut(i).bits  := stu.io.stout.bits
+    io.stOut(i).valid := stu.io.stout.valid
+    io.stOut(i).bits  := stu.io.stout.bits
     stu.io.stout.ready := true.B
   }
 
   // mmio store writeback will use store writeback port 0
   lsq.io.mmioStout.ready := false.B
   when (lsq.io.mmioStout.valid && !storeUnits(0).io.stout.valid) {
-    io.toCtrlBlock.stOut(0).valid := true.B
-    io.toCtrlBlock.stOut(0).bits  := lsq.io.mmioStout.bits
+    io.stOut(0).valid := true.B
+    io.stOut(0).bits  := lsq.io.mmioStout.bits
     lsq.io.mmioStout.ready := true.B
   }
 
   // Lsq
   lsq.io.roq            <> io.lsqio.roq
-  lsq.io.enq            <> io.fromCtrlBlock.enqLsq
-  lsq.io.brqRedirect    <> io.fromCtrlBlock.redirect
-  lsq.io.flush          <> io.fromCtrlBlock.flush
-  io.toCtrlBlock.replay <> lsq.io.rollback
+  lsq.io.enq            <> io.enqLsq
+  lsq.io.brqRedirect    <> io.redirect
+  lsq.io.flush          <> io.flush
+  io.memoryViolation    <> lsq.io.rollback
   lsq.io.uncache        <> uncache.io.lsq
   // delay dcache refill for 1 cycle for better timing
   // TODO: remove RegNext after fixing refill paddr timing
@@ -338,21 +227,21 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
 
   val atomic_rs0  = exuParameters.LduCnt + 0
   val atomic_rs1  = exuParameters.LduCnt + 1
-  val st0_atomics = reservationStations(atomic_rs0).io.deq(0).valid && FuType.storeIsAMO(reservationStations(atomic_rs0).io.deq(0).bits.uop.ctrl.fuType)
-  val st1_atomics = reservationStations(atomic_rs1).io.deq(0).valid && FuType.storeIsAMO(reservationStations(atomic_rs1).io.deq(0).bits.uop.ctrl.fuType)
+  val st0_atomics = io.issue(atomic_rs0).valid && FuType.storeIsAMO(io.issue(atomic_rs0).bits.uop.ctrl.fuType)
+  val st1_atomics = io.issue(atomic_rs1).valid && FuType.storeIsAMO(io.issue(atomic_rs1).bits.uop.ctrl.fuType)
 
-  val st0_data_atomics = reservationStations(atomic_rs0).io.stData.valid && FuType.storeIsAMO(reservationStations(atomic_rs0).io.stData.bits.uop.ctrl.fuType)
-  val st1_data_atomics = reservationStations(atomic_rs1).io.stData.valid && FuType.storeIsAMO(reservationStations(atomic_rs1).io.stData.bits.uop.ctrl.fuType)
+  val st0_data_atomics = io.stData(0).valid && FuType.storeIsAMO(io.stData(0).bits.uop.ctrl.fuType)
+  val st1_data_atomics = io.stData(1).valid && FuType.storeIsAMO(io.stData(1).bits.uop.ctrl.fuType)
 
   when (st0_atomics) {
-    reservationStations(atomic_rs0).io.deq(0).ready := atomicsUnit.io.in.ready
+    io.issue(atomic_rs0).ready := atomicsUnit.io.in.ready
     storeUnits(0).io.stin.valid := false.B
 
     state := s_atomics_0
     assert(!st1_atomics)
   }
   when (st1_atomics) {
-    reservationStations(atomic_rs1).io.deq(0).ready := atomicsUnit.io.in.ready
+    io.issue(atomic_rs1).ready := atomicsUnit.io.in.ready
     storeUnits(1).io.stin.valid := false.B
 
     state := s_atomics_1
@@ -364,12 +253,12 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   }
 
   atomicsUnit.io.in.valid := st0_atomics || st1_atomics
-  atomicsUnit.io.in.bits  := Mux(st0_atomics, reservationStations(atomic_rs0).io.deq(0).bits, reservationStations(atomic_rs1).io.deq(0).bits)
+  atomicsUnit.io.in.bits  := Mux(st0_atomics, io.issue(atomic_rs0).bits, io.issue(atomic_rs1).bits)
   atomicsUnit.io.storeDataIn.valid := st0_data_atomics || st1_data_atomics
-  atomicsUnit.io.storeDataIn.bits  := Mux(st0_data_atomics, reservationStations(atomic_rs0).io.stData.bits, reservationStations(atomic_rs1).io.stData.bits)
-  atomicsUnit.io.rsIdx    := Mux(st0_atomics, reservationStations(atomic_rs0).io.rsIdx, reservationStations(atomic_rs1).io.rsIdx)
-  atomicsUnit.io.redirect <> io.fromCtrlBlock.redirect
-  atomicsUnit.io.flush <> io.fromCtrlBlock.flush
+  atomicsUnit.io.storeDataIn.bits  := Mux(st0_data_atomics, io.stData(0).bits, io.stData(1).bits)
+  atomicsUnit.io.rsIdx    := Mux(st0_atomics, io.rsIdx(atomic_rs0), io.rsIdx(atomic_rs1))
+  atomicsUnit.io.redirect <> io.redirect
+  atomicsUnit.io.flush <> io.flush
 
   atomicsUnit.io.dtlb.resp.valid := false.B
   atomicsUnit.io.dtlb.resp.bits  := DontCare
@@ -391,12 +280,12 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   }
 
   when (state === s_atomics_0) {
-    atomicsUnit.io.rsFeedback <> reservationStations(atomic_rs0).io.memfeedback
+    atomicsUnit.io.rsFeedback <> io.replay(atomic_rs0)
 
     assert(!storeUnits(0).io.rsFeedback.valid)
   }
   when (state === s_atomics_1) {
-    atomicsUnit.io.rsFeedback <> reservationStations(atomic_rs1).io.memfeedback
+    atomicsUnit.io.rsFeedback <> io.replay(atomic_rs1)
 
     assert(!storeUnits(1).io.rsFeedback.valid)
   }
@@ -409,8 +298,8 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   io.memInfo.lqFull := RegNext(lsq.io.lqFull)
   io.memInfo.dcacheMSHRFull := RegNext(dcache.io.mshrFull)
 
-  val ldDeqCount = PopCount(reservationStations.take(2).map(_.io.deq(0).valid))
-  val stDeqCount = PopCount(reservationStations.drop(2).map(_.io.deq(0).valid))
+  val ldDeqCount = PopCount(io.issue.take(2).map(_.valid))
+  val stDeqCount = PopCount(io.issue.drop(2).map(_.valid))
   val rsDeqCount = ldDeqCount + stDeqCount
   XSPerfAccumulate("load_rs_deq_count", ldDeqCount)
   XSPerfHistogram("load_rs_deq_count", ldDeqCount, true.B, 1, 2, 1)

--- a/src/main/scala/xiangshan/backend/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/Scheduler.scala
@@ -18,12 +18,277 @@ package xiangshan.backend
 import chisel3._
 import chisel3.util._
 import chipsalliance.rocketchip.config.Parameters
+import difftest.{DifftestArchFpRegState, DifftestArchIntRegState}
 import xiangshan._
 import utils._
+import xiangshan.backend.issue.ReservationStation
+import xiangshan.backend.regfile.Regfile
+import xiangshan.mem.{SqPtr, StoreDataBundle}
 
+// TODO: parameters
 class Scheduler(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle {
-
+    // global control
+    val redirect = Flipped(ValidIO(new Redirect))
+    val flush = Input(Bool())
+    // dispatch and issue ports
+    val allocate = Vec(12, Flipped(DecoupledIO(new MicroOp)))
+    // read regfile
+    val readIntRf = Vec(NRIntReadPorts, Input(UInt(PhyRegIdxWidth.W)))
+    val readFpRf = Vec(NRFpReadPorts, Input(UInt(PhyRegIdxWidth.W)))
+    val issue = Vec(17, DecoupledIO(new ExuInput))
+    val writeback = Vec(16, Flipped(ValidIO(new ExuOutput)))
+    val replay = Vec(4, Flipped(ValidIO(new RSFeedback)))
+    val rsIdx = Vec(4, Output(UInt(log2Up(IssQueSize).W)))
+    val isFirstIssue = Vec(4, Output(Bool()))
+    val stData = Vec(2, ValidIO(new StoreDataBundle))
+    // 2LOAD, data is selected from writeback ports
+    val otherFastWakeup = Vec(2, Flipped(ValidIO(new MicroOp)))
+    // misc
+    val jumpPc = Input(UInt(VAddrBits.W))
+    val jalr_target = Input(UInt(VAddrBits.W))
+    val stIssuePtr = Input(new SqPtr())
+    // debug
+    val debug_int_rat = Vec(32, Input(UInt(PhyRegIdxWidth.W)))
+    val debug_fp_rat = Vec(32, Input(UInt(PhyRegIdxWidth.W)))
   })
+
+  // write ports: 0-3 ALU, 4-5 MUL, 6-7 LOAD
+  val intRf = Module(new Regfile(
+    numReadPorts = NRIntReadPorts,
+    numWirtePorts = NRIntWritePorts,
+    hasZero = true,
+    len = XLEN
+  ))
+  // write ports: 0-3 FMA 4-5 FMISC, 6-7 LOAD
+  val fpRf = Module(new Regfile(
+    numReadPorts = NRFpReadPorts,
+    numWirtePorts = NRFpWritePorts,
+    hasZero = false,
+    len = XLEN
+  ))
+  io.readIntRf <> intRf.io.readPorts.map(_.addr)
+  io.readFpRf <> fpRf.io.readPorts.map(_.addr)
+
+  val jmp_rs = Module(new ReservationStation(JumpExeUnitCfg, IssQueSize, XLEN, 6, 4, -1, false, false, 1, 1))
+  val mul_rs_0 = Module(new ReservationStation(MulDivExeUnitCfg, IssQueSize, XLEN, 6, 4, 2, false, false, 2, 1))
+  val mul_rs_1 = Module(new ReservationStation(MulDivExeUnitCfg, IssQueSize, XLEN, 6, 4, 2, false, false, 2, 1))
+  val alu_rs_0 = Module(new ReservationStation(AluExeUnitCfg, 4*IssQueSize, XLEN,
+    8, 4, 0, true, false, 4, 4
+  ))
+
+  val fmac_rs0 = Module(new ReservationStation(FmacExeUnitCfg, 4*IssQueSize, XLEN,
+    4, 4, fixedDelay = 4, fastWakeup = true, feedback = false,4, 4))
+  val fmisc_rs0 = Module(new ReservationStation(FmiscExeUnitCfg, IssQueSize, XLEN,
+    4, 4, fixedDelay = -1, fastWakeup = false, feedback = false,2, 1))
+  val fmisc_rs1 = Module(new ReservationStation(FmiscExeUnitCfg, IssQueSize, XLEN,
+    4, 4, fixedDelay = -1, fastWakeup = false, feedback = false,2, 1))
+
+  val load_rs0 = Module(new ReservationStation(LdExeUnitCfg, IssQueSize, XLEN,
+    8, 4, fixedDelay = -1, fastWakeup = false, feedback = true, 1, 1))
+  val load_rs1 = Module(new ReservationStation(LdExeUnitCfg, IssQueSize, XLEN,
+    8, 4, fixedDelay = -1, fastWakeup = false, feedback = true, 1, 1))
+  val store_rs0 = Module(new ReservationStation(StExeUnitCfg, IssQueSize, XLEN,
+    6, 12, fixedDelay = -1, fastWakeup = false, feedback = true, 1, 1))
+  val store_rs1 = Module(new ReservationStation(StExeUnitCfg, IssQueSize, XLEN,
+    6, 12, fixedDelay = -1, fastWakeup = false, feedback = true, 1, 1))
+
+  val intRs = Seq(jmp_rs, mul_rs_0, mul_rs_1, alu_rs_0)
+  val fpRs = Seq(fmac_rs0, fmisc_rs0, fmisc_rs1)
+  val lsRs = Seq(load_rs0, load_rs1, store_rs0, store_rs1)
+  val reservationStations = intRs ++ fpRs ++ lsRs
+
+  for (rs <- reservationStations) {
+    rs.io.redirect <> io.redirect
+    rs.io.redirect <> io.redirect
+    rs.io.flush <> io.flush
+  }
+
+  val mulFastData = VecInit(io.writeback.slice(6, 8).map(_.bits.data))
+  val aluFastData = VecInit(io.writeback.slice(0, 4).map(_.bits.data))
+  val memFastData = VecInit(io.writeback.slice(4, 6).map(_.bits.data))
+  val fmaFastData = VecInit(io.writeback.slice(8, 12).map(_.bits.data))
+
+  jmp_rs.io.fromDispatch <> io.allocate.take(1)
+  jmp_rs.io.fromDispatch(0).valid := io.allocate(0).valid && FuType.jmpCanAccept(io.allocate(0).bits.ctrl.fuType)
+  jmp_rs.io.srcRegValue(0) <> VecInit(intRf.io.readPorts.take(2).map(_.data))
+  jmp_rs.io.jumpPc := io.jumpPc
+  jmp_rs.io.jalr_target := io.jalr_target
+  jmp_rs.io.fastDatas <> mulFastData ++ aluFastData
+  jmp_rs.io.deq(0) <> io.issue(0)
+
+  mul_rs_0.io.fromDispatch <> io.allocate.slice(0, 1) ++ io.allocate.slice(2, 3)
+  mul_rs_0.io.fromDispatch(0).valid := io.allocate(0).valid && FuType.mduCanAccept(io.allocate(0).bits.ctrl.fuType)
+  mul_rs_0.io.fromDispatch(1).valid := io.allocate(2).valid && FuType.mduCanAccept(io.allocate(2).bits.ctrl.fuType)
+  mul_rs_0.io.srcRegValue(0) <> VecInit(intRf.io.readPorts.slice(0, 2).map(_.data))
+  mul_rs_0.io.srcRegValue(1) <> VecInit(intRf.io.readPorts.slice(4, 6).map(_.data))
+  mul_rs_0.io.fastDatas <> mulFastData ++ aluFastData
+  mul_rs_0.io.deq(0) <> io.issue(1)
+
+  mul_rs_1.io.fromDispatch <> io.allocate.slice(1, 2) ++ io.allocate.slice(3, 4)
+  mul_rs_1.io.fromDispatch(0).valid := io.allocate(1).valid && FuType.mduCanAccept(io.allocate(1).bits.ctrl.fuType)
+  mul_rs_1.io.fromDispatch(1).valid := io.allocate(3).valid && FuType.mduCanAccept(io.allocate(3).bits.ctrl.fuType)
+  mul_rs_1.io.srcRegValue(0) <> VecInit(intRf.io.readPorts.slice(2, 4).map(_.data))
+  mul_rs_1.io.srcRegValue(1) <> VecInit(intRf.io.readPorts.slice(6, 8).map(_.data))
+  mul_rs_1.io.fastDatas <> mulFastData ++ aluFastData
+  mul_rs_1.io.deq(0) <> io.issue(2)
+
+  alu_rs_0.io.fromDispatch <> VecInit(io.allocate.take(4))
+  for (i <- 0 until 4) {
+    alu_rs_0.io.fromDispatch(i).valid := io.allocate(i).valid && FuType.aluCanAccept(io.allocate(i).bits.ctrl.fuType)
+  }
+  alu_rs_0.io.srcRegValue(0) <> VecInit(intRf.io.readPorts.take(2).map(_.data))
+  alu_rs_0.io.srcRegValue(1) <> VecInit(intRf.io.readPorts.slice(2, 4).map(_.data))
+  alu_rs_0.io.srcRegValue(2) <> VecInit(intRf.io.readPorts.slice(4, 6).map(_.data))
+  alu_rs_0.io.srcRegValue(3) <> VecInit(intRf.io.readPorts.slice(6, 8).map(_.data))
+  alu_rs_0.io.fastDatas <> mulFastData ++ aluFastData ++ memFastData
+  alu_rs_0.io.deq <> io.issue.slice(3, 7)
+
+  io.allocate(0).ready := jmp_rs.io.fromDispatch(0).fire() || mul_rs_0.io.fromDispatch(0).fire() || alu_rs_0.io.fromDispatch(0).fire()
+  io.allocate(1).ready := mul_rs_1.io.fromDispatch(0).fire() || alu_rs_0.io.fromDispatch(1).fire()
+  io.allocate(2).ready := mul_rs_0.io.fromDispatch(1).fire() || alu_rs_0.io.fromDispatch(2).fire()
+  io.allocate(3).ready := mul_rs_1.io.fromDispatch(1).fire() || alu_rs_0.io.fromDispatch(3).fire()
+
+  fmac_rs0.io.fromDispatch <> VecInit(io.allocate.slice(4, 8))
+  for (i <- 0 until 4) {
+    fmac_rs0.io.fromDispatch(i).valid := io.allocate(i + 4).valid && FuType.fmacCanAccept(io.allocate(i + 4).bits.ctrl.fuType)
+    fmac_rs0.io.srcRegValue(i) <> VecInit(fpRf.io.readPorts.slice(3*i, 3*i+3).map(_.data))
+  }
+  fmac_rs0.io.fastDatas <> fmaFastData
+  fmac_rs0.io.deq <> io.issue.slice(7, 11)
+
+  fmisc_rs0.io.fromDispatch <> VecInit(io.allocate.slice(4, 5) ++ io.allocate.slice(6, 7))
+  for (i <- 0 until 2) {
+    fmisc_rs0.io.fromDispatch(i).valid := io.allocate(i*2+4).valid && FuType.fmiscCanAccept(io.allocate(i*2+4).bits.ctrl.fuType)
+  }
+  fmisc_rs0.io.srcRegValue(0) <> VecInit(fpRf.io.readPorts.slice(0, 2).map(_.data))
+  fmisc_rs0.io.srcRegValue(1) <> VecInit(fpRf.io.readPorts.slice(6, 8).map(_.data))
+  fmisc_rs0.io.fastDatas <> fmaFastData
+  fmisc_rs0.io.deq <> io.issue.slice(11, 12)
+
+  fmisc_rs1.io.fromDispatch <> VecInit(io.allocate.slice(5, 6) ++ io.allocate.slice(7, 8))
+  for (i <- 0 until 2) {
+    fmisc_rs1.io.fromDispatch(i).valid := io.allocate(i*2+5).valid && FuType.fmiscCanAccept(io.allocate(i*2+5).bits.ctrl.fuType)
+  }
+  fmisc_rs1.io.srcRegValue(0) <> VecInit(fpRf.io.readPorts.slice(3, 5).map(_.data))
+  fmisc_rs1.io.srcRegValue(1) <> VecInit(fpRf.io.readPorts.slice(9, 11).map(_.data))
+  fmisc_rs1.io.fastDatas <> fmaFastData
+  fmisc_rs1.io.deq <> io.issue.slice(12, 13)
+
+  io.allocate(4).ready := fmisc_rs0.io.fromDispatch(0).fire() || fmac_rs0.io.fromDispatch(0).fire()
+  io.allocate(5).ready := fmisc_rs1.io.fromDispatch(0).fire() || fmac_rs0.io.fromDispatch(1).fire()
+  io.allocate(6).ready := fmisc_rs0.io.fromDispatch(1).fire() || fmac_rs0.io.fromDispatch(2).fire()
+  io.allocate(7).ready := fmisc_rs1.io.fromDispatch(1).fire() || fmac_rs0.io.fromDispatch(3).fire()
+
+  load_rs0.io.fromDispatch <> io.allocate.slice(8, 9)
+  load_rs0.io.srcRegValue(0) <> VecInit(intRf.io.readPorts.slice(8, 9).map(_.data))
+  load_rs0.io.fastDatas <> mulFastData ++ aluFastData ++ memFastData
+  load_rs0.io.deq <> io.issue.slice(13, 14)
+
+  load_rs1.io.fromDispatch <> io.allocate.slice(9, 10)
+  load_rs1.io.srcRegValue(0) <> VecInit(intRf.io.readPorts.slice(9, 10).map(_.data))
+  load_rs1.io.fastDatas <> mulFastData ++ aluFastData ++ memFastData
+  load_rs1.io.deq <> io.issue.slice(14, 15)
+
+  store_rs0.io.fromDispatch <> io.allocate.slice(10, 11)
+  store_rs0.io.srcRegValue(0) <> VecInit(intRf.io.readPorts.slice(10, 12).map(_.data))
+  when (RegNext(store_rs0.io.fromDispatch(0).bits.ctrl.srcType(1) === SrcType.fp)) {
+    store_rs0.io.srcRegValue(0)(1) := fpRf.io.readPorts(12).data
+  }
+  store_rs0.io.fastDatas <> mulFastData ++ aluFastData
+  store_rs0.io.deq <> io.issue.slice(15, 16)
+
+  store_rs1.io.fromDispatch <> io.allocate.slice(11, 12)
+  store_rs1.io.srcRegValue(0) <> VecInit(intRf.io.readPorts.slice(12, 14).map(_.data))
+  when (RegNext(store_rs1.io.fromDispatch(0).bits.ctrl.srcType(1) === SrcType.fp)) {
+    store_rs1.io.srcRegValue(0)(1) := fpRf.io.readPorts(13).data
+  }
+  store_rs1.io.fastDatas <> mulFastData ++ aluFastData
+  store_rs1.io.deq <> io.issue.slice(16, 17)
+
+  val aluFastUop = alu_rs_0.io.fastUopOut
+  val mulFastUop = mul_rs_0.io.fastUopOut ++ mul_rs_1.io.fastUopOut
+  val memFastUop = io.otherFastWakeup
+  val fmacFastUop = fmac_rs0.io.fastUopOut
+
+  jmp_rs.io.fastUopsIn := mulFastUop ++ aluFastUop
+  mul_rs_0.io.fastUopsIn := mulFastUop ++ aluFastUop
+  mul_rs_1.io.fastUopsIn := mulFastUop ++ aluFastUop
+  alu_rs_0.io.fastUopsIn := mulFastUop ++ aluFastUop ++ memFastUop
+  fmac_rs0.io.fastUopsIn := fmacFastUop
+  fmisc_rs0.io.fastUopsIn := fmacFastUop
+  fmisc_rs1.io.fastUopsIn := fmacFastUop
+  load_rs0.io.fastUopsIn := mulFastUop ++ aluFastUop ++ memFastUop
+  load_rs1.io.fastUopsIn := mulFastUop ++ aluFastUop ++ memFastUop
+  store_rs0.io.fastUopsIn := mulFastUop ++ aluFastUop
+  store_rs1.io.fastUopsIn := mulFastUop ++ aluFastUop
+
+  jmp_rs.io.slowPorts := io.writeback.slice(4, 8)
+  mul_rs_0.io.slowPorts := io.writeback.slice(4, 8)
+  mul_rs_1.io.slowPorts := io.writeback.slice(4, 8)
+  alu_rs_0.io.slowPorts := io.writeback.slice(4, 8)
+  fmac_rs0.io.slowPorts := io.writeback.drop(12)
+  fmisc_rs0.io.slowPorts := io.writeback.drop(12)
+  fmisc_rs1.io.slowPorts := io.writeback.drop(12)
+  load_rs0.io.slowPorts := io.writeback.slice(4, 8)
+  load_rs1.io.slowPorts := io.writeback.slice(4, 8)
+  store_rs0.io.slowPorts := io.writeback.drop(4)
+  store_rs1.io.slowPorts := io.writeback.drop(4)
+
+  // load-store specific connections
+  load_rs0.io.memfeedback <> io.replay(0)
+  load_rs1.io.memfeedback <> io.replay(1)
+  store_rs0.io.memfeedback <> io.replay(2)
+  store_rs1.io.memfeedback <> io.replay(3)
+  load_rs0.io.rsIdx <> io.rsIdx(0)
+  load_rs1.io.rsIdx <> io.rsIdx(1)
+  store_rs0.io.rsIdx <> io.rsIdx(2)
+  store_rs1.io.rsIdx <> io.rsIdx(3)
+  load_rs0.io.isFirstIssue <> io.isFirstIssue(0)
+  load_rs1.io.isFirstIssue <> io.isFirstIssue(1)
+  store_rs0.io.isFirstIssue <> io.isFirstIssue(2)
+  store_rs1.io.isFirstIssue <> io.isFirstIssue(3)
+  store_rs0.io.stData <> io.stData(0)
+  store_rs1.io.stData <> io.stData(1)
+  store_rs0.io.stIssuePtr <> io.stIssuePtr
+  store_rs1.io.stIssuePtr <> io.stIssuePtr
+  load_rs0.io.stIssuePtr <> io.stIssuePtr
+  load_rs1.io.stIssuePtr <> io.stIssuePtr
+
+  // regfile write ports
+  intRf.io.writePorts.zip(io.writeback.take(8)).foreach {
+    case (rf, wb) =>
+      rf.wen := wb.valid && wb.bits.uop.ctrl.rfWen
+      rf.addr := wb.bits.uop.pdest
+      rf.data := wb.bits.data
+  }
+  fpRf.io.writePorts.zip(io.writeback.drop(8)).foreach{
+    case (rf, wb) =>
+      rf.wen := wb.valid
+      rf.addr := wb.bits.uop.pdest
+      rf.data := wb.bits.data
+  }
+
+  intRf.io.debug_rports := DontCare
+  fpRf.io.debug_rports := DontCare
+  if (!env.FPGAPlatform) {
+    for ((rport, rat) <- intRf.io.debug_rports.zip(io.debug_int_rat)) {
+      rport.addr := rat
+    }
+    val difftest = Module(new DifftestArchIntRegState)
+    difftest.io.clock  := clock
+    difftest.io.coreid := hardId.U
+    difftest.io.gpr    := VecInit(intRf.io.debug_rports.map(_.data))
+  }
+
+  if (!env.FPGAPlatform) {
+    for ((rport, rat) <- fpRf.io.debug_rports.zip(io.debug_fp_rat)) {
+      rport.addr := rat
+    }
+    val difftest = Module(new DifftestArchFpRegState)
+    difftest.io.clock  := clock
+    difftest.io.coreid := hardId.U
+    difftest.io.fpr    := VecInit(fpRf.io.debug_rports.map(_.data))
+  }
 
 }

--- a/src/main/scala/xiangshan/backend/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/Scheduler.scala
@@ -1,0 +1,29 @@
+/***************************************************************************************
+  * Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+  *
+  * XiangShan is licensed under Mulan PSL v2.
+  * You can use this software according to the terms and conditions of the Mulan PSL v2.
+  * You may obtain a copy of Mulan PSL v2 at:
+  *          http://license.coscl.org.cn/MulanPSL2
+  *
+  * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+  * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+  * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+  *
+  * See the Mulan PSL v2 for more details.
+  ***************************************************************************************/
+
+package xiangshan.backend
+
+import chisel3._
+import chisel3.util._
+import chipsalliance.rocketchip.config.Parameters
+import xiangshan._
+import utils._
+
+class Scheduler(implicit p: Parameters) extends XSModule {
+  val io = IO(new Bundle {
+
+  })
+
+}

--- a/src/main/scala/xiangshan/backend/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/Scheduler.scala
@@ -221,17 +221,17 @@ class Scheduler(implicit p: Parameters) extends XSModule {
   store_rs0.io.fastUopsIn := mulFastUop ++ aluFastUop
   store_rs1.io.fastUopsIn := mulFastUop ++ aluFastUop
 
-  jmp_rs.io.slowPorts := io.writeback.slice(4, 8)
-  mul_rs_0.io.slowPorts := io.writeback.slice(4, 8)
-  mul_rs_1.io.slowPorts := io.writeback.slice(4, 8)
-  alu_rs_0.io.slowPorts := io.writeback.slice(4, 8)
-  fmac_rs0.io.slowPorts := io.writeback.drop(12)
-  fmisc_rs0.io.slowPorts := io.writeback.drop(12)
-  fmisc_rs1.io.slowPorts := io.writeback.drop(12)
-  load_rs0.io.slowPorts := io.writeback.slice(4, 8)
-  load_rs1.io.slowPorts := io.writeback.slice(4, 8)
-  store_rs0.io.slowPorts := io.writeback.drop(4)
-  store_rs1.io.slowPorts := io.writeback.drop(4)
+  jmp_rs.io.slowPorts := io.writeback.take(8)
+  mul_rs_0.io.slowPorts := io.writeback.take(8)
+  mul_rs_1.io.slowPorts := io.writeback.take(8)
+  alu_rs_0.io.slowPorts := io.writeback.take(8)
+  fmac_rs0.io.slowPorts := io.writeback.drop(8)
+  fmisc_rs0.io.slowPorts := io.writeback.drop(8)
+  fmisc_rs1.io.slowPorts := io.writeback.drop(8)
+  load_rs0.io.slowPorts := io.writeback.take(8)
+  load_rs1.io.slowPorts := io.writeback.take(8)
+  store_rs0.io.slowPorts := io.writeback
+  store_rs1.io.slowPorts := io.writeback
 
   // load-store specific connections
   load_rs0.io.memfeedback <> io.replay(0)

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -57,7 +57,6 @@ class Dispatch(implicit p: Parameters) extends XSModule {
     val readIntState= Vec(NRIntReadPorts, Flipped(new BusyTableReadIO))
     val readFpState = Vec(NRFpReadPorts, Flipped(new BusyTableReadIO))
     // to reservation stations
-    val numExist = Input(Vec(exuParameters.ExuCnt, UInt(log2Ceil(IssQueSize).W)))
     val enqIQCtrl = Vec(exuParameters.ExuCnt, DecoupledIO(new MicroOp))
     // send reg file read port index to reservation stations
     val readPortIndex = new Bundle {
@@ -117,7 +116,6 @@ class Dispatch(implicit p: Parameters) extends XSModule {
   intDispatch.io.fromDq <> intDq.io.deq
   intDispatch.io.readRf.zipWithIndex.map({case (r, i) => r <> io.readIntRf(i)})
   intDispatch.io.readState.zipWithIndex.map({case (r, i) => r <> io.readIntState(i)})
-  intDispatch.io.numExist.zipWithIndex.map({case (num, i) => num := io.numExist(i)})
   intDispatch.io.enqIQCtrl.zipWithIndex.map({case (enq, i) => enq <> io.enqIQCtrl(i)})
 //  intDispatch.io.enqIQData.zipWithIndex.map({case (enq, i) => enq <> io.enqIQData(i)})
   intDispatch.io.readPortIndex <> io.readPortIndex.intIndex
@@ -127,7 +125,6 @@ class Dispatch(implicit p: Parameters) extends XSModule {
   fpDispatch.io.fromDq <> fpDq.io.deq
   fpDispatch.io.readRf.zipWithIndex.map({case (r, i) => r <> io.readFpRf(i)})
   fpDispatch.io.readState.zipWithIndex.map({case (r, i) => r <> io.readFpState(i)})
-  fpDispatch.io.numExist.zipWithIndex.map({case (num, i) => num := io.numExist(i + exuParameters.IntExuCnt)})
   fpDispatch.io.enqIQCtrl.zipWithIndex.map({case (enq, i) => enq <> io.enqIQCtrl(i + exuParameters.IntExuCnt)})
 //  fpDispatch.io.enqIQData.zipWithIndex.map({case (enq, i) => enq <> io.enqIQData(i + exuParameters.IntExuCnt)})
   fpDispatch.io.readPortIndex <> io.readPortIndex.fpIndex
@@ -139,7 +136,6 @@ class Dispatch(implicit p: Parameters) extends XSModule {
   lsDispatch.io.readFpRf.zipWithIndex.map({case (r, i) => r <> io.readFpRf(i + 12)})
   lsDispatch.io.readIntState.zipWithIndex.map({case (r, i) => r <> io.readIntState(i + 8)})
   lsDispatch.io.readFpState.zipWithIndex.map({case (r, i) => r <> io.readFpState(i + 12)})
-  lsDispatch.io.numExist.zipWithIndex.map({case (num, i) => num := io.numExist(exuParameters.IntExuCnt + exuParameters.FpExuCnt + i)})
   lsDispatch.io.enqIQCtrl.zipWithIndex.map({case (enq, i) => enq <> io.enqIQCtrl(exuParameters.IntExuCnt + exuParameters.FpExuCnt + i)})
 //  lsDispatch.io.enqIQData.zipWithIndex.map({case (enq, i) => enq <> io.enqIQData(exuParameters.IntExuCnt + exuParameters.FpExuCnt + i)})
 

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch2Fp.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch2Fp.scala
@@ -27,25 +27,35 @@ class Dispatch2Fp(implicit p: Parameters) extends XSModule {
     val fromDq = Flipped(Vec(dpParams.FpDqDeqWidth, DecoupledIO(new MicroOp)))
     val readRf = Vec(NRFpReadPorts - exuParameters.StuCnt, Output(UInt(PhyRegIdxWidth.W)))
     val readState = Vec(NRFpReadPorts - exuParameters.StuCnt, Flipped(new BusyTableReadIO))
-    val numExist = Input(Vec(exuParameters.FpExuCnt, UInt(log2Ceil(IssQueSize).W)))
     val enqIQCtrl = Vec(exuParameters.FpExuCnt, DecoupledIO(new MicroOp))
     val readPortIndex = Vec(exuParameters.FpExuCnt, Output(UInt(log2Ceil((NRFpReadPorts - exuParameters.StuCnt) / 3).W)))
   })
+
+  io.enqIQCtrl <> DontCare
+  io.fromDq <> io.enqIQCtrl.take(4)
+  io.enqIQCtrl(4).valid := false.B
+  io.enqIQCtrl(5).valid := false.B
+
+  for (i <- 0 until 4) {
+    io.readRf(3*i) := io.enqIQCtrl(i).bits.psrc(0)
+    io.readRf(3*i+1) := io.enqIQCtrl(i).bits.psrc(1)
+    io.readRf(3*i+2) := io.enqIQCtrl(i).bits.psrc(2)
+  }
 
   /**
     * Part 1: generate indexes for reservation stations
     */
   // val fmacIndexGen = Module(new IndexMapping(dpParams.FpDqDeqWidth, exuParameters.FmacCnt, true))
-  val fmacCanAccept = VecInit(io.fromDq.map(deq => deq.valid && FuType.fmacCanAccept(deq.bits.ctrl.fuType)))
-  val (fmacPriority, fmacIndex) = PriorityGen((0 until exuParameters.FmacCnt).map(i => io.numExist(i)))
+//  val fmacCanAccept = VecInit(io.fromDq.map(deq => deq.valid && FuType.fmacCanAccept(deq.bits.ctrl.fuType)))
+//  val (fmacPriority, fmacIndex) = PriorityGen((0 until exuParameters.FmacCnt).map(i => 0.U))
   // fmacIndexGen.io.validBits := fmacCanAccept
   // fmacIndexGen.io.priority := fmacPriority
 
-  val fmiscIndexGen = Module(new IndexMapping(dpParams.FpDqDeqWidth, exuParameters.FmiscCnt, true))
-  val fmiscCanAccept = VecInit(io.fromDq.map(deq => deq.valid && FuType.fmiscCanAccept(deq.bits.ctrl.fuType)))
-  val (fmiscPriority, _) = PriorityGen((0 until exuParameters.FmiscCnt).map(i => io.numExist(i+exuParameters.FmacCnt)))
-  fmiscIndexGen.io.validBits := fmiscCanAccept
-  fmiscIndexGen.io.priority := fmiscPriority
+//  val fmiscIndexGen = Module(new IndexMapping(dpParams.FpDqDeqWidth, exuParameters.FmiscCnt, true))
+//  val fmiscCanAccept = VecInit(io.fromDq.map(deq => deq.valid && FuType.fmiscCanAccept(deq.bits.ctrl.fuType)))
+//  val (fmiscPriority, _) = PriorityGen((0 until exuParameters.FmiscCnt).map(i => 0.U))
+//  fmiscIndexGen.io.validBits := fmiscCanAccept
+//  fmiscIndexGen.io.priority := fmiscPriority
 
   // val allIndexGen = Seq(fmacIndexGen, fmiscIndexGen)
   // val validVec = allIndexGen.map(_.io.mapping.map(_.valid)).reduceLeft(_ ++ _)
@@ -78,63 +88,66 @@ class Dispatch2Fp(implicit p: Parameters) extends XSModule {
     io.readState(3*i  ).req := io.fromDq(i).bits.psrc(0)
     io.readState(3*i+1).req := io.fromDq(i).bits.psrc(1)
     io.readState(3*i+2).req := io.fromDq(i).bits.psrc(2)
+    io.enqIQCtrl(i).bits.srcState(0) := io.readState(3*i).resp
+    io.enqIQCtrl(i).bits.srcState(1) := io.readState(3*i+1).resp
+    io.enqIQCtrl(i).bits.srcState(2) := io.readState(3*i+2).resp
   }
-  io.readRf(0)  := io.enqIQCtrl(0).bits.psrc(0)
-  io.readRf(1)  := io.enqIQCtrl(0).bits.psrc(1)
-  io.readRf(2)  := io.enqIQCtrl(0).bits.psrc(2)
-  io.readRf(3)  := io.enqIQCtrl(1).bits.psrc(0)
-  io.readRf(4)  := io.enqIQCtrl(1).bits.psrc(1)
-  io.readRf(5)  := io.enqIQCtrl(1).bits.psrc(2)
-  io.readRf(6)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc(0), io.enqIQCtrl(4).bits.psrc(0))
-  io.readRf(7)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc(1), io.enqIQCtrl(4).bits.psrc(1))
-  io.readRf(8)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc(2), io.enqIQCtrl(4).bits.psrc(2))
-  io.readRf(9)  := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc(0), io.enqIQCtrl(5).bits.psrc(0))
-  io.readRf(10) := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc(1), io.enqIQCtrl(5).bits.psrc(1))
-  io.readRf(11) := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc(2), io.enqIQCtrl(5).bits.psrc(2))
+//  io.readRf(0)  := io.enqIQCtrl(0).bits.psrc(0)
+//  io.readRf(1)  := io.enqIQCtrl(0).bits.psrc(1)
+//  io.readRf(2)  := io.enqIQCtrl(0).bits.psrc(2)
+//  io.readRf(3)  := io.enqIQCtrl(1).bits.psrc(0)
+//  io.readRf(4)  := io.enqIQCtrl(1).bits.psrc(1)
+//  io.readRf(5)  := io.enqIQCtrl(1).bits.psrc(2)
+//  io.readRf(6)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc(0), io.enqIQCtrl(4).bits.psrc(0))
+//  io.readRf(7)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc(1), io.enqIQCtrl(4).bits.psrc(1))
+//  io.readRf(8)  := Mux(io.enqIQCtrl(2).valid, io.enqIQCtrl(2).bits.psrc(2), io.enqIQCtrl(4).bits.psrc(2))
+//  io.readRf(9)  := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc(0), io.enqIQCtrl(5).bits.psrc(0))
+//  io.readRf(10) := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc(1), io.enqIQCtrl(5).bits.psrc(1))
+//  io.readRf(11) := Mux(io.enqIQCtrl(3).valid, io.enqIQCtrl(3).bits.psrc(2), io.enqIQCtrl(5).bits.psrc(2))
 
   /**
     * Part 3: dispatch to reservation stations
     */
   // val fmacReady = Cat(io.enqIQCtrl.take(exuParameters.FmacCnt).map(_.ready)).andR
-  val fmiscReady = Cat(io.enqIQCtrl.drop(exuParameters.FmacCnt).map(_.ready)).andR
-  for (i <- 0 until exuParameters.FpExuCnt) {
-    val enq = io.enqIQCtrl(i)
-    val deqIndex = if (i < exuParameters.FmacCnt) fmacPriority(i) else fmiscIndexGen.io.mapping(i-exuParameters.FmacCnt).bits
-    if (i < exuParameters.FmacCnt) {
-      enq.valid := fmacCanAccept(fmacPriority(i))//fmacIndexGen.io.mapping(i).valid && fmacReady
-    }
-    else {
-      enq.valid := fmiscIndexGen.io.mapping(i - exuParameters.FmacCnt).valid && fmiscReady && !io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid
-    }
-    enq.bits := io.fromDq(deqIndex).bits
-
-    val src1Ready = VecInit((0 until 4).map(i => io.readState(i * 3).resp))
-    val src2Ready = VecInit((0 until 4).map(i => io.readState(i * 3 + 1).resp))
-    val src3Ready = VecInit((0 until 4).map(i => io.readState(i * 3 + 2).resp))
-    enq.bits.srcState(0) := src1Ready(deqIndex)
-    enq.bits.srcState(1) := src2Ready(deqIndex)
-    enq.bits.srcState(2) := src3Ready(deqIndex)
-
-    XSInfo(enq.fire(), p"pc 0x${Hexadecimal(enq.bits.cf.pc)} with type ${enq.bits.ctrl.fuType} " +
-      p"srcState(${enq.bits.srcState(0)} ${enq.bits.srcState(1)} ${enq.bits.srcState(2)}) " +
-      p"enters reservation station $i from ${deqIndex}\n")
-  }
+//  val fmiscReady = Cat(io.enqIQCtrl.drop(exuParameters.FmacCnt).map(_.ready)).andR
+//  for (i <- 0 until exuParameters.FpExuCnt) {
+//    val enq = io.enqIQCtrl(i)
+//    val deqIndex = if (i < exuParameters.FmacCnt) fmacPriority(i) else fmiscIndexGen.io.mapping(i-exuParameters.FmacCnt).bits
+//    if (i < exuParameters.FmacCnt) {
+//      enq.valid := fmacCanAccept(fmacPriority(i))//fmacIndexGen.io.mapping(i).valid && fmacReady
+//    }
+//    else {
+//      enq.valid := fmiscIndexGen.io.mapping(i - exuParameters.FmacCnt).valid && fmiscReady && !io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid
+//    }
+//    enq.bits := io.fromDq(deqIndex).bits
+//
+//    val src1Ready = VecInit((0 until 4).map(i => io.readState(i * 3).resp))
+//    val src2Ready = VecInit((0 until 4).map(i => io.readState(i * 3 + 1).resp))
+//    val src3Ready = VecInit((0 until 4).map(i => io.readState(i * 3 + 2).resp))
+//    enq.bits.srcState(0) := src1Ready(deqIndex)
+//    enq.bits.srcState(1) := src2Ready(deqIndex)
+//    enq.bits.srcState(2) := src3Ready(deqIndex)
+//
+//    XSInfo(enq.fire(), p"pc 0x${Hexadecimal(enq.bits.cf.pc)} with type ${enq.bits.ctrl.fuType} " +
+//      p"srcState(${enq.bits.srcState(0)} ${enq.bits.srcState(1)} ${enq.bits.srcState(2)}) " +
+//      p"enters reservation station $i from ${deqIndex}\n")
+//  }
 
   /**
     * Part 4: response to dispatch queue
     */
-  val fmisc2CanOut = !(fmiscCanAccept(0) && fmiscCanAccept(1))
-  val fmisc3CanOut = !(fmiscCanAccept(0) && fmiscCanAccept(1) || fmiscCanAccept(0) && fmiscCanAccept(2) || fmiscCanAccept(1) && fmiscCanAccept(2))
-  val fmacReadyVec = VecInit(io.enqIQCtrl.take(4).map(_.ready))
-  for (i <- 0 until dpParams.FpDqDeqWidth) {
-    io.fromDq(i).ready := fmacCanAccept(i) && fmacReadyVec(fmacIndex(i)) ||
-                          fmiscCanAccept(i) && (if (i <= 1) true.B else if (i == 2) fmisc2CanOut else fmisc3CanOut) && fmiscReady && !io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid
-
-    XSInfo(io.fromDq(i).fire(),
-      p"pc 0x${Hexadecimal(io.fromDq(i).bits.cf.pc)} leaves Fp dispatch queue $i with nroq ${io.fromDq(i).bits.roqIdx}\n")
-    XSDebug(io.fromDq(i).valid && !io.fromDq(i).ready,
-      p"pc 0x${Hexadecimal(io.fromDq(i).bits.cf.pc)} waits at Fp dispatch queue with index $i\n")
-  }
+//  val fmisc2CanOut = !(fmiscCanAccept(0) && fmiscCanAccept(1))
+//  val fmisc3CanOut = !(fmiscCanAccept(0) && fmiscCanAccept(1) || fmiscCanAccept(0) && fmiscCanAccept(2) || fmiscCanAccept(1) && fmiscCanAccept(2))
+//  val fmacReadyVec = VecInit(io.enqIQCtrl.take(4).map(_.ready))
+//  for (i <- 0 until dpParams.FpDqDeqWidth) {
+//    io.fromDq(i).ready := fmacCanAccept(i) && fmacReadyVec(fmacIndex(i)) ||
+//                          fmiscCanAccept(i) && (if (i <= 1) true.B else if (i == 2) fmisc2CanOut else fmisc3CanOut) && fmiscReady && !io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid
+//
+//    XSInfo(io.fromDq(i).fire(),
+//      p"pc 0x${Hexadecimal(io.fromDq(i).bits.cf.pc)} leaves Fp dispatch queue $i with nroq ${io.fromDq(i).bits.roqIdx}\n")
+//    XSDebug(io.fromDq(i).valid && !io.fromDq(i).ready,
+//      p"pc 0x${Hexadecimal(io.fromDq(i).bits.cf.pc)} waits at Fp dispatch queue with index $i\n")
+//  }
   XSError(PopCount(io.fromDq.map(_.fire())) =/= PopCount(io.enqIQCtrl.map(_.fire())), "deq =/= enq\n")
 
   /**
@@ -162,29 +175,29 @@ class Dispatch2Fp(implicit p: Parameters) extends XSModule {
 //        p"(${readPortIndexReg(i)+2.U}, ${uopReg(i).psrc(2)}, ${Hexadecimal(io.enqIQData(i).src(2))})\n")
 //  }
 
-  XSPerfAccumulate("in", PopCount(io.fromDq.map(_.valid)))
-  XSPerfAccumulate("out", PopCount(io.enqIQCtrl.map(_.fire())))
-  XSPerfAccumulate("out_fmac0", io.enqIQCtrl(0).fire())
-  XSPerfAccumulate("out_fmac1", io.enqIQCtrl(1).fire())
-  XSPerfAccumulate("out_fmac2", io.enqIQCtrl(2).fire())
-  XSPerfAccumulate("out_fmac3", io.enqIQCtrl(3).fire())
-  XSPerfAccumulate("out_fmisc0", io.enqIQCtrl(4).fire())
-  XSPerfAccumulate("out_fmisc1", io.enqIQCtrl(5).fire())
-  val block_num = PopCount(io.fromDq.map(deq => deq.valid && !deq.ready))
-  XSPerfAccumulate("blocked", block_num)
-  XSPerfAccumulate("blocked_index", Mux(block_num =/= 0.U, PriorityEncoder(io.fromDq.map(deq => deq.valid && !deq.ready)), 0.U))
-  XSPerfAccumulate("misc_deq", PopCount(fmiscCanAccept))
-  XSPerfAccumulate("misc_deq_exceed_limit", Mux(PopCount(fmiscCanAccept) >= 2.U, PopCount(fmiscCanAccept) - 2.U, 0.U))
-  XSPerfAccumulate("mac0_blocked_by_mac0", io.enqIQCtrl(0).valid && !io.enqIQCtrl(0).ready)
-  XSPerfAccumulate("mac1_blocked_by_mac1", io.enqIQCtrl(1).valid && !io.enqIQCtrl(1).ready)
-  XSPerfAccumulate("mac2_blocked_by_mac2", io.enqIQCtrl(2).valid && !io.enqIQCtrl(2).ready)
-  XSPerfAccumulate("mac3_blocked_by_mac3", io.enqIQCtrl(3).valid && !io.enqIQCtrl(3).ready)
-  XSPerfAccumulate("misc0_blocked_by_mac", fmiscIndexGen.io.mapping(0).valid && fmiscReady && (io.enqIQCtrl(2).valid || io.enqIQCtrl(3).valid))
-  XSPerfAccumulate("misc0_blocked_by_mac2", fmiscIndexGen.io.mapping(0).valid && fmiscReady && io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid)
-  XSPerfAccumulate("misc0_blocked_by_mac3", fmiscIndexGen.io.mapping(0).valid && fmiscReady && !io.enqIQCtrl(2).valid && io.enqIQCtrl(3).valid)
-  XSPerfAccumulate("misc0_blocked_by_misc1", fmiscIndexGen.io.mapping(0).valid && io.enqIQCtrl(4).ready && !io.enqIQCtrl(5).ready && !io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid)
-  XSPerfAccumulate("misc1_blocked_by_mac", fmiscIndexGen.io.mapping(1).valid && fmiscReady && (io.enqIQCtrl(2).valid || io.enqIQCtrl(3).valid))
-  XSPerfAccumulate("misc1_blocked_by_mac2", fmiscIndexGen.io.mapping(1).valid && fmiscReady && io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid)
-  XSPerfAccumulate("misc1_blocked_by_mac3", fmiscIndexGen.io.mapping(1).valid && fmiscReady && !io.enqIQCtrl(2).valid && io.enqIQCtrl(3).valid)
-  XSPerfAccumulate("misc1_blocked_by_misc0", fmiscIndexGen.io.mapping(1).valid && !io.enqIQCtrl(4).ready && io.enqIQCtrl(5).ready && !io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid)
+//  XSPerfAccumulate("in", PopCount(io.fromDq.map(_.valid)))
+//  XSPerfAccumulate("out", PopCount(io.enqIQCtrl.map(_.fire())))
+//  XSPerfAccumulate("out_fmac0", io.enqIQCtrl(0).fire())
+//  XSPerfAccumulate("out_fmac1", io.enqIQCtrl(1).fire())
+//  XSPerfAccumulate("out_fmac2", io.enqIQCtrl(2).fire())
+//  XSPerfAccumulate("out_fmac3", io.enqIQCtrl(3).fire())
+//  XSPerfAccumulate("out_fmisc0", io.enqIQCtrl(4).fire())
+//  XSPerfAccumulate("out_fmisc1", io.enqIQCtrl(5).fire())
+//  val block_num = PopCount(io.fromDq.map(deq => deq.valid && !deq.ready))
+//  XSPerfAccumulate("blocked", block_num)
+//  XSPerfAccumulate("blocked_index", Mux(block_num =/= 0.U, PriorityEncoder(io.fromDq.map(deq => deq.valid && !deq.ready)), 0.U))
+//  XSPerfAccumulate("misc_deq", PopCount(fmiscCanAccept))
+//  XSPerfAccumulate("misc_deq_exceed_limit", Mux(PopCount(fmiscCanAccept) >= 2.U, PopCount(fmiscCanAccept) - 2.U, 0.U))
+//  XSPerfAccumulate("mac0_blocked_by_mac0", io.enqIQCtrl(0).valid && !io.enqIQCtrl(0).ready)
+//  XSPerfAccumulate("mac1_blocked_by_mac1", io.enqIQCtrl(1).valid && !io.enqIQCtrl(1).ready)
+//  XSPerfAccumulate("mac2_blocked_by_mac2", io.enqIQCtrl(2).valid && !io.enqIQCtrl(2).ready)
+//  XSPerfAccumulate("mac3_blocked_by_mac3", io.enqIQCtrl(3).valid && !io.enqIQCtrl(3).ready)
+//  XSPerfAccumulate("misc0_blocked_by_mac", fmiscIndexGen.io.mapping(0).valid && fmiscReady && (io.enqIQCtrl(2).valid || io.enqIQCtrl(3).valid))
+//  XSPerfAccumulate("misc0_blocked_by_mac2", fmiscIndexGen.io.mapping(0).valid && fmiscReady && io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid)
+//  XSPerfAccumulate("misc0_blocked_by_mac3", fmiscIndexGen.io.mapping(0).valid && fmiscReady && !io.enqIQCtrl(2).valid && io.enqIQCtrl(3).valid)
+//  XSPerfAccumulate("misc0_blocked_by_misc1", fmiscIndexGen.io.mapping(0).valid && io.enqIQCtrl(4).ready && !io.enqIQCtrl(5).ready && !io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid)
+//  XSPerfAccumulate("misc1_blocked_by_mac", fmiscIndexGen.io.mapping(1).valid && fmiscReady && (io.enqIQCtrl(2).valid || io.enqIQCtrl(3).valid))
+//  XSPerfAccumulate("misc1_blocked_by_mac2", fmiscIndexGen.io.mapping(1).valid && fmiscReady && io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid)
+//  XSPerfAccumulate("misc1_blocked_by_mac3", fmiscIndexGen.io.mapping(1).valid && fmiscReady && !io.enqIQCtrl(2).valid && io.enqIQCtrl(3).valid)
+//  XSPerfAccumulate("misc1_blocked_by_misc0", fmiscIndexGen.io.mapping(1).valid && !io.enqIQCtrl(4).ready && io.enqIQCtrl(5).ready && !io.enqIQCtrl(2).valid && !io.enqIQCtrl(3).valid)
 }

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch2Int.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch2Int.scala
@@ -27,7 +27,6 @@ class Dispatch2Int(implicit p: Parameters) extends XSModule {
     val fromDq = Flipped(Vec(dpParams.IntDqDeqWidth, DecoupledIO(new MicroOp)))
     val readRf = Vec(NRIntReadPorts - NRMemReadPorts, Output(UInt(PhyRegIdxWidth.W)))
     val readState = Vec(NRIntReadPorts - NRMemReadPorts, Flipped(new BusyTableReadIO))
-    val numExist = Input(Vec(exuParameters.IntExuCnt, UInt(log2Ceil(IssQueSize).W)))
     val enqIQCtrl = Vec(exuParameters.IntExuCnt, DecoupledIO(new MicroOp))
     val readPortIndex = Vec(exuParameters.IntExuCnt, Output(UInt(log2Ceil(8 / 2).W)))
   })

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch2Ls.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch2Ls.scala
@@ -30,7 +30,6 @@ class Dispatch2Ls(implicit p: Parameters) extends XSModule {
     val readFpRf = Vec(exuParameters.StuCnt, Output(UInt(PhyRegIdxWidth.W)))
     val readIntState = Vec(NRMemReadPorts, Flipped(new BusyTableReadIO))
     val readFpState = Vec(exuParameters.StuCnt, Flipped(new BusyTableReadIO))
-    val numExist = Input(Vec(exuParameters.LsExuCnt, UInt(log2Ceil(IssQueSize).W)))
     val enqIQCtrl = Vec(exuParameters.LsExuCnt, DecoupledIO(new MicroOp))
   })
 
@@ -39,13 +38,13 @@ class Dispatch2Ls(implicit p: Parameters) extends XSModule {
     */
   val loadIndexGen = Module(new IndexMapping(dpParams.LsDqDeqWidth, exuParameters.LduCnt, true))
   val loadCanAccept = VecInit(io.fromDq.map(deq => deq.valid && FuType.loadCanAccept(deq.bits.ctrl.fuType)))
-  val (loadPriority, _) = PriorityGen((0 until exuParameters.LduCnt).map(i => io.numExist(i)))
+  val (loadPriority, _) = PriorityGen((0 until exuParameters.LduCnt).map(i => 0.U))
   loadIndexGen.io.validBits := loadCanAccept
   loadIndexGen.io.priority := loadPriority
 
   val storeIndexGen = Module(new IndexMapping(dpParams.LsDqDeqWidth, exuParameters.StuCnt, true))
   val storeCanAccept = VecInit(io.fromDq.map(deq => deq.valid && FuType.storeCanAccept(deq.bits.ctrl.fuType)))
-  val (storePriority, _) = PriorityGen((0 until exuParameters.StuCnt).map(i => io.numExist(i+exuParameters.LduCnt)))
+  val (storePriority, _) = PriorityGen((0 until exuParameters.StuCnt).map(i => 0.U))
   storeIndexGen.io.validBits := storeCanAccept
   storeIndexGen.io.priority := storePriority
 

--- a/src/main/scala/xiangshan/backend/issue/DataArray.scala
+++ b/src/main/scala/xiangshan/backend/issue/DataArray.scala
@@ -50,29 +50,29 @@ class DataArrayMultiWriteIO(numEntries: Int, numSrc: Int, dataBits: Int)(implici
     new DataArrayMultiWriteIO(numEntries, numSrc, dataBits).asInstanceOf[this.type]
 }
 
-class DataArrayIO(config: RSConfig)(implicit p: Parameters) extends XSBundle {
-  val read = Vec(config.numDeq, new DataArrayReadIO(config.numEntries, config.numSrc, config.dataBits))
-  val write = Vec(config.numEnq, new DataArrayWriteIO(config.numEntries, config.numSrc, config.dataBits))
-  val multiWrite = Vec(config.numValueBroadCast, new DataArrayMultiWriteIO(config.numEntries, config.numSrc, config.dataBits))
-  val delayedWrite = if (config.delayedRf) Vec(config.numEnq, Flipped(ValidIO(UInt(config.dataBits.W)))) else null
+class DataArrayIO(params: RSParams)(implicit p: Parameters) extends XSBundle {
+  val read = Vec(params.numDeq, new DataArrayReadIO(params.numEntries, params.numSrc, params.dataBits))
+  val write = Vec(params.numEnq, new DataArrayWriteIO(params.numEntries, params.numSrc, params.dataBits))
+  val multiWrite = Vec(params.numValueBroadCast, new DataArrayMultiWriteIO(params.numEntries, params.numSrc, params.dataBits))
+  val delayedWrite = if (params.delayedRf) Vec(params.numEnq, Flipped(ValidIO(UInt(params.dataBits.W)))) else null
 
   override def cloneType: DataArrayIO.this.type =
-    new DataArrayIO(config).asInstanceOf[this.type]
+    new DataArrayIO(params).asInstanceOf[this.type]
 }
 
-class DataArray(config: RSConfig)(implicit p: Parameters) extends XSModule {
-  val io = IO(new DataArrayIO(config))
+class DataArray(params: RSParams)(implicit p: Parameters) extends XSModule {
+  val io = IO(new DataArrayIO(params))
 
-  for (i <- 0 until config.numSrc) {
-    val delayedWen = if (i == 1 && config.delayedRf) io.delayedWrite.map(_.valid) else Seq()
-    val delayedWaddr = if (i == 1 && config.delayedRf) RegNext(VecInit(io.write.map(_.addr))) else Seq()
-    val delayedWdata = if (i == 1 && config.delayedRf) io.delayedWrite.map(_.bits) else Seq()
+  for (i <- 0 until params.numSrc) {
+    val delayedWen = if (i == 1 && params.delayedRf) io.delayedWrite.map(_.valid) else Seq()
+    val delayedWaddr = if (i == 1 && params.delayedRf) RegNext(VecInit(io.write.map(_.addr))) else Seq()
+    val delayedWdata = if (i == 1 && params.delayedRf) io.delayedWrite.map(_.bits) else Seq()
 
     val wen = io.write.map(w => w.enable && w.mask(i)) ++ io.multiWrite.map(_.enable) ++ delayedWen
     val waddr = io.write.map(_.addr) ++ io.multiWrite.map(_.addr(i)) ++ delayedWaddr
     val wdata = io.write.map(_.data(i)) ++ io.multiWrite.map(_.data) ++ delayedWdata
 
-    val dataModule = Module(new AsyncRawDataModuleTemplate(UInt(config.dataBits.W), config.numEntries, io.read.length, wen.length))
+    val dataModule = Module(new AsyncRawDataModuleTemplate(UInt(params.dataBits.W), params.numEntries, io.read.length, wen.length))
     dataModule.io.rvec := VecInit(io.read.map(_.addr))
     io.read.map(_.data(i)).zip(dataModule.io.rdata).map{ case (d, r) => d := r }
     dataModule.io.wen := wen
@@ -112,7 +112,7 @@ class AluImmExtractor(implicit p: Parameters) extends ImmExtractor(2, 64) {
 }
 
 object ImmExtractor {
-  def apply(config: RSConfig, exuCfg: ExuConfig, uop: MicroOp, data_in: Vec[UInt], pc: UInt, target: UInt)(implicit p: Parameters): Vec[UInt] = {
+  def apply(config: RSParams, exuCfg: ExuConfig, uop: MicroOp, data_in: Vec[UInt], pc: UInt, target: UInt)(implicit p: Parameters): Vec[UInt] = {
     val immExt = exuCfg match {
       case JumpExeUnitCfg => {
         val ext = Module(new JumpImmExtractor)

--- a/src/main/scala/xiangshan/backend/issue/DataArray.scala
+++ b/src/main/scala/xiangshan/backend/issue/DataArray.scala
@@ -53,7 +53,7 @@ class DataArrayMultiWriteIO(numEntries: Int, numSrc: Int, dataBits: Int)(implici
 class DataArrayIO(params: RSParams)(implicit p: Parameters) extends XSBundle {
   val read = Vec(params.numDeq, new DataArrayReadIO(params.numEntries, params.numSrc, params.dataBits))
   val write = Vec(params.numEnq, new DataArrayWriteIO(params.numEntries, params.numSrc, params.dataBits))
-  val multiWrite = Vec(params.numValueBroadCast, new DataArrayMultiWriteIO(params.numEntries, params.numSrc, params.dataBits))
+  val multiWrite = Vec(params.numDataCapture, new DataArrayMultiWriteIO(params.numEntries, params.numSrc, params.dataBits))
   val delayedWrite = if (params.delayedRf) Vec(params.numEnq, Flipped(ValidIO(UInt(params.dataBits.W)))) else null
 
   override def cloneType: DataArrayIO.this.type =

--- a/src/main/scala/xiangshan/backend/issue/PayloadArray.scala
+++ b/src/main/scala/xiangshan/backend/issue/PayloadArray.scala
@@ -21,30 +21,30 @@ import chisel3.util._
 import xiangshan._
 import utils._
 
-class PayloadArrayReadIO[T <: Data](gen: T, config: RSConfig) extends Bundle {
-  val addr = Input(UInt(config.numEntries.W))
+class PayloadArrayReadIO[T <: Data](gen: T, params: RSParams) extends Bundle {
+  val addr = Input(UInt(params.numEntries.W))
   val data = Output(gen)
 
   override def cloneType: PayloadArrayReadIO.this.type =
-    new PayloadArrayReadIO(gen, config).asInstanceOf[this.type]
+    new PayloadArrayReadIO(gen, params).asInstanceOf[this.type]
 }
 
-class PayloadArrayWriteIO[T <: Data](gen: T, config: RSConfig) extends Bundle {
+class PayloadArrayWriteIO[T <: Data](gen: T, params: RSParams) extends Bundle {
   val enable = Input(Bool())
-  val addr   = Input(UInt(config.numEntries.W))
+  val addr   = Input(UInt(params.numEntries.W))
   val data   = Input(gen)
 
   override def cloneType: PayloadArrayWriteIO.this.type =
-    new PayloadArrayWriteIO(gen, config).asInstanceOf[this.type]
+    new PayloadArrayWriteIO(gen, params).asInstanceOf[this.type]
 }
 
-class PayloadArray[T <: Data](gen: T, config: RSConfig)(implicit p: Parameters) extends XSModule {
+class PayloadArray[T <: Data](gen: T, params: RSParams)(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle {
-    val read = Vec(config.numDeq, new PayloadArrayReadIO(gen, config))
-    val write = Vec(config.numEnq, new PayloadArrayWriteIO(gen, config))
+    val read = Vec(params.numDeq, new PayloadArrayReadIO(gen, params))
+    val write = Vec(params.numEnq, new PayloadArrayWriteIO(gen, params))
   })
 
-  val payload = Reg(Vec(config.numEntries, gen))
+  val payload = Reg(Vec(params.numEntries, gen))
 
   // read ports
   io.read.map(_.data).zip(io.read.map(_.addr)).map {
@@ -53,7 +53,7 @@ class PayloadArray[T <: Data](gen: T, config: RSConfig)(implicit p: Parameters) 
   }
 
   // write ports
-  for (i <- 0 until config.numEntries) {
+  for (i <- 0 until params.numEntries) {
     val wenVec = VecInit(io.write.map(w => w.enable && w.addr(i)))
     val wen = wenVec.asUInt.orR
     val wdata = Mux1H(wenVec, io.write.map(_.data))

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -27,7 +27,6 @@ import xiangshan.mem.{SqPtr, StoreDataBundle}
 import scala.math.max
 
 case class RSParams(
-  name: String,
   numEntries: Int,
   numEnq: Int,
   numDeq: Int,
@@ -46,7 +45,6 @@ case class RSParams(
 
 class ReservationStation
 (
-  myName : String,
   val exuCfg: ExuConfig,
   iqSize : Int,
   srcLen: Int,
@@ -64,7 +62,6 @@ class ReservationStation
 
   // require(nonBlocked==fastWakeup)
   val params = RSParams(
-    name = myName,
     numEntries = iqSize,
     numEnq = enqNum,
     numDeq = deqNum,
@@ -76,7 +73,7 @@ class ReservationStation
     numWakeup = fastPortsCnt + (4 + slowPortsCnt),
     numValueBroadCast = (4 + slowPortsCnt),
     hasFeedback = feedback,
-    delayedRf = exuCfg == StExeUnitCfg,
+    delayedRf = false,
     fixedLatency = fixedDelay,
     checkWaitBit = if (exuCfg == LdExeUnitCfg || exuCfg == StExeUnitCfg) true else false,
     optBuf = if (exuCfg == AluExeUnitCfg) true else false

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -26,7 +26,7 @@ import xiangshan.mem.{SqPtr, StoreDataBundle}
 
 import scala.math.max
 
-case class RSConfig (
+case class RSParams(
   name: String,
   numEntries: Int,
   numEnq: Int,
@@ -63,7 +63,7 @@ class ReservationStation
   val srcNum = if (exuCfg == JumpExeUnitCfg) 2 else max(exuCfg.intSrcCnt, exuCfg.fpSrcCnt)
 
   // require(nonBlocked==fastWakeup)
-  val config = RSConfig(
+  val params = RSParams(
     name = myName,
     numEntries = iqSize,
     numEnq = enqNum,
@@ -85,35 +85,35 @@ class ReservationStation
   val io = IO(new Bundle {
     val numExist = Output(UInt(iqIdxWidth.W))
     // enq
-    val fromDispatch = Vec(config.numEnq, Flipped(DecoupledIO(new MicroOp)))
-    val srcRegValue = Vec(config.numEnq, Input(Vec(srcNum, UInt(srcLen.W))))
-    val fpRegValue = if (config.delayedRf) Input(UInt(srcLen.W)) else null
+    val fromDispatch = Vec(params.numEnq, Flipped(DecoupledIO(new MicroOp)))
+    val srcRegValue = Vec(params.numEnq, Input(Vec(srcNum, UInt(srcLen.W))))
+    val fpRegValue = if (params.delayedRf) Input(UInt(srcLen.W)) else null
     // deq
-    val deq = Vec(config.numDeq, DecoupledIO(new ExuInput))
+    val deq = Vec(params.numDeq, DecoupledIO(new ExuInput))
     val stData = if (exuCfg == StExeUnitCfg) ValidIO(new StoreDataBundle) else null
 
-    val stIssuePtr = if (config.checkWaitBit) Input(new SqPtr()) else null
+    val stIssuePtr = if (params.checkWaitBit) Input(new SqPtr()) else null
 
     val jumpPc = if(exuCfg == JumpExeUnitCfg) Input(UInt(VAddrBits.W)) else null
     val jalr_target = if(exuCfg == JumpExeUnitCfg) Input(UInt(VAddrBits.W)) else null
 
-    val fastUopOut = Vec(config.numDeq, ValidIO(new MicroOp))
-    val fastUopsIn = Vec(config.numFastWakeup, Flipped(ValidIO(new MicroOp)))
-    val fastDatas = Vec(config.numFastWakeup, Input(UInt(srcLen.W)))
+    val fastUopOut = Vec(params.numDeq, ValidIO(new MicroOp))
+    val fastUopsIn = Vec(params.numFastWakeup, Flipped(ValidIO(new MicroOp)))
+    val fastDatas = Vec(params.numFastWakeup, Input(UInt(srcLen.W)))
     val slowPorts = Vec(slowPortsCnt, Flipped(ValidIO(new ExuOutput)))
 
     val redirect = Flipped(ValidIO(new Redirect))
     val flush = Input(Bool())
 
-    val memfeedback = if (config.hasFeedback) Flipped(ValidIO(new RSFeedback)) else null
-    val rsIdx = if (config.hasFeedback) Output(UInt(log2Up(iqSize).W)) else null
-    val isFirstIssue = if (config.hasFeedback) Output(Bool()) else null // NOTE: just use for tlb perf cnt
+    val memfeedback = if (params.hasFeedback) Flipped(ValidIO(new RSFeedback)) else null
+    val rsIdx = if (params.hasFeedback) Output(UInt(log2Up(iqSize).W)) else null
+    val isFirstIssue = if (params.hasFeedback) Output(Bool()) else null // NOTE: just use for tlb perf cnt
   })
 
-  val statusArray = Module(new StatusArray(config))
-  val select = Module(new SelectPolicy(config))
-  val dataArray = Module(new DataArray(config))
-  val payloadArray = Module(new PayloadArray(new MicroOp, config))
+  val statusArray = Module(new StatusArray(params))
+  val select = Module(new SelectPolicy(params))
+  val dataArray = Module(new DataArray(params))
+  val payloadArray = Module(new PayloadArray(new MicroOp, params))
 
   io.numExist := PopCount(statusArray.io.isValid)
   statusArray.io.redirect := io.redirect
@@ -124,9 +124,9 @@ class ReservationStation
    */
   // enqueue from dispatch
   select.io.validVec := statusArray.io.isValid
-  val doEnqueue = Wire(Vec(config.numEnq, Bool()))
-  val needFpSource = Wire(Vec(config.numEnq, Bool()))
-  for (i <- 0 until config.numEnq) {
+  val doEnqueue = Wire(Vec(params.numEnq, Bool()))
+  val needFpSource = Wire(Vec(params.numEnq, Bool()))
+  for (i <- 0 until params.numEnq) {
     io.fromDispatch(i).ready := select.io.allocate(i).valid
     // agreement with dispatch: don't enqueue when io.redirect.valid
     doEnqueue(i) := io.fromDispatch(i).fire() && !io.redirect.valid && !io.flush
@@ -135,12 +135,12 @@ class ReservationStation
     statusArray.io.update(i).addr := select.io.allocate(i).bits
     statusArray.io.update(i).data.valid := true.B
     needFpSource(i) := io.fromDispatch(i).bits.needRfRPort(1, 1, false)
-    statusArray.io.update(i).data.scheduled := (if (config.delayedRf) needFpSource(i) else false.B)
-    statusArray.io.update(i).data.blocked := (if (config.checkWaitBit) io.fromDispatch(i).bits.cf.loadWaitBit else false.B)
-    statusArray.io.update(i).data.credit := (if (config.delayedRf) Mux(needFpSource(i), 2.U, 0.U) else 0.U)
-    statusArray.io.update(i).data.srcState := VecInit(io.fromDispatch(i).bits.srcIsReady.take(config.numSrc))
-    statusArray.io.update(i).data.psrc := VecInit(io.fromDispatch(i).bits.psrc.take(config.numSrc))
-    statusArray.io.update(i).data.srcType := VecInit(io.fromDispatch(i).bits.ctrl.srcType.take(config.numSrc))
+    statusArray.io.update(i).data.scheduled := (if (params.delayedRf) needFpSource(i) else false.B)
+    statusArray.io.update(i).data.blocked := (if (params.checkWaitBit) io.fromDispatch(i).bits.cf.loadWaitBit else false.B)
+    statusArray.io.update(i).data.credit := (if (params.delayedRf) Mux(needFpSource(i), 2.U, 0.U) else 0.U)
+    statusArray.io.update(i).data.srcState := VecInit(io.fromDispatch(i).bits.srcIsReady.take(params.numSrc))
+    statusArray.io.update(i).data.psrc := VecInit(io.fromDispatch(i).bits.psrc.take(params.numSrc))
+    statusArray.io.update(i).data.srcType := VecInit(io.fromDispatch(i).bits.ctrl.srcType.take(params.numSrc))
     statusArray.io.update(i).data.roqIdx := io.fromDispatch(i).bits.roqIdx
     statusArray.io.update(i).data.sqIdx := io.fromDispatch(i).bits.sqIdx
     payloadArray.io.write(i).enable := doEnqueue(i)
@@ -148,7 +148,7 @@ class ReservationStation
     payloadArray.io.write(i).data := io.fromDispatch(i).bits
   }
   // when config.checkWaitBit is set, we need to block issue until the corresponding store issues
-  if (config.checkWaitBit) {
+  if (params.checkWaitBit) {
     statusArray.io.stIssuePtr := io.stIssuePtr
   }
   // wakeup from other RS or function units
@@ -170,9 +170,9 @@ class ReservationStation
   }
   val wakeupValid = io.fastUopsIn.map(_.valid) ++ RegNext(VecInit(fastNotInSlowWakeup.map(_.valid))) ++ io.slowPorts.map(_.valid)
   val wakeupDest = io.fastUopsIn.map(_.bits) ++ RegNext(VecInit(fastNotInSlowWakeup.map(_.bits))) ++ io.slowPorts.map(_.bits.uop)
-  require(wakeupValid.size == config.numWakeup)
-  require(wakeupDest.size == config.numWakeup)
-  for (i <- 0 until config.numWakeup) {
+  require(wakeupValid.size == params.numWakeup)
+  require(wakeupDest.size == params.numWakeup)
+  for (i <- 0 until params.numWakeup) {
     statusArray.io.wakeup(i).valid := wakeupValid(i)
     statusArray.io.wakeup(i).bits := wakeupDest(i)
   }
@@ -182,10 +182,10 @@ class ReservationStation
     */
   // select the issue instructions
   select.io.request := statusArray.io.canIssue
-  for (i <- 0 until config.numDeq) {
+  for (i <- 0 until params.numDeq) {
     select.io.grant(i).ready := io.deq(i).ready
-    if (config.hasFeedback) {
-      require(config.numDeq == 1)
+    if (params.hasFeedback) {
+      require(params.numDeq == 1)
       statusArray.io.issueGranted(0).valid := select.io.grant(0).fire
       statusArray.io.issueGranted(0).bits := select.io.grant(0).bits
       statusArray.io.deqResp(0).valid := io.memfeedback.valid
@@ -219,9 +219,9 @@ class ReservationStation
   // for read-before-issue, it's done over the enqueue uop (and store the imm in dataArray to save space)
   // lastAllocateUop: Vec(config.numEnq, new MicroOp)
   val lastAllocateUop = RegNext(VecInit(io.fromDispatch.map(_.bits)))
-  val immBypassedData = Wire(Vec(config.numEnq, Vec(config.numSrc, UInt(config.dataBits.W))))
+  val immBypassedData = Wire(Vec(params.numEnq, Vec(params.numSrc, UInt(params.dataBits.W))))
   for (((uop, data), bypass) <- lastAllocateUop.zip(io.srcRegValue).zip(immBypassedData)) {
-    bypass := ImmExtractor(config, exuCfg, uop, data, io.jumpPc, io.jalr_target)
+    bypass := ImmExtractor(params, exuCfg, uop, data, io.jumpPc, io.jalr_target)
   }
 
   /**
@@ -230,12 +230,12 @@ class ReservationStation
    * Note: this is only needed when read-before-issue
    */
   // dispatch data: the next cycle after enqueue
-  for (i <- 0 until config.numEnq) {
+  for (i <- 0 until params.numEnq) {
     dataArray.io.write(i).enable := RegNext(doEnqueue(i))
     dataArray.io.write(i).mask := RegNext(statusArray.io.update(i).data.srcState)
     dataArray.io.write(i).addr := RegNext(select.io.allocate(i).bits)
     dataArray.io.write(i).data := immBypassedData(i)
-    if (config.delayedRf) {
+    if (params.delayedRf) {
       dataArray.io.delayedWrite(i).valid := RegNext(RegNext(doEnqueue(i) && needFpSource(i)))
       dataArray.io.delayedWrite(i).bits := io.fpRegValue
     }
@@ -243,17 +243,17 @@ class ReservationStation
   // data broadcast: from function units (only slow wakeup date are needed)
   val broadcastValid = RegNext(VecInit(fastNotInSlowWakeup.map(_.valid))) ++ io.slowPorts.map(_.valid)
   val broadcastValue = fastNotInSlowData ++ VecInit(io.slowPorts.map(_.bits.data))
-  require(broadcastValid.size == config.numValueBroadCast)
-  require(broadcastValue.size == config.numValueBroadCast)
-  val slowWakeupMatchVec = Wire(Vec(config.numEntries, Vec(config.numSrc, Vec(config.numValueBroadCast, Bool()))))
-  for (i <- 0 until config.numEntries) {
-    for (j <- 0 until config.numSrc) {
-      slowWakeupMatchVec(i)(j) := statusArray.io.wakeupMatch(i)(j).asBools.drop(config.numFastWakeup)
+  require(broadcastValid.size == params.numValueBroadCast)
+  require(broadcastValue.size == params.numValueBroadCast)
+  val slowWakeupMatchVec = Wire(Vec(params.numEntries, Vec(params.numSrc, Vec(params.numValueBroadCast, Bool()))))
+  for (i <- 0 until params.numEntries) {
+    for (j <- 0 until params.numSrc) {
+      slowWakeupMatchVec(i)(j) := statusArray.io.wakeupMatch(i)(j).asBools.drop(params.numFastWakeup)
     }
   }
   dataArray.io.multiWrite.zipWithIndex.map { case (w, i) =>
     w.enable := broadcastValid(i)
-    for (j <- 0 until config.numSrc) {
+    for (j <- 0 until params.numSrc) {
       w.addr(j) := VecInit(slowWakeupMatchVec.map(_(j)(i))).asUInt
     }
     w.data := broadcastValue(i)
@@ -262,8 +262,8 @@ class ReservationStation
   /**
    * S1: read data from regfile
    */
-  val s1_out = Wire(Vec(config.numDeq, Decoupled(new ExuInput)))
-  for (i <- 0 until config.numDeq) {
+  val s1_out = Wire(Vec(params.numDeq, Decoupled(new ExuInput)))
+  for (i <- 0 until params.numDeq) {
     dataArray.io.read(i).addr := select.io.grant(i).bits
     // for read-before-issue, we need to bypass the enqueue data here
     // for read-after-issue, we need to bypass the imm here
@@ -288,7 +288,7 @@ class ReservationStation
 
     s1_out(i).valid := select.io.grant(i).valid && !deqUop.roqIdx.needFlush(io.redirect, io.flush)
     s1_out(i).bits := DontCare
-    for (j <- 0 until config.numSrc) {
+    for (j <- 0 until params.numSrc) {
       s1_out(i).bits.src(j) := deqData(j)
     }
     s1_out(i).bits.uop := deqUop
@@ -299,24 +299,24 @@ class ReservationStation
    * S1: detect bypass from fast wakeup
    */
   // control: check the fast wakeup match
-  val fastWakeupMatchVec = Wire(Vec(config.numEntries, Vec(config.numSrc, Vec(config.numFastWakeup, Bool()))))
-  for (i <- 0 until config.numEntries) {
-    for (j <- 0 until config.numSrc) {
-      fastWakeupMatchVec(i)(j) := statusArray.io.wakeupMatch(i)(j).asBools.take(config.numFastWakeup)
+  val fastWakeupMatchVec = Wire(Vec(params.numEntries, Vec(params.numSrc, Vec(params.numFastWakeup, Bool()))))
+  for (i <- 0 until params.numEntries) {
+    for (j <- 0 until params.numSrc) {
+      fastWakeupMatchVec(i)(j) := statusArray.io.wakeupMatch(i)(j).asBools.take(params.numFastWakeup)
     }
   }
   val fastWakeupMatchRegVec = RegNext(fastWakeupMatchVec)
-  for (i <- 0 until config.numDeq) {
+  for (i <- 0 until params.numDeq) {
     val targetFastWakeupMatch = Mux1H(select.io.grant(i).bits, fastWakeupMatchRegVec)
-    val wakeupBypassMask = Wire(Vec(config.numFastWakeup, Vec(config.numSrc, Bool())))
-    for (j <- 0 until config.numFastWakeup) {
+    val wakeupBypassMask = Wire(Vec(params.numFastWakeup, Vec(params.numSrc, Bool())))
+    for (j <- 0 until params.numFastWakeup) {
       wakeupBypassMask(j) := VecInit(targetFastWakeupMatch.map(_(j)))
     }
     // data: send to bypass network
     // TODO: these should be done outside RS
-    val bypassNetwork = Module(new BypassNetwork(config.numSrc, config.numFastWakeup, config.dataBits, config.optBuf))
+    val bypassNetwork = Module(new BypassNetwork(params.numSrc, params.numFastWakeup, params.dataBits, params.optBuf))
     bypassNetwork.io.hold := !io.deq(i).ready
-    bypassNetwork.io.source := s1_out(i).bits.src.take(config.numSrc)
+    bypassNetwork.io.source := s1_out(i).bits.src.take(params.numSrc)
     bypassNetwork.io.bypass.zip(wakeupBypassMask.zip(io.fastDatas)).map { case (by, (m, d)) =>
       by.valid := m
       by.data := d
@@ -329,12 +329,12 @@ class ReservationStation
     // TODO: these should be done outside RS
     PipelineConnect(s1_out(i), io.deq(i), io.deq(i).ready || io.deq(i).bits.uop.roqIdx.needFlush(io.redirect, io.flush), false.B)
     val pipeline_fire = s1_out(i).valid && io.deq(i).ready
-    if (config.hasFeedback) {
+    if (params.hasFeedback) {
       io.rsIdx := RegEnable(OHToUInt(select.io.grant(i).bits), pipeline_fire)
       io.isFirstIssue := false.B
     }
 
-    for (j <- 0 until config.numSrc) {
+    for (j <- 0 until params.numSrc) {
       io.deq(i).bits.src(j) := bypassNetwork.io.target(j)
     }
 

--- a/src/main/scala/xiangshan/backend/issue/SelectPolicy.scala
+++ b/src/main/scala/xiangshan/backend/issue/SelectPolicy.scala
@@ -21,21 +21,21 @@ import chisel3.util._
 import xiangshan._
 import utils._
 
-class SelectPolicy(config: RSConfig)(implicit p: Parameters) extends XSModule {
+class SelectPolicy(params: RSParams)(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle {
     // select for enqueue
-    val validVec = Input(UInt(config.numEntries.W))
-    val allocate = Vec(config.numEnq, DecoupledIO(UInt(config.numEntries.W)))
+    val validVec = Input(UInt(params.numEntries.W))
+    val allocate = Vec(params.numEnq, DecoupledIO(UInt(params.numEntries.W)))
     // select for issue
-    val request = Input(UInt(config.numEntries.W))
-    val grant = Vec(config.numDeq, DecoupledIO(UInt(config.numEntries.W))) //TODO: optimize it
+    val request = Input(UInt(params.numEntries.W))
+    val grant = Vec(params.numDeq, DecoupledIO(UInt(params.numEntries.W))) //TODO: optimize it
   })
 
-  val policy = if (config.numDeq > 2 && config.numEntries > 32) "oddeven" else if (config.numDeq > 2) "circ" else "naive"
+  val policy = if (params.numDeq > 2 && params.numEntries > 32) "oddeven" else if (params.numDeq > 2) "circ" else "naive"
 
   val emptyVec = VecInit(io.validVec.asBools.map(v => !v))
-  val allocate = SelectOne(policy, emptyVec, config.numEnq)
-  for (i <- 0 until config.numEnq) {
+  val allocate = SelectOne(policy, emptyVec, params.numEnq)
+  for (i <- 0 until params.numEnq) {
     val sel = allocate.getNthOH(i + 1)
     io.allocate(i).valid := sel._1
     io.allocate(i).bits := sel._2.asUInt
@@ -47,8 +47,8 @@ class SelectPolicy(config: RSConfig)(implicit p: Parameters) extends XSModule {
 
   // a better one: select from both directions
   val request = io.request.asBools
-  val select = SelectOne(policy, request, config.numDeq)
-  for (i <- 0 until config.numDeq) {
+  val select = SelectOne(policy, request, params.numDeq)
+  for (i <- 0 until params.numDeq) {
     val sel = select.getNthOH(i + 1)
     io.grant(i).valid := sel._1
     io.grant(i).bits := sel._2.asUInt


### PR DESCRIPTION
This PR adds an non-parameterized scheduler containing all reservation stations. Now IntegerBlock, FloatBlock, MemBlock contain only function units. The Schduler connects dispatch with all function units.

Parameterization to be added later.