### PR TITLE
<bug-fix>: fix IFU misOffset bug and optimize code

### DIFF
--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -155,7 +155,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
 
   val f1_ready, f2_ready, f3_ready         = WireInit(false.B)
 
-  fromFtq.req.ready := toICache(0).ready && toICache(1).ready && f2_ready && GTimer() > 500.U
+  fromFtq.req.ready := toICache(0).ready && toICache(1).ready && f1_ready //&& GTimer() > 500.U
 
   toICache(0).valid       := fromFtq.req.valid //&& !f0_flush
   toICache(0).bits.vaddr  := fromFtq.req.bits.startAddr
@@ -186,9 +186,9 @@ class NewIFU(implicit p: Parameters) extends XSModule
   // val f1_situation  = RegEnable(f0_situation,  f0_fire)
   val f1_doubleLine = RegEnable(f0_doubleLine, f0_fire)
   val f1_vSetIdx    = RegEnable(f0_vSetIdx,    f0_fire)
-  val f1_fire       = f1_valid && f1_ready
+  val f1_fire       = f1_valid && f2_ready
 
-  f1_ready := f2_ready || !f1_valid
+  f1_ready := f1_fire || !f1_valid
 
   from_bpu_f1_flush := fromFtq.flushFromBpu.shouldFlushByStage3(f1_ftq_req.ftqIdx) && f1_valid
   // from_bpu_f1_flush := false.B
@@ -220,9 +220,9 @@ class NewIFU(implicit p: Parameters) extends XSModule
   // val f2_situation  = RegEnable(f1_situation,  f1_fire)
   val f2_doubleLine = RegEnable(f1_doubleLine, f1_fire)
   val f2_vSetIdx    = RegEnable(f1_vSetIdx,    f1_fire)
-  val f2_fire       = f2_valid && f2_ready
+  val f2_fire       = f2_valid && f3_ready && icacheRespAllValid
 
-  f2_ready := f3_ready && icacheRespAllValid || !f2_valid
+  f2_ready := f2_fire || !f2_valid
   //TODO: addr compare may be timing critical
   val f2_icache_all_resp_wire       =  fromICache(0).valid && (fromICache(0).bits.vaddr ===  f2_ftq_req.startAddr) && ((fromICache(1).valid && (fromICache(1).bits.vaddr ===  f2_ftq_req.nextlineStart)) || !f2_doubleLine)
   val f2_icache_all_resp_reg        = RegInit(false.B)
@@ -330,7 +330,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f3_doubleLine     = RegEnable(f2_doubleLine, f2_fire)
   val f3_fire           = io.toIbuffer.fire()
 
-  f3_ready := io.toIbuffer.ready || !f3_valid
+  f3_ready := f3_fire || !f3_valid
 
   val f3_cut_data       = RegEnable(f2_cut_data, f2_fire)
 
@@ -435,8 +435,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
                      io.iTLBInter.resp.bits.excp.af.instr
       mmio_state :=  Mux(tlbExept,m_waitCommit,m_sendPMP)
       mmio_resend_addr := io.iTLBInter.resp.bits.paddr
