### PR TITLE
backend: optimize aluOpType to 7 bits

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -58,12 +58,12 @@ jobs:
       - name: Basic Test - riscv-tests
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --threads 8 --rvtest /home/ci-runner/xsenv/riscv-tests --ci riscv-tests 2> /dev/zero
-      - name: Misc Bitmanip Test
+      - name: Basic Test - misc-tests
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --threads 8 --numa --ci bitmanip 2> /dev/zero
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --threads 8 --ci misc-tests 2> /dev/zero
       - name: Simple Test - microbench
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --threads 8 --numa --ci microbench 2> perf.log
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --threads 8 --ci microbench 2> perf.log
           cat perf.log | sort | tee $PERF_HOME/microbench.log
       - name: Simple Test - CoreMark
         run: |

--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -209,6 +209,17 @@ class XiangShan(object):
         riscv_tests = map(lambda x: os.path.join(base_dir, x), riscv_tests)
         return riscv_tests
 
+    def __get_ci_misc(self, name=None):
+        base_dir = "/home/ci-runner/xsenv/workloads"
+        workloads = [
+            "bitmanip/bitMisc.bin",
+            "coremark_rv64gc_o2/coremark-riscv64-xs.bin",
+            "coremark_rv64gc_o3/coremark-riscv64-xs.bin",
+            "coremark_rv64gcb_o3/coremark-riscv64-xs.bin"
+        ]
+        misc_tests = map(lambda x: os.path.join(base_dir, x), workloads)
+        return misc_tests
+
     def __am_apps_path(self, bench):
         filename = f"{bench}-riscv64-noop.bin"
         return [os.path.join(self.args.am_home, "apps", bench, "build", filename)]
@@ -216,7 +227,6 @@ class XiangShan(object):
     def __get_ci_workloads(self, name):
         workloads = {
             "linux-hello": "bbl.bin",
-            "bitmanip": "bitMisc.bin",
             "povray": "_700480000000_.gz",
             "mcf": "_17520000000_.gz",
             "xalancbmk": "_266100000000_.gz",
@@ -232,6 +242,7 @@ class XiangShan(object):
         all_tests = {
             "cputest": self.__get_ci_cputest,
             "riscv-tests": self.__get_ci_rvtest,
+            "misc-tests": self.__get_ci_misc,
             "microbench": self.__am_apps_path,
             "coremark": self.__am_apps_path
         }

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -206,18 +206,20 @@ object XDecode extends DecodeConstants {
     ANDN    -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.andn, Y, N, N, N, N, N, N, SelImm.IMM_X),
     ORN     -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.orn, Y, N, N, N, N, N, N, SelImm.IMM_X),
     XNOR    -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.xnor, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    ORC_B   -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.alu, ALUOpType.orcb, Y, N, N, N, N, N, N, SelImm.IMM_X),
 
     MIN     -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.min, Y, N, N, N, N, N, N, SelImm.IMM_X),
     MINU    -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.minu, Y, N, N, N, N, N, N, SelImm.IMM_X),
     MAX     -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.max, Y, N, N, N, N, N, N, SelImm.IMM_X),
     MAXU    -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.maxu, Y, N, N, N, N, N, N, SelImm.IMM_X),
 
-    SEXT_B  -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.alu, ALUOpType.sext_b, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    SEXT_H  -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.alu, ALUOpType.sext_h, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    // ZEXT_H  -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.alu, ALUOpType.zext_h, Y, N, N, N, N, N, N, SelImm.IMM_X),
-
-    ORC_B   -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.alu, ALUOpType.orc_b, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    SEXT_B  -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.alu, ALUOpType.sextb, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    PACKH   -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.packh, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    SEXT_H  -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.alu, ALUOpType.sexth, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    PACKW   -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.packw, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    REVB    -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.alu, ALUOpType.revb, Y, N, N, N, N, N, N, SelImm.IMM_X),
     REV8    -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.alu, ALUOpType.rev8, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    PACK    -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.pack, Y, N, N, N, N, N, N, SelImm.IMM_X),
 
     BSET    -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.bset, Y, N, N, N, N, N, N, SelImm.IMM_X),
     BSETI   -> List(SrcType.reg, SrcType.imm, SrcType.DC, FuType.alu, ALUOpType.bset, Y, N, N, N, N, N, N, SelImm.IMM_I),
@@ -235,11 +237,11 @@ object XDecode extends DecodeConstants {
     SH1ADD  -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.sh1add, Y, N, N, N, N, N, N, SelImm.IMM_X),
     SH2ADD  -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.sh2add, Y, N, N, N, N, N, N, SelImm.IMM_X),
     SH3ADD  -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.sh3add, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    SH1ADDU_W   -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.sh1add_uw, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    SH2ADDU_W   -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.sh2add_uw, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    SH3ADDU_W   -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.sh3add_uw, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    ADDU_W      -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.add_uw, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    SLLIU_W     -> List(SrcType.reg, SrcType.imm, SrcType.DC, FuType.alu, ALUOpType.slli_uw, Y, N, N, N, N, N, N, SelImm.IMM_I)
+    SH1ADDU_W   -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.sh1adduw, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    SH2ADDU_W   -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.sh2adduw, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    SH3ADDU_W   -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.sh3adduw, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    ADDU_W      -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.alu, ALUOpType.adduw, Y, N, N, N, N, N, N, SelImm.IMM_X),
+    SLLIU_W     -> List(SrcType.reg, SrcType.imm, SrcType.DC, FuType.alu, ALUOpType.slliuw, Y, N, N, N, N, N, N, SelImm.IMM_I)
   )
 }
 
