### PR TITLE
test,verilator: --no-diff should not init nemu

### DIFF
--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -236,8 +236,8 @@ uint64_t Emulator::execute(uint64_t max_cycle, uint64_t max_instr) {
   init_device();
   if (args.enable_diff) {
     init_goldenmem();
+    init_nemuproxy();
   }
-  init_nemuproxy();
 
   uint32_t lasttime_poll = 0;
   uint32_t lasttime_snapshot = 0;


### PR DESCRIPTION
When --no-diff option is enable, nemuproxy should not be initialized, to avoid the dependence on NEMU.