### PR TITLE
ICache: fix DataArray non-ecc width

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -275,7 +275,11 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray
 
   def getECCFromEncUnit(encUnit: UInt) = {
     require(encUnit.getWidth == encDataUnitBits)
-    encUnit(encDataUnitBits - 1, dataCodeUnit)
+    if (encDataUnitBits == dataCodeUnit) {
+      0.U.asTypeOf(UInt(1.W))
+    } else {
+      encUnit(encDataUnitBits - 1, dataCodeUnit)
+    }
   }
 
   def getECCFromBlock(cacheblock: UInt) = {


### PR DESCRIPTION
set ECC data to hardwired zero when ECC is disabled