### PR TITLE
decode: parallel fusion decoder and rat read

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -21,13 +21,18 @@ import chisel3._
 import chisel3.util._
 import xiangshan._
 import utils._
+import xiangshan.backend.rename.RatReadPort
 
 class DecodeStage(implicit p: Parameters) extends XSModule with HasPerfEvents {
   val io = IO(new Bundle() {
     // from Ibuffer
     val in = Vec(DecodeWidth, Flipped(DecoupledIO(new CtrlFlow)))
-    // to DecBuffer
+    // to Rename
     val out = Vec(DecodeWidth, DecoupledIO(new CfCtrl))
+    val fusionInfo = Vec(DecodeWidth - 1, new FusionDecodeInfo)
+    // RAT read
+    val intRat = Vec(RenameWidth, Vec(3, Flipped(new RatReadPort)))
+    val fpRat = Vec(RenameWidth, Vec(4, Flipped(new RatReadPort)))
     // csr control
     val csrCtrl = Input(new CustomCSRCtrlIO)
   })
@@ -43,6 +48,19 @@ class DecodeStage(implicit p: Parameters) extends XSModule with HasPerfEvents {
     io.out(i).valid      := io.in(i).valid
     io.out(i).bits       := decoders(i).io.deq.cf_ctrl
     io.in(i).ready       := io.out(i).ready
+
+    // We use the lsrc/ldest before fusion decoder to read RAT for better timing.
+    io.intRat(i)(0).addr := decoders(i).io.deq.cf_ctrl.ctrl.lsrc(0)
+    io.intRat(i)(1).addr := decoders(i).io.deq.cf_ctrl.ctrl.lsrc(1)
+    io.intRat(i)(2).addr := decoders(i).io.deq.cf_ctrl.ctrl.ldest
+    io.intRat(i).foreach(_.hold := !io.out(i).ready)
+
+    // Floating-point instructions can not be fused now.
+    io.fpRat(i)(0).addr := decoders(i).io.deq.cf_ctrl.ctrl.lsrc(0)
+    io.fpRat(i)(1).addr := decoders(i).io.deq.cf_ctrl.ctrl.lsrc(1)
+    io.fpRat(i)(2).addr := decoders(i).io.deq.cf_ctrl.ctrl.lsrc(2)
+    io.fpRat(i)(3).addr := decoders(i).io.deq.cf_ctrl.ctrl.ldest
+    io.fpRat(i).foreach(_.hold := !io.out(i).ready)
   }
 
   // instruction fusion
@@ -76,6 +94,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule with HasPerfEvents {
       v := false.B
     }
   }
+  io.fusionInfo := fusionDecoder.io.info
 
   val hasValid = VecInit(io.in.map(_.valid)).asUInt.orR
   XSPerfAccumulate("utilization", PopCount(io.in.map(_.valid)))

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -46,7 +46,7 @@ abstract trait DecodeConstants {
     //   |            |            |            |           |           |  |  |  |  |  |  |  selImm
     List(SrcType.DC, SrcType.DC, SrcType.DC, FuType.alu, ALUOpType.sll, N, N, N, N, N, N, N, SelImm.INVALID_INSTR) // Use SelImm to indicate invalid instr
 
-    val table: Array[(BitPat, List[BitPat])]
+  val table: Array[(BitPat, List[BitPat])]
 }
 
 trait DecodeUnitConstants

--- a/src/main/scala/xiangshan/backend/decode/FusionDecoder.scala
+++ b/src/main/scala/xiangshan/backend/decode/FusionDecoder.scala
@@ -28,35 +28,57 @@ abstract class BaseFusionCase(pair: Seq[Valid[UInt]])(implicit p: Parameters)
   require(pair.length == 2)
 
   protected def instr: Seq[UInt] = pair.map(_.bits)
-  protected def pairValid: Bool = VecInit(pair.map(_.valid)).asUInt().andR()
+  protected def pairValid: Bool = VecInit(pair.map(_.valid)).asUInt.andR
   protected def instr1Rs1: UInt = instr(0)(RS1_MSB, RS1_LSB)
   protected def instr1Rs2: UInt = instr(0)(RS2_MSB, RS2_LSB)
   protected def instr1Rd: UInt = instr(0)(RD_MSB, RD_LSB)
