### PR TITLE
arbiter: better balance among function units

### DIFF
--- a/src/main/scala/xiangshan/backend/exu/WbArbiter.scala
+++ b/src/main/scala/xiangshan/backend/exu/WbArbiter.scala
@@ -108,8 +108,7 @@ class WbArbiter(cfgs: Seq[ExuConfig], numOut: Int, isFp: Boolean)(implicit p: Pa
       if (in.size < n) {
         Seq(in) ++ Seq.fill(n - 1)(Seq())
       } else {
-        val m = in.size / n
-        in.take(m) +: splitN(in.drop(m), n - 1)
+        (0 until n).map(i => in.zipWithIndex.filter(_._2 % n == i).map(_._1).toSeq)
       }
     }
   }

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -805,13 +805,10 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     exceptionGen.io.wb(index).bits.trigger := io.exeWbResults(wb_index).bits.uop.cf.trigger
   }
 
-  // 4 fmac + 2 fmisc + 1 i2f
-  val fmacWb = (0 until exuParameters.FmacCnt).map(_ + numIntWbPorts)
-  val fmiscWb = (0 until exuParameters.FmiscCnt).map(_ + numIntWbPorts + exuParameters.FmacCnt)
-  val i2fWb = Seq(numIntWbPorts - 1) // last port in int
-  val fflags_wb = io.exeWbResults.zipWithIndex.filter(w => {
-    (fmacWb ++ fmiscWb ++ i2fWb).contains(w._2)
-  }).map(_._1)
+  // f2i + wb from fp arbiter (no load)
+  val fmiscIntWbPorts = Seq(exuParameters.FmiscCnt, exuParameters.MduCnt).min
+  // Drop alu + load + stu
+  val fflags_wb = io.exeWbResults.drop(NRIntWritePorts - fmiscIntWbPorts).dropRight(exuParameters.StuCnt)
   val fflagsDataModule = Module(new SyncDataModuleTemplate(
     UInt(5.W), RobSize, CommitWidth, fflags_wb.size)
   )


### PR DESCRIPTION
This commit changes the splitN algorithm for the write-back arbiter.

Previously we split the function units as follows:
(FU0 FU1 FU2) (FU3 FU4 FU5).
However, this strategy tends to group the function units with the same
type into the same arbiter and may cause performance loss.

In this commit, we change the strategy to: (FU0 FU2 FU4) (FU1 FU3 FU5).