### PR TITLE
core: refactor hardware performance counters

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -434,5 +434,4 @@ trait HasXSParameter {
   val numCSRPCntCtrl     = 8
   val numCSRPCntLsu      = 8
   val numCSRPCntHc       = 5
-  val print_perfcounter  = false
 }

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -130,7 +130,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
 
     core.module.io.hartId := io.hartId
     if(l2cache.isDefined){
-      core.module.io.perfEvents <> l2cache.get.module.io.perfEvents.flatten
+      core.module.io.perfEvents.zip(l2cache.get.module.io.perfEvents.flatten).foreach(x => x._1.value := x._2)
     }
     else {
       core.module.io.perfEvents <> DontCare

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -172,7 +172,8 @@ class RedirectGenerator(implicit p: Parameters) extends XSModule
   }
 }
 
-class CtrlBlock(implicit p: Parameters) extends LazyModule with HasWritebackSink with HasWritebackSource {
+class CtrlBlock(implicit p: Parameters) extends LazyModule
+  with HasWritebackSink with HasWritebackSource {
   val rob = LazyModule(new Rob)
 
   override def addWritebackSink(source: Seq[HasWritebackSource], index: Option[Seq[Int]]): HasWritebackSink = {
@@ -196,7 +197,11 @@ class CtrlBlock(implicit p: Parameters) extends LazyModule with HasWritebackSink
 }
 
 class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleImp(outer)
-  with HasXSParameter with HasCircularQueuePtrHelper with HasWritebackSourceImp {
+  with HasXSParameter
+  with HasCircularQueuePtrHelper
+  with HasWritebackSourceImp
+  with HasPerfEvents
+{
   val writebackLengths = outer.writebackSinksParams.map(_.length)
 
   val io = IO(new Bundle {
@@ -252,9 +257,9 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
   val waittable = Module(new WaitTable)
   val rename = Module(new Rename)
   val dispatch = Module(new Dispatch)
-  val intDq = Module(new DispatchQueue(dpParams.IntDqSize, RenameWidth, dpParams.IntDqDeqWidth, "int"))
-  val fpDq = Module(new DispatchQueue(dpParams.FpDqSize, RenameWidth, dpParams.FpDqDeqWidth, "fp"))
-  val lsDq = Module(new DispatchQueue(dpParams.LsDqSize, RenameWidth, dpParams.LsDqDeqWidth, "ls"))
+  val intDq = Module(new DispatchQueue(dpParams.IntDqSize, RenameWidth, dpParams.IntDqDeqWidth))
+  val fpDq = Module(new DispatchQueue(dpParams.FpDqSize, RenameWidth, dpParams.FpDqDeqWidth))
+  val lsDq = Module(new DispatchQueue(dpParams.LsDqSize, RenameWidth, dpParams.LsDqDeqWidth))
   val redirectGen = Module(new RedirectGenerator)
 
   val rob = outer.rob.module
@@ -414,41 +419,17 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
   io.perfInfo.ctrlInfo.lsdqFull := RegNext(lsDq.io.dqFull)
 
   val pfevent = Module(new PFEvent)
+  pfevent.io.distribute_csr := RegNext(io.csrCtrl.distribute_csr)
   val csrevents = pfevent.io.hpmevent.slice(8,16)
+
   val perfinfo = IO(new Bundle(){
-    val perfEvents        = Output(new PerfEventsBundle(csrevents.length))
-    val perfEventsRs      = Input(new PerfEventsBundle(NumRs))
-    val perfEventsEu0     = Input(new PerfEventsBundle(10))
-    val perfEventsEu1     = Input(new PerfEventsBundle(10))
+    val perfEventsRs      = Input(Vec(NumRs, new PerfEvent))
+    val perfEventsEu0     = Input(Vec(6, new PerfEvent))
+    val perfEventsEu1     = Input(Vec(6, new PerfEvent))
   })
 
-  if(print_perfcounter){
-    val decode_perf     = decode.perfEvents.map(_._1).zip(decode.perfinfo.perfEvents.perf_events)
-    val rename_perf     = rename.perfEvents.map(_._1).zip(rename.perfinfo.perfEvents.perf_events)
-    val dispat_perf     = dispatch.perfEvents.map(_._1).zip(dispatch.perfinfo.perfEvents.perf_events)
-    val intdq_perf      = intDq.perfEvents.map(_._1).zip(intDq.perfinfo.perfEvents.perf_events)
-    val fpdq_perf       = fpDq.perfEvents.map(_._1).zip(fpDq.perfinfo.perfEvents.perf_events)
-    val lsdq_perf       = lsDq.perfEvents.map(_._1).zip(lsDq.perfinfo.perfEvents.perf_events)
-    val rob_perf        = rob.perfEvents.map(_._1).zip(rob.perfinfo.perfEvents.perf_events)
-    val perfEvents =  decode_perf ++ rename_perf ++ dispat_perf ++ intdq_perf ++ fpdq_perf ++ lsdq_perf ++ rob_perf
-
-    for (((perf_name,perf),i) <- perfEvents.zipWithIndex) {
-      println(s"ctrl perf $i: $perf_name")
-    }
-  }
-
-  val hpmEvents = decode.perfinfo.perfEvents.perf_events ++ rename.perfinfo.perfEvents.perf_events ++ 
-                  dispatch.perfinfo.perfEvents.perf_events ++ 
-                  intDq.perfinfo.perfEvents.perf_events ++ fpDq.perfinfo.perfEvents.perf_events ++
-                  lsDq.perfinfo.perfEvents.perf_events ++ rob.perfinfo.perfEvents.perf_events ++
-                  perfinfo.perfEventsEu0.perf_events ++ perfinfo.perfEventsEu1.perf_events ++ 
-                  perfinfo.perfEventsRs.perf_events
-
-  val perf_length = hpmEvents.length
-  val hpm_ctrl = Module(new HPerfmonitor(perf_length,csrevents.length))
-  hpm_ctrl.io.hpm_event := csrevents
-  hpm_ctrl.io.events_sets.perf_events := hpmEvents
-  perfinfo.perfEvents := RegNext(hpm_ctrl.io.events_selected)
-  pfevent.io.distribute_csr := RegNext(io.csrCtrl.distribute_csr)
-
+  val allPerfEvents = Seq(decode, rename, dispatch, intDq, fpDq, lsDq, rob).flatMap(_.getPerf)
+  val hpmEvents = allPerfEvents ++ perfinfo.perfEventsEu0 ++ perfinfo.perfEventsEu1 ++ perfinfo.perfEventsRs
+  val perfEvents = HPerfMonitor(csrevents, hpmEvents).getPerfEvents
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/backend/ExuBlock.scala
+++ b/src/main/scala/xiangshan/backend/ExuBlock.scala
@@ -54,7 +54,7 @@ class ExuBlock(
 }
 
 class ExuBlockImp(outer: ExuBlock)(implicit p: Parameters) extends LazyModuleImp(outer)
-  with HasWritebackSourceImp {
+  with HasWritebackSourceImp with HasPerfEvents {
   val scheduler = outer.scheduler.module
 
   val fuConfigs = outer.fuConfigs
@@ -91,10 +91,8 @@ class ExuBlockImp(outer: ExuBlock)(implicit p: Parameters) extends LazyModuleImp
   scheduler.io.fastUopIn <> io.fastUopIn
   scheduler.io.extra <> io.scheExtra
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(scheduler.perfinfo.perfEvents.length))
-  })
-  scheduler.perfinfo <> perfinfo
+  val perfEvents = scheduler.getPerfEvents
+  generatePerfEvent()
 
   // the scheduler issues instructions to function units
   scheduler.io.issue <> fuBlock.io.issue ++ io.issue.getOrElse(Seq())

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -37,7 +37,7 @@ case class DispatchParameters
 )
 
 // read rob and enqueue
-class Dispatch(implicit p: Parameters) extends XSModule {
+class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents {
   val io = IO(new Bundle() {
     val hartId = Input(UInt(8.W))
     // from rename
@@ -294,9 +294,6 @@ class Dispatch(implicit p: Parameters) extends XSModule {
   XSPerfAccumulate("stall_cycle_fp_dq", hasValidInstr && io.enqRob.canAccept && io.toIntDq.canAccept && !io.toFpDq.canAccept && io.toLsDq.canAccept)
   XSPerfAccumulate("stall_cycle_ls_dq", hasValidInstr && io.enqRob.canAccept && io.toIntDq.canAccept && io.toFpDq.canAccept && !io.toLsDq.canAccept)
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(9))
-  })
   val perfEvents = Seq(
     ("dispatch_in                 ", PopCount(io.fromRename.map(_.valid & io.fromRename(0).ready))                                                                       ),
     ("dispatch_empty              ", !hasValidInstr                                                                                                                      ),
@@ -308,8 +305,5 @@ class Dispatch(implicit p: Parameters) extends XSModule {
     ("dispatch_stall_cycle_fp_dq  ", hasValidInstr && io.enqRob.canAccept && io.toIntDq.canAccept && !io.toFpDq.canAccept && io.toLsDq.canAccept  ),
     ("dispatch_stall_cycle_ls_dq  ", hasValidInstr && io.enqRob.canAccept && io.toIntDq.canAccept && io.toFpDq.canAccept && !io.toLsDq.canAccept  ),
   )
-
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
@@ -23,7 +23,7 @@ import xiangshan._
 import utils._
 
 
-class StdFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) {
+class StdFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) with HasPerfEvents {
 
   val freeList = RegInit(VecInit(Seq.tabulate(size)( i => (i + 32).U(PhyRegIdxWidth.W) )))
   val headPtr  = RegInit(FreeListPtr(false.B, 0.U))
@@ -84,17 +84,12 @@ class StdFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) 
   XSPerfAccumulate("utilization", freeRegCnt)
   XSPerfAccumulate("allocation_blocked", !io.canAllocate)
   XSPerfAccumulate("can_alloc_wrong", !io.canAllocate && freeRegCnt >= RenameWidth.U)
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(4))
-  })
+
   val perfEvents = Seq(
     ("std_freelist_1_4_valid", (freeRegCnt < (size / 4).U)                                   ),
     ("std_freelist_2_4_valid", (freeRegCnt > (size / 4).U) & (freeRegCnt <= (size / 2).U)    ),
     ("std_freelist_3_4_valid", (freeRegCnt > (size / 2).U) & (freeRegCnt <= (size * 3 / 4).U)),
     ("std_freelist_4_4_valid", (freeRegCnt > (size * 3 / 4).U)                               )
   )
-
-  for (((perf_out, (perf_name, perf)), i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -385,7 +385,7 @@ class DCache()(implicit p: Parameters) extends LazyModule with HasDCacheParamete
 }
 
 
-class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParameters {
+class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParameters with HasPerfEvents {
 
   val io = IO(new DCacheIO)
 
@@ -703,22 +703,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   }
   XSPerfAccumulate("access_early_replace", PopCount(Cat(access_early_replace)))
 
-  val wb_perf      = wb.perfEvents.map(_._1).zip(wb.perfinfo.perfEvents.perf_events)
-  val mainp_perf     = mainPipe.perfEvents.map(_._1).zip(mainPipe.perfinfo.perfEvents.perf_events)
-  val missq_perf     = missQueue.perfEvents.map(_._1).zip(missQueue.perfinfo.perfEvents.perf_events)
-  val probq_perf     = probeQueue.perfEvents.map(_._1).zip(probeQueue.perfinfo.perfEvents.perf_events)
-  val ldu_0_perf     = ldu(0).perfEvents.map(_._1).zip(ldu(0).perfinfo.perfEvents.perf_events)
-  val ldu_1_perf     = ldu(1).perfEvents.map(_._1).zip(ldu(1).perfinfo.perfEvents.perf_events)
-  val perfEvents = wb_perf ++ mainp_perf ++ missq_perf ++ probq_perf ++ ldu_0_perf ++ ldu_1_perf
-  val perflist = wb.perfinfo.perfEvents.perf_events ++ mainPipe.perfinfo.perfEvents.perf_events ++
-                 missQueue.perfinfo.perfEvents.perf_events ++ probeQueue.perfinfo.perfEvents.perf_events ++
-                 ldu(0).perfinfo.perfEvents.perf_events ++ ldu(1).perfinfo.perfEvents.perf_events
-  val perf_length = perflist.length
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(perflist.length))
-  })
-  perfinfo.perfEvents.perf_events := perflist
-
+  val perfEvents = (Seq(wb, mainPipe, missQueue, probeQueue) ++ ldu).flatMap(_.getPerfEvents)
+  generatePerfEvent()
 }
 
 class AMOHelper() extends ExtModule {
@@ -740,20 +726,18 @@ class DCacheWrapper()(implicit p: Parameters) extends LazyModule with HasXSParam
     clientNode := dcache.clientNode
   }
 
-  lazy val module = new LazyModuleImp(this) {
+  lazy val module = new LazyModuleImp(this) with HasPerfEvents {
     val io = IO(new DCacheIO)
-    val perfinfo = IO(new Bundle(){
-      val perfEvents = Output(new PerfEventsBundle(dcache.asInstanceOf[DCache].module.perf_length))
-    })
-    val perfEvents = dcache.asInstanceOf[DCache].module.perfEvents.map(_._1).zip(dcache.asInstanceOf[DCache].module.perfinfo.perfEvents.perf_events)
-    if (!useDcache) {
+    val perfEvents = if (!useDcache) {
       // a fake dcache which uses dpi-c to access memory, only for debug usage!
       val fake_dcache = Module(new FakeDCache())
       io <> fake_dcache.io
+      Seq()
     }
     else {
       io <> dcache.module.io
-      perfinfo := dcache.asInstanceOf[DCache].module.perfinfo
+      dcache.module.getPerfEvents
     }
+    generatePerfEvent()
   }
 }

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -20,9 +20,9 @@ import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.tilelink.ClientMetadata
-import utils.{XSDebug, XSPerfAccumulate, PerfEventsBundle}
+import utils.{HasPerfEvents, XSDebug, XSPerfAccumulate}
 
-class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule {
+class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPerfEvents {
   def metaBits = (new Meta).getWidth
   def encMetaBits = cacheParams.tagCode.width((new MetaAndTag).getWidth) - tagBits
   def getMeta(encMeta: UInt): UInt = {
@@ -300,18 +300,12 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule {
   XSPerfAccumulate("actual_ld_fast_wakeup", s1_fire && s1_tag_match && !io.disable_ld_fast_wakeup)
   XSPerfAccumulate("ideal_ld_fast_wakeup", io.banked_data_read.fire() && s1_tag_match)
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(5))
-  })
   val perfEvents = Seq(
-    ("load_req                     ", io.lsu.req.fire()                                               ),
-    ("load_replay                  ", io.lsu.resp.fire() && resp.bits.replay                          ),
-    ("load_replay_for_data_nack    ", io.lsu.resp.fire() && resp.bits.replay && s2_nack_data          ),
-    ("load_replay_for_no_mshr      ", io.lsu.resp.fire() && resp.bits.replay && s2_nack_no_mshr       ),
-    ("load_replay_for_conflict     ", io.lsu.resp.fire() && resp.bits.replay && io.bank_conflict_slow ),
+    ("load_req                 ", io.lsu.req.fire()                                               ),
+    ("load_replay              ", io.lsu.resp.fire() && resp.bits.replay                          ),
+    ("load_replay_for_data_nack", io.lsu.resp.fire() && resp.bits.replay && s2_nack_data          ),
+    ("load_replay_for_no_mshr  ", io.lsu.resp.fire() && resp.bits.replay && s2_nack_no_mshr       ),
+    ("load_replay_for_conflict ", io.lsu.resp.fire() && resp.bits.replay && io.bank_conflict_slow ),
   )
-
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -84,7 +84,7 @@ class MainPipeReq(implicit p: Parameters) extends DCacheBundle {
   }
 }
 
-class MainPipe(implicit p: Parameters) extends DCacheModule {
+class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents {
   val metaBits = (new Meta).getWidth
   val encMetaBits = cacheParams.tagCode.width((new MetaAndTag).getWidth) - tagBits
 
@@ -669,15 +669,9 @@ class MainPipe(implicit p: Parameters) extends DCacheModule {
   io.status.s3.bits.set := s3_idx
   io.status.s3.bits.way_en := s3_way_en
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(2))
-  })
   val perfEvents = Seq(
-    ("dcache_mp_req                    ", s0_fire                                                                     ),
-    ("dcache_mp_total_penalty          ", (PopCount(VecInit(Seq(s0_fire, s1_valid, s2_valid, s3_valid))))             ),
+    ("dcache_mp_req          ", s0_fire                                                      ),
+    ("dcache_mp_total_penalty", PopCount(VecInit(Seq(s0_fire, s1_valid, s2_valid, s3_valid))))
   )
-
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -677,7 +677,6 @@ class PtwIO(implicit p: Parameters) extends PtwBundle {
     val tlb = Input(new TlbCsrBundle)
     val distribute_csr = Flipped(new DistributedCSRIO)
   }
-  val perfEvents      = Output(new PerfEventsBundle(numPCntPtw))
 }
 
 class L2TlbMemReqBundle(implicit p: Parameters) extends PtwBundle {

--- a/src/main/scala/xiangshan/cache/mmu/PTW.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PTW.scala
@@ -42,7 +42,7 @@ class PTW()(implicit p: Parameters) extends LazyModule with HasPtwConst {
 }
 
 @chiselName
-class PTWImp(outer: PTW)(implicit p: Parameters) extends PtwModule(outer) with HasCSRConst {
+class PTWImp(outer: PTW)(implicit p: Parameters) extends PtwModule(outer) with HasCSRConst with HasPerfEvents {
 
   val (mem, edge) = outer.node.out.head
 
@@ -327,22 +327,8 @@ class PTWImp(outer: PTW)(implicit p: Parameters) extends PtwModule(outer) with H
   }
 
 
-  if(print_perfcounter){
-    val missq_perf     = missQueue.perfEvents.map(_._1).zip(missQueue.perfinfo.perfEvents.perf_events)
-    val cache_perf     = cache.perfEvents.map(_._1).zip(cache.perfinfo.perfEvents.perf_events)
-    val fsm_perf       = fsm.perfEvents.map(_._1).zip(fsm.perfinfo.perfEvents.perf_events)
-    val perfEvents  = missq_perf ++ cache_perf ++ fsm_perf
-    for (((perf_name,perf),i) <- perfEvents.zipWithIndex) {
-      println(s"ptw perf $i: $perf_name")
-    }
-  }
-  val perf_list = missQueue.perfinfo.perfEvents.perf_events ++ cache.perfinfo.perfEvents.perf_events ++ fsm.perfinfo.perfEvents.perf_events
-  val perf_length = perf_list.length
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(perf_list.length))
-  })
-  perfinfo.perfEvents.perf_events := perf_list
-
+  val perfEvents  = Seq(missQueue, cache, fsm).flatMap(_.getPerfEvents)
+  generatePerfEvent()
 }
 
 class PTEHelper() extends ExtModule {
@@ -389,18 +375,17 @@ class PTWWrapper()(implicit p: Parameters) extends LazyModule with HasXSParamete
     node := ptw.node
   }
 
-  lazy val module = new LazyModuleImp(this) {
+  lazy val module = new LazyModuleImp(this) with HasPerfEvents {
     val io = IO(new PtwIO)
-    val perfinfo = IO(new Bundle(){
-      val perfEvents = Output(new PerfEventsBundle(ptw.asInstanceOf[PTW].module.perf_length))
-    })
-    if(useSoftPTW) {
+    val perfEvents = if (useSoftPTW) {
       val fake_ptw = Module(new FakePTW())
       io <> fake_ptw.io
+      Seq()
     }
     else {
         io <> ptw.module.io
-        perfinfo := ptw.asInstanceOf[PTW].module.perfinfo
+        ptw.module.getPerfEvents
     }
+    generatePerfEvent()
   }
 }

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -85,7 +85,7 @@ class PtwCacheIO()(implicit p: Parameters) extends MMUIOBaseBundle with HasPtwCo
 }
 
 @chiselName
-class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst {
+class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPerfEvents {
   val io = IO(new PtwCacheIO)
 
   val ecc = Code.fromString(l2tlbParams.ecc)
@@ -659,9 +659,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst {
   XSDebug(RegNext(sfence.valid), p"[sfence] l3g:${Binary(l3g)}\n")
   XSDebug(RegNext(sfence.valid), p"[sfence] spv:${Binary(spv)}\n")
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(8))
-  })
   val perfEvents = Seq(
     ("access           ", base_valid_access_0             ),
     ("l1_hit           ", l1Hit                           ),
@@ -672,8 +669,5 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst {
     ("rwHarzad         ",  io.req.valid && !io.req.ready  ),
     ("out_blocked      ",  io.resp.valid && !io.resp.ready),
   )
-
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -18,10 +18,8 @@ package xiangshan.cache.mmu
 
 import chipsalliance.rocketchip.config.Parameters
 import chisel3._
-import chisel3.util._
 import chisel3.experimental.chiselName
-import freechips.rocketchip.util.SRAMAnnotation
-import xiangshan._
+import chisel3.util._
 import utils._
 
 @chiselName
@@ -34,7 +32,7 @@ class TLBFA(
   saveLevel: Boolean = false,
   normalPage: Boolean,
   superPage: Boolean
-)(implicit p: Parameters) extends TlbModule{
+)(implicit p: Parameters) extends TlbModule with HasPerfEvents {
   require(!(sameCycle && saveLevel))
 
   val io = IO(new TlbStorageIO(nSets, nWays, ports))
@@ -143,17 +141,11 @@ class TLBFA(
     XSPerfAccumulate(s"refill${i}", io.w.valid && io.w.bits.wayIdx === i.U)
   }
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(2))
-  })
   val perfEvents = Seq(
-    ("tlbstore_access            ", io.r.resp.map(_.valid.asUInt()).fold(0.U)(_ + _)                            ),
-    ("tlbstore_hit               ", io.r.resp.map(a => a.valid && a.bits.hit).fold(0.U)(_.asUInt() + _.asUInt())),
+    ("tlbstore_access", io.r.resp.map(_.valid.asUInt()).fold(0.U)(_ + _)                            ),
+    ("tlbstore_hit   ", io.r.resp.map(a => a.valid && a.bits.hit).fold(0.U)(_.asUInt() + _.asUInt())),
   )
-
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
+  generatePerfEvent()
 
   println(s"tlb_fa: nSets${nSets} nWays:${nWays}")
 }

--- a/src/main/scala/xiangshan/frontend/BPU.scala
+++ b/src/main/scala/xiangshan/frontend/BPU.scala
@@ -295,7 +295,7 @@ class FakeBPU(implicit p: Parameters) extends XSModule with HasBPUConst {
 }
 
 @chiselName
-class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst {
+class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with HasPerfEvents {
   val io = IO(new PredictorIO)
 
   val predictors = Module(if (useBPD) new Composer else new FakePredictor)
@@ -658,10 +658,6 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst {
   XSPerfAccumulate("s2_redirect", s2_redirect)
   XSPerfAccumulate("s3_redirect", s3_redirect)
 
-  val perfEvents = predictors.asInstanceOf[Composer].perfEvents.map(_._1).zip(predictors.asInstanceOf[Composer].perfinfo.perfEvents.perf_events)
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(predictors.asInstanceOf[Composer].perfinfo.perfEvents.perf_events.length))
-  })
-  perfinfo.perfEvents := predictors.asInstanceOf[Composer].perfinfo.perfEvents
-
+  val perfEvents = predictors.asInstanceOf[Composer].getPerfEvents
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/frontend/Composer.scala
+++ b/src/main/scala/xiangshan/frontend/Composer.scala
@@ -24,7 +24,7 @@ import xiangshan._
 import utils._
 
 @chiselName
-class Composer(implicit p: Parameters) extends BasePredictor with HasBPUConst {
+class Composer(implicit p: Parameters) extends BasePredictor with HasBPUConst with HasPerfEvents {
   val (components, resp) = getBPDComponents(io.in.bits.resp_in(0), p)
   io.out.resp := resp
 
@@ -77,15 +77,9 @@ class Composer(implicit p: Parameters) extends BasePredictor with HasBPUConst {
 
   override def getFoldedHistoryInfo = Some(components.map(_.getFoldedHistoryInfo.getOrElse(Set())).reduce(_++_))
 
-  val comp_1_perf = components(1).asInstanceOf[MicroBTB].perfEvents.map(_._1).zip(components(1).asInstanceOf[MicroBTB].perfinfo.perfEvents.perf_events)
-  val comp_2_perf = components(2).asInstanceOf[Tage_SC].perfEvents.map(_._1).zip(components(2).asInstanceOf[Tage_SC].perfinfo.perfEvents.perf_events)
-  val comp_3_perf = components(3).asInstanceOf[FTB].perfEvents.map(_._1).zip(components(3).asInstanceOf[FTB].perfinfo.perfEvents.perf_events)
+  val comp_1_perf = components(1).asInstanceOf[MicroBTB].getPerfEvents
+  val comp_2_perf = components(2).asInstanceOf[Tage_SC].getPerfEvents
+  val comp_3_perf = components(3).asInstanceOf[FTB].getPerfEvents
   val perfEvents = comp_1_perf ++ comp_2_perf ++ comp_3_perf
-  val perf_list = components(1).asInstanceOf[MicroBTB].perfinfo.perfEvents.perf_events ++
-                  components(2).asInstanceOf[Tage_SC].perfinfo.perfEvents.perf_events ++
-                  components(3).asInstanceOf[FTB].perfinfo.perfEvents.perf_events
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(perf_list.length))
-  })
-  perfinfo.perfEvents.perf_events := perf_list
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/frontend/FTB.scala
+++ b/src/main/scala/xiangshan/frontend/FTB.scala
@@ -265,7 +265,8 @@ object FTBMeta {
 //   }
 // }
 
-class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUUtils with HasCircularQueuePtrHelper {
+class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUUtils
+  with HasCircularQueuePtrHelper with HasPerfEvents {
   override val meta_size = WireInit(0.U.asTypeOf(new FTBMeta)).getWidth
 
   val ftbAddr = new TableAddr(log2Up(numSets), 1)
@@ -503,15 +504,9 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
   XSPerfAccumulate("ftb_update_ignored", io.update.valid && io.update.bits.old_entry)
   XSPerfAccumulate("ftb_updated", u_valid)
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(2))
-  })
   val perfEvents = Seq(
     ("ftb_commit_hits            ", u_valid  &&  update.preds.hit),
     ("ftb_commit_misses          ", u_valid  && !update.preds.hit),
   )
-
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/frontend/Ibuffer.scala
+++ b/src/main/scala/xiangshan/frontend/Ibuffer.scala
@@ -36,7 +36,7 @@ class IBufferIO(implicit p: Parameters) extends XSBundle {
   val full = Output(Bool())
 }
 
-class Ibuffer(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelper {
+class Ibuffer(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelper with HasPerfEvents {
   val io = IO(new IBufferIO)
 
   class IBufEntry(implicit p: Parameters) extends XSBundle {
@@ -189,21 +189,16 @@ class Ibuffer(implicit p: Parameters) extends XSModule with HasCircularQueuePtrH
   QueuePerf(IBufSize, validEntries, !allowEnq)
   XSPerfAccumulate("flush", io.flush)
   XSPerfAccumulate("hungry", instrHungry)
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(8))
-  })
-  val perfEvents = Seq(
-    ("IBuffer_Flushed        ", io.flush                                                                     ),
-    ("IBuffer_hungry         ", instrHungry                                                                  ),
-    ("IBuffer_1/4_valid      ", (validEntries >  (0*(IBufSize/4)).U) & (validEntries < (1*(IBufSize/4)).U)   ),
-    ("IBuffer_2/4_valid      ", (validEntries >= (1*(IBufSize/4)).U) & (validEntries < (2*(IBufSize/4)).U)   ),
-    ("IBuffer_3/4_valid      ", (validEntries >= (2*(IBufSize/4)).U) & (validEntries < (3*(IBufSize/4)).U)   ),
-    ("IBuffer_4/4_valid      ", (validEntries >= (3*(IBufSize/4)).U) & (validEntries < (4*(IBufSize/4)).U)   ),
-    ("IBuffer_full           ",  validEntries.andR                                                           ),
-    ("Front_Bubble           ", PopCount((0 until DecodeWidth).map(i => io.out(i).ready && !io.out(i).valid))),
-  )
 
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
+  val perfEvents = Seq(
+    ("IBuffer_Flushed  ", io.flush                                                                     ),
+    ("IBuffer_hungry   ", instrHungry                                                                  ),
+    ("IBuffer_1_4_valid", (validEntries >  (0*(IBufSize/4)).U) & (validEntries < (1*(IBufSize/4)).U)   ),
+    ("IBuffer_2_4_valid", (validEntries >= (1*(IBufSize/4)).U) & (validEntries < (2*(IBufSize/4)).U)   ),
+    ("IBuffer_3_4_valid", (validEntries >= (2*(IBufSize/4)).U) & (validEntries < (3*(IBufSize/4)).U)   ),
+    ("IBuffer_4_4_valid", (validEntries >= (3*(IBufSize/4)).U) & (validEntries < (4*(IBufSize/4)).U)   ),
+    ("IBuffer_full     ",  validEntries.andR                                                           ),
+    ("Front_Bubble     ", PopCount((0 until DecodeWidth).map(i => io.out(i).ready && !io.out(i).valid)))
+  )
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -174,7 +174,7 @@ object SCThreshold {
 }
 
 
-trait HasSC extends HasSCParameter { this: Tage =>
+trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
   val update_on_mispred, update_on_unconf = WireInit(0.U.asTypeOf(Vec(TageBanks, Bool())))
   var sc_fh_info = Set[FoldedHistoryInfo]()
   if (EnableSC) {
@@ -343,16 +343,10 @@ trait HasSC extends HasSCParameter { this: Tage =>
 
   override def getFoldedHistoryInfo = Some(tage_fh_info ++ sc_fh_info)
 
-
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(3))
-  })
   val perfEvents = Seq(
     ("tage_tht_hit                  ", updateMetas(1).provider.valid + updateMetas(0).provider.valid),
     ("sc_update_on_mispred          ", PopCount(update_on_mispred) ),
     ("sc_update_on_unconf           ", PopCount(update_on_unconf)  ),
   )
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -444,7 +444,7 @@ class ICache()(implicit p: Parameters) extends LazyModule with HasICacheParamete
   lazy val module = new ICacheImp(this)
 }
 
-class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParameters {
+class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParameters with HasPerfEvents {
   val io = IO(new ICacheIO)
 
   val (bus, edge) = outer.clientNode.out.head
@@ -576,15 +576,13 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
     assert (!bus.d.fire())
   }
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(2))
-  })
   val perfEvents = Seq(
-    ("icache_miss_cnt         ", false.B                               ),
-    ("icache_miss_penty       ", BoolStopWatch(start = false.B, stop = false.B || false.B, startHighPriority = true)                               ),
+    ("icache_miss_cnt  ", false.B),
+    ("icache_miss_penty", BoolStopWatch(start = false.B, stop = false.B || false.B, startHighPriority = true)),
   )
+  generatePerfEvent()
 
-    // Customized csr cache op support
+  // Customized csr cache op support
   val cacheOpDecoder = Module(new CSRCacheOpDecoder("icache", CacheInstrucion.COP_ID_ICACHE))
   cacheOpDecoder.io.csr <> io.csr
   dataArray.io.cacheOp.req := cacheOpDecoder.io.cache.req

--- a/src/main/scala/xiangshan/frontend/uBTB.scala
+++ b/src/main/scala/xiangshan/frontend/uBTB.scala
@@ -33,7 +33,7 @@ trait MicroBTBParams extends HasXSParameter {
 
 @chiselName
 class MicroBTB(implicit p: Parameters) extends BasePredictor
-  with MicroBTBParams
+  with MicroBTBParams with HasPerfEvents
 {
   val ubtbAddr = new TableAddr(log2Up(numWays), 1)
 
@@ -129,15 +129,9 @@ class MicroBTB(implicit p: Parameters) extends BasePredictor
   XSPerfAccumulate("ubtb_commit_hits", u_valid && u_meta.hit)
   XSPerfAccumulate("ubtb_commit_misses", u_valid && !u_meta.hit)
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(2))
-  })
   val perfEvents = Seq(
-    ("ubtb_commit_hits       ", u_valid &&  u_meta.hit),
-    ("ubtb_commit_misse      ", u_valid && !u_meta.hit),
+    ("ubtb_commit_hit       ", u_valid &&  u_meta.hit),
+    ("ubtb_commit_miss      ", u_valid && !u_meta.hit),
   )
-
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
+  generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -52,7 +52,7 @@ class LsqEnqIO(implicit p: Parameters) extends XSBundle {
 }
 
 // Load / Store Queue Wrapper for XiangShan Out of Order LSU
-class LsqWrappper(implicit p: Parameters) extends XSModule with HasDCacheParameters {
+class LsqWrappper(implicit p: Parameters) extends XSModule with HasDCacheParameters with HasPerfEvents {
   val io = IO(new Bundle() {
     val hartId = Input(UInt(8.W))
     val enq = new LsqEnqIO
@@ -191,12 +191,6 @@ class LsqWrappper(implicit p: Parameters) extends XSModule with HasDCacheParamet
   io.lqFull := loadQueue.io.lqFull
   io.sqFull := storeQueue.io.sqFull
 
-  val ldq_perf = loadQueue.perfEvents.map(_._1).zip(loadQueue.perfinfo.perfEvents.perf_events)
-  val stq_perf = storeQueue.perfEvents.map(_._1).zip(storeQueue.perfinfo.perfEvents.perf_events)
-  val perfEvents = ldq_perf ++ stq_perf
-  val perf_list = storeQueue.perfinfo.perfEvents.perf_events ++ loadQueue.perfinfo.perfEvents.perf_events
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(perf_list.length))
-  })
-  perfinfo.perfEvents.perf_events := perf_list
-}                          
+  val perfEvents = Seq(loadQueue, storeQueue).flatMap(_.getPerfEvents)
+  generatePerfEvent()
+}

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -75,6 +75,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   with HasDCacheParameters
   with HasCircularQueuePtrHelper
   with HasLoadHelper
+  with HasPerfEvents
 {
   val io = IO(new Bundle() {
     val enq = new LqEnqIO
@@ -772,25 +773,20 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("writeback_blocked", PopCount(VecInit(io.ldout.map(i => i.valid && !i.ready))))
   XSPerfAccumulate("utilization_miss", PopCount((0 until LoadQueueSize).map(i => allocated(i) && miss(i))))
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(10))
-  })
   val perfEvents = Seq(
-    ("rollback          ", io.rollback.valid                                                               ),
-    ("mmioCycle         ", uncacheState =/= s_idle                                                         ),
-    ("mmio_Cnt          ", io.uncache.req.fire()                                                           ),
-    ("refill            ", io.dcache.valid                                                                 ),
-    ("writeback_success ", PopCount(VecInit(io.ldout.map(i => i.fire())))                                  ),
-    ("writeback_blocked ", PopCount(VecInit(io.ldout.map(i => i.valid && !i.ready)))                       ),
-    ("ltq_1/4_valid     ", (validCount < (LoadQueueSize.U/4.U))                                            ),
-    ("ltq_2/4_valid     ", (validCount > (LoadQueueSize.U/4.U)) & (validCount <= (LoadQueueSize.U/2.U))    ),
-    ("ltq_3/4_valid     ", (validCount > (LoadQueueSize.U/2.U)) & (validCount <= (LoadQueueSize.U*3.U/4.U))),
-    ("ltq_4/4_valid     ", (validCount > (LoadQueueSize.U*3.U/4.U))                                        ),
+    ("rollback         ", io.rollback.valid                                                               ),
+    ("mmioCycle        ", uncacheState =/= s_idle                                                         ),
+    ("mmio_Cnt         ", io.uncache.req.fire()                                                           ),
+    ("refill           ", io.dcache.valid                                                                 ),
+    ("writeback_success", PopCount(VecInit(io.ldout.map(i => i.fire())))                                  ),
+    ("writeback_blocked", PopCount(VecInit(io.ldout.map(i => i.valid && !i.ready)))                       ),
+    ("ltq_1_4_valid    ", (validCount < (LoadQueueSize.U/4.U))                                            ),
+    ("ltq_2_4_valid    ", (validCount > (LoadQueueSize.U/4.U)) & (validCount <= (LoadQueueSize.U/2.U))    ),
+    ("ltq_3_4_valid    ", (validCount > (LoadQueueSize.U/2.U)) & (validCount <= (LoadQueueSize.U*3.U/4.U))),
+    ("ltq_4_4_valid    ", (validCount > (LoadQueueSize.U*3.U/4.U))                                        )
   )
+  generatePerfEvent()
 
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
   // debug info
   XSDebug("enqPtrExt %d:%d deqPtrExt %d:%d\n", enqPtrExt(0).flag, enqPtr, deqPtrExt.flag, deqPtr)
 

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -60,7 +60,8 @@ class DataBufferEntry (implicit p: Parameters)  extends DCacheBundle {
 }
 
 // Store Queue
-class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParameters with HasCircularQueuePtrHelper {
+class StoreQueue(implicit p: Parameters) extends XSModule
+  with HasDCacheParameters with HasCircularQueuePtrHelper with HasPerfEvents {
   val io = IO(new Bundle() {
     val hartId = Input(UInt(8.W))
     val enq = new SqEnqIO
@@ -630,23 +631,18 @@ class StoreQueue(implicit p: Parameters) extends XSModule with HasDCacheParamete
   XSPerfAccumulate("cmtEntryCnt", distanceBetween(cmtPtrExt(0), deqPtrExt(0)))
   XSPerfAccumulate("nCmtEntryCnt", distanceBetween(enqPtrExt(0), cmtPtrExt(0)))
 
-  val perfinfo = IO(new Bundle(){
-    val perfEvents = Output(new PerfEventsBundle(8))
-  })
   val perfEvents = Seq(
-    ("mmioCycle         ", uncacheState =/= s_idle                                                                                                                             ),
-    ("mmioCnt           ", io.uncache.req.fire()                                                                                                                               ),
-    ("mmio_wb_success   ", io.mmioStout.fire()                                                                                                                                 ),
-    ("mmio_wb_blocked   ", io.mmioStout.valid && !io.mmioStout.ready                                                                                                           ),
-    ("stq_1/4_valid     ", (distanceBetween(enqPtrExt(0), deqPtrExt(0)) < (StoreQueueSize.U/4.U))                                                                              ),
-    ("stq_2/4_valid     ", (distanceBetween(enqPtrExt(0), deqPtrExt(0)) > (StoreQueueSize.U/4.U)) & (distanceBetween(enqPtrExt(0), deqPtrExt(0)) <= (StoreQueueSize.U/2.U))    ),
-    ("stq_3/4_valid     ", (distanceBetween(enqPtrExt(0), deqPtrExt(0)) > (StoreQueueSize.U/2.U)) & (distanceBetween(enqPtrExt(0), deqPtrExt(0)) <= (StoreQueueSize.U*3.U/4.U))),
-    ("stq_4/4_valid     ", (distanceBetween(enqPtrExt(0), deqPtrExt(0)) > (StoreQueueSize.U*3.U/4.U))                                                                          ),
+    ("mmioCycle      ", uncacheState =/= s_idle                                                                                                                             ),
+    ("mmioCnt        ", io.uncache.req.fire()                                                                                                                               ),
+    ("mmio_wb_success", io.mmioStout.fire()                                                                                                                                 ),
+    ("mmio_wb_blocked", io.mmioStout.valid && !io.mmioStout.ready                                                                                                           ),
+    ("stq_1_4_valid  ", (distanceBetween(enqPtrExt(0), deqPtrExt(0)) < (StoreQueueSize.U/4.U))                                                                              ),
+    ("stq_2_4_valid  ", (distanceBetween(enqPtrExt(0), deqPtrExt(0)) > (StoreQueueSize.U/4.U)) & (distanceBetween(enqPtrExt(0), deqPtrExt(0)) <= (StoreQueueSize.U/2.U))    ),
+    ("stq_3_4_valid  ", (distanceBetween(enqPtrExt(0), deqPtrExt(0)) > (StoreQueueSize.U/2.U)) & (distanceBetween(enqPtrExt(0), deqPtrExt(0)) <= (StoreQueueSize.U*3.U/4.U))),
+    ("stq_4_4_valid  ", (distanceBetween(enqPtrExt(0), deqPtrExt(0)) > (StoreQueueSize.U*3.U/4.U))                                                                          ),
   )
+  generatePerfEvent()
 
-  for (((perf_out,(perf_name,perf)),i) <- perfinfo.perfEvents.perf_events.zip(perfEvents).zipWithIndex) {
-    perf_out.incr_step := RegNext(perf)
-  }
   // debug info
   XSDebug("enqPtrExt %d:%d deqPtrExt %d:%d\n", enqPtrExt(0).flag, enqPtr, deqPtrExt(0).flag, deqPtr)
 


### PR DESCRIPTION
This commit optimizes the coding style and timing for hardware
performance counters.

By default, performance counters are RegNext(RegNext(_)).