-  protected def instr2Rs1: UInt = instr(1)(RS1_MSB, RS1_LSB)
-  protected def instr2Rs2: UInt = instr(1)(RS2_MSB, RS2_LSB)
+  def instr2Rs1: UInt = instr(1)(RS1_MSB, RS1_LSB)
+  def instr2Rs2: UInt = instr(1)(RS2_MSB, RS2_LSB)
   protected def instr2Rd: UInt = instr(1)(RD_MSB, RD_LSB)
   protected def withSameDest: Bool = instr1Rd === instr2Rd
-  protected def destToRs1: Bool = instr1Rd === instr2Rs1
+  def destToRs1: Bool = instr1Rd === instr2Rs1
   protected def destToRs2: Bool = instr1Rd === instr2Rs2
 
-  protected def getBaseCS(pat: BitPat): CtrlSignals = {
+  protected def getInstrTable(pat: BitPat): List[BitPat] = {
+    // Only these instructions can be fused now
     val allDecodeTable = XDecode.table ++ X64Decode.table ++ BDecode.table
-    val baseTable = allDecodeTable.filter(_._1 == pat).map(_._2).head
-    val cs = Wire(new CtrlSignals)
-    cs := DontCare
-    cs.decode(baseTable)
-    // For simple instruction fusions, we assume their destination registers are the same.
-    cs.ldest := instr1Rd
-    cs
+    allDecodeTable.filter(_._1 == pat).map(_._2).head
   }
+  // Must sync these indices with MicroOp.decode
+  protected def getInstrFuType(pat: BitPat): BitPat = getInstrTable(pat)(3)
+  protected def getInstrFuOpType(pat: BitPat): BitPat = getInstrTable(pat)(4)
+  protected def getInstrSrc1Type(pat: BitPat): BitPat = getInstrTable(pat)(0)
+  protected def getInstrSrc2Type(pat: BitPat): BitPat = getInstrTable(pat)(1)
 
   def isValid: Bool
-  // TODO: optimize timing
-  def target: CtrlSignals
-  // clear the next instruction
-  // def needClear: Boolean = true
+  // To optimize the timing, only these control signals can be affected by instruction fusion.
+  def thisInstr: Option[BitPat] = None
+  def fusedInstr: Option[BitPat] = None
+  // By default, None means unchanged.
+  private def compareAndGet(func: BitPat => BitPat): Option[Int] = {
+    if (fusedInstr.isDefined) {
+      require(thisInstr.isDefined, "thisInstr must be defined to infer the ctrl signals")
+      val fused = func(fusedInstr.get)
+      // Only when the two instructions have different control field, we make it not None.
+      if (fused != func(thisInstr.get)) Some(fused.value.toInt) else None
+    } else None
+  }
+  // We assume only fuType, fuOpType, lsrc2 may be changed now.
+  def fuType: Option[Int] = compareAndGet(getInstrFuType)
+  def fuOpType: Option[UInt => UInt] = {
+    val t = compareAndGet(getInstrFuOpType)
+    if (t.isDefined) Some((_: UInt) => t.get.U) else None
+  }
+  def src2Type: Option[Int] = compareAndGet(getInstrSrc2Type)
+  def lsrc2NeedZero: Boolean = false
+  def lsrc2NeedMux: Boolean = false
+
   def fusionName: String
 }
+
+// There are 2 types of instruction fusion.
+// (1) fused into a fixed new instruction with new control signals.
+// (2) the first instruction's op is replaced with another one.
 
 // Case: clear upper 32 bits / get lower 32 bits
 // Source: `slli r1, r0, 32` + `srli r1, r1, 32`
@@ -66,12 +88,9 @@ class FusedAdduw(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFus
   def inst2Cond = instr(1) === Instructions.SRLI && instr(1)(25, 20) === 32.U
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && destToRs1
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.ADD_UW)
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := 0.U
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SLLI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.ADD_UW)
+  override def lsrc2NeedZero: Boolean = true
 
   def fusionName: String = "slli32_srli32"
 }
