### PR TITLE
core: refactor writeback parameters

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -237,10 +237,14 @@ class MicroOp(implicit p: Parameters) extends CfCtrl {
   }
   def doWriteIntRf: Bool = ctrl.rfWen && ctrl.ldest =/= 0.U
   def doWriteFpRf: Bool = ctrl.fpWen
-  def clearExceptions(): MicroOp = {
-    cf.exceptionVec.map(_ := false.B)
-    ctrl.replayInst := false.B
-    ctrl.flushPipe := false.B
+  def clearExceptions(
+    exceptionBits: Seq[Int] = Seq(),
+    flushPipe: Boolean = false,
+    replayInst: Boolean = false
+  ): MicroOp = {
+    cf.exceptionVec.zipWithIndex.filterNot(x => exceptionBits.contains(x._2)).foreach(_._1 := false.B)
+    if (!flushPipe) { ctrl.flushPipe := false.B }
+    if (!replayInst) { ctrl.replayInst := false.B }
     this
   }
 }

--- a/src/main/scala/xiangshan/backend/FUBlock.scala
+++ b/src/main/scala/xiangshan/backend/FUBlock.scala
@@ -25,7 +25,6 @@ import xiangshan._
 import xiangshan.backend.exu._
 import xiangshan.backend.fu.CSRFileIO
 import xiangshan.backend.fu.fpu.FMAMidResultIO
-import xiangshan.mem.StoreDataBundle
 
 class WakeUpBundle(numFast: Int, numSlow: Int)(implicit p: Parameters) extends XSBundle {
   val fastUops = Vec(numFast, Flipped(ValidIO(new MicroOp)))
@@ -35,67 +34,16 @@ class WakeUpBundle(numFast: Int, numSlow: Int)(implicit p: Parameters) extends X
   override def cloneType = (new WakeUpBundle(numFast, numSlow)).asInstanceOf[this.type]
 }
 