@@ -336,14 +338,9 @@ object BDecode extends DecodeConstants{
     CLZ     -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.bmu, BMUOpType.clz, Y, N, N, N, N, N, N, SelImm.IMM_X),
     CTZ     -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.bmu, BMUOpType.ctz, Y, N, N, N, N, N, N, SelImm.IMM_X),
     CPOP    -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.bmu, BMUOpType.cpop, Y, N, N, N, N, N, N, SelImm.IMM_X),
-
-    REVB    -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.bmu, BMUOpType.revb, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    PACK    -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.bmu, BMUOpType.pack, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    PACKH   -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.bmu, BMUOpType.packh, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    PACKW   -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.bmu, BMUOpType.packw, Y, N, N, N, N, N, N, SelImm.IMM_X),
     XPERM_B -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.bmu, BMUOpType.xpermb, Y, N, N, N, N, N, N, SelImm.IMM_X),
     XPERM_N -> List(SrcType.reg, SrcType.reg, SrcType.DC, FuType.bmu, BMUOpType.xpermn, Y, N, N, N, N, N, N, SelImm.IMM_X),
-    
+
     CLZW    -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.bmu, BMUOpType.clzw, Y, N, N, N, N, N, N, SelImm.IMM_X),
     CTZW    -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.bmu, BMUOpType.ctzw, Y, N, N, N, N, N, N, SelImm.IMM_X),
     CPOPW   -> List(SrcType.reg, SrcType.DC, SrcType.DC, FuType.bmu, BMUOpType.cpopw, Y, N, N, N, N, N, N, SelImm.IMM_X),

