### PR TITLE
freelist: optimize timing of read and writing

### DIFF
--- a/src/main/scala/xiangshan/backend/rename/freelist/BaseFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/BaseFreeList.scala
@@ -39,13 +39,15 @@ abstract class BaseFreeList(size: Int)(implicit p: Parameters) extends XSModule 
     val stepBack = Input(UInt(log2Up(CommitWidth + 1).W))
   })
 
-  class FreeListPtr extends CircularQueuePtr[FreeListPtr](size)
+  class FreeListPtr extends CircularQueuePtr[FreeListPtr](size) {
+    def toOH: UInt = UIntToOH(value, size)
+  }
 
   object FreeListPtr {
-    def apply(f: Bool, v: UInt): FreeListPtr = {
+    def apply(f: Boolean, v: Int): FreeListPtr = {
       val ptr = Wire(new FreeListPtr)
-      ptr.flag := f
-      ptr.value := v
+      ptr.flag := f.B
+      ptr.value := v.U
       ptr
     }
   }

--- a/src/main/scala/xiangshan/backend/rename/freelist/MEFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/MEFreeList.scala
@@ -28,7 +28,7 @@ class MEFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) w
 
   // head and tail pointer
   val headPtr = RegInit(FreeListPtr(false, 0))
-  val headPtrOH = RegInit(0.U(size.W))
+  val headPtrOH = RegInit(1.U(size.W))
   XSError(headPtr.toOH =/= headPtrOH, p"wrong one-hot reg between $headPtr and $headPtrOH")
   val headPtrOHShift = CircularShift(headPtrOH)
   val headPtrOHVec = VecInit.tabulate(RenameWidth)(headPtrOHShift.left)

--- a/src/main/scala/xiangshan/backend/rename/freelist/MEFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/MEFreeList.scala
@@ -31,7 +31,8 @@ class MEFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) w
   val headPtrOH = RegInit(1.U(size.W))
   XSError(headPtr.toOH =/= headPtrOH, p"wrong one-hot reg between $headPtr and $headPtrOH")
   val headPtrOHShift = CircularShift(headPtrOH)
-  val headPtrOHVec = VecInit.tabulate(RenameWidth)(headPtrOHShift.left)
+  // may shift [0, RenameWidth] steps
+  val headPtrOHVec = VecInit.tabulate(RenameWidth + 1)(headPtrOHShift.left)
   val tailPtr = RegInit(FreeListPtr(false, size - 32))
 
   val doRename = io.canAllocate && io.doAllocate && !io.redirect && !io.walk

