### PR TITLE
scheduler: allow multiple-dequeue RS for load and store

### DIFF
--- a/src/main/scala/xiangshan/backend/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/Scheduler.scala
@@ -113,9 +113,12 @@ class Scheduler(
   println("Scheduler: ")
   val numIssuePorts = configs.map(_._2).sum
   println(s"  number of issue ports: ${numIssuePorts}")
-  val numReplayPorts = reservationStations.count(_.params.hasFeedback == true)
+  val numReplayPorts = reservationStations.filter(_.params.hasFeedback == true).map(_.params.numDeq).sum
   println(s"  number of replay ports: ${numReplayPorts}")
-  val numSTDPorts = reservationStations.count(_.params.isStore == true)
+  val memRsEntries = reservationStations.filter(_.params.hasFeedback == true).map(_.params.numEntries)
+  require(memRsEntries.max == memRsEntries.min, "different indexes not supported")
+  println(s"  size of load and store RSes: ${memRsEntries.max}")
+  val numSTDPorts = reservationStations.filter(_.params.isStore == true).map(_.params.numDeq).sum
   println(s"  number of std ports: ${numSTDPorts}")
   val numOutsideWakeup = reservationStations.map(_.numExtFastWakeupPort).sum
   println(s"  number of outside fast wakeup ports: ${numOutsideWakeup}")
@@ -124,6 +127,13 @@ class Scheduler(
 }
 
 class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSParameter {
+  val memRsEntries = outer.memRsEntries.max
+  val updatedP = p.alter((site, here, up) => {
+    case XSCoreParamsKey => up(XSCoreParamsKey).copy(
+      IssQueSize = memRsEntries
+    )
+  })
+
   val io = IO(new Bundle {
     // global control
     val redirect = Flipped(ValidIO(new Redirect))
@@ -135,8 +145,8 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
     val readFpRf = Vec(outer.fpRfReadPorts, Input(UInt(PhyRegIdxWidth.W)))
     val issue = Vec(outer.numIssuePorts, DecoupledIO(new ExuInput))
     val writeback = Vec(outer.intRfWritePorts + outer.fpRfWritePorts, Flipped(ValidIO(new ExuOutput)))
-    val replay = Vec(outer.numReplayPorts, Flipped(ValidIO(new RSFeedback)))
-    val rsIdx = Vec(outer.numReplayPorts, Output(UInt(log2Up(IssQueSize).W)))
+    val replay = Vec(outer.numReplayPorts, Flipped(ValidIO(new RSFeedback()(updatedP))))
+    val rsIdx = Vec(outer.numReplayPorts, Output(UInt(log2Up(memRsEntries).W)))
     val isFirstIssue = Vec(outer.numReplayPorts, Output(Bool()))
     val stData = Vec(outer.numSTDPorts, ValidIO(new StoreDataBundle))
     // 2LOAD, data is selected from writeback ports
@@ -189,14 +199,17 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
       rs.module.io_checkwait.get.stIssuePtr <> io.stIssuePtr
     }
     if (rs.module.io_feedback.isDefined) {
-      rs.module.io_feedback.get.memfeedback <> io.replay(feedbackIdx)
-      rs.module.io_feedback.get.rsIdx <> io.rsIdx(feedbackIdx)
-      rs.module.io_feedback.get.isFirstIssue <> io.isFirstIssue(feedbackIdx)
-      feedbackIdx += 1
+      require(io.rsIdx(0).getWidth == rs.module.io_feedback.get.rsIdx(0).getWidth)
+      val width = rs.module.io_feedback.get.memfeedback.length
+      rs.module.io_feedback.get.memfeedback <> io.replay.slice(feedbackIdx, feedbackIdx + width)
+      rs.module.io_feedback.get.rsIdx <> io.rsIdx.slice(feedbackIdx, feedbackIdx + width)
+      rs.module.io_feedback.get.isFirstIssue <> io.isFirstIssue.slice(feedbackIdx, feedbackIdx + width)
+      feedbackIdx += width
     }
     if (rs.module.io_store.isDefined) {
-      rs.module.io_store.get.stData <> io.stData(stDataIdx)
-      stDataIdx += 1
+      val width = rs.module.io_store.get.stData.length
+      rs.module.io_store.get.stData <> io.stData.slice(stDataIdx, stDataIdx + width)
+      stDataIdx += width
     }
 
     (rs.intSrcCnt > 0, rs.fpSrcCnt > 0) match {
@@ -262,6 +275,7 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
       }
       intReadPort += numIntRfPorts
     }
+
     val numFpRfPorts = dp.map(_._1).map(rs_all(_).fpSrcCnt).max
     if (numFpRfPorts > 0) {
       val fpRfPorts = VecInit(fpRf.io.readPorts.slice(fpReadPort, fpReadPort + numFpRfPorts).map(_.data))
@@ -272,7 +286,7 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
         if (numIntRfPorts > 0) {
           require(numFpRfPorts == 1)
           require(numIntRfPorts == 2)
-          when(RegNext(mod.io.fromDispatch(0).bits.ctrl.srcType(1) === SrcType.fp)) {
+          when(RegNext(mod.io.fromDispatch(idx).bits.ctrl.srcType(1) === SrcType.fp)) {
             target(1) := fpRfPorts(0)
           }
         }

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -135,7 +135,15 @@ class ReservationStation(implicit p: Parameters) extends LazyModule with HasXSPa
 
   override def toString: String = params.toString
 
+  def indexWidth = log2Up(params.numEntries)
+
   lazy val module = new LazyModuleImp(this) {
+    val updatedP = p.alter((site, here, up) => {
+      case XSCoreParamsKey => up(XSCoreParamsKey).copy(
+        IssQueSize = params.numEntries
+      )
+    })
+
     val io = IO(new Bundle {
       val redirect = Flipped(ValidIO(new Redirect))
       val flush = Input(Bool())
@@ -147,7 +155,6 @@ class ReservationStation(implicit p: Parameters) extends LazyModule with HasXSPa
       // deq
       val deq = Vec(params.numDeq, DecoupledIO(new ExuInput))
 
-//      val fastUopOut = Vec(params.numDeq, ValidIO(new MicroOp))
       val fastUopsIn = Vec(params.numFastWakeup, Flipped(ValidIO(new MicroOp)))
       val fastDatas = Vec(params.numFastWakeup, Input(UInt(params.dataBits.W)))
       val slowPorts = Vec(params.numWakeup, Flipped(ValidIO(new ExuOutput)))
@@ -158,15 +165,15 @@ class ReservationStation(implicit p: Parameters) extends LazyModule with HasXSPa
       val jalr_target = Input(UInt(VAddrBits.W))
     })) else None
     val io_feedback = if (params.hasFeedback) Some(IO(new Bundle {
-      val memfeedback = Flipped(ValidIO(new RSFeedback))
-      val rsIdx = Output(UInt(log2Up(params.numEntries).W))
-      val isFirstIssue = Output(Bool()) // NOTE: just use for tlb perf cnt
+      val memfeedback = Vec(params.numDeq, Flipped(ValidIO(new RSFeedback()(updatedP))))
+      val rsIdx = Vec(params.numDeq, Output(UInt(indexWidth.W)))
+      val isFirstIssue = Vec(params.numDeq, Output(Bool())) // NOTE: just use for tlb perf cnt
     })) else None
     val io_checkwait = if (params.checkWaitBit) Some(IO(new Bundle {
       val stIssuePtr = Input(new SqPtr())
     })) else None
     val io_store = if (params.isStore) Some(IO(new Bundle {
-      val stData = ValidIO(new StoreDataBundle)
+      val stData = Vec(params.numDeq, ValidIO(new StoreDataBundle))
     })) else None
 
     val statusArray = Module(new StatusArray(params))
@@ -226,20 +233,15 @@ class ReservationStation(implicit p: Parameters) extends LazyModule with HasXSPa
     select.io.request := statusArray.io.canIssue
     for (i <- 0 until params.numDeq) {
       select.io.grant(i).ready := io.deq(i).ready
+      statusArray.io.issueGranted(i).valid := select.io.grant(i).fire
+      statusArray.io.issueGranted(i).bits := select.io.grant(i).bits
+      statusArray.io.deqResp(i).valid := select.io.grant(i).fire
+      statusArray.io.deqResp(i).bits.rsMask := select.io.grant(i).bits
+      statusArray.io.deqResp(i).bits.success := io.deq(i).ready
       if (io_feedback.isDefined) {
-        require(params.numDeq == 1)
-        statusArray.io.issueGranted(0).valid := select.io.grant(0).fire
-        statusArray.io.issueGranted(0).bits := select.io.grant(0).bits
-        statusArray.io.deqResp(0).valid := io_feedback.get.memfeedback.valid
-        statusArray.io.deqResp(0).bits.rsMask := UIntToOH(io_feedback.get.memfeedback.bits.rsIdx)
-        statusArray.io.deqResp(0).bits.success := io_feedback.get.memfeedback.bits.hit
-      }
-      else {
-        statusArray.io.issueGranted(i).valid := select.io.grant(i).fire
-        statusArray.io.issueGranted(i).bits := select.io.grant(i).bits
-        statusArray.io.deqResp(i).valid := select.io.grant(i).fire
-        statusArray.io.deqResp(i).bits.rsMask := select.io.grant(i).bits
-        statusArray.io.deqResp(i).bits.success := io.deq(i).ready
+        statusArray.io.deqResp(i).valid := io_feedback.get.memfeedback(i).valid
+        statusArray.io.deqResp(i).bits.rsMask := UIntToOH(io_feedback.get.memfeedback(i).bits.rsIdx)
+        statusArray.io.deqResp(i).bits.success := io_feedback.get.memfeedback(i).bits.hit
       }
       payloadArray.io.read(i).addr := select.io.grant(i).bits
       if (io_fastWakeup.isDefined) {
@@ -370,8 +372,8 @@ class ReservationStation(implicit p: Parameters) extends LazyModule with HasXSPa
       PipelineConnect(s1_out(i), io.deq(i), io.deq(i).ready || io.deq(i).bits.uop.roqIdx.needFlush(io.redirect, io.flush), false.B)
       val pipeline_fire = s1_out(i).valid && io.deq(i).ready
       if (params.hasFeedback) {
-        io_feedback.get.rsIdx := RegEnable(OHToUInt(select.io.grant(i).bits), pipeline_fire)
-        io_feedback.get.isFirstIssue := RegEnable(statusArray.io.isFirstIssue.head, pipeline_fire)
+        io_feedback.get.rsIdx(i) := RegEnable(OHToUInt(select.io.grant(i).bits), pipeline_fire)
+        io_feedback.get.isFirstIssue(i) := RegEnable(statusArray.io.isFirstIssue(i), pipeline_fire)
       }
 
       for (j <- 0 until params.numSrc) {
@@ -379,9 +381,9 @@ class ReservationStation(implicit p: Parameters) extends LazyModule with HasXSPa
       }
 
       if (io_store.isDefined) {
-        io_store.get.stData.valid := io.deq(i).valid
-        io_store.get.stData.bits.data := io.deq(i).bits.src(1)
-        io_store.get.stData.bits.uop := io.deq(i).bits.uop
+        io_store.get.stData(i).valid := io.deq(i).valid
+        io_store.get.stData(i).bits.data := io.deq(i).bits.src(1)
+        io_store.get.stData(i).bits.uop := io.deq(i).bits.uop
       }
     }
 


### PR DESCRIPTION
This commit adds support for multiple enqueue for load and store RS.
Also update the parameters in XSCore to avoid explicitly setting wakeup ports.