### PR TITLE
core: use redirect ports for flush

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -260,7 +260,6 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   val stdIssue = exuBlocks(0).io.issue.get.takeRight(exuParameters.StuCnt)
   exuBlocks.map(_.io).foreach { exu =>
     exu.redirect <> ctrlBlock.io.redirect
-    exu.flush <> ctrlBlock.io.flush
     exu.allocPregs <> ctrlBlock.io.allocPregs
     exu.rfWriteback <> rfWriteback
     exu.fastUopIn <> allFastUop1
@@ -311,7 +310,6 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   fenceio.sbuffer <> memBlock.io.fenceToSbuffer
 
   memBlock.io.redirect <> ctrlBlock.io.redirect
-  memBlock.io.flush <> ctrlBlock.io.flush
   memBlock.io.rsfeedback <> exuBlocks(0).io.scheExtra.feedback.get
   memBlock.io.csrCtrl <> csrioIn.customCtrl
   memBlock.io.tlbCsr <> csrioIn.tlb

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -33,11 +33,7 @@ class CtrlToFtqIO(implicit p: Parameters) extends XSBundle {
   val rob_commits = Vec(CommitWidth, Valid(new RobCommitInfo))
   val stage2Redirect = Valid(new Redirect)
   val stage3Redirect = ValidIO(new Redirect)
-  val robFlush = Valid(new Bundle {
-    val ftqIdx = Output(new FtqPtr)
-    val ftqOffset = Output(UInt(log2Up(PredictWidth).W))
-    val replayInst = Output(Bool()) // not used for now
-  })
+  val robFlush = ValidIO(new Redirect)
 }
 
 class RedirectGenerator(implicit p: Parameters) extends XSModule
@@ -100,7 +96,7 @@ class RedirectGenerator(implicit p: Parameters) extends XSModule
   val jumpOut = io.exuMispredict.head
   val allRedirect = VecInit(io.exuMispredict.map(x => getRedirect(x)) :+ io.loadReplay)
   val oldestOneHot = selectOldestRedirect(allRedirect)
-  val needFlushVec = VecInit(allRedirect.map(_.bits.robIdx.needFlush(io.stage2Redirect, io.flush)))
+  val needFlushVec = VecInit(allRedirect.map(_.bits.robIdx.needFlush(io.stage2Redirect) || io.flush))
   val oldestValid = VecInit(oldestOneHot.zip(needFlushVec).map{ case (v, f) => v && !f }).asUInt.orR
   val oldestExuOutput = Mux1H(io.exuMispredict.indices.map(oldestOneHot), io.exuMispredict)
   val oldestRedirect = Mux1H(oldestOneHot, allRedirect)
@@ -206,7 +202,6 @@ class CtrlBlock(implicit p: Parameters) extends XSModule
     val writeback = Vec(NRIntWritePorts + NRFpWritePorts, Flipped(ValidIO(new ExuOutput)))
     // redirect out
     val redirect = ValidIO(new Redirect)
-    val flush = Output(Bool())
     val debug_int_rat = Vec(32, Output(UInt(PhyRegIdxWidth.W)))
     val debug_fp_rat = Vec(32, Output(UInt(PhyRegIdxWidth.W)))
   })
@@ -223,14 +218,30 @@ class CtrlBlock(implicit p: Parameters) extends XSModule
   val robWbSize = NRIntWritePorts + NRFpWritePorts + exuParameters.StuCnt
   val rob = Module(new Rob(robWbSize))
 
-  val stage2Redirect = redirectGen.io.stage2Redirect
-  val stage3Redirect = redirectGen.io.stage3Redirect
-  val flush = rob.io.flushOut.valid
-  val flushReg = RegNext(flush)
+  val robPcRead = io.frontend.fromFtq.getRobFlushPcRead
+  val flushPC = robPcRead(rob.io.flushOut.bits.ftqIdx, rob.io.flushOut.bits.ftqOffset)
+
+  val flushRedirect = Wire(Valid(new Redirect))
+  flushRedirect.valid := RegNext(rob.io.flushOut.valid)
+  flushRedirect.bits := RegEnable(rob.io.flushOut.bits, rob.io.flushOut.valid)
+  flushRedirect.bits.cfiUpdate.target := Mux(io.robio.toCSR.isXRet || rob.io.exception.valid,
+    io.robio.toCSR.trapTarget,
+    Mux(flushRedirect.bits.flushItself(),
+      flushPC, // replay inst
+      flushPC + 4.U // flush pipe
+    )
+  )
+
+  val flushRedirectReg = Wire(Valid(new Redirect))
+  flushRedirectReg.valid := RegNext(flushRedirect.valid, init = false.B)
+  flushRedirectReg.bits := RegEnable(flushRedirect.bits, enable = flushRedirect.valid)
+
+  val stage2Redirect = Mux(flushRedirect.valid, flushRedirect, redirectGen.io.stage2Redirect)
+  val stage3Redirect = Mux(flushRedirectReg.valid, flushRedirectReg, redirectGen.io.stage3Redirect)
 
   val exuRedirect = io.exuRedirect.map(x => {
     val valid = x.valid && x.bits.redirectValid
-    val killedByOlder = x.bits.uop.robIdx.needFlush(stage2Redirect, flushReg)
+    val killedByOlder = x.bits.uop.robIdx.needFlush(stage2Redirect)
     val delayed = Wire(Valid(new ExuOutput))
     delayed.valid := RegNext(valid && !killedByOlder, init = false.B)
     delayed.bits := RegEnable(x.bits, x.valid)
@@ -238,7 +249,7 @@ class CtrlBlock(implicit p: Parameters) extends XSModule
   })
   val loadReplay = Wire(Valid(new Redirect))
   loadReplay.valid := RegNext(io.memoryViolation.valid &&
-    !io.memoryViolation.bits.robIdx.needFlush(stage2Redirect, flushReg),
+    !io.memoryViolation.bits.robIdx.needFlush(stage2Redirect),
     init = false.B
   )
   loadReplay.bits := RegEnable(io.memoryViolation.bits, io.memoryViolation.valid)
@@ -246,7 +257,7 @@ class CtrlBlock(implicit p: Parameters) extends XSModule
   io.frontend.fromFtq.getMemPredPcRead <> redirectGen.io.memPredPcRead
   redirectGen.io.exuMispredict <> exuRedirect
   redirectGen.io.loadReplay <> loadReplay
-  redirectGen.io.flush := flushReg
+  redirectGen.io.flush := RegNext(rob.io.flushOut.valid)
 
   for(i <- 0 until CommitWidth){
     io.frontend.toFtq.rob_commits(i).valid := rob.io.commits.valid(i) && !rob.io.commits.isWalk
@@ -254,30 +265,7 @@ class CtrlBlock(implicit p: Parameters) extends XSModule
   }
   io.frontend.toFtq.stage2Redirect <> stage2Redirect
   io.frontend.toFtq.robFlush <> RegNext(rob.io.flushOut)
-
-  val robPcRead = io.frontend.fromFtq.getRobFlushPcRead
-  val flushPC = robPcRead(rob.io.flushOut.bits.ftqIdx, rob.io.flushOut.bits.ftqOffset)
-
-  val flushRedirect = Wire(Valid(new Redirect))
-  flushRedirect.valid := flushReg
-  flushRedirect.bits := DontCare
-  flushRedirect.bits.ftqIdx := RegEnable(rob.io.flushOut.bits.ftqIdx, flush)
-  flushRedirect.bits.interrupt := true.B
-  flushRedirect.bits.cfiUpdate.target := Mux(io.robio.toCSR.isXRet || rob.io.exception.valid,
-    io.robio.toCSR.trapTarget,
-    Mux(RegEnable(rob.io.flushOut.bits.replayInst, flush),
-      flushPC, // replay inst
-      flushPC + 4.U // flush pipe
-    )
-  )
-  when (flushRedirect.valid && RegEnable(rob.io.flushOut.bits.replayInst, flush)) {
-    XSDebug("replay inst (%x) from rob\n", flushPC);
-  }
-  val flushRedirectReg = Wire(Valid(new Redirect))
-  flushRedirectReg.valid := RegNext(flushRedirect.valid, init = false.B)
-  flushRedirectReg.bits := RegEnable(flushRedirect.bits, enable = flushRedirect.valid)
-
-  io.frontend.toFtq.stage3Redirect := Mux(flushRedirectReg.valid, flushRedirectReg, stage3Redirect)
+  io.frontend.toFtq.stage3Redirect := stage3Redirect
 
   decode.io.in <> io.frontend.cfVec
   // currently, we only update wait table when isReplay