--- a/src/main/scala/xiangshan/backend/rename/freelist/MEFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/MEFreeList.scala
@@ -24,26 +24,31 @@ import utils._
 
 
 class MEFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) with HasPerfEvents {
-  val freeList = Mem(size, UInt(PhyRegIdxWidth.W))
+  val freeList = Reg(Vec(size, UInt(PhyRegIdxWidth.W)))
 
   // head and tail pointer
-  val headPtr = RegInit(FreeListPtr(false.B, 0.U))
-  val tailPtr = RegInit(FreeListPtr(false.B, (NRPhyRegs - 32).U))
+  val headPtr = RegInit(FreeListPtr(false, 0))
+  val headPtrOH = RegInit(0.U(size.W))
+  XSError(headPtr.toOH =/= headPtrOH, p"wrong one-hot reg between $headPtr and $headPtrOH")
+  val headPtrOHShift = CircularShift(headPtrOH)
+  val headPtrOHVec = VecInit.tabulate(RenameWidth)(headPtrOHShift.left)
+  val tailPtr = RegInit(FreeListPtr(false, size - 32))
 
   val doRename = io.canAllocate && io.doAllocate && !io.redirect && !io.walk
 
   /**
     * Allocation: from freelist (same as StdFreelist)
     */
-  val allocatePtr = (0 until RenameWidth).map(i => headPtr + i.U)
-  val phyRegCandidates = VecInit(allocatePtr.map(ptr => freeList(ptr.value)))
+  val phyRegCandidates = VecInit(headPtrOHVec.map(sel => Mux1H(sel, freeList)))
   for (i <- 0 until RenameWidth) {
     // enqueue instr, is move elimination
     io.allocatePhyReg(i) := phyRegCandidates(PopCount(io.allocateReq.take(i)))
   }
   // update head pointer
-  val headPtrNext = headPtr + PopCount(io.allocateReq)
+  val numAllocate = PopCount(io.allocateReq)
+  val headPtrNext = headPtr + numAllocate
   headPtr := Mux(doRename, headPtrNext, headPtr)
+  headPtrOH := Mux(doRename, headPtrOHVec(numAllocate), headPtrOH)
 
 
   /**
@@ -56,7 +61,7 @@ class MEFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) w
     }
   }
   when (reset.asBool) {
-    for (i <- 0 until NRPhyRegs - 32) {
+    for (i <- 0 until size - 32) {
       freeList(i) := (i + 32).U
     }
   }
@@ -66,13 +71,14 @@ class MEFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) w
   tailPtr := tailPtrNext
 
   val freeRegCnt = Mux(doRename, distanceBetween(tailPtrNext, headPtrNext), distanceBetween(tailPtrNext, headPtr))
-  io.canAllocate := RegNext(freeRegCnt) >= RenameWidth.U
+  val freeRegCntReg = RegNext(freeRegCnt)
+  io.canAllocate := freeRegCntReg >= RenameWidth.U
 
   val perfEvents = Seq(
-    ("me_freelist_1_4_valid", (freeRegCnt < ((NRPhyRegs-32).U/4.U))                                             ),
-    ("me_freelist_2_4_valid", (freeRegCnt > ((NRPhyRegs-32).U/4.U)) & (freeRegCnt <= ((NRPhyRegs-32).U/2.U))    ),
-    ("me_freelist_3_4_valid", (freeRegCnt > ((NRPhyRegs-32).U/2.U)) & (freeRegCnt <= ((NRPhyRegs-32).U*3.U/4.U))),
-    ("me_freelist_4_4_valid", (freeRegCnt > ((NRPhyRegs-32).U*3.U/4.U))                                         ),
+    ("me_freelist_1_4_valid", freeRegCntReg <  (size / 4).U                                     ),
+    ("me_freelist_2_4_valid", freeRegCntReg >= (size / 4).U && freeRegCntReg <= (size / 2).U    ),
+    ("me_freelist_3_4_valid", freeRegCntReg >= (size / 2).U && freeRegCntReg <= (size * 3 / 4).U),
+    ("me_freelist_4_4_valid", freeRegCntReg >= (size * 3 / 4).U                                 ),
   )
   generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
@@ -26,25 +26,35 @@ import utils._
 class StdFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) with HasPerfEvents {
 
   val freeList = RegInit(VecInit(Seq.tabulate(size)( i => (i + 32).U(PhyRegIdxWidth.W) )))
-  val headPtr  = RegInit(FreeListPtr(false.B, 0.U))
-  val tailPtr  = RegInit(FreeListPtr(true.B,  0.U))
+  val headPtr  = RegInit(FreeListPtr(false, 0))
+  val headPtrOH = RegInit(0.U(size.W))
+  val headPtrOHShift = CircularShift(headPtrOH)
+  val headPtrOHVec = VecInit.tabulate(RenameWidth)(headPtrOHShift.left)
+  XSError(headPtr.toOH =/= headPtrOH, p"wrong one-hot reg between $headPtr and $headPtrOH")
+  val fakeTailPtr = RegInit(FreeListPtr(true, 0)) // tailPtr in the last cycle (need to add freeReqReg)
+  val tailPtr = Wire(new FreeListPtr) // this is the real tailPtr
+  val tailPtrOHReg = RegInit(0.U(size.W))
 
   //
   // free committed instructions' `old_pdest` reg
   //
+  val freeReqReg = RegNext(io.freeReq)
   for (i <- 0 until CommitWidth) {
     val offset = if (i == 0) 0.U else PopCount(io.freeReq.take(i))
     val ptr = tailPtr + offset
     val idx = ptr.value
 
-    when (io.freeReq(i)) {
-      freeList(idx) := io.freePhyReg(i)
-      XSDebug(p"req#$i free physical reg: ${io.freePhyReg(i)}\n")
+    // Why RegNext: for better timing
+    // Why we can RegNext: these free registers won't be used in the next cycle,
+    // since we set canAllocate only when the current free regs > RenameWidth.
+    when (freeReqReg(i)) {
+      freeList(RegNext(idx)) := RegNext(io.freePhyReg(i))
     }
+    XSDebug(io.freeReq(i), p"req#$i free physical reg: ${io.freePhyReg(i)}\n")
   }
 
-  val tailPtrNext = tailPtr + PopCount(io.freeReq)
-  tailPtr := tailPtrNext
+  tailPtr := fakeTailPtr + PopCount(freeReqReg)
+  fakeTailPtr := tailPtr
 
   //
   // allocate new physical registers for instructions at rename stage
@@ -53,21 +63,29 @@ class StdFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) 
   io.canAllocate := RegNext(freeRegCnt >= RenameWidth.U) // use RegNext for better timing
   XSDebug(p"freeRegCnt: $freeRegCnt\n")
 
-  val allocatePtr = (0 until RenameWidth).map(i => headPtr + i.U)
-  val phyRegCandidates = VecInit(allocatePtr.map(ptr => freeList(ptr.value)))
+  val phyRegCandidates = VecInit(headPtrOHVec.map(sel => Mux1H(sel, freeList)))
 
   for(i <- 0 until RenameWidth){
     io.allocatePhyReg(i) := phyRegCandidates(/* if (i == 0) 0.U else */PopCount(io.allocateReq.take(i)))
     XSDebug(p"req:${io.allocateReq(i)} canAllocate:${io.canAllocate} pdest:${io.allocatePhyReg(i)}\n")
   }
