### PR TITLE
dcache: do not access plru when refill

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -637,8 +637,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   }
 
   val replAccessReqs = ldu.map(_.io.replace_access) ++ Seq(
-    mainPipe.io.replace_access,
-    refillPipe.io.replace_access
+    mainPipe.io.replace_access
   )
   val touchWays = Seq.fill(replAccessReqs.size)(Wire(ValidIO(UInt(log2Up(nWays).W))))
   touchWays.zip(replAccessReqs).foreach {

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/RefillPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/RefillPipe.scala
@@ -51,7 +51,6 @@ class RefillPipe(implicit p: Parameters) extends DCacheModule {
     val tag_write = DecoupledIO(new TagWriteReq)
     val store_resp = ValidIO(new DCacheLineResp)
     val release_wakeup = ValidIO(UInt(log2Up(cfg.nMissEntries).W))
-    val replace_access = ValidIO(new ReplacementAccessBundle)
   })
 
   // Assume that write in refill pipe is always ready
@@ -98,8 +97,4 @@ class RefillPipe(implicit p: Parameters) extends DCacheModule {
 
   io.release_wakeup.valid := refill_w_valid
   io.release_wakeup.bits := refill_w_req.miss_id
-
-  io.replace_access.valid := refill_w_valid
-  io.replace_access.bits.set := idx
-  io.replace_access.bits.way := OHToUInt(refill_w_req.way_en)
 }


### PR DESCRIPTION
Now we have accessed plru when load miss, we should not access plru
when refill