### PR TITLE
tlb: add parameter 'missSameCycle' to resp (only) miss at same cycle

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -290,6 +290,7 @@ class TlbStorageIO(nSets: Int, nWays: Int, ports: Int)(implicit p: Parameters) e
       val ppn = Output(UInt(ppnLen.W))
       val perm = Output(new TlbPermBundle())
     }))
+    val resp_hit_sameCycle = Output(Vec(ports, Bool())) // req hit or not same cycle with req
   }
   val w = Flipped(ValidIO(new Bundle {
     val wayIdx = Output(UInt(log2Up(nWays).W))
@@ -311,7 +312,7 @@ class TlbStorageIO(nSets: Int, nWays: Int, ports: Int)(implicit p: Parameters) e
   }
 
   def r_resp_apply(i: Int) = {
-    (this.r.resp(i).bits.hit, this.r.resp(i).bits.ppn, this.r.resp(i).bits.perm)
+    (this.r.resp_hit_sameCycle(i), this.r.resp(i).bits.hit, this.r.resp(i).bits.ppn, this.r.resp(i).bits.perm)
   }
 
   def w_apply(valid: Bool, wayIdx: UInt, data: PtwResp): Unit = {

--- a/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
@@ -31,6 +31,7 @@ case class TLBParameters
   fetchi: Boolean = false, // TODO: remove it
   useDmode: Boolean = true,
   sameCycle: Boolean = false,
+  missSameCycle: Boolean = false,
   normalNSets: Int = 1, // when da or sa
   normalNWays: Int = 8, // when fa or sa
   superNSets: Int = 1,

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -33,7 +33,7 @@ class TLB(Width: Int, q: TLBParameters)(implicit p: Parameters) extends TlbModul
   val io = IO(new TlbIO(Width, q))
 
   require(q.superAssociative == "fa")
-  if (q.sameCycle) {
+  if (q.sameCycle || q.missSameCycle) {
     require(q.normalAssociative == "fa")
   }
 
@@ -109,11 +109,12 @@ class TLB(Width: Int, q: TLBParameters)(implicit p: Parameters) extends TlbModul
   superPage.csr <> io.csr
 
   def TLBNormalRead(i: Int) = {
-    val (normal_hit, normal_ppn, normal_perm) = normalPage.r_resp_apply(i)
-    val (super_hit, super_ppn, super_perm) = superPage.r_resp_apply(i)
+    val (n_hit_sameCycle, normal_hit, normal_ppn, normal_perm) = normalPage.r_resp_apply(i)
+    val (s_hit_sameCycle, super_hit, super_ppn, super_perm) = superPage.r_resp_apply(i)
     assert(!(normal_hit && super_hit && vmEnable && RegNext(req(i).valid, init = false.B)))
 
     val hit = normal_hit || super_hit
+    val hit_sameCycle = n_hit_sameCycle || s_hit_sameCycle
     val ppn = Mux(normal_hit, normal_ppn, super_ppn)
     val perm = Mux(normal_hit, normal_perm, super_perm)
 
@@ -126,6 +127,7 @@ class TLB(Width: Int, q: TLBParameters)(implicit p: Parameters) extends TlbModul
 
     /** *************** next cycle when two cycle is false******************* */
     val miss = !hit && vmEnable
+    val miss_sameCycle = !hit_sameCycle && vmEnable
     hit.suggestName(s"hit_${i}")
     miss.suggestName(s"miss_${i}")
 
@@ -137,7 +139,7 @@ class TLB(Width: Int, q: TLBParameters)(implicit p: Parameters) extends TlbModul
     req(i).ready := resp(i).ready
     resp(i).valid := validReg
     resp(i).bits.paddr := Mux(vmEnable, paddr, if (!q.sameCycle) RegNext(vaddr) else vaddr)
-    resp(i).bits.miss := miss
+    resp(i).bits.miss := { if (q.missSameCycle) miss_sameCycle else miss }
     resp(i).bits.ptwBack := io.ptw.resp.fire()
 
     pmp(i).valid := resp(i).valid
@@ -362,7 +364,14 @@ object TLB {
         tlb.io.requestor(i).req.bits := in(i).req.bits
         in(i).req.ready := !tlb.io.requestor(i).resp.bits.miss && in(i).resp.ready && tlb.io.requestor(i).req.ready
 
-        in(i).resp.valid := tlb.io.requestor(i).resp.valid && !tlb.io.requestor(i).resp.bits.miss
+        require(q.missSameCycle || q.sameCycle)
+        // NOTE: the resp.valid seems to be useless, it must be true when need
+        //       But don't know what happens when true but not need, so keep it correct value, not just true.B
+        if (q.missSameCycle && !q.sameCycle) {
+          in(i).resp.valid := tlb.io.requestor(i).resp.valid && !RegNext(tlb.io.requestor(i).resp.bits.miss)
+        } else {
+          in(i).resp.valid := tlb.io.requestor(i).resp.valid && !tlb.io.requestor(i).resp.bits.miss
+        }
         in(i).resp.bits := tlb.io.requestor(i).resp.bits
         tlb.io.requestor(i).resp.ready := in(i).resp.ready
       }

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -61,6 +61,7 @@ class TLBFA(
     resp.bits.hit := Cat(hitVecReg).orR
     resp.bits.ppn := ParallelMux(hitVecReg zip entries.map(_.genPPN(vpn_reg)))
     resp.bits.perm := ParallelMux(hitVecReg zip entries.map(_.perm))
+    io.r.resp_hit_sameCycle(i) := Cat(hitVec).orR
 
     access.sets := get_set_idx(vpn_reg, nSets) // no use
     access.touch_ways.valid := resp.valid && Cat(hitVecReg).orR
@@ -192,6 +193,7 @@ class TLBSA(
     resp.bits.hit := Cat(hitVec).orR && RegNext(req.ready, init = false.B)
     resp.bits.ppn := ParallelMux(hitVec zip data.map(_.genPPN(vpn_reg)))
     resp.bits.perm := ParallelMux(hitVec zip data.map(_.perm))
+    io.r.resp_hit_sameCycle(i) := DontCare
 
     resp.valid := {
       if (sramSinglePort) RegNext(req.fire()) else RegNext(req.valid)


### PR DESCRIPTION
It helps frontend to get hit result at same cycle and keep req when miss. 
Then the itlb can set 'samecycle' to false for better timing.