@@ -84,12 +103,9 @@ class FusedZexth(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFus
   def inst2Cond = instr(1) === Instructions.SRLI && instr(1)(25, 20) === 48.U
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && destToRs1
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.PACKW)
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := 0.U
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SLLI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.PACKW)
+  override def lsrc2NeedZero: Boolean = true
 
   def fusionName: String = "slli48_srli48"
 }
@@ -100,6 +116,8 @@ class FusedZexth(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFus
 class FusedZexth1(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends FusedZexth(pair) {
   override def inst1Cond: Bool = instr(0) === Instructions.SLLIW && instr(0)(24, 20) === 16.U
   override def inst2Cond: Bool = instr(1) === Instructions.SRLIW && instr(1)(24, 20) === 16.U
+
+  override def thisInstr: Option[BitPat] = Some(Instructions.SLLIW)
 
   override def fusionName: String = "slliw16_srliw16"
 }
@@ -112,11 +130,9 @@ class FusedSexth(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFus
   def inst2Cond = instr(1) === Instructions.SRAIW && instr(1)(24, 20) === 16.U
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && destToRs1
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SEXT_H)
-    cs.lsrc(0) := instr1Rs1
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SLLIW)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.SEXT_H)
+  override def lsrc2NeedZero: Boolean = true
 
   def fusionName: String = "slliw16_sraiw16"
 }
@@ -129,12 +145,9 @@ class FusedSh1add(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFu
   def inst2Cond = instr(1) === Instructions.ADD
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SH1ADD)
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SLLI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.SH1ADD)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "slli1_add"
 }
@@ -147,12 +160,9 @@ class FusedSh2add(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFu
   def inst2Cond = instr(1) === Instructions.ADD
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SH2ADD)
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SLLI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.SH2ADD)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "slli2_add"
 }
@@ -165,69 +175,48 @@ class FusedSh3add(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFu
   def inst2Cond = instr(1) === Instructions.ADD
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SH3ADD)
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SLLI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.SH3ADD)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "slli3_add"
 }
 
 // Case: shift zero-extended word left by one
-// Source: `slli r1, r0, 32` + `srli r1, r0, 31`
+// Source: `slli r1, r0, 32` + `srli r1, r1, 31`
 // Target: `szewl1 r1, r0` (customized internal opcode)
 class FusedSzewl1(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFusionCase(pair) {
   def inst1Cond = instr(0) === Instructions.SLLI && instr(0)(25, 20) === 32.U
   def inst2Cond = instr(1) === Instructions.SRLI && instr(1)(25, 20) === 31.U
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && destToRs1
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SEXT_H)
-    // replace the fuOpType with szewl1
-    cs.fuOpType := ALUOpType.szewl1
-    cs.lsrc(0) := instr1Rs1
-    cs
-  }
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.szewl1)
 
   def fusionName: String = "slli32_srli31"
 }
 
 // Case: shift zero-extended word left by two
-// Source: `slli r1, r0, 32` + `srli r1, r0, 30`
+// Source: `slli r1, r0, 32` + `srli r1, r1, 30`
 // Target: `szewl2 r1, r0` (customized internal opcode)
 class FusedSzewl2(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFusionCase(pair) {
   def inst1Cond = instr(0) === Instructions.SLLI && instr(0)(25, 20) === 32.U
   def inst2Cond = instr(1) === Instructions.SRLI && instr(1)(25, 20) === 30.U
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && destToRs1
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SEXT_H)
-    // replace the fuOpType with szewl2
-    cs.fuOpType := ALUOpType.szewl2
-    cs.lsrc(0) := instr1Rs1
-    cs
-  }
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.szewl2)
 
   def fusionName: String = "slli32_srli30"
 }
 
 // Case: shift zero-extended word left by three
