### PR TITLE
sram-tlb: change SRAMTemplate & when tlb refill, just resp a miss/fast_miss

### DIFF
--- a/src/main/scala/utils/SRAMTemplate.scala
+++ b/src/main/scala/utils/SRAMTemplate.scala
@@ -118,7 +118,7 @@ class SRAMTemplate[T <: Data](gen: T, set: Int, way: Int = 1,
   val waymask = Mux(resetState, Fill(way, "b1".U), io.w.req.bits.waymask.getOrElse("b1".U))
   when (wen) { array.write(setIdx, wdata, waymask.asBools) }
 
-  val raw_rdata = Mux(RegNext(io.w.req.valid, false.B), RegNext(io.r.resp.data), array.read(io.r.req.bits.setIdx, realRen))
+  val raw_rdata = array.read(io.r.req.bits.setIdx, realRen)
 
   // bypass for dual-port SRAMs
   require(!bypassWrite || bypassWrite && !singlePort)
@@ -134,7 +134,7 @@ class SRAMTemplate[T <: Data](gen: T, set: Int, way: Int = 1,
     else VecInit((0 until way).map(_ => LFSR64().asTypeOf(wordType)))
   val bypass_mask = need_bypass(io.w.req.valid, io.w.req.bits.setIdx, io.w.req.bits.waymask.getOrElse("b1".U), io.r.req.valid, io.r.req.bits.setIdx)
   val mem_rdata = {
-    if (singlePort) raw_rdata
+    if (singlePort) Mux(RegNext(io.w.req.valid, false.B), RegNext(raw_rdata), raw_rdata)
     else VecInit(bypass_mask.asBools.zip(raw_rdata).zip(bypass_wdata).map {
       case ((m, r), w) => Mux(m, w, r)
     })

--- a/src/main/scala/utils/SRAMTemplate.scala
+++ b/src/main/scala/utils/SRAMTemplate.scala
@@ -118,7 +118,7 @@ class SRAMTemplate[T <: Data](gen: T, set: Int, way: Int = 1,
   val waymask = Mux(resetState, Fill(way, "b1".U), io.w.req.bits.waymask.getOrElse("b1".U))
   when (wen) { array.write(setIdx, wdata, waymask.asBools) }
 
-  val raw_rdata = array.read(io.r.req.bits.setIdx, realRen)
+  val raw_rdata = Mux(RegNext(io.w.req.valid, false.B), RegNext(io.r.resp.data), array.read(io.r.req.bits.setIdx, realRen))
 
   // bypass for dual-port SRAMs
   require(!bypassWrite || bypassWrite && !singlePort)

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -138,12 +138,12 @@ class TLB(Width: Int, q: TLBParameters)(implicit p: Parameters) extends TlbModul
 
     val paddr = Cat(ppn, offReg)
     val vaddr = SignExt(req(i).bits.vaddr, PAddrBits)
-
+    val refill_reg = RegNext(io.ptw.resp.valid)
     req(i).ready := resp(i).ready
     resp(i).valid := validReg
     resp(i).bits.paddr := Mux(vmEnable, paddr, if (!q.sameCycle) RegNext(vaddr) else vaddr)
-    resp(i).bits.miss := { if (q.missSameCycle) miss_sameCycle else (miss || RegNext(io.ptw.resp.valid)) }
-    resp(i).bits.fast_miss := fast_miss
+    resp(i).bits.miss := { if (q.missSameCycle) miss_sameCycle else (miss || refill_reg) }
+    resp(i).bits.fast_miss := fast_miss || refill_reg
     resp(i).bits.ptwBack := io.ptw.resp.fire()
 
     // for timing optimization, pmp check is divided into dynamic and static

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -113,7 +113,7 @@ class TLB(Width: Int, q: TLBParameters)(implicit p: Parameters) extends TlbModul
   def TLBNormalRead(i: Int) = {
     val (n_hit_sameCycle, normal_hit, normal_ppn, normal_perm) = normalPage.r_resp_apply(i)
     val (s_hit_sameCycle, super_hit, super_ppn, super_perm) = superPage.r_resp_apply(i)
-    assert(!(normal_hit && super_hit && vmEnable && RegNext(req(i).valid, init = false.B)))
+    // assert(!(normal_hit && super_hit && vmEnable && RegNext(req(i).valid, init = false.B)))
 
     val hit = normal_hit || super_hit
     val hit_sameCycle = n_hit_sameCycle || s_hit_sameCycle

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -142,7 +142,7 @@ class TLB(Width: Int, q: TLBParameters)(implicit p: Parameters) extends TlbModul
     req(i).ready := resp(i).ready
     resp(i).valid := validReg
     resp(i).bits.paddr := Mux(vmEnable, paddr, if (!q.sameCycle) RegNext(vaddr) else vaddr)
-    resp(i).bits.miss := { if (q.missSameCycle) miss_sameCycle else miss }
+    resp(i).bits.miss := { if (q.missSameCycle) miss_sameCycle else (miss || RegNext(io.ptw.resp.valid)) }
     resp(i).bits.fast_miss := fast_miss
     resp(i).bits.ptwBack := io.ptw.resp.fire()
 


### PR DESCRIPTION
SRAMTemplate:
Chisel(RTL) Module : when write, read will get random data
Replace Physical Module: when write, read will return last cycle's read data(or in other words, keep last cycle's data)

This difference make tlb's bug difficult to appear.
tlb forgot to check if read is valid or not, but check for data's tag part, which is random in Chisel Module.
The random tag makes it never hit with vpn. However in Physical Module, the "last cycle" tag hit with
vpn. The tag domain in tlb doesn't care index part, so the stored part is always the same.

Fix: when refill, just resp a miss/fast_miss