### PR TITLE
backend: clean up exception vector usages

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -279,6 +279,8 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   memScheduler.io.redirect <> ctrlBlock.io.redirect
   memScheduler.io.flush <> ctrlBlock.io.flush
   memBlock.io.issue <> memScheduler.io.issue
+  // By default, instructions do not have exceptions when they enter the function units.
+  memBlock.io.issue.map(_.bits.uop.clearExceptions())
   memScheduler.io.writeback <> rfWriteback
   memScheduler.io.fastUopIn <> allFastUop1
   memScheduler.io.extra.jumpPc <> ctrlBlock.io.jumpPc

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -123,7 +123,7 @@ class RedirectGenerator(implicit p: Parameters) extends XSModule
   val brTarget = real_pc + SignExt(ImmUnion.B.toImm32(s1_imm12_reg), XLEN)
   val snpc = real_pc + Mux(s1_pd.isRVC, 2.U, 4.U)
   val target = Mux(s1_isReplay,
-    real_pc, // repaly from itself
+    real_pc, // replay from itself
     Mux(s1_redirect_bits_reg.cfiUpdate.taken,
       Mux(s1_isJump, s1_jumpTarget, brTarget),
       snpc

--- a/src/main/scala/xiangshan/backend/ExuBlock.scala
+++ b/src/main/scala/xiangshan/backend/ExuBlock.scala
@@ -189,4 +189,12 @@ class ExuBlockImp(outer: ExuBlock)(implicit p: Parameters) extends LazyModuleImp
       }
     }
   })
+
+  // By default, instructions do not have exceptions when they enter the function units.
+  fuBlock.io.issue.map(_.bits.uop.clearExceptions())
+  // For exe units that don't have exceptions, we assign zeroes to their exception vector.
+  for ((cfg, wb) <- flattenFuConfigs.zip(io.fuWriteback).filterNot(_._1.hasExceptionOut)) {
+    wb.bits.uop.clearExceptions()
+  }
+
 }

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -498,6 +498,7 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
   cf_ctrl.cf := ctrl_flow
   val cs = Wire(new CtrlSignals()).decode(ctrl_flow.instr, decode_table)
   cs.singleStep := false.B
+  cs.replayInst := false.B
 
   cs.isFused := 0.U
 

--- a/src/main/scala/xiangshan/backend/exu/Exu.scala
+++ b/src/main/scala/xiangshan/backend/exu/Exu.scala
@@ -67,6 +67,7 @@ case class ExuConfig
   val writeFpRf = fuConfigs.map(_.writeFpRf).reduce(_ || _)
   val hasRedirect = fuConfigs.map(_.hasRedirect).reduce(_ || _)
   val hasFastUopOut = fuConfigs.map(_.fastUopOut).reduce(_ || _)
+  val hasExceptionOut = fuConfigs.map(_.hasExceptionOut).reduce(_ || _)
 
   val latency: HasFuLatency = {
     val lats = fuConfigs.map(_.latency)

--- a/src/main/scala/xiangshan/backend/fu/Fence.scala
+++ b/src/main/scala/xiangshan/backend/fu/Fence.scala
@@ -72,7 +72,7 @@ class Fence(implicit p: Parameters) extends FunctionUnit with HasExceptionNO {
   io.out.valid := state =/= s_idle && state =/= s_wait
   io.out.bits.data := DontCare
   io.out.bits.uop := uop
-  io.out.bits.uop.cf.exceptionVec(illegalInstr) := uop.cf.exceptionVec(illegalInstr) || (func === FenceOpType.sfence && disableSfence)
+  io.out.bits.uop.cf.exceptionVec(illegalInstr) := func === FenceOpType.sfence && disableSfence
 
   XSDebug(valid, p"In(${io.in.valid} ${io.in.ready}) state:${state} Inpc:0x${Hexadecimal(io.in.bits.uop.cf.pc)} InroqIdx:${io.in.bits.uop.roqIdx}\n")
   XSDebug(state =/= s_idle, p"state:${state} sbuffer(flush:${sbuffer} empty:${sbEmpty}) fencei:${fencei} sfence:${sfence}\n")

--- a/src/main/scala/xiangshan/backend/fu/FunctionUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FunctionUnit.scala
@@ -50,7 +50,8 @@ case class FuConfig
   latency: HasFuLatency = CertainLatency(0),
   fastUopOut: Boolean = false,
   fastImplemented: Boolean = false,
-  hasInputBuffer: Boolean = false
+  hasInputBuffer: Boolean = false,
+  hasExceptionOut: Boolean = false
 ) {
   def srcCnt: Int = math.max(numIntSrc, numFpSrc)
 }

--- a/src/main/scala/xiangshan/frontend/Ibuffer.scala
+++ b/src/main/scala/xiangshan/frontend/Ibuffer.scala
@@ -128,7 +128,6 @@ class Ibuffer(implicit p: Parameters) extends XSModule with HasCircularQueuePtrH
     io.out(i).bits.loadWaitBit := DontCare
     io.out(i).bits.storeSetHit := DontCare
     io.out(i).bits.ssid := DontCare
-    io.out(i).bits.replayInst := false.B
   }
   val next_head_vec = VecInit(head_vec.map(_ + numDeq))
   ibuf.io.raddr := VecInit(next_head_vec.map(_.value))

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -279,7 +279,8 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
     io.out.bits.miss := s2_cache_miss && !s2_exception && !s2_forward_fail
   }
   io.out.bits.uop.ctrl.fpWen := io.in.bits.uop.ctrl.fpWen && !s2_exception