-      mmio_resend_af := mmio_resend_af || io.iTLBInter.resp.bits.excp.af.instr
-      mmio_resend_pf := mmio_resend_pf || io.iTLBInter.resp.bits.excp.pf.instr
+      mmio_resend_af := io.iTLBInter.resp.bits.excp.af.instr
+      mmio_resend_pf := io.iTLBInter.resp.bits.excp.pf.instr
     }
 
     is(m_sendPMP){
@@ -659,7 +659,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   checkFlushWb.bits.ftqIdx            := wb_ftq_req.ftqIdx
   checkFlushWb.bits.ftqOffset         := wb_ftq_req.ftqOffset.bits
   checkFlushWb.bits.misOffset.valid   := ParallelOR(wb_check_result.fixedMissPred) || wb_half_flush
-  checkFlushWb.bits.misOffset.bits    := Mux(wb_half_flush, (PredictWidth - 1).U, ParallelPriorityEncoder(wb_check_result.fixedMissPred))
+  checkFlushWb.bits.misOffset.bits    := Mux(wb_half_flush, wb_lastIdx, ParallelPriorityEncoder(wb_check_result.fixedMissPred))
   checkFlushWb.bits.cfiOffset.valid   := ParallelOR(wb_check_result.fixedTaken)
   checkFlushWb.bits.cfiOffset.bits    := ParallelPriorityEncoder(wb_check_result.fixedTaken)
   checkFlushWb.bits.target            := Mux(wb_half_flush, wb_half_target, wb_check_result.fixedTarget(ParallelPriorityEncoder(wb_check_result.fixedMissPred)))

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -1014,6 +1014,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
     }
 
     XSError(isBefore(bpuPtr, prefetchPtr) && !isFull(bpuPtr, prefetchPtr), "\nprefetchPtr is before bpuPtr!\n")
+    XSError(isBefore(prefetchPtr, ifuPtr) && !isFull(ifuPtr, prefetchPtr), "\nifuPtr is before prefetchPtr!\n")
   }
   else {
     io.toPrefetch.req <> DontCare

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -188,6 +188,8 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray
     tagArray
   }
 
+  io.read.ready := !io.write.valid && tagArrays.map(_.io.r.req.ready).reduce(_&&_)
+
   //Parity Decode
   val read_metas = Wire(Vec(2,Vec(nWays,new ICacheMetadata())))
   for((tagArray,i) <- tagArrays.zipWithIndex){
@@ -291,8 +293,6 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray
     val cacheOp  = Flipped(new L1CacheInnerOpIO) // customized cache op port 
   }}
 
-  io.read.ready := !io.write.valid
-
   val port_0_read_0 = io.read.valid  && !io.read.bits.vSetIdx(0)(0)
   val port_0_read_1 = io.read.valid  &&  io.read.bits.vSetIdx(0)(0)
   val port_1_read_1  = io.read.valid &&  io.read.bits.vSetIdx(1)(0) && io.read.bits.isDoubleLine
@@ -362,6 +362,8 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray
     
     codeArray
   }
+
+  io.read.ready := !io.write.valid && dataArrays.map(_.io.r.req.ready).reduce(_ && _) && codeArrays.map(_.io.r.req.ready).reduce(_ && _)
 
   //Parity Decode
   val read_datas = Wire(Vec(2,Vec(nWays,UInt(blockBits.W) )))

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -234,7 +234,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   //TODO: fix GTimer() condition
   fromIFU.map(_.ready := fetch_req(0).ready && fetch_req(1).ready && !missSwitchBit  &&
                          !tlb_slot.valid && 
-                         s1_ready && GTimer() > 500.U )
+                         s1_ready )//&& GTimer() > 500.U )
   /**
     ******************************************************************************
     * ICache Stage 1

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -108,7 +108,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
 
   fromITLB.ready := true.B
 
-  fromFtq.req.ready :=  (!enableBit || (enableBit && p3_ready)) && GTimer() > 500.U
+  fromFtq.req.ready :=  (!enableBit || (enableBit && p3_ready)) && toIMeta.ready //&& GTimer() > 500.U
 
   /** Prefetch Stage 1: cache probe filter */
   val p1_valid =  generatePipeControl(lastFire = p0_fire, thisFire = p1_fire || p1_discard, thisFlush = false.B, lastFlush = false.B)


### PR DESCRIPTION
* fix mmio_resend_af wrong assignment
* fix wb_half_flush missOffset ( using wb_lastIdx instead of PredictWidth-1 )
* change pipeline ready condition ( this_ready =  this_stage_fire || this_stage_empty )
* delete 500-cycle ready condition ( toICache(*).ready means the SRAM has been reset and ready for read)