### PR TITLE
utils,MaskData: assert wmask is wider than data

### DIFF
--- a/src/main/scala/device/AXI4DummySD.scala
+++ b/src/main/scala/device/AXI4DummySD.scala
@@ -79,7 +79,7 @@ class AXI4DummySD
     val sdcmd :: sdarg :: sdtout :: sdcdiv :: sdrsp0 :: sdrsp1 :: sdrsp2 :: sdrsp3 :: sdhsts :: __pad0 :: __pad1 :: __pad2 :: sdvdd :: sdedm :: sdhcfg :: sdhbct :: sddata :: __pad10 :: __pad11 :: __pad12 :: sdhblc :: Nil = range
 
     val regs = List.fill(range.size)(RegInit(0.U(32.W)))
-    val edmConst = (8 << 4).U // number of data in fifo
+    val edmConst = (8 << 4).U(32.W) // number of data in fifo
 
     val MMC_SEND_OP_COND = 1
     val MMC_ALL_SEND_CID = 2
@@ -146,10 +146,10 @@ class AXI4DummySD
     def getOffset(addr: UInt) = addr(12, 0)
 
     val strb = Mux(waddr(2), in.w.bits.strb(7, 4), in.w.bits.strb(3, 0))
-    val rdata = Wire(UInt(64.W))
+    val rdata = Wire(UInt(32.W))
     RegMap.generate(mapping, getOffset(raddr), rdata,
-      getOffset(waddr), in.w.fire(), in.w.bits.data, MaskExpand(strb))
+      getOffset(waddr), in.w.fire(), in.w.bits.data(31, 0), MaskExpand(strb))
 
-    in.r.bits.data := Fill(2, rdata(31, 0))
+    in.r.bits.data := Fill(2, rdata)
   }
 }

