### PR TITLE
l2tlb.cache: store invalid entries(only super entries) into sp to avoid mem access waste

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -689,6 +689,7 @@ class PtwResp(implicit p: Parameters) extends PtwBundle {
     this.entry.ppn := pte.ppn
     this.entry.prefetch := DontCare
     this.entry.asid := asid
+    this.entry.v := !pf
     this.pf := pf
     this.af := af
   }

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -510,6 +510,7 @@ class PtwEntry(tagLen: Int, hasPerm: Boolean = false, hasLevel: Boolean = false)
   val perm = if (hasPerm) Some(new PtePermBundle) else None
   val level = if (hasLevel) Some(UInt(log2Up(Level).W)) else None
   val prefetch = Bool()
+  val v = Bool()
 
   def hit(vpn: UInt, asid: UInt, allType: Boolean = false, ignoreAsid: Boolean = false) = {
     require(vpn.getWidth == vpnLen)
@@ -532,7 +533,7 @@ class PtwEntry(tagLen: Int, hasPerm: Boolean = false, hasLevel: Boolean = false)
     }
   }
 
-  def refill(vpn: UInt, asid: UInt, pte: UInt, level: UInt = 0.U, prefetch: Bool) {
+  def refill(vpn: UInt, asid: UInt, pte: UInt, level: UInt = 0.U, prefetch: Bool, valid: Bool = false.B) {
     require(this.asid.getWidth <= asid.getWidth) // maybe equal is better, but ugly outside
 
     tag := vpn(vpnLen - 1, vpnLen - tagLen)
@@ -540,12 +541,13 @@ class PtwEntry(tagLen: Int, hasPerm: Boolean = false, hasLevel: Boolean = false)
     perm.map(_ := pte.asTypeOf(new PteBundle().cloneType).perm)
     this.asid := asid
     this.prefetch := prefetch
+    this.v := valid
     this.level.map(_ := level)
   }
 
-  def genPtwEntry(vpn: UInt, asid: UInt, pte: UInt, level: UInt = 0.U, prefetch: Bool) = {
+  def genPtwEntry(vpn: UInt, asid: UInt, pte: UInt, level: UInt = 0.U, prefetch: Bool, valid: Bool = false.B) = {
     val e = Wire(new PtwEntry(tagLen, hasPerm, hasLevel))
-    e.refill(vpn, asid, pte, level, prefetch)
+    e.refill(vpn, asid, pte, level, prefetch, valid)
     e
   }
 

--- a/src/main/scala/xiangshan/cache/mmu/PTW.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PTW.scala
@@ -243,7 +243,7 @@ class PTWImp(outer: PTW)(implicit p: Parameters) extends PtwModule(outer) with H
   for (i <- 0 until PtwWidth) {
     outArb(i).in(outArbCachePort).valid := cache.io.resp.valid && cache.io.resp.bits.hit && cache.io.resp.bits.req_info.source===i.U
     outArb(i).in(outArbCachePort).bits.entry := cache.io.resp.bits.toTlb
-    outArb(i).in(outArbCachePort).bits.pf := false.B
+    outArb(i).in(outArbCachePort).bits.pf := !cache.io.resp.bits.toTlb.v
     outArb(i).in(outArbCachePort).bits.af := false.B
     outArb(i).in(outArbFsmPort).valid := fsm.io.resp.valid && fsm.io.resp.bits.source===i.U
     outArb(i).in(outArbFsmPort).bits := fsm.io.resp.bits.resp

--- a/src/main/scala/xiangshan/cache/mmu/PTW.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PTW.scala
@@ -291,6 +291,7 @@ class PTWImp(outer: PTW)(implicit p: Parameters) extends PtwModule(outer) with H
     ptw_resp.entry.tag := vpn
     ptw_resp.pf := (if (af_first) !af else true.B) && pte_in.isPf(2.U)
     ptw_resp.af := (if (!af_first) pte_in.isPf(2.U) else true.B) && af
+    ptw_resp.entry.v := !ptw_resp.pf
     ptw_resp.entry.prefetch := DontCare
     ptw_resp.entry.asid := satp.asid
     ptw_resp


### PR DESCRIPTION
Corner Case that makes l2tlb's performance decrease sharply:
core may have mis-speculative memory access, which may cause tlb-miss and ptw req to l2tlb.
In l2tlb, the reqs may still miss and even have invalid pte that won't be stored in l2tlb.cache.
If the relative ptes are invalid, these reqs will be held by miss queue and wait for page walker performing
page table walk one by one. It's too slow and will raise time out assert in l2tlb.missqueue.

Solution:
store invalid entries(only super entries) into sp. 
Bad news is that sp only has16 entries, so invaid entries will pollute sp as well.
Good news is that the invalid reqs are always in same super page, so only one entries is mostly enough.