### PR TITLE
rename: don't update refCounter 0

### DIFF
--- a/src/main/scala/xiangshan/backend/rename/freelist/RefCounter.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/RefCounter.scala
@@ -68,8 +68,11 @@ class RefCounter(size: Int)(implicit p: Parameters) extends XSModule {
     * (1) rename: increase as move instructions are renamed
     * (2) walk: decrease as physical registers are released (pdest)
     * (3) commit: decrease as physical registers are release (old_pdest)
+    *
+    * We don't count the number of references for physical register 0.
+    * It should never be released to freelist.
     */
-  for (i <- 0 until NRPhyRegs) {
+  for (i <- 1 until NRPhyRegs) {
     val numAlloc = PopCount(allocate.map(alloc => alloc.valid && alloc.bits === i.U))
     val numDealloc = PopCount(deallocate.map(dealloc => dealloc.valid && dealloc.bits === i.U))
     refCounterNext(i) := refCounter(i) + numAlloc - numDealloc
@@ -80,6 +83,8 @@ class RefCounter(size: Int)(implicit p: Parameters) extends XSModule {
   for (i <- 0 until RobSize) {
     val numCounters = PopCount(refCounter.map(_ === i.U))
     XSPerfAccumulate(s"ref_counter_$i", numCounters)
+    val isFreed = io.freeRegs.map(f => f.valid && f.bits === i.U)
+    XSPerfAccumulate(s"free_reg_$i", VecInit(isFreed).asUInt.orR)
   }
 }
 


### PR DESCRIPTION
This commit removes the update logic for ref counter 0.

For simplicity, we don't count the number of references for physical
register 0. It should never be released to freelist.

Previously we track register 0's references. It works fine but it makes
the performance counters confusing because it may increase to a large
number. It never causes real issues.