--- a/src/main/scala/utils/BitUtils.scala
+++ b/src/main/scala/utils/BitUtils.scala
@@ -29,9 +29,11 @@ object MaskExpand {
 }
 
 object MaskData {
- def apply(oldData: UInt, newData: UInt, fullmask: UInt) = {
-   (newData & fullmask) | (oldData & ~fullmask)
- }
+  def apply(oldData: UInt, newData: UInt, fullmask: UInt) = {
+    require(oldData.getWidth <= fullmask.getWidth, s"${oldData.getWidth} < ${fullmask.getWidth}")
+    require(newData.getWidth <= fullmask.getWidth, s"${newData.getWidth} < ${fullmask.getWidth}")
+    (newData & fullmask) | (oldData & ~fullmask)
+  }
 }
 
 object SignExt {

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -302,7 +302,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst
 // | prv      | 2 bits
   val dcsrData = Wire(new DcsrStruct)
   dcsrData := dcsr.asTypeOf(new DcsrStruct)
-  val dcsrMask = GenMask(15) | GenMask(13, 11) | GenMask(2, 0)// Dcsr write mask
+  val dcsrMask = ZeroExt(GenMask(15) | GenMask(13, 11) | GenMask(2, 0), XLEN)// Dcsr write mask
   def dcsrUpdateSideEffect(dcsr: UInt): UInt = {
     val dcsrOld = WireInit(dcsr.asTypeOf(new DcsrStruct))
     val dcsrNew = dcsr | (dcsrOld.prv(0) | dcsrOld.prv(1)).asUInt // turn 10 priv into 11
@@ -320,8 +320,8 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst
 
   val mie = RegInit(0.U(XLEN.W))
   val mipWire = WireInit(0.U.asTypeOf(new Interrupt))
-  val mipReg  = RegInit(0.U.asTypeOf(new Interrupt).asUInt)
-  val mipFixMask = GenMask(9) | GenMask(5) | GenMask(1)
+  val mipReg  = RegInit(0.U(XLEN.W))
+  val mipFixMask = ZeroExt(GenMask(9) | GenMask(5) | GenMask(1), XLEN)
   val mip = (mipWire.asUInt | mipReg).asTypeOf(new Interrupt)
 
   def getMisaMxl(mxl: Int): UInt = {mxl.U << (XLEN-2)}.asUInt()
@@ -392,7 +392,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst
   // Superviser-Level CSRs
 
   // val sstatus = RegInit(UInt(XLEN.W), "h00000000".U)
-  val sstatusWmask = "hc6122".U
+  val sstatusWmask = "hc6122".U(XLEN.W)
   // Sstatus Write Mask
   // -------------------------------------------------------
   //    19           9   5     2
@@ -405,10 +405,10 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst
   // val sie = RegInit(0.U(XLEN.W))
   val sieMask = "h222".U & mideleg
   val sipMask = "h222".U & mideleg
-  val sipWMask = "h2".U // ssip is writeable in smode
+  val sipWMask = "h2".U(XLEN.W) // ssip is writeable in smode
   val satp = if(EnbaleTlbDebug) RegInit(UInt(XLEN.W), "h8000000000087fbe".U) else RegInit(0.U(XLEN.W))
   // val satp = RegInit(UInt(XLEN.W), "h8000000000087fbe".U) // only use for tlb naive debug
-  val satpMask = "h80000fffffffffff".U // disable asid, mode can only be 8 / 0
+  val satpMask = "h80000fffffffffff".U(XLEN.W) // disable asid, mode can only be 8 / 0
   val sepc = RegInit(UInt(XLEN.W), 0.U)
   val scause = RegInit(UInt(XLEN.W), 0.U)
   val stval = Reg(UInt(XLEN.W))
@@ -605,16 +605,16 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst
     MaskedRegMap(Srnctl, srnctl),
 
     //--- Machine Information Registers ---
-    MaskedRegMap(Mvendorid, mvendorid, 0.U, MaskedRegMap.Unwritable),
-    MaskedRegMap(Marchid, marchid, 0.U, MaskedRegMap.Unwritable),
-    MaskedRegMap(Mimpid, mimpid, 0.U, MaskedRegMap.Unwritable),
-    MaskedRegMap(Mhartid, mhartid, 0.U, MaskedRegMap.Unwritable),
+    MaskedRegMap(Mvendorid, mvendorid, 0.U(XLEN.W), MaskedRegMap.Unwritable),
+    MaskedRegMap(Marchid, marchid, 0.U(XLEN.W), MaskedRegMap.Unwritable),
+    MaskedRegMap(Mimpid, mimpid, 0.U(XLEN.W), MaskedRegMap.Unwritable),
+    MaskedRegMap(Mhartid, mhartid, 0.U(XLEN.W), MaskedRegMap.Unwritable),
 
     //--- Machine Trap Setup ---
     MaskedRegMap(Mstatus, mstatus, mstatusMask, mstatusUpdateSideEffect, mstatusMask),
     MaskedRegMap(Misa, misa), // now MXL, EXT is not changeable
-    MaskedRegMap(Medeleg, medeleg, "hf3ff".U),
-    MaskedRegMap(Mideleg, mideleg, "h222".U),
+    MaskedRegMap(Medeleg, medeleg, "hf3ff".U(XLEN.W)),
+    MaskedRegMap(Mideleg, mideleg, "h222".U(XLEN.W)),
     MaskedRegMap(Mie, mie),
     MaskedRegMap(Mtvec, mtvec),
     MaskedRegMap(Mcounteren, mcounteren),
@@ -624,7 +624,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst
     MaskedRegMap(Mepc, mepc),
     MaskedRegMap(Mcause, mcause),
     MaskedRegMap(Mtval, mtval),
-    MaskedRegMap(Mip, mip.asUInt, 0.U, MaskedRegMap.Unwritable),
+    MaskedRegMap(Mip, mip.asUInt, 0.U(XLEN.W), MaskedRegMap.Unwritable),
 
     //--- Debug Mode ---
     MaskedRegMap(Dcsr, dcsr, dcsrMask, dcsrUpdateSideEffect),


### PR DESCRIPTION
This commit adds assertion in MaskData to check the width of mask
and data. When the width of mask is smaller than the width of data,
(~mask & data) and (mask & data) will always clear the upper bits
of the data. This usually causes unexpected behavior.

This commit adds explicit width declarations where MaskData is used.