-  val headPtrAllocate = headPtr + PopCount(io.allocateReq)
+  val numAllocate = PopCount(io.allocateReq)
+  val headPtrAllocate = headPtr + numAllocate
   val headPtrNext = Mux(io.canAllocate && io.doAllocate, headPtrAllocate, headPtr)
   freeRegCnt := distanceBetween(tailPtr, headPtrNext)
 
   // priority: (1) exception and flushPipe; (2) walking; (3) mis-prediction; (4) normal dequeue
+  val realDoAllocate = !io.redirect && io.canAllocate && io.doAllocate
   headPtr := Mux(io.walk,
     headPtr - io.stepBack,
-    Mux(io.redirect, headPtr, headPtrNext))
+    Mux(realDoAllocate, headPtrAllocate, headPtr))
+
+  // Since the update of headPtr should have a good timing,
+  // we calculate the OH index here to optimize the freelist read timing.
+  val stepBackHeadPtrOHVec = VecInit.tabulate(RenameWidth)(headPtrOHShift.right)
+  val stepBackHeadPtrOH = stepBackHeadPtrOHVec(io.stepBack)
+  headPtrOH := Mux(io.walk, stepBackHeadPtrOH,
+    Mux(realDoAllocate, headPtrOHVec(numAllocate), headPtrOH))
 
   XSDebug(p"head:$headPtr tail:$tailPtr\n")
 
@@ -85,11 +103,12 @@ class StdFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) 
   XSPerfAccumulate("allocation_blocked", !io.canAllocate)
   XSPerfAccumulate("can_alloc_wrong", !io.canAllocate && freeRegCnt >= RenameWidth.U)
 
