### PR TITLE
difftest: delay commit and regfile for two cycles

### DIFF
--- a/src/main/scala/xiangshan/backend/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/Scheduler.scala
@@ -511,13 +511,13 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
     val difftest = Module(new DifftestArchIntRegState)
     difftest.io.clock := clock
     difftest.io.coreid := io.hartId
-    difftest.io.gpr := intRfReadData.takeRight(32)
+    difftest.io.gpr := RegNext(RegNext(VecInit(intRfReadData.takeRight(32))))
   }
   if ((env.AlwaysBasicDiff || env.EnableDifftest) && fpRfConfig._1) {
     val difftest = Module(new DifftestArchFpRegState)
     difftest.io.clock := clock
     difftest.io.coreid := io.hartId
-    difftest.io.fpr := fpRfReadData.takeRight(32)
+    difftest.io.fpr := RegNext(RegNext(VecInit(fpRfReadData.takeRight(32))))
   }
 
   XSPerfAccumulate("allocate_valid", PopCount(allocate.map(_.valid)))

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -968,17 +968,17 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
       val uop = commitDebugUop(i)
       val exuOut = debug_exuDebug(ptr)
       val exuData = debug_exuData(ptr)
-      difftest.io.valid    := RegNext(io.commits.valid(i) && !io.commits.isWalk)
-      difftest.io.pc       := RegNext(SignExt(uop.cf.pc, XLEN))
-      difftest.io.instr    := RegNext(uop.cf.instr)
-      difftest.io.special  := RegNext(CommitType.isFused(io.commits.info(i).commitType))
+      difftest.io.valid    := RegNext(RegNext(RegNext(io.commits.valid(i) && !io.commits.isWalk)))
+      difftest.io.pc       := RegNext(RegNext(RegNext(SignExt(uop.cf.pc, XLEN))))
+      difftest.io.instr    := RegNext(RegNext(RegNext(uop.cf.instr)))
+      difftest.io.special  := RegNext(RegNext(RegNext(CommitType.isFused(io.commits.info(i).commitType))))
       // when committing an eliminated move instruction,
       // we must make sure that skip is properly set to false (output from EXU is random value)
-      difftest.io.skip     := RegNext(Mux(uop.eliminatedMove, false.B, exuOut.isMMIO || exuOut.isPerfCnt))
-      difftest.io.isRVC    := RegNext(uop.cf.pd.isRVC)
-      difftest.io.wen      := RegNext(io.commits.valid(i) && io.commits.info(i).rfWen && io.commits.info(i).ldest =/= 0.U)
-      difftest.io.wpdest   := RegNext(io.commits.info(i).pdest)
-      difftest.io.wdest    := RegNext(io.commits.info(i).ldest)
+      difftest.io.skip     := RegNext(RegNext(RegNext(Mux(uop.eliminatedMove, false.B, exuOut.isMMIO || exuOut.isPerfCnt))))
+      difftest.io.isRVC    := RegNext(RegNext(RegNext(uop.cf.pd.isRVC)))
+      difftest.io.wen      := RegNext(RegNext(RegNext(io.commits.valid(i) && io.commits.info(i).rfWen && io.commits.info(i).ldest =/= 0.U)))
+      difftest.io.wpdest   := RegNext(RegNext(RegNext(io.commits.info(i).pdest)))
+      difftest.io.wdest    := RegNext(RegNext(RegNext(io.commits.info(i).ldest)))
 
       // runahead commit hint
       val runahead_commit = Module(new DifftestRunaheadCommitEvent)
@@ -1020,13 +1020,13 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
       difftest.io.clock   := clock
       difftest.io.coreid  := io.hartId
       difftest.io.index   := i.U
-      difftest.io.valid   := RegNext(io.commits.valid(i) && !io.commits.isWalk)
-      difftest.io.special := RegNext(CommitType.isFused(commitInfo.commitType))
-      difftest.io.skip    := RegNext(Mux(eliminatedMove, false.B, exuOut.isMMIO || exuOut.isPerfCnt))
-      difftest.io.isRVC   := RegNext(isRVC)
-      difftest.io.wen     := RegNext(io.commits.valid(i) && commitInfo.rfWen && commitInfo.ldest =/= 0.U)
-      difftest.io.wpdest  := RegNext(commitInfo.pdest)
-      difftest.io.wdest   := RegNext(commitInfo.ldest)
+      difftest.io.valid   := RegNext(RegNext(RegNext(io.commits.valid(i) && !io.commits.isWalk)))
+      difftest.io.special := RegNext(RegNext(RegNext(CommitType.isFused(commitInfo.commitType))))
+      difftest.io.skip    := RegNext(RegNext(RegNext(Mux(eliminatedMove, false.B, exuOut.isMMIO || exuOut.isPerfCnt))))
+      difftest.io.isRVC   := RegNext(RegNext(RegNext(isRVC)))
+      difftest.io.wen     := RegNext(RegNext(RegNext(io.commits.valid(i) && commitInfo.rfWen && commitInfo.ldest =/= 0.U)))
+      difftest.io.wpdest  := RegNext(RegNext(RegNext(commitInfo.pdest)))
+      difftest.io.wdest   := RegNext(RegNext(RegNext(commitInfo.ldest)))
     }
   }
 

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -581,10 +581,10 @@ class StoreQueue(implicit p: Parameters) extends XSModule
       difftest.io.clock       := clock
       difftest.io.coreid      := io.hartId
       difftest.io.index       := i.U
-      difftest.io.valid       := storeCommit
-      difftest.io.storeAddr   := waddr
-      difftest.io.storeData   := wdata
-      difftest.io.storeMask   := wmask
+      difftest.io.valid       := RegNext(RegNext(storeCommit))
+      difftest.io.storeAddr   := RegNext(RegNext(waddr))
+      difftest.io.storeData   := RegNext(RegNext(wdata))
+      difftest.io.storeMask   := RegNext(RegNext(wmask))
     }
   }
 


### PR DESCRIPTION
CSRs are updated later after instructions commit from ROB. Thus, we
need to delay difftest commit for several cycles.