### PR TITLE
queuePtr: set isAfter when different flags and same value

### DIFF
--- a/src/main/scala/utils/CircularQueuePtr.scala
+++ b/src/main/scala/utils/CircularQueuePtr.scala
@@ -81,10 +81,14 @@ trait HasCircularQueuePtrHelper {
   }
 
   def isAfter[T <: CircularQueuePtr[T]](left: T, right: T): Bool = {
-    Mux(left.flag === right.flag, left.value > right.value, left.value < right.value)
+    val differentFlag = left.flag ^ right.flag
+    val compare = left.value > right.value
+    differentFlag ^ compare
   }
 
   def isBefore[T <: CircularQueuePtr[T]](left: T, right: T): Bool = {
-    Mux(left.flag === right.flag, left.value < right.value, left.value > right.value)
+    val differentFlag = left.flag ^ right.flag
+    val compare = left.value < right.value
+    differentFlag ^ compare
   }
 }


### PR DESCRIPTION
For 0:x and 1:x, 1:x should be after 0:x.