### PR TITLE
l2tlb: optimize l2tlb prefetcher, able to across 2MB

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/L2TlbPrefetch.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TlbPrefetch.scala
@@ -35,9 +35,8 @@ class L2TlbPrefetchIO(implicit p: Parameters) extends PtwBundle {
 class L2TlbPrefetch(implicit p: Parameters) extends XSModule with HasPtwConst {
   val io = IO(new L2TlbPrefetchIO())
 
-  val next_vpn = get_next_line(io.in.bits.vpn)
-  val next_line = RegEnable(next_vpn, io.in.valid)
-  val v = ValidHold(io.in.valid && !io.sfence.valid && same_l2entry(next_vpn, io.in.bits.vpn), io.out.fire(), io.sfence.valid)
+  val next_line = RegEnable(get_next_line(io.in.bits.vpn), io.in.valid)
+  val v = ValidHold(io.in.valid && !io.sfence.valid, io.out.fire(), io.sfence.valid)
 
   io.out.valid := v
   io.out.bits.vpn := next_line

--- a/src/main/scala/xiangshan/cache/mmu/PTW.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PTW.scala
@@ -114,7 +114,7 @@ class PTWImp(outer: PTW)(implicit p: Parameters) extends PtwModule(outer) with H
     val prefetch = Module(new L2TlbPrefetch())
     val recv = cache.io.resp
     prefetch.io.in.valid := recv.fire() && !from_pre(recv.bits.source) && (!recv.bits.hit  ||
-      recv.bits.hit && recv.bits.prefetch) && recv.bits.toFsm.l2Hit
+      recv.bits.prefetch)
     prefetch.io.in.bits.vpn := recv.bits.vpn
     prefetch.io.sfence := sfence
     arb2.io.in(InArbPrefetchPort) <> prefetch.io.out


### PR DESCRIPTION
when enq l2tlb miss queue, if the pre-fetch req  will not access mem (needs to re-access page cache), then it would be dropped.