### PR TITLE
dpq: optimize read and write timing of data module

### DIFF
--- a/src/main/scala/utils/CircularQueuePtr.scala
+++ b/src/main/scala/utils/CircularQueuePtr.scala
@@ -61,6 +61,8 @@ class CircularQueuePtr[T <: CircularQueuePtr[T]](val entries: Int) extends Bundl
   final def === (that_ptr: T): Bool = this.asUInt()===that_ptr.asUInt()
 
   final def =/= (that_ptr: T): Bool = this.asUInt()=/=that_ptr.asUInt()
+
+  def toOH: UInt = UIntToOH(value, entries)
 }
 
 trait HasCircularQueuePtrHelper {

--- a/src/main/scala/xiangshan/backend/dispatch/DispatchQueue.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/DispatchQueue.scala
@@ -45,9 +45,7 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
   val s_invalid :: s_valid :: Nil = Enum(2)
 
   // queue data array
-  val dataModule = Module(new SyncDataModuleTemplate(new MicroOp, size, deqnum, enqnum))
-  val robIdxEntries = Reg(Vec(size, new RobPtr))
-  val debug_uopEntries = Mem(size, new MicroOp)
+  val data = Reg(Vec(size, new MicroOp))
   val stateEntries = RegInit(VecInit(Seq.fill(size)(s_invalid)))
 
   class DispatchQueuePtr extends CircularQueuePtr[DispatchQueuePtr](size)
@@ -55,14 +53,20 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
   // head: first valid entry (dispatched entry)
   val headPtr = RegInit(VecInit((0 until deqnum).map(_.U.asTypeOf(new DispatchQueuePtr))))
   val headPtrMask = UIntToMask(headPtr(0).value, size)
+  val headPtrOH = RegInit(1.U(size.W))
+  val headPtrOHShift = CircularShift(headPtrOH)
+  val headPtrOHVec = VecInit.tabulate(deqnum + 1)(headPtrOHShift.left)
   // tail: first invalid entry (free entry)
   val tailPtr = RegInit(VecInit((0 until enqnum).map(_.U.asTypeOf(new DispatchQueuePtr))))
   val tailPtrMask = UIntToMask(tailPtr(0).value, size)
+  val tailPtrOH = RegInit(1.U(size.W))
+  val tailPtrOHShift = CircularShift(tailPtrOH)
+  val tailPtrOHVec = VecInit.tabulate(enqnum + 1)(tailPtrOHShift.left)
   // valid entries counter
   val validCounter = RegInit(0.U(log2Ceil(size + 1).W))
   val allowEnqueue = RegInit(true.B)
 
-  val isTrueEmpty = ~Cat((0 until size).map(i => stateEntries(i) === s_valid)).orR
+  val isTrueEmpty = !VecInit(stateEntries.map(_ === s_valid)).asUInt.orR
   val canEnqueue = allowEnqueue
   val canActualEnqueue = canEnqueue && !io.redirect.valid
 
@@ -80,41 +84,34 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
    */
   // enqueue: from s_invalid to s_valid
   io.enq.canAccept := canEnqueue
-  dataModule.io.wen := VecInit((0 until enqnum).map(_ => false.B))
-  dataModule.io.waddr := DontCare
-  dataModule.io.wdata := VecInit(io.enq.req.map(_.bits))
-  for (i <- 0 until enqnum) {
-    when(io.enq.req(i).valid && canActualEnqueue) {
-      dataModule.io.wen(i) := true.B
-      val sel = if (i == 0) 0.U else PopCount(io.enq.needAlloc.take(i))
-      dataModule.io.waddr(i) := tailPtr(sel).value
-      robIdxEntries(tailPtr(sel).value) := io.enq.req(i).bits.robIdx
-      debug_uopEntries(tailPtr(sel).value) := io.enq.req(i).bits
-      stateEntries(tailPtr(sel).value) := s_valid
-      XSError(sel =/= PopCount(io.enq.req.take(i).map(_.valid)), "why not continuous??\n")
+  val enqIndexOH = (0 until enqnum).map(i => tailPtrOHVec(PopCount(io.enq.needAlloc.take(i))))
+  for (i <- 0 until size) {
+    val validVec = io.enq.req.map(_.valid).zip(enqIndexOH).map{ case (v, oh) => v && oh(i) }
+    when (VecInit(validVec).asUInt.orR && canActualEnqueue) {
+      data(i) := Mux1H(validVec, io.enq.req.map(_.bits))
+      stateEntries(i) := s_valid
     }
   }
 
   // dequeue: from s_valid to s_dispatched
-  for (i <- 0 until deqnum) {
-    when(io.deq(i).fire() && !io.redirect.valid) {
-      stateEntries(headPtr(i).value) := s_invalid
-
-      // XSError(stateEntries(headPtr(i).value) =/= s_valid, "state of the dispatch entry is not s_valid\n")
+  for (i <- 0 until size) {
+    val validVec = io.deq.map(_.fire).zip(headPtrOHVec).map{ case (v, oh) => v && oh(i) }
+    when (VecInit(validVec).asUInt.orR && !io.redirect.valid) {
+      stateEntries(i) := s_invalid
     }
   }
 
   // redirect: cancel uops currently in the queue
   val needCancel = Wire(Vec(size, Bool()))
   for (i <- 0 until size) {
-    needCancel(i) := stateEntries(i) =/= s_invalid && robIdxEntries(i).needFlush(io.redirect)
+    needCancel(i) := stateEntries(i) =/= s_invalid && data(i).robIdx.needFlush(io.redirect)
 
     when(needCancel(i)) {
       stateEntries(i) := s_invalid
     }
 
-    XSInfo(needCancel(i), p"valid entry($i)(pc = ${Hexadecimal(debug_uopEntries(i).cf.pc)}) " +
-      p"robIndex ${robIdxEntries(i)} " +
+    XSInfo(needCancel(i), p"valid entry($i)(pc = ${Hexadecimal(data(i).cf.pc)}) " +
+      p"robIndex ${data(i).robIdx} " +
       p"cancelled with redirect robIndex 0x${Hexadecimal(io.redirect.bits.robIdx.asUInt)}\n")
   }
 
@@ -132,7 +129,7 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
     // For dequeue, the first entry should never be s_invalid
     // Otherwise, there should be a redirect and tail walks back
     // in this case, we set numDeq to 0
-    !deq.fire() && (if (i == 0) true.B else stateEntries(headPtr(i).value) =/= s_invalid)
+    !deq.fire && (if (i == 0) true.B else stateEntries(headPtr(i).value) =/= s_invalid)
   } :+ true.B)
   val numDeq = Mux(numDeqTry > numDeqFire, numDeqFire, numDeqTry)
   // agreement with reservation station: don't dequeue when redirect.valid
@@ -141,6 +138,8 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
     nextHeadPtr(i) := Mux(io.redirect.valid, headPtr(i), headPtr(i) + numDeq)
     headPtr(i) := nextHeadPtr(i)
   }
+  headPtrOH := Mux(io.redirect.valid, headPtrOH, headPtrOHVec(numDeq))
+  XSError(headPtrOH =/= headPtr.head.toOH, p"head: $headPtrOH != UIntToOH(${headPtr.head})")
 
   // For branch mis-prediction or memory violation replay,
   // we delay updating the indices for one clock cycle.
@@ -149,7 +148,7 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
   // find the last one's position, starting from headPtr and searching backwards
   val validBitVec = VecInit((0 until size).map(i => stateEntries(i) === s_valid))
   val loValidBitVec = Cat((0 until size).map(i => validBitVec(i) && headPtrMask(i)))
-  val hiValidBitVec = Cat((0 until size).map(i => validBitVec(i) && ~headPtrMask(i)))
+  val hiValidBitVec = Cat((0 until size).map(i => validBitVec(i) && !headPtrMask(i)))
   val flippedFlag = loValidBitVec.orR || validBitVec(size - 1)
   val leadingZeros = PriorityEncoder(Mux(loValidBitVec.orR, loValidBitVec, hiValidBitVec))
   val lastOneIndex = Mux(leadingZeros === 0.U, 0.U, size.U - leadingZeros)
@@ -174,6 +173,9 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
         tailPtr(i) + numEnq)
     )
   }
