### PR TITLE
decode: move fusion decoder result Mux to rename

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -19,17 +19,17 @@ package xiangshan.backend
 import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
-import difftest._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utils._
 import xiangshan._
-import xiangshan.backend.decode.{DecodeStage, ImmUnion}
+import xiangshan.backend.decode.{DecodeStage, FusionDecoder, ImmUnion}
 import xiangshan.backend.dispatch.{Dispatch, DispatchQueue}
 import xiangshan.backend.fu.PFEvent
 import xiangshan.backend.rename.{Rename, RenameTableWrapper}
 import xiangshan.backend.rob.{Rob, RobCSRIO, RobLsqIO}
 import xiangshan.frontend.FtqRead
 import xiangshan.mem.mdp.{LFST, SSIT, WaitTable}
+import xiangshan.ExceptionNO._
 
 class CtrlToFtqIO(implicit p: Parameters) extends XSBundle {
   def numRedirect = exuParameters.JmpCnt + exuParameters.AluCnt
@@ -277,6 +277,7 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
   }
 
   val decode = Module(new DecodeStage)
+  val fusionDecoder = Module(new FusionDecoder)
   val rat = Module(new RenameTableWrapper)
   val ssit = Module(new SSIT)
   val waittable = Module(new WaitTable)
@@ -409,14 +410,47 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
 
   // pipeline between decode and rename
   for (i <- 0 until RenameWidth) {
-    PipelineConnect(decode.io.out(i), rename.io.in(i), rename.io.in(i).ready,
+    // fusion decoder
+    val decodeHasException = io.frontend.cfVec(i).bits.exceptionVec(instrPageFault) || io.frontend.cfVec(i).bits.exceptionVec(instrAccessFault)
+    val disableFusion = decode.io.csrCtrl.singlestep
+    fusionDecoder.io.in(i).valid := io.frontend.cfVec(i).valid && !(decodeHasException || disableFusion)
+    fusionDecoder.io.in(i).bits := io.frontend.cfVec(i).bits.instr
+    if (i > 0) {
+      fusionDecoder.io.inReady(i - 1) := decode.io.out(i).ready
+    }
+
+    // Pipeline
+    val renamePipe = PipelineNext(decode.io.out(i), rename.io.in(i).ready,
       stage2Redirect.valid || pendingRedirect)
+    renamePipe.ready := rename.io.in(i).ready
+    rename.io.in(i).valid := renamePipe.valid && !fusionDecoder.io.clear(i)
+    rename.io.in(i).bits := renamePipe.bits
     rename.io.intReadPorts(i) := rat.io.intReadPorts(i).map(_.data)
     rename.io.fpReadPorts(i) := rat.io.fpReadPorts(i).map(_.data)
-    if (i < RenameWidth - 1) {
-      rename.io.fusionInfo(i) := RegEnable(decode.io.fusionInfo(i), decode.io.out(i).fire)
-    }
     rename.io.waittable(i) := RegEnable(waittable.io.rdata(i), decode.io.out(i).fire)
+
+    if (i < RenameWidth - 1) {
+      // fusion decoder sees the raw decode info
+      fusionDecoder.io.dec(i) := renamePipe.bits.ctrl
+      rename.io.fusionInfo(i) := fusionDecoder.io.info(i)
+
+      // update the first RenameWidth - 1 instructions
+      decode.io.fusion(i) := fusionDecoder.io.out(i).valid && rename.io.out(i).fire
+      when (fusionDecoder.io.out(i).valid) {
+        fusionDecoder.io.out(i).bits.update(rename.io.in(i).bits.ctrl)
+        // TODO: remove this dirty code for ftq update
+        val sameFtqPtr = rename.io.in(i).bits.cf.ftqPtr.value === rename.io.in(i + 1).bits.cf.ftqPtr.value
+        val ftqOffset0 = rename.io.in(i).bits.cf.ftqOffset
+        val ftqOffset1 = rename.io.in(i + 1).bits.cf.ftqOffset
+        val ftqOffsetDiff = ftqOffset1 - ftqOffset0
+        val cond1 = sameFtqPtr && ftqOffsetDiff === 1.U
+        val cond2 = sameFtqPtr && ftqOffsetDiff === 2.U
+        val cond3 = !sameFtqPtr && ftqOffset1 === 0.U
+        val cond4 = !sameFtqPtr && ftqOffset1 === 1.U
+        rename.io.in(i).bits.ctrl.commitType := Mux(cond1, 4.U, Mux(cond2, 5.U, Mux(cond3, 6.U, 7.U)))
+        XSError(!cond1 && !cond2 && !cond3 && !cond4, p"new condition $sameFtqPtr $ftqOffset0 $ftqOffset1\n")
+      }
+    }
   }
 
   rename.io.redirect <> stage2Redirect

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -29,12 +29,13 @@ class DecodeStage(implicit p: Parameters) extends XSModule with HasPerfEvents {
     val in = Vec(DecodeWidth, Flipped(DecoupledIO(new CtrlFlow)))
     // to Rename
     val out = Vec(DecodeWidth, DecoupledIO(new CfCtrl))
-    val fusionInfo = Vec(DecodeWidth - 1, new FusionDecodeInfo)
     // RAT read
     val intRat = Vec(RenameWidth, Vec(3, Flipped(new RatReadPort)))
     val fpRat = Vec(RenameWidth, Vec(4, Flipped(new RatReadPort)))
     // csr control
     val csrCtrl = Input(new CustomCSRCtrlIO)
+    // perf only
+    val fusion = Vec(DecodeWidth - 1, Input(Bool()))
   })
 
   val decoders = Seq.fill(DecodeWidth)(Module(new DecodeUnit))
