### PR TITLE
backend,rs: move select logic to stage 0

### DIFF
--- a/src/main/scala/xiangshan/backend/issue/DataArray.scala
+++ b/src/main/scala/xiangshan/backend/issue/DataArray.scala
@@ -73,7 +73,7 @@ class DataArray(params: RSParams)(implicit p: Parameters) extends XSModule {
     val waddr = io.write.map(_.addr) ++ io.multiWrite.map(_.addr(i)) ++ delayedWaddr
     val wdata = io.write.map(_.data(i)) ++ io.multiWrite.map(_.data) ++ delayedWdata
 
-    val dataModule = Module(new AsyncRawDataModuleTemplate(UInt(params.dataBits.W), params.numEntries, io.read.length, wen.length))
+    val dataModule = Module(new SyncRawDataModuleTemplate(UInt(params.dataBits.W), params.numEntries, io.read.length, wen.length))
     dataModule.io.rvec := VecInit(io.read.map(_.addr))
     io.read.map(_.data(i)).zip(dataModule.io.rdata).foreach{ case (d, r) => d := r }
     dataModule.io.wen := wen

--- a/src/main/scala/xiangshan/backend/issue/PayloadArray.scala
+++ b/src/main/scala/xiangshan/backend/issue/PayloadArray.scala
@@ -49,7 +49,7 @@ class PayloadArray[T <: Data](gen: T, params: RSParams)(implicit p: Parameters) 
 
   // read ports
   io.read.map(_.data).zip(io.read.map(_.addr)).map {
-    case (data, addr) => data := Mux1H(addr, payload)
+    case (data, addr) => data := Mux1H(RegNext(addr), payload)
     XSError(PopCount(addr) > 1.U, p"raddr ${Binary(addr)} is not one-hot\n")
   }
 

--- a/src/main/scala/xiangshan/backend/issue/StatusArray.scala
+++ b/src/main/scala/xiangshan/backend/issue/StatusArray.scala
@@ -220,7 +220,7 @@ class StatusArray(params: RSParams)(implicit p: Parameters) extends XSModule
   }
 
   io.isValid := VecInit(statusArray.map(_.valid)).asUInt
-  io.canIssue := VecInit(statusArray.map(_.valid).zip(readyVec).map{ case (v, r) => v && r}).asUInt
+  io.canIssue := VecInit(statusArrayNext.map(_.valid).zip(readyVecNext).map{ case (v, r) => v && r}).asUInt
   io.isFirstIssue := VecInit(io.issueGranted.map(iss => Mux1H(iss.bits, statusArray.map(_.isFirstIssue))))
   io.flushed := flushedVec.asUInt
 


### PR DESCRIPTION
This commit moves issue select logic in reservation stations to stage 0
from stage 1. It helps timing of stage 1, which load-to-load requires.

Now, reservation stations have the following stages:

* S0: enqueue and wakeup, select. Selection results are RegNext-ed.
* S1: data/uop read and data bypass. Bypassed results are RegNext-ed.
* S2: issue instructions to function units.