### PR TITLE
mstatus.tvm: add tvm check for satp access and sfence.vma

### DIFF
--- a/src/main/scala/xiangshan/backend/exu/JumpExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/JumpExeUnit.scala
@@ -51,6 +51,7 @@ class JumpExeUnit(implicit p: Parameters) extends Exu(JumpExeUnitCfg)
   fenceio.fencei <> fence.fencei
   fenceio.sbuffer <> fence.toSbuffer
   fence.io.out.ready := true.B
+  fence.disableSfence := csr.csrio.disableSfence
 
   val uop = io.fromInt.bits.uop
   val instr_rm = uop.ctrl.fpu.rm

--- a/src/main/scala/xiangshan/backend/fu/Fence.scala
+++ b/src/main/scala/xiangshan/backend/fu/Fence.scala
@@ -26,14 +26,12 @@ class FenceToSbuffer extends Bundle {
   val sbIsEmpty = Input(Bool())
 }
 
-// class Fence extends FunctionUnit(FuConfig(
-  // /*FuType.fence, 1, 0, writeIntRf = false, writeFpRf = false, hasRedirect = false,*/ latency = UncertainLatency()
-// )){
-class Fence(implicit p: Parameters) extends FunctionUnit{ // TODO: check it
+class Fence(implicit p: Parameters) extends FunctionUnit with HasExceptionNO {
 
   val sfence = IO(Output(new SfenceBundle))
   val fencei = IO(Output(Bool()))
   val toSbuffer = IO(new FenceToSbuffer)
+  val disableSfence = IO(Input(Bool()))
 
   val (valid, src1) = (
     io.in.valid,
@@ -56,16 +54,16 @@ class Fence(implicit p: Parameters) extends FunctionUnit{ // TODO: check it
   val func = uop.ctrl.fuOpType
 
   // NOTE: icache & tlb & sbuffer must receive flush signal at any time
-  sbuffer      := state === s_wait
+  sbuffer      := state === s_wait && !(func === FenceOpType.sfence && disableSfence)
   fencei       := state === s_icache
-  sfence.valid := state === s_tlb
+  sfence.valid := state === s_tlb && !disableSfence
   sfence.bits.rs1  := uop.ctrl.lsrc(0) === 0.U
   sfence.bits.rs2  := uop.ctrl.lsrc(1) === 0.U
   sfence.bits.addr := RegEnable(src1, io.in.fire())
 
   when (state === s_idle && valid) { state := s_wait }
   when (state === s_wait && func === FenceOpType.fencei && sbEmpty) { state := s_icache }
-  when (state === s_wait && func === FenceOpType.sfence && sbEmpty) { state := s_tlb }
+  when (state === s_wait && func === FenceOpType.sfence && (sbEmpty || disableSfence)) { state := s_tlb }
   when (state === s_wait && func === FenceOpType.fence  && sbEmpty) { state := s_fence }
   when (state =/= s_idle && state =/= s_wait) { state := s_idle }
 
@@ -73,6 +71,7 @@ class Fence(implicit p: Parameters) extends FunctionUnit{ // TODO: check it
   io.out.valid := state =/= s_idle && state =/= s_wait
   io.out.bits.data := DontCare
   io.out.bits.uop := uop
+  io.out.bits.uop.cf.exceptionVec(illegalInstr) := uop.cf.exceptionVec(illegalInstr) || (func === FenceOpType.sfence && disableSfence)
 
   XSDebug(valid, p"In(${io.in.valid} ${io.in.ready}) state:${state} Inpc:0x${Hexadecimal(io.in.bits.uop.cf.pc)} InroqIdx:${io.in.bits.uop.roqIdx}\n")
   XSDebug(state =/= s_idle, p"state:${state} sbuffer(flush:${sbuffer} empty:${sbEmpty}) fencei:${fencei} sfence:${sfence}\n")


### PR DESCRIPTION
mstatus.tvm: trap virtual memory
When tvm is set and priv mode is s-mode, access to satp and sfence.vma are disallowed and will raise illegal instr exception.
tvm helps to manage guest os.
See priv isa mannual for more info.