+  tailPtrOH := Mux(lastLastCycleMisprediction, tailPtr.head.toOH, tailPtrOHVec(numEnq))
+  val tailPtrOHAccurate = !lastCycleMisprediction && !lastLastCycleMisprediction
+  XSError(tailPtrOHAccurate && tailPtrOH =/= tailPtr.head.toOH, p"tail: $tailPtrOH != UIntToOH(${tailPtr.head})")
 
   // update valid counter and allowEnqueue reg
   validCounter := Mux(io.redirect.valid,
@@ -187,14 +189,10 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
   /**
    * Part 3: set output and input
    */
-  // TODO: remove this when replay moves to rob
-  dataModule.io.raddr := VecInit(nextHeadPtr.map(_.value))
   for (i <- 0 until deqnum) {
-    io.deq(i).bits := dataModule.io.rdata(i)
-    io.deq(i).bits.robIdx := robIdxEntries(headPtr(i).value)
-    // io.deq(i).bits := debug_uopEntries(headPtr(i).value)
+    io.deq(i).bits := Mux1H(headPtrOHVec(i), data)
     // do not dequeue when io.redirect valid because it may cause dispatchPtr work improperly
-    io.deq(i).valid := stateEntries(headPtr(i).value) === s_valid && !lastCycleMisprediction
+    io.deq(i).valid := Mux1H(headPtrOHVec(i), stateEntries) === s_valid && !lastCycleMisprediction
   }
 
   // debug: dump dispatch queue states
@@ -217,20 +215,21 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
   QueuePerf(size, PopCount(stateEntries.map(_ =/= s_invalid)), !canEnqueue)
   io.dqFull := !canEnqueue
   XSPerfAccumulate("in", numEnq)
-  XSPerfAccumulate("out", PopCount(io.deq.map(_.fire())))
+  XSPerfAccumulate("out", PopCount(io.deq.map(_.fire)))
   XSPerfAccumulate("out_try", PopCount(io.deq.map(_.valid)))
   val fake_block = currentValidCounter <= (size - enqnum).U && !canEnqueue
   XSPerfAccumulate("fake_block", fake_block)
 
+  val validEntries = RegNext(PopCount(stateEntries.map(_ =/= s_invalid)))
   val perfEvents = Seq(
-    ("dispatchq_in        ", numEnq),
-    ("dispatchq_out       ", PopCount(io.deq.map(_.fire()))),
-    ("dispatchq_out_try   ", PopCount(io.deq.map(_.valid))),
-    ("dispatchq_fake_block", fake_block),
-    ("dispatchq_1_4_valid ", (PopCount(stateEntries.map(_ =/= s_invalid)) < (size.U / 4.U))),
-    ("dispatchq_2_4_valid ", (PopCount(stateEntries.map(_ =/= s_invalid)) > (size.U / 4.U)) & (PopCount(stateEntries.map(_ =/= s_invalid)) <= (size.U / 2.U))),
-    ("dispatchq_3_4_valid ", (PopCount(stateEntries.map(_ =/= s_invalid)) > (size.U / 2.U)) & (PopCount(stateEntries.map(_ =/= s_invalid)) <= (size.U * 3.U / 4.U))),
-    ("dispatchq_4_4_valid ", (PopCount(stateEntries.map(_ =/= s_invalid)) > (size.U * 3.U / 4.U))),
+    ("dispatchq_in",         numEnq                                                          ),
+    ("dispatchq_out",        PopCount(io.deq.map(_.fire))                                    ),
+    ("dispatchq_out_try",    PopCount(io.deq.map(_.valid))                                   ),
+    ("dispatchq_fake_block", fake_block                                                      ),
+    ("dispatchq_1_4_valid ", validEntries <  (size / 4).U                                    ),
+    ("dispatchq_2_4_valid ", validEntries >= (size / 4).U && validEntries <= (size / 2).U    ),
+    ("dispatchq_3_4_valid ", validEntries >= (size / 2).U && validEntries <= (size * 3 / 4).U),
+    ("dispatchq_4_4_valid ", validEntries >= (size * 3 / 4).U                                )
   )
   generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/backend/rename/freelist/BaseFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/BaseFreeList.scala
@@ -39,9 +39,7 @@ abstract class BaseFreeList(size: Int)(implicit p: Parameters) extends XSModule 
     val stepBack = Input(UInt(log2Up(CommitWidth + 1).W))
   })
 
-  class FreeListPtr extends CircularQueuePtr[FreeListPtr](size) {
-    def toOH: UInt = UIntToOH(value, size)
-  }
+  class FreeListPtr extends CircularQueuePtr[FreeListPtr](size)
 
   object FreeListPtr {
     def apply(f: Boolean, v: Int): FreeListPtr = {


### PR DESCRIPTION
This commit changes the data modules in Dispatch Queue. We use one-hot
indices to read and write the data array.