-  io.out.bits.uop.cf.replayInst := s2_forward_fail && !s2_mmio // if forward fail, repaly this inst
+  // if forward fail, replay this inst
+  io.out.bits.uop.ctrl.replayInst := s2_forward_fail && !s2_mmio
   io.out.bits.mmio := s2_mmio
   
   // For timing reasons, sometimes we can not let

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -485,7 +485,8 @@ package object xiangshan {
     fuGen = fenceGen,
     fuSel = (uop: MicroOp) => uop.ctrl.fuType === FuType.fence,
     FuType.fence, 1, 0, writeIntRf = false, writeFpRf = false, hasRedirect = false,
-    UncertainLatency() // TODO: need rewrite latency structure, not just this value
+    latency = UncertainLatency(), // TODO: need rewrite latency structure, not just this value,
+    hasExceptionOut = true
   )
 
   val csrCfg = FuConfig(
@@ -497,7 +498,8 @@ package object xiangshan {
     numFpSrc = 0,
     writeIntRf = true,
     writeFpRf = false,
-    hasRedirect = false
+    hasRedirect = false,
+    hasExceptionOut = true
   )
 
   val i2fCfg = FuConfig(
@@ -596,7 +598,7 @@ package object xiangshan {
     null, // DontCare
     null,
     FuType.ldu, 1, 0, writeIntRf = true, writeFpRf = true, hasRedirect = false,
-    UncertainLatency()
+    latency = UncertainLatency(), hasExceptionOut = true
   )
 
   val staCfg = FuConfig(
@@ -604,7 +606,7 @@ package object xiangshan {
     null,
     null,
     FuType.stu, 1, 0, writeIntRf = false, writeFpRf = false, hasRedirect = false,
-    UncertainLatency()
+    latency = UncertainLatency(), hasExceptionOut = true
   )
 
   val stdCfg = FuConfig(
@@ -618,7 +620,7 @@ package object xiangshan {
     null,
     null,
     FuType.mou, 1, 0, writeIntRf = false, writeFpRf = false, hasRedirect = false,
-    UncertainLatency()
+    latency = UncertainLatency(), hasExceptionOut = true
   )
 
   val JumpExeUnitCfg = ExuConfig("JmpExeUnit", "Int", Seq(jmpCfg, i2fCfg), 2, Int.MaxValue)


### PR DESCRIPTION
This commit cleans up exception vector usages in backend.

Previously the exception vector will go through the pipeline with the
uop. However, instructions with exceptions will enter ROB when they are
dispatched. Thus, actually we don't need the exception vector when an
instruction enters a function unit.

* exceptionVec, flushPipe, replayInst are reset when an instruction
enters function units.

* For execution units that don't have exceptions, we reset their output
exception vectors to avoid ROB to record them.

* Move replayInst to CtrlSignals.