### PR TITLE
dispatch: block enq when previous instructions have exception

### DIFF
--- a/src/main/scala/xiangshan/backend/dispatch/DispatchQueue.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/DispatchQueue.scala
@@ -93,6 +93,7 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
       robIdxEntries(tailPtr(sel).value) := io.enq.req(i).bits.robIdx
       debug_uopEntries(tailPtr(sel).value) := io.enq.req(i).bits
       stateEntries(tailPtr(sel).value) := s_valid
+      XSError(sel =/= PopCount(io.enq.req.take(i).map(_.valid)), "why not continuous??\n")
     }
   }
 
@@ -101,7 +102,7 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
     when(io.deq(i).fire() && !io.redirect.valid) {
       stateEntries(headPtr(i).value) := s_invalid
 
-      //      XSError(stateEntries(headPtr(i).value) =/= s_valid, "state of the dispatch entry is not s_valid\n")
+      // XSError(stateEntries(headPtr(i).value) =/= s_valid, "state of the dispatch entry is not s_valid\n")
     }
   }
 


### PR DESCRIPTION
This commit adds blocking logic for instructions when they enter
dispatch queues. If previous instructions have exceptions, any
following instructions should be enter dispatch queue.

Consider the following case. If uop(0) has an exception and is a load.
If uop(1) does not have an exception and is a load as well. Then the
allocation logic in dispatch queue will allocate an entry for both
uop(0) and uop(1). However, uop(0) will not set enq.valid and leave
the entry in dispatch queue empty. uop(1) will be allocated in dpq.
In dispatch queue, pointers are updated according to the real number
of instruction enqueue, which is one. While the second is actually
allocated. This causes errors.