### PR TITLE
github,ci: use action id for perf data filename

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -44,7 +44,7 @@ jobs:
           submodules: 'recursive'
       - name: set env
         run: |
-          export HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          export HEAD_SHA=${{ github.run_number }}
           echo "NEMU_HOME=/home/ci-runner/xsenv/NEMU" >> $GITHUB_ENV
           echo "AM_HOME=/home/ci-runner/xsenv/nexus-am" >> $GITHUB_ENV
           echo "PERF_HOME=/bigdata/xs-perf/${HEAD_SHA}" >> $GITHUB_ENV
@@ -85,7 +85,7 @@ jobs:
           submodules: 'recursive'
       - name: set env
         run: |
-          export HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          export HEAD_SHA=${{ github.run_number }}
           echo "NEMU_HOME=/home/ci-runner/xsenv/NEMU" >> $GITHUB_ENV
           echo "AM_HOME=/home/ci-runner/xsenv/nexus-am" >> $GITHUB_ENV
           echo "PERF_HOME=/bigdata/xs-perf/${HEAD_SHA}" >> $GITHUB_ENV


### PR DESCRIPTION
This commit changes how performance data file is named. Previously
we use GITHUB_SHA or pull_request.head.sha. However, we cannot easily
get the sha or they do not work for master branch.