### PR TITLE
IFU: fix fetching RVC instructions from mmio space bug 

### DIFF
--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -21,8 +21,8 @@ import chisel3.util._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utils._
 import xiangshan._
-import xiangshan.backend.fu.{PFEvent, PMP, PMPChecker}
-import xiangshan.cache.mmu.{TLB, TlbPtwIO}
+import xiangshan.backend.fu.{PFEvent, PMP, PMPChecker,PMPReqBundle}
+import xiangshan.cache.mmu._
 import xiangshan.frontend.icache._
 
 
@@ -77,13 +77,31 @@ class FrontendImp (outer: Frontend) extends LazyModuleImp(outer)
   val pmp = Module(new PMP())
   val pmp_check = VecInit(Seq.fill(2)(Module(new PMPChecker(3, sameCycle = true)).io))
   pmp.io.distribute_csr := csrCtrl.distribute_csr
+  val pmp_req_vec     = Wire(Vec(2, Valid(new PMPReqBundle())))
+  pmp_req_vec(0) <> icache.io.pmp(0).req
+  pmp_req_vec(1).valid  :=  icache.io.pmp(1).req.valid || ifu.io.pmp.req.valid 
+  pmp_req_vec(1).bits   := Mux(ifu.io.pmp.req.valid, ifu.io.pmp.req.bits, icache.io.pmp(1).req.bits)
+
   for (i <- pmp_check.indices) {
-    pmp_check(i).apply(tlbCsr.priv.imode, pmp.io.pmp, pmp.io.pma, icache.io.pmp(i).req)
+    pmp_check(i).apply(tlbCsr.priv.imode, pmp.io.pmp, pmp.io.pma, pmp_req_vec(i))
     icache.io.pmp(i).resp <> pmp_check(i).resp
   }
+  ifu.io.pmp.resp <> pmp_check(1).resp
+  ifu.io.pmp.req.ready := false.B
+
+  val tlb_req_arb     = Module(new Arbiter(new TlbReq, 2))
+  tlb_req_arb.io.in(0) <> ifu.io.iTLBInter.req
+  tlb_req_arb.io.in(1) <> icache.io.itlb(1).req
+
+  val itlb_requestors = Wire(Vec(2, new BlockTlbRequestIO))
+  itlb_requestors(0) <> icache.io.itlb(0)
+  itlb_requestors(1).req <>  tlb_req_arb.io.out
+  ifu.io.iTLBInter.resp  <> itlb_requestors(1).resp
+  icache.io.itlb(1).resp <> itlb_requestors(1).resp
 
   io.ptw <> TLB(
-    in = Seq(icache.io.itlb(0), icache.io.itlb(1)),
+    //in = Seq(icache.io.itlb(0), icache.io.itlb(1)),
+    in = Seq(itlb_requestors(0), itlb_requestors(1)),
     sfence = io.sfence,
     csr = tlbCsr,
     width = 2,
@@ -109,8 +127,6 @@ class FrontendImp (outer: Frontend) extends LazyModuleImp(outer)
   icache.io.stop := ifu.io.icacheStop
 
   ifu.io.icachePerfInfo := icache.io.perfInfo
-
-  //icache.io.missQueue.flush := ifu.io.ftqInter.fromFtq.redirect.valid || (ifu.io.ftqInter.toFtq.pdWb.valid && ifu.io.ftqInter.toFtq.pdWb.bits.misOffset.valid)
 
   icache.io.csr.distribute_csr <> csrCtrl.distribute_csr
   io.csrUpdate := RegNext(icache.io.csr.update)

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -65,6 +65,8 @@ class NewIFUIO(implicit p: Parameters) extends XSBundle {
   val frontendTrigger = Flipped(new FrontendTdataDistributeIO)
   val csrTriggerEnable = Input(Vec(4, Bool()))
   val rob_commits = Flipped(Vec(CommitWidth, Valid(new RobCommitInfo)))
+  val iTLBInter       = new BlockTlbRequestIO
+  val pmp             =   new IPrefetchPMPBundle
 }
 
 // record the situation in which fallThruAddr falls into
@@ -121,6 +123,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val frontendTrigger = Module(new FrontendTrigger)
   val (preDecoderIn, preDecoderOut)   = (preDecoder.io.in, preDecoder.io.out)
   val (checkerIn, checkerOut)         = (predChecker.io.in, predChecker.io.out)
+
+  io.iTLBInter.resp.ready := true.B 
 
   /**
     ******************************************************************************
@@ -243,6 +247,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f2_half_snpc        = RegEnable(next = f1_half_snpc, enable = f1_fire)
   val f2_cut_ptr          = RegEnable(next = f1_cut_ptr, enable = f1_fire)
 
+  val f2_resend_vaddr     = RegEnable(next = f1_ftq_req.startAddr + 2.U, enable = f1_fire)
 
   def isNextLine(pc: UInt, startAddr: UInt) = {
     startAddr(blockOffBits) ^ pc(blockOffBits)
@@ -340,21 +345,25 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f3_except         = VecInit((0 until 2).map{i => f3_except_pf(i) || f3_except_af(i)})
   val f3_has_except     = f3_valid && (f3_except_af.reduce(_||_) || f3_except_pf.reduce(_||_))
   val f3_pAddrs   = RegEnable(next = f2_paddrs, enable = f2_fire)
+  val f3_resend_vaddr   = RegEnable(next = f2_resend_vaddr,      enable = f2_fire)
+
 
   val f3_oversize_target = f3_pc.last + 2.U
 
   /*** MMIO State Machine***/
   val f3_mmio_data    = Reg(Vec(2, UInt(16.W)))
   val mmio_is_RVC     = RegInit(false.B)
+  val mmio_resend_addr =RegInit(0.U(PAddrBits.W))
+  val mmio_resend_af  = RegInit(false.B)
 
-  val mmio_idle :: mmio_send_req :: mmio_w_resp :: mmio_resend :: mmio_resend_w_resp :: mmio_wait_commit :: mmio_commited :: Nil = Enum(7)
-  val mmio_state = RegInit(mmio_idle)
+  val m_idle :: m_sendReq :: m_waitResp :: m_sendTLB :: m_tlbResp :: m_sendPMP :: m_resendReq :: m_waitResendResp :: m_waitCommit :: m_commited :: Nil = Enum(10)
+  val mmio_state = RegInit(m_idle)
 
   val f3_req_is_mmio     = f3_mmio && f3_valid
   val mmio_commit = VecInit(io.rob_commits.map{commit => commit.valid && commit.bits.ftqIdx === f3_ftq_req.ftqIdx &&  commit.bits.ftqOffset === 0.U}).asUInt.orR
-  val f3_mmio_req_commit = f3_req_is_mmio && mmio_state === mmio_commited
+  val f3_mmio_req_commit = f3_req_is_mmio && mmio_state === m_commited
    
-  val f3_mmio_to_commit =  f3_req_is_mmio && mmio_state === mmio_wait_commit
+  val f3_mmio_to_commit =  f3_req_is_mmio && mmio_state === m_waitCommit
   val f3_mmio_to_commit_next = RegNext(f3_mmio_to_commit)
   val f3_mmio_can_go      = f3_mmio_to_commit && !f3_mmio_to_commit_next
 
@@ -382,21 +391,21 @@ class NewIFU(implicit p: Parameters) extends XSModule
 
 
   switch(mmio_state){
-    is(mmio_idle){
+    is(m_idle){
       when(f3_req_is_mmio){
-        mmio_state :=  mmio_send_req
+        mmio_state :=  m_sendReq
       }
     }
   
-    is(mmio_send_req){
-      mmio_state :=  Mux(toUncache.fire(), mmio_w_resp, mmio_send_req )
+    is(m_sendReq){
+      mmio_state :=  Mux(toUncache.fire(), m_waitResp, m_sendReq )
     }
 
-    is(mmio_w_resp){
+    is(m_waitResp){
       when(fromUncache.fire()){
           val isRVC =  fromUncache.bits.data(1,0) =/= 3.U
           val needResend = !isRVC && f3_pAddrs(0)(2,1) === 3.U
-          mmio_state :=  Mux(needResend, mmio_resend , mmio_wait_commit)
+          mmio_state :=  Mux(needResend, m_sendTLB , m_waitCommit)
 
           mmio_is_RVC := isRVC
           f3_mmio_data(0)   :=  fromUncache.bits.data(15,0)
@@ -404,37 +413,72 @@ class NewIFU(implicit p: Parameters) extends XSModule
       }
     }  
 
-    is(mmio_resend){
-      mmio_state :=  Mux(toUncache.fire(), mmio_resend_w_resp, mmio_resend )
+    is(m_sendTLB){
+          mmio_state :=  m_tlbResp
+    }
+
+    is(m_tlbResp){
+          mmio_state :=  m_sendPMP
+          mmio_resend_addr := io.iTLBInter.resp.bits.paddr
+    }
+
+    is(m_sendPMP){
+          val pmpExcpAF = io.pmp.resp.instr
+          mmio_state :=  Mux(pmpExcpAF, m_waitCommit , m_resendReq)
+          mmio_resend_af := pmpExcpAF
+    }
+
+    is(m_resendReq){
+      mmio_state :=  Mux(toUncache.fire(), m_waitResendResp, m_resendReq )
     }  
 
-    is(mmio_resend_w_resp){
+    is(m_waitResendResp){
       when(fromUncache.fire()){
-          mmio_state :=  mmio_wait_commit
+          mmio_state :=  m_waitCommit
           f3_mmio_data(1)   :=  fromUncache.bits.data(15,0)
       }
     }  
 
-    is(mmio_wait_commit){
+    is(m_waitCommit){
       when(mmio_commit){
-          mmio_state  :=  mmio_commited
+          mmio_state  :=  m_commited
       }
     }  
 
-    is(mmio_commited){
-        mmio_state := mmio_idle
+    //normal mmio instruction 
+    is(m_commited){
+        mmio_state := m_idle
+        mmio_is_RVC := false.B 
+        mmio_resend_addr := 0.U 
     }
   }
 
+  //exception or flush by older branch prediction
   when(f3_ftq_flush_self || f3_ftq_flush_by_older)  {
-    mmio_state := mmio_idle 
+    mmio_state := m_idle 
+    mmio_is_RVC := false.B 
+    mmio_resend_addr := 0.U 
+    mmio_resend_af := false.B
     f3_mmio_data.map(_ := 0.U) 
   }
 
-  toUncache.valid     :=  ((mmio_state === mmio_send_req) || (mmio_state === mmio_resend)) && f3_req_is_mmio
-  toUncache.bits.addr := Mux((mmio_state === mmio_resend), f3_pAddrs(0) + 2.U, f3_pAddrs(0))
+  toUncache.valid     :=  ((mmio_state === m_sendReq) || (mmio_state === m_resendReq)) && f3_req_is_mmio
+  toUncache.bits.addr := Mux((mmio_state === m_resendReq), mmio_resend_addr, f3_pAddrs(0))
   fromUncache.ready   := true.B
 
+  io.iTLBInter.req.valid         := (mmio_state === m_sendTLB) && f3_req_is_mmio
+  io.iTLBInter.req.bits.size     := 3.U 
+  io.iTLBInter.req.bits.vaddr    := f3_resend_vaddr
+  io.iTLBInter.req.bits.debug.pc := f3_resend_vaddr
+
+  io.iTLBInter.req.bits.cmd                 := TlbCmd.exec
+  io.iTLBInter.req.bits.robIdx              := DontCare
+  io.iTLBInter.req.bits.debug.isFirstIssue  := DontCare
+
+  io.pmp.req.valid := (mmio_state === m_sendPMP) && f3_req_is_mmio
+  io.pmp.req.bits.addr  := mmio_resend_addr
+  io.pmp.req.bits.size  := 3.U
+  io.pmp.req.bits.cmd   := TlbCmd.exec
 
   val f3_lastHalf       = RegInit(0.U.asTypeOf(new LastHalfInfo))
 
@@ -523,6 +567,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
     io.toIbuffer.bits.pd(0).isCall  := isCall
     io.toIbuffer.bits.pd(0).isRet   := isRet
 
+    io.toIbuffer.bits.acf(0) := mmio_resend_af
+
     io.toIbuffer.bits.enqEnable   := f3_mmio_range.asUInt
   }
 
@@ -536,7 +582,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   f3_mmio_missOffset.valid := f3_req_is_mmio
   f3_mmio_missOffset.bits  := 0.U
 
-  mmioFlushWb.valid           := (f3_req_is_mmio && mmio_state === mmio_wait_commit && RegNext(fromUncache.fire())  && f3_mmio_use_seq_pc)
+  mmioFlushWb.valid           := (f3_req_is_mmio && mmio_state === m_waitCommit && RegNext(fromUncache.fire())  && f3_mmio_use_seq_pc)
   mmioFlushWb.bits.pc         := f3_pc
   mmioFlushWb.bits.pd         := f3_pd
   mmioFlushWb.bits.pd.zipWithIndex.map{case(instr,i) => instr.valid :=  f3_mmio_range(i)}
@@ -548,7 +594,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   mmioFlushWb.bits.jalTarget  := DontCare
   mmioFlushWb.bits.instrRange := f3_mmio_range
 
-  mmio_redirect := (f3_req_is_mmio && mmio_state === mmio_wait_commit && RegNext(fromUncache.fire())  && f3_mmio_use_seq_pc)
+  mmio_redirect := (f3_req_is_mmio && mmio_state === m_waitCommit && RegNext(fromUncache.fire())  && f3_mmio_use_seq_pc)
 
   /**
     ******************************************************************************


### PR DESCRIPTION
* fix bugs when flash image including RVC instructions

*when a mmio fetch an RVI instruction cross 64 bits, IFU must send paddr + 2.U to fetch the higher 16 bits.
But the paddr + 2.U is not checked by TLB or PMP. This may cause some unexpected fetch stuck problems.