### PR TITLE
mem: fix ld-ld violation writeback priority

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -337,7 +337,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
   val s2_ldld_violation = io.loadViolationQueryResp.valid &&
     io.loadViolationQueryResp.bits.have_violation &&
     RegNext(io.csrCtrl.ldld_vio_check_enable)
-  val s2_data_invalid = io.lsq.dataInvalid && !s2_forward_fail
+  val s2_data_invalid = io.lsq.dataInvalid && !s2_forward_fail && !s2_ldld_violation
 
   io.dcache_kill := pmp.ld || pmp.mmio // move pmp resp kill to outside
   io.dcacheResp.ready := true.B
@@ -432,14 +432,14 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
   if (EnableFastForward) {
     s2_need_replay_from_rs :=
       s2_tlb_miss || // replay if dtlb miss
-      s2_cache_replay && !s2_is_prefetch && !s2_ldld_violation && !s2_forward_fail && !s2_ldld_violation && !s2_mmio && !s2_exception && !fullForward || // replay if dcache miss queue full / busy
-      s2_data_invalid && !s2_is_prefetch && !s2_ldld_violation && !s2_forward_fail && !s2_ldld_violation // replay if store to load forward data is not ready 
+      s2_cache_replay && !s2_is_prefetch && !s2_forward_fail && !s2_ldld_violation && !s2_mmio && !s2_exception && !fullForward || // replay if dcache miss queue full / busy
+      s2_data_invalid && !s2_is_prefetch && !s2_forward_fail && !s2_ldld_violation // replay if store to load forward data is not ready 
   } else {
     // Note that if all parts of data are available in sq / sbuffer, replay required by dcache will not be scheduled   
     s2_need_replay_from_rs := 
       s2_tlb_miss || // replay if dtlb miss
-      s2_cache_replay && !s2_is_prefetch && !s2_ldld_violation && !s2_forward_fail && !s2_ldld_violation && !s2_mmio && !s2_exception && !io.dataForwarded || // replay if dcache miss queue full / busy
-      s2_data_invalid && !s2_is_prefetch && !s2_ldld_violation && !s2_forward_fail && !s2_ldld_violation // replay if store to load forward data is not ready
+      s2_cache_replay && !s2_is_prefetch && !s2_forward_fail && !s2_ldld_violation && !s2_mmio && !s2_exception && !io.dataForwarded || // replay if dcache miss queue full / busy
+      s2_data_invalid && !s2_is_prefetch && !s2_forward_fail && !s2_ldld_violation // replay if store to load forward data is not ready
   }
   assert(!RegNext(io.in.valid && s2_need_replay_from_rs && s2_need_replay_from_fetch))
   io.rsFeedback.bits.hit := !s2_need_replay_from_rs


### PR DESCRIPTION
If s2_data_invalid and s2_ldld_violation happens together, enter
s2_ldld_violation workflow.

Note:
ld-ld violation or forward failure will let an normal load inst replay
from fetch. If TLB hit and ld-ld violation / forward failure happens,
we write back that inst immediately. Meanwhile, such insts will not be
replayed from rs.