### PR TITLE
rs,bypass: add left and right bypass strategy

### DIFF
--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -448,7 +448,7 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
         wakeupBypassMask(j) := VecInit(targetFastWakeupMatch.map(_ (j)))
       }
 
-      val bypassNetwork = Module(new BypassNetwork(params.numSrc, params.numFastWakeup, params.dataBits, params.optBuf))
+      val bypassNetwork = BypassNetwork(params.numSrc, params.numFastWakeup, params.dataBits, params.optBuf)
       bypassNetwork.io.hold := !io.deq(i).ready
       bypassNetwork.io.source := s1_out(i).bits.src.take(params.numSrc)
       bypassNetwork.io.bypass.zip(wakeupBypassMask.zip(io.fastDatas)).foreach { case (by, (m, d)) =>


### PR DESCRIPTION
This commit adds another bypass network implementation to optimize timing of the first stage of function units.

In BypassNetworkLeft, we bypass data at the same cycle that function units write data back. This increases the length of the critical path of the last stage of function units but reduces the length of the critical path of the first stage of function units. Some function units that require a shorter stage zero, like LOAD, may use BypassNetworkLeft.

In this commit, we set all bypass networks to the left style, but we will make it configurable depending on different function units in the future.