### PR TITLE
backend, rename: support elimination of move instruction whose lsrc is 0 + bug fix

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -266,7 +266,8 @@ trait HasXSParameter {
   val EnableIntMoveElim = coreParams.EnableIntMoveElim
   val IntRefCounterWidth = coreParams.IntRefCounterWidth
   val StdFreeListSize = NRPhyRegs - 32
-  val MEFreeListSize = NRPhyRegs - { if (IntRefCounterWidth > 0 && IntRefCounterWidth < 5) (32 / Math.pow(2, IntRefCounterWidth)).toInt else 1 }
+  // val MEFreeListSize = NRPhyRegs - { if (IntRefCounterWidth > 0 && IntRefCounterWidth < 5) (32 / Math.pow(2, IntRefCounterWidth)).toInt else 1 }
+  val MEFreeListSize = NRPhyRegs
   val LoadQueueSize = coreParams.LoadQueueSize
   val StoreQueueSize = coreParams.StoreQueueSize
   val dpParams = coreParams.dpParams

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -504,6 +504,7 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
   cs.fpu := fpDecoder.io.fpCtrl
 
   val isMove = BitPat("b000000000000_?????_000_?????_0010011") === ctrl_flow.instr
+  cs.isMove := isMove
 
   // read src1~3 location
   cs.lsrc(0) := Mux(ctrl_flow.instr === LUI, 0.U,ctrl_flow.instr(RS1_MSB,RS1_LSB))
@@ -535,8 +536,6 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
       x._1 -> minBits
     }
   ))
-
-  cs.isMove := isMove && cs.lsrc(0) =/= 0.U /* TODO these special Move instructions can be optimized */
 
   cf_ctrl.ctrl := cs
 

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -186,7 +186,7 @@ class Rename(implicit p: Parameters) extends XSModule {
 
       if (i == 0) {
         // calculate meEnable
-        meEnable(i) := isMove(i) && !isMax.get(uops(i).psrc(0))      
+        meEnable(i) := isMove(i) && (!isMax.get(uops(i).psrc(0)) || uops(i).ctrl.lsrc(0) === 0.U)
       } else {
         // compare psrc0
         psrc_cmp(i-1) := Cat((0 until i).map(j => {
@@ -194,7 +194,7 @@ class Rename(implicit p: Parameters) extends XSModule {
         }) /* reverse is not necessary here */)
   
         // calculate meEnable
-        meEnable(i) := isMove(i) && !(io.renameBypass.lsrc1_bypass(i-1).orR | psrc_cmp(i-1).orR | isMax.get(uops(i).psrc(0)))
+        meEnable(i) := isMove(i) && (!(io.renameBypass.lsrc1_bypass(i-1).orR | psrc_cmp(i-1).orR | isMax.get(uops(i).psrc(0))) || uops(i).ctrl.lsrc(0) === 0.U)
       }
       uops(i).eliminatedMove := meEnable(i) || (uops(i).ctrl.isMove && uops(i).ctrl.ldest === 0.U)
   

--- a/src/main/scala/xiangshan/backend/roq/Roq.scala
+++ b/src/main/scala/xiangshan/backend/roq/Roq.scala
@@ -688,7 +688,7 @@ class Roq(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     when (canEnqueue(i)) {
       if (EnableIntMoveElim) {
         eliminatedMove(enqPtrVec(i).value) := io.enq.req(i).bits.eliminatedMove
-        writebacked(enqPtrVec(i).value) := io.enq.req(i).bits.eliminatedMove
+        writebacked(enqPtrVec(i).value) := io.enq.req(i).bits.eliminatedMove && !io.enq.req(i).bits.cf.exceptionVec.asUInt().orR
       } else {
         writebacked(enqPtrVec(i).value) := false.B
       }


### PR DESCRIPTION
**new feature**: instructions like `mv foo,x0` or `li foo,0` can be eliminated now.

**bug fix**: when eliminated move instruction enters roq, if there already exists valid bit in `exceptionVec`, then it shouldn't be labeled `writebacked` immediately.

Next: optimize verilog code length & timing