### PR TITLE
l2tlb: add counter to ptw-filter to avoid l2tlb deadlock & sync sfence to mmu

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -160,8 +160,8 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   atomicsUnit.io.hartId := io.hartId
 
   // dtlb
-  val sfence = RegNext(io.sfence)
-  val tlbcsr = RegNext(io.tlbCsr)
+  val sfence = RegNext(RegNext(io.sfence))
+  val tlbcsr = RegNext(RegNext(io.tlbCsr))
   val dtlb_ld = VecInit(Seq.fill(exuParameters.LduCnt){
     val tlb_ld = Module(new TLB(1, ldtlbParams))
     tlb_ld.io // let the module have name in waveform

--- a/src/main/scala/xiangshan/cache/mmu/Repeater.scala
+++ b/src/main/scala/xiangshan/cache/mmu/Repeater.scala
@@ -231,10 +231,10 @@ class PTWFilter(Width: Int, Size: Int)(implicit p: Parameters) extends XSModule 
   io.tlb.resp.bits.data := ptwResp
   io.tlb.resp.bits.vector := resp_vector
 
-  val issue_valid = v(issPtr) && !isEmptyIss
+  val issue_valid = v(issPtr) && !isEmptyIss && !inflight_full
   val issue_filtered = ptwResp_valid && ptwResp.entry.hit(io.ptw.req(0).bits.vpn, io.csr.satp.asid, allType=true, ignoreAsid=true)
   val issue_fire_fake = issue_valid && (io.ptw.req(0).ready || (issue_filtered && false.B /*timing-opt*/))
-  io.ptw.req(0).valid := issue_valid && !issue_filtered && !inflight_full
+  io.ptw.req(0).valid := issue_valid && !issue_filtered
   io.ptw.req(0).bits.vpn := vpn(issPtr)
   io.ptw.resp.ready := true.B
 
@@ -258,10 +258,10 @@ class PTWFilter(Width: Int, Size: Int)(implicit p: Parameters) extends XSModule 
   when (do_enq) {
     enqPtr := enqPtr + enqNum
   }
-  when (do_deq && !inflight_full) {
+  when (do_deq) {
     deqPtr := deqPtr + 1.U
   }
-  when (do_iss && !inflight_full) {
+  when (do_iss) {
     issPtr := issPtr + 1.U
   }
   when (issue_fire_fake && issue_filtered) { // issued but is filtered
@@ -279,7 +279,8 @@ class PTWFilter(Width: Int, Size: Int)(implicit p: Parameters) extends XSModule 
   }
 
   counter := counter - do_deq + Mux(do_enq, enqNum, 0.U)
-  assert(counter <= Size.U, "counter should be less than Size")
+  assert(counter <= Size.U, "counter should be no more than Size")
+  assert(inflight_counter <= Size.U, "inflight should be no more than Size")
   when (counter === 0.U) {
     assert(!io.ptw.req(0).fire(), "when counter is 0, should not req")
     assert(isEmptyDeq && isEmptyIss, "when counter is 0, should be empty")

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -69,6 +69,7 @@ class FrontendImp (outer: Frontend) extends LazyModuleImp(outer)
 
   val tlbCsr = DelayN(io.tlbCsr, 2)
   val csrCtrl = DelayN(io.csrCtrl, 2)
+  val sfence = RegNext(RegNext(io.sfence))
 
   // trigger
   ifu.io.frontendTrigger := csrCtrl.frontend_trigger
@@ -117,7 +118,7 @@ class FrontendImp (outer: Frontend) extends LazyModuleImp(outer)
   io.ptw <> TLB(
     //in = Seq(icache.io.itlb(0), icache.io.itlb(1)),
     in = Seq(itlb_requestors(0),itlb_requestors(1),itlb_requestors(2),itlb_requestors(3),itlb_requestors(4),itlb_requestors(5)),
-    sfence = io.sfence,
+    sfence = sfence,
     csr = tlbCsr,
     width = 6,
     shouldBlock = true,


### PR DESCRIPTION
These  commits are from branch `nanhu-0621`. Some bugs are fixed but forgot to cherry-pick to master.
1. fix l2tlb dead-lock bug
l2tlb won't merge requests at same addr. It will be blocked when having too many requests. 
PtwFilter has a bug that will send too many requests. Add a counter to avoid that.
2. fix sfence sync at mmu
different modules in mmu may get sfence at different latency, which will lost requests or some requests have no receiver.
Sync the sfence latency manually to avoid the bug.