+  val freeRegCntReg = RegNext(freeRegCnt)
   val perfEvents = Seq(
-    ("std_freelist_1_4_valid", (freeRegCnt < (size / 4).U)                                   ),
-    ("std_freelist_2_4_valid", (freeRegCnt > (size / 4).U) & (freeRegCnt <= (size / 2).U)    ),
-    ("std_freelist_3_4_valid", (freeRegCnt > (size / 2).U) & (freeRegCnt <= (size * 3 / 4).U)),
-    ("std_freelist_4_4_valid", (freeRegCnt > (size * 3 / 4).U)                               )
+    ("std_freelist_1_4_valid", freeRegCntReg <  (size / 4).U                                    ),
+    ("std_freelist_2_4_valid", freeRegCntReg >= (size / 4).U && freeRegCntReg < (size / 2).U    ),
+    ("std_freelist_3_4_valid", freeRegCntReg >= (size / 2).U && freeRegCntReg < (size * 3 / 4).U),
+    ("std_freelist_4_4_valid", freeRegCntReg >= (size * 3 / 4).U                                )
   )
   generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
@@ -29,7 +29,8 @@ class StdFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) 
   val headPtr  = RegInit(FreeListPtr(false, 0))
   val headPtrOH = RegInit(1.U(size.W))
   val headPtrOHShift = CircularShift(headPtrOH)
-  val headPtrOHVec = VecInit.tabulate(RenameWidth)(headPtrOHShift.left)
+  // may shift [0, RenameWidth] steps
+  val headPtrOHVec = VecInit.tabulate(RenameWidth + 1)(headPtrOHShift.left)
   XSError(headPtr.toOH =/= headPtrOH, p"wrong one-hot reg between $headPtr and $headPtrOH")
   val fakeTailPtr = RegInit(FreeListPtr(true, 0)) // tailPtr in the last cycle (need to add freeReqReg)
   val tailPtr = Wire(new FreeListPtr) // this is the real tailPtr
@@ -82,7 +83,8 @@ class StdFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) 
 
   // Since the update of headPtr should have a good timing,
   // we calculate the OH index here to optimize the freelist read timing.
-  val stepBackHeadPtrOHVec = VecInit.tabulate(RenameWidth)(headPtrOHShift.right)
+  // may shift [0, RenameWidth] steps
+  val stepBackHeadPtrOHVec = VecInit.tabulate(RenameWidth + 1)(headPtrOHShift.right)
   val stepBackHeadPtrOH = stepBackHeadPtrOHVec(io.stepBack)
   headPtrOH := Mux(io.walk, stepBackHeadPtrOH,
     Mux(realDoAllocate, headPtrOHVec(numAllocate), headPtrOH))

--- a/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
@@ -27,7 +27,7 @@ class StdFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) 
 
   val freeList = RegInit(VecInit(Seq.tabulate(size)( i => (i + 32).U(PhyRegIdxWidth.W) )))
   val headPtr  = RegInit(FreeListPtr(false, 0))
-  val headPtrOH = RegInit(0.U(size.W))
+  val headPtrOH = RegInit(1.U(size.W))
   val headPtrOHShift = CircularShift(headPtrOH)
   val headPtrOHVec = VecInit.tabulate(RenameWidth)(headPtrOHShift.left)
   XSError(headPtr.toOH =/= headPtrOH, p"wrong one-hot reg between $headPtr and $headPtrOH")


### PR DESCRIPTION
This commit optimizes the timing of freelist by changing the updating
function of headPtr and tailPtr.

We maintains an one-hot representation of headPtr and further uses it to
read the free registers from the list, which should be better than the
previous implementation where headPtr is used to indexed into the queue.

The update of tailPtr and the freelist is delayed by one cycle to
optimize the timing. Because freelist allocates new registers in the
next cycle iff there are more than RenameWidth free registers in this
cycle. The freed registers in this cycle will never be used in the next
cycle. Thus, we can delay the updating of queue data to the next cycle.
We also move the update of tailPtr to the next cycle, since PopCount
takes a long timing and we move the last adder to the next cycle. Now
the adder works parallely with PopCount. That is, the updating of
tailPtr is pipelined.