--- a/src/main/scala/xiangshan/backend/decode/FusionDecoder.scala
+++ b/src/main/scala/xiangshan/backend/decode/FusionDecoder.scala
@@ -408,12 +408,13 @@ class FusedAddwbyte(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(im
     cs
   }
 
-  def fusionName: String = "andw_andi255"
+  def fusionName: String = "addw_andi255"
 }
 
 // Case: addw and extract its lower 1 bit (fused into addwbit)
 class FusedAddwbit(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(implicit p: Parameters)
   extends FusedAddwbyte(pair, csPair) {
+
   override def inst2Cond = instr(1) === Instructions.ANDI && instr(1)(31, 20) === 0x1.U
   override def target: CtrlSignals = {
     val cs = WireInit(csPair.get(0))
@@ -421,7 +422,38 @@ class FusedAddwbit(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(imp
     cs.fuOpType := ALUOpType.addwbit
     cs
   }
-  override def fusionName: String = "andw_andi1"
+
+  override def fusionName: String = "addw_andi1"
+}
+
+// Case: addw and zext.h (fused into addwzexth)
+class FusedAddwzexth(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(implicit p: Parameters)
+  extends FusedAddwbyte(pair, csPair) {
+
+  override def inst2Cond = instr(1) === Instructions.ZEXT_H
+  override def target: CtrlSignals = {
+    val cs = WireInit(csPair.get(0))
+    // replace the fuOpType with addwzexth
+    cs.fuOpType := ALUOpType.addwzexth
+    cs
+  }
+
+  override def fusionName: String = "addw_zexth"
+}
+
+// Case: addw and sext.h (fused into addwsexth)
+class FusedAddwsexth(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(implicit p: Parameters)
+  extends FusedAddwbyte(pair, csPair) {
+
+  override def inst2Cond = instr(1) === Instructions.SEXT_H
+  override def target: CtrlSignals = {
+    val cs = WireInit(csPair.get(0))
+    // replace the fuOpType with addwsexth
+    cs.fuOpType := ALUOpType.addwsexth
+    cs
+  }
+
+  override def fusionName: String = "addw_sexth"
 }
 
 // Case: logic operation and extract its LSB
@@ -430,18 +462,32 @@ class FusedLogiclsb(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(im
   require(csPair.isDefined)
 
   // the first instruction is a logic
-  def inst1Cond = csPair.get(0).fuType === FuType.alu && ALUOpType.isLogic(csPair.get(0).fuOpType)
+  def inst1Cond = csPair.get(0).fuType === FuType.alu && ALUOpType.isSimpleLogic(csPair.get(0).fuOpType)
   def inst2Cond = instr(1) === Instructions.ANDI && instr(1)(31, 20) === 1.U
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && destToRs1
   def target: CtrlSignals = {
     val cs = WireInit(csPair.get(0))
     // change the opType to lsb format
-    cs.fuOpType := ALUOpType.logicToLSB(csPair.get(0).fuOpType)
+    cs.fuOpType := ALUOpType.logicToLsb(csPair.get(0).fuOpType)
     cs
   }
 
   def fusionName: String = "logic_andi1"
+}
+
+class FusedLogicZexth(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(implicit p: Parameters)
+  extends FusedLogiclsb(pair, csPair) {
+
+  override def inst2Cond = instr(1) === Instructions.ZEXT_H
+  override def target: CtrlSignals = {
+    val cs = WireInit(csPair.get(0))
+    // change the opType to lzext format
+    cs.fuOpType := ALUOpType.logicToZexth(csPair.get(0).fuOpType)
+    cs
+  }
+
+  override def fusionName: String = "logic_zexth"
 }
 
 // Case: OR(Cat(src1(63, 8), 0.U(8.W)), src2)
@@ -524,7 +570,10 @@ class FusionDecoder(implicit p: Parameters) extends XSModule {
       new FusedOddaddw(pair),
       new FusedAddwbyte(pair, Some(cs)),
       new FusedAddwbit(pair, Some(cs)),
+      new FusedAddwzexth(pair, Some(cs)),
+      new FusedAddwsexth(pair, Some(cs)),
       new FusedLogiclsb(pair, Some(cs)),
+      new FusedLogicZexth(pair, Some(cs)),
       new FusedOrh48(pair),
       new FusedMulw7(pair, Some(cs))
     )

--- a/src/main/scala/xiangshan/backend/decode/Instructions.scala
+++ b/src/main/scala/xiangshan/backend/decode/Instructions.scala
@@ -14,6 +14,9 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
+// See LICENSE.SiFive for license details.
+// See LICENSE.Berkeley for license details.
+
 package xiangshan.backend.decode
 
 import chisel3._

--- a/src/main/scala/xiangshan/backend/fu/Alu.scala
+++ b/src/main/scala/xiangshan/backend/fu/Alu.scala
@@ -96,50 +96,58 @@ class RightShiftWordModule(implicit p: Parameters) extends XSModule {
 
 class MiscResultSelect(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
-    val func = Input(UInt(5.W))
-    val andn, orn, xnor, and, or, xor, orh48, sextb, sexth, zexth, rev8, orcb = Input(UInt(XLEN.W))
+    val func = Input(UInt(6.W))
+    val and, or, xor, orcb, orh48, sextb, packh, sexth, packw, revb, rev8, pack = Input(UInt(XLEN.W))
     val src = Input(UInt(XLEN.W))
     val miscRes = Output(UInt(XLEN.W))
   })
 
-  val logicResSel = ParallelMux(List(
-    ALUOpType.andn  -> io.andn,
-    ALUOpType.and   -> io.and,
-    ALUOpType.orn   -> io.orn,
-    ALUOpType.or    -> io.or,
-    ALUOpType.xnor  -> io.xnor,
-    ALUOpType.xor   -> io.xor,
-    ALUOpType.orh48 -> io.orh48,
-    ALUOpType.orc_b -> io.orcb
-  ).map(x => (x._1(2, 0) === io.func(2, 0), x._2)))
-  val maskedLogicRes = Cat(Fill(63, ~io.func(3)), 1.U(1.W)) & logicResSel
+  val logicRes = VecInit(Seq(
+    io.and,
+    io.or,
+    io.xor,
+    io.orcb
+  ))(io.func(2, 1))
+  val miscRes = VecInit(Seq(io.sextb, io.packh, io.sexth, io.packw))(io.func(1, 0))
+  val logicBase = Mux(io.func(3), miscRes, logicRes)
 
-  val miscRes = ParallelMux(List(
-    ALUOpType.sext_b -> io.sextb,
-    ALUOpType.sext_h -> io.sexth,
-    // ALUOpType.zext_h -> io.zexth,
-    ALUOpType.rev8   -> io.rev8,
-    ALUOpType.szewl1 -> Cat(0.U(31.W), io.src(31, 0), 0.U(1.W)),
-    ALUOpType.szewl2 -> Cat(0.U(30.W), io.src(31, 0), 0.U(2.W)),
-    ALUOpType.szewl3 -> Cat(0.U(29.W), io.src(31, 0), 0.U(3.W)),
-    ALUOpType.byte2  -> Cat(0.U(56.W), io.src(15, 8))
-  ).map(x => (x._1(2, 0) === io.func(2, 0), x._2)))
+  val revRes = VecInit(Seq(io.revb, io.rev8, io.pack, io.orh48))(io.func(1, 0))
+  val customRes = VecInit(Seq(
+    Cat(0.U(31.W), io.src(31, 0), 0.U(1.W)),
+    Cat(0.U(30.W), io.src(31, 0), 0.U(2.W)),
+    Cat(0.U(29.W), io.src(31, 0), 0.U(3.W)),
+    Cat(0.U(56.W), io.src(15, 8))))(io.func(1, 0))
+  val logicAdv = Mux(io.func(3), customRes, revRes)
 
-  io.miscRes := Mux(io.func(3) && !io.func(4), miscRes, maskedLogicRes)
+  val mask = Cat(Fill(15, io.func(0)), 1.U(1.W))
+  val maskedLogicRes = mask & logicRes
+
+  io.miscRes := Mux(io.func(5), maskedLogicRes, Mux(io.func(4), logicAdv, logicBase))
 }
 
 class ShiftResultSelect(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
-    val func = Input(UInt())
+    val func = Input(UInt(4.W))
     val sll, srl, sra, rol, ror, bclr, bset, binv, bext = Input(UInt(XLEN.W))
     val shiftRes = Output(UInt(XLEN.W))
   })
-  
-  val leftBit  = Mux(io.func(1), io.binv, Mux(io.func(0), io.bset, io.bclr))
-  val leftRes  = Mux(io.func(2), leftBit, io.sll)
-  val rightRes = Mux(io.func(2), io.sra, Mux(io.func(1), io.bext, io.srl))
 
-  io.shiftRes := Mux(io.func(4), Mux(io.func(3), io.ror, io.rol), Mux(io.func(3), rightRes, leftRes))
+  // val leftBit  = Mux(io.func(1), io.binv, Mux(io.func(0), io.bset, io.bclr))
+  // val leftRes  = Mux(io.func(2), leftBit, io.sll)
+  // val rightRes = Mux(io.func(1) && io.func(0), io.sra, Mux(io.func(1), io.bext, io.srl))
+  val resultSource = VecInit(Seq(
+    io.sll,
+    io.sll,
+    io.bclr,
+    io.bset,
+    io.binv,
+    io.srl,
+    io.bext,
+    io.sra
+  ))
+  val simple = resultSource(io.func(2, 0))
+
+  io.shiftRes := Mux(io.func(3), Mux(io.func(0), io.ror, io.rol), simple)
 }
 
 class WordResultSelect(implicit p: Parameters) extends XSModule {
@@ -149,28 +157,23 @@ class WordResultSelect(implicit p: Parameters) extends XSModule {
     val wordRes = Output(UInt(XLEN.W))
   })
 
-  val addsubRes = Mux(io.func(6), io.subw, io.addw)
-  val shiftRes = Mux(io.func(4), 
-                  Mux(io.func(3), io.rorw, io.rolw),
-                  Mux(io.func(3), 
-                    Mux(io.func(2), io.sraw, io.srlw), 
-                    io.sllw))
-  val wordRes = Mux(io.func(6,5) === 2.U, shiftRes, addsubRes)
+  val addsubRes = Mux(!io.func(2) && io.func(1), io.subw, io.addw)
+  val shiftRes = Mux(io.func(2), Mux(io.func(0), io.rorw, io.rolw),
+                  Mux(io.func(1), io.sraw, Mux(io.func(0), io.srlw, io.sllw)))
+  val wordRes = Mux(io.func(3), shiftRes, addsubRes)
   io.wordRes := SignExt(wordRes, XLEN)
 }
 
 
 class AluResSel(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
-    val func = Input(UInt())
+    val func = Input(UInt(3.W))
     val addRes, shiftRes, miscRes, compareRes, wordRes = Input(UInt(XLEN.W))
     val aluRes = Output(UInt(XLEN.W))
   })
-  
-  val res = Mux(io.func(7), io.wordRes, Mux(io.func(6),
-    Mux(io.func(5), io.compareRes, io.shiftRes),
-    Mux(io.func(5), io.addRes, io.miscRes)
-  ))
+
+  val res = Mux(io.func(2, 1) === 0.U, Mux(io.func(0), io.wordRes, io.shiftRes),
+            Mux(!io.func(2), Mux(io.func(0), io.compareRes, io.addRes), io.miscRes))
   io.aluRes := res
 }
 
@@ -184,10 +187,73 @@ class AluDataModule(implicit p: Parameters) extends XSModule {
   })
   val (src1, src2, func) = (io.src(0), io.src(1), io.func)
 