-// Source: `slli r1, r0, 32` + `srli r1, r0, 29`
+// Source: `slli r1, r0, 32` + `srli r1, r1, 29`
 // Target: `szewl3 r1, r0` (customized internal opcode)
 class FusedSzewl3(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFusionCase(pair) {
   def inst1Cond = instr(0) === Instructions.SLLI && instr(0)(25, 20) === 32.U
   def inst2Cond = instr(1) === Instructions.SRLI && instr(1)(25, 20) === 29.U
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && destToRs1
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SEXT_H)
-    // replace the fuOpType with szewl3
-    cs.fuOpType := ALUOpType.szewl3
-    cs.lsrc(0) := instr1Rs1
-    cs
-  }
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.szewl3)
 
   def fusionName: String = "slli32_srli29"
 }
@@ -240,13 +229,7 @@ class FusedByte2(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFus
   def inst2Cond = instr(1) === Instructions.ANDI && instr(1)(31, 20) === 255.U
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && destToRs1
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SEXT_H)
-    // replace the fuOpType with byte2
-    cs.fuOpType := ALUOpType.byte2
-    cs.lsrc(0) := instr1Rs1
-    cs
-  }
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.byte2)
 
   def fusionName: String = "srli8_andi255"
 }
@@ -259,14 +242,10 @@ class FusedSh4add(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFu
   def inst2Cond = instr(1) === Instructions.ADD
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SH3ADD)
-    // replace the fuOpType with sh4add
-    cs.fuOpType := ALUOpType.sh4add
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SLLI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.ADD)
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.sh4add)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "slli4_add"
 }
@@ -279,14 +258,10 @@ class FusedSr29add(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseF
   def inst2Cond = instr(1) === Instructions.ADD
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SH3ADD)
-    // replace the fuOpType with sr29add
-    cs.fuOpType := ALUOpType.sr29add
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SRLI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.ADD)
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.sr29add)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "srli29_add"
 }
@@ -299,14 +274,10 @@ class FusedSr30add(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseF
   def inst2Cond = instr(1) === Instructions.ADD
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SH3ADD)
-    // replace the fuOpType with sr30add
-    cs.fuOpType := ALUOpType.sr30add
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SRLI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.ADD)
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.sr30add)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "srli30_add"
 }
@@ -319,14 +290,10 @@ class FusedSr31add(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseF
   def inst2Cond = instr(1) === Instructions.ADD
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SH3ADD)
-    // replace the fuOpType with sr31add
-    cs.fuOpType := ALUOpType.sr31add
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SRLI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.ADD)
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.sr31add)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "srli31_add"
 }
@@ -339,14 +306,10 @@ class FusedSr32add(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseF
   def inst2Cond = instr(1) === Instructions.ADD
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SH3ADD)
-    // replace the fuOpType with sr32add
-    cs.fuOpType := ALUOpType.sr32add
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.SRLI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.ADD)
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.sr32add)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "srli32_add"
 }
@@ -359,14 +322,10 @@ class FusedOddadd(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFu
   def inst2Cond = instr(1) === Instructions.ADD
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SH3ADD)
-    // replace the fuOpType with oddadd
-    cs.fuOpType := ALUOpType.oddadd
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.ANDI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.ADD)
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.oddadd)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "andi1_add"
 }
@@ -379,20 +338,16 @@ class FusedOddaddw(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseF
   def inst2Cond = instr(1) === Instructions.ADDW
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.SH3ADD)
-    // replace the fuOpType with oddaddw
-    cs.fuOpType := ALUOpType.oddaddw
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.ANDI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.ADD)
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.oddaddw)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "andi1_addw"
 }
 
 // Case: addw and extract its lower 8 bits (fused into addwbyte)
