### PR TITLE
core: add buffers for function units across int/fp

### DIFF
--- a/src/main/scala/utils/PipelineConnect.scala
+++ b/src/main/scala/utils/PipelineConnect.scala
@@ -19,39 +19,159 @@ package utils
 import chisel3._
 import chisel3.util._
 
-object PipelineConnect {
+class PipelineConnectPipe[T <: Data](gen: T) extends Module {
+  val io = IO(new Bundle() {
+    val in = Flipped(DecoupledIO(gen.cloneType))
+    val out = DecoupledIO(gen.cloneType)
+    val rightOutFire = Input(Bool())
+    val isFlush = Input(Bool())
+  })
 
-  class PipelineConnectModule[T <: Data](gen: T) extends Module {
-    val io = IO(new Bundle() {
-      val in = Flipped(DecoupledIO(gen.cloneType))
-      val out = DecoupledIO(gen.cloneType)
-      val rightOutFire = Input(Bool())
-      val isFlush = Input(Bool())
-      val block = Input(Bool())
-    })
+  val valid = RegInit(false.B)
+  val leftFire = io.in.valid && io.out.ready
+  when (io.rightOutFire) { valid := false.B }
+  when (leftFire) { valid := true.B }
+  when (io.isFlush) { valid := false.B }
 
-    val valid = RegInit(false.B)
-    valid.suggestName("pipeline_valid")
-    val leftFire = io.in.valid && io.out.ready && !io.block
-    when (io.rightOutFire) { valid := false.B }
-    when (leftFire) { valid := true.B }
-    when (io.isFlush) { valid := false.B }
+  io.in.ready := io.out.ready
+  io.out.bits := RegEnable(io.in.bits, leftFire)
+  io.out.valid := valid
+}
 
-    io.in.ready := io.out.ready && !io.block
-    io.out.bits := RegEnable(io.in.bits, leftFire)
-    io.out.valid := valid //&& !isFlush
+class PipelineConnectBuffer[T <: Data, FlushT <: Data](gen: T, flushGen: FlushT, flushFunc: (T, FlushT) => Bool)
+  extends Module {
+  val io = IO(new Bundle() {
+    val in = Flipped(DecoupledIO(gen.cloneType))
+    val out = DecoupledIO(gen.cloneType)
+    val flush = Input(flushGen.cloneType)
+  })
+
+  val valid = RegInit(VecInit.fill(2)(false.B))
+  val data = Reg(Vec(2, gen.cloneType))
+  val older = RegInit(false.B)
+
+  // out
+  io.out.valid := valid.asUInt.orR
+  io.out.bits := data(older)
+  when (io.out.fire) {
+    valid(older) := false.B
+    older := !older
   }
 
-  def apply[T <: Data]
-  (left: DecoupledIO[T], right: DecoupledIO[T], rightOutFire: Bool, isFlush: Bool, block: Bool = false.B,
-   moduleName: Option[String] = None
-  ){
-    val pipelineConnect = Module(new PipelineConnectModule[T](left.bits.cloneType))
-    if(moduleName.nonEmpty) pipelineConnect.suggestName(moduleName.get)
-    pipelineConnect.io.in <> left
-    pipelineConnect.io.block := block
-    pipelineConnect.io.rightOutFire := rightOutFire
-    pipelineConnect.io.isFlush := isFlush
-    right <> pipelineConnect.io.out
+  // in
+  io.in.ready := !valid.asUInt.andR
+  val updateVec = WireInit(VecInit.fill(2)(false.B))
+  when (io.in.valid && !flushFunc(io.in.bits, io.flush)) {
+    // how to choose: this_empty && (this_older || other_older && other_not_empty)
+    when (!valid(0) && (!older || older && valid(1))) {
+      valid(0) := true.B
+      data(0) := io.in.bits
+      updateVec(0) := true.B
+    }.elsewhen (!valid(1) && (older || !older && valid(0))) {
+      valid(1) := true.B
+      data(1) := io.in.bits
+      updateVec(1) := true.B
+    }
+  }
+
+  // flush
+  val flushVec = data.zip(valid).map{ case (d, v) => flushFunc(d, io.flush) && v }
+  flushVec.zip(valid).foreach{ case (f, v) =>
+    when (f) {
+      v := false.B
+    }
+  }
+}
+
+class PipelineConnectBufferWithExtraData[T <: Data, FlushT <: Data, ExtraT <: Data](
+  gen: T, flushGen: FlushT, flushFunc: (T, FlushT) => Bool, extraGen: ExtraT, extraLatency: Int
+) extends PipelineConnectBuffer(gen, flushGen, flushFunc) {
+  require(extraLatency > 0, "why not use PipelineConnectBuffer?")
+  require(extraLatency == 1, "only 1 is supported now")
+
+  val extra = IO(new Bundle {
+    val in = Input(extraGen.cloneType)
+    val out = Output(extraGen.cloneType)
+  })
+
+  val extraData = Reg(Vec(2, extraGen.cloneType))
+  for (i <- 0 until 2) {
+    when (RegNext(updateVec(i) && !flushVec(i))) {
+      extraData(i) := extra.in
+    }
+  }
+
+  // after out.fire, we assert(!older === RegNext(older))
+  extra.out := extraData(!older)
+}
+
+object PipelineConnect {
+  def apply[T <: Data](
+    left: DecoupledIO[T],
+    right: DecoupledIO[T],
+    rightOutFire: Bool,
+    isFlush: Bool,
+    block: Bool = false.B,
+    moduleName: Option[String] = None
+  ): Unit = {
+    val pipeline = Module(new PipelineConnectPipe(left.bits))
+    if(moduleName.nonEmpty) pipeline.suggestName(moduleName.get)
+    pipeline.io.in <> left
+    pipeline.io.rightOutFire := rightOutFire
+    pipeline.io.isFlush := isFlush
+    pipeline.io.out <> right
+    pipeline.io.out.ready := right.ready && !block
+  }
+
+  def apply[T <: Data, FlushT <: Data](
+    left: DecoupledIO[T],
+    right: DecoupledIO[T],
+    flushFunc: (T, FlushT) => Bool,
+    flush: FlushT,
+    moduleName: Option[String]
+  ): Unit = {
+    val pipe_buffer = Module(new PipelineConnectBuffer(left.bits, flush, flushFunc))
+    if(moduleName.nonEmpty) pipe_buffer.suggestName(moduleName.get)
+    pipe_buffer.io.in <> left
+    pipe_buffer.io.out <> right
+    pipe_buffer.io.flush := flush
+  }
+
+
+  def apply[T <: Data, FlushT <: Data, ExtraT <: Data](
+    left: DecoupledIO[T],
+    right: DecoupledIO[T],
+    flushFunc: (T, FlushT) => Bool,
+    flush: FlushT,
+    extraGen: ExtraT,
+    extraLatency: Int
+  ): PipelineConnectBufferWithExtraData[T, FlushT, ExtraT] = {
+    val pipe_buffer = Module(new PipelineConnectBufferWithExtraData(left.bits, flush, flushFunc, extraGen, extraLatency))
+    pipe_buffer.io.in <> left
+    pipe_buffer.io.out <> right
+    pipe_buffer.io.flush := flush
+    pipe_buffer
+  }
+}
+
+object PipelineNext {
+  def apply[T <: Data](
+    left: DecoupledIO[T],
+    rightOutFire: Bool,
+    isFlush: Bool
+  ): DecoupledIO[T] = {
+    val right = Wire(Decoupled(left.bits.cloneType))
+    PipelineConnect(left, right, rightOutFire, isFlush, moduleName = Some("pipeline"))
+    right
+  }
+
+  def apply[T <: Data, FlushT <: Data](
+    left: DecoupledIO[T],
+    flushFunc: (T, FlushT) => Bool,
+    flush: FlushT
+  ): DecoupledIO[T] = {
+    val right = Wire(Decoupled(left.bits.cloneType))
+    PipelineConnect(left, right, flushFunc, flush, Some("buffer"))
+    right
   }
 }

--- a/src/main/scala/xiangshan/backend/exu/Exu.scala
+++ b/src/main/scala/xiangshan/backend/exu/Exu.scala
@@ -99,8 +99,12 @@ case class ExuConfig
   val hasExclusiveWbPort = (wbIntPriority == 0 && writeIntRf) || (wbFpPriority == 0 && writeFpRf)
   val needLoadBalance = hasUncertainlatency
 
+  def needWbPipeline(isFp: Boolean): Boolean = {
+    (isFp && readIntRf && writeFpRf) || (!isFp && readFpRf && writeIntRf)
+  }
+
   def canAccept(fuType: UInt): Bool = {
-    Cat(fuConfigs.map(_.fuType === fuType)).orR()
+    Cat(fuConfigs.map(_.fuType === fuType)).orR
   }
 }
 


### PR DESCRIPTION
This commit adds a buffer after the function unit that operate across
the integer block and the floating-point block, such as f2i and i2f.

For example, previously the out.ready of f2i depends on whether
mul/div/csr/jump has a valid instruction out, since f2i has lower
priority than them. This ready back-propagates from the integer function
units to the floating-point function units, and finally to the
floating-point reservation stations (since f2i is fully pipelined).

We add a buffer after the function unit to break this ready
back-propagation. It incurs one more cycle of execution latency, but we
leave it not-fully-optimized for now.

Timing can be further optimized if we separates the int writeback and fp
writeback in function units. In the current version, the ready of f2i
affects the ready of f2f pipelines, which is unnecessary. This is the
future work.