### PR TITLE
ctrl: optimize the timing of dispatch2 stage

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -224,7 +224,8 @@ abstract class XSCoreBase()(implicit p: config.Parameters) extends LazyModule
 
   val wb2Ctrl = LazyModule(new Wb2Ctrl(exuConfigs))
   wb2Ctrl.addWritebackSink(exuBlocks :+ memBlock)
-  val ctrlBlock = LazyModule(new CtrlBlock)
+  val dpExuConfigs = exuBlocks.flatMap(_.scheduler.dispatch2.map(_.configs))
+  val ctrlBlock = LazyModule(new CtrlBlock(dpExuConfigs))
   val writebackSources = Seq(Seq(wb2Ctrl), Seq(wbArbiter))
   writebackSources.foreach(s => ctrlBlock.addWritebackSink(s))
 }
@@ -316,6 +317,11 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   val allFastUop1 = intFastUop1 ++ fpFastUop1
 
   ctrlBlock.io.dispatch <> exuBlocks.flatMap(_.io.in)
+  ctrlBlock.io.rsReady := exuBlocks.flatMap(_.io.scheExtra.rsReady)
+  ctrlBlock.io.enqLsq <> memBlock.io.enqLsq
+  ctrlBlock.io.sqDeq := memBlock.io.sqDeq
+  ctrlBlock.io.lqCancelCnt := memBlock.io.lqCancelCnt
+  ctrlBlock.io.sqCancelCnt := memBlock.io.sqCancelCnt
 
   exuBlocks(0).io.scheExtra.fpRfReadIn.get <> exuBlocks(1).io.scheExtra.fpRfReadOut.get
   exuBlocks(0).io.scheExtra.fpStateReadIn.get <> exuBlocks(1).io.scheExtra.fpStateReadOut.get

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -23,13 +23,15 @@ import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utils._
 import xiangshan._
 import xiangshan.backend.decode.{DecodeStage, FusionDecoder, ImmUnion}
-import xiangshan.backend.dispatch.{Dispatch, DispatchQueue}
+import xiangshan.backend.dispatch.{Dispatch, Dispatch2Rs, DispatchQueue}
 import xiangshan.backend.fu.PFEvent
 import xiangshan.backend.rename.{Rename, RenameTableWrapper}
 import xiangshan.backend.rob.{Rob, RobCSRIO, RobLsqIO}
 import xiangshan.frontend.FtqRead
 import xiangshan.mem.mdp.{LFST, SSIT, WaitTable}
 import xiangshan.ExceptionNO._
+import xiangshan.backend.exu.ExuConfig
+import xiangshan.mem.{LsqEnqCtrl, LsqEnqIO}
 
 class CtrlToFtqIO(implicit p: Parameters) extends XSBundle {
   def numRedirect = exuParameters.JmpCnt + exuParameters.AluCnt
@@ -196,7 +198,7 @@ class RedirectGenerator(implicit p: Parameters) extends XSModule
   // }
 }
 
-class CtrlBlock(implicit p: Parameters) extends LazyModule
+class CtrlBlock(dpExuConfigs: Seq[Seq[Seq[ExuConfig]]])(implicit p: Parameters) extends LazyModule
   with HasWritebackSink with HasWritebackSource {
   val rob = LazyModule(new Rob)
 
@@ -205,6 +207,8 @@ class CtrlBlock(implicit p: Parameters) extends LazyModule
     super.addWritebackSink(source, index)
   }
 