-class FusedAddwbyte(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(implicit p: Parameters)
+class FusedAddwbyte(pair: Seq[Valid[UInt]])(implicit p: Parameters)
   extends BaseFusionCase(pair) {
   // the first instruction is a ALUOpType.addw
   // According to DecodeUnit.scala, only ADDIW and ADDW are ALUOpType.addw, which are used for inst1Cond.
@@ -400,67 +355,48 @@ class FusedAddwbyte(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(im
   def inst2Cond = instr(1) === Instructions.ANDI && instr(1)(31, 20) === 0xff.U
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && destToRs1
-  def target: CtrlSignals = {
-    val cs = WireInit(csPair.get(0))
-    // replace the fuOpType with addwbyte
-    cs.fuOpType := ALUOpType.addwbyte
-    cs
-  }
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.addwbyte)
 
   def fusionName: String = "addw_andi255"
 }
 
 // Case: addw and extract its lower 1 bit (fused into addwbit)
-class FusedAddwbit(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(implicit p: Parameters)
-  extends FusedAddwbyte(pair, csPair) {
+class FusedAddwbit(pair: Seq[Valid[UInt]])(implicit p: Parameters)
+  extends FusedAddwbyte(pair) {
 
   override def inst2Cond = instr(1) === Instructions.ANDI && instr(1)(31, 20) === 0x1.U
-  override def target: CtrlSignals = {
-    val cs = WireInit(csPair.get(0))
-    // replace the fuOpType with addwbit
-    cs.fuOpType := ALUOpType.addwbit
-    cs
-  }
+
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.addwbit)
 
   override def fusionName: String = "addw_andi1"
 }
 
 // Case: addw and zext.h (fused into addwzexth)
-class FusedAddwzexth(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(implicit p: Parameters)
-  extends FusedAddwbyte(pair, csPair) {
+class FusedAddwzexth(pair: Seq[Valid[UInt]])(implicit p: Parameters)
+  extends FusedAddwbyte(pair) {
 
   override def inst2Cond = instr(1) === Instructions.ZEXT_H
-  override def target: CtrlSignals = {
-    val cs = WireInit(csPair.get(0))
-    // replace the fuOpType with addwzexth
-    cs.fuOpType := ALUOpType.addwzexth
-    cs
-  }
+
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.addwzexth)
 
   override def fusionName: String = "addw_zexth"
 }
 
 // Case: addw and sext.h (fused into addwsexth)
-class FusedAddwsexth(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(implicit p: Parameters)
-  extends FusedAddwbyte(pair, csPair) {
+class FusedAddwsexth(pair: Seq[Valid[UInt]])(implicit p: Parameters)
+  extends FusedAddwbyte(pair) {
 
   override def inst2Cond = instr(1) === Instructions.SEXT_H
-  override def target: CtrlSignals = {
-    val cs = WireInit(csPair.get(0))
-    // replace the fuOpType with addwsexth
-    cs.fuOpType := ALUOpType.addwsexth
-    cs
-  }
+
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.addwsexth)
 
   override def fusionName: String = "addw_sexth"
 }
 
 // Case: logic operation and extract its LSB
 
-class FusedLogiclsb(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(implicit p: Parameters)
+class FusedLogiclsb(pair: Seq[Valid[UInt]])(implicit p: Parameters)
   extends BaseFusionCase(pair) {
-  require(csPair.isDefined)
-
   // the first instruction is a logic (and, or, xor, orcb)
   // (1) def ANDI               = BitPat("b?????????????????111?????0010011")
   // (2) def AND                = BitPat("b0000000??????????111?????0110011")
@@ -475,26 +411,16 @@ class FusedLogiclsb(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(im
   def inst2Cond = instr(1) === Instructions.ANDI && instr(1)(31, 20) === 1.U
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && destToRs1
-  def target: CtrlSignals = {
-    val cs = WireInit(csPair.get(0))
-    // change the opType to lsb format
-    cs.fuOpType := ALUOpType.logicToLsb(csPair.get(0).fuOpType)
-    cs
-  }
+  override def fuOpType: Option[UInt => UInt] = Some(ALUOpType.logicToLsb)
 
   def fusionName: String = "logic_andi1"
 }
 
-class FusedLogicZexth(pair: Seq[Valid[UInt]], csPair: Option[Seq[CtrlSignals]])(implicit p: Parameters)
-  extends FusedLogiclsb(pair, csPair) {
+class FusedLogicZexth(pair: Seq[Valid[UInt]])(implicit p: Parameters)
+  extends FusedLogiclsb(pair) {
 
   override def inst2Cond = instr(1) === Instructions.ZEXT_H
-  override def target: CtrlSignals = {
-    val cs = WireInit(csPair.get(0))
-    // change the opType to lzext format
-    cs.fuOpType := ALUOpType.logicToZexth(csPair.get(0).fuOpType)
-    cs
-  }
+  override def fuOpType: Option[UInt => UInt] = Some(ALUOpType.logicToZexth)
 
   override def fusionName: String = "logic_zexth"
 }
@@ -506,14 +432,10 @@ class FusedOrh48(pair: Seq[Valid[UInt]])(implicit p: Parameters) extends BaseFus
   def inst2Cond = instr(1) === Instructions.OR
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    val cs = getBaseCS(Instructions.OR)
-    // replace the fuOpType with orh48
-    cs.fuOpType := ALUOpType.orh48
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.ANDI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.OR)
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => ALUOpType.orh48)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "andi_f00_or"
 }
@@ -527,17 +449,18 @@ class FusedMulw7(pair: Seq[Valid[UInt]])(implicit p: Parameters)
   def inst2Cond = instr(1) === Instructions.MULW
 
   def isValid: Bool = inst1Cond && inst2Cond && withSameDest && (destToRs1 || destToRs2)
-  def target: CtrlSignals = {
-    // use MULW as the base
-    val cs = getBaseCS(Instructions.MULW)
-    // replace the fuOpType with mulw7
-    cs.fuOpType := MDUOpType.mulw7
-    cs.lsrc(0) := instr1Rs1
-    cs.lsrc(1) := Mux(destToRs1, instr2Rs2, instr2Rs1)
-    cs
-  }
+  override def thisInstr: Option[BitPat] = Some(Instructions.ANDI)
+  override def fusedInstr: Option[BitPat] = Some(Instructions.MULW)
+  override def fuOpType: Option[UInt => UInt] = Some((_: UInt) => MDUOpType.mulw7)
+  override def lsrc2NeedMux: Boolean = true
 
   def fusionName: String = "andi127_mulw"
+}
+
+class FusionDecodeInfo extends Bundle {
+  val rs2FromRs1 = Output(Bool())
+  val rs2FromRs2 = Output(Bool())
+  val rs2FromZero = Output(Bool())
 }
 
 class FusionDecoder(implicit p: Parameters) extends XSModule {
@@ -547,6 +470,7 @@ class FusionDecoder(implicit p: Parameters) extends XSModule {
     val dec = Vec(DecodeWidth, Input(new CtrlSignals()))
     // whether an instruction fusion is found
     val out = Vec(DecodeWidth - 1, DecoupledIO(new CtrlSignals))
+    val info = Vec(DecodeWidth - 1, new FusionDecodeInfo)
     // fused instruction needs to be cleared
     val clear = Vec(DecodeWidth, Output(Bool()))
   })
@@ -577,25 +501,64 @@ class FusionDecoder(implicit p: Parameters) extends XSModule {
       new FusedOddaddw(pair),
       new FusedOrh48(pair),
       new FusedMulw7(pair),
-      new FusedAddwbyte(pair, Some(cs)),
-      new FusedAddwbit(pair, Some(cs)),
-      new FusedAddwzexth(pair, Some(cs)),
-      new FusedAddwsexth(pair, Some(cs)),
-      new FusedLogiclsb(pair, Some(cs)),
-      new FusedLogicZexth(pair, Some(cs))
+      new FusedAddwbyte(pair),
+      new FusedAddwbit(pair),
+      new FusedAddwzexth(pair),
+      new FusedAddwsexth(pair),
+      new FusedLogiclsb(pair),
+      new FusedLogicZexth(pair)
     )
-    val pairValid = VecInit(pair.map(_.valid)).asUInt().andR
+    val pairValid = VecInit(pair.map(_.valid)).asUInt.andR
     val thisCleared = io.clear(i)
     val fusionVec = VecInit(fusionList.map(_.isValid))
-    out.valid := pairValid && !thisCleared && fusionVec.asUInt().orR()
+    out.valid := pairValid && !thisCleared && fusionVec.asUInt.orR
     XSError(PopCount(fusionVec) > 1.U, "more then one fusion matched\n")
-    out.bits := Mux1H(fusionVec, fusionList.map(_.target))
+    out.bits := cs.head
+    def connectByInt(field: CtrlSignals => UInt, replace: Seq[Option[Int]]): Unit = {
+      val replaceVec = fusionVec.zip(replace).filter(_._2.isDefined)
+      if (replaceVec.nonEmpty) {
+        // constant values are grouped together for better timing.
+        val replTypes = replaceVec.map(_._2.get).distinct
+        val replEnable= replTypes.map(t => VecInit(replaceVec.filter(_._2.get == t).map(_._1)).asUInt.orR)
+        when (VecInit(replaceVec.map(_._1)).asUInt.orR) {
+          field(out.bits) := Mux1H(replEnable, replTypes.map(_.U))
+        }
+      }
+    }
+    def connectByUIntFunc(field: CtrlSignals => UInt, replace: Seq[Option[UInt => UInt]]): Unit = {
+      val replaceVec = fusionVec.zip(replace).filter(_._2.isDefined).map(x => (x._1, x._2.get(field(cs.head))))
+      if (replaceVec.nonEmpty) {
+        // constant values are grouped together for better timing.
+        val constReplVec = replaceVec.filter(_._2.isLit).map(x => (x._1, x._2.litValue))
+        val constReplTypes = constReplVec.map(_._2).distinct
+        val constReplEnable = constReplTypes.map(t => VecInit(constReplVec.filter(_._2 == t).map(_._1)).asUInt.orR)
+        val constReplResult = Mux1H(constReplEnable, constReplTypes.map(_.U))
+        // non-constant values have to be processed naively.
+        val noLitRepl = replaceVec.filterNot(_._2.isLit)
+        when (VecInit(replaceVec.map(_._1)).asUInt.orR) {
+          field(out.bits) := Mux(VecInit(noLitRepl.map(_._1)).asUInt.orR, Mux1H(noLitRepl), constReplResult)
+        }
+      }
+    }
+    connectByInt((x: CtrlSignals) => x.fuType, fusionList.map(_.fuType))
+    connectByUIntFunc((x: CtrlSignals) => x.fuOpType, fusionList.map(_.fuOpType))
+    connectByInt((x: CtrlSignals) => x.srcType(1), fusionList.map(_.src2Type))
+    val src2WithZero = VecInit(fusionVec.zip(fusionList.map(_.lsrc2NeedZero)).filter(_._2).map(_._1)).asUInt.orR
+    val src2WithMux = VecInit(fusionVec.zip(fusionList.map(_.lsrc2NeedMux)).filter(_._2).map(_._1)).asUInt.orR
+    io.info(i).rs2FromZero := src2WithZero
+    io.info(i).rs2FromRs1 := src2WithMux && !fusionList.head.destToRs1
+    io.info(i).rs2FromRs2 := src2WithMux && fusionList.head.destToRs1
+    when (src2WithMux) {
+      out.bits.lsrc(1) := Mux(fusionList.head.destToRs1, fusionList.head.instr2Rs2, fusionList.head.instr2Rs1)
+    }.elsewhen (src2WithZero) {
+      out.bits.lsrc(1) := 0.U
+    }
     // TODO: assume every instruction fusion clears the second instruction now
     io.clear(i + 1) := out.valid
     fusionList.zip(fusionVec).foreach { case (f, v) =>
       XSPerfAccumulate(s"case_${f.fusionName}_$i", pairValid && !thisCleared && v && out.ready)
     }
-    XSPerfAccumulate(s"conflict_fusion_$i", pairValid && thisCleared && fusionVec.asUInt().orR() && out.ready)
+    XSPerfAccumulate(s"conflict_fusion_$i", pairValid && thisCleared && fusionVec.asUInt.orR && out.ready)
   }
 
   XSPerfAccumulate("fused_instr", PopCount(io.out.map(_.fire)))

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -21,7 +21,7 @@ import chisel3._
 import chisel3.util._
 import xiangshan._
 import utils._
-import xiangshan.backend.decode.{Imm_I, Imm_LUI_LOAD, Imm_U}
+import xiangshan.backend.decode.{FusionDecodeInfo, Imm_I, Imm_LUI_LOAD, Imm_U}
 import xiangshan.backend.rob.RobPtr
 import xiangshan.backend.rename.freelist._
 import xiangshan.mem.mdp._
@@ -32,6 +32,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasPerfEvents {
     val robCommits = Flipped(new RobCommitIO)
     // from decode
     val in = Vec(RenameWidth, Flipped(DecoupledIO(new CfCtrl)))
+    val fusionInfo = Vec(DecodeWidth - 1, Flipped(new FusionDecodeInfo))
     // ssit read result
     val ssit = Flipped(Vec(RenameWidth, Output(new SSITEntry)))
     // waittable read result
@@ -104,7 +105,6 @@ class Rename(implicit p: Parameters) extends XSModule with HasPerfEvents {
   val hasValid = Cat(io.in.map(_.valid)).orR
 
   val isMove = io.in.map(_.bits.ctrl.isMove)
-  val intPsrc = Wire(Vec(RenameWidth, UInt()))
 
   val intSpecWen = Wire(Vec(RenameWidth, Bool()))
   val fpSpecWen = Wire(Vec(RenameWidth, Bool()))
@@ -135,15 +135,18 @@ class Rename(implicit p: Parameters) extends XSModule with HasPerfEvents {
 
     uops(i).robIdx := robIdxHead + PopCount(io.in.take(i).map(_.valid))
 
-    val intPhySrcVec = io.intReadPorts(i).take(2)
-    val intOldPdest = io.intReadPorts(i).last
-    intPsrc(i) := intPhySrcVec(0)
-    val fpPhySrcVec = io.fpReadPorts(i).take(3)
-    val fpOldPdest = io.fpReadPorts(i).last
-    uops(i).psrc(0) := Mux(uops(i).ctrl.srcType(0) === SrcType.reg, intPhySrcVec(0), fpPhySrcVec(0))
-    uops(i).psrc(1) := Mux(uops(i).ctrl.srcType(1) === SrcType.reg, intPhySrcVec(1), fpPhySrcVec(1))
-    uops(i).psrc(2) := fpPhySrcVec(2)
-    uops(i).old_pdest := Mux(uops(i).ctrl.rfWen, intOldPdest, fpOldPdest)
+    uops(i).psrc(0) := Mux(uops(i).ctrl.srcType(0) === SrcType.reg, io.intReadPorts(i)(0), io.fpReadPorts(i)(0))
+    uops(i).psrc(1) := Mux(uops(i).ctrl.srcType(1) === SrcType.reg, io.intReadPorts(i)(1), io.fpReadPorts(i)(1))
+    // int psrc2 should be bypassed from next instruction if it is fused
+    if (i < RenameWidth - 1) {
+      when (io.fusionInfo(i).rs2FromRs2 || io.fusionInfo(i).rs2FromRs1) {
+        uops(i).psrc(1) := Mux(io.fusionInfo(i).rs2FromRs2, io.intReadPorts(i + 1)(1), io.intReadPorts(i + 1)(0))
+      }.elsewhen(io.fusionInfo(i).rs2FromZero) {
+        uops(i).psrc(1) := 0.U
+      }
+    }
+    uops(i).psrc(2) := io.fpReadPorts(i)(2)
+    uops(i).old_pdest := Mux(uops(i).ctrl.rfWen, io.intReadPorts(i).last, io.fpReadPorts(i).last)
     uops(i).eliminatedMove := isMove(i)
 
     // update pdest


### PR DESCRIPTION
This commit optimizes the timing of instruction fusion decoder.

Previously we update all control signals after the fusion decoder,
including the lsrc/ldest sent to rename table. However, RAT has a
critical timing.

Thus, in this commit, we break this critical path into (1) raw
lsrc/ldest gen; (2) read RAT; (3) update RAT read data according to
fusionInfo from the fusion decoder. Now the RAT read works parallelly
with the fusion decoder.