### PR TITLE
rob: add separated optimized walk valid bits

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -349,6 +349,8 @@ class RobCommitInfo(implicit p: Parameters) extends XSBundle {
 class RobCommitIO(implicit p: Parameters) extends XSBundle {
   val isWalk = Output(Bool())
   val valid = Vec(CommitWidth, Output(Bool()))
+  // valid bits optimized for walk
+  val walkValid = Vec(CommitWidth, Output(Bool()))
   val info = Vec(CommitWidth, Output(new RobCommitInfo))
 
   def hasWalkInstr = isWalk && valid.asUInt.orR

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -65,7 +65,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasPerfEvents {
     fl.io.walk := io.robCommits.isWalk
     // when isWalk, use stepBack to restore head pointer of free list
     // (if ME enabled, stepBack of intFreeList should be useless thus optimized out)
-    fl.io.stepBack := PopCount(io.robCommits.valid.zip(io.robCommits.info).map{case (v, i) => v && needDestRegCommit(isFp, i)})
+    fl.io.stepBack := PopCount(io.robCommits.walkValid.zip(io.robCommits.info).map{case (v, i) => v && needDestRegCommit(isFp, i)})
   }
   // walk has higher priority than allocation and thus we don't use isWalk here
   // only when both fp and int free list and dispatch1 has enough space can we do allocation


### PR DESCRIPTION
Some modules rely on the walk valid bits of ROB. This commit
optimizes the timing by providing separated walk valid bits, which
is far better than the commit valid bits.