### PR TITLE
backend, rs: add an age matrix to find the oldest instruction

### DIFF
--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -226,6 +226,8 @@ class ReservationStation(implicit p: Parameters) extends LazyModule with HasXSPa
       statusArray.io.wakeup(i).valid := wakeupValid(i)
       statusArray.io.wakeup(i).bits := wakeupDest(i)
     }
+    val enqVec = VecInit(doEnqueue.zip(select.io.allocate.map(_.bits)).map{ case (d, b) => Mux(d, b, 0.U) })
+    select.io.best := AgeDetector(params.numEntries, enqVec, statusArray.io.flushed)
 
     /**
       * S1: scheduler (and regfile read)

--- a/src/main/scala/xiangshan/backend/issue/SelectPolicy.scala
+++ b/src/main/scala/xiangshan/backend/issue/SelectPolicy.scala
@@ -71,6 +71,7 @@ class SelectPolicy(params: RSParams)(implicit p: Parameters) extends XSModule {
     io.grant.last.valid := true.B
     io.grant.last.bits := io.best
   }
+  XSPerfAccumulate("oldest_not_selected", best_not_selected)
 }
 
 class AgeDetector(numEntries: Int, numEnq: Int)(implicit p: Parameters) extends XSModule {


### PR DESCRIPTION
This commit adds an age matrix to reservation station to find
the oldest instruction. This enables the RS to schedule the oldest
instruction first.