+  val shamt = src2(5, 0)
+  val revShamt = ~src2(5,0) + 1.U
+
+  // slliuw, sll
+  val leftShiftModule = Module(new LeftShiftModule)
+  val sll = leftShiftModule.io.sll
+  val revSll = leftShiftModule.io.revSll
+  leftShiftModule.io.sllSrc := Cat(Fill(32, func(0)), Fill(32, 1.U)) & src1
+  leftShiftModule.io.shamt := shamt
+  leftShiftModule.io.revShamt := revShamt
+
+  // bclr, bset, binv
+  val bitShift = 1.U << src2(5, 0)
+  val bclr = src1 & ~bitShift
+  val bset = src1 | bitShift
+  val binv = src1 ^ bitShift
+
+  // srl, sra, bext
+  val rightShiftModule = Module(new RightShiftModule)
+  val srl = rightShiftModule.io.srl
+  val revSrl = rightShiftModule.io.revSrl
+  val sra = rightShiftModule.io.sra
+  rightShiftModule.io.shamt := shamt
+  rightShiftModule.io.revShamt := revShamt
+  rightShiftModule.io.srlSrc := src1
+  rightShiftModule.io.sraSrc := src1
+  val bext = srl(0)
+
+  val rol = revSrl | sll
+  val ror = srl | revSll
+
+  // addw
   val addModule = Module(new AddModule)
