### PR TITLE
rename: add fused lui and load

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -318,7 +318,7 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
   }
 
   decode.io.in <> io.frontend.cfVec
-  decode.io.csrCtrl := io.csrCtrl
+  decode.io.csrCtrl := RegNext(io.csrCtrl)
 
   // memory dependency predict
   // when decode, send fold pc to mdp

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -471,7 +471,7 @@ abstract class Imm(val len: Int) extends Bundle {
 }
 
 case class Imm_I() extends Imm(12) {
-  override def do_toImm32(minBits: UInt): UInt = SignExt(minBits, 32)
+  override def do_toImm32(minBits: UInt): UInt = SignExt(minBits(len - 1, 0), 32)
 
   override def minBitsFromInstr(instr: UInt): UInt =
     Cat(instr(31, 20))
@@ -492,7 +492,7 @@ case class Imm_B() extends Imm(12) {
 }
 
 case class Imm_U() extends Imm(20){
-  override def do_toImm32(minBits: UInt): UInt = Cat(minBits, 0.U(12.W))
+  override def do_toImm32(minBits: UInt): UInt = Cat(minBits(len - 1, 0), 0.U(12.W))
 
   override def minBitsFromInstr(instr: UInt): UInt = {
     instr(31, 12)
@@ -545,6 +545,17 @@ object ImmUnion {
   println(s"ImmUnion max len: $maxLen")
 }
 
+case class Imm_LUI_LOAD() {
+  def immFromLuiLoad(lui_imm: UInt, load_imm: UInt): UInt = {
+    val loadImm = load_imm(Imm_I().len - 1, 0)
+    Cat(lui_imm(Imm_U().len - loadImm.getWidth - 1, 0), loadImm)
+  }
+  def getLuiImm(uop: MicroOp): UInt = {
+    val loadImmLen = Imm_I().len
+    val imm_u = Cat(uop.psrc(1), uop.psrc(0), uop.ctrl.imm(ImmUnion.maxLen - 1, loadImmLen))
+    Imm_U().do_toImm32(imm_u)
+  }
+}
 
 /**
  * IO bundle for the Decode unit

--- a/src/main/scala/xiangshan/backend/issue/DataArray.scala
+++ b/src/main/scala/xiangshan/backend/issue/DataArray.scala
@@ -21,7 +21,7 @@ import chisel3._
 import chisel3.util._
 import xiangshan._
 import utils._
-import xiangshan.backend.decode.{ImmUnion, Imm_U}
+import xiangshan.backend.decode.{ImmUnion, Imm_LUI_LOAD, Imm_U}
 import xiangshan.backend.exu.ExuConfig
 
 class DataArrayReadIO(numEntries: Int, numSrc: Int, dataBits: Int)(implicit p: Parameters) extends XSBundle {
@@ -134,20 +134,25 @@ class MduImmExtractor(implicit p: Parameters) extends ImmExtractor(2, 64) {
   }
 }
 
+class LoadImmExtractor(implicit p: Parameters) extends ImmExtractor(1, 64) {
+  when (SrcType.isImm(io.uop.ctrl.srcType(0))) {
+    io.data_out(0) := SignExt(Imm_LUI_LOAD().getLuiImm(io.uop), XLEN)
+  }
+}
+
 object ImmExtractor {
   def apply(params: RSParams, uop: MicroOp, data_in: Vec[UInt], pc: Option[UInt], target: Option[UInt])
            (implicit p: Parameters): Vec[UInt] = {
-    val immExt = (params.isJump, params.isAlu, params.isMul) match {
-      case (true, false, false) => {
-        val ext = Module(new JumpImmExtractor)
-        ext.jump_pc := pc.get
-        ext.jalr_target := target.get
-        ext
-      }
-      case (false, true, false) => Module(new AluImmExtractor)
-      case (false, false, true) => Module(new MduImmExtractor)
-      case _ => Module(new ImmExtractor(params.numSrc, params.dataBits))
+    val immExt = if (params.isJump) {
+      val ext = Module(new JumpImmExtractor)
+      ext.jump_pc := pc.get
+      ext.jalr_target := target.get
+      ext
     }
+    else if (params.isAlu) { Module(new AluImmExtractor) }
+    else if (params.isMul) { Module(new MduImmExtractor) }
+    else if (params.isLoad) { Module(new LoadImmExtractor) }
+    else { Module(new ImmExtractor(params.numSrc, params.dataBits)) }
     immExt.io.uop := uop
     immExt.io.data_in := data_in
     immExt.io.data_out

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -21,6 +21,7 @@ import chisel3._
 import chisel3.util._
 import xiangshan._
 import utils._
+import xiangshan.backend.decode.{Imm_I, Imm_LUI_LOAD, Imm_U}
 import xiangshan.backend.rob.RobPtr
 import xiangshan.backend.rename.freelist._
 import xiangshan.mem.mdp._
@@ -218,6 +219,26 @@ class Rename(implicit p: Parameters) extends XSModule with HasPerfEvents {
       (z, next) => Mux(next._2, next._1, z)
     }
     io.out(i).bits.pdest := Mux(isMove(i), io.out(i).bits.psrc(0), uops(i).pdest)
+
+    // For fused-lui-load, load.src(0) is replaced by the imm.
+    val last_is_lui = io.in(i - 1).bits.ctrl.selImm === SelImm.IMM_U && io.in(i - 1).bits.ctrl.srcType(0) =/= SrcType.pc
+    val this_is_load = io.in(i).bits.ctrl.fuType === FuType.ldu && !LSUOpType.isPrefetch(io.in(i).bits.ctrl.fuOpType)
+    val lui_to_load = io.in(i - 1).bits.ctrl.ldest === io.in(i).bits.ctrl.lsrc(0)
+    val fused_lui_load = last_is_lui && this_is_load && lui_to_load
+    when (fused_lui_load) {
+      // The first LOAD operand (base address) is replaced by LUI-imm and stored in {psrc, imm}
+      val lui_imm = io.in(i - 1).bits.ctrl.imm
+      val ld_imm = io.in(i).bits.ctrl.imm
+      io.out(i).bits.ctrl.srcType(0) := SrcType.imm
+      io.out(i).bits.ctrl.imm := Imm_LUI_LOAD().immFromLuiLoad(lui_imm, ld_imm)
+      val psrcWidth = uops(i).psrc.head.getWidth
+      val lui_imm_in_imm = uops(i).ctrl.imm.getWidth - Imm_I().len
+      val left_lui_imm = Imm_U().len - lui_imm_in_imm
+      require(2 * psrcWidth >= left_lui_imm, "cannot fused lui and load with psrc")
+      io.out(i).bits.psrc(0) := lui_imm(lui_imm_in_imm + psrcWidth - 1, lui_imm_in_imm)
+      io.out(i).bits.psrc(1) := lui_imm(lui_imm.getWidth - 1, lui_imm_in_imm + psrcWidth)
+    }
+
   }
 
   /**
@@ -298,6 +319,8 @@ class Rename(implicit p: Parameters) extends XSModule with HasPerfEvents {
   XSPerfAccumulate("stall_cycle_walk", hasValid && io.out(0).ready && fpFreeList.io.canAllocate && intFreeList.io.canAllocate && io.robCommits.isWalk)
 
   XSPerfAccumulate("move_instr_count", PopCount(io.out.map(out => out.fire() && out.bits.ctrl.isMove)))
+  val is_fused_lui_load = io.out.map(o => o.fire() && o.bits.ctrl.fuType === FuType.ldu && o.bits.ctrl.srcType(0) === SrcType.imm)
+  XSPerfAccumulate("fused_lui_load_instr_count", PopCount(is_fused_lui_load))
 
 
   val renamePerf = Seq(


### PR DESCRIPTION
This commit adds fused load support by bypassing LUI results to load.

For better timing, detection is done at the rename stage. Imm is stored
in psrc(1), psrc(0) and imm.