-trait HasExeBlockHelper {
-  def fpUopValid(x: ValidIO[MicroOp]): ValidIO[MicroOp] = {
-    val uop = WireInit(x)
-    uop.valid := x.valid && x.bits.ctrl.fpWen
-    uop
-  }
-  def fpOutValid(x: ValidIO[ExuOutput]): ValidIO[ExuOutput] = {
-    val out = WireInit(x)
-    out.valid := x.valid && x.bits.uop.ctrl.fpWen
-    out
-  }
-  def fpOutValid(x: DecoupledIO[ExuOutput], connectReady: Boolean = false): DecoupledIO[ExuOutput] = {
-    val out = WireInit(x)
-    if(connectReady) x.ready := out.ready
-    out.valid := x.valid && x.bits.uop.ctrl.fpWen
-    out
-  }
-  def intUopValid(x: ValidIO[MicroOp]): ValidIO[MicroOp] = {
-    val uop = WireInit(x)
-    uop.valid := x.valid && x.bits.ctrl.rfWen
-    uop
-  }
-  def intOutValid(x: ValidIO[ExuOutput]): ValidIO[ExuOutput] = {
-    val out = WireInit(x)
-    out.valid := x.valid && !x.bits.uop.ctrl.fpWen
-    out
-  }
-  def intOutValid(x: DecoupledIO[ExuOutput], connectReady: Boolean = false): DecoupledIO[ExuOutput] = {
-    val out = WireInit(x)
-    if(connectReady) x.ready := out.ready
-    out.valid := x.valid && !x.bits.uop.ctrl.fpWen
-    out
-  }
-  def decoupledIOToValidIO[T <: Data](d: DecoupledIO[T]): Valid[T] = {
-    val v = Wire(Valid(d.bits.cloneType))
-    v.valid := d.valid
-    v.bits := d.bits
-    v
-  }
-
-  def validIOToDecoupledIO[T <: Data](v: Valid[T]): DecoupledIO[T] = {
-    val d = Wire(DecoupledIO(v.bits.cloneType))
-    d.valid := v.valid
-    d.ready := true.B
-    d.bits := v.bits
-    d
-  }
-}
-
 class FUBlockExtraIO(configs: Seq[(ExuConfig, Int)])(implicit p: Parameters) extends XSBundle {
   val hasCSR = configs.map(_._1).contains(JumpCSRExeUnitCfg)
   val hasFence = configs.map(_._1).contains(JumpCSRExeUnitCfg)
   val hasFrm = configs.map(_._1).contains(FmacExeUnitCfg) || configs.map(_._1).contains(FmiscExeUnitCfg)
   val numRedirectOut = configs.filter(_._1.hasRedirect).map(_._2).sum
-  val numStd = configs.filter(_._1 == StdExeUnitCfg).map(_._2).sum
 
   val exuRedirect = Vec(numRedirectOut, ValidIO(new ExuOutput))
   val csrio = if (hasCSR) Some(new CSRFileIO) else None
   val fenceio = if (hasFence) Some(new FenceIO) else None
   val frm = if (hasFrm) Some(Input(UInt(3.W))) else None
-  val stData = if (numStd > 0) Some(Vec(numStd, ValidIO(new StoreDataBundle))) else None
 
   override def cloneType: FUBlockExtraIO.this.type =
     new FUBlockExtraIO(configs).asInstanceOf[this.type]
@@ -150,10 +98,6 @@ class FUBlock(configs: Seq[(ExuConfig, Int)])(implicit p: Parameters) extends XS
     if (exu.frm.isDefined) {
       exu.frm.get := io.extra.frm.get
     }
-  }
-
-  if (io.extra.stData.isDefined) {
-    io.extra.stData.get := VecInit(exeUnits.map(_.stData).filter(_.isDefined).map(_.get))
   }
 
   if (io.fmaMid.isDefined) {

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -19,11 +19,10 @@ package xiangshan.backend.decode
 import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.{UIntIsOneOf, uintToBitPat}
-import xiangshan._
+import freechips.rocketchip.util.uintToBitPat
 import utils._
-import xiangshan.backend._
-import xiangshan.backend.decode.BDecode.{N, Y}
+import xiangshan.ExceptionNO.illegalInstr
+import xiangshan._
 import xiangshan.backend.decode.Instructions._
 
 /**

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -19,12 +19,11 @@ package xiangshan.backend.dispatch
 import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
-import utils._
-import xiangshan._
 import difftest._
-import xiangshan.backend.fu.HasExceptionNO
+import utils._
+import xiangshan.ExceptionNO._
+import xiangshan._
 import xiangshan.backend.rob.RobEnqIO
-import xiangshan.mem.LsqEnqIO
 import xiangshan.mem.mdp._
 
 case class DispatchParameters
@@ -38,7 +37,7 @@ case class DispatchParameters
 )
 
 // read rob and enqueue
-class Dispatch(implicit p: Parameters) extends XSModule with HasExceptionNO {
+class Dispatch(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
     val hartId = Input(UInt(8.W))
     // from rename

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -23,7 +23,6 @@ import chisel3.experimental.hierarchy.{Definition, instantiable, public}
 import chisel3.util._
 import utils._
 import xiangshan._
-import xiangshan.backend.Std
 import xiangshan.backend.fu.fpu.{FMA, FPUSubModule}
 import xiangshan.backend.fu.{CSR, FUWithRedirect, Fence, FenceToSbuffer}
 
@@ -92,17 +91,6 @@ class ExeUnit(config: ExuConfig)(implicit p: Parameters) extends Exu(config) {
   if (fmaModules.nonEmpty) {
     require(fmaModules.length == 1)
     fmaModules.head.midResult <> fmaMid.get
-  }
-
-  if (config.fuConfigs.contains(stdCfg)) {
-    val std = functionUnits.collectFirst {
-      case s: Std => s
-    }.get
-    stData.get.valid := std.io.out.valid
-    stData.get.bits.uop := std.io.out.bits.uop
-    stData.get.bits.data := std.io.out.bits.data
-    io.out.valid := false.B
-    io.out.bits := DontCare
   }
 
   if (config.readIntRf) {

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -19,110 +19,14 @@ package xiangshan.backend.fu
 import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
+import difftest._
 import freechips.rocketchip.util._
 import utils.MaskedRegMap.WritableMask
 import utils._
+import xiangshan.ExceptionNO._
 import xiangshan._
-import xiangshan.backend._
-import xiangshan.cache._
-import xiangshan.frontend.BPUCtrl
 import xiangshan.backend.fu.util._
-import difftest._
-
-trait HasExceptionNO {
-  def instrAddrMisaligned = 0
-  def instrAccessFault    = 1
-  def illegalInstr        = 2
-  def breakPoint          = 3
-  def loadAddrMisaligned  = 4
-  def loadAccessFault     = 5
-  def storeAddrMisaligned = 6
-  def storeAccessFault    = 7
-  def ecallU              = 8
-  def ecallS              = 9
-  def ecallM              = 11
-  def instrPageFault      = 12
-  def loadPageFault       = 13
-  def storePageFault      = 15
-
-//  def singleStep          = 14
-
-  val ExcPriority = Seq(
-    breakPoint, // TODO: different BP has different priority
-    instrPageFault,
-    instrAccessFault,
-    illegalInstr,
-    instrAddrMisaligned,
-    ecallM, ecallS, ecallU,
-    storePageFault,
-    loadPageFault,
-    storeAccessFault,
-    loadAccessFault,
-    storeAddrMisaligned,
-    loadAddrMisaligned
-  )
-  val frontendSet = List(
-    // instrAddrMisaligned,
-    instrAccessFault,
-    illegalInstr,
-    instrPageFault
-  )
-  val csrSet = List(
-    illegalInstr,
-    breakPoint,
-    ecallU,
-    ecallS,
-    ecallM
-  )
-  val loadUnitSet = List(
-    loadAddrMisaligned,
-    loadAccessFault,
-    loadPageFault
-  )
-  val storeUnitSet = List(
-    storeAddrMisaligned,
-    storeAccessFault,
-    storePageFault
-  )
-  val atomicsUnitSet = (loadUnitSet ++ storeUnitSet).distinct
-  val allPossibleSet = (frontendSet ++ csrSet ++ loadUnitSet ++ storeUnitSet).distinct
-  val csrWbCount = (0 until 16).map(i => if (csrSet.contains(i)) 1 else 0)
-  val loadWbCount = (0 until 16).map(i => if (loadUnitSet.contains(i)) 1 else 0)
-  val storeWbCount = (0 until 16).map(i => if (storeUnitSet.contains(i)) 1 else 0)
-  val atomicsWbCount = (0 until 16).map(i => if (atomicsUnitSet.contains(i)) 1 else 0)
-  val writebackCount = (0 until 16).map(i => csrWbCount(i) + atomicsWbCount(i) + loadWbCount(i) + 2 * storeWbCount(i))
-  def partialSelect(vec: Vec[Bool], select: Seq[Int], dontCareBits: Boolean = true, falseBits: Boolean = false): Vec[Bool] = {
-    if (dontCareBits) {
-      val new_vec = Wire(ExceptionVec())
-      new_vec := DontCare
-      select.map(i => new_vec(i) := vec(i))
-      return new_vec
-    }
-    else if (falseBits) {
-      val new_vec = Wire(ExceptionVec())
-      new_vec.map(_ := false.B)
-      select.map(i => new_vec(i) := vec(i))
-      return new_vec
-    }
-    else {
-      val new_vec = Wire(Vec(select.length, Bool()))
-      select.zipWithIndex.map{ case(s, i) => new_vec(i) := vec(s) }
-      return new_vec
-    }
-  }
-  def selectFrontend(vec: Vec[Bool], dontCareBits: Boolean = true, falseBits: Boolean = false): Vec[Bool] =
-    partialSelect(vec, frontendSet, dontCareBits, falseBits)
-  def selectCSR(vec: Vec[Bool], dontCareBits: Boolean = true, falseBits: Boolean = false): Vec[Bool] =
-    partialSelect(vec, csrSet, dontCareBits, falseBits)
-  def selectLoad(vec: Vec[Bool], dontCareBits: Boolean = true, falseBits: Boolean = false): Vec[Bool] =
-    partialSelect(vec, loadUnitSet, dontCareBits, falseBits)
-  def selectStore(vec: Vec[Bool], dontCareBits: Boolean = true, falseBits: Boolean = false): Vec[Bool] =
-    partialSelect(vec, storeUnitSet, dontCareBits, falseBits)
-  def selectAtomics(vec: Vec[Bool], dontCareBits: Boolean = true, falseBits: Boolean = false): Vec[Bool] =
-    partialSelect(vec, atomicsUnitSet, dontCareBits, falseBits)
-  def selectAll(vec: Vec[Bool], dontCareBits: Boolean = true, falseBits: Boolean = false): Vec[Bool] =
-    partialSelect(vec, allPossibleSet, dontCareBits, falseBits)
-}
+import xiangshan.cache._
 
 // Trigger Tdata1 bundles
 trait HasTriggerConst {
@@ -1029,7 +933,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   val hasTriggerHit = csrio.exception.bits.uop.cf.trigger.triggerHitVec.orR && raiseException
 
   val raiseExceptionVec = csrio.exception.bits.uop.cf.exceptionVec
-  val regularExceptionNO = ExcPriority.foldRight(0.U)((i: Int, sum: UInt) => Mux(raiseExceptionVec(i), i.U, sum))
+  val regularExceptionNO = ExceptionNO.priorities.foldRight(0.U)((i: Int, sum: UInt) => Mux(raiseExceptionVec(i), i.U, sum))
   val exceptionNO = Mux(hasSingleStep || hasTriggerHit, 3.U, regularExceptionNO)
   val causeNO = (raiseIntr << (XLEN-1)).asUInt() | Mux(raiseIntr, intrNO, exceptionNO)
 

--- a/src/main/scala/xiangshan/backend/fu/Fence.scala
+++ b/src/main/scala/xiangshan/backend/fu/Fence.scala
@@ -21,13 +21,14 @@ import chisel3._
 import chisel3.util._
 import xiangshan._
 import utils._
+import xiangshan.ExceptionNO.illegalInstr
 
 class FenceToSbuffer extends Bundle {
   val flushSb = Output(Bool())
   val sbIsEmpty = Input(Bool())
 }
 
-class Fence(implicit p: Parameters) extends FunctionUnit with HasExceptionNO {
+class Fence(implicit p: Parameters) extends FunctionUnit {
 
   val sfence = IO(Output(new SfenceBundle))
   val fencei = IO(Output(Bool()))

--- a/src/main/scala/xiangshan/backend/fu/FunctionUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FunctionUnit.scala
@@ -46,12 +46,16 @@ case class FuConfig
   numFpSrc: Int,
   writeIntRf: Boolean,
   writeFpRf: Boolean,
-  hasRedirect: Boolean,
+  writeFflags: Boolean = false,
+  hasRedirect: Boolean = false,
   latency: HasFuLatency = CertainLatency(0),
   fastUopOut: Boolean = false,
   fastImplemented: Boolean = false,
   hasInputBuffer: Boolean = false,
-  hasExceptionOut: Boolean = false
+  exceptionOut: Seq[Int] = Seq(),
+  flushPipe: Boolean = false,
+  replayInst: Boolean = false,
+  trigger: Boolean = false
 ) {
   def srcCnt: Int = math.max(numIntSrc, numFpSrc)
 }

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -17,13 +17,14 @@
 package xiangshan.backend.rob
 
 import chipsalliance.rocketchip.config.Parameters
-import chisel3.ExcitingUtils._
 import chisel3._
 import chisel3.util._
-import xiangshan._
-import utils._
-import xiangshan.frontend.FtqPtr
 import difftest._
+import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
+import utils._
+import xiangshan._
+import xiangshan.backend.exu.ExuConfig
+import xiangshan.frontend.FtqPtr
 
 class RobPtr(implicit p: Parameters) extends CircularQueuePtr[RobPtr](
   p => p(XSCoreParamsKey).RobSize
@@ -64,7 +65,6 @@ class RobLsqIO(implicit p: Parameters) extends XSBundle {
   val pendingld = Output(Bool())
   val pendingst = Output(Bool())
   val commit = Output(Bool())
-  val storeDataRobWb = Input(Vec(StorePipelineWidth, Valid(new RobPtr)))
 }
 
 class RobEnqIO(implicit p: Parameters) extends XSBundle {
@@ -263,7 +263,24 @@ class RobFlushInfo(implicit p: Parameters) extends XSBundle {
   val replayInst = Bool()
 }
 
-class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelper {
+class Rob(implicit p: Parameters) extends LazyModule with HasWritebackSink with HasXSParameter {
+
+  lazy val module = new RobImp(this)
+
+  override def generateWritebackIO(
+    thisMod: Option[HasWritebackSource] = None,
+    thisModImp: Option[HasWritebackSourceImp] = None
+  ): Unit = {
+    val sources = writebackSinksImp(thisMod, thisModImp)
+    module.io.writeback.zip(sources).foreach(x => x._1 := x._2)
+  }
+}
+
+class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
+  with HasXSParameter with HasCircularQueuePtrHelper {
+  val wbExuConfigs = outer.writebackSinksParams.map(_.exuConfigs)
+  val numWbPorts = wbExuConfigs.map(_.length)
+
   val io = IO(new Bundle() {
     val hartId = Input(UInt(8.W))
     val redirect = Input(Valid(new Redirect))
@@ -271,7 +288,7 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     val flushOut = ValidIO(new Redirect)
     val exception = ValidIO(new ExceptionInfo)
     // exu + brq
-    val exeWbResults = Vec(numWbPorts, Flipped(ValidIO(new ExuOutput)))
+    val writeback = MixedVec(numWbPorts.map(num => Vec(num, Flipped(ValidIO(new ExuOutput)))))
     val commits = new RobCommitIO
     val lsq = new RobLsqIO
     val bcommit = Output(UInt(log2Up(CommitWidth + 1).W))
@@ -280,7 +297,24 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     val robFull = Output(Bool())
   })
 
-  println("Rob: size:" + RobSize + " wbports:" + numWbPorts  + " commitwidth:" + CommitWidth)
+  def selectWb(index: Int, func: Seq[ExuConfig] => Boolean): Seq[(Seq[ExuConfig], ValidIO[ExuOutput])] = {
+    wbExuConfigs(index).zip(io.writeback(index)).filter(x => func(x._1))
+  }
+  val exeWbSel = outer.selWritebackSinks(_.exuConfigs.length)
+  val fflagsWbSel = outer.selWritebackSinks(_.exuConfigs.count(_.exists(_.writeFflags)))
+  val fflagsPorts = selectWb(fflagsWbSel, _.exists(_.writeFflags))
+  val exceptionWbSel = outer.selWritebackSinks(_.exuConfigs.count(_.exists(_.needExceptionGen)))
+  val exceptionPorts = selectWb(fflagsWbSel, _.exists(_.needExceptionGen))
+  val exuWbPorts = selectWb(exeWbSel, _.forall(_ != StdExeUnitCfg))
+  val stdWbPorts = selectWb(exeWbSel, _.contains(StdExeUnitCfg))
+  println(s"Rob: size $RobSize, numWbPorts: $numWbPorts, commitwidth: $CommitWidth")
+  println(s"exuPorts: ${exuWbPorts.map(_._1.map(_.name))}")
+  println(s"stdPorts: ${stdWbPorts.map(_._1.map(_.name))}")
+  println(s"fflags: ${fflagsPorts.map(_._1.map(_.name))}")
+
+
+  val exuWriteback = exuWbPorts.map(_._2)
+  val stdWriteback = stdWbPorts.map(_._2)
 
   // instvalid field
   val valid = Mem(RobSize, Bool())
@@ -361,31 +395,34 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   for (i <- 0 until RenameWidth) {
     // we don't check whether io.redirect is valid here since redirect has higher priority
     when (canEnqueue(i)) {
+      val enqUop = io.enq.req(i).bits
       // store uop in data module and debug_microOp Vec
-      debug_microOp(enqPtrVec(i).value) := io.enq.req(i).bits
+      debug_microOp(enqPtrVec(i).value) := enqUop
       debug_microOp(enqPtrVec(i).value).debugInfo.dispatchTime := timer
       debug_microOp(enqPtrVec(i).value).debugInfo.enqRsTime := timer
       debug_microOp(enqPtrVec(i).value).debugInfo.selectTime := timer
       debug_microOp(enqPtrVec(i).value).debugInfo.issueTime := timer
       debug_microOp(enqPtrVec(i).value).debugInfo.writebackTime := timer
-      when (io.enq.req(i).bits.ctrl.blockBackward) {
+      when (enqUop.ctrl.blockBackward) {
         hasBlockBackward := true.B
       }
-      when (io.enq.req(i).bits.ctrl.noSpecExec) {
+      when (enqUop.ctrl.noSpecExec) {
         hasNoSpecExec := true.B
       }
+      val enqHasException = ExceptionNO.selectFrontend(enqUop.cf.exceptionVec).asUInt.orR
       // the begin instruction of Svinval enqs so mark doingSvinval as true to indicate this process
-      when(!Cat(io.enq.req(i).bits.cf.exceptionVec).orR && FuType.isSvinvalBegin(io.enq.req(i).bits.ctrl.fuType,io.enq.req(i).bits.ctrl.fuOpType,io.enq.req(i).bits.ctrl.flushPipe))
+      when(!enqHasException && FuType.isSvinvalBegin(enqUop.ctrl.fuType, enqUop.ctrl.fuOpType, enqUop.ctrl.flushPipe))
       {
         doingSvinval := true.B
       }
       // the end instruction of Svinval enqs so clear doingSvinval 
-      when(!Cat(io.enq.req(i).bits.cf.exceptionVec).orR && FuType.isSvinvalEnd(io.enq.req(i).bits.ctrl.fuType,io.enq.req(i).bits.ctrl.fuOpType,io.enq.req(i).bits.ctrl.flushPipe))
+      when(!enqHasException && FuType.isSvinvalEnd(enqUop.ctrl.fuType, enqUop.ctrl.fuOpType, enqUop.ctrl.flushPipe))
       {
         doingSvinval := false.B
       }
       // when we are in the process of Svinval software code area , only Svinval.vma and end instruction of Svinval can appear
-      assert( !doingSvinval || (FuType.isSvinval(io.enq.req(i).bits.ctrl.fuType,io.enq.req(i).bits.ctrl.fuOpType,io.enq.req(i).bits.ctrl.flushPipe) || FuType.isSvinvalEnd(io.enq.req(i).bits.ctrl.fuType,io.enq.req(i).bits.ctrl.fuOpType,io.enq.req(i).bits.ctrl.flushPipe)))
+      assert(!doingSvinval || (FuType.isSvinval(enqUop.ctrl.fuType, enqUop.ctrl.fuOpType, enqUop.ctrl.flushPipe) ||
+        FuType.isSvinvalEnd(enqUop.ctrl.fuType, enqUop.ctrl.fuOpType, enqUop.ctrl.flushPipe)))
     }
   }
   val dispatchNum = Mux(io.enq.canAccept, PopCount(Cat(io.enq.req.map(_.valid))), 0.U)
@@ -399,29 +436,26 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   /**
     * Writeback (from execution units)
     */
-  for (i <- 0 until numWbPorts) {
-    when (io.exeWbResults(i).valid) {
-      val wbIdx = io.exeWbResults(i).bits.uop.robIdx.value
-      debug_microOp(wbIdx).cf.exceptionVec := io.exeWbResults(i).bits.uop.cf.exceptionVec
-      debug_microOp(wbIdx).ctrl.flushPipe := io.exeWbResults(i).bits.uop.ctrl.flushPipe
-      debug_microOp(wbIdx).ctrl.replayInst := io.exeWbResults(i).bits.uop.ctrl.replayInst
-      debug_microOp(wbIdx).diffTestDebugLrScValid := io.exeWbResults(i).bits.uop.diffTestDebugLrScValid
-      debug_exuData(wbIdx) := io.exeWbResults(i).bits.data
-      debug_exuDebug(wbIdx) := io.exeWbResults(i).bits.debug
-      debug_microOp(wbIdx).debugInfo.enqRsTime := io.exeWbResults(i).bits.uop.debugInfo.enqRsTime
-      debug_microOp(wbIdx).debugInfo.selectTime := io.exeWbResults(i).bits.uop.debugInfo.selectTime
-      debug_microOp(wbIdx).debugInfo.issueTime := io.exeWbResults(i).bits.uop.debugInfo.issueTime
-      debug_microOp(wbIdx).debugInfo.writebackTime := io.exeWbResults(i).bits.uop.debugInfo.writebackTime
+  for (wb <- exuWriteback) {
+    when (wb.valid) {
+      val wbIdx = wb.bits.uop.robIdx.value
+      debug_microOp(wbIdx).diffTestDebugLrScValid := wb.bits.uop.diffTestDebugLrScValid
+      debug_exuData(wbIdx) := wb.bits.data
+      debug_exuDebug(wbIdx) := wb.bits.debug
+      debug_microOp(wbIdx).debugInfo.enqRsTime := wb.bits.uop.debugInfo.enqRsTime
+      debug_microOp(wbIdx).debugInfo.selectTime := wb.bits.uop.debugInfo.selectTime
+      debug_microOp(wbIdx).debugInfo.issueTime := wb.bits.uop.debugInfo.issueTime
+      debug_microOp(wbIdx).debugInfo.writebackTime := wb.bits.uop.debugInfo.writebackTime
 
       val debug_Uop = debug_microOp(wbIdx)
       XSInfo(true.B,
         p"writebacked pc 0x${Hexadecimal(debug_Uop.cf.pc)} wen ${debug_Uop.ctrl.rfWen} " +
-        p"data 0x${Hexadecimal(io.exeWbResults(i).bits.data)} ldst ${debug_Uop.ctrl.ldest} pdst ${debug_Uop.pdest} " +
-        p"skip ${io.exeWbResults(i).bits.debug.isMMIO} robIdx: ${io.exeWbResults(i).bits.uop.robIdx}\n"
+        p"data 0x${Hexadecimal(wb.bits.data)} ldst ${debug_Uop.ctrl.ldest} pdst ${debug_Uop.pdest} " +
+        p"skip ${wb.bits.debug.isMMIO} robIdx: ${wb.bits.uop.robIdx}\n"
       )
     }
   }
-  val writebackNum = PopCount(io.exeWbResults.map(_.valid))
+  val writebackNum = PopCount(exuWriteback.map(_.valid))
   XSInfo(writebackNum =/= 0.U, "writebacked %d insts\n", writebackNum)
 
 
@@ -508,8 +542,8 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
 
   // when mispredict branches writeback, stop commit in the next 2 cycles
   // TODO: don't check all exu write back
-  val misPredWb = Cat(VecInit((0 until numWbPorts).map(i =>
-    io.exeWbResults(i).bits.redirect.cfiUpdate.isMisPred && io.exeWbResults(i).bits.redirectValid
+  val misPredWb = Cat(VecInit(exuWriteback.map(wb =>
+    wb.bits.redirect.cfiUpdate.isMisPred && wb.bits.redirectValid
   ))).orR()
   val misPredBlockCounter = Reg(UInt(3.W))
   misPredBlockCounter := Mux(misPredWb,
@@ -701,7 +735,8 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   // enqueue logic set 6 writebacked to false
   for (i <- 0 until RenameWidth) {
     when (canEnqueue(i)) {
-      writebacked(enqPtrVec(i).value) := io.enq.req(i).bits.eliminatedMove && !io.enq.req(i).bits.cf.exceptionVec.asUInt.orR
+      val enqHasException = ExceptionNO.selectFrontend(io.enq.req(i).bits.cf.exceptionVec)
+      writebacked(enqPtrVec(i).value) := io.enq.req(i).bits.eliminatedMove && !enqHasException.asUInt.orR
       val isStu = io.enq.req(i).bits.ctrl.fuType === FuType.stu
       store_data_writebacked(enqPtrVec(i).value) := !isStu
     }
@@ -712,20 +747,20 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     store_data_writebacked(wbIdx) := true.B
   }
   // writeback logic set numWbPorts writebacked to true
-  for (i <- 0 until numWbPorts) {
-    when (io.exeWbResults(i).valid) {
-      val wbIdx = io.exeWbResults(i).bits.uop.robIdx.value
-      val block_wb =
-        selectAll(io.exeWbResults(i).bits.uop.cf.exceptionVec, false, true).asUInt.orR ||
-        io.exeWbResults(i).bits.uop.ctrl.flushPipe ||
-        io.exeWbResults(i).bits.uop.ctrl.replayInst
+  for ((wb, cfgs) <- exuWriteback.zip(wbExuConfigs(exeWbSel))) {
+    when (wb.valid) {
+      val wbIdx = wb.bits.uop.robIdx.value
+      val wbHasException = ExceptionNO.selectByExu(wb.bits.uop.cf.exceptionVec, cfgs).asUInt.orR
+      val wbHasFlushPipe = cfgs.exists(_.flushPipe).B && wb.bits.uop.ctrl.flushPipe
+      val wbHasReplayInst = cfgs.exists(_.replayInst).B && wb.bits.uop.ctrl.replayInst
+      val block_wb = wbHasException || wbHasFlushPipe || wbHasReplayInst
       writebacked(wbIdx) := !block_wb
     }
   }
   // store data writeback logic mark store as data_writebacked
-  for (i <- 0 until StorePipelineWidth) {
-    when(RegNext(io.lsq.storeDataRobWb(i).valid)) {
-      store_data_writebacked(RegNext(io.lsq.storeDataRobWb(i).bits.value)) := true.B
+  for (wb <- stdWriteback) {
+    when(RegNext(wb.valid)) {
+      store_data_writebacked(RegNext(wb.bits.uop.robIdx.value)) := true.B
     }
   }
 
@@ -781,7 +816,7 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
   for (i <- 0 until RenameWidth) {
     exceptionGen.io.enq(i).valid := canEnqueue(i)
     exceptionGen.io.enq(i).bits.robIdx := io.enq.req(i).bits.robIdx
-    exceptionGen.io.enq(i).bits.exceptionVec := selectFrontend(io.enq.req(i).bits.cf.exceptionVec, false, true)
+    exceptionGen.io.enq(i).bits.exceptionVec := ExceptionNO.selectFrontend(io.enq.req(i).bits.cf.exceptionVec)
     exceptionGen.io.enq(i).bits.flushPipe := io.enq.req(i).bits.ctrl.flushPipe
     exceptionGen.io.enq(i).bits.replayInst := io.enq.req(i).bits.ctrl.replayInst
     assert(exceptionGen.io.enq(i).bits.replayInst === false.B)
@@ -790,37 +825,25 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
     exceptionGen.io.enq(i).bits.trigger := io.enq.req(i).bits.cf.trigger
   }
 
-  // TODO: don't hard code these idxes
-  val numIntWbPorts = exuParameters.AluCnt + exuParameters.LduCnt + exuParameters.MduCnt
-  // CSR is after Alu and Load
-  def csr_wb_idx = exuParameters.AluCnt + exuParameters.LduCnt
-  def atomic_wb_idx = exuParameters.AluCnt // first port for load
-  def load_wb_idxes = Seq(exuParameters.AluCnt + 1) // second port for load
-  def store_wb_idxes = io.exeWbResults.indices.takeRight(2)
-  val all_exception_possibilities = Seq(csr_wb_idx, atomic_wb_idx) ++ load_wb_idxes ++ store_wb_idxes
-  all_exception_possibilities.zipWithIndex.foreach{ case (p, i) => connect_exception(i, p) }
-  def connect_exception(index: Int, wb_index: Int) = {
-    exceptionGen.io.wb(index).valid             := io.exeWbResults(wb_index).valid
-    exceptionGen.io.wb(index).bits.robIdx       := io.exeWbResults(wb_index).bits.uop.robIdx
-    val selectFunc = if (wb_index == csr_wb_idx) selectCSR _
-    else if (wb_index == atomic_wb_idx) selectAtomics _
-    else if (load_wb_idxes.contains(wb_index)) selectLoad _
-    else {
-      assert(store_wb_idxes.contains(wb_index))
-      selectStore _
-    }
-    exceptionGen.io.wb(index).bits.exceptionVec    := selectFunc(io.exeWbResults(wb_index).bits.uop.cf.exceptionVec, false, true)
-    exceptionGen.io.wb(index).bits.flushPipe       := io.exeWbResults(wb_index).bits.uop.ctrl.flushPipe
-    exceptionGen.io.wb(index).bits.replayInst      := io.exeWbResults(wb_index).bits.uop.ctrl.replayInst
-    exceptionGen.io.wb(index).bits.singleStep      := false.B
-    exceptionGen.io.wb(index).bits.crossPageIPFFix := false.B
-    exceptionGen.io.wb(index).bits.trigger := io.exeWbResults(wb_index).bits.uop.cf.trigger
+  println(s"ExceptionGen:")
+  val exceptionCases = exceptionPorts.map(_._1.flatMap(_.exceptionOut).distinct.sorted)
+  require(exceptionCases.length == exceptionGen.io.wb.length)
+  for ((((configs, wb), exc_wb), i) <- exceptionPorts.zip(exceptionGen.io.wb).zipWithIndex) {
+    exc_wb.valid                := wb.valid
+    exc_wb.bits.robIdx          := wb.bits.uop.robIdx
+    exc_wb.bits.exceptionVec    := ExceptionNO.selectByExu(wb.bits.uop.cf.exceptionVec, configs)
+    exc_wb.bits.flushPipe       := configs.exists(_.flushPipe).B && wb.bits.uop.ctrl.flushPipe
+    exc_wb.bits.replayInst      := configs.exists(_.replayInst).B && wb.bits.uop.ctrl.replayInst
+    exc_wb.bits.singleStep      := false.B
+    exc_wb.bits.crossPageIPFFix := false.B
+    // TODO: make trigger configurable
+    exc_wb.bits.trigger         := wb.bits.uop.cf.trigger
+    println(s"  [$i] ${configs.map(_.name)}: exception ${exceptionCases(i)}, " +
+      s"flushPipe ${configs.exists(_.flushPipe)}, " +
+      s"replayInst ${configs.exists(_.replayInst)}")
   }
 
-  // f2i + wb from fp arbiter (no load)
-  val fmiscIntWbPorts = Seq(exuParameters.FmiscCnt, exuParameters.MduCnt).min
-  // Drop alu + load + stu
-  val fflags_wb = io.exeWbResults.drop(NRIntWritePorts - fmiscIntWbPorts).dropRight(exuParameters.StuCnt)
+  val fflags_wb = fflagsPorts.map(_._2)
   val fflagsDataModule = Module(new SyncDataModuleTemplate(
     UInt(5.W), RobSize, CommitWidth, fflags_wb.size)
   )
@@ -988,10 +1011,10 @@ class Rob(numWbPorts: Int)(implicit p: Parameters) extends XSModule with HasCirc
         dt_isRVC(enqPtrVec(i).value) := io.enq.req(i).bits.cf.pd.isRVC
       }
     }
-    for (i <- 0 until numWbPorts) {
-      when (io.exeWbResults(i).valid) {
-        val wbIdx = io.exeWbResults(i).bits.uop.robIdx.value
-        dt_exuDebug(wbIdx) := io.exeWbResults(i).bits.debug
+    for (wb <- exuWriteback) {
+      when (wb.valid) {
+        val wbIdx = wb.bits.uop.robIdx.value
+        dt_exuDebug(wbIdx) := wb.bits.debug
       }
     }
     // Always instantiate basic difftest modules.

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -15,16 +15,15 @@
 ***************************************************************************************/
 
 package xiangshan.frontend
-import utils._
+import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
-import chipsalliance.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
+import utils._
 import xiangshan._
-import xiangshan.cache._
+import xiangshan.backend.fu.{PFEvent, PMP, PMPChecker}
+import xiangshan.cache.mmu.{TLB, TlbPtwIO}
 import xiangshan.frontend.icache._
-import xiangshan.cache.mmu.{TlbRequestIO, TlbPtwIO,TLB}
-import xiangshan.backend.fu.{HasExceptionNO, PMP, PMPChecker, PFEvent}
 
 
 class Frontend()(implicit p: Parameters) extends LazyModule with HasXSParameter{
@@ -38,7 +37,6 @@ class Frontend()(implicit p: Parameters) extends LazyModule with HasXSParameter{
 
 class FrontendImp (outer: Frontend) extends LazyModuleImp(outer)
   with HasXSParameter
-  with HasExceptionNO
 {
   val io = IO(new Bundle() {
     val fencei = Input(Bool())

--- a/src/main/scala/xiangshan/frontend/Ibuffer.scala
+++ b/src/main/scala/xiangshan/frontend/Ibuffer.scala
@@ -21,6 +21,7 @@ import chisel3._
 import chisel3.util._
 import xiangshan._
 import utils._
+import xiangshan.ExceptionNO._
 
 class IbufPtr(implicit p: Parameters) extends CircularQueuePtr[IbufPtr](
   p => p(XSCoreParamsKey).IBufSize

--- a/src/main/scala/xiangshan/mem/MemCommon.scala
+++ b/src/main/scala/xiangshan/mem/MemCommon.scala
@@ -73,11 +73,6 @@ class LsPipelineBundle(implicit p: Parameters) extends XSBundle {
   val isFirstIssue = Bool()
 }
 
-class StoreDataBundle(implicit p: Parameters) extends XSBundle {
-  val data = UInt((XLEN+1).W)
-  val uop = new MicroOp
-}
-
 class LoadForwardQueryIO(implicit p: Parameters) extends XSBundle {
   val vaddr = Output(UInt(VAddrBits.W))
   val paddr = Output(UInt(PAddrBits.W))

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -60,7 +60,7 @@ class LsqWrappper(implicit p: Parameters) extends XSModule with HasDCacheParamet
     val loadIn = Vec(LoadPipelineWidth, Flipped(Valid(new LsPipelineBundle)))
     val storeIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle)))
     val storeInRe = Vec(StorePipelineWidth, Input(new LsPipelineBundle()))
-    val storeDataIn = Vec(StorePipelineWidth, Flipped(Valid(new StoreDataBundle))) // store data, send to sq from rs
+    val storeDataIn = Vec(StorePipelineWidth, Flipped(Valid(new ExuOutput))) // store data, send to sq from rs
     val loadDataForwarded = Vec(LoadPipelineWidth, Input(Bool()))
     val needReplayFromRS = Vec(LoadPipelineWidth, Input(Bool()))
     val sbuffer = Vec(StorePipelineWidth, Decoupled(new DCacheWordReqWithVaddr))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -21,14 +21,10 @@ import chisel3._
 import chisel3.util._
 import utils._
 import xiangshan._
-import xiangshan.cache._
-import xiangshan.cache.{DCacheLineIO, DCacheWordIO, MemoryOpConstants}
-import xiangshan.cache.mmu.TlbRequestIO
-import xiangshan.mem._
-import xiangshan.backend.rob.RobLsqIO
-import xiangshan.backend.fu.HasExceptionNO
-import xiangshan.frontend.FtqPtr
 import xiangshan.backend.fu.fpu.FPU
+import xiangshan.backend.rob.RobLsqIO
+import xiangshan.cache._
+import xiangshan.frontend.FtqPtr
 
 
 class LqPtr(implicit p: Parameters) extends CircularQueuePtr[LqPtr](
@@ -79,7 +75,6 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   with HasDCacheParameters
   with HasCircularQueuePtrHelper
   with HasLoadHelper
-  with HasExceptionNO
 {
   val io = IO(new Bundle() {
     val enq = new LqEnqIO
@@ -766,8 +761,6 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   /**
     * misc
     */
-  io.rob.storeDataRobWb := DontCare // will be overwriten by store queue's result
-
   // perf counter
   QueuePerf(LoadQueueSize, validCount, !allowEnqueue)
   io.lqFull := !allowEnqueue

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -67,7 +67,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParamete
     val brqRedirect = Flipped(ValidIO(new Redirect))
     val storeIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle))) // store addr, data is not included
     val storeInRe = Vec(StorePipelineWidth, Input(new LsPipelineBundle())) // store more mmio and exception
-    val storeDataIn = Vec(StorePipelineWidth, Flipped(Valid(new StoreDataBundle))) // store data, send to sq from rs
+    val storeDataIn = Vec(StorePipelineWidth, Flipped(Valid(new ExuOutput))) // store data, send to sq from rs
     val sbuffer = Vec(StorePipelineWidth, Decoupled(new DCacheWordReqWithVaddr)) // write committed store to sbuffer
     val mmioStout = DecoupledIO(new ExuOutput) // writeback uncached store
     val forward = Vec(LoadPipelineWidth, Flipped(new PipeLoadForwardQueryIO))
@@ -301,8 +301,6 @@ class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParamete
         dataModule.io.data.wdata(i)
       )
     }
-    io.rob.storeDataRobWb(i).valid := RegNext(io.storeDataIn(i).fire())
-    io.rob.storeDataRobWb(i).bits := RegNext(io.storeDataIn(i).bits.uop.robIdx)
   }
 
   /**

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -24,13 +24,14 @@ import xiangshan._
 import xiangshan.cache.{DCacheWordIOWithVaddr, MemoryOpConstants}
 import xiangshan.cache.mmu.{TlbCmd, TlbRequestIO}
 import difftest._
+import xiangshan.ExceptionNO._
 import xiangshan.backend.fu.PMPRespBundle
 
 class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstants{
   val io = IO(new Bundle() {
     val hartId = Input(UInt(8.W))
     val in            = Flipped(Decoupled(new ExuInput))
-    val storeDataIn   = Flipped(Valid(new StoreDataBundle)) // src2 from rs
+    val storeDataIn   = Flipped(Valid(new ExuOutput)) // src2 from rs
     val out           = Decoupled(new ExuOutput)
     val dcache        = new DCacheWordIOWithVaddr
     val dtlb          = new TlbRequestIO

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -20,11 +20,10 @@ import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
 import utils._
+import xiangshan.ExceptionNO._
 import xiangshan._
-import xiangshan.backend.decode.ImmUnion
 import xiangshan.backend.fu.PMPRespBundle
-import xiangshan.cache._
-import xiangshan.cache.mmu.{TLB, TlbCmd, TlbPtwIO, TlbReq, TlbRequestIO, TlbResp}
+import xiangshan.cache.mmu.{TlbCmd, TlbReq, TlbRequestIO, TlbResp}
 
 // Store Pipeline Stage 0
 // Generate addr, use addr to query DCache and DTLB
@@ -107,7 +106,7 @@ class StoreUnit_S1(implicit p: Parameters) extends XSModule {
   val s1_paddr = io.dtlbResp.bits.paddr
   val s1_tlb_miss = io.dtlbResp.bits.miss
   val s1_mmio = is_mmio_cbo
-  val s1_exception = selectStore(io.out.bits.uop.cf.exceptionVec, false).asUInt.orR
+  val s1_exception = ExceptionNO.selectByFu(io.out.bits.uop.cf.exceptionVec, staCfg).asUInt.orR
 
   io.in.ready := true.B
 
@@ -157,7 +156,7 @@ class StoreUnit_S2(implicit p: Parameters) extends XSModule {
     val out = Decoupled(new LsPipelineBundle)
   })
 
-  val s2_exception = selectStore(io.out.bits.uop.cf.exceptionVec, false).asUInt.orR
+  val s2_exception = ExceptionNO.selectByFu(io.out.bits.uop.cf.exceptionVec, staCfg).asUInt.orR
 
   io.in.ready := true.B
   io.out.bits := io.in.bits

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -18,10 +18,11 @@ import chisel3._
 import chisel3.util._
 import chipsalliance.rocketchip.config.Parameters
 import freechips.rocketchip.tile.XLen
+import xiangshan.ExceptionNO._
 import xiangshan.backend.fu._
 import xiangshan.backend.fu.fpu._
 import xiangshan.backend.exu._
-import xiangshan.backend.{AmoData, Std}
+import xiangshan.backend.Std
 
 package object xiangshan {
   object SrcType {
@@ -387,11 +388,11 @@ package object xiangshan {
 
     // l1 cache op
     // bit encoding: | cbo_zero 01 | size(2bit) 11 |
-    def cbo_zero  = "b0111".U 
+    def cbo_zero  = "b0111".U
 
-    // llc op 
+    // llc op
     // bit encoding: | prefetch 11 | suboptype(2bit) |
-    def cbo_clean = "b1100".U 
+    def cbo_clean = "b1100".U
     def cbo_flush = "b1101".U
     def cbo_inval = "b1110".U
 
@@ -499,6 +500,59 @@ package object xiangshan {
     def apply() = UInt(4.W)
   }
 
+  object ExceptionNO {
+    def instrAddrMisaligned = 0
+    def instrAccessFault    = 1
+    def illegalInstr        = 2
+    def breakPoint          = 3
+    def loadAddrMisaligned  = 4
+    def loadAccessFault     = 5
+    def storeAddrMisaligned = 6
+    def storeAccessFault    = 7
+    def ecallU              = 8
+    def ecallS              = 9
+    def ecallM              = 11
+    def instrPageFault      = 12
+    def loadPageFault       = 13
+    // def singleStep          = 14
+    def storePageFault      = 15
+    def priorities = Seq(
+      breakPoint, // TODO: different BP has different priority
+      instrPageFault,
+      instrAccessFault,
+      illegalInstr,
+      instrAddrMisaligned,
+      ecallM, ecallS, ecallU,
+      storePageFault,
+      loadPageFault,
+      storeAccessFault,
+      loadAccessFault,
+      storeAddrMisaligned,
+      loadAddrMisaligned
+    )
+    def all = priorities.distinct.sorted
+    def frontendSet = Seq(
+      instrAddrMisaligned,
+      instrAccessFault,
+      illegalInstr,
+      instrPageFault
+    )
+    def partialSelect(vec: Vec[Bool], select: Seq[Int]): Vec[Bool] = {
+      val new_vec = Wire(ExceptionVec())
+      new_vec.foreach(_ := false.B)
+      select.foreach(i => new_vec(i) := vec(i))
+      new_vec
+    }
+    def selectFrontend(vec: Vec[Bool]): Vec[Bool] = partialSelect(vec, frontendSet)
+    def selectAll(vec: Vec[Bool]): Vec[Bool] = partialSelect(vec, ExceptionNO.all)
+    def selectByFu(vec:Vec[Bool], fuConfig: FuConfig): Vec[Bool] =
+      partialSelect(vec, fuConfig.exceptionOut)
+    def selectByExu(vec:Vec[Bool], exuConfig: ExuConfig): Vec[Bool] =
+      partialSelect(vec, exuConfig.exceptionOut)
+    def selectByExu(vec:Vec[Bool], exuConfigs: Seq[ExuConfig]): Vec[Bool] =
+      partialSelect(vec, exuConfigs.map(_.exceptionOut).reduce(_ ++ _).distinct.sorted)
+  }
+
   def dividerGen(p: Parameters) = new SRT16Divider(p(XLen))(p)
   def multiplierGen(p: Parameters) = new ArrayMultiplier(p(XLen) + 1)(p)
   def aluGen(p: Parameters) = new Alu()(p)
@@ -512,7 +566,7 @@ package object xiangshan {
   def f2fGen(p: Parameters) = new FPToFP()(p)
   def fdivSqrtGen(p: Parameters) = new FDivSqrt()(p)
   def stdGen(p: Parameters) = new Std()(p)
-  def mouDataGen(p: Parameters) = new AmoData()(p)
+  def mouDataGen(p: Parameters) = new Std()(p)
 
   def f2iSel(uop: MicroOp): Bool = {
     uop.ctrl.rfWen
@@ -560,9 +614,8 @@ package object xiangshan {
     name = "fence",
     fuGen = fenceGen,
     fuSel = (uop: MicroOp) => uop.ctrl.fuType === FuType.fence,
-    FuType.fence, 2, 0, writeIntRf = false, writeFpRf = false, hasRedirect = false,
-    latency = UncertainLatency(), // TODO: need rewrite latency structure, not just this value,
-    hasExceptionOut = true
+    FuType.fence, 2, 0, writeIntRf = false, writeFpRf = false,
+    latency = UncertainLatency(), exceptionOut = Seq(illegalInstr) // TODO: need rewrite latency structure, not just this value,
   )
 
   val csrCfg = FuConfig(
@@ -574,8 +627,8 @@ package object xiangshan {
     numFpSrc = 0,
     writeIntRf = true,
     writeFpRf = false,
-    hasRedirect = false,
-    hasExceptionOut = true
+    exceptionOut = Seq(illegalInstr, breakPoint, ecallU, ecallS, ecallM),
+    flushPipe = true
   )
 
   val i2fCfg = FuConfig(
@@ -587,7 +640,7 @@ package object xiangshan {
     numFpSrc = 0,
     writeIntRf = false,
     writeFpRf = true,
-    hasRedirect = false,
+    writeFflags = true,
     latency = CertainLatency(2),
     fastUopOut = true, fastImplemented = true
   )
@@ -601,7 +654,6 @@ package object xiangshan {
     0,
     writeIntRf = true,
     writeFpRf = false,
-    hasRedirect = false,
     latency = UncertainLatency(),
     fastUopOut = true,
     fastImplemented = true
@@ -616,7 +668,6 @@ package object xiangshan {
     0,
     writeIntRf = true,
     writeFpRf = false,
-    hasRedirect = false,
     latency = CertainLatency(2),
     fastUopOut = true,
     fastImplemented = true
@@ -631,7 +682,6 @@ package object xiangshan {
     numFpSrc = 0,
     writeIntRf = true,
     writeFpRf = false,
-    hasRedirect = false,
     latency = CertainLatency(1),
     fastUopOut = true,
     fastImplemented = true
@@ -641,7 +691,7 @@ package object xiangshan {
     name = "fmac",
     fuGen = fmacGen,
     fuSel = _ => true.B,
-    FuType.fmac, 0, 3, writeIntRf = false, writeFpRf = true, hasRedirect = false,
+    FuType.fmac, 0, 3, writeIntRf = false, writeFpRf = true, writeFflags = true,
     latency = UncertainLatency(), fastUopOut = true, fastImplemented = true
   )
 
@@ -649,7 +699,7 @@ package object xiangshan {
     name = "f2i",
     fuGen = f2iGen,
     fuSel = f2iSel,
-    FuType.fmisc, 0, 1, writeIntRf = true, writeFpRf = false, hasRedirect = false, CertainLatency(2),
+    FuType.fmisc, 0, 1, writeIntRf = true, writeFpRf = false, writeFflags = true, latency = CertainLatency(2),
     fastUopOut = true, fastImplemented = true
   )
 
@@ -657,7 +707,7 @@ package object xiangshan {
     name = "f2f",
     fuGen = f2fGen,
     fuSel = f2fSel,
-    FuType.fmisc, 0, 1, writeIntRf = false, writeFpRf = true, hasRedirect = false, CertainLatency(2),
+    FuType.fmisc, 0, 1, writeIntRf = false, writeFpRf = true, writeFflags = true, latency = CertainLatency(2),
     fastUopOut = true, fastImplemented = true
   )
 
@@ -665,7 +715,7 @@ package object xiangshan {
     name = "fdivSqrt",
     fuGen = fdivSqrtGen,
     fuSel = fdivSqrtSel,
-    FuType.fDivSqrt, 0, 2, writeIntRf = false, writeFpRf = true, hasRedirect = false, UncertainLatency(),
+    FuType.fDivSqrt, 0, 2, writeIntRf = false, writeFpRf = true, writeFflags = true, latency = UncertainLatency(),
     fastUopOut = true, fastImplemented = true, hasInputBuffer = true
   )
 
@@ -673,38 +723,42 @@ package object xiangshan {
     "ldu",
     null, // DontCare
     (uop: MicroOp) => FuType.loadCanAccept(uop.ctrl.fuType),
-    FuType.ldu, 1, 0, writeIntRf = true, writeFpRf = true, hasRedirect = false,
-    latency = UncertainLatency(), hasExceptionOut = true
+    FuType.ldu, 1, 0, writeIntRf = true, writeFpRf = true,
+    latency = UncertainLatency(),
+    exceptionOut = Seq(loadAddrMisaligned, loadAccessFault, loadPageFault),
+    flushPipe = true,
+    replayInst = true
   )
 
   val staCfg = FuConfig(
     "sta",
     null,
     (uop: MicroOp) => FuType.storeCanAccept(uop.ctrl.fuType),
-    FuType.stu, 1, 0, writeIntRf = false, writeFpRf = false, hasRedirect = false,
-    latency = UncertainLatency(), hasExceptionOut = true
+    FuType.stu, 1, 0, writeIntRf = false, writeFpRf = false,
+    latency = UncertainLatency(),
+    exceptionOut = Seq(storeAddrMisaligned, storeAccessFault, storePageFault)
   )
 
   val stdCfg = FuConfig(
     "std",
     fuGen = stdGen, fuSel = (uop: MicroOp) => FuType.storeCanAccept(uop.ctrl.fuType), FuType.stu, 1, 1,
-    writeIntRf = false, writeFpRf = false, hasRedirect = false, latency = CertainLatency(1)
+    writeIntRf = false, writeFpRf = false, latency = CertainLatency(1)
   )
 
   val mouCfg = FuConfig(
     "mou",
     null,
     (uop: MicroOp) => FuType.storeCanAccept(uop.ctrl.fuType),
-    FuType.mou, 1, 0, writeIntRf = false, writeFpRf = false, hasRedirect = false,
-    latency = UncertainLatency(), hasExceptionOut = true
+    FuType.mou, 1, 0, writeIntRf = false, writeFpRf = false,
+    latency = UncertainLatency(), exceptionOut = lduCfg.exceptionOut ++ staCfg.exceptionOut
   )
 
   val mouDataCfg = FuConfig(
     "mou",
     mouDataGen,
     (uop: MicroOp) => FuType.storeCanAccept(uop.ctrl.fuType),
-    FuType.mou, 1, 0, writeIntRf = false, writeFpRf = false, hasRedirect = false,
-    latency = UncertainLatency(), hasExceptionOut = true
+    FuType.mou, 1, 0, writeIntRf = false, writeFpRf = false,
+    latency = UncertainLatency()
   )
 
   val JumpExeUnitCfg = ExuConfig("JmpExeUnit", "Int", Seq(jmpCfg, i2fCfg), 2, Int.MaxValue)


### PR DESCRIPTION
This commit adds WritebackSink and WritebackSource parameters for
multiple modules. These traits hide implementation details from
other modules by defining IO-related functions in modules.

By using WritebackSink, ROB is able to choose the writeback sources.
Now fflags and exceptions are connected from exe units to reduce write
ports and optimize timing.

Further optimizations on write-back to RS and better coding style to
be added later.