### PR TITLE
backend: add performance counters for first issue

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/fpu/FMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/fpu/FMA.scala
@@ -263,4 +263,6 @@ class FMA(implicit p: Parameters) extends FPUSubModule {
   )
   io.out.valid := add_pipe.io.out.valid || (mul_pipe.io.out.valid && !isFMA && !waitAddOperand)
 
+  XSPerfAccumulate("fma_partial_issue_fire", io.in.fire && midResult.waitForAdd)
+  XSPerfAccumulate("fma_mid_result_in_fire", io.in.fire && midResult.in.valid)
 }

--- a/src/main/scala/xiangshan/mem/MemUtils.scala
+++ b/src/main/scala/xiangshan/mem/MemUtils.scala
@@ -64,6 +64,9 @@ class LsPipelineBundle(implicit p: Parameters) extends XSBundle {
 
   val forwardMask = Vec(8, Bool())
   val forwardData = Vec(8, UInt(8.W))
+
+  // For debug usage
+  val isFirstIssue = Bool()
 }
 
 class StoreDataBundle(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -109,13 +109,16 @@ class LoadUnit_S0(implicit p: Parameters) extends XSModule {
   io.out.bits.uop := s0_uop
   io.out.bits.uop.cf.exceptionVec(loadAddrMisaligned) := !addrAligned
   io.out.bits.rsIdx := io.rsIdx
+  io.out.bits.isFirstIssue := io.isFirstIssue
 
   io.in.ready := !io.in.valid || (io.out.ready && io.dcacheReq.ready)
 
   XSDebug(io.dcacheReq.fire(),
     p"[DCACHE LOAD REQ] pc ${Hexadecimal(s0_uop.cf.pc)}, vaddr ${Hexadecimal(s0_vaddr)}\n"
   )
-  XSPerfAccumulate("in", io.in.valid)
+  XSPerfAccumulate("in_valid", io.in.valid)
+  XSPerfAccumulate("in_fire", io.in.fire)
+  XSPerfAccumulate("in_fire_first_issue", io.in.valid && io.isFirstIssue)
   XSPerfAccumulate("stall_out", io.out.valid && !io.out.ready && io.dcacheReq.ready)
   XSPerfAccumulate("stall_dcache", io.out.valid && io.out.ready && !io.dcacheReq.ready)
   XSPerfAccumulate("addr_spec_success", io.out.fire() && s0_vaddr(VAddrBits-1, 12) === io.in.bits.src(0)(VAddrBits-1, 12))
@@ -188,8 +191,11 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
 
   io.in.ready := !io.in.valid || io.out.ready
 
-  XSPerfAccumulate("in", io.in.valid)
-  XSPerfAccumulate("tlb_miss", io.in.valid && s1_tlb_miss)
+  XSPerfAccumulate("in_valid", io.in.valid)
+  XSPerfAccumulate("in_fire", io.in.fire)
+  XSPerfAccumulate("in_fire_first_issue", io.in.fire && io.in.bits.isFirstIssue)
+  XSPerfAccumulate("tlb_miss", io.in.fire && s1_tlb_miss)
+  XSPerfAccumulate("tlb_miss_first_issue", io.in.fire && s1_tlb_miss && io.in.bits.isFirstIssue)
   XSPerfAccumulate("stall_out", io.out.valid && !io.out.ready)
 }
 
@@ -322,8 +328,11 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
     forwardData.asUInt, forwardMask.asUInt
   )
 
-  XSPerfAccumulate("in", io.in.valid)
-  XSPerfAccumulate("dcache_miss", io.in.valid && s2_cache_miss)
+  XSPerfAccumulate("in_valid", io.in.valid)
+  XSPerfAccumulate("in_fire", io.in.fire)
+  XSPerfAccumulate("in_fire_first_issue", io.in.fire && io.in.bits.isFirstIssue)
+  XSPerfAccumulate("dcache_miss", io.in.fire && s2_cache_miss)
+  XSPerfAccumulate("dcache_miss_first_issue", io.in.fire && s2_cache_miss && io.in.bits.isFirstIssue)
   XSPerfAccumulate("full_forward", io.in.valid && fullForward)
   XSPerfAccumulate("dcache_miss_full_forward", io.in.valid && s2_cache_miss && fullForward)
   XSPerfAccumulate("replay",  io.rsFeedback.valid && !io.rsFeedback.bits.hit)

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -63,6 +63,7 @@ class StoreUnit_S0(implicit p: Parameters) extends XSModule {
   io.out.bits.miss := DontCare
   io.out.bits.rsIdx := io.rsIdx
   io.out.bits.mask := genWmask(io.out.bits.vaddr, io.in.bits.uop.ctrl.fuOpType(1,0))
+  io.out.bits.isFirstIssue := io.isFirstIssue
   io.out.valid := io.in.valid
   io.in.ready := io.out.ready
 
@@ -75,13 +76,16 @@ class StoreUnit_S0(implicit p: Parameters) extends XSModule {
   ))
   io.out.bits.uop.cf.exceptionVec(storeAddrMisaligned) := !addrAligned
 
+  XSPerfAccumulate("in_valid", io.in.valid)
+  XSPerfAccumulate("in_fire", io.in.fire)
+  XSPerfAccumulate("in_fire_first_issue", io.in.fire && io.isFirstIssue)
   XSPerfAccumulate("addr_spec_success", io.out.fire() && saddr(VAddrBits-1, 12) === io.in.bits.src(0)(VAddrBits-1, 12))
   XSPerfAccumulate("addr_spec_failed", io.out.fire() && saddr(VAddrBits-1, 12) =/= io.in.bits.src(0)(VAddrBits-1, 12))
   XSPerfAccumulate("addr_spec_success_once", io.out.fire() && saddr(VAddrBits-1, 12) === io.in.bits.src(0)(VAddrBits-1, 12) && io.isFirstIssue)
   XSPerfAccumulate("addr_spec_failed_once", io.out.fire() && saddr(VAddrBits-1, 12) =/= io.in.bits.src(0)(VAddrBits-1, 12) && io.isFirstIssue)
 }
 
-// Load Pipeline Stage 1
+// Store Pipeline Stage 1
 // TLB resp (send paddr to dcache)
 class StoreUnit_S1(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
@@ -127,6 +131,12 @@ class StoreUnit_S1(implicit p: Parameters) extends XSModule {
   // mmio inst with exception will be writebacked immediately
   io.out.valid := io.in.valid && (!io.out.bits.mmio || s1_exception) && !s1_tlb_miss
   io.out.bits := io.lsq.bits
+
+  XSPerfAccumulate("in_valid", io.in.valid)
+  XSPerfAccumulate("in_fire", io.in.fire)
+  XSPerfAccumulate("in_fire_first_issue", io.in.fire && io.in.bits.isFirstIssue)
+  XSPerfAccumulate("tlb_miss", io.in.fire && s1_tlb_miss)
+  XSPerfAccumulate("tlb_miss_first_issue", io.in.fire && s1_tlb_miss && io.in.bits.isFirstIssue)
 }
 
 class StoreUnit_S2(implicit p: Parameters) extends XSModule {


### PR DESCRIPTION
This commit adds performance counters for function units that have
feedback to reservation stations, including FMA, Load and Store.
We add performance counters to show how many instructions are issued for
multiple times.