-  // For 64-bit adder:
-  // BITS(2, 1): shamt (0, 1, 2, 3)
-  // BITS(3   ): different fused cases
+  addModule.io.srcw := Mux(!func(2) && func(0), ZeroExt(src1(0), XLEN), src1(31, 0))
+  val addwResultAll = VecInit(Seq(
+    ZeroExt(addModule.io.addw(0), XLEN),
+    ZeroExt(addModule.io.addw(7, 0), XLEN),
+    ZeroExt(addModule.io.addw(15, 0), XLEN),
+    SignExt(addModule.io.addw(15, 0), XLEN)
+  ))
+  val addw = Mux(func(2), addwResultAll(func(1, 0)), addModule.io.addw)
+
+  // subw
+  val subModule = Module(new SubModule)
+  val subw = subModule.io.sub
+
+  // sllw
+  val leftShiftWordModule = Module(new LeftShiftWordModule)
+  val sllw = leftShiftWordModule.io.sllw
+  val revSllw = leftShiftWordModule.io.revSllw
+  leftShiftWordModule.io.sllSrc := src1
+  leftShiftWordModule.io.shamt := shamt
+  leftShiftWordModule.io.revShamt := revShamt
+
+  val rightShiftWordModule = Module(new RightShiftWordModule)
+  val srlw = rightShiftWordModule.io.srlw
+  val revSrlw = rightShiftWordModule.io.revSrlw
+  val sraw = rightShiftWordModule.io.sraw
+  rightShiftWordModule.io.shamt := shamt
+  rightShiftWordModule.io.revShamt := revShamt
+  rightShiftWordModule.io.srlSrc := src1
+  rightShiftWordModule.io.sraSrc := src1
+
+  val rolw = revSrlw | sllw
+  val rorw = srlw | revSllw
+
+  // add
   val wordMaskAddSource = Cat(Fill(32, func(0)), Fill(32, 1.U)) & src1
   val shaddSource = VecInit(Seq(
     Cat(wordMaskAddSource(62, 0), 0.U(1.W)),
@@ -203,91 +269,42 @@ class AluDataModule(implicit p: Parameters) extends XSModule {
   ))
   // TODO: use decoder or other libraries to optimize timing
   // Now we assume shadd has the worst timing.
-  addModule.io.src(0) := Mux(ALUOpType.isShAdd(func), shaddSource(func(2, 1)),
-    Mux(ALUOpType.isSrAdd(func), sraddSource(func(2, 1)),
-    Mux(ALUOpType.isAddOddBit(func), ZeroExt(src1(0), XLEN), wordMaskAddSource))
+  addModule.io.src(0) := Mux(func(3), shaddSource(func(2, 1)),
+    Mux(func(2), sraddSource(func(1, 0)),
+    Mux(func(1), ZeroExt(src1(0), XLEN), wordMaskAddSource))
   )
   addModule.io.src(1) := src2
   val add = addModule.io.add
-  // For 32-bit adder: its source comes from lower 32bits or lowest bit.
-  addModule.io.srcw := Mux(ALUOpType.isAddOddBit(func), ZeroExt(src1(0), XLEN), src1(31,0))
-  val byteMask = Cat(Fill(56, ~func(1)), 0xff.U(8.W))
-  val bitMask = Cat(Fill(63, ~func(2)), 0x1.U(1.W))
-  val addw = addModule.io.addw & byteMask & bitMask
 
-  val subModule = Module(new SubModule)
+  // sub
   val sub  = subModule.io.sub
-  val subw = subModule.io.sub
   subModule.io.src(0) := src1
   subModule.io.src(1) := src2
-
-  val shamt = src2(5, 0)
-  val revShamt = ~src2(5,0) + 1.U
-
-  val leftShiftModule = Module(new LeftShiftModule)
-  val sll = leftShiftModule.io.sll
-  val revSll = leftShiftModule.io.revSll
-  leftShiftModule.io.sllSrc := Cat(Fill(32, func(0)), Fill(32,1.U)) & src1
-  leftShiftModule.io.shamt := shamt
-  leftShiftModule.io.revShamt := revShamt
-  
-  val leftShiftWordModule = Module(new LeftShiftWordModule)
-  val sllw = leftShiftWordModule.io.sllw
-  val revSllw = leftShiftWordModule.io.revSllw
-  leftShiftWordModule.io.sllSrc := src1
-  leftShiftWordModule.io.shamt := shamt
-  leftShiftWordModule.io.revShamt := revShamt
-
-  val rightShiftModule = Module(new RightShiftModule)
-  val srl = rightShiftModule.io.srl
-  val revSrl = rightShiftModule.io.revSrl
-  val sra = rightShiftModule.io.sra
-  rightShiftModule.io.shamt := shamt
-  rightShiftModule.io.revShamt := revShamt
-  rightShiftModule.io.srlSrc := src1
-  rightShiftModule.io.sraSrc := src1
-
-  val rightShiftWordModule = Module(new RightShiftWordModule)
-  val srlw = rightShiftWordModule.io.srlw
-  val revSrlw = rightShiftWordModule.io.revSrlw
-  val sraw = rightShiftWordModule.io.sraw
-  rightShiftWordModule.io.shamt := shamt
-  rightShiftWordModule.io.revShamt := revShamt
-  rightShiftWordModule.io.srlSrc := src1
-  rightShiftWordModule.io.sraSrc := src1
-
-  val rol = revSrl | sll
-  val ror = srl | revSll
-  val rolw = revSrlw | sllw
-  val rorw = srlw | revSllw
-  
-  val bitShift = 1.U << src2(5, 0)
-  val bset = src1 | bitShift
-  val bclr = src1 & ~bitShift
-  val binv = src1 ^ bitShift
-  val bext = srl(0)
-
-  val andn    = src1 & ~src2
-  val orn     = src1 | ~src2
-  val xnor    = src1 ^ ~src2
-  val and     = src1 & src2
-  val or      = src1 | src2
-  val xor     = src1 ^ src2
-  val orh48   = Cat(src1(63, 8), 0.U(8.W)) | src2
   val sgtu    = sub(XLEN)
   val sltu    = !sgtu
-  val slt     = xor(XLEN-1) ^ sltu
-  // val maxMin  = Mux(slt ^ func(0), src2, src1)
-  // val maxMinU = Mux(sltu^ func(0), src2, src1)
+  val slt     = src1(XLEN - 1) ^ src2(XLEN - 1) ^ sltu
   val maxMin  = Mux(slt ^ func(0), src2, src1)
   val maxMinU = Mux((sgtu && func(0)) || ~(sgtu && func(0)), src2, src1)
-  val sextb   = SignExt(src1(7, 0), XLEN)
-  val sexth   = SignExt(src1(15, 0), XLEN)
-  val zexth   = ZeroExt(src1(15, 0), XLEN)
-  val rev8    = Cat(src1(7,0), src1(15,8), src1(23,16), src1(31,24), 
-                    src1(39,32), src1(47,40), src1(55,48), src1(63,56))
-  val orcb    = Cat( (7 to 0) map {i => Fill(8, src1(i*8+7, i*8).orR)} )
+  val compareRes = Mux(func(2), Mux(func(1), maxMin, maxMinU), Mux(func(1), slt, Mux(func(0), sltu, sub)))
 
+  // logic
+  val logicSrc2 = Mux(!func(5) && func(0), ~src2, src2)
+  val and     = src1 & logicSrc2
+  val or      = src1 | logicSrc2
+  val xor     = src1 ^ logicSrc2
+  val orcb    = Cat((7 to 0).map(i => Fill(8, src1(i * 8 + 7, i * 8).orR)))
+  val orh48   = Cat(src1(63, 8), 0.U(8.W)) | src2
+
+  val sextb = SignExt(src1(7, 0), XLEN)
+  val packh = Cat(src2(7,0), src1(7,0))
+  val sexth = SignExt(src1(15, 0), XLEN)
+  val packw = SignExt(Cat(src2(15, 0), src1(15, 0)), XLEN)
+
+  val revb = Cat((7 to 0).map(i => Reverse(src1(8 * i + 7, 8 * i))))
+  val pack = Cat(src2(31, 0), src1(31, 0))
+  val rev8 = Cat((0 until 8).map(i => src1(8 * i + 7, 8 * i)))
+
+  // branch
   val branchOpTable = List(
     ALUOpType.getBranchType(ALUOpType.beq)  -> !xor.orR,
     ALUOpType.getBranchType(ALUOpType.blt)  -> slt,
@@ -295,13 +312,9 @@ class AluDataModule(implicit p: Parameters) extends XSModule {
   )
   val taken = LookupTree(ALUOpType.getBranchType(func), branchOpTable) ^ ALUOpType.isBranchInvert(func)
 
-
   // Result Select
-
-  val compareRes = Mux(func(2), Mux(func(1), maxMin, maxMinU), Mux(func(1), slt, Mux(func(0), sltu, sub)))
-
   val shiftResSel = Module(new ShiftResultSelect)
-  shiftResSel.io.func := func(4,0)
+  shiftResSel.io.func := func(3, 0)
   shiftResSel.io.sll  := sll
   shiftResSel.io.srl  := srl
   shiftResSel.io.sra  := sra
@@ -314,19 +327,19 @@ class AluDataModule(implicit p: Parameters) extends XSModule {
   val shiftRes = shiftResSel.io.shiftRes
 
   val miscResSel = Module(new MiscResultSelect)
-  miscResSel.io.func    := func(4, 0)
-  miscResSel.io.andn    := andn
-  miscResSel.io.orn     := orn
-  miscResSel.io.xnor    := xnor
+  miscResSel.io.func    := func(5, 0)
   miscResSel.io.and     := and
   miscResSel.io.or      := or
   miscResSel.io.xor     := xor
+  miscResSel.io.orcb    := orcb
   miscResSel.io.orh48   := orh48
   miscResSel.io.sextb   := sextb
+  miscResSel.io.packh   := packh
   miscResSel.io.sexth   := sexth
-  miscResSel.io.zexth   := zexth
+  miscResSel.io.packw   := packw
+  miscResSel.io.revb    := revb
   miscResSel.io.rev8    := rev8
-  miscResSel.io.orcb    := orcb
+  miscResSel.io.pack    := pack
   miscResSel.io.src     := src1
   val miscRes = miscResSel.io.miscRes
 
@@ -342,14 +355,14 @@ class AluDataModule(implicit p: Parameters) extends XSModule {
   val wordRes = wordResSel.io.wordRes
 
   val aluResSel = Module(new AluResSel)
-  aluResSel.io.func := func
+  aluResSel.io.func := func(6, 4)
   aluResSel.io.addRes := add
   aluResSel.io.compareRes := compareRes
   aluResSel.io.shiftRes := shiftRes
   aluResSel.io.miscRes := miscRes
   aluResSel.io.wordRes := wordRes
   val aluRes = aluResSel.io.aluRes
-  
+
   io.result := aluRes
   io.taken := taken
   io.mispredict := (io.pred_taken ^ taken) && io.isBranch
@@ -357,21 +370,13 @@ class AluDataModule(implicit p: Parameters) extends XSModule {
 
 class Alu(implicit p: Parameters) extends FUWithRedirect {
 
-  val (src1, src2, func, pc, uop) = (
-    io.in.bits.src(0),
-    io.in.bits.src(1),
-    io.in.bits.uop.ctrl.fuOpType,
-    SignExt(io.in.bits.uop.cf.pc, AddrBits),
-    io.in.bits.uop
-  )
+  val uop = io.in.bits.uop
 
-  val valid = io.in.valid
-  val isBranch = ALUOpType.isBranch(func)
+  val isBranch = ALUOpType.isBranch(io.in.bits.uop.ctrl.fuOpType)
   val dataModule = Module(new AluDataModule)
 
-  dataModule.io.src(0) := src1
-  dataModule.io.src(1) := src2
-  dataModule.io.func := func
+  dataModule.io.src := io.in.bits.src.take(2)
+  dataModule.io.func := io.in.bits.uop.ctrl.fuOpType
   dataModule.io.pred_taken := uop.cf.pred_taken
   dataModule.io.isBranch := isBranch
 
@@ -386,7 +391,7 @@ class Alu(implicit p: Parameters) extends FUWithRedirect {
   redirectOut.cfiUpdate.predTaken := uop.cf.pred_taken
 
   io.in.ready := io.out.ready
-  io.out.valid := valid
+  io.out.valid := io.in.valid
   io.out.bits.uop <> io.in.bits.uop
   io.out.bits.data := dataModule.io.result
 }

--- a/src/main/scala/xiangshan/backend/fu/Bmu.scala
+++ b/src/main/scala/xiangshan/backend/fu/Bmu.scala
@@ -115,20 +115,7 @@ class MiscModule(implicit p: Parameters) extends XSModule {
   (0 until 8).map( i => xpermbVec(i) := Mux(src2(i*8+7, i*8+3).orR, 0.U, xpermLUT(src1, src2(i*8+2, i*8), 8)))
   val xpermb = Cat(xpermbVec.reverse)
 
-  val pack = Cat(src2(31,0), src1(31,0))
-  val packh = Cat(src2(7,0), src1(7,0))
-  val packw = SignExt(Cat(src2(15,0), src1(15,0)), XLEN)
-  val revb = Cat(Reverse(src1(63,56)), Reverse(src1(55,48)), Reverse(src1(47,40)), Reverse(src1(39,32)),
-                    Reverse(src1(31,24)), Reverse(src1(23,16)), Reverse(src1(15,8)), Reverse(src1(7,0)))
- 
-  io.out := RegNext(LookupTreeDefault(io.func, revb, List(
-    BMUOpType.xpermn  -> xpermn,
-    BMUOpType.xpermb  -> xpermb,
-    BMUOpType.pack    -> pack,
-    BMUOpType.packh   -> packh,
-    BMUOpType.packw   -> packw,
-    BMUOpType.revb    -> revb
-  )))
+  io.out := RegNext(Mux(io.func(0), xpermb, xpermn))
 }
 
 class Bmu(implicit p: Parameters) extends FunctionUnit with HasPipelineReg {

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -112,7 +112,7 @@ package object xiangshan {
   }
 
   object FuOpType {
-    def apply() = UInt(8.W)
+    def apply() = UInt(7.W)
   }
 
   object CommitType {
@@ -207,106 +207,114 @@ package object xiangshan {
   }
 
   object ALUOpType {
-    // misc & branch optype
-    def and         = "b0_00_00_000".U
-    def andn        = "b0_00_00_001".U
-    def or          = "b0_00_00_010".U
-    def orn         = "b0_00_00_011".U
-    def xor         = "b0_00_00_100".U
-    def xnor        = "b0_00_00_101".U
-    def orh48       = "b0_00_00_110".U
-    def orc_b       = "b0_00_00_111".U
-
-    def andlsb      = "b0_00_11_000".U
-    def andnlsb     = "b0_00_11_001".U
-    def orlsb       = "b0_00_11_010".U
-    def ornlsb      = "b0_00_11_011".U
-    def xorlsb      = "b0_00_11_100".U
-    def xnorlsb     = "b0_00_11_101".U
-
-    def sext_b      = "b0_00_01_000".U
-    def sext_h      = "b0_00_01_001".U
-    // def zext_h      = "b0_00_01_010".U // packw
-    def rev8        = "b0_00_01_011".U
-    // TOOD: optimize it
-    def szewl1      = "b0_00_01_100".U
-    def szewl2      = "b0_00_01_101".U
-    def szewl3      = "b0_00_01_110".U
-    def byte2       = "b0_00_01_111".U
-
-    def beq         = "b0_00_10_000".U
-    def bne         = "b0_00_10_001".U
-    def blt         = "b0_00_10_100".U
-    def bge         = "b0_00_10_101".U
-    def bltu        = "b0_00_10_110".U
-    def bgeu        = "b0_00_10_111".U
-
-    // add & sub optype
-    def add_uw       = "b0_01_00_000".U
-    def add          = "b0_01_00_001".U
-
-    def oddadd       = "b0_01_11_001".U
-
-    def sh1add_uw    = "b0_01_10_000".U
-    def sh1add       = "b0_01_10_001".U
-    def sh2add_uw    = "b0_01_10_010".U
-    def sh2add       = "b0_01_10_011".U
-    def sh3add_uw    = "b0_01_10_100".U
-    def sh3add       = "b0_01_10_101".U
-    def sh4add       = "b0_01_10_111".U
-
-    def sr29add      = "b0_01_01_001".U
-    def sr30add      = "b0_01_01_011".U
-    def sr31add      = "b0_01_01_101".U
-    def sr32add      = "b0_01_01_111".U
-
     // shift optype
-    def slli_uw     = "b0_10_00_000".U
-    def sll         = "b0_10_00_001".U
-    def bclr        = "b0_10_00_100".U
-    def bset        = "b0_10_00_101".U
-    def binv        = "b0_10_00_110".U
+    def slliuw     = "b000_0000".U // slliuw: ZEXT(src1[31:0]) << shamt
+    def sll        = "b000_0001".U // sll:     src1 << src2
 
-    def srl         = "b0_10_01_001".U
-    def bext        = "b0_10_01_010".U
-    def sra         = "b0_10_01_100".U
+    def bclr       = "b000_0010".U // bclr:    src1 & ~(1 << src2[5:0])
+    def bset       = "b000_0011".U // bset:    src1 | (1 << src2[5:0])
+    def binv       = "b000_0100".U // binv:    src1 ^ ~(1 << src2[5:0])
 
-    def rol         = "b0_10_10_000".U
+    def srl        = "b000_0101".U // srl:     src1 >> src2
+    def bext       = "b000_0110".U // bext:    (src1 >> src2)[0]
+    def sra        = "b000_0111".U // sra:     src1 >> src2 (arithmetic)
 
-    def ror         = "b0_10_11_000".U
-
-    def sub         = "b0_11_00_000".U
-    def sltu        = "b0_11_00_001".U
-    def slt         = "b0_11_00_010".U
-    def maxu        = "b0_11_00_100".U
-    def minu        = "b0_11_00_101".U
-    def max         = "b0_11_00_110".U
-    def min         = "b0_11_00_111".U
+    def rol        = "b000_1000".U // rol:     (src1 << src2) | (src1 >> (xlen - src2))
+    def ror        = "b000_1001".U // ror:     (src1 >> src2) | (src1 << (xlen - src2))
 
     // RV64 32bit optype
-    def addw        = "b1_01_00_001".U
-    def addwbyte    = "b1_01_00_011".U
-    def addwbit     = "b1_01_00_101".U
-    def oddaddw     = "b1_01_11_001".U
-    def subw        = "b1_11_00_000".U
-    def sllw        = "b1_10_00_000".U
-    def srlw        = "b1_10_01_001".U
-    def sraw        = "b1_10_01_100".U
-    def rolw        = "b1_10_10_000".U
-    def rorw        = "b1_10_11_000".U
+    def addw       = "b001_0000".U // addw:      SEXT((src1 + src2)[31:0])
+    def oddaddw    = "b001_0001".U // oddaddw:   SEXT((src1[0] + src2)[31:0])
+    def subw       = "b001_0010".U // subw:      SEXT((src1 - src2)[31:0])
 
-    def isWordOp(func: UInt) = func(7)
-    def isAddw(func: UInt) = func(7, 5) === "b101".U
-    def isLogic(func: UInt) = func(7, 3) === "b00000".U
-    def logicToLSB(func: UInt) = Cat(func(7, 5), "b11".U(2.W), func(2, 0))
-    def isBranch(func: UInt) = func(6, 3) === "b0010".U
-    def getBranchType(func: UInt) = func(2, 1)
-    def isBranchInvert(func: UInt) = func(0)
-    def isAddOddBit(func: UInt) = func(4, 3) === "b11".U(2.W)
-    def isShAdd(func: UInt) = func(4, 3) === "b10".U(2.W)
-    def isSrAdd(func: UInt) = func(4, 3) === "b01".U(2.W)
+    def addwbit    = "b001_0100".U // addwbit:   (src1 + src2)[0]
+    def addwbyte   = "b001_0101".U // addwbyte:  (src1 + src2)[7:0]
+    def addwzexth  = "b001_0110".U // addwzexth: ZEXT((src1  + src2)[15:0])
+    def addwsexth  = "b001_0111".U // addwsexth: SEXT((src1  + src2)[15:0])
 
-    def apply() = UInt(8.W)
+    def sllw       = "b001_1000".U // sllw:     SEXT((src1 << src2)[31:0])
+    def srlw       = "b001_1001".U // srlw:     SEXT((src1[31:0] >> src2)[31:0])
+    def sraw       = "b001_1010".U // sraw:     SEXT((src1[31:0] >> src2)[31:0])
+    def rolw       = "b001_1100".U
+    def rorw       = "b001_1101".U
+
+    // ADD-op
+    def adduw      = "b010_0000".U // adduw:  src1[31:0]  + src2
+    def add        = "b010_0001".U // add:     src1        + src2
+    def oddadd     = "b010_0010".U // oddadd:  src1[0]     + src2
+
+    def sr29add    = "b010_0100".U // sr29add: src1[63:29] + src2
+    def sr30add    = "b010_0101".U // sr30add: src1[63:30] + src2
+    def sr31add    = "b010_0110".U // sr31add: src1[63:31] + src2
+    def sr32add    = "b010_0111".U // sr32add: src1[63:32] + src2
+
+    def sh1adduw   = "b010_1000".U // sh1adduw: {src1[31:0], 1'b0} + src2
+    def sh1add     = "b010_1001".U // sh1add: {src1[62:0], 1'b0} + src2
+    def sh2adduw   = "b010_1010".U // sh2add_uw: {src1[31:0], 2'b0} + src2
+    def sh2add     = "b010_1011".U // sh2add: {src1[61:0], 2'b0} + src2
+    def sh3adduw   = "b010_1100".U // sh3add_uw: {src1[31:0], 3'b0} + src2
+    def sh3add     = "b010_1101".U // sh3add: {src1[60:0], 3'b0} + src2
+    def sh4add     = "b010_1111".U // sh4add: {src1[59:0], 4'b0} + src2
+
+    // SUB-op: src1 - src2
+    def sub        = "b011_0000".U
+    def sltu       = "b011_0001".U
+    def slt        = "b011_0010".U
+    def maxu       = "b011_0100".U
+    def minu       = "b011_0101".U
+    def max        = "b011_0110".U
+    def min        = "b011_0111".U
+
+    // branch
+    def beq        = "b111_0000".U
+    def bne        = "b111_0010".U
+    def blt        = "b111_1000".U
+    def bge        = "b111_1010".U
+    def bltu       = "b111_1100".U
+    def bgeu       = "b111_1110".U
+
+    // misc optype
+    def and        = "b100_0000".U
+    def andn       = "b100_0001".U
+    def or         = "b100_0010".U
+    def orn        = "b100_0011".U
+    def xor        = "b100_0100".U
+    def xnor       = "b100_0101".U
+    def orcb       = "b100_0110".U
+
+    def sextb      = "b100_1000".U
+    def packh      = "b100_1001".U
+    def sexth      = "b100_1010".U
+    def packw      = "b100_1011".U
+
+    def revb       = "b101_0000".U
+    def rev8       = "b101_0001".U
+    def pack       = "b101_0010".U
+    def orh48      = "b101_0011".U
+
+    def szewl1     = "b101_1000".U
+    def szewl2     = "b101_1001".U
+    def szewl3     = "b101_1010".U
+    def byte2      = "b101_1011".U
+
+    def andlsb     = "b110_0000".U
+    def andzexth   = "b110_0001".U
+    def orlsb      = "b110_0010".U
+    def orzexth    = "b110_0011".U
+    def xorlsb     = "b110_0100".U
+    def xorzexth   = "b110_0101".U
+    def orcblsb    = "b110_0110".U
+    def orcbzexth  = "b110_0111".U
+
+    def isAddw(func: UInt) = func(6, 4) === "b001".U && !func(3) && !func(1)
+    def isSimpleLogic(func: UInt) = func(6, 4) === "b100".U && !func(0)
+    def logicToLsb(func: UInt) = Cat("b110".U(3.W), func(3, 1), 0.U(1.W))
+    def logicToZexth(func: UInt) = Cat("b110".U(3.W), func(3, 1), 1.U(1.W))
+    def isBranch(func: UInt) = func(6, 4) === "b111".U
+    def getBranchType(func: UInt) = func(3, 2)
+    def isBranchInvert(func: UInt) = func(1)
+
+    def apply() = UInt(7.W)
   }
 
   object MDUOpType {
@@ -404,10 +412,6 @@ package object xiangshan {
     // TODO: move to alu
     def xpermn      = "b10000".U
     def xpermb      = "b10001".U
-    def pack        = "b10100".U
-    def packh       = "b10101".U
-    def packw       = "b10110".U
-    def revb        = "b11000".U
   }
 
   object BTBtype {


### PR DESCRIPTION
This commit optimizes ALUOpType to 7 bits. Alu timing will be checked
later.

We also apply some misc changes including:

* Move REVB, PACK, PACKH, PACKW to ALU

* Add fused logicZexth, addwZext, addwSexth

* Add instruction fusion test cases to CI