@@ -286,7 +274,6 @@ class CtrlBlock(implicit p: Parameters) extends XSModule
   decode.io.memPredUpdate(1).valid := false.B
   decode.io.csrCtrl := RegNext(io.csrCtrl)
 
-  rat.io.flush := flushReg
   rat.io.robCommits := rob.io.commits
   for ((r, i) <- rat.io.intReadPorts.zipWithIndex) {
     val raddr = decode.io.out(i).bits.ctrl.lsrc.take(2) :+ decode.io.out(i).bits.ctrl.ldest
@@ -306,24 +293,21 @@ class CtrlBlock(implicit p: Parameters) extends XSModule
   rat.io.debug_fp_rat <> io.debug_fp_rat
 
   // pipeline between decode and rename
-  val redirectValid = stage2Redirect.valid || flushReg
   for (i <- 0 until RenameWidth) {
     PipelineConnect(decode.io.out(i), rename.io.in(i), rename.io.in(i).ready,
-      flushReg || io.frontend.toFtq.stage3Redirect.valid)
+      stage2Redirect.valid || stage3Redirect.valid)
   }
 
   rename.io.redirect <> stage2Redirect
-  rename.io.flush := flushReg
   rename.io.robCommits <> rob.io.commits
 
   // pipeline between rename and dispatch
   for (i <- 0 until RenameWidth) {
-    PipelineConnect(rename.io.out(i), dispatch.io.fromRename(i), dispatch.io.recv(i), redirectValid)
+    PipelineConnect(rename.io.out(i), dispatch.io.fromRename(i), dispatch.io.recv(i), stage2Redirect.valid)
   }
   dispatch.io.renameBypass := RegEnable(rename.io.renameBypass, rename.io.out(0).fire)
   dispatch.io.preDpInfo := RegEnable(rename.io.dispatchInfo, rename.io.out(0).fire)
 
-  dispatch.io.flush <> flushReg
   dispatch.io.redirect <> stage2Redirect
   dispatch.io.enqRob <> rob.io.enq
   dispatch.io.enqLsq <> io.enqLsq
@@ -336,11 +320,8 @@ class CtrlBlock(implicit p: Parameters) extends XSModule
   dispatch.io.singleStep := false.B
 
   intDq.io.redirect <> stage2Redirect
-  intDq.io.flush <> flushReg
   fpDq.io.redirect <> stage2Redirect
-  fpDq.io.flush <> flushReg
   lsDq.io.redirect <> stage2Redirect
-  lsDq.io.flush <> flushReg
 
   io.dispatch <> intDq.io.deq ++ lsDq.io.deq ++ fpDq.io.deq
 
@@ -356,13 +337,12 @@ class CtrlBlock(implicit p: Parameters) extends XSModule
   val exeWbResults = VecInit(io.writeback ++ io.stOut)
   val timer = GTimer()
   for((rob_wb, wb) <- rob.io.exeWbResults.zip(exeWbResults)) {
-    rob_wb.valid := RegNext(wb.valid && !wb.bits.uop.robIdx.needFlush(stage2Redirect, flushReg))
+    rob_wb.valid := RegNext(wb.valid && !wb.bits.uop.robIdx.needFlush(stage2Redirect))
     rob_wb.bits := RegNext(wb.bits)
     rob_wb.bits.uop.debugInfo.writebackTime := timer
   }
 
   io.redirect <> stage2Redirect
-  io.flush <> flushReg
 
   // rob to int block
   io.robio.toCSR <> rob.io.csr

--- a/src/main/scala/xiangshan/backend/FUBlock.scala
+++ b/src/main/scala/xiangshan/backend/FUBlock.scala
@@ -107,7 +107,6 @@ class FUBlock(configs: Seq[(ExuConfig, Int)])(implicit p: Parameters) extends XS
 
   val io = IO(new Bundle {
     val redirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
     // in
     val issue = Vec(numIn, Flipped(DecoupledIO(new ExuInput)))
     // out
@@ -137,7 +136,6 @@ class FUBlock(configs: Seq[(ExuConfig, Int)])(implicit p: Parameters) extends XS
 
   for ((exu, i) <- exeUnits.zipWithIndex) {
     exu.io.redirect <> io.redirect
-    exu.io.flush <> io.flush
 
     if (exu.csrio.isDefined) {
       exu.csrio.get <> io.extra.csrio.get

--- a/src/main/scala/xiangshan/backend/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/Scheduler.scala
@@ -222,7 +222,6 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
   val io = IO(new Bundle {
     // global control
     val redirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
     // dispatch and issue ports
     // val allocate = Vec(outer.numDpPorts, Flipped(DecoupledIO(new MicroOp)))
     val allocPregs = Vec(RenameWidth, Input(new ResetPregStateReq))
@@ -243,7 +242,6 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
   val readIntState = dispatch2.flatMap(_.io.readIntState.getOrElse(Seq()))
   if (readIntState.nonEmpty) {
     val busyTable = Module(new BusyTable(readIntState.length, intRfWritePorts))
-    busyTable.io.flush := io.flush
     busyTable.io.allocPregs.zip(io.allocPregs).foreach{ case (pregAlloc, allocReq) =>
       pregAlloc.valid := allocReq.isInt
       pregAlloc.bits := allocReq.preg
@@ -262,7 +260,6 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
     val numBusyTableRead = readFpState.length - numInFpStateRead
     if (numBusyTableRead > 0) {
       val busyTable = Module(new BusyTable(numBusyTableRead, fpRfWritePorts))
-      busyTable.io.flush := io.flush
       busyTable.io.allocPregs.zip(io.allocPregs).foreach { case (pregAlloc, allocReq) =>
         pregAlloc.valid := allocReq.isFp
         pregAlloc.bits := allocReq.preg
@@ -338,7 +335,6 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
 
     rs.io.redirect <> io.redirect
     rs.io.redirect <> io.redirect
-    rs.io.flush <> io.flush
 
     val issueWidth = rs.io.deq.length
     rs.io.deq <> io.issue.slice(issueIdx, issueIdx + issueWidth)

--- a/src/main/scala/xiangshan/backend/decode/StoreSet.scala
+++ b/src/main/scala/xiangshan/backend/decode/StoreSet.scala
@@ -173,7 +173,6 @@ class LFST(implicit p: Parameters) extends XSModule  {
     // val update = Input(new MemPredUpdateReq) // RegNext should be added outside
     // when redirect, mark canceled store as invalid
     val redirect = Input(Valid(new Redirect))
-    val flush = Input(Bool())
     // when store is dispatched, mark it as valid
     val dispatch = Vec(RenameWidth, Flipped(Valid(new DispatchToLFST)))
     // when store issued, mark store as invalid
@@ -244,7 +243,7 @@ class LFST(implicit p: Parameters) extends XSModule  {
   // when redirect, cancel store influenced
   (0 until LFSTSize).map(i => {
     (0 until LFSTWidth).map(j => {
-      when(robIdxVec(i)(j).needFlush(io.redirect, io.flush)){
+      when(robIdxVec(i)(j).needFlush(io.redirect)){
         validVec(i)(j) := false.B
       }
     })

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -73,9 +73,8 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasExceptionNO {
     }
     // to store set LFST
     val lfst = Vec(RenameWidth, Valid(new DispatchToLFST))
-    // flush or replay, for LFST
+    // redirect for LFST
     val redirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
     // LFST ctrl
     val csrCtrl = Input(new CustomCSRCtrlIO)
     // LFST state sync
@@ -92,7 +91,6 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasExceptionNO {
 
   val lfst = Module(new LFST)
   lfst.io.redirect <> RegNext(io.redirect)
-  lfst.io.flush <> RegNext(io.flush)
   lfst.io.storeIssue <> RegNext(io.storeIssue)
   lfst.io.csrCtrl <> RegNext(io.csrCtrl)
   lfst.io.dispatch := io.lfst
@@ -120,7 +118,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasExceptionNO {
     */
 
   val singleStepStatus = RegInit(false.B)
-  when (io.flush) {
+  when (io.redirect.valid) {
     singleStepStatus := false.B
   }.elsewhen (io.singleStep && io.fromRename(0).fire()) {
     singleStepStatus := true.B

--- a/src/main/scala/xiangshan/backend/exu/Exu.scala
+++ b/src/main/scala/xiangshan/backend/exu/Exu.scala
@@ -108,7 +108,6 @@ abstract class Exu(cfg: ExuConfig)(implicit p: Parameters) extends XSModule {
     val fromInt = if (config.readIntRf) Flipped(DecoupledIO(new ExuInput)) else null
     val fromFp = if (config.readFpRf) Flipped(DecoupledIO(new ExuInput)) else null
     val redirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
     val out = DecoupledIO(new ExuOutput)
   })
 
@@ -137,12 +136,10 @@ abstract class Exu(cfg: ExuConfig)(implicit p: Parameters) extends XSModule {
 
   val fuInReady = config.fuConfigs.zip(fuIn).zip(functionUnits.zip(fuSel)).map { case ((fuCfg, in), (fu, sel)) =>
     fu.io.redirectIn := io.redirect
-    fu.io.flushIn := io.flush
 
     if (fuCfg.hasInputBuffer) {
       val buffer = Module(new InputBuffer(8))
       buffer.io.redirect <> io.redirect
-      buffer.io.flush <> io.flush
       buffer.io.in.valid := in.valid && sel
       buffer.io.in.bits.uop := in.bits.uop
       buffer.io.in.bits.src := in.bits.src

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -985,7 +985,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   // ctrl block will use theses later for flush
   val isXRetFlag = RegInit(false.B)
   val retTargetReg = Reg(retTarget.cloneType)
-  when (io.flushIn) {
+  when (io.redirectIn.valid) {
     isXRetFlag := false.B
   }.elsewhen (isXRet) {
     isXRetFlag := true.B

--- a/src/main/scala/xiangshan/backend/fu/FunctionUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FunctionUnit.scala
@@ -73,7 +73,6 @@ class FunctionUnitIO(val len: Int)(implicit p: Parameters) extends XSBundle {
   val out = DecoupledIO(new FuOutput(len))
 
   val redirectIn = Flipped(ValidIO(new Redirect))
-  val flushIn = Input(Bool())
 }
 
 abstract class FunctionUnit(len: Int = 64)(implicit p: Parameters) extends XSModule {
@@ -102,7 +101,7 @@ trait HasPipelineReg {
 
 
   // if flush(0), valid 0 will not given, so set flushVec(0) to false.B
-  val flushVec = validVec.zip(uopVec).map(x => x._1 && x._2.robIdx.needFlush(io.redirectIn, io.flushIn))
+  val flushVec = validVec.zip(uopVec).map(x => x._1 && x._2.robIdx.needFlush(io.redirectIn))
 
   for (i <- 0 until latency - 1) {
     rdyVec(i) := !validVec(i + 1) || rdyVec(i + 1)

--- a/src/main/scala/xiangshan/backend/fu/InputBuffer.scala
+++ b/src/main/scala/xiangshan/backend/fu/InputBuffer.scala
@@ -26,7 +26,6 @@ import xiangshan.backend.issue.AgeDetector
 class InputBuffer(numEntries: Int)(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
     val redirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
 
     val in = Flipped(DecoupledIO(new FunctionUnitInput(XLEN)))
     val out = DecoupledIO(new FunctionUnitInput(XLEN))
@@ -40,7 +39,7 @@ class InputBuffer(numEntries: Int)(implicit p: Parameters) extends XSModule {
   val enqVec = selectEnq._2
 
   // enqueue
-  val doEnqueue = io.in.fire() && !io.in.bits.uop.robIdx.needFlush(io.redirect, io.flush)
+  val doEnqueue = io.in.fire() && !io.in.bits.uop.robIdx.needFlush(io.redirect)
   when (doEnqueue) {
     for (i <- 0 until numEntries) {
       when (enqVec(i)) {
@@ -66,7 +65,7 @@ class InputBuffer(numEntries: Int)(implicit p: Parameters) extends XSModule {
   }
 
   // flush
-  val flushVec = data.map(_.uop.robIdx).zip(emptyVec).map{ case (r, e) => !e && r.needFlush(io.redirect, io.flush) }
+  val flushVec = data.map(_.uop.robIdx).zip(emptyVec).map{ case (r, e) => !e && r.needFlush(io.redirect) }
   for (i <- 0 until numEntries) {
     when (flushVec(i)) {
       emptyVec(i) := true.B

--- a/src/main/scala/xiangshan/backend/fu/Jump.scala
+++ b/src/main/scala/xiangshan/backend/fu/Jump.scala
@@ -69,7 +69,7 @@ class Jump(implicit p: Parameters) extends FUWithRedirect {
     io.in.bits.uop
   )
 
-  val redirectHit = uop.robIdx.needFlush(io.redirectIn, io.flushIn)
+  val redirectHit = uop.robIdx.needFlush(io.redirectIn)
   val valid = io.in.valid
   val isRVC = uop.cf.pd.isRVC
 

--- a/src/main/scala/xiangshan/backend/fu/Radix2Divider.scala
+++ b/src/main/scala/xiangshan/backend/fu/Radix2Divider.scala
@@ -58,7 +58,7 @@ class Radix2Divider(len: Int)(implicit p: Parameters) extends AbstractDivider(le
   val uopReg = RegEnable(uop, newReq)
 
   val cnt = Counter(len)
-  when (newReq && !io.in.bits.uop.robIdx.needFlush(io.redirectIn, io.flushIn)) {
+  when (newReq && !io.in.bits.uop.robIdx.needFlush(io.redirectIn)) {
     state := s_log2
   } .elsewhen (state === s_log2) {
     // `canSkipShift` is calculated as following:
@@ -88,7 +88,7 @@ class Radix2Divider(len: Int)(implicit p: Parameters) extends AbstractDivider(le
     }
   }
 
-  val kill = state=/=s_idle && uopReg.robIdx.needFlush(io.redirectIn, io.flushIn)
+  val kill = state=/=s_idle && uopReg.robIdx.needFlush(io.redirectIn)
   when(kill){
     state := s_idle
   }

--- a/src/main/scala/xiangshan/backend/fu/SRT16Divider.scala
+++ b/src/main/scala/xiangshan/backend/fu/SRT16Divider.scala
@@ -448,8 +448,8 @@ class SRT16Divider(len: Int)(implicit p: Parameters) extends AbstractDivider(len
 
   val divDataModule = Module(new SRT16DividerDataModule(len))
 
-  val kill_w = uop.robIdx.needFlush(io.redirectIn, io.flushIn)
-  val kill_r = !divDataModule.io.in_ready && uopReg.robIdx.needFlush(io.redirectIn, io.flushIn)
+  val kill_w = uop.robIdx.needFlush(io.redirectIn)
+  val kill_r = !divDataModule.io.in_ready && uopReg.robIdx.needFlush(io.redirectIn)
 
   divDataModule.io.src(0) := io.in.bits.src(0)
   divDataModule.io.src(1) := io.in.bits.src(1)

--- a/src/main/scala/xiangshan/backend/fu/SRT4Divider.scala
+++ b/src/main/scala/xiangshan/backend/fu/SRT4Divider.scala
@@ -437,8 +437,8 @@ class SRT4Divider(len: Int)(implicit p: Parameters) extends AbstractDivider(len)
 
   val divDataModule = Module(new SRT4DividerDataModule(len))
 
-  val kill_w = uop.robIdx.needFlush(io.redirectIn, io.flushIn)
-  val kill_r = !divDataModule.io.in_ready && uopReg.robIdx.needFlush(io.redirectIn, io.flushIn)
+  val kill_w = uop.robIdx.needFlush(io.redirectIn)
+  val kill_r = !divDataModule.io.in_ready && uopReg.robIdx.needFlush(io.redirectIn)
 
   divDataModule.io.src(0) := io.in.bits.src(0)
   divDataModule.io.src(1) := io.in.bits.src(1)

--- a/src/main/scala/xiangshan/backend/fu/fpu/FDivSqrt.scala
+++ b/src/main/scala/xiangshan/backend/fu/fpu/FDivSqrt.scala
@@ -130,13 +130,13 @@ class FDivSqrtDataModule(implicit p: Parameters) extends FPUDataModule {
 class FDivSqrt(implicit p: Parameters) extends FPUSubModule {
 
   val uopReg = RegEnable(io.in.bits.uop, io.in.fire())
-  val kill_r = !io.in.ready && uopReg.robIdx.needFlush(io.redirectIn, io.flushIn)
+  val kill_r = !io.in.ready && uopReg.robIdx.needFlush(io.redirectIn)
 
   override val dataModule = Module(new FDivSqrtDataModule)
   connectDataModule
   dataModule.in_valid := io.in.valid
   dataModule.out_ready := io.out.ready
-  dataModule.kill_w := io.in.bits.uop.robIdx.needFlush(io.redirectIn, io.flushIn)
+  dataModule.kill_w := io.in.bits.uop.robIdx.needFlush(io.redirectIn)
   dataModule.kill_r := kill_r
   io.in.ready := dataModule.in_ready
   io.out.valid := dataModule.out_valid

--- a/src/main/scala/xiangshan/backend/fu/fpu/FMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/fpu/FMA.scala
@@ -197,11 +197,9 @@ class FMA(implicit p: Parameters) extends FPUSubModule {
 
 
   mul_pipe.io.redirectIn := io.redirectIn
-  mul_pipe.io.flushIn := io.flushIn
   mul_pipe.rm := rm
 
   add_pipe.io.redirectIn := io.redirectIn
-  add_pipe.io.flushIn := io.flushIn
   add_pipe.rm := rm
 
   val fpCtrl = io.in.bits.uop.ctrl.fpu
@@ -212,7 +210,7 @@ class FMA(implicit p: Parameters) extends FPUSubModule {
   val waitAddOperand = RegEnable(midResult.waitForAdd, !mul_pipe.io.out.valid || mul_pipe.io.out.ready)
   val isFMA = mul_pipe.io.out.valid && mul_pipe.io.out.bits.uop.ctrl.fpu.ren3 && !waitAddOperand
   // However, when sending instructions to add_pipe, we need to determine whether it's flushed.
-  val mulFlushed = mul_pipe.io.out.bits.uop.robIdx.needFlush(io.redirectIn, io.flushIn)
+  val mulFlushed = mul_pipe.io.out.bits.uop.robIdx.needFlush(io.redirectIn)
   val isFMAReg = RegNext(isFMA && !mulFlushed)
 
   add_pipe.mulToAdd <> mul_pipe.toAdd

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -156,7 +156,6 @@ class ReservationStationWrapper(implicit p: Parameters) extends LazyModule with 
     val perf = IO(Vec(rs.length, Output(new RsPerfCounter)))
 
     rs.foreach(_.io.redirect <> io.redirect)
-    rs.foreach(_.io.flush <> io.flush)
     io.numExist <> rs.map(_.io.numExist).reduce(_ +& _)
     io.fromDispatch <> rs.flatMap(_.io.fromDispatch)
     io.srcRegValue <> rs.flatMap(_.io.srcRegValue)
@@ -206,7 +205,6 @@ class ReservationStationWrapper(implicit p: Parameters) extends LazyModule with 
 
 class ReservationStationIO(params: RSParams)(implicit p: Parameters) extends XSBundle {
   val redirect = Flipped(ValidIO(new Redirect))
-  val flush = Input(Bool())
   val numExist = Output(UInt(log2Up(params.numEntries + 1).W))
   // enq
   val fromDispatch = Vec(params.numEnq, Flipped(DecoupledIO(new MicroOp)))
@@ -262,7 +260,6 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
   io.numExist := PopCount(statusArray.io.isValid)
   perf.full := RegNext(statusArray.io.isValid.andR)
   statusArray.io.redirect := io.redirect
-  statusArray.io.flush := io.flush
 
   /**
     * S0: Update status (from dispatch and wakeup) and schedule possible instructions to issue.
@@ -270,8 +267,8 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
   // enqueue from dispatch
   select.io.validVec := statusArray.io.isValid
   // agreement with dispatch: don't enqueue when io.redirect.valid
-  val doEnqueue = VecInit(io.fromDispatch.map(_.fire && !io.redirect.valid && !io.flush))
-  val enqShouldNotFlushed = io.fromDispatch.map(d => d.fire && !d.bits.robIdx.needFlush(io.redirect, io.flush))
+  val doEnqueue = VecInit(io.fromDispatch.map(_.fire && !io.redirect.valid))
+  val enqShouldNotFlushed = io.fromDispatch.map(d => d.fire && !d.bits.robIdx.needFlush(io.redirect))
   XSPerfAccumulate("wrong_stall", Mux(io.redirect.valid, PopCount(enqShouldNotFlushed), 0.U))
   val needFpSource = io.fromDispatch.map(_.bits.needRfRPort(1, 1, false))
   for (i <- 0 until params.numEnq) {
@@ -367,7 +364,7 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
   s1_out.foreach(_.bits.uop.debugInfo.selectTime := GTimer())
 
   for (i <- 0 until params.numDeq) {
-    s1_out(i).valid := issueVec(i).valid && !s1_out(i).bits.uop.robIdx.needFlush(io.redirect, io.flush)
+    s1_out(i).valid := issueVec(i).valid && !s1_out(i).bits.uop.robIdx.needFlush(io.redirect)
     statusArray.io.issueGranted(i).valid := issueVec(i).valid && s1_out(i).ready
     statusArray.io.issueGranted(i).bits := issueVec(i).bits
     if (io.feedback.isDefined) {
@@ -401,7 +398,6 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
       wakeupQueue.io.in.bits := s1_out(i).bits.uop
       wakeupQueue.io.in.bits.debugInfo.issueTime := GTimer() + 1.U
       wakeupQueue.io.redirect := io.redirect
-      wakeupQueue.io.flush := io.flush
       io.fastWakeup.get(i) := wakeupQueue.io.out
       XSPerfAccumulate(s"fast_blocked_$i", issueVec(i).valid && fuCheck && !s1_out(i).ready)
     }
@@ -522,7 +518,7 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
   for (i <- 0 until params.numDeq) {
     // payload: send to function units
     // TODO: these should be done outside RS
-    PipelineConnect(s1_out(i), s2_deq(i), s2_deq(i).ready || s2_deq(i).bits.uop.robIdx.needFlush(io.redirect, io.flush), false.B)
+    PipelineConnect(s1_out(i), s2_deq(i), s2_deq(i).ready || s2_deq(i).bits.uop.robIdx.needFlush(io.redirect), false.B)
     if (params.hasFeedback) {
       io.feedback.get(i).rsIdx := s2_issue_index(i)
       io.feedback.get(i).isFirstIssue := s2_first_issue(i)
@@ -732,7 +728,6 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
   }
 
   XSPerfAccumulate("redirect_num", io.redirect.valid)
-  XSPerfAccumulate("flush_num", io.flush)
   XSPerfHistogram("allocate_num", PopCount(io.fromDispatch.map(_.valid)), true.B, 0, params.numEnq, 1)
   XSPerfHistogram("issue_num", PopCount(io.deq.map(_.valid)), true.B, 0, params.numDeq, 1)
 

--- a/src/main/scala/xiangshan/backend/issue/StatusArray.scala
+++ b/src/main/scala/xiangshan/backend/issue/StatusArray.scala
@@ -80,7 +80,6 @@ class StatusArray(params: RSParams)(implicit p: Parameters) extends XSModule
   with HasCircularQueuePtrHelper {
   val io = IO(new Bundle {
     val redirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
     // current status
     val isValid = Output(UInt(params.numEntries.W))
     val canIssue = Output(UInt(params.numEntries.W))
@@ -171,10 +170,10 @@ class StatusArray(params: RSParams)(implicit p: Parameters) extends XSModule
   for (((status, statusNext), i) <- statusArray.zip(statusArrayNext).zipWithIndex) {
     // valid: when the entry holds a valid instruction, mark it true.
     // Set when (1) not (flushed or deq); AND (2) update.
-    val isFlushed = status.valid && status.robIdx.needFlush(io.redirect, io.flush)
+    val isFlushed = status.valid && status.robIdx.needFlush(io.redirect)
     val (deqRespValid, deqRespSucc, deqRespType, deqRespDataInvalidSqIdx) = deqResp(i)
     flushedVec(i) := isFlushed || (deqRespValid && deqRespSucc)
-    val realUpdateValid = updateValid(i) && !io.redirect.valid && !io.flush
+    val realUpdateValid = updateValid(i) && !io.redirect.valid
     statusNext.valid := !flushedVec(i) && (realUpdateValid || status.valid)
     XSError(updateValid(i) && status.valid, p"should not update a valid entry $i\n")
 

--- a/src/main/scala/xiangshan/backend/issue/WakeupQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/WakeupQueue.scala
@@ -27,7 +27,6 @@ class WakeupQueue(number: Int)(implicit p: Parameters) extends XSModule {
     val in  = Flipped(ValidIO(new MicroOp))
     val out = ValidIO(new MicroOp)
     val redirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
   })
   if (number < 0) {
     io.out.valid := false.B
@@ -41,11 +40,11 @@ class WakeupQueue(number: Int)(implicit p: Parameters) extends XSModule {
       val valid = Bool()
       val bits = new MicroOp
     })))
-    queue(0).valid := io.in.valid && !io.in.bits.robIdx.needFlush(io.redirect, io.flush)
+    queue(0).valid := io.in.valid && !io.in.bits.robIdx.needFlush(io.redirect)
     queue(0).bits  := io.in.bits
     (0 until (number-1)).map{i =>
       queue(i+1) := queue(i)
-      queue(i+1).valid := queue(i).valid && !queue(i).bits.robIdx.needFlush(io.redirect, io.flush)
+      queue(i+1).valid := queue(i).valid && !queue(i).bits.robIdx.needFlush(io.redirect)
     }
     io.out.valid := queue(number-1).valid
     io.out.bits := queue(number-1).bits

--- a/src/main/scala/xiangshan/backend/rename/BusyTable.scala
+++ b/src/main/scala/xiangshan/backend/rename/BusyTable.scala
@@ -29,7 +29,6 @@ class BusyTableReadIO(implicit p: Parameters) extends XSBundle {
 
 class BusyTable(numReadPorts: Int, numWritePorts: Int)(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
-    val flush = Input(Bool())
     // set preg state to busy
     val allocPregs = Vec(RenameWidth, Flipped(ValidIO(UInt(PhyRegIdxWidth.W))))
     // set preg state to ready (write back regfile + rob walk)
@@ -53,10 +52,6 @@ class BusyTable(numReadPorts: Int, numWritePorts: Int)(implicit p: Parameters) e
   io.read.map(r => r.resp := !table(r.req))
 
   table := tableAfterAlloc
-
-  when(io.flush){
-    table := 0.U(NRPhyRegs.W)
-  }
 
   XSDebug(p"table    : ${Binary(table)}\n")
   XSDebug(p"tableNext: ${Binary(tableAfterAlloc)}\n")

--- a/src/main/scala/xiangshan/backend/rename/freelist/FreeListBaseIO.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/FreeListBaseIO.scala
@@ -24,7 +24,6 @@ import utils._
 trait FreeListBaseIO {
 
   // control signals from CtrlBlock
-  def flush: Bool
   def redirect: Bool
   def walk: Bool
 

--- a/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
@@ -23,7 +23,6 @@ import utils._
 import chipsalliance.rocketchip.config
 
 class StdFreeList(implicit val p: config.Parameters) extends MultiIOModule with FreeListBaseIO with HasXSParameter with HasCircularQueuePtrHelper {
-  val flush = IO(Input(Bool()))
   val redirect = IO(Input(Bool()))
   val walk = IO(Input(Bool()))
 
@@ -90,12 +89,9 @@ class StdFreeList(implicit val p: config.Parameters) extends MultiIOModule with 
   freeRegCnt := distanceBetween(tailPtr, headPtrNext)
 
   // priority: (1) exception and flushPipe; (2) walking; (3) mis-prediction; (4) normal dequeue
-  headPtr := Mux(flush,
-    FreeListPtr(!tailPtrNext.flag, tailPtrNext.value),
-    Mux(walk,
+  headPtr := Mux(walk,
       headPtr - stepBack,
       Mux(redirect, headPtr, headPtrNext))
-  )
 
   XSDebug(p"head:$headPtr tail:$tailPtr\n")
 

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -29,9 +29,9 @@ class RobPtr(implicit p: Parameters) extends CircularQueuePtr[RobPtr](
   p => p(XSCoreParamsKey).RobSize
 ) with HasCircularQueuePtrHelper {
 
-  def needFlush(redirect: Valid[Redirect], flush: Bool): Bool = {
+  def needFlush(redirect: Valid[Redirect]): Bool = {
     val flushItself = redirect.bits.flushItself() && this === redirect.bits.robIdx
-    flush || (redirect.valid && (flushItself || isAfter(this, redirect.bits.robIdx)))
+    redirect.valid && (flushItself || isAfter(this, redirect.bits.robIdx))
   }
 
   override def cloneType = (new RobPtr).asInstanceOf[this.type]
@@ -103,7 +103,7 @@ class RobDeqPtrWrapper(implicit p: Parameters) extends XSModule with HasCircular
   // for exceptions (flushPipe included) and interrupts:
   // only consider the first instruction
   val intrEnable = io.intrBitSetReg && !io.hasNoSpecExec && !CommitType.isLoadStore(io.commitType)
-  val exceptionEnable = io.deq_w(0) && io.exception_state.valid && io.exception_state.bits.robIdx === deqPtrVec(0)
+  val exceptionEnable = io.deq_w(0) && io.exception_state.valid && !io.exception_state.bits.flushPipe && io.exception_state.bits.robIdx === deqPtrVec(0)
   val redirectOutValid = io.state === 0.U && io.deq_v(0) && (intrEnable || exceptionEnable)
 
   // for normal commits: only to consider when there're no exceptions
@@ -111,13 +111,13 @@ class RobDeqPtrWrapper(implicit p: Parameters) extends XSModule with HasCircular
   val commit_exception = io.exception_state.valid && !isAfter(io.exception_state.bits.robIdx, deqPtrVec.last)
   val canCommit = VecInit((0 until CommitWidth).map(i => io.deq_v(i) && io.deq_w(i) && !io.misPredBlock && !io.isReplaying))
   val normalCommitCnt = PriorityEncoder(canCommit.map(c => !c) :+ true.B)
-  // when io.intrBitSetReg or there're possible exceptions in these instructions, only one instruction is allowed to commit
+  // when io.intrBitSetReg or there're possible exceptions in these instructions,
+  // only one instruction is allowed to commit
   val allowOnlyOne = commit_exception || io.intrBitSetReg
   val commitCnt = Mux(allowOnlyOne, canCommit(0), normalCommitCnt)
 
-  val resetDeqPtrVec = VecInit((0 until CommitWidth).map(_.U.asTypeOf(new RobPtr)))
   val commitDeqPtrVec = VecInit(deqPtrVec.map(_ + commitCnt))
-  val deqPtrVec_next = Mux(redirectOutValid, resetDeqPtrVec, Mux(io.state === 0.U, commitDeqPtrVec, deqPtrVec))
+  val deqPtrVec_next = Mux(io.state === 0.U && !redirectOutValid, commitDeqPtrVec, deqPtrVec)
 
   deqPtrVec := deqPtrVec_next
 
@@ -132,15 +132,6 @@ class RobDeqPtrWrapper(implicit p: Parameters) extends XSModule with HasCircular
 
 class RobEnqPtrWrapper(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelper {
   val io = IO(new Bundle {
-    // for exceptions and interrupts
-    val state = Input(UInt(2.W))
-    val deq_v = Input(Bool())
-    val deq_w = Input(Bool())
-    val deqPtr = Input(new RobPtr)
-    val exception_state = Flipped(ValidIO(new RobExceptionInfo))
-    val intrBitSetReg = Input(Bool())
-    val hasNoSpecExec = Input(Bool())
-    val commitType = Input(CommitType())
     // for input redirect
     val redirect = Input(Valid(new Redirect))
     // for enqueue
@@ -152,19 +143,11 @@ class RobEnqPtrWrapper(implicit p: Parameters) extends XSModule with HasCircular
 
   val enqPtr = RegInit(0.U.asTypeOf(new RobPtr))
 
-  // for exceptions (flushPipe included) and interrupts:
-  // only consider the first instruction
-  val intrEnable = io.intrBitSetReg && !io.hasNoSpecExec && !CommitType.isLoadStore(io.commitType)
-  val exceptionEnable = io.deq_w(0) && io.exception_state.valid && io.exception_state.bits.robIdx === io.deqPtr
-  val redirectOutValid = io.state === 0.U && io.deq_v && (intrEnable || exceptionEnable)
-
   // enqueue
   val canAccept = io.allowEnqueue && !io.hasBlockBackward
-  val dispatchNum = Mux(canAccept && !RegNext(redirectOutValid), PopCount(io.enq), 0.U)
+  val dispatchNum = Mux(canAccept, PopCount(io.enq), 0.U)
 
-  when (redirectOutValid) {
-    enqPtr := 0.U.asTypeOf(new RobPtr)
-  }.elsewhen (io.redirect.valid) {
+  when (io.redirect.valid) {
     enqPtr := io.redirect.bits.robIdx + Mux(io.redirect.bits.flushItself(), 0.U, 1.U)
   }.otherwise {
     enqPtr := enqPtr + dispatchNum
@@ -205,7 +188,7 @@ class ExceptionGen(implicit p: Parameters) extends XSModule with HasCircularQueu
   val in_wb_valid = io.wb.map(w => w.valid && w.bits.has_exception && !lastCycleFlush)
 
   // s0: compare wb(1),wb(2) and wb(3),wb(4)
-  val wb_valid = in_wb_valid.zip(io.wb.map(_.bits)).map{ case (v, bits) => v && !bits.robIdx.needFlush(io.redirect, io.flush) }
+  val wb_valid = in_wb_valid.zip(io.wb.map(_.bits)).map{ case (v, bits) => v && !(bits.robIdx.needFlush(io.redirect) || io.flush) }
   val csr_wb_bits = io.wb(0).bits
   val load_wb_bits = Mux(!in_wb_valid(2) || in_wb_valid(1) && isAfter(io.wb(2).bits.robIdx, io.wb(1).bits.robIdx), io.wb(1).bits, io.wb(2).bits)
   val store_wb_bits = Mux(!in_wb_valid(4) || in_wb_valid(3) && isAfter(io.wb(4).bits.robIdx, io.wb(3).bits.robIdx), io.wb(3).bits, io.wb(4).bits)
@@ -213,7 +196,7 @@ class ExceptionGen(implicit p: Parameters) extends XSModule with HasCircularQueu
   val s0_out_bits = RegNext(VecInit(Seq(csr_wb_bits, load_wb_bits, store_wb_bits)))
 
   // s1: compare last four and current flush
-  val s1_valid = VecInit(s0_out_valid.zip(s0_out_bits).map{ case (v, b) => v && !b.robIdx.needFlush(io.redirect, io.flush) })
+  val s1_valid = VecInit(s0_out_valid.zip(s0_out_bits).map{ case (v, b) => v && !(b.robIdx.needFlush(io.redirect) || io.flush) })
   val compare_01_valid = s0_out_valid(0) || s0_out_valid(1)
   val compare_01_bits = Mux(!s0_out_valid(0) || s0_out_valid(1) && isAfter(s0_out_bits(0).robIdx, s0_out_bits(1).robIdx), s0_out_bits(1), s0_out_bits(0))
   val compare_bits = Mux(!s0_out_valid(2) || compare_01_valid && isAfter(s0_out_bits(2).robIdx, compare_01_bits.robIdx), compare_01_bits, s0_out_bits(2))
@@ -228,8 +211,8 @@ class ExceptionGen(implicit p: Parameters) extends XSModule with HasCircularQueu
   // (1) system reset
   // (2) current is valid: flush, remain, merge, update
   // (3) current is not valid: s1 or enq
-  val current_flush = current.bits.robIdx.needFlush(io.redirect, io.flush)
-  val s1_flush = s1_out_bits.robIdx.needFlush(io.redirect, io.flush)
+  val current_flush = current.bits.robIdx.needFlush(io.redirect) || io.flush
+  val s1_flush = s1_out_bits.robIdx.needFlush(io.redirect) || io.flush
   when (reset.asBool) {
     current.valid := false.B
   }.elsewhen (current.valid) {
@@ -262,6 +245,7 @@ class ExceptionGen(implicit p: Parameters) extends XSModule with HasCircularQueu
 
 class RobFlushInfo(implicit p: Parameters) extends XSBundle {
   val ftqIdx = new FtqPtr
+  val robIdx = new RobPtr
   val ftqOffset = UInt(log2Up(PredictWidth).W)
   val replayInst = Bool()
 }
@@ -270,7 +254,7 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   val io = IO(new Bundle() {
     val redirect = Input(Valid(new Redirect))
     val enq = new RobEnqIO
-    val flushOut = ValidIO(new RobFlushInfo)
+    val flushOut = ValidIO(new Redirect)
     val exception = ValidIO(new ExceptionInfo)
     // exu + brq
     val exeWbResults = Vec(numWbPorts, Flipped(ValidIO(new ExuOutput)))
@@ -434,16 +418,23 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   val exceptionEnable = writebacked(deqPtr.value) && deqHasException
   val isFlushPipe = writebacked(deqPtr.value) && (deqHasFlushPipe || deqHasReplayInst)
 
-  io.flushOut.valid := (state === s_idle) && valid(deqPtr.value) && (intrEnable || exceptionEnable || isFlushPipe)
+  // io.flushOut will trigger redirect at the next cycle.
+  // Block any redirect or commit at the next cycle.
+  val lastCycleFlush = RegNext(io.flushOut.valid)
+
+  io.flushOut.valid := (state === s_idle) && valid(deqPtr.value) && (intrEnable || exceptionEnable || isFlushPipe) && !lastCycleFlush
+  io.flushOut.bits := DontCare
+  io.flushOut.bits.robIdx := deqPtr
   io.flushOut.bits.ftqIdx := deqDispatchData.ftqIdx
   io.flushOut.bits.ftqOffset := deqDispatchData.ftqOffset
-  io.flushOut.bits.replayInst := deqHasReplayInst
+  io.flushOut.bits.level := Mux(deqHasReplayInst || intrEnable || exceptionEnable, RedirectLevel.flush, RedirectLevel.flushAfter)
+  io.flushOut.bits.interrupt := true.B
   XSPerfAccumulate("interrupt_num", io.flushOut.valid && intrEnable)
   XSPerfAccumulate("exception_num", io.flushOut.valid && exceptionEnable)
   XSPerfAccumulate("flush_pipe_num", io.flushOut.valid && isFlushPipe)
   XSPerfAccumulate("replay_inst_num", io.flushOut.valid && isFlushPipe && deqHasReplayInst)
 
-  val exceptionHappen = (state === s_idle) && valid(deqPtr.value) && (intrEnable || exceptionEnable)
+  val exceptionHappen = (state === s_idle) && valid(deqPtr.value) && (intrEnable || exceptionEnable) && !lastCycleFlush
   io.exception.valid := RegNext(exceptionHappen)
   io.exception.bits.uop := RegEnable(debug_deqUop, exceptionHappen)
   io.exception.bits.uop.ctrl.commitType := RegEnable(deqDispatchData.commitType, exceptionHappen)
@@ -513,7 +504,7 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     // defaults: state === s_idle and instructions commit
     // when intrBitSetReg, allow only one instruction to commit at each clock cycle
     val isBlocked = if (i != 0) Cat(commit_block.take(i)).orR || allowOnlyOneCommit else intrEnable || deqHasException || deqHasReplayInst
-    io.commits.valid(i) := commit_v(i) && commit_w(i) && !isBlocked && !misPredBlock && !isReplaying
+    io.commits.valid(i) := commit_v(i) && commit_w(i) && !isBlocked && !misPredBlock && !isReplaying && !lastCycleFlush
     io.commits.info(i)  := dispatchDataRead(i)
 
     when (state === s_walk) {
@@ -572,14 +563,11 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     * (3) walk: when walking comes to the end, switch to s_walk
     * (4) s_extrawalk to s_walk
     */
-  val state_next = Mux(io.flushOut.valid,
-    s_idle,
-    Mux(io.redirect.valid,
-      Mux(io.enq.needAlloc.asUInt.orR, s_extrawalk, s_walk),
-      Mux(state === s_walk && walkFinished,
-        s_idle,
-        Mux(state === s_extrawalk, s_walk, state)
-      )
+  val state_next = Mux(io.redirect.valid,
+    Mux(io.enq.needAlloc.asUInt.orR, s_extrawalk, s_walk),
+    Mux(state === s_walk && walkFinished,
+      s_idle,
+      Mux(state === s_extrawalk, s_walk, state)
     )
   )
   state := state_next
@@ -602,14 +590,6 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   val deqPtrVec_next = deqPtrGenModule.io.next_out
 
   val enqPtrGenModule = Module(new RobEnqPtrWrapper)
-  enqPtrGenModule.io.state := state
-  enqPtrGenModule.io.deq_v := commit_v(0)
-  enqPtrGenModule.io.deq_w := commit_w(0)
-  enqPtrGenModule.io.deqPtr := deqPtr
-  enqPtrGenModule.io.exception_state := exceptionDataRead
-  enqPtrGenModule.io.intrBitSetReg := intrBitSetReg
-  enqPtrGenModule.io.hasNoSpecExec := hasNoSpecExec
-  enqPtrGenModule.io.commitType := deqDispatchData.commitType
   enqPtrGenModule.io.redirect := io.redirect
   enqPtrGenModule.io.allowEnqueue := allowEnqueue
   enqPtrGenModule.io.hasBlockBackward := hasBlockBackward
@@ -632,20 +612,14 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   val lastCycleRedirect = RegNext(io.redirect.valid)
   val trueValidCounter = Mux(lastCycleRedirect, distanceBetween(enqPtr, deqPtr), validCounter)
   val commitCnt = PopCount(io.commits.valid)
-  validCounter := Mux(io.flushOut.valid,
-    0.U,
-    Mux(state === s_idle,
-      (validCounter - commitCnt) + dispatchNum,
-      trueValidCounter
-    )
+  validCounter := Mux(state === s_idle,
+    (validCounter - commitCnt) + dispatchNum,
+    trueValidCounter
   )
 
-  allowEnqueue := Mux(io.flushOut.valid,
-    true.B,
-    Mux(state === s_idle,
-      validCounter + dispatchNum <= (RobSize - RenameWidth).U,
-      trueValidCounter <= (RobSize - RenameWidth).U
-    )
+  allowEnqueue := Mux(state === s_idle,
+    validCounter + dispatchNum <= (RobSize - RenameWidth).U,
+    trueValidCounter <= (RobSize - RenameWidth).U
   )
 
   val currentWalkPtr = Mux(state === s_walk || state === s_extrawalk, walkPtr, enqPtr - 1.U)
@@ -672,7 +646,7 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
 
   // enqueue logic writes 6 valid
   for (i <- 0 until RenameWidth) {
-    when (canEnqueue(i) && !io.redirect.valid && !RegNext(io.flushOut.valid)) {
+    when (canEnqueue(i) && !io.redirect.valid) {
       valid(enqPtrVec(i).value) := true.B
     }
   }
@@ -683,11 +657,6 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     }
   }
   // reset: when exception, reset all valid to false
-  when (io.flushOut.valid) {
-    for (i <- 0 until RobSize) {
-      valid(i) := false.B
-    }
-  }
   when (reset.asBool) {
     for (i <- 0 until RobSize) {
       valid(i) := false.B

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -789,12 +789,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
     }
   }
   val redirectVec = Wire(Vec(3, new RedirectInfo))
-  val robRedirect = Wire(Valid(new Redirect))
-  robRedirect := DontCare
-  robRedirect.valid := robFlush.valid
-  robRedirect.bits.ftqIdx := robFlush.bits.ftqIdx
-  robRedirect.bits.ftqOffset := robFlush.bits.ftqOffset
-  robRedirect.bits.level := RedirectLevel.flush
+  val robRedirect = robFlush
 
   redirectVec.zip(Seq(robRedirect, stage2Redirect, fromIfuRedirect)).map {
     case (ve, r) => ve(r)

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -57,7 +57,6 @@ class LsqWrappper(implicit p: Parameters) extends XSModule with HasDCacheParamet
   val io = IO(new Bundle() {
     val enq = new LsqEnqIO
     val brqRedirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
     val loadIn = Vec(LoadPipelineWidth, Flipped(Valid(new LsPipelineBundle)))
     val storeIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle)))
     val storeDataIn = Vec(StorePipelineWidth, Flipped(Valid(new StoreDataBundle))) // store data, send to sq from rs
@@ -102,7 +101,6 @@ class LsqWrappper(implicit p: Parameters) extends XSModule with HasDCacheParamet
 
   // load queue wiring
   loadQueue.io.brqRedirect <> io.brqRedirect
-  loadQueue.io.flush <> io.flush
   loadQueue.io.loadIn <> io.loadIn
   loadQueue.io.storeIn <> io.storeIn
   loadQueue.io.loadDataForwarded <> io.loadDataForwarded
@@ -117,7 +115,6 @@ class LsqWrappper(implicit p: Parameters) extends XSModule with HasDCacheParamet
   // store queue wiring
   // storeQueue.io <> DontCare
   storeQueue.io.brqRedirect <> io.brqRedirect
-  storeQueue.io.flush <> io.flush
   storeQueue.io.storeIn <> io.storeIn
   storeQueue.io.storeDataIn <> io.storeDataIn
   storeQueue.io.sbuffer <> io.sbuffer

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -55,7 +55,6 @@ class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParamete
   val io = IO(new Bundle() {
     val enq = new SqEnqIO
     val brqRedirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
     val storeIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle))) // store addr, data is not included
     val storeDataIn = Vec(StorePipelineWidth, Flipped(Valid(new StoreDataBundle))) // store data, send to sq from rs
     val sbuffer = Vec(StorePipelineWidth, Decoupled(new DCacheWordReqWithVaddr)) // write commited store to sbuffer
@@ -159,7 +158,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParamete
     val offset = if (i == 0) 0.U else PopCount(io.enq.needAlloc.take(i))
     val sqIdx = enqPtrExt(offset)
     val index = sqIdx.value
-    when (io.enq.req(i).valid && io.enq.canAccept && io.enq.lqCanAccept && !(io.brqRedirect.valid || io.flush)) {
+    when (io.enq.req(i).valid && io.enq.canAccept && io.enq.lqCanAccept && !io.brqRedirect.valid) {
       uop(index) := io.enq.req(i).bits
       allocated(index) := true.B
       datavalid(index) := false.B
@@ -183,7 +182,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParamete
   val nextIssuePtr = issuePtrExt + PriorityEncoder(VecInit(issueLookup.map(!_) :+ true.B))
   issuePtrExt := nextIssuePtr
 
-  when (io.brqRedirect.valid || io.flush) {
+  when (io.brqRedirect.valid) {
     issuePtrExt := Mux(
       isAfter(cmtPtrExt(0), deqPtrExt(0)),
       cmtPtrExt(0),
@@ -511,7 +510,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParamete
   // invalidate sq term using robIdx
   val needCancel = Wire(Vec(StoreQueueSize, Bool()))
   for (i <- 0 until StoreQueueSize) {
-    needCancel(i) := uop(i).robIdx.needFlush(io.brqRedirect, io.flush) && allocated(i) && !commited(i)
+    needCancel(i) := uop(i).robIdx.needFlush(io.brqRedirect) && allocated(i) && !commited(i)
     when (needCancel(i)) {
         allocated(i) := false.B
     }
@@ -521,11 +520,10 @@ class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParamete
     * update pointers
     */
   val lastCycleRedirect = RegNext(io.brqRedirect.valid)
-  val lastCycleFlush = RegNext(io.flush)
   val lastCycleCancelCount = PopCount(RegNext(needCancel))
   // when io.brqRedirect.valid, we don't allow eneuque even though it may fire.
-  val enqNumber = Mux(io.enq.canAccept && io.enq.lqCanAccept && !(io.brqRedirect.valid || io.flush), PopCount(io.enq.req.map(_.valid)), 0.U)
-  when (lastCycleRedirect || lastCycleFlush) {
+  val enqNumber = Mux(io.enq.canAccept && io.enq.lqCanAccept && !io.brqRedirect.valid, PopCount(io.enq.req.map(_.valid)), 0.U)
+  when (lastCycleRedirect) {
     // we recover the pointers in the next cycle after redirect
     enqPtrExt := VecInit(enqPtrExt.map(_ - lastCycleCancelCount))
   }.otherwise {

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -36,7 +36,6 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
     val flush_sbuffer = new SbufferFlushBundle
     val feedbackSlow  = ValidIO(new RSFeedback)
     val redirect      = Flipped(ValidIO(new Redirect))
-    val flush         = Input(Bool())
     val exceptionAddr = ValidIO(UInt(VAddrBits.W))
   })
 
@@ -274,7 +273,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
     data_valid := false.B
   }
 
-  when(io.redirect.valid || io.flush){
+  when (io.redirect.valid) {
     atom_override_xtval := false.B
   }
 

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -419,7 +419,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper {
     val ldin = Flipped(Decoupled(new ExuInput))
     val ldout = Decoupled(new ExuOutput)
     val redirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
     val feedbackSlow = ValidIO(new RSFeedback)
     val feedbackFast = ValidIO(new RSFeedback)
     val rsIdx = Input(UInt(log2Up(IssQueSize).W))
@@ -449,7 +448,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper {
   load_s0.io.fastpath := io.fastpathIn
   load_s0.io.loadFastMatch := io.loadFastMatch
 
-  PipelineConnect(load_s0.io.out, load_s1.io.in, true.B, load_s0.io.out.bits.uop.robIdx.needFlush(io.redirect, io.flush))
+  PipelineConnect(load_s0.io.out, load_s1.io.in, true.B, load_s0.io.out.bits.uop.robIdx.needFlush(io.redirect))
 
   load_s1.io.dtlbResp <> io.tlb.resp
   io.dcache.s1_paddr <> load_s1.io.dcachePAddr
@@ -458,7 +457,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper {
   load_s1.io.lsq <> io.lsq.forward
   load_s1.io.dcacheBankConflict <> io.dcache.s1_bank_conflict
 
-  PipelineConnect(load_s1.io.out, load_s2.io.in, true.B, load_s1.io.out.bits.uop.robIdx.needFlush(io.redirect, io.flush))
+  PipelineConnect(load_s1.io.out, load_s2.io.in, true.B, load_s1.io.out.bits.uop.robIdx.needFlush(io.redirect))
 
   io.dcache.s2_kill <> load_s2.io.dcache_kill
   load_s2.io.dcacheResp <> io.dcache.resp
@@ -480,7 +479,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper {
 
   // feedback tlb miss / dcache miss queue full
   io.feedbackSlow.bits := RegNext(load_s2.io.rsFeedback.bits)
-  io.feedbackSlow.valid := RegNext(load_s2.io.rsFeedback.valid && !load_s2.io.out.bits.uop.robIdx.needFlush(io.redirect, io.flush))
+  io.feedbackSlow.valid := RegNext(load_s2.io.rsFeedback.valid && !load_s2.io.out.bits.uop.robIdx.needFlush(io.redirect))
 
   // feedback bank conflict to rs
   io.feedbackFast.bits := load_s1.io.rsFeedback.bits

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -179,7 +179,6 @@ class StoreUnit(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
     val stin = Flipped(Decoupled(new ExuInput))
     val redirect = Flipped(ValidIO(new Redirect))
-    val flush = Input(Bool())
     val feedbackSlow = ValidIO(new RSFeedback)
     val tlb = new TlbRequestIO()
     val pmp = Input(new PMPRespBundle())
@@ -199,16 +198,16 @@ class StoreUnit(implicit p: Parameters) extends XSModule {
   store_s0.io.rsIdx := io.rsIdx
   store_s0.io.isFirstIssue := io.isFirstIssue
 
-  PipelineConnect(store_s0.io.out, store_s1.io.in, true.B, store_s0.io.out.bits.uop.robIdx.needFlush(io.redirect, io.flush))
+  PipelineConnect(store_s0.io.out, store_s1.io.in, true.B, store_s0.io.out.bits.uop.robIdx.needFlush(io.redirect))
 
   store_s1.io.lsq <> io.lsq // send result to sq
   store_s1.io.dtlbResp <> io.tlb.resp
   store_s1.io.rsFeedback <> io.feedbackSlow
 
-  PipelineConnect(store_s1.io.out, store_s2.io.in, true.B, store_s1.io.out.bits.uop.robIdx.needFlush(io.redirect, io.flush))
+  PipelineConnect(store_s1.io.out, store_s2.io.in, true.B, store_s1.io.out.bits.uop.robIdx.needFlush(io.redirect))
 
   store_s2.io.pmpResp <> io.pmp
-  PipelineConnect(store_s2.io.out, store_s3.io.in, true.B, store_s2.io.out.bits.uop.robIdx.needFlush(io.redirect, io.flush))
+  PipelineConnect(store_s2.io.out, store_s3.io.in, true.B, store_s2.io.out.bits.uop.robIdx.needFlush(io.redirect))
 
   store_s3.io.stout <> io.stout
 


### PR DESCRIPTION
This commit removes flush IO for every modules. Flush now re-uses
redirect ports to flush the instructions.