### PR TITLE
refCounter: delay de-allocation for one more cycle

### DIFF
--- a/src/main/scala/xiangshan/backend/rename/freelist/MEFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/MEFreeList.scala
@@ -24,10 +24,7 @@ import utils._
 
 
 class MEFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) {
-  val freeList = RegInit(VecInit(Seq.tabulate(size){
-    case n if (n >= 0 && n < NRPhyRegs - 32) => (n + 32).U
-    case _ => DontCare
-  }))
+  val freeList = Mem(size, UInt(PhyRegIdxWidth.W))
 
   // head and tail pointer
   val headPtr = RegInit(FreeListPtr(false.B, 0.U))
@@ -58,6 +55,12 @@ class MEFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) {
       freeList(freePtr.value) := io.freePhyReg(i)
     }
   }
+  when (reset.asBool) {
+    for (i <- 0 until NRPhyRegs - 32) {
+      freeList(i) := (i + 32).U
+    }
+  }
+
   // update tail pointer
   val tailPtrNext = tailPtr + PopCount(io.freeReq)
   tailPtr := tailPtrNext


### PR DESCRIPTION
This commit changes how de-allocation is done in RefCounter. One cycle
after we update the reference counters, the free registers are released
to the freelist.

Previous version creates a critical path, starting from deallocate ports
and ending at freelist registers. This commit adds one more cycle in the
allocation --> updating reference counters --> freeing physical
registers --> allocation loop.