+  // duplicated dispatch2 here to avoid cross-module timing path loop.
+  val dispatch2 = dpExuConfigs.map(c => LazyModule(new Dispatch2Rs(c)))
   lazy val module = new CtrlBlockImp(this)
 
   override lazy val writebackSourceParams: Seq[WritebackSourceParams] = {
@@ -232,8 +236,14 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
     val hartId = Input(UInt(8.W))
     val cpu_halt = Output(Bool())
     val frontend = Flipped(new FrontendToCtrlIO)
+    // to exu blocks
     val allocPregs = Vec(RenameWidth, Output(new ResetPregStateReq))
     val dispatch = Vec(3*dpParams.IntDqDeqWidth, DecoupledIO(new MicroOp))
+    val rsReady = Vec(outer.dispatch2.map(_.module.io.out.length).sum, Input(Bool()))
+    val enqLsq = Flipped(new LsqEnqIO)
+    val lqCancelCnt = Input(UInt(log2Up(LoadQueueSize + 1).W))
+    val sqCancelCnt = Input(UInt(log2Up(StoreQueueSize + 1).W))
+    val sqDeq = Input(UInt(log2Ceil(EnsbufferWidth + 1).W))
     // from int block
     val exuRedirect = Vec(exuParameters.AluCnt + exuParameters.JmpCnt, Flipped(ValidIO(new ExuOutput)))
     val stIn = Vec(exuParameters.StuCnt, Flipped(ValidIO(new ExuInput)))
@@ -476,7 +486,37 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
   fpDq.io.redirect <> redirectForExu
   lsDq.io.redirect <> redirectForExu
 
-  io.dispatch <> intDq.io.deq ++ lsDq.io.deq ++ fpDq.io.deq
+  val dpqOut = intDq.io.deq ++ lsDq.io.deq ++ fpDq.io.deq
+  io.dispatch <> dpqOut
+
+  for (dp2 <- outer.dispatch2.map(_.module.io)) {
+    dp2.redirect := redirectForExu
+    if (dp2.readFpState.isDefined) {
+      dp2.readFpState.get := DontCare
+    }
+    if (dp2.readIntState.isDefined) {
+      dp2.readIntState.get := DontCare
+    }
+    if (dp2.enqLsq.isDefined) {
+      val lsqCtrl = Module(new LsqEnqCtrl)
+      lsqCtrl.io.redirect <> redirectForExu
+      lsqCtrl.io.enq <> dp2.enqLsq.get
+      lsqCtrl.io.lcommit := rob.io.lsq.lcommit
+      lsqCtrl.io.scommit := io.sqDeq
+      lsqCtrl.io.lqCancelCnt := io.lqCancelCnt
+      lsqCtrl.io.sqCancelCnt := io.sqCancelCnt
+      io.enqLsq <> lsqCtrl.io.enqLsq
+    }
+  }
+  for ((dp2In, i) <- outer.dispatch2.flatMap(_.module.io.in).zipWithIndex) {
+    dp2In.valid := dpqOut(i).valid
+    dp2In.bits := dpqOut(i).bits
+    // override ready here to avoid cross-module loop path
+    dpqOut(i).ready := dp2In.ready
+  }
+  for ((dp2Out, i) <- outer.dispatch2.flatMap(_.module.io.out).zipWithIndex) {
+    dp2Out.ready := io.rsReady(i)
+  }
 
   val pingpong = RegInit(false.B)
   pingpong := !pingpong

--- a/src/main/scala/xiangshan/backend/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/Scheduler.scala
@@ -132,7 +132,7 @@ class Scheduler(
 )(implicit p: Parameters) extends LazyModule with HasXSParameter with HasExuWbHelper {
   val numDpPorts = dpPorts.length
   val dpExuConfigs = dpPorts.map(port => port.map(_._1).map(configs(_)._1))
-  def getDispatch2 = {
+  def getDispatch2: Seq[Dispatch2Rs] = {
     if (dpExuConfigs.length > exuParameters.AluCnt) {
       val intDispatch = LazyModule(new Dispatch2Rs(dpExuConfigs.take(exuParameters.AluCnt)))
       val lsDispatch = LazyModule(new Dispatch2Rs(dpExuConfigs.drop(exuParameters.AluCnt)))
@@ -236,6 +236,8 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
   }
 
   class SchedulerExtraIO extends XSBundle {
+    // feedback to dispatch
+    val rsReady = Vec(outer.dispatch2.map(_.module.io.out.length).sum, Output(Bool()))
     // feedback ports
     val feedback = if (outer.numReplayPorts > 0) Some(Vec(outer.numReplayPorts, Flipped(new MemRSFeedbackIO()(updatedP)))) else None
     // special ports for RS that needs to read from other schedulers
@@ -288,6 +290,7 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
 
   val dispatch2 = outer.dispatch2.map(_.module)
   dispatch2.foreach(_.io.redirect := io.redirect)
+  io.extra.rsReady := outer.dispatch2.flatMap(_.module.io.out.map(_.ready))
 
   // dirty code for ls dp
   dispatch2.foreach(dp => if (dp.io.enqLsq.isDefined) {

--- a/src/main/scala/xiangshan/backend/dispatch/DispatchQueue.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/DispatchQueue.scala
@@ -45,13 +45,15 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
   val s_invalid :: s_valid :: Nil = Enum(2)
 
   // queue data array
-  val data = Reg(Vec(size, new MicroOp))
+  val dataModule = Module(new SyncDataModuleTemplate(new MicroOp, size, deqnum, enqnum))
+  val robIdxEntries = Reg(Vec(size, new RobPtr))
   val stateEntries = RegInit(VecInit(Seq.fill(size)(s_invalid)))
 
   class DispatchQueuePtr extends CircularQueuePtr[DispatchQueuePtr](size)
 
   // head: first valid entry (dispatched entry)
-  val headPtr = RegInit(VecInit((0 until deqnum).map(_.U.asTypeOf(new DispatchQueuePtr))))
+  val headPtr = RegInit(VecInit((0 until 2 * deqnum).map(_.U.asTypeOf(new DispatchQueuePtr))))
+  val headPtrNext = Wire(Vec(2 * deqnum, new DispatchQueuePtr))
   val headPtrMask = UIntToMask(headPtr(0).value, size)
   val headPtrOH = RegInit(1.U(size.W))
   val headPtrOHShift = CircularShift(headPtrOH)
@@ -83,13 +85,19 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
    */
   // enqueue: from s_invalid to s_valid
   io.enq.canAccept := canEnqueue
-  val enqIndexOH = (0 until enqnum).map(i => tailPtrOHVec(PopCount(io.enq.needAlloc.take(i))))
+  val enqOffset = (0 until enqnum).map(i => PopCount(io.enq.needAlloc.take(i)))
+  val enqIndexOH = (0 until enqnum).map(i => tailPtrOHVec(enqOffset(i)))
   for (i <- 0 until size) {
     val validVec = io.enq.req.map(_.valid).zip(enqIndexOH).map{ case (v, oh) => v && oh(i) }
     when (VecInit(validVec).asUInt.orR && canEnqueue) {
-      data(i) := Mux1H(validVec, io.enq.req.map(_.bits))
+      robIdxEntries(i) := Mux1H(validVec, io.enq.req.map(_.bits.robIdx))
       stateEntries(i) := s_valid
     }
+  }
+  for (i <- 0 until enqnum) {
+    dataModule.io.wen(i) := canEnqueue && io.enq.req(i).valid
+    dataModule.io.waddr(i) := tailPtr(enqOffset(i)).value
+    dataModule.io.wdata(i) := io.enq.req(i).bits
   }
 
   // dequeue: from s_valid to s_dispatched
@@ -103,14 +111,13 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
   // redirect: cancel uops currently in the queue
   val needCancel = Wire(Vec(size, Bool()))
   for (i <- 0 until size) {
-    needCancel(i) := stateEntries(i) =/= s_invalid && data(i).robIdx.needFlush(io.redirect)
+    needCancel(i) := stateEntries(i) =/= s_invalid && robIdxEntries(i).needFlush(io.redirect)
 
     when(needCancel(i)) {
       stateEntries(i) := s_invalid
     }
 
-    XSInfo(needCancel(i), p"valid entry($i)(pc = ${Hexadecimal(data(i).cf.pc)}) " +
-      p"robIndex ${data(i).robIdx} " +
+    XSInfo(needCancel(i), p"valid entry($i): robIndex ${robIdxEntries(i)} " +
       p"cancelled with redirect robIndex 0x${Hexadecimal(io.redirect.bits.robIdx.asUInt)}\n")
   }
 
@@ -123,21 +130,28 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
 
   // dequeue
   val currentValidCounter = distanceBetween(tailPtr(0), headPtr(0))
-  val numDeqTry = Mux(currentValidCounter > deqnum.U, deqnum.U, currentValidCounter)
-  val numDeqFire = PriorityEncoder(io.deq.zipWithIndex.map { case (deq, i) =>
+  val numDeqTryMask = Mux(currentValidCounter >= deqnum.U,
+    // all deq are valid
+    (1 << deqnum).U,
+    // only the valid bits are set
+    UIntToOH(currentValidCounter, deqnum)
+  )
+  val deqEnable_n = io.deq.zipWithIndex.map { case (deq, i) =>
     // For dequeue, the first entry should never be s_invalid
     // Otherwise, there should be a redirect and tail walks back
     // in this case, we set numDeq to 0
-    !deq.fire && (if (i == 0) true.B else stateEntries(headPtr(i).value) =/= s_invalid)
-  } :+ true.B)
-  val numDeq = Mux(numDeqTry > numDeqFire, numDeqFire, numDeqTry)
+    if (i == 0) !deq.fire || numDeqTryMask(i)
+    // When the state is s_invalid, we set deqEnable_n to false.B because
+    // the entry may leave earlier and require to move forward the deqPtr.
+    else (!deq.fire && stateEntries(headPtr(i).value) =/= s_invalid) || numDeqTryMask(i)
+  } :+ true.B
+  val numDeq = PriorityEncoder(deqEnable_n)
   // agreement with reservation station: don't dequeue when redirect.valid
-  val nextHeadPtr = Wire(Vec(deqnum, new DispatchQueuePtr))
-  for (i <- 0 until deqnum) {
-    nextHeadPtr(i) := Mux(io.redirect.valid, headPtr(i), headPtr(i) + numDeq)
-    headPtr(i) := nextHeadPtr(i)
+  for (i <- 0 until 2 * deqnum) {
+    headPtrNext(i) := Mux(io.redirect.valid, headPtr(i), headPtr(i) + numDeq)
   }
-  headPtrOH := Mux(io.redirect.valid, headPtrOH, headPtrOHVec(numDeq))
+  headPtr := headPtrNext
+  headPtrOH := Mux(io.redirect.valid, headPtrOH, ParallelPriorityMux(deqEnable_n, headPtrOHVec))
   XSError(headPtrOH =/= headPtr.head.toOH, p"head: $headPtrOH != UIntToOH(${headPtr.head})")
 
   // For branch mis-prediction or memory violation replay,
@@ -186,13 +200,34 @@ class DispatchQueue(size: Int, enqnum: Int, deqnum: Int)(implicit p: Parameters)
   allowEnqueue := Mux(currentValidCounter > (size - enqnum).U, false.B, numEnq <= (size - enqnum).U - currentValidCounter)
 
   /**
-   * Part 3: set output and input
+   * Part 3: set output valid and data bits
    */
+  val deqData = Reg(Vec(deqnum, new MicroOp))
+  // How to pipeline the data read:
+  // T: get the required read data
   for (i <- 0 until deqnum) {
-    io.deq(i).bits := Mux1H(headPtrOHVec(i), data)
+    io.deq(i).bits := deqData(i)
     // do not dequeue when io.redirect valid because it may cause dispatchPtr work improperly
     io.deq(i).valid := Mux1H(headPtrOHVec(i), stateEntries) === s_valid && !lastCycleMisprediction
   }
+  // T-1: select data from the following (deqnum + 1 + numEnq) sources with priority
+  // For data(i): (1) current output (deqnum - i); (2) next-step data (i + 1)
+  // For the next-step data(i): (1) enqueue data (enqnum); (2) data from storage (1)
+  val nextStepData = Wire(Vec(2 * deqnum, new MicroOp))
+  for (i <- 0 until 2 * deqnum) {
+    val enqBypassEnVec = VecInit(io.enq.needAlloc.zipWithIndex.map{ case (v, j) =>
+      v && dataModule.io.waddr(j) === headPtr(i).value
+    })
+    val enqBypassEn = io.enq.canAccept && enqBypassEnVec.asUInt.orR
+    val enqBypassData = Mux1H(enqBypassEnVec, io.enq.req.map(_.bits))
+    val readData = if (i < deqnum) deqData(i) else dataModule.io.rdata(i - deqnum)
+    nextStepData(i) := Mux(enqBypassEn, enqBypassData, readData)
+  }
+  when (!io.redirect.valid) {
+    deqData := (0 until deqnum).map(i => ParallelPriorityMux(deqEnable_n, nextStepData.drop(i).take(deqnum + 1)))
+  }
+  // T-2: read data from storage: next
+  dataModule.io.raddr := headPtrNext.drop(deqnum).map(_.value)
 
   // debug: dump dispatch queue states
   XSDebug(p"head: ${headPtr(0)}, tail: ${tailPtr(0)}\n")


### PR DESCRIPTION
This commit makes copies of dispatch2 in CtrlBlock to avoid long
cross-module timing loop paths. Should be good for timing.