### PR TITLE
core: update dispatch port parameters

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -122,7 +122,7 @@ abstract class XSCoreBase()(implicit p: config.Parameters) extends LazyModule
   // allow mdu and fmisc to have 2*numDeq enqueue ports
   val intDpPorts = (0 until exuParameters.AluCnt).map(i => {
     if (i < exuParameters.JmpCnt) Seq((0, i), (1, i), (2, i))
-    else if (i < exuParameters.MduCnt) Seq((0, i), (1, i))
+    else if (i < 2 * exuParameters.MduCnt) Seq((0, i), (1, i))
     else Seq((0, i))
   })
   val lsDpPorts = Seq(
@@ -132,7 +132,7 @@ abstract class XSCoreBase()(implicit p: config.Parameters) extends LazyModule
     Seq((4, 1))
   ) ++ (0 until exuParameters.StuCnt).map(i => Seq((5, i)))
   val fpDpPorts = (0 until exuParameters.FmacCnt).map(i => {
-    if (i < exuParameters.FmiscCnt) Seq((0, i), (1, i))
+    if (i < 2 * exuParameters.FmiscCnt) Seq((0, i), (1, i))
     else Seq((0, i))
   })
 

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch2Rs.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch2Rs.scala
@@ -37,18 +37,15 @@ class Dispatch2Rs(val configs: Seq[Seq[ExuConfig]])(implicit p: Parameters) exte
 
   // Different mode of dispatch
   // (1) isDistinct: no overlap
-  val isDistinct = exuConfigCases.flatMap(_._1).distinct.length == exuConfigCases.flatMap(_._1).length
+  val isDistinct = exuConfigCases.flatMap(_._1).distinct.length == exuConfigCases.flatMap(_._1).length && exuConfigCases.length > 1
   // (2) isLessExu: exu becomes less and less
-  val isSubset = configs.dropRight(1).zip(configs.tail).forall(x => x._2.toSet.subsetOf(x._1.toSet))
-  val isLessExu = configs.length > 1 && isSubset
+  val isLessExu = configs.dropRight(1).zip(configs.tail).forall(x => x._2.toSet.subsetOf(x._1.toSet))
   val supportedDpMode = Seq(isDistinct, isLessExu)
-  println(exuConfigTypes)
   require(supportedDpMode.count(x => x) == 1, s"dispatch mode valid iff one mode is found in $supportedDpMode")
 
   val numIntStateRead = if (isLessExu) numIntSrc.max * numIn else numIntSrc.sum
   val numFpStateRead = if (isLessExu) numFpSrc.max * numIn else numFpSrc.sum
 
-  println(numIntStateRead, numFpStateRead)
   lazy val module = Dispatch2RsImp(this, supportedDpMode.zipWithIndex.filter(_._1).head._2)
 }
 

--- a/src/main/scala/xiangshan/backend/issue/SelectPolicy.scala
+++ b/src/main/scala/xiangshan/backend/issue/SelectPolicy.scala
@@ -33,10 +33,9 @@ class SelectPolicy(params: RSParams)(implicit p: Parameters) extends XSModule {
     val grantBalance = Output(Bool())
   })
 
-  val policy = if (params.numDeq > 2 && params.numEntries > 32) "oddeven" else if (params.numDeq >= 2) "circ" else "naive"
-
+  val enqPolicy = if (params.numEnq > 2) "oddeven" else "circ"
   val emptyVec = VecInit(io.validVec.asBools.map(v => !v))
-  val allocate = SelectOne(policy, emptyVec, params.numEnq)
+  val allocate = SelectOne(enqPolicy, emptyVec, params.numEnq)
   for (i <- 0 until params.numEnq) {
     val sel = allocate.getNthOH(i + 1)
     io.allocate(i).valid := sel._1
@@ -47,8 +46,9 @@ class SelectPolicy(params: RSParams)(implicit p: Parameters) extends XSModule {
     XSDebug(io.allocate(i).fire(), p"select for allocation: ${Binary(io.allocate(i).bits)}\n")
   }
 
+  val deqPolicy = if (params.numDeq > 2 && params.numEntries > 32) "oddeven" else if (params.numDeq >= 2) "circ" else "naive"
   val request = io.request.asBools
-  val select = SelectOne(policy, request, params.numDeq)
+  val select = SelectOne(deqPolicy, request, params.numDeq)
   for (i <- 0 until params.numDeq) {
     val sel = select.getNthOH(i + 1, params.needBalance)
     io.grant(i).valid := sel._1


### PR DESCRIPTION
This commit changes how dispatch ports (regfile ports) are connected to
reservation station ports:

INT regfile:
* INT(0-1) --> ALU0, MUL0, JUMP
* INT(2-3) --> ALU1, MUL0
* INT(4-5) --> ALU2, MUL1
* INT(6-7) --> ALU3, MUL1
* INT(8)   --> LOAD0
* INT(9)   --> LOAD1
* INT(10)  --> STA0
* INT(11)  --> STA1
* INT(12)  --> STD0
* INT(13)  --> STD1

FP regfile:
* FP(0-2)  --> FMA0, FMISC0
* FP(3-5)  --> FMA1, FMISC0
* FP(6-8)  --> FMA2, FMISC1
* FP(9-11) --> FMA3, FMISC1
* FP(12)   --> STD0
* FP(13)   --> STD1