@@ -63,45 +64,12 @@ class DecodeStage(implicit p: Parameters) extends XSModule with HasPerfEvents {
     io.fpRat(i).foreach(_.hold := !io.out(i).ready)
   }
 
-  // instruction fusion
-  val fusionDecoder = Module(new FusionDecoder())
-  fusionDecoder.io.in.zip(io.in).foreach{ case (d, in) =>
-    // TODO: instructions with exceptions should not be considered fusion
-    d.valid := in.valid
-    d.bits := in.bits.instr
-  }
-  fusionDecoder.io.dec := decoders.map(_.io.deq.cf_ctrl.ctrl)
-  fusionDecoder.io.out.zip(io.out.dropRight(1)).zipWithIndex.foreach{ case ((d, out), i) =>
-    d.ready := out.ready
-    when (d.valid && !io.csrCtrl.singlestep) { // TODO && nosinglestep
-      out.bits.ctrl := d.bits
-      // TODO: remove this
-      // Dirty code for ftq update
-      val sameFtqPtr = out.bits.cf.ftqPtr.value === io.out(i + 1).bits.cf.ftqPtr.value
-      val ftqOffset0 = out.bits.cf.ftqOffset
-      val ftqOffset1 = io.out(i + 1).bits.cf.ftqOffset
-      val ftqOffsetDiff = ftqOffset1 - ftqOffset0
-      val cond1 = sameFtqPtr && ftqOffsetDiff === 1.U
-      val cond2 = sameFtqPtr && ftqOffsetDiff === 2.U
-      val cond3 = !sameFtqPtr && ftqOffset1 === 0.U
-      val cond4 = !sameFtqPtr && ftqOffset1 === 1.U
-      out.bits.ctrl.commitType := Mux(cond1, 4.U, Mux(cond2, 5.U, Mux(cond3, 6.U, 7.U)))
-      XSError(!cond1 && !cond2 && !cond3 && !cond4, p"new condition $sameFtqPtr $ftqOffset0 $ftqOffset1\n")
-    }
-  }
-  fusionDecoder.io.clear.zip(io.out.map(_.valid)).foreach{ case (c, v) =>
-    when (c) {
-      v := false.B
-    }
-  }
-  io.fusionInfo := fusionDecoder.io.info
-
   val hasValid = VecInit(io.in.map(_.valid)).asUInt.orR
   XSPerfAccumulate("utilization", PopCount(io.in.map(_.valid)))
   XSPerfAccumulate("waitInstr", PopCount((0 until DecodeWidth).map(i => io.in(i).valid && !io.in(i).ready)))
   XSPerfAccumulate("stall_cycle", hasValid && !io.out(0).ready)
 
