### PR TITLE
scheduler: support reading fp state from others

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -246,6 +246,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   ctrlBlock.io.dispatch <> exuBlocks.flatMap(_.io.in)
 
   exuBlocks(0).io.scheExtra.fpRfReadIn.get <> exuBlocks(1).io.scheExtra.fpRfReadOut.get
+  exuBlocks(0).io.scheExtra.fpStateReadIn.get <> exuBlocks(1).io.scheExtra.fpStateReadOut.get
 
   memBlock.io.issue <> exuBlocks(0).io.issue.get
   // By default, instructions do not have exceptions when they enter the function units.


### PR DESCRIPTION
This commit adds fpStateReadOut and fpStateReadIn ports to Scheduler to
support reading fp reg states from other schedulers.

It should have better timing because now ExuBlock(0) has only int
regfile and busytable. This block does not need fp writeback any more.