### PR TITLE
ctrl: mark all flushes as level.flush for frontend

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -304,12 +304,18 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
   redirectGen.io.flush := flushRedirect.valid
 
   val frontendFlush = DelayN(flushRedirect, 5)
-  val frontendStage2Redirect = Mux(frontendFlush.valid, frontendFlush, redirectGen.io.stage2Redirect)
+  // When ROB commits an instruction with a flush, we notify the frontend of the flush without the commit.
+  // Flushes to frontend may be delayed by some cycles and commit before flush causes errors.
+  // Thus, we make all flush reasons to behave the same as exceptions for frontend.
   for (i <- 0 until CommitWidth) {
-    io.frontend.toFtq.rob_commits(i).valid := RegNext(rob.io.commits.valid(i) && !rob.io.commits.isWalk)
-    io.frontend.toFtq.rob_commits(i).bits := RegNext(rob.io.commits.info(i))
+    val is_commit = rob.io.commits.valid(i) && !rob.io.commits.isWalk && !rob.io.flushOut.valid
+    io.frontend.toFtq.rob_commits(i).valid := RegNext(is_commit)
+    io.frontend.toFtq.rob_commits(i).bits := RegEnable(rob.io.commits.info(i), is_commit)
   }
-  io.frontend.toFtq.stage2Redirect := frontendStage2Redirect
+  io.frontend.toFtq.stage2Redirect := Mux(frontendFlush.valid, frontendFlush, redirectGen.io.stage2Redirect)
+  when (frontendFlush.valid) {
+    io.frontend.toFtq.stage2Redirect.bits.level := RedirectLevel.flush
+  }
   val pendingRedirect = RegInit(false.B)
   when (stage2Redirect.valid) {
     pendingRedirect := true.B


### PR DESCRIPTION
This commit changes how flushes behave for frontend.

When ROB commits an instruction with a flush, we notify the frontend
of the flush without the commit.

Flushes to frontend may be delayed by some cycles and commit before
flush causes errors. Thus, we make all flush reasons to behave the
same as exceptions for frontend, that is, RedirectLevel.flush.