### PR TITLE
Temporarily disable TLMonitor

### DIFF
--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -413,9 +413,9 @@ class XSTopWithoutDMA()(implicit p: Parameters) extends BaseXSSoc()
 object TopMain extends App with HasRocketChipStageUtils {
   override def main(args: Array[String]): Unit = {
     val (config, firrtlOpts) = ArgParser.parse(args)
+    val soc = DisableMonitors(p => LazyModule(new XSTop()(p)))(config)
     XiangShanStage.execute(firrtlOpts, Seq(
       ChiselGeneratorAnnotation(() => {
-        val soc = LazyModule(new XSTop()(config))
         soc.module
       })
     ))

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -99,7 +99,7 @@ object SimTop extends App {
     XiangShanStage.execute(
       firrtlOpts,
       Seq(
-        ChiselGeneratorAnnotation(() => new SimTop()(config))
+        ChiselGeneratorAnnotation(() => DisableMonitors(p => new SimTop()(p))(config))
       )
     )
   }


### PR DESCRIPTION
Current dcache may use same source id for different TL transactions (will not cause functional errors but not conform to spec), so we need to disable TLMonitor until we fix dcache.