### PR TITLE
ftb: fix a bug on replacement policy, remove multiple hit assertion

### DIFF
--- a/src/main/scala/xiangshan/frontend/FTB.scala
+++ b/src/main/scala/xiangshan/frontend/FTB.scala
@@ -299,6 +299,7 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
 
     // Extract holdRead logic to fix bug that update read override predict read result
     val ftb = Module(new SRAMTemplate(new FTBEntryWithTag, set = numSets, way = numWays, shouldReset = true, holdRead = false, singlePort = true))
+    val ftb_r_entries = ftb.io.r.resp.data.map(_.entry)
 
     val pred_rdata   = HoldUnless(ftb.io.r.resp.data, RegNext(io.req_pc.valid && !io.update_access))
     ftb.io.r.req.valid := io.req_pc.valid || io.u_req_pc.valid // io.s0_fire
@@ -328,8 +329,12 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
     // val hit_way_1h = VecInit(PriorityEncoderOH(total_hits))
     val u_hit_way = OHToUInt(u_total_hits)
 
-    assert(PopCount(total_hits) === 1.U || PopCount(total_hits) === 0.U)
-    assert(PopCount(u_total_hits) === 1.U || PopCount(u_total_hits) === 0.U)
+    // assert(PopCount(total_hits) === 1.U || PopCount(total_hits) === 0.U)
+    // assert(PopCount(u_total_hits) === 1.U || PopCount(u_total_hits) === 0.U)
+    for (n <- 1 to numWays) {
+      XSPerfAccumulate(f"ftb_pred_${n}_way_hit", PopCount(total_hits) === n.U)
+      XSPerfAccumulate(f"ftb_update_${n}_way_hit", PopCount(u_total_hits) === n.U)
+    }
 
     val replacer = ReplacementPolicy.fromString(Some("setplru"), numWays, numSets)
     // val allocWriteWay = replacer.way(req_idx)
@@ -395,12 +400,12 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
     val u_valid = io.update_write_data.valid
     val u_data = io.update_write_data.bits
     val u_idx = ftbAddr.getIdx(io.update_pc)
-    val allocWriteWay = allocWay(VecInit(read_entries.map(_.valid)).asUInt, u_idx)
+    val allocWriteWay = allocWay(VecInit(ftb_r_entries.map(_.valid)).asUInt, u_idx)
     val u_mask = UIntToOH(Mux(io.update_write_alloc, allocWriteWay, io.update_write_way))
 
     for (i <- 0 until numWays) {
       XSPerfAccumulate(f"ftb_replace_way$i", u_valid && io.update_write_alloc && OHToUInt(u_mask) === i.U)
-      XSPerfAccumulate(f"ftb_replace_way${i}_has_empty", u_valid && io.update_write_alloc && !read_entries.map(_.valid).reduce(_&&_) && OHToUInt(u_mask) === i.U)
+      XSPerfAccumulate(f"ftb_replace_way${i}_has_empty", u_valid && io.update_write_alloc && !ftb_r_entries.map(_.valid).reduce(_&&_) && OHToUInt(u_mask) === i.U)
       XSPerfAccumulate(f"ftb_hit_way$i", hit && !io.update_access && hit_way === i.U)
     }
 


### PR DESCRIPTION
the mulitple-hit problem is yet to be solved (although it may be very rare)