### PR TITLE
backend: change the second regfile to 6R8W

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -127,7 +127,7 @@ abstract class XSCoreBase()(implicit p: config.Parameters) extends LazyModule
 
   // allow mdu and fmisc to have 2*numDeq enqueue ports
   val intDpPorts = (0 until exuParameters.AluCnt).map(i => Seq((0, i)))
-  val int1DpPorts = (0 until 2*exuParameters.MduCnt).map(i => {
+  val int1DpPorts = (0 until exuParameters.MduCnt).map(i => {
     if (i < exuParameters.JmpCnt) Seq((0, i), (1, i))
     else Seq((0, i))
   }) ++ (0 until exuParameters.StuCnt).map(i => Seq((2, i)))
@@ -251,13 +251,20 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   val allFastUop1 = intFastUop1 ++ fpFastUop1
 
   ctrlBlock.io.enqIQ <> exuBlocks(0).io.allocate ++ exuBlocks(2).io.allocate ++ memScheduler.io.allocate
-  for (i <- 0 until exuParameters.AluCnt) {
+  for (i <- 0 until exuParameters.MduCnt) {
     val rsIn = VecInit(Seq(exuBlocks(0).io.allocate(i), exuBlocks(1).io.allocate(i)))
     val func1 = (op: MicroOp) => outer.exuBlocks(0).scheduler.canAccept(op.ctrl.fuType)
     val func2 = (op: MicroOp) => outer.exuBlocks(1).scheduler.canAccept(op.ctrl.fuType)
     val arbiterOut = DispatchArbiter(ctrlBlock.io.enqIQ(i), Seq(func1, func2))
     rsIn <> arbiterOut
   }
+  for (i <- exuParameters.MduCnt until exuParameters.AluCnt) {
+    val rsIn = exuBlocks(0).io.allocate(i)
+    val dpOut = ctrlBlock.io.enqIQ(i)
+    rsIn.valid := dpOut.valid && outer.exuBlocks(0).scheduler.canAccept(dpOut.bits.ctrl.fuType)
+    dpOut.ready := rsIn.ready && outer.exuBlocks(0).scheduler.canAccept(dpOut.bits.ctrl.fuType)
+  }
+
   val stdAllocate = exuBlocks(1).io.allocate.takeRight(2)
   val staAllocate = memScheduler.io.allocate.takeRight(2)
   stdAllocate.zip(staAllocate).zip(ctrlBlock.io.enqIQ.takeRight(2)).zipWithIndex.foreach{ case (((std, sta), enq), i) =>
@@ -270,9 +277,9 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
     std.bits.srcState(0) := enq.bits.srcState(1)
     std.bits.ctrl.srcType(0) := enq.bits.ctrl.srcType(1)
     enq.ready := sta.ready && std.ready
-    XSPerfAccumulate(s"st_not_ready_$i", enq.valid && !enq.ready)
-    XSPerfAccumulate(s"sta_not_ready_$i", sta.valid && !sta.ready)
-    XSPerfAccumulate(s"std_not_ready_$i", std.valid && !std.ready)
+    XSPerfAccumulate(s"st_rs_not_ready_$i", enq.valid && !enq.ready)
+    XSPerfAccumulate(s"sta_rs_not_ready_$i", sta.valid && !sta.ready)
+    XSPerfAccumulate(s"std_rs_not_ready_$i", std.valid && !std.ready)
   }
   exuBlocks(1).io.scheExtra.fpRfReadIn.get <> exuBlocks(2).io.scheExtra.fpRfReadOut.get
 


### PR DESCRIPTION
This commit changes how to organize reservation stations in the
second ExuBlock. Now the second ExuBlock accepts MUL, MUL, STD, STD.
The int regfile in this ExuBlock becomes 6R8W.