### PR TITLE
decode: lsrc should not be overrided for XSTrap

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -439,9 +439,6 @@ object CBODecode extends DecodeConstants {
  */
 object XSTrapDecode extends DecodeConstants {
   def TRAP = BitPat("b000000000000?????000000001101011")
-  // calculate as ADDI => addi zero, a0, 0
-  // replace rs '?????' with '01010'(a0) in decode stage
-  def lsrc1 = "b01010".U // $a0
   val table: Array[(BitPat, List[BitPat])] = Array(
     TRAP    -> List(SrcType.reg, SrcType.imm, SrcType.DC, FuType.alu, ALUOpType.add, Y, N, Y, Y, Y, N, N, SelImm.IMM_I)
   )
@@ -632,11 +629,6 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
   val isFrflags = BitPat("b000000000001_00000_010_?????_1110011") === ctrl_flow.instr
   when (cs.fuType === FuType.csr && isFrflags) {
     cs.blockBackward := false.B
-  }
-
-  // fix isXSTrap
-  when (cs.isXSTrap) {
-    cs.lsrc(0) := XSTrapDecode.lsrc1
   }
 
   //to selectout prefetch.r/prefetch.w


### PR DESCRIPTION
This commit fixes the bug that the lsrc(0) of trap instructions is
overrided with $a0, which causes timing issues as well.