### PR TITLE
pmp: add static pmp check that stored in tlb entries

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -127,6 +127,7 @@ class MinimalConfig(n: Int = 1) extends Config(
           normalReplacer = Some("setplru"),
           superNWays = 4,
           normalAsVictim = true,
+          partialStaticPMP = true,
           outReplace = true
         ),
         sttlbParameters = TLBParameters(
@@ -137,6 +138,7 @@ class MinimalConfig(n: Int = 1) extends Config(
           normalReplacer = Some("setplru"),
           normalAsVictim = true,
           superNWays = 4,
+          partialStaticPMP = true,
           outReplace = true
         ),
         btlbParameters = TLBParameters(

--- a/src/main/scala/xiangshan/PMParameters.scala
+++ b/src/main/scala/xiangshan/PMParameters.scala
@@ -29,10 +29,10 @@ case class PMParameters
   NumPMP: Int = 16,
   NumPMA: Int = 16,
 
-  PlatformGrain: Int = log2Ceil(512/8), // 512 bits
+  PlatformGrain: Int = log2Ceil(4*1024), // 4KB, a normal page
   mmpma: MMPMAConfig = MMPMAConfig(
     address = 0x38021000,
-    mask = 0x1ff,
+    mask = 0xfff,
     lgMaxSize = 3,
     sameCycle = true,
     num = 2

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -184,6 +184,7 @@ case class XSCoreParameters
     superNWays = 8,
     normalAsVictim = true,
     outReplace = true,
+    partialStaticPMP = true,
     saveLevel = true
   ),
   sttlbParameters: TLBParameters = TLBParameters(
@@ -195,6 +196,7 @@ case class XSCoreParameters
     superNWays = 8,
     normalAsVictim = true,
     outReplace = true,
+    partialStaticPMP = true,
     saveLevel = true
   ),
   refillBothTlb: Boolean = false,

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -175,11 +175,16 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   val dtlb = dtlb_ld ++ dtlb_st
 
   val ptw_resp_next = RegEnable(io.ptw.resp.bits, io.ptw.resp.valid)
-  val ptw_resp_v = RegNext(io.ptw.resp.valid, init = false.B)
+  val ptw_resp_v = RegNext(io.ptw.resp.valid && !(sfence.valid && tlbcsr.satp.changed), init = false.B)
   io.ptw.resp.ready := true.B
 
   (dtlb_ld.map(_.ptw.req) ++ dtlb_st.map(_.ptw.req)).zipWithIndex.map{ case (tlb, i) =>
     tlb(0) <> io.ptw.req(i)
+    val vector_hit = if (refillBothTlb) Cat(ptw_resp_next.vector).orR
+      else if (i < exuParameters.LduCnt) Cat(ptw_resp_next.vector.take(exuParameters.LduCnt)).orR
+      else Cat(ptw_resp_next.vector.drop(exuParameters.LduCnt)).orR
+    io.ptw.req(i).valid := tlb(0).valid && !(ptw_resp_v && vector_hit &&
+      ptw_resp_next.data.entry.hit(tlb(0).bits.vpn, tlbcsr.satp.asid, allType = true, ignoreAsid = true))
   }
   dtlb_ld.map(_.ptw.resp.bits := ptw_resp_next.data)
   dtlb_st.map(_.ptw.resp.bits := ptw_resp_next.data)
@@ -201,6 +206,12 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     p.apply(tlbcsr.priv.dmode, pmp.io.pmp, pmp.io.pma, d)
     require(p.req.bits.size.getWidth == d.bits.size.getWidth)
   }
+  val pmp_check_ptw = Module(new PMPCheckerv2(lgMaxSize = 3, sameCycle = false, leaveHitMux = true))
+  pmp_check_ptw.io.apply(tlbcsr.priv.dmode, pmp.io.pmp, pmp.io.pma, io.ptw.resp.valid,
+    Cat(io.ptw.resp.bits.data.entry.ppn, 0.U(12.W)).asUInt)
+  dtlb_ld.map(_.ptw_replenish := pmp_check_ptw.io.resp)
+  dtlb_st.map(_.ptw_replenish := pmp_check_ptw.io.resp)
+
   val tdata = Reg(Vec(6, new MatchTriggerIO))
   val tEnable = RegInit(VecInit(Seq.fill(6)(false.B)))
   val en = csrCtrl.trigger_enable

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -174,19 +174,23 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   }
   val dtlb = dtlb_ld ++ dtlb_st
 
+  val ptw_resp_next = RegEnable(io.ptw.resp.bits, io.ptw.resp.valid)
+  val ptw_resp_v = RegNext(io.ptw.resp.valid, init = false.B)
+  io.ptw.resp.ready := true.B
+
   (dtlb_ld.map(_.ptw.req) ++ dtlb_st.map(_.ptw.req)).zipWithIndex.map{ case (tlb, i) =>
     tlb(0) <> io.ptw.req(i)
   }
-  dtlb_ld.map(_.ptw.resp.bits := io.ptw.resp.bits.data)
-  dtlb_st.map(_.ptw.resp.bits := io.ptw.resp.bits.data)
+  dtlb_ld.map(_.ptw.resp.bits := ptw_resp_next.data)
+  dtlb_st.map(_.ptw.resp.bits := ptw_resp_next.data)
   if (refillBothTlb) {
-    dtlb_ld.map(_.ptw.resp.valid := io.ptw.resp.valid && Cat(io.ptw.resp.bits.vector).orR)
-    dtlb_st.map(_.ptw.resp.valid := io.ptw.resp.valid && Cat(io.ptw.resp.bits.vector).orR)
+    dtlb_ld.map(_.ptw.resp.valid := ptw_resp_v && Cat(ptw_resp_next.vector).orR)
+    dtlb_st.map(_.ptw.resp.valid := ptw_resp_v && Cat(ptw_resp_next.vector).orR)
   } else {
-    dtlb_ld.map(_.ptw.resp.valid := io.ptw.resp.valid && Cat(io.ptw.resp.bits.vector.take(exuParameters.LduCnt)).orR)
-    dtlb_st.map(_.ptw.resp.valid := io.ptw.resp.valid && Cat(io.ptw.resp.bits.vector.drop(exuParameters.LduCnt)).orR)
+    dtlb_ld.map(_.ptw.resp.valid := ptw_resp_v && Cat(ptw_resp_next.vector.take(exuParameters.LduCnt)).orR)
+    dtlb_st.map(_.ptw.resp.valid := ptw_resp_v && Cat(ptw_resp_next.vector.drop(exuParameters.LduCnt)).orR)
   }
-  io.ptw.resp.ready := true.B
+
 
   // pmp
   val pmp = Module(new PMP())

--- a/src/main/scala/xiangshan/backend/fu/PMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMA.scala
@@ -101,12 +101,12 @@ trait PMAMethod extends PMAConst {
       MemMap("h00_3800_0000", "h00_3800_FFFF",   "h0", "CLINT",       "RW"),
       MemMap("h00_3801_0000", "h00_3801_FFFF",   "h0", "BEU",         "RW"),
       MemMap("h00_3802_0000", "h00_3802_0FFF",   "h0", "DebugModule", "RWX"),
-      MemMap("h00_3802_1000", "h00_3802_11FF",   "h0", "MMPMA",       "RW"),
-      MemMap("h00_3802_1200", "h00_3900_0FFF",   "h0", "Reserved",    ""),
-      MemMap("h00_3900_1000", "h00_3900_103F",   "h0", "Core_reset",  "RW"),
-      MemMap("h00_3900_1020", "h00_39FF_FFFF",   "h0", "Reserved",    ""),
-      MemMap("h00_3A00_0000", "h00_3A00_003F",   "h0", "PLL0",        "RW),
-      MemMap('h00_3A00_0020", "h00_3BFF_FFFF",   "h0", "Reserved",    ""),
+      MemMap("h00_3802_1000", "h00_3802_1FFF",   "h0", "MMPMA",       "RW"),
+      MemMap("h00_3802_2000", "h00_3900_0FFF",   "h0", "Reserved",    ""),
+      MemMap("h00_3900_1000", "h00_3900_1FFF",   "h0", "Core_reset",  "RW"),
+      MemMap("h00_3900_2000", "h00_39FF_FFFF",   "h0", "Reserved",    ""),
+      MemMap("h00_3A00_0000", "h00_3A00_0FFF",   "h0", "PLL0",        "RW),
+      MemMap('h00_3A00_1000", "h00_3BFF_FFFF",   "h0", "Reserved",    ""),
       MemMap("h00_3C00_0000", "h00_3FFF_FFFF",   "h0", "PLIC",        "RW"),
       MemMap("h00_4000_0000", "h00_7FFF_FFFF",   "h0", "PCIe",        "RW"),
       MemMap("h00_8000_0000", "h0F_FFFF_FFFF",   "h0", "DDR",         "RWXIDSA"),
@@ -148,7 +148,7 @@ trait PMAMethod extends PMAConst {
     cfg(idx).a := 1.U
     idx = idx - 1
 
-    addr(idx) := shift_addr(0x3A000040)
+    addr(idx) := shift_addr(0x3A001000)
     cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B
     idx = idx - 1
 
@@ -156,7 +156,7 @@ trait PMAMethod extends PMAConst {
     cfg(idx).a := 1.U
     idx = idx - 1
 
-    addr(idx) := shift_addr(0x39001040)
+    addr(idx) := shift_addr(0x39002000)
     cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B
     idx = idx - 1
 
@@ -164,7 +164,7 @@ trait PMAMethod extends PMAConst {
     cfg(idx).a := 1.U
     idx = idx - 1
 
-    addr(idx) := shift_addr(0x38021200)
+    addr(idx) := shift_addr(0x38022000)
     cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B
     idx = idx - 1
 

--- a/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
@@ -43,6 +43,7 @@ case class TLBParameters
   normalAsVictim: Boolean = false, // when get replace from fa, store it into sram
   outReplace: Boolean = false,
   shouldBlock: Boolean = false, // only for perf, not support for io
+  partialStaticPMP: Boolean = false, // partila static pmp result stored in entries
   saveLevel: Boolean = false
 )
 

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -80,7 +80,7 @@ class TLBFA(
 
   when (io.w.valid) {
     v(io.w.bits.wayIdx) := true.B
-    entries(io.w.bits.wayIdx).apply(io.w.bits.data, io.csr.satp.asid)
+    entries(io.w.bits.wayIdx).apply(io.w.bits.data, io.csr.satp.asid, io.w.bits.data_replenish)
   }
 
   val refill_vpn_reg = RegNext(io.w.bits.data.entry.tag)
@@ -213,8 +213,12 @@ class TLBSA(
 
     entries.io.w.apply(
       valid = io.w.valid || io.victim.in.valid,
-      setIdx = Mux(io.w.valid, get_set_idx(io.w.bits.data.entry.tag, nSets), get_set_idx(io.victim.in.bits.entry.tag, nSets)),
-      data = Mux(io.w.valid, (Wire(new TlbEntry(normalPage, superPage)).apply(io.w.bits.data, io.csr.satp.asid)), io.victim.in.bits.entry),
+      setIdx = Mux(io.w.valid,
+        get_set_idx(io.w.bits.data.entry.tag, nSets),
+        get_set_idx(io.victim.in.bits.entry.tag, nSets)),
+      data = Mux(io.w.valid,
+        (Wire(new TlbEntry(normalPage, superPage)).apply(io.w.bits.data, io.csr.satp.asid, io.w.bits.data_replenish)),
+        io.victim.in.bits.entry),
       waymask = UIntToOH(io.w.bits.wayIdx)
     )
   }

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -277,16 +277,25 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
     val loadViolationQueryResp = Flipped(Valid(new LoadViolationQueryResp))
     val csrCtrl = Flipped(new CustomCSRCtrlIO)
     val sentFastUop = Input(Bool())
+    val static_pm = Input(Valid(Bool())) // valid for static, bits for mmio
   })
+  val pmp = WireInit(io.pmpResp)
+  when (io.static_pm.valid) {
+    pmp.ld := false.B
+    pmp.st := false.B
+    pmp.instr := false.B
+    pmp.mmio := io.static_pm.bits
+  }
+
   val s2_is_prefetch = io.in.bits.isSoftPrefetch
   val excep = WireInit(io.in.bits.uop.cf.exceptionVec)
-  excep(loadAccessFault) := io.in.bits.uop.cf.exceptionVec(loadAccessFault) || io.pmpResp.ld
+  excep(loadAccessFault) := io.in.bits.uop.cf.exceptionVec(loadAccessFault) || pmp.ld
   when (s2_is_prefetch) {
     excep := 0.U.asTypeOf(excep.cloneType)
   }
   val s2_exception = ExceptionNO.selectByFu(io.out.bits.uop.cf.exceptionVec, lduCfg).asUInt.orR
 
-  val actually_mmio = io.pmpResp.mmio
+  val actually_mmio = pmp.mmio
   val s2_uop = io.in.bits.uop
   val s2_mask = io.in.bits.mask
   val s2_paddr = io.in.bits.paddr
@@ -302,7 +311,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
 
   val s2_forward_fail = io.lsq.matchInvalid || io.sbuffer.matchInvalid
   // assert(!s2_forward_fail)
-  io.dcache_kill := false.B // move pmp resp kill to outside
+  io.dcache_kill := pmp.ld || pmp.mmio // false.B // move pmp resp kill to outside
   io.dcacheResp.ready := true.B
   val dcacheShouldResp = !(s2_tlb_miss || s2_exception || s2_mmio || s2_is_prefetch)
   assert(!(io.in.valid && (dcacheShouldResp && !io.dcacheResp.valid)), "DCache response got lost")
@@ -496,9 +505,10 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper with 
 
   PipelineConnect(load_s1.io.out, load_s2.io.in, true.B, load_s1.io.out.bits.uop.robIdx.needFlush(io.redirect))
 
-  io.dcache.s2_kill := load_s2.io.dcache_kill || (io.pmp.ld || io.pmp.mmio) // to kill mmio resp which are redirected
+  io.dcache.s2_kill := load_s2.io.dcache_kill // to kill mmio resp which are redirected
   load_s2.io.dcacheResp <> io.dcache.resp
   load_s2.io.pmpResp <> io.pmp
+  load_s2.io.static_pm := RegNext(io.tlb.resp.bits.static_pm)
   load_s2.io.lsq.forwardData <> io.lsq.forward.forwardData
   load_s2.io.lsq.forwardMask <> io.lsq.forward.forwardMask
   load_s2.io.lsq.forwardMaskFast <> io.lsq.forward.forwardMaskFast // should not be used in load_s2


### PR DESCRIPTION
long latency: tlb's sram may be slow to gen ppn, ppn to pmp may be long latency.
Solution: add static pmp check.

Fatal problem: pmp grain is smalled than TLB pages(4KB, 2MB, 1GB)
Solution part 1: increase pmp'grain to 4K, for 4K entries, pre-check pmp and
store the result into tlb storage. For super pages, still dynamic check
that translation and check.