### PR TITLE
rs: add IOs for performance counters

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -269,6 +269,10 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   XSPerfHistogram("fastIn_count", PopCount(allFastUop1.map(_.valid)), true.B, 0, allFastUop1.length, 1)
   XSPerfHistogram("wakeup_count", PopCount(rfWriteback.map(_.valid)), true.B, 0, rfWriteback.length, 1)
 
+  // TODO: connect rsPerf
+  val rsPerf = VecInit(exuBlocks.flatMap(_.io.scheExtra.perf))
+  dontTouch(rsPerf)
+
   csrioIn.hartId <> io.hartId
   csrioIn.perf <> DontCare
   csrioIn.perf.retiredInstr <> ctrlBlock.io.robio.toCSR.perfinfo.retiredInstr

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -153,6 +153,7 @@ class ReservationStationWrapper(implicit p: Parameters) extends LazyModule with 
       )
     })
     val io = IO(new ReservationStationIO(params)(updatedP))
+    val perf = IO(Vec(rs.length, Output(new RsPerfCounter)))
 
     rs.foreach(_.io.redirect <> io.redirect)
     rs.foreach(_.io.flush <> io.flush)
@@ -187,6 +188,7 @@ class ReservationStationWrapper(implicit p: Parameters) extends LazyModule with 
     if (io.fmaMid.isDefined) {
       io.fmaMid.get <> rs.flatMap(_.io.fmaMid.get)
     }
+    perf <> rs.map(_.perf)
   }
 
   var fastWakeupIdx = 0
@@ -240,8 +242,13 @@ class ReservationStationIO(params: RSParams)(implicit p: Parameters) extends XSB
     new ReservationStationIO(params).asInstanceOf[this.type]
 }
 
+class RsPerfCounter(implicit p: Parameters) extends XSBundle {
+  val full = Bool()
+}
+
 class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSModule {
   val io = IO(new ReservationStationIO(params))
+  val perf = IO(Output(new RsPerfCounter))
 
   val statusArray = Module(new StatusArray(params))
   val select = Module(new SelectPolicy(params))
@@ -251,6 +258,7 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
   val s2_deq = Wire(io.deq.cloneType)
 
   io.numExist := PopCount(statusArray.io.isValid)
+  perf.full := RegNext(statusArray.io.isValid.andR)
   statusArray.io.redirect := io.redirect
   statusArray.io.flush := io.flush
 


### PR DESCRIPTION
This commit adds IOs for performance counters in reservation stations.
Only `full` is included for now.