### PR TITLE
Updated to priv 1.12

### DIFF
--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -242,6 +242,7 @@ class XiangShan(object):
             "Svinval/rv64mi-p-svinval.bin",
             "pmp/pmp.riscv.bin",
             "asid/asid.bin",
+            "isa_misc/xret_clear_mprv.bin",
             "cache-management/softprefetch-riscv64-noop.bin"
         ]
         misc_tests = map(lambda x: os.path.join(base_dir, x), workloads)

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -266,7 +266,9 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   class MstatusStruct extends Bundle {
     val sd = Output(UInt(1.W))
 
-    val pad1 = if (XLEN == 64) Output(UInt(27.W)) else null
+    val pad1 = if (XLEN == 64) Output(UInt(25.W)) else null
+    val mbe  = if (XLEN == 64) Output(UInt(1.W)) else null
+    val sbe  = if (XLEN == 64) Output(UInt(1.W)) else null
     val sxl  = if (XLEN == 64) Output(UInt(2.W))  else null
     val uxl  = if (XLEN == 64) Output(UInt(2.W))  else null
     val pad0 = if (XLEN == 64) Output(UInt(9.W))  else Output(UInt(8.W))
@@ -285,6 +287,11 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     val pie = new Priv
     val ie = new Priv
     assert(this.getWidth == XLEN)
+
+    def ube = pie.h // a little ugly
+    def ube_(r: UInt): Unit = {
+      pie.h := r(0)
+    }
   }
 
   class Interrupt extends Bundle {

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -913,7 +913,6 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     val dcsrNew = WireInit(dcsr.asTypeOf(new DcsrStruct))
     val debugModeNew = WireInit(debugMode)
     when (dcsr.asTypeOf(new DcsrStruct).prv =/= ModeM) {mstatusNew.mprv := 0.U} //If the new privilege mode is less privileged than M-mode, MPRV in mstatus is cleared.
-    when (mstatusOld.mpp =/= ModeM) { mstatusNew.mprv := 0.U }
     mstatus := mstatusNew.asUInt
     priviledgeMode := dcsrNew.prv
     retTarget := dpc(VAddrBits-1, 0)
@@ -944,7 +943,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     mstatusNew.pie.s := true.B
     mstatusNew.spp := ModeU
     mstatus := mstatusNew.asUInt
-    when (mstatusOld.mpp =/= ModeM) { mstatusNew.mprv := 0.U }
+    when (mstatusOld.spp =/= ModeM) { mstatusNew.mprv := 0.U }
     // lr := false.B
     retTarget := sepc(VAddrBits-1, 0)
   }
@@ -956,7 +955,6 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     mstatusNew.ie.u := mstatusOld.pie.u
     priviledgeMode := ModeU
     mstatusNew.pie.u := true.B
-    when (mstatusOld.mpp =/= ModeM) { mstatusNew.mprv := 0.U }
     mstatus := mstatusNew.asUInt
     retTarget := uepc(VAddrBits-1, 0)
   }

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -904,6 +904,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     val dcsrNew = WireInit(dcsr.asTypeOf(new DcsrStruct))
     val debugModeNew = WireInit(debugMode)
     when (dcsr.asTypeOf(new DcsrStruct).prv =/= ModeM) {mstatusNew.mprv := 0.U} //If the new privilege mode is less privileged than M-mode, MPRV in mstatus is cleared.
+    when (mstatusOld.mpp =/= ModeM) { mstatusNew.mprv := 0.U }
     mstatus := mstatusNew.asUInt
     priviledgeMode := dcsrNew.prv
     retTarget := dpc(VAddrBits-1, 0)
@@ -934,7 +935,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     mstatusNew.pie.s := true.B
     mstatusNew.spp := ModeU
     mstatus := mstatusNew.asUInt
-    mstatusNew.mprv := 0.U
+    when (mstatusOld.mpp =/= ModeM) { mstatusNew.mprv := 0.U }
     // lr := false.B
     retTarget := sepc(VAddrBits-1, 0)
   }
@@ -946,6 +947,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     mstatusNew.ie.u := mstatusOld.pie.u
     priviledgeMode := ModeU
     mstatusNew.pie.u := true.B
+    when (mstatusOld.mpp =/= ModeM) { mstatusNew.mprv := 0.U }
     mstatus := mstatusNew.asUInt
     retTarget := uepc(VAddrBits-1, 0)
   }

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -459,6 +459,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   val marchid = RegInit(UInt(XLEN.W), 0.U) // return 0 to indicate the field is not implemented
   val mimpid = RegInit(UInt(XLEN.W), 0.U) // provides a unique encoding of the version of the processor implementation
   val mhartid = RegInit(UInt(XLEN.W), csrio.hartId) // the hardware thread running the code
+  val mconfigptr = RegInit(UInt(XLEN.W), 0.U) // the read-only pointer pointing to the platform config structure, 0 for not supported.
   val mstatus = RegInit(UInt(XLEN.W), 0.U)
 
   // mstatus Value Table
@@ -719,6 +720,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     MaskedRegMap(Marchid, marchid, 0.U(XLEN.W), MaskedRegMap.Unwritable),
     MaskedRegMap(Mimpid, mimpid, 0.U(XLEN.W), MaskedRegMap.Unwritable),
     MaskedRegMap(Mhartid, mhartid, 0.U(XLEN.W), MaskedRegMap.Unwritable),
+    MaskedRegMap(Mconfigptr, mconfigptr, 0.U(XLEN.W), MaskedRegMap.Unwritable),
 
     //--- Machine Trap Setup ---
     MaskedRegMap(Mstatus, mstatus, mstatusMask, mstatusUpdateSideEffect, mstatusMask),

--- a/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
@@ -81,6 +81,7 @@ trait HasCSRConst {
   val Marchid       = 0xF12
   val Mimpid        = 0xF13
   val Mhartid       = 0xF14
+  val Mconfigptr    = 0xF15
 
   // Machine Trap Setup
   val Mstatus       = 0x300
@@ -104,7 +105,7 @@ trait HasCSRConst {
   val PmpaddrBase   = 0x3B0
   // Machine level PMA
   val PmacfgBase    = 0x7C0
-  val PmaaddrBase   = 0x7C8 // 84 entry at most
+  val PmaaddrBase   = 0x7C8 // 64 entry at most
 
   // Machine Counter/Timers
   // Currently, we uses perfcnt csr set instead of standard Machine Counter/Timers


### PR DESCRIPTION
updated to priv 1.12.
but currently only necessary and not difficult updates are updated.
1. mconfigptr is added but hardwired to 0
2. xret will clear mprv if xpp is not M
3. add xBE, but hardwired to 0. (Acctually it is doned before, just change mstatusStruct)
more priv 1.12 updates may be added later (maybe).

test: add simple unit test of (2)