### PR TITLE
FoldedSRAMTemplate: hold ridx when holdRead is set

### DIFF
--- a/src/main/scala/utils/SRAMTemplate.scala
+++ b/src/main/scala/utils/SRAMTemplate.scala
@@ -180,7 +180,9 @@ class FoldedSRAMTemplate[T <: Data](gen: T, set: Int, width: Int = 4, way: Int =
   val rdata = array.io.r.resp.data
   for (w <- 0 until way) {
     val wayData = VecInit(rdata.indices.filter(_ % way == w).map(rdata(_)))
-    io.r.resp.data(w) := Mux1H(UIntToOH(ridx, width), wayData)
+    val holdRidx = HoldUnless(ridx, RegNext(io.r.req.valid))
+    val realRidx = if (holdRead) holdRidx else ridx
+    io.r.resp.data(w) := Mux1H(UIntToOH(realRidx, width), wayData)
   }
 
   val wen = io.w.req.valid


### PR DESCRIPTION
Previously we use ridx to select between several data of folded srams. ridx is simply RegNext of req.bits.setIdx. However, when holdRead is set, setIdx may change the next cycle, while ren become low, in which case rdata should remain unchanged.
Now we use HoldUnless logic to keep the value of ridx when no new read is requested.

This may improve the accuracy of tage and ittage predictors.