### PR TITLE
IPrefetch: fix prefetchPtr stop problem

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -218,7 +218,7 @@ case class XSCoreParameters
     nReleaseEntries = 2,
     nProbeEntries = 2,
     nPrefetchEntries = 4,
-    hasPrefetch = true,
+    hasPrefetch = false,
   ),
   dcacheParametersOpt: Option[DCacheParameters] = Some(DCacheParameters(
     tagECC = Some("secded"),

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -338,7 +338,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
 
   //send physical address to PMP
   io.pmp.zipWithIndex.map { case (p, i) =>
-    p.req.valid := s2_valid
+    p.req.valid := s2_valid && !missSwitchBit
     p.req.bits.addr := s2_req_paddr(i)
     p.req.bits.size := 3.U // TODO
     p.req.bits.cmd := TlbCmd.exec

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
@@ -317,7 +317,7 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
 
   val alloc = Wire(UInt(log2Ceil(nPrefetchEntries).W))
 
-  val prefEntries = (PortNumber until PortNumber + nPrefetchEntries - 1) map { i =>
+  val prefEntries = (PortNumber until PortNumber + nPrefetchEntries) map { i =>
     val prefetchEntry = Module(new IPrefetchEntry(edge, PortNumber))
 
     prefetchEntry.io.mem_hint_ack.valid := false.B
@@ -327,12 +327,8 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
       prefetchEntry.io.mem_hint_ack <> io.mem_grant
     }
 
-    prefetchEntry.io.req <> DontCare
-
-    when(i.U === alloc){
-      prefetchEntry.io.req.valid := io.prefetch_req.valid
-      prefetchEntry.io.req.bits  := io.prefetch_req.bits
-    }
+    prefetchEntry.io.req.valid := io.prefetch_req.valid && ((i-PortNumber).U === alloc)
+    prefetchEntry.io.req.bits  := io.prefetch_req.bits
 
     prefetchEntry.io.id := i.U
 

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -24,7 +24,7 @@ import utils._
 import xiangshan.cache.mmu._
 import xiangshan.frontend._
 import xiangshan.backend.fu.{PMPReqBundle, PMPRespBundle}
-
+import huancun.{PreferCacheKey}
 
 
 abstract class IPrefetchBundle(implicit p: Parameters) extends ICacheBundle
@@ -217,6 +217,7 @@ class IPrefetchEntry(edge: TLEdgeOut, id: Int)(implicit p: Parameters) extends I
     param = TLHints.PREFETCH_READ
   )._2
   io.mem_hint.bits := hint
+  io.mem_hint.bits.user.lift(PreferCacheKey).foreach(_ := true.B)
 
 
   XSPerfAccumulate(


### PR DESCRIPTION
* This problem happens because prefetchPtr still exits when close IPrefetch

* Fix PMP req port still be occupied even when ICache miss