-  val fusionValid = RegNext(VecInit(fusionDecoder.io.out.map(_.fire)))
+  val fusionValid = RegNext(io.fusion)
   val inFire = io.in.map(in => RegNext(in.valid && !in.ready))
   val perfEvents = Seq(
     ("decoder_fused_instr", PopCount(fusionValid)       ),

--- a/src/main/scala/xiangshan/backend/decode/FusionDecoder.scala
+++ b/src/main/scala/xiangshan/backend/decode/FusionDecoder.scala
@@ -72,6 +72,7 @@ abstract class BaseFusionCase(pair: Seq[Valid[UInt]])(implicit p: Parameters)
   def src2Type: Option[Int] = compareAndGet(getInstrSrc2Type)
   def lsrc2NeedZero: Boolean = false
   def lsrc2NeedMux: Boolean = false
+  def lsrc2MuxResult: UInt = Mux(destToRs1, instr2Rs2, instr2Rs1)
 
   def fusionName: String
 }
@@ -463,23 +464,46 @@ class FusionDecodeInfo extends Bundle {
   val rs2FromZero = Output(Bool())
 }
 
+class FusionDecodeReplace extends Bundle {
+  val fuType = Valid(FuType())
+  val fuOpType = Valid(FuOpType())
+  val lsrc2 = Valid(UInt(5.W))
+  val src2Type = Valid(SrcType())
+
+  def update(cs: CtrlSignals): Unit = {
+    when (fuType.valid) {
+      cs.fuType := fuType.bits
+    }
+    when (fuOpType.valid) {
+      cs.fuOpType := fuOpType.bits
+    }
+    when (lsrc2.valid) {
+      cs.lsrc(1) := lsrc2.bits
+    }
+    when (src2Type.valid) {
+      cs.srcType(1) := src2Type.bits
+    }
+  }
+}
+
 class FusionDecoder(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle {
-    // detect instruction fusions in these instructions
+    // T0: detect instruction fusions in these instructions
     val in = Vec(DecodeWidth, Flipped(ValidIO(UInt(32.W))))
-    val dec = Vec(DecodeWidth, Input(new CtrlSignals()))
-    // whether an instruction fusion is found
-    val out = Vec(DecodeWidth - 1, DecoupledIO(new CtrlSignals))
-    val info = Vec(DecodeWidth - 1, new FusionDecodeInfo)
-    // fused instruction needs to be cleared
+    val inReady = Vec(DecodeWidth - 1, Input(Bool())) // dropRight(1)
+    // T1: decode result
+    val dec = Vec(DecodeWidth - 1, Input(new CtrlSignals)) // dropRight(1)
+    // T1: whether an instruction fusion is found
+    val out = Vec(DecodeWidth - 1, ValidIO(new FusionDecodeReplace)) // dropRight(1)
+    val info = Vec(DecodeWidth - 1, new FusionDecodeInfo) // dropRight(1)
+    // T1: fused instruction needs to be cleared
     val clear = Vec(DecodeWidth, Output(Bool()))
   })
 
   io.clear.head := false.B
 
   val instrPairs = io.in.dropRight(1).zip(io.in.drop(1)).map(x => Seq(x._1, x._2))
