### PR TITLE
tlb: timing optimization in 'genPPN', 'pmp check' and 'data out when nWays is 1'

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -161,7 +161,8 @@ case class XSCoreParameters
     normalReplacer = Some("setplru"),
     superNWays = 8,
     normalAsVictim = true,
-    outReplace = true
+    outReplace = true,
+    saveLevel = true
   ),
   sttlbParameters: TLBParameters = TLBParameters(
     name = "sttlb",
@@ -171,7 +172,8 @@ case class XSCoreParameters
     normalReplacer = Some("setplru"),
     superNWays = 8,
     normalAsVictim = true,
-    outReplace = true
+    outReplace = true,
+    saveLevel = true
   ),
   refillBothTlb: Boolean = false,
   btlbParameters: TLBParameters = TLBParameters(

--- a/src/main/scala/xiangshan/backend/fu/PMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMA.scala
@@ -169,7 +169,13 @@ trait PMACheckMethod extends HasXSParameter with HasCSRConst { this: PMPChecker 
     resp
   }
 
-  def pma_match_res(addr: UInt, size: UInt, pmaEntries: Vec[PMPEntry], mode: UInt, lgMaxSize: Int) = {
+  def pma_match_res(leaveHitMux: Boolean = false, valid: Bool = true.B)(
+    addr: UInt,
+    size: UInt,
+    pmaEntries: Vec[PMPEntry],
+    mode: UInt,
+    lgMaxSize: Int
+  ) = {
     val num = pmaEntries.size
     require(num == NumPMA)
     // pma should always be checked, could not be ignored
@@ -198,7 +204,10 @@ trait PMACheckMethod extends HasXSParameter with HasCSRConst { this: PMPChecker 
 
     match_vec(num) := true.B
     cfg_vec(num) := pmaDefault
-
-    ParallelPriorityMux(match_vec, cfg_vec)
+    if (leaveHitMux) {
+      ParallelPriorityMux(match_vec.map(RegEnable(_, init = false.B, valid)), RegEnable(cfg_vec, valid))
+    } else {
+      ParallelPriorityMux(match_vec, cfg_vec)
+    }
   }
 }

--- a/src/main/scala/xiangshan/backend/fu/PMP.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMP.scala
@@ -367,7 +367,13 @@ trait PMPCheckMethod extends HasXSParameter with HasCSRConst { this: PMPChecker 
     resp
   }
 
-  def pmp_match_res(addr: UInt, size: UInt, pmpEntries: Vec[PMPEntry], mode: UInt, lgMaxSize: Int) = {
+  def pmp_match_res(leaveHitMux: Boolean = false, valid: Bool = true.B)(
+    addr: UInt,
+    size: UInt,
+    pmpEntries: Vec[PMPEntry],
+    mode: UInt,
+    lgMaxSize: Int
+  ) = {
     val num = pmpEntries.size
     require(num == NumPMP)
 
@@ -399,7 +405,11 @@ trait PMPCheckMethod extends HasXSParameter with HasCSRConst { this: PMPChecker 
     match_vec(num) := true.B
     cfg_vec(num) := pmpDefault
 
-    ParallelPriorityMux(match_vec, cfg_vec)
+    if (leaveHitMux) {
+      ParallelPriorityMux(match_vec.map(RegEnable(_, init = false.B, valid)), RegEnable(cfg_vec, valid))
+    } else {
+      ParallelPriorityMux(match_vec, cfg_vec)
+    }
   }
 }
 
@@ -407,7 +417,8 @@ trait PMPCheckMethod extends HasXSParameter with HasCSRConst { this: PMPChecker 
 class PMPChecker
 (
   lgMaxSize: Int = 3,
-  sameCycle: Boolean = false
+  sameCycle: Boolean = false,
+  leaveHitMux: Boolean = false
 )(implicit p: Parameters)
   extends PMPModule
   with PMPCheckMethod
@@ -422,17 +433,18 @@ class PMPChecker
     val req = Flipped(Valid(new PMPReqBundle(lgMaxSize))) // usage: assign the valid to fire signal
     val resp = new PMPRespBundle()
   })
+  require(!(leaveHitMux && sameCycle))
 
   val req = io.req.bits
 
-  val res_pmp = pmp_match_res(req.addr, req.size, io.env.pmp, io.env.mode, lgMaxSize)
-  val res_pma = pma_match_res(req.addr, req.size, io.env.pma, io.env.mode, lgMaxSize)
+  val res_pmp = pmp_match_res(leaveHitMux, io.req.valid)(req.addr, req.size, io.env.pmp, io.env.mode, lgMaxSize)
+  val res_pma = pma_match_res(leaveHitMux, io.req.valid)(req.addr, req.size, io.env.pma, io.env.mode, lgMaxSize)
 
   val resp_pmp = pmp_check(req.cmd, res_pmp.cfg)
   val resp_pma = pma_check(req.cmd, res_pma.cfg)
   val resp = resp_pmp | resp_pma
 
-  if (sameCycle) {
+  if (sameCycle || leaveHitMux) {
     io.resp := resp
   } else {
     io.resp := RegEnable(resp, io.req.valid)

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -214,8 +214,8 @@ class TlbEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parameters) 
     this
   }
 
-  def genPPN(vpn: UInt) : UInt = {
-    if (!pageSuper) ppn
+  def genPPN(saveLevel: Boolean = false, valid: Bool = false.B)(vpn: UInt) : UInt = {
+    val ppn_res = if (!pageSuper) ppn
     else if (!pageNormal) MuxLookup(level.get, 0.U, Seq(
       0.U -> Cat(ppn(ppn.getWidth-1, vpnnLen), vpn(vpnnLen*2-1, 0)),
       1.U -> Cat(ppn, vpn(vpnnLen-1, 0))
@@ -225,6 +225,10 @@ class TlbEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parameters) 
       1.U -> Cat(ppn(ppn.getWidth-1, vpnnLen), vpn(vpnnLen-1, 0)),
       2.U -> ppn
     ))
+
+    val static_part_length = ppn_res.getWidth - vpnnLen*2
+    if (saveLevel) Cat(ppn(ppn.getWidth-1, ppn.getWidth-static_part_length), RegEnable(ppn_res(vpnnLen*2-1, 0), valid))
+    else ppn_res
   }
 
   override def toPrintable: Printable = {

--- a/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
@@ -42,7 +42,8 @@ case class TLBParameters
   superAssociative: String = "fa", // must be fa
   normalAsVictim: Boolean = false, // when get replace from fa, store it into sram
   outReplace: Boolean = false,
-  shouldBlock: Boolean = false // only for perf, not support for io
+  shouldBlock: Boolean = false, // only for perf, not support for io
+  saveLevel: Boolean = false
 )
 
 case class L2TLBParameters

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -70,6 +70,7 @@ class TLB(Width: Int, q: TLBParameters)(implicit p: Parameters) extends TlbModul
     nSets = q.normalNSets,
     nWays = q.normalNWays,
     sramSinglePort = sramSinglePort,
+    saveLevel = q.saveLevel,
     normalPage = true,
     superPage = false
   )
@@ -81,6 +82,7 @@ class TLB(Width: Int, q: TLBParameters)(implicit p: Parameters) extends TlbModul
     nSets = q.superNSets,
     nWays = q.superNWays,
     sramSinglePort = sramSinglePort,
+    saveLevel = q.saveLevel,
     normalPage = q.normalAsVictim,
     superPage = true,
   )

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -60,10 +60,10 @@ class TLBFA(
     resp.valid := { if (sameCycle) req.valid else RegNext(req.valid) }
     resp.bits.hit := Cat(hitVecReg).orR
     if (nWays == 1) {
-      resp.bits.ppn := entries(0).genPPN(vpn_reg)
+      resp.bits.ppn := entries(0).genPPN(!sameCycle, req.valid)(vpn_reg)
       resp.bits.perm := entries(0).perm
     } else {
-      resp.bits.ppn := ParallelMux(hitVecReg zip entries.map(_.genPPN(vpn_reg)))
+      resp.bits.ppn := ParallelMux(hitVecReg zip entries.map(_.genPPN(!sameCycle, req.valid)(vpn_reg)))
       resp.bits.perm := ParallelMux(hitVecReg zip entries.map(_.perm))
     }
     io.r.resp_hit_sameCycle(i) := Cat(hitVec).orR
@@ -197,10 +197,10 @@ class TLBSA(
     val hitVec = VecInit(data.zip(vidx).map { case (e, vi) => e.hit(vpn_reg, io.csr.satp.asid, nSets) && vi })
     resp.bits.hit := Cat(hitVec).orR && RegNext(req.ready, init = false.B)
     if (nWays == 1) {
-      resp.bits.ppn := data(0).genPPN(vpn_reg)
+      resp.bits.ppn := data(0).genPPN()(vpn_reg)
       resp.bits.perm := data(0).perm
     } else {
-      resp.bits.ppn := ParallelMux(hitVec zip data.map(_.genPPN(vpn_reg)))
+      resp.bits.ppn := ParallelMux(hitVec zip data.map(_.genPPN()(vpn_reg)))
       resp.bits.perm := ParallelMux(hitVec zip data.map(_.perm))
     }
     io.r.resp_hit_sameCycle(i) := DontCare


### PR DESCRIPTION
timing optimization:
1. when nWays is 1, output data directly and doesn't care if hit or not
2. add parameter to control if put ParallelPriorityMux part into next cycle, but default false
3. put genPPN part into first cycle, may need registers