### PR TITLE
ittage: we should write new target when alloc

### DIFF
--- a/src/main/scala/xiangshan/frontend/ITTAGE.scala
+++ b/src/main/scala/xiangshan/frontend/ITTAGE.scala
@@ -278,7 +278,7 @@ class ITTageTable
   update_wdata.ctr   := Mux(io.update.alloc, 2.U, inc_ctr(old_ctr, io.update.correct))
   update_wdata.tag   := update_tag
   // only when ctr is null
-  update_wdata.target := Mux(ctr_null(old_ctr), update_target, io.update.old_target)
+  update_wdata.target := Mux(io.update.alloc || ctr_null(old_ctr), update_target, io.update.old_target)
   
   val newValidArray = VecInit(validArray.asBools)
   when (io.update.valid) {


### PR DESCRIPTION
Previous logic checked the value of old_ctr to select between old target and
new target when updating ittage table. However, when we need to alloc a new
entry, the value of old_ctr is X because we do not reset ittage table. So we
would definitely write an X to the target field, which is the output of the
mux, as the selector is X.