### PR TITLE
atomics: delay exception.valid for more cycles

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -515,10 +515,12 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   }
 
   lsq.io.exceptionAddr.isStore := io.lsqio.exceptionAddr.isStore
-  // Address is delayed by one cycle, so does the atomics address
-  val atomicsException = RegNext(atomicsUnit.io.exceptionAddr.valid)
-  val atomicsExceptionAddress = RegNext(atomicsUnit.io.exceptionAddr.bits)
+  // Exception address is used serveral cycles after flush.
+  // We delay it by 10 cycles to ensure its flush safety.
+  val atomicsException = DelayN(atomicsUnit.io.exceptionAddr.valid, 10)
+  val atomicsExceptionAddress = RegEnable(atomicsUnit.io.exceptionAddr.bits, atomicsUnit.io.exceptionAddr.valid)
   io.lsqio.exceptionAddr.vaddr := Mux(atomicsException, atomicsExceptionAddress, lsq.io.exceptionAddr.vaddr)
+  XSError(atomicsException && atomicsUnit.io.in.valid, "new instruction before exception triggers\n")
 
   io.memInfo.sqFull := RegNext(lsq.io.sqFull)
   io.memInfo.lqFull := RegNext(lsq.io.lqFull)


### PR DESCRIPTION
Exception address is used serveral cycles after flush. We delay it
by more cycles to ensure its flush safety.