-  val csPairs = io.dec.dropRight(1).zip(io.dec.drop(1)).map(x => Seq(x._1, x._2))
-  instrPairs.zip(csPairs).zip(io.out).zipWithIndex.foreach{ case (((pair, cs), out), i) =>
+  instrPairs.zip(io.dec).zip(io.out).zipWithIndex.foreach{ case (((pair, dec), out), i) =>
     val fusionList = Seq(
       new FusedAdduw(pair),
       new FusedZexth(pair),
@@ -508,26 +532,35 @@ class FusionDecoder(implicit p: Parameters) extends XSModule {
       new FusedLogiclsb(pair),
       new FusedLogicZexth(pair)
     )
-    val pairValid = VecInit(pair.map(_.valid)).asUInt.andR
+    val fire = io.in(i).valid && io.inReady(i)
+    val instrPairValid = RegEnable(VecInit(pair.map(_.valid)).asUInt.andR, false.B, fire)
+    val fusionVec = RegEnable(VecInit(fusionList.map(_.isValid)), fire)
     val thisCleared = io.clear(i)
-    val fusionVec = VecInit(fusionList.map(_.isValid))
-    out.valid := pairValid && !thisCleared && fusionVec.asUInt.orR
-    XSError(PopCount(fusionVec) > 1.U, "more then one fusion matched\n")
-    out.bits := cs.head
-    def connectByInt(field: CtrlSignals => UInt, replace: Seq[Option[Int]]): Unit = {
+    out.valid := instrPairValid && !thisCleared && fusionVec.asUInt.orR
+    XSError(instrPairValid && PopCount(fusionVec) > 1.U, "more then one fusion matched\n")
+    def connectByInt(field: FusionDecodeReplace => Valid[UInt], replace: Seq[Option[Int]]): Unit = {
+      field(out.bits).valid := false.B
+      field(out.bits).bits := DontCare
       val replaceVec = fusionVec.zip(replace).filter(_._2.isDefined)
       if (replaceVec.nonEmpty) {
         // constant values are grouped together for better timing.
+        val replEnable = VecInit(replaceVec.map(_._1)).asUInt.orR
         val replTypes = replaceVec.map(_._2.get).distinct
-        val replEnable= replTypes.map(t => VecInit(replaceVec.filter(_._2.get == t).map(_._1)).asUInt.orR)
-        when (VecInit(replaceVec.map(_._1)).asUInt.orR) {
-          field(out.bits) := Mux1H(replEnable, replTypes.map(_.U))
-        }
+        val replSel = replTypes.map(t => VecInit(replaceVec.filter(_._2.get == t).map(_._1)).asUInt.orR)
+        field(out.bits).valid := replEnable
+        field(out.bits).bits := Mux1H(replSel, replTypes.map(_.U))
       }
     }
-    def connectByUIntFunc(field: CtrlSignals => UInt, replace: Seq[Option[UInt => UInt]]): Unit = {
-      val replaceVec = fusionVec.zip(replace).filter(_._2.isDefined).map(x => (x._1, x._2.get(field(cs.head))))
+    def connectByUIntFunc(
+      field: FusionDecodeReplace => Valid[UInt],
+      csField: CtrlSignals => UInt,
+      replace: Seq[Option[UInt => UInt]]
+    ): Unit = {
+      field(out.bits).valid := false.B
+      field(out.bits).bits := DontCare
+      val replaceVec = fusionVec.zip(replace).filter(_._2.isDefined).map(x => (x._1, x._2.get(csField(dec))))
       if (replaceVec.nonEmpty) {
+        val replEnable = VecInit(replaceVec.map(_._1)).asUInt.orR
         // constant values are grouped together for better timing.
         val constReplVec = replaceVec.filter(_._2.isLit).map(x => (x._1, x._2.litValue))
         val constReplTypes = constReplVec.map(_._2).distinct
@@ -535,30 +568,31 @@ class FusionDecoder(implicit p: Parameters) extends XSModule {
         val constReplResult = Mux1H(constReplEnable, constReplTypes.map(_.U))
         // non-constant values have to be processed naively.
         val noLitRepl = replaceVec.filterNot(_._2.isLit)
-        when (VecInit(replaceVec.map(_._1)).asUInt.orR) {
-          field(out.bits) := Mux(VecInit(noLitRepl.map(_._1)).asUInt.orR, Mux1H(noLitRepl), constReplResult)
-        }
+        field(out.bits).valid := replEnable
+        field(out.bits).bits := Mux(VecInit(noLitRepl.map(_._1)).asUInt.orR, Mux1H(noLitRepl), constReplResult)
       }
     }
-    connectByInt((x: CtrlSignals) => x.fuType, fusionList.map(_.fuType))
-    connectByUIntFunc((x: CtrlSignals) => x.fuOpType, fusionList.map(_.fuOpType))
-    connectByInt((x: CtrlSignals) => x.srcType(1), fusionList.map(_.src2Type))
+    connectByInt((x: FusionDecodeReplace) => x.fuType, fusionList.map(_.fuType))
+    connectByUIntFunc((x: FusionDecodeReplace) => x.fuOpType, (x: CtrlSignals) => x.fuOpType, fusionList.map(_.fuOpType))
+    connectByInt((x: FusionDecodeReplace) => x.src2Type, fusionList.map(_.src2Type))
     val src2WithZero = VecInit(fusionVec.zip(fusionList.map(_.lsrc2NeedZero)).filter(_._2).map(_._1)).asUInt.orR
     val src2WithMux = VecInit(fusionVec.zip(fusionList.map(_.lsrc2NeedMux)).filter(_._2).map(_._1)).asUInt.orR
     io.info(i).rs2FromZero := src2WithZero
-    io.info(i).rs2FromRs1 := src2WithMux && !fusionList.head.destToRs1
-    io.info(i).rs2FromRs2 := src2WithMux && fusionList.head.destToRs1
+    io.info(i).rs2FromRs1 := src2WithMux && !RegEnable(fusionList.head.destToRs1, fire)
+    io.info(i).rs2FromRs2 := src2WithMux && RegEnable(fusionList.head.destToRs1, fire)
+    out.bits.lsrc2.valid := src2WithMux || src2WithZero
     when (src2WithMux) {
-      out.bits.lsrc(1) := Mux(fusionList.head.destToRs1, fusionList.head.instr2Rs2, fusionList.head.instr2Rs1)
-    }.elsewhen (src2WithZero) {
-      out.bits.lsrc(1) := 0.U
+      out.bits.lsrc2.bits := RegEnable(fusionList.head.lsrc2MuxResult, fire)
+    }.otherwise {//elsewhen (src2WithZero) {
+      out.bits.lsrc2.bits := 0.U
     }
     // TODO: assume every instruction fusion clears the second instruction now
     io.clear(i + 1) := out.valid
+    val lastFire = RegNext(fire)
     fusionList.zip(fusionVec).foreach { case (f, v) =>
-      XSPerfAccumulate(s"case_${f.fusionName}_$i", pairValid && !thisCleared && v && out.ready)
+      XSPerfAccumulate(s"case_${f.fusionName}_$i", instrPairValid && !thisCleared && v && lastFire)
     }
-    XSPerfAccumulate(s"conflict_fusion_$i", pairValid && thisCleared && fusionVec.asUInt.orR && out.ready)
+    XSPerfAccumulate(s"conflict_fusion_$i", instrPairValid && thisCleared && fusionVec.asUInt.orR && lastFire)
   }
 
   XSPerfAccumulate("fused_instr", PopCount(io.out.map(_.fire)))

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -122,11 +122,9 @@ class Rename(implicit p: Parameters) extends XSModule with HasPerfEvents {
     // update cf according to waittable result
     uops(i).cf.loadWaitBit := io.waittable(i)
 
-    val inValid = io.in(i).valid
-
     // alloc a new phy reg
-    needFpDest(i) := inValid && needDestReg(fp = true, io.in(i).bits)
-    needIntDest(i) := inValid && needDestReg(fp = false, io.in(i).bits)
+    needFpDest(i) := io.in(i).valid && needDestReg(fp = true, io.in(i).bits)
+    needIntDest(i) := io.in(i).valid && needDestReg(fp = false, io.in(i).bits)
     fpFreeList.io.allocateReq(i) := needFpDest(i)
     intFreeList.io.allocateReq(i) := needIntDest(i) && !isMove(i)
 


### PR DESCRIPTION
This commit moves the fusion decoder to both decode and rename stage.

In the decode stage, fusion decoder determines whether the instruction
pairs can be fused. Valid bits of decode are not affected by fusion
decoder. This should fix the timing issues of rename.valid.

In the rename stage, some fields are updated according the result of
fusion decoder. This will bring a minor timing path to both valid and
other fields in uop in the rename stage. However, since freelist and
rat have worse timing. This should not cause timing issues.