### PR TITLE
rs: add pcMem to store pc for jalr instructions

### DIFF
--- a/.github/workflows/check_pc.py
+++ b/.github/workflows/check_pc.py
@@ -1,0 +1,18 @@
+import sys
+
+if __name__ == "__main__":
+    in_module = False
+    line_number = 0
+    with open(sys.argv[1], "r") as f:
+        for line in f:
+            if "module Decode" in line:
+                in_module = True
+            elif "endmodule" in line:
+                in_module = False
+            elif in_module and "_pc" in line:
+                print("PC should not be in decode!!!\n")
+                print(f"{sys.argv[1]}:{line_number}:")
+                print(line)
+                exit(1)
+            line_number += 1
+    exit(0)

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -25,6 +25,9 @@ jobs:
       - name: generate verilog file
         run:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --generate --dual-core
+      - name: check pc usages
+        run:
+          python3 $GITHUB_WORKSPACE/.github/workflows/check_pc.py build/XSTop.v
       - name: build MinimalConfig emu
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \


### PR DESCRIPTION
This commit adds storage for PC in JUMP reservation station. Jalr needs
four operands now, including rs1, pc, jalr_target and imm. Since Jump
currently stores two operands and imm, we have to allocate extra space
to store the one more extra operand for jalr.

It should be optimized later (possibly by reading jalr_target when
issuing the instruction).

This commit also adds regression check for PC usages. PC should not
enter decode stage.