### PR TITLE
renameTable: optimize read and write timing

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -111,7 +111,6 @@ case class XSCoreParameters
   LoadQueueSize: Int = 80,
   StoreQueueSize: Int = 64,
   RobSize: Int = 256,
-  EnableIntMoveElim: Boolean = true,
   IntRefCounterWidth: Int = 2,
   dpParams: DispatchParameters = DispatchParameters(
     IntDqSize = 16,
@@ -291,7 +290,6 @@ trait HasXSParameter {
   val NRPhyRegs = coreParams.NRPhyRegs
   val PhyRegIdxWidth = log2Up(NRPhyRegs)
   val RobSize = coreParams.RobSize
-  val EnableIntMoveElim = coreParams.EnableIntMoveElim
   val IntRefCounterWidth = coreParams.IntRefCounterWidth
   val StdFreeListSize = NRPhyRegs - 32
   // val MEFreeListSize = NRPhyRegs - { if (IntRefCounterWidth > 0 && IntRefCounterWidth < 5) (32 / Math.pow(2, IntRefCounterWidth)).toInt else 1 }

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -169,11 +169,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasExceptionNO {
     updatedUop(i).psrc(1) := updatedPsrc2(i)
     updatedUop(i).psrc(2) := updatedPsrc3(i)
     updatedUop(i).old_pdest := updatedOldPdest(i)
-    if (EnableIntMoveElim) {
-      updatedUop(i).debugInfo.eliminatedMove := io.fromRename(i).bits.eliminatedMove
-    } else {
-      updatedUop(i).debugInfo.eliminatedMove := DontCare
-    }
+    updatedUop(i).debugInfo.eliminatedMove := io.fromRename(i).bits.eliminatedMove
     // update commitType
     updatedUop(i).ctrl.commitType := updatedCommitType(i)
     // update robIdx, lqIdx, sqIdx
@@ -333,15 +329,9 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasExceptionNO {
     // send uops to dispatch queues
     // Note that if one of their previous instructions cannot enqueue, they should not enter dispatch queue.
     // We use notBlockedByPrevious here.
-    if (EnableIntMoveElim) {
-      io.toIntDq.needAlloc(i) := io.fromRename(i).valid && isInt(i) && !io.fromRename(i).bits.eliminatedMove
-      io.toIntDq.req(i).valid := io.fromRename(i).valid && !hasException(i) && isInt(i) && thisCanActualOut(i) &&
-                             io.enqLsq.canAccept && io.enqRob.canAccept && io.toFpDq.canAccept && io.toLsDq.canAccept && !io.fromRename(i).bits.eliminatedMove
-    } else {
-      io.toIntDq.needAlloc(i) := io.fromRename(i).valid && isInt(i)
-      io.toIntDq.req(i).valid := io.fromRename(i).valid && !hasException(i) && isInt(i) && thisCanActualOut(i) &&
-                             io.enqLsq.canAccept && io.enqRob.canAccept && io.toFpDq.canAccept && io.toLsDq.canAccept
-    }
+    io.toIntDq.needAlloc(i) := io.fromRename(i).valid && isInt(i) && !io.fromRename(i).bits.eliminatedMove
+    io.toIntDq.req(i).valid := io.fromRename(i).valid && !hasException(i) && isInt(i) && thisCanActualOut(i) &&
+                           io.enqLsq.canAccept && io.enqRob.canAccept && io.toFpDq.canAccept && io.toLsDq.canAccept && !io.fromRename(i).bits.eliminatedMove
     io.toIntDq.req(i).bits  := updatedUop(i)
 
     io.toFpDq.needAlloc(i)  := io.fromRename(i).valid && isFp(i)
@@ -373,11 +363,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasExceptionNO {
       p"rob ${updatedUop(i).robIdx}, lq ${updatedUop(i).lqIdx}, sq ${updatedUop(i).sqIdx})\n"
     )
 
-    if (EnableIntMoveElim) {
-      io.allocPregs(i).isInt := io.fromRename(i).valid && io.fromRename(i).bits.ctrl.rfWen && (io.fromRename(i).bits.ctrl.ldest =/= 0.U) && !io.fromRename(i).bits.eliminatedMove
-    } else {
-      io.allocPregs(i).isInt := io.fromRename(i).valid && io.fromRename(i).bits.ctrl.rfWen && (io.fromRename(i).bits.ctrl.ldest =/= 0.U)
-    }
+    io.allocPregs(i).isInt := io.fromRename(i).valid && io.fromRename(i).bits.ctrl.rfWen && (io.fromRename(i).bits.ctrl.ldest =/= 0.U) && !io.fromRename(i).bits.eliminatedMove
     io.allocPregs(i).isFp  := io.fromRename(i).valid && io.fromRename(i).bits.ctrl.fpWen
     io.allocPregs(i).preg  := io.fromRename(i).bits.pdest
   }

--- a/src/main/scala/xiangshan/backend/rename/RenameTable.scala
+++ b/src/main/scala/xiangshan/backend/rename/RenameTable.scala
@@ -19,59 +19,132 @@ package xiangshan.backend.rename
 import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
+import utils.{ParallelPriorityMux, XSError}
 import xiangshan._
 
 class RatReadPort(implicit p: Parameters) extends XSBundle {
+  val hold = Input(Bool())
   val addr = Input(UInt(5.W))
-  val rdata = Output(UInt(PhyRegIdxWidth.W))
+  val data = Output(UInt(PhyRegIdxWidth.W))
 }
 
 class RatWritePort(implicit p: Parameters) extends XSBundle {
-  val wen = Input(Bool())
-  val addr = Input(UInt(5.W))
-  val wdata = Input(UInt(PhyRegIdxWidth.W))
+  val wen = Bool()
+  val addr = UInt(5.W)
+  val data = UInt(PhyRegIdxWidth.W)
 }
 
 class RenameTable(float: Boolean)(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
-    val redirect = Input(Bool())
     val flush = Input(Bool())
-    val walkWen = Input(Bool())
     val readPorts = Vec({if(float) 4 else 3} * RenameWidth, new RatReadPort)
-    val specWritePorts = Vec(CommitWidth, new RatWritePort)
-    val archWritePorts = Vec(CommitWidth, new RatWritePort)
+    val specWritePorts = Vec(CommitWidth, Input(new RatWritePort))
+    val archWritePorts = Vec(CommitWidth, Input(new RatWritePort))
     val debug_rdata = Vec(32, Output(UInt(PhyRegIdxWidth.W)))
   })
 
   // speculative rename table
   val spec_table = RegInit(VecInit(Seq.tabulate(32)(i => i.U(PhyRegIdxWidth.W))))
-
+  val spec_table_next = WireInit(spec_table)
   // arch state rename table
   val arch_table = RegInit(VecInit(Seq.tabulate(32)(i => i.U(PhyRegIdxWidth.W))))
 
-  // When redirect happens (mis-prediction), don't update the rename table
-  // However, when mis-prediction and walk happens at the same time, rename table needs to be updated
-  for (w <- io.specWritePorts){
-    when (w.wen && (!(io.redirect || io.flush) || io.walkWen)) {
-      spec_table(w.addr) := w.wdata
-    }
+  // For better timing, we optimize reading and writing to RenameTable as follows:
+  // (1) Writing at T0 will be actually processed at T1.
+  // (2) Reading is synchronous now.
+  // (3) RAddr at T0 will be used to access the table and get data at T0.
+  // (4) WData at T0 is bypassed to RData at T1.
+  val t1_rdata = io.readPorts.map(p => RegNext(Mux(p.hold, p.data, spec_table_next(p.addr))))
+  val t1_raddr = io.readPorts.map(p => RegEnable(p.addr, !p.hold))
+  val t1_wSpec = RegNext(io.specWritePorts)
+
+  // WRITE: when instruction commits or walking
+  val t1_flush = RegNext(io.flush)
+  val t1_wSpec_addr = t1_wSpec.map(w => Mux(w.wen, UIntToOH(w.addr), 0.U))
+  for ((next, i) <- spec_table_next.zipWithIndex) {
+    val matchVec = t1_wSpec_addr.map(w => w(i))
+    val wMatch = ParallelPriorityMux(matchVec.reverse, t1_wSpec.map(_.data).reverse)
+    // When there's a flush, we use arch_table to update spec_table.
+    next := Mux(t1_flush, arch_table(i), Mux(VecInit(matchVec).asUInt.orR, wMatch, spec_table(i)))
+  }
+  spec_table := spec_table_next
+
+  // READ: decode-rename stage
+  for ((r, i) <- io.readPorts.zipWithIndex) {
+    // We use two comparisons here because r.hold has bad timing but addrs have better timing.
+    val t0_bypass = io.specWritePorts.map(w => w.wen && Mux(r.hold, w.addr === t1_raddr(i), w.addr === r.addr))
+    val t1_bypass = RegNext(VecInit(t0_bypass))
+    val bypass_data = ParallelPriorityMux(t1_bypass.reverse, t1_wSpec.map(_.data).reverse)
+    r.data := Mux(t1_bypass.asUInt.orR, bypass_data, t1_rdata(i))
   }
 
-  for((r, i) <- io.readPorts.zipWithIndex){
-    r.rdata := spec_table(r.addr)
-  }
-
-  for(w <- io.archWritePorts){
-    when(w.wen){ arch_table(w.addr) := w.wdata }
-  }
-
-  when (io.flush) {
-    spec_table := arch_table
-    // spec table needs to be updated when flushPipe
-    for (w <- io.archWritePorts) {
-      when(w.wen){ spec_table(w.addr) := w.wdata }
+  for (w <- io.archWritePorts) {
+    when (w.wen) {
+      arch_table(w.addr) := w.data
     }
   }
 
   io.debug_rdata := arch_table
+}
+
+class RenameTableWrapper(implicit p: Parameters) extends XSModule {
+  val io = IO(new Bundle() {
+    val flush = Input(Bool())
+    val robCommits = Flipped(new RobCommitIO)
+    val intReadPorts = Vec(RenameWidth, Vec(3, new RatReadPort))
+    val intRenamePorts = Vec(RenameWidth, Input(new RatWritePort))
+    val fpReadPorts = Vec(RenameWidth, Vec(4, new RatReadPort))
+    val fpRenamePorts = Vec(RenameWidth, Input(new RatWritePort))
+    // for debug printing
+    val debug_int_rat = Vec(32, Output(UInt(PhyRegIdxWidth.W)))
+    val debug_fp_rat = Vec(32, Output(UInt(PhyRegIdxWidth.W)))
+  })
+
+  val intRat = Module(new RenameTable(float = false))
+  val fpRat = Module(new RenameTable(float = true))
+
+  intRat.io.flush := io.flush
+  intRat.io.debug_rdata <> io.debug_int_rat
+  intRat.io.readPorts <> io.intReadPorts.flatten
+  val intDestValid = io.robCommits.info.map(info => info.rfWen && info.ldest =/= 0.U)
+  for ((arch, i) <- intRat.io.archWritePorts.zipWithIndex) {
+    arch.wen  := !io.robCommits.isWalk && io.robCommits.valid(i) && intDestValid(i)
+    arch.addr := io.robCommits.info(i).ldest
+    arch.data := io.robCommits.info(i).pdest
+  }
+  for ((spec, i) <- intRat.io.specWritePorts.zipWithIndex) {
+    spec.wen  := io.robCommits.isWalk && io.robCommits.valid(i) && intDestValid(i)
+    spec.addr := io.robCommits.info(i).ldest
+    spec.data := io.robCommits.info(i).old_pdest
+  }
+  for ((spec, rename) <- intRat.io.specWritePorts.zip(io.intRenamePorts)) {
+    when (rename.wen) {
+      spec.wen  := true.B
+      spec.addr := rename.addr
+      spec.data := rename.data
+    }
+  }
+
+  fpRat.io.flush := io.flush
+  // debug read ports for difftest
+  fpRat.io.debug_rdata <> io.debug_fp_rat
+  fpRat.io.readPorts <> io.fpReadPorts.flatten
+  for ((arch, i) <- fpRat.io.archWritePorts.zipWithIndex) {
+    arch.wen  := !io.robCommits.isWalk && io.robCommits.valid(i) && io.robCommits.info(i).fpWen
+    arch.addr := io.robCommits.info(i).ldest
+    arch.data := io.robCommits.info(i).pdest
+  }
+  for ((spec, i) <- fpRat.io.specWritePorts.zipWithIndex) {
+    spec.wen  := io.robCommits.isWalk && io.robCommits.valid(i) && io.robCommits.info(i).fpWen
+    spec.addr := io.robCommits.info(i).ldest
+    spec.data := io.robCommits.info(i).old_pdest
+  }
+  for ((spec, rename) <- fpRat.io.specWritePorts.zip(io.fpRenamePorts)) {
+    when (rename.wen) {
+      spec.wen  := true.B
+      spec.addr := rename.addr
+      spec.data := rename.data
+    }
+  }
+
 }


### PR DESCRIPTION
This commit optimizes RenameTable's timing.

Read addresses come from instruction buffer directly and has best
timing. So we let data read at decode stage and bypass write data
from this clock cycle to the read data at next cycle.

For write, we latch the write request and process it at the next cycle.