### PR TITLE
mem: fix soft prefetch

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -457,7 +457,8 @@ class CustomCSRCtrlIO(implicit p: Parameters) extends XSBundle {
   val bp_ctrl = Output(new BPUCtrl)
   // Memory Block
   val sbuffer_threshold = Output(UInt(4.W))
-  val ldld_vio_check = Output(Bool())
+  val ldld_vio_check_enable = Output(Bool())
+  val soft_prefetch_enable = Output(Bool())
   // Rename
   val move_elim_enable = Output(Bool())
   // Decode

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -616,7 +616,7 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
 
   //to selectout prefetch.r/prefetch.w
   val isORI = BitPat("b?????????????????110?????0010011") === ctrl_flow.instr
-  when(isORI) {
+  when(isORI && io.csrCtrl.soft_prefetch_enable) {
     // TODO: add CSR based Zicbop config
     when(cs.ldest === 0.U) {
       cs.selImm := SelImm.IMM_S

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -496,11 +496,13 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   // bits 0-3: store buffer flush threshold (default: 8 entries)
   val smblockctl_init_val =
     ("hf".U & StoreBufferThreshold.U) |
-    (EnableLdVioCheckAfterReset.B.asUInt << 4)
+    (EnableLdVioCheckAfterReset.B.asUInt << 4) |
+    GenMask(5) // enable soft prefetch by default
   val smblockctl = RegInit(UInt(XLEN.W), smblockctl_init_val)
   csrio.customCtrl.sbuffer_threshold := smblockctl(3, 0)
   // bits 4: enable load load violation check
-  csrio.customCtrl.ldld_vio_check := smblockctl(4)
+  csrio.customCtrl.ldld_vio_check_enable := smblockctl(4)
+  csrio.customCtrl.soft_prefetch_enable := smblockctl(5)
 
   val srnctl = RegInit(UInt(XLEN.W), "h3".U)
   csrio.customCtrl.move_elim_enable := srnctl(0)

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -394,14 +394,15 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
     io.rsFeedback.bits.hit := 
       (!s2_cache_replay || s2_mmio || s2_exception || fullForward) && // replay if dcache miss queue full / busy
       !s2_tlb_miss && // replay if dtlb miss
-      !s2_data_invalid || // replay if store to load forward data is not ready 
-      s2_is_prefetch // prefetch will not be replayed
+      !s2_data_invalid // replay if store to load forward data is not ready 
   } else {
     io.rsFeedback.bits.hit := 
       (!s2_cache_replay || s2_mmio || s2_exception) && // replay if dcache miss queue full / busy
       !s2_tlb_miss && // replay if dtlb miss
-      !s2_data_invalid || // replay if store to load forward data is not ready
-      s2_is_prefetch // prefetch will not be replayed
+      !s2_data_invalid // replay if store to load forward data is not ready
+  }
+  when(s2_is_prefetch){
+    io.rsFeedback.bits.hit := !s2_tlb_miss // replay if dtlb miss
   }
   io.rsFeedback.bits.rsIdx := io.in.bits.rsIdx
   io.rsFeedback.bits.flushState := io.in.bits.ptwBack

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -222,7 +222,7 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
   // * need redo ld-ld violation check
   val needLdVioCheckRedo = io.loadViolationQueryReq.valid &&
     !io.loadViolationQueryReq.ready &&
-    RegNext(io.csrCtrl.ldld_vio_check)
+    RegNext(io.csrCtrl.ldld_vio_check_enable)
   io.needLdVioCheckRedo := needLdVioCheckRedo
   io.rsFeedback.valid := io.in.valid && (s1_bank_conflict || needLdVioCheckRedo)
   io.rsFeedback.bits.hit := false.B // we have found s1_bank_conflict / re do ld-ld violation check
@@ -369,7 +369,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
   // if ld-ld violation is detected, replay from this inst from fetch
   val ldldVioReplay = io.loadViolationQueryResp.valid &&
     io.loadViolationQueryResp.bits.have_violation &&
-    RegNext(io.csrCtrl.ldld_vio_check)
+    RegNext(io.csrCtrl.ldld_vio_check_enable)
   io.out.bits.uop.ctrl.replayInst := forwardFailReplay || ldldVioReplay
   io.out.bits.mmio := s2_mmio
   io.out.bits.uop.ctrl.flushPipe := s2_mmio && io.sentFastUop


### PR DESCRIPTION
* Soft prefetch will only be replayed when TLB miss
* `soft_prefetch_enable` bit is added to smblockctl (CSR)