### PR TITLE
Debug mode: various bug fixes

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -400,7 +400,7 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
   dispatch.io.toFpDq <> fpDq.io.enq
   dispatch.io.toLsDq <> lsDq.io.enq
   dispatch.io.allocPregs <> io.allocPregs
-  dispatch.io.singleStep := false.B
+  dispatch.io.singleStep := RegNext(io.csrCtrl.singlestep)
 
   intDq.io.redirect <> stage2Redirect
   fpDq.io.redirect <> stage2Redirect

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -224,7 +224,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   dtlb_ld.map(_.ptw_replenish := pmp_check_ptw.io.resp)
   dtlb_st.map(_.ptw_replenish := pmp_check_ptw.io.resp)
 
-  val tdata = Reg(Vec(6, new MatchTriggerIO))
+  val tdata = RegInit(VecInit(Seq.fill(6)(0.U.asTypeOf(new MatchTriggerIO))))
   val tEnable = RegInit(VecInit(Seq.fill(6)(false.B)))
   val en = csrCtrl.trigger_enable
   tEnable := VecInit(en(2), en (3), en(4), en(5), en(7), en(9))
@@ -348,22 +348,28 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
 
     stu.io.stout.ready := true.B
 
-   // store vaddr
-   when(stOut(i).fire()){
-     val hit = Wire(Vec(3, Bool()))
-     for (j <- 0 until 3) {
-       when(!tdata(sTriggerMapping(j)).select) {
-         hit(j) := TriggerCmp(stOut(i).bits.debug.vaddr, tdata(sTriggerMapping(j)).tdata2, tdata(sTriggerMapping(j)).matchType, tEnable(sTriggerMapping(j)))
-         stOut(i).bits.uop.cf.trigger.backendHit(sTriggerMapping(j)) := hit(j)
-//         stOut(i).bits.uop.cf.trigger.backendTiming(sTriggerMapping(j)) := tdata(sTriggerMapping(j)).timing
-//          if (sChainMapping.contains(j)) stOut(i).bits.uop.cf.trigger.triggerChainVec(sChainMapping(j)) := hit && tdata(j + 3).chain
-       } .otherwise {
-         hit := VecInit(Seq.fill(3)(false.B))
-       }
+    // -------------------------
+    // Store Triggers
+    // -------------------------
+    when(stOut(i).fire()){
+      val hit = Wire(Vec(3, Bool()))
+      for (j <- 0 until 3) {
+         hit(j) := !tdata(sTriggerMapping(j)).select && TriggerCmp(
+           stOut(i).bits.debug.vaddr,
+           tdata(sTriggerMapping(j)).tdata2,
+           tdata(sTriggerMapping(j)).matchType,
+           tEnable(sTriggerMapping(j))
+         )
+       stOut(i).bits.uop.cf.trigger.backendHit(sTriggerMapping(j)) := hit(j)
+     }
 
-       when(!stOut(i).bits.uop.cf.trigger.backendEn(0)) {
-         stOut(i).bits.uop.cf.trigger.backendHit(4) := false.B
-       }
+     when(tdata(0).chain) {
+       io.writeback(i).bits.uop.cf.trigger.backendHit(0) := hit(0) && hit(1)
+       io.writeback(i).bits.uop.cf.trigger.backendHit(1) := hit(0) && hit(1)
+     }
+
+     when(!stOut(i).bits.uop.cf.trigger.backendEn(0)) {
+       stOut(i).bits.uop.cf.trigger.backendHit(4) := false.B
      }
    }
     // store data

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -296,7 +296,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
       loadUnits(i).io.trigger(j).matchType := tdata(lTriggerMapping(j)).matchType
       loadUnits(i).io.trigger(j).tEnable := tEnable(lTriggerMapping(j))
       // Just let load triggers that match data unavailable
-      hit(j) := loadUnits(i).io.trigger(j).addrHit && tdata(j).select // Mux(tdata(j + 3).select, loadUnits(i).io.trigger(j).lastDataHit, loadUnits(i).io.trigger(j).addrHit)
+      hit(j) := loadUnits(i).io.trigger(j).addrHit && !tdata(lTriggerMapping(j)).select // Mux(tdata(j + 3).select, loadUnits(i).io.trigger(j).lastDataHit, loadUnits(i).io.trigger(j).addrHit)
       io.writeback(i).bits.uop.cf.trigger.backendHit(lTriggerMapping(j)) := hit(j)
 //      io.writeback(i).bits.uop.cf.trigger.backendTiming(lTriggerMapping(j)) := tdata(lTriggerMapping(j)).timing
       //      if (lChainMapping.contains(j)) io.writeback(i).bits.uop.cf.trigger.triggerChainVec(lChainMapping(j)) := hit && tdata(j+3).chain

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -227,7 +227,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   val tdata = Reg(Vec(6, new MatchTriggerIO))
   val tEnable = RegInit(VecInit(Seq.fill(6)(false.B)))
   val en = csrCtrl.trigger_enable
-  tEnable := VecInit(en(2), en (3), en(7), en(4), en(5), en(9))
+  tEnable := VecInit(en(2), en (3), en(4), en(5), en(7), en(9))
   when(csrCtrl.mem_trigger.t.valid) {
     tdata(csrCtrl.mem_trigger.t.bits.addr) := csrCtrl.mem_trigger.t.bits.tdata
   }
@@ -292,7 +292,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     // --------------------------------
     val hit = Wire(Vec(3, Bool()))
     for (j <- 0 until 3) {
-      loadUnits(i).io.trigger(j).tdata2 := tdata(j + 3).tdata2
+      loadUnits(i).io.trigger(j).tdata2 := tdata(lTriggerMapping(j)).tdata2
       loadUnits(i).io.trigger(j).matchType := tdata(lTriggerMapping(j)).matchType
       loadUnits(i).io.trigger(j).tEnable := tEnable(lTriggerMapping(j))
       // Just let load triggers that match data unavailable

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -353,7 +353,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
      val hit = Wire(Vec(3, Bool()))
      for (j <- 0 until 3) {
        when(!tdata(sTriggerMapping(j)).select) {
-         hit(j) := TriggerCmp(stOut(i).bits.data, tdata(sTriggerMapping(j)).tdata2, tdata(sTriggerMapping(j)).matchType, tEnable(sTriggerMapping(j)))
+         hit(j) := TriggerCmp(stOut(i).bits.debug.vaddr, tdata(sTriggerMapping(j)).tdata2, tdata(sTriggerMapping(j)).matchType, tEnable(sTriggerMapping(j)))
          stOut(i).bits.uop.cf.trigger.backendHit(sTriggerMapping(j)) := hit(j)
 //         stOut(i).bits.uop.cf.trigger.backendTiming(sTriggerMapping(j)) := tdata(sTriggerMapping(j)).timing
 //          if (sChainMapping.contains(j)) stOut(i).bits.uop.cf.trigger.triggerChainVec(sChainMapping(j)) := hit && tdata(j + 3).chain

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -946,8 +946,8 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   XSDebug(debugIntr, "Debug Mode: debug interrupt is asserted and valid!")
   // send interrupt information to ROB
   val intrVecEnable = Wire(Vec(12, Bool()))
-  intrVecEnable.zip(ideleg.asBools).map{case(x,y) => x := priviledgedEnableDetect(y)}
-  val intrVec = Cat(debugIntr, (mie(11,0) & mip.asUInt & intrVecEnable.asUInt))
+  intrVecEnable.zip(ideleg.asBools).map{case(x,y) => x := priviledgedEnableDetect(y) && !debugMode}
+  val intrVec = Cat(debugIntr && !debugMode, (mie(11,0) & mip.asUInt & intrVecEnable.asUInt))
   val intrBitSet = intrVec.orR()
   csrio.interrupt := intrBitSet
   mipWire.t.m := csrio.externalInterrupt.mtip

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -1086,7 +1086,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
         // ebreak or ss in running hart
         debugModeNew := true.B
         dpc := iexceptionPC
-        dcsrNew.cause := Mux(hasTriggerHit, 4.U, Mux(hasbreakPoint, 3.U, 0.U))
+        dcsrNew.cause := Mux(hasTriggerHit, 2.U, Mux(hasbreakPoint, 1.U, 4.U))
         dcsrNew.prv := priviledgeMode // TODO
         priviledgeMode := ModeM
         mstatusNew.mprv := false.B

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -121,7 +121,7 @@ class CSRFileIO(implicit p: Parameters) extends XSBundle {
   // TLB
   val tlb = Output(new TlbCsrBundle)
   // Debug Mode
-  val singleStep = Output(Bool())
+  // val singleStep = Output(Bool())
   val debugMode = Output(Bool())
   // to Fence to disable sfence
   val disableSfence = Output(Bool())
@@ -254,8 +254,8 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     val dcsrNew = dcsr | (dcsrOld.prv(0) | dcsrOld.prv(1)).asUInt // turn 10 priv into 11
     dcsrNew
   }
-  csrio.singleStep := dcsrData.step
-  csrio.customCtrl.singlestep := dcsrData.step
+  // csrio.singleStep := dcsrData.step
+  csrio.customCtrl.singlestep := dcsrData.step && !debugMode
 
   // Trigger CSRs
 

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -831,7 +831,7 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
     exc_wb.bits.crossPageIPFFix := false.B
     // TODO: make trigger configurable
     exc_wb.bits.trigger.clear()
-    exc_wb.bits.trigger.backendHit := wb.bits.uop.cf.trigger
+    exc_wb.bits.trigger.backendHit := wb.bits.uop.cf.trigger.backendHit
     println(s"  [$i] ${configs.map(_.name)}: exception ${exceptionCases(i)}, " +
       s"flushPipe ${configs.exists(_.flushPipe)}, " +
       s"replayInst ${configs.exists(_.replayInst)}")

--- a/src/main/scala/xiangshan/frontend/PreDecode.scala
+++ b/src/main/scala/xiangshan/frontend/PreDecode.scala
@@ -274,7 +274,6 @@ class FrontendTrigger(implicit p: Parameters) extends XSModule {
   io.triggered.map{i => i := 0.U.asTypeOf(new TriggerCf)}
   val triggerEnable = RegInit(VecInit(Seq.fill(4)(false.B))) // From CSR, controlled by priv mode, etc.
   triggerEnable := io.csrTriggerEnable
-  val triggerHitVec = Wire(Vec(4, Bool()))
   XSDebug(triggerEnable.asUInt.orR, "Debug Mode: At least one frontend trigger is enabled\n")
 
   for (i <- 0 until 4) {PrintTriggerInfo(triggerEnable(i), tdata(i))}
@@ -283,6 +282,7 @@ class FrontendTrigger(implicit p: Parameters) extends XSModule {
     val currentPC = io.pc(i)
     val currentIsRVC = io.pds(i).isRVC
     val inst = WireInit(rawInsts(i))
+    val triggerHitVec = Wire(Vec(4, Bool()))
 
     for (j <- 0 until 4) {
       triggerHitVec(j) := Mux(tdata(j).select, TriggerCmp(Mux(currentIsRVC, inst(15, 0), inst), tdata(j).tdata2, tdata(j).matchType, triggerEnable(j)),

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -337,7 +337,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
   val s2_ldld_violation = io.loadViolationQueryResp.valid &&
     io.loadViolationQueryResp.bits.have_violation &&
     RegNext(io.csrCtrl.ldld_vio_check_enable)
-  val s2_data_invalid = io.lsq.dataInvalid && !s2_forward_fail
+  val s2_data_invalid = io.lsq.dataInvalid && !s2_forward_fail && !s2_ldld_violation
 
   io.dcache_kill := pmp.ld || pmp.mmio // move pmp resp kill to outside
   io.dcacheResp.ready := true.B
@@ -432,14 +432,14 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
   if (EnableFastForward) {
     s2_need_replay_from_rs :=
       s2_tlb_miss || // replay if dtlb miss
-      s2_cache_replay && !s2_is_prefetch && !s2_ldld_violation && !s2_forward_fail && !s2_ldld_violation && !s2_mmio && !s2_exception && !fullForward || // replay if dcache miss queue full / busy
-      s2_data_invalid && !s2_is_prefetch && !s2_ldld_violation && !s2_forward_fail && !s2_ldld_violation // replay if store to load forward data is not ready 
+      s2_cache_replay && !s2_is_prefetch && !s2_forward_fail && !s2_ldld_violation && !s2_mmio && !s2_exception && !fullForward || // replay if dcache miss queue full / busy
+      s2_data_invalid && !s2_is_prefetch && !s2_forward_fail && !s2_ldld_violation // replay if store to load forward data is not ready 
   } else {
     // Note that if all parts of data are available in sq / sbuffer, replay required by dcache will not be scheduled   
     s2_need_replay_from_rs := 
       s2_tlb_miss || // replay if dtlb miss
-      s2_cache_replay && !s2_is_prefetch && !s2_ldld_violation && !s2_forward_fail && !s2_ldld_violation && !s2_mmio && !s2_exception && !io.dataForwarded || // replay if dcache miss queue full / busy
-      s2_data_invalid && !s2_is_prefetch && !s2_ldld_violation && !s2_forward_fail && !s2_ldld_violation // replay if store to load forward data is not ready
+      s2_cache_replay && !s2_is_prefetch && !s2_forward_fail && !s2_ldld_violation && !s2_mmio && !s2_exception && !io.dataForwarded || // replay if dcache miss queue full / busy
+      s2_data_invalid && !s2_is_prefetch && !s2_forward_fail && !s2_ldld_violation // replay if store to load forward data is not ready
   }
   assert(!RegNext(io.in.valid && s2_need_replay_from_rs && s2_need_replay_from_fetch))
   io.rsFeedback.bits.hit := !s2_need_replay_from_rs


### PR DESCRIPTION
* Reduce trigger hit wires that goes into exceptiongen
* Fix frontend triggers rewriting hit wire
* Retrieved some accidentally dropped changes in branch dm-debug (mainly fixes to debug mode)
* Fix dmode in tdata1
* Fix ebreaks not causing exception in debug mode
* Fix dcsr field bugs
* Fix faulty distributed tEnable
* Fix store triggers not using vaddr
* Fix store trigger rewriting hit vector
* Initialize distributed tdata registers in MemBlock and Frontend to zero
* Fix load trigger select bit in mcontrol
* Fix singlestep bit valid in debug mode
* Mask all interrupts in debug mode