### PR TITLE
assert: fix dcache mp s1_way_en assertion

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -282,7 +282,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents {
       )
     )
   )
-  assert(!RegNext(s1_fire && PopCount(s1_tag_match_way) > 1.U))
+  assert(!RegNext(s1_fire && PopCount(s1_way_en) > 1.U))
   val s1_tag = Mux(
     s1_req.replace,
     get_tag(s1_req.addr),


### PR DESCRIPTION
`s1_tag_match_way` is vaild iff `tag_read.valid` and `meta_read.valid` in s0
for the same req