### PR TITLE
backend: remove lsrc usages after rename

### DIFF
--- a/.github/workflows/check_verilog.py
+++ b/.github/workflows/check_verilog.py
@@ -7,17 +7,23 @@ def err(line, loc, msg):
     exit(1)
 
 if __name__ == "__main__":
-    in_module = False
+    in_decode = False
+    in_dispatch = False
     line_number = 0
     with open(sys.argv[1], "r") as f:
         for line in f:
             if "$fatal" in line or "$fwrite" in line:
                 err(line, line_number, "'fatal' or 'fwrite' statement was found!")
             if "module Decode" in line:
-                in_module = True
+                in_decode = True
+            elif "module Dispatch" in line:
+                in_dispatch = True
             elif "endmodule" in line:
-                in_module = False
-            elif in_module and "_pc" in line:
+                in_decode = False
+                in_dispatch = False
+            elif in_decode and "_pc" in line:
                 err(line, line_number, "PC should not be in decode!!!\n")
+            elif in_dispatch and "_lsrc" in line:
+                err(line, line_number, "lsrc should not be in dispatch!!!\n")
             line_number += 1
     exit(0)

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch2Rs.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch2Rs.scala
@@ -184,7 +184,6 @@ class Dispatch2RsDistinctImp(outer: Dispatch2Rs)(implicit p: Parameters) extends
         io.out(idx).valid := selectValid && sta.ready
         sta.valid := selectValid && io.out(idx).ready
         io.out(idx).bits.ctrl.srcType(0) := Mux1H(selectIdxOH, io.in.map(_.bits.ctrl.srcType(1)))
-        io.out(idx).bits.ctrl.lsrc(0) := Mux1H(selectIdxOH, io.in.map(_.bits.ctrl.lsrc(1)))
         io.out(idx).bits.psrc(0) := Mux1H(selectIdxOH, io.in.map(_.bits.psrc(1)))
         io.in.zip(selectIdxOH).foreach{ case (in, v) => when (v) { in.ready := io.out(idx).ready && sta.ready }}
         XSPerfAccumulate(s"st_rs_not_ready_$idx", selectValid && (!sta.ready || !io.out(idx).ready))

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -149,6 +149,9 @@ class Rename(implicit p: Parameters) extends XSModule {
 
     io.out(i).valid := io.in(i).valid && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && !io.robCommits.isWalk
     io.out(i).bits := uops(i)
+    when (io.out(i).bits.ctrl.fuType === FuType.fence) {
+      io.out(i).bits.ctrl.imm := Cat(io.in(i).bits.ctrl.lsrc(1), io.in(i).bits.ctrl.lsrc(0))
+    }
 
     // write speculative rename table
     // we update rat later inside commit code


### PR DESCRIPTION
This commit removes lsrc usages in the fence unit and lsrc is no longer
needed after an instruction is renamed. It helps timing and area.

lsrc is placed in imm at rename stage (the last stage we need lsrc).
They are extracted in the fence unit. Imm needs to go through the
pipelines because Jump needs it (and we re-use it for lsrc).