### PR TITLE
csr: add write mask to satp.ppn & xstatus.xs

### DIFF
--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -246,6 +246,7 @@ class XiangShan(object):
             "pmp/pmp.riscv.bin",
             "asid/asid.bin",
             "isa_misc/xret_clear_mprv.bin",
+            "isa_misc/satp_ppn.bin",
             "cache-management/softprefetch-riscv64-noop.bin"
         ]
         misc_tests = map(lambda x: os.path.join(base_dir, x), workloads)

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -546,7 +546,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   // val satpMask = "h80000fffffffffff".U(XLEN.W) // disable asid, mode can only be 8 / 0
   // TODO: use config to control the length of asid
   // val satpMask = "h8fffffffffffffff".U(XLEN.W) // enable asid, mode can only be 8 / 0
-  val satpMask = Cat("h8".U(4.W),Asid_true_mask(AsidLength),"hfffffffffff".U((XLEN - 4 - 16).W))
+  val satpMask = Cat("h8".U(Satp_Mode_len.W), satp_part_wmask(Satp_Asid_len, AsidLength), satp_part_wmask(Satp_Addr_len, PAddrBits-12))
   val sepc = RegInit(UInt(XLEN.W), 0.U)
   // Page 60 in riscv-priv: The low bit of sepc (sepc[0]) is always zero.
   val sepcMask = ~(0x1.U(XLEN.W))

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -502,6 +502,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     GenMask(XLEN - 2, 36) | // WPRI
     GenMask(35, 32)       | // SXL and UXL cannot be changed
     GenMask(31, 23)       | // WPRI
+    GenMask(16, 15)       | // XS is ready-only
     GenMask(10, 9)        | // WPRI
     GenMask(6)            | // WPRI
     GenMask(2)              // WPRI

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -502,7 +502,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     GenMask(XLEN - 2, 36) | // WPRI
     GenMask(35, 32)       | // SXL and UXL cannot be changed
     GenMask(31, 23)       | // WPRI
-    GenMask(16, 15)       | // XS is ready-only
+    GenMask(16, 15)       | // XS is read-only
     GenMask(10, 9)        | // WPRI
     GenMask(6)            | // WPRI
     GenMask(2)              // WPRI

--- a/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
@@ -215,20 +215,12 @@ trait HasCSRConst {
 
   def IRQ_DEBUG = 12
 
-  val Asid_true_len = 16
-  
-  def Asid_true_mask(AsidLength : Int) : UInt = {
-    val res = Wire(Vec(Asid_true_len,Bool()))
-    (0 until Asid_true_len).map(i => {
-      res(i) := (i <= AsidLength).B
-  })
-    Cat(res.reverse)
-  // val zero = "h0".U(1.W)
-  // val one = "h1".U(1.W)
-  // val mask_high = Fill(Asid_true_len - AsidLength, zero)
-  // val mask_low  = Fill(AsidLength, one)
-
-  // Cat(mask_high, mask_low)
+  val Satp_Mode_len = 4
+  val Satp_Asid_len = 16
+  val Satp_Addr_len = 44
+  def satp_part_wmask(max_length: Int, length: Int) : UInt = {
+    require(length > 0 && length <= max_length)
+    ((1L << length) - 1).U(max_length.W)
   }
 
   val IntPriority = Seq(


### PR DESCRIPTION
1. satp.ppn should have length of (PADDTBITS - PAGE_OFFSET_LEN) , higher bits should be masked
2. xstatus.xs is read-only according to spec. 
(2) seems to be more complicated, see:
https://github.com/riscv-software-src/riscv-isa-sim/issues/878