### PR TITLE
core: add timer counters for important stages

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -179,10 +179,12 @@ class CfCtrl(implicit p: Parameters) extends XSBundle {
 class PerfDebugInfo(implicit p: Parameters) extends XSBundle {
   val eliminatedMove = Bool()
   // val fetchTime = UInt(64.W)
-  val renameTime = UInt(64.W)
-  val dispatchTime = UInt(64.W)
-  val issueTime = UInt(64.W)
-  val writebackTime = UInt(64.W)
+  val renameTime = UInt(XLEN.W)
+  val dispatchTime = UInt(XLEN.W)
+  val enqRsTime = UInt(XLEN.W)
+  val selectTime = UInt(XLEN.W)
+  val issueTime = UInt(XLEN.W)
+  val writebackTime = UInt(XLEN.W)
   // val commitTime = UInt(64.W)
 }
 

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -328,9 +328,11 @@ class CtrlBlock(implicit p: Parameters) extends XSModule
 
   roq.io.redirect <> stage2Redirect
   val exeWbResults = VecInit(io.writeback ++ io.stOut)
+  val timer = GTimer()
   for((roq_wb, wb) <- roq.io.exeWbResults.zip(exeWbResults)) {
     roq_wb.valid := RegNext(wb.valid && !wb.bits.uop.roqIdx.needFlush(stage2Redirect, flushReg))
     roq_wb.bits := RegNext(wb.bits)
+    roq_wb.bits.uop.debugInfo.writebackTime := timer
   }
 
   // TODO: is 'backendRedirect' necesscary?

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -148,12 +148,7 @@ class Rename(implicit p: Parameters) extends XSModule {
     //   fl.cpReqs(i).bits := io.in(i).bits.brTag
     // }
 
-
     uops(i).roqIdx := roqIdxHead + PopCount(io.in.take(i).map(_.valid))
-
-    io.out(i).valid := io.in(i).valid && intFreeList.canAllocate && fpFreeList.canAllocate && !io.roqCommits.isWalk
-    io.out(i).bits := uops(i)
-
 
     // read rename table
     def readRat(lsrcList: List[UInt], ldest: UInt, fp: Boolean) = {
@@ -222,6 +217,12 @@ class Rename(implicit p: Parameters) extends XSModule {
                        Mux(uops(i).ctrl.ldest===0.U && uops(i).ctrl.rfWen, 0.U // int inst with dst=r0
                        /* default */, fpFreeList.allocatePhyReg(i))) // normal fp inst
     }
+
+    // Assign performance counters
+    uops(i).debugInfo.renameTime := GTimer()
+
+    io.out(i).valid := io.in(i).valid && intFreeList.canAllocate && fpFreeList.canAllocate && !io.roqCommits.isWalk
+    io.out(i).bits := uops(i)
 
     // write speculative rename table
     // we update rat later inside commit code

--- a/src/main/scala/xiangshan/backend/roq/Roq.scala
+++ b/src/main/scala/xiangshan/backend/roq/Roq.scala
@@ -360,11 +360,17 @@ class Roq(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   io.enq.canAccept := allowEnqueue && !hasBlockBackward
   io.enq.resp      := enqPtrVec
   val canEnqueue = VecInit(io.enq.req.map(_.valid && io.enq.canAccept))
+  val timer = GTimer()
   for (i <- 0 until RenameWidth) {
     // we don't check whether io.redirect is valid here since redirect has higher priority
     when (canEnqueue(i)) {
       // store uop in data module and debug_microOp Vec
       debug_microOp(enqPtrVec(i).value) := io.enq.req(i).bits
+      debug_microOp(enqPtrVec(i).value).debugInfo.dispatchTime := timer
+      debug_microOp(enqPtrVec(i).value).debugInfo.enqRsTime := timer
+      debug_microOp(enqPtrVec(i).value).debugInfo.selectTime := timer
+      debug_microOp(enqPtrVec(i).value).debugInfo.issueTime := timer
+      debug_microOp(enqPtrVec(i).value).debugInfo.writebackTime := timer
       when (io.enq.req(i).bits.ctrl.blockBackward) {
         hasBlockBackward := true.B
       }
@@ -393,6 +399,8 @@ class Roq(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
       debug_microOp(wbIdx).diffTestDebugLrScValid := io.exeWbResults(i).bits.uop.diffTestDebugLrScValid
       debug_exuData(wbIdx) := io.exeWbResults(i).bits.data
       debug_exuDebug(wbIdx) := io.exeWbResults(i).bits.debug
+      debug_microOp(wbIdx).debugInfo.enqRsTime := io.exeWbResults(i).bits.uop.debugInfo.enqRsTime
+      debug_microOp(wbIdx).debugInfo.selectTime := io.exeWbResults(i).bits.uop.debugInfo.selectTime
       debug_microOp(wbIdx).debugInfo.issueTime := io.exeWbResults(i).bits.uop.debugInfo.issueTime
       debug_microOp(wbIdx).debugInfo.writebackTime := io.exeWbResults(i).bits.uop.debugInfo.writebackTime
 
@@ -741,7 +749,7 @@ class Roq(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   )
   dispatchData.io.wen := canEnqueue
   dispatchData.io.waddr := enqPtrVec.map(_.value)
-  dispatchData.io.wdata.zip(io.enq.req.map(_.bits)).map{ case (wdata, req) =>
+  dispatchData.io.wdata.zip(io.enq.req.map(_.bits)).foreach{ case (wdata, req) =>
     wdata.ldest := req.ctrl.ldest
     wdata.rfWen := req.ctrl.rfWen
     wdata.fpWen := req.ctrl.fpWen
@@ -855,36 +863,67 @@ class Roq(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     if(i % 4 == 3) XSDebug(false, true.B, "\n")
   }
 
+  def ifCommit(counter: UInt): UInt = Mux(io.commits.isWalk, 0.U, counter)
+
+  val commitDebugUop = deqPtrVec.map(_.value).map(debug_microOp(_))
   XSPerfAccumulate("clock_cycle", 1.U)
   QueuePerf(RoqSize, PopCount((0 until RoqSize).map(valid(_))), !allowEnqueue)
-  XSPerfAccumulate("commitUop", Mux(io.commits.isWalk, 0.U, commitCnt))
-  XSPerfAccumulate("commitInstr", Mux(io.commits.isWalk, 0.U, trueCommitCnt))
-  val commitIsMove = deqPtrVec.map(_.value).map(ptr => debug_microOp(ptr).ctrl.isMove)
-  XSPerfAccumulate("commitInstrMove", Mux(io.commits.isWalk, 0.U, PopCount(io.commits.valid.zip(commitIsMove).map{ case (v, m) => v && m })))
+  XSPerfAccumulate("commitUop", ifCommit(commitCnt))
+  XSPerfAccumulate("commitInstr", ifCommit(trueCommitCnt))
+  val commitIsMove = commitDebugUop.map(_.ctrl.isMove)
+  XSPerfAccumulate("commitInstrMove", ifCommit(PopCount(io.commits.valid.zip(commitIsMove).map{ case (v, m) => v && m })))
   if (EnableIntMoveElim) {
-    val commitMoveElim = deqPtrVec.map(_.value).map(ptr => debug_microOp(ptr).debugInfo.eliminatedMove)
-    XSPerfAccumulate("commitInstrMoveElim", Mux(io.commits.isWalk, 0.U, PopCount(io.commits.valid zip commitMoveElim map { case (v, e) => v && e })))
+    val commitMoveElim = commitDebugUop.map(_.debugInfo.eliminatedMove)
+    XSPerfAccumulate("commitInstrMoveElim", ifCommit(PopCount(io.commits.valid zip commitMoveElim map { case (v, e) => v && e })))
   }
-  XSPerfAccumulate("commitInstrFused", Mux(io.commits.isWalk, 0.U, fuseCommitCnt))
+  XSPerfAccumulate("commitInstrFused", ifCommit(fuseCommitCnt))
   val commitIsLoad = io.commits.info.map(_.commitType).map(_ === CommitType.LOAD)
   val commitLoadValid = io.commits.valid.zip(commitIsLoad).map{ case (v, t) => v && t }
-  XSPerfAccumulate("commitInstrLoad", Mux(io.commits.isWalk, 0.U, PopCount(commitLoadValid)))
-  val commitLoadWaitBit = deqPtrVec.map(_.value).map(ptr => debug_microOp(ptr).cf.loadWaitBit)
-  XSPerfAccumulate("commitInstrLoadWait", Mux(io.commits.isWalk, 0.U, PopCount(commitLoadValid.zip(commitLoadWaitBit).map{ case (v, w) => v && w })))
+  XSPerfAccumulate("commitInstrLoad", ifCommit(PopCount(commitLoadValid)))
+  val commitLoadWaitBit = commitDebugUop.map(_.cf.loadWaitBit)
+  XSPerfAccumulate("commitInstrLoadWait", ifCommit(PopCount(commitLoadValid.zip(commitLoadWaitBit).map{ case (v, w) => v && w })))
   val commitIsStore = io.commits.info.map(_.commitType).map(_ === CommitType.STORE)
-  XSPerfAccumulate("commitInstrStore", Mux(io.commits.isWalk, 0.U, PopCount(io.commits.valid.zip(commitIsStore).map{ case (v, t) => v && t })))
+  XSPerfAccumulate("commitInstrStore", ifCommit(PopCount(io.commits.valid.zip(commitIsStore).map{ case (v, t) => v && t })))
   XSPerfAccumulate("writeback", PopCount((0 until RoqSize).map(i => valid(i) && writebacked(i))))
   // XSPerfAccumulate("enqInstr", PopCount(io.dp1Req.map(_.fire())))
   // XSPerfAccumulate("d2rVnR", PopCount(io.dp1Req.map(p => p.valid && !p.ready)))
-  XSPerfAccumulate("walkInstrAcc", Mux(io.commits.isWalk, PopCount(io.commits.valid), 0.U))
-  XSPerfAccumulate("walkCycleAcc", state === s_walk || state === s_extrawalk)
+  XSPerfAccumulate("walkInstr", Mux(io.commits.isWalk, PopCount(io.commits.valid), 0.U))
+  XSPerfAccumulate("walkCycle", state === s_walk || state === s_extrawalk)
   val deqNotWritebacked = valid(deqPtr.value) && !writebacked(deqPtr.value)
   val deqUopCommitType = io.commits.info(0).commitType
-  XSPerfAccumulate("waitNormalCycleAcc", deqNotWritebacked && deqUopCommitType === CommitType.NORMAL)
-  XSPerfAccumulate("waitBranchCycleAcc", deqNotWritebacked && deqUopCommitType === CommitType.BRANCH)
-  XSPerfAccumulate("waitLoadCycleAcc", deqNotWritebacked && deqUopCommitType === CommitType.LOAD)
-  XSPerfAccumulate("waitStoreCycleAcc", deqNotWritebacked && deqUopCommitType === CommitType.STORE)
+  XSPerfAccumulate("waitNormalCycle", deqNotWritebacked && deqUopCommitType === CommitType.NORMAL)
+  XSPerfAccumulate("waitBranchCycle", deqNotWritebacked && deqUopCommitType === CommitType.BRANCH)
+  XSPerfAccumulate("waitLoadCycle", deqNotWritebacked && deqUopCommitType === CommitType.LOAD)
+  XSPerfAccumulate("waitStoreCycle", deqNotWritebacked && deqUopCommitType === CommitType.STORE)
   XSPerfAccumulate("roqHeadPC", io.commits.info(0).pc)
+  val dispatchLatency = commitDebugUop.map(uop => uop.debugInfo.dispatchTime - uop.debugInfo.renameTime)
+  val enqRsLatency = commitDebugUop.map(uop => uop.debugInfo.enqRsTime - uop.debugInfo.dispatchTime)
+  val selectLatency = commitDebugUop.map(uop => uop.debugInfo.selectTime - uop.debugInfo.enqRsTime)
+  val issueLatency = commitDebugUop.map(uop => uop.debugInfo.issueTime - uop.debugInfo.selectTime)
+  val executeLatency = commitDebugUop.map(uop => uop.debugInfo.writebackTime - uop.debugInfo.issueTime)
+  val rsFuLatency = commitDebugUop.map(uop => uop.debugInfo.writebackTime - uop.debugInfo.enqRsTime)
+  val commitLatency = commitDebugUop.map(uop => timer - uop.debugInfo.writebackTime)
+  def latencySum(cond: Seq[Bool], latency: Seq[UInt]): UInt = {
+    cond.zip(latency).map(x => Mux(x._1, x._2, 0.U)).reduce(_ +& _)
+  }
+  for (fuType <- FuType.functionNameMap.keys) {
+    val fuName = FuType.functionNameMap(fuType)
+    val commitIsFuType = io.commits.valid.zip(commitDebugUop).map(x => x._1 && x._2.ctrl.fuType === fuType.U )
+    XSPerfAccumulate(s"${fuName}_instr_cnt", ifCommit(PopCount(commitIsFuType)))
+    XSPerfAccumulate(s"${fuName}_latency_dispatch", ifCommit(latencySum(commitIsFuType, dispatchLatency)))
+    XSPerfAccumulate(s"${fuName}_latency_enq_rs", ifCommit(latencySum(commitIsFuType, enqRsLatency)))
+    XSPerfAccumulate(s"${fuName}_latency_select", ifCommit(latencySum(commitIsFuType, selectLatency)))
+    XSPerfAccumulate(s"${fuName}_latency_issue", ifCommit(latencySum(commitIsFuType, issueLatency)))
+    XSPerfAccumulate(s"${fuName}_latency_execute", ifCommit(latencySum(commitIsFuType, executeLatency)))
+    XSPerfAccumulate(s"${fuName}_latency_enq_rs_execute", ifCommit(latencySum(commitIsFuType, rsFuLatency)))
+    XSPerfAccumulate(s"${fuName}_latency_commit", ifCommit(latencySum(commitIsFuType, commitLatency)))
+    if (fuType == FuType.fmac.litValue()) {
+      val commitIsFma = commitIsFuType.zip(commitDebugUop).map(x => x._1 && x._2.ctrl.fpu.ren3 )
+      XSPerfAccumulate(s"${fuName}_instr_cnt_fma", ifCommit(PopCount(commitIsFma)))
+      XSPerfAccumulate(s"${fuName}_latency_enq_rs_execute_fma", ifCommit(latencySum(commitIsFma, rsFuLatency)))
+      XSPerfAccumulate(s"${fuName}_latency_execute_fma", ifCommit(latencySum(commitIsFma, executeLatency)))
+    }
+  }
 
   val l1Miss = Wire(Bool())
   l1Miss := false.B
@@ -899,12 +938,10 @@ class Roq(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   val wpc = Wire(Vec(CommitWidth, UInt(XLEN.W)))
   val trapVec = Wire(Vec(CommitWidth, Bool()))
   for(i <- 0 until CommitWidth) {
-    // io.commits(i).valid
     val idx = deqPtrVec(i).value
-    val uop = debug_microOp(idx)
     wdata(i) := debug_exuData(idx)
-    wpc(i) := SignExt(uop.cf.pc, XLEN)
-    trapVec(i) := io.commits.valid(i) && (state===s_idle) && uop.ctrl.isXSTrap
+    wpc(i) := SignExt(commitDebugUop(i).cf.pc, XLEN)
+    trapVec(i) := io.commits.valid(i) && (state===s_idle) && commitDebugUop(i).ctrl.isXSTrap
   }
   val retireCounterFix = Mux(io.exception.valid, 1.U, retireCounter)
   val retirePCFix = SignExt(Mux(io.exception.valid, io.exception.bits.uop.cf.pc, debug_microOp(firstValidCommit).cf.pc), XLEN)
@@ -922,7 +959,7 @@ class Roq(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
       difftest.io.index    := i.U
 
       val ptr = deqPtrVec(i).value
-      val uop = debug_microOp(ptr)
+      val uop = commitDebugUop(i)
       val exuOut = debug_exuDebug(ptr)
       val exuData = debug_exuData(ptr)
       difftest.io.valid    := RegNext(io.commits.valid(i) && !io.commits.isWalk)
@@ -956,7 +993,7 @@ class Roq(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
       difftest.io.index  := i.U
 
       val ptr = deqPtrVec(i).value
-      val uop = debug_microOp(ptr)
+      val uop = commitDebugUop(i)
       val exuOut = debug_exuDebug(ptr)
       difftest.io.valid  := RegNext(io.commits.valid(i) && !io.commits.isWalk)
       difftest.io.paddr  := RegNext(exuOut.paddr)
@@ -972,7 +1009,7 @@ class Roq(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     difftest.io.valid    := hitTrap
     difftest.io.code     := trapCode
     difftest.io.pc       := trapPC
-    difftest.io.cycleCnt := GTimer()
+    difftest.io.cycleCnt := timer
     difftest.io.instrCnt := instrCnt
   }
 }

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -215,7 +215,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
       val dcacheMissed = io.loadIn(i).bits.miss && !io.loadIn(i).bits.mmio
       miss(loadWbIndex) := dcacheMissed && !io.loadDataForwarded(i) && !io.needReplayFromRS(i)
       pending(loadWbIndex) := io.loadIn(i).bits.mmio
-      uop(loadWbIndex).debugInfo.issueTime := io.loadIn(i).bits.uop.debugInfo.issueTime
+      uop(loadWbIndex).debugInfo := io.loadIn(i).bits.uop.debugInfo
     }
     // vaddrModule write is delayed, as vaddrModule will not be read right after write
     vaddrModule.io.waddr(i) := RegNext(loadWbIndex)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -229,6 +229,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParamete
 
       mmio(stWbIndex) := io.storeIn(i).bits.mmio
 
+      uop(stWbIndex).debugInfo := io.storeIn(i).bits.uop.debugInfo
       XSInfo("store addr write to sq idx %d pc 0x%x vaddr %x paddr %x mmio %x\n",
         io.storeIn(i).bits.uop.sqIdx.value,
         io.storeIn(i).bits.uop.cf.pc,

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -95,19 +95,20 @@ package object xiangshan {
 
     val functionNameMap = Map(
       jmp.litValue() -> "jmp",
-      i2f.litValue() -> "int to float",
+      i2f.litValue() -> "int_to_float",
       csr.litValue() -> "csr",
       alu.litValue() -> "alu",
       mul.litValue() -> "mul",
       div.litValue() -> "div",
       fence.litValue() -> "fence",
+      bmu.litValue() -> "bmu",
       fmac.litValue() -> "fmac",
       fmisc.litValue() -> "fmisc",
       fDivSqrt.litValue() -> "fdiv/fsqrt",
       ldu.litValue() -> "load",
-      stu.litValue() -> "store"
+      stu.litValue() -> "store",
+      mou.litValue() -> "mou"
     )
-
   }
 
   object FuOpType {


### PR DESCRIPTION
This commit adds timer counters for some important pipeline stages,
including rename, dispatch, dispatch2, select, issue, execute, commit.
We add performance counters for different types of instructions to see
the latency in different pipeline stages.