### PR TITLE
backend, fu: support fastUopOut for pipelined fu

### DIFF
--- a/src/main/scala/xiangshan/backend/exu/Exu.scala
+++ b/src/main/scala/xiangshan/backend/exu/Exu.scala
@@ -153,7 +153,6 @@ abstract class Exu(val config: ExuConfig)(implicit p: Parameters) extends XSModu
   def writebackArb(in: Seq[DecoupledIO[FuOutput]], out: DecoupledIO[ExuOutput]): Seq[Bool] = {
     if (needArbiter) {
       if(in.size == 1){
-        require(!config.hasFastUopOut)
         in.head.ready := out.ready
         out.bits.data := in.head.bits.data
         out.bits.uop := in.head.bits.uop
@@ -170,7 +169,6 @@ abstract class Exu(val config: ExuConfig)(implicit p: Parameters) extends XSModu
         arb.io.out <> out
       }
     } else {
-      require(!config.hasFastUopOut)
       in.foreach(_.ready := out.ready)
       val sel = Mux1H(in.map(x => x.valid -> x))
       out.bits.data := sel.bits.data

--- a/src/main/scala/xiangshan/backend/exu/FmacExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/FmacExeUnit.scala
@@ -34,10 +34,6 @@ class FmacExeUnit(implicit p: Parameters) extends ExeUnit(FmacExeUnitCfg)
   val instr_rm = io.fromFp.bits.uop.ctrl.fpu.rm
   fma.rm := Mux(instr_rm =/= 7.U, instr_rm, frm.get)
 
-  fma.io.redirectIn := io.redirect
-  fma.io.flushIn := io.flush
-  fma.io.out.ready := io.out.ready
-
   io.out.bits.data := fma.io.out.bits.data
   io.out.bits.fflags := fma.fflags
 }

--- a/src/main/scala/xiangshan/backend/exu/WbArbiter.scala
+++ b/src/main/scala/xiangshan/backend/exu/WbArbiter.scala
@@ -140,8 +140,13 @@ class WbArbiterImp(outer: WbArbiter)(implicit p: Parameters) extends LazyModuleI
   io.out.take(exclusiveIn.size).zip(exclusiveIn).zipWithIndex.foreach{
     case ((out, in), i) =>
       val hasFastUopOut = outer.hasFastUopOut(i)
-      out.valid := (if (hasFastUopOut) RegNext(in.valid) else in.valid)
+      out.valid := in.valid
       out.bits := in.bits
+      if (hasFastUopOut) {
+        // When hasFastUopOut, only uop comes at the same cycle with valid.
+        out.valid := RegNext(in.valid)
+        out.bits.uop := RegNext(in.bits.uop)
+      }
       in.ready := true.B
   }
 

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -522,10 +522,9 @@ package object xiangshan {
     writeIntRf = true,
     writeFpRf = false,
     hasRedirect = false,
-    // TODO: change this back to 2 when mul is ready for fastUopOut
-    latency = CertainLatency(3),
+    latency = CertainLatency(2),
     fastUopOut = true,
-    fastImplemented = false
+    fastImplemented = true
   )
 
   val bmuCfg = FuConfig(
@@ -547,7 +546,8 @@ package object xiangshan {
     name = "fmac",
     fuGen = fmacGen,
     fuSel = _ => true.B,
-    FuType.fmac, 0, 3, writeIntRf = false, writeFpRf = true, hasRedirect = false, CertainLatency(4)
+    FuType.fmac, 0, 3, writeIntRf = false, writeFpRf = true, hasRedirect = false, CertainLatency(4),
+    fastUopOut = true, fastImplemented = true
   )
 
   val f2iCfg = FuConfig(
@@ -555,7 +555,7 @@ package object xiangshan {
     fuGen = f2iGen,
     fuSel = f2iSel,
     FuType.fmisc, 0, 1, writeIntRf = true, writeFpRf = false, hasRedirect = false, CertainLatency(2),
-    fastUopOut = true, fastImplemented = false
+    fastUopOut = true, fastImplemented = true
   )
 
   val f2fCfg = FuConfig(
@@ -563,7 +563,7 @@ package object xiangshan {
     fuGen = f2fGen,
     fuSel = f2fSel,
     FuType.fmisc, 0, 1, writeIntRf = false, writeFpRf = true, hasRedirect = false, CertainLatency(2),
-    fastUopOut = true, fastImplemented = false
+    fastUopOut = true, fastImplemented = true
   )
 
   val fdivSqrtCfg = FuConfig(


### PR DESCRIPTION
This commit adds fastUopOut support for pipelined function units via
implementing fastUopOut in trait HasPipelineReg.

The following function units now support fastUopOut:
- MUL
- FMA
- F2I
- F2F