### PR TITLE
sram-tlb: change SRAMTemplate & when tlb refill, just resp a miss/fast_miss

### DIFF
--- a/src/main/scala/utils/SRAMTemplate.scala
+++ b/src/main/scala/utils/SRAMTemplate.scala
@@ -134,7 +134,7 @@ class SRAMTemplate[T <: Data](gen: T, set: Int, way: Int = 1,
     else VecInit((0 until way).map(_ => LFSR64().asTypeOf(wordType)))
   val bypass_mask = need_bypass(io.w.req.valid, io.w.req.bits.setIdx, io.w.req.bits.waymask.getOrElse("b1".U), io.r.req.valid, io.r.req.bits.setIdx)
   val mem_rdata = {
-    if (singlePort) raw_rdata
+    if (singlePort) Mux(RegNext(io.w.req.valid, false.B), RegNext(raw_rdata), raw_rdata)
     else VecInit(bypass_mask.asBools.zip(raw_rdata).zip(bypass_wdata).map {
       case ((m, r), w) => Mux(m, w, r)
     })


### PR DESCRIPTION
SRAMTemplate:
Chisel(RTL) Module : when write, read will get random data
Replace Physical Module: when write, read will return last cycle's read data(or in other words, keep last cycle's data)

This difference make tlb's bug difficult to appear.
tlb forgot to check if read is valid or not, but check for data's tag part, which is random in Chisel Module.
The random tag makes it never hit with vpn. However in Physical Module, the "last cycle" tag hit with
vpn. The tag domain in tlb doesn't care index part, so the stored part is always the same.

Fix: when refill, just resp a miss/fast_miss