### PR TITLE
dcache,ldu: simplify load issue ready logic

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -484,13 +484,19 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   //----------------------------------------
   // tag array
   require(tagArray.io.read.size == (ldu.size + 1))
+  val tag_write_intend = missQueue.io.refill_pipe_req.valid || mainPipe.io.tag_write_intend
+  assert(!RegNext(!tag_write_intend && tagArray.io.write.valid))
   ldu.zipWithIndex.foreach {
     case (ld, i) =>
       tagArray.io.read(i) <> ld.io.tag_read
       ld.io.tag_resp := tagArray.io.resp(i)
+      ld.io.tag_read.ready := !tag_write_intend
   }
   tagArray.io.read.last <> mainPipe.io.tag_read
   mainPipe.io.tag_resp := tagArray.io.resp.last
+
+  val fake_tag_read_conflict_this_cycle = PopCount(ldu.map(ld=> ld.io.tag_read.valid))
+  XSPerfAccumulate("fake_tag_read_conflict", fake_tag_read_conflict_this_cycle)
 
   val tag_write_arb = Module(new Arbiter(new TagWriteReq, 2))
   tag_write_arb.io.in(0) <> refillPipe.io.tag_write

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -125,6 +125,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents {
     val tag_read = DecoupledIO(new TagReadReq)
     val tag_resp = Input(Vec(nWays, UInt(encTagBits.W)))
     val tag_write = DecoupledIO(new TagWriteReq)
+    val tag_write_intend = Output(new Bool())
 
     // update state vec in replacement algo
     val replace_access = ValidIO(new ReplacementAccessBundle)
@@ -695,6 +696,12 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents {
   io.tag_write.bits.idx := s3_idx
   io.tag_write.bits.way_en := s3_way_en
   io.tag_write.bits.tag := get_tag(s3_req.addr)
+
+  io.tag_write_intend := s3_req.miss && s3_valid
+  XSPerfAccumulate("fake_tag_write_intend", io.tag_write_intend && !io.tag_write.valid)
+  XSPerfAccumulate("mainpipe_tag_write", io.tag_write.valid)
+
+  assert(!RegNext(io.tag_write.valid && !io.tag_write_intend))
 
   io.data_write.valid := s3_valid && s3_update_data_cango && update_data
   io.data_write.bits.way_en := s3_way_en


### PR DESCRIPTION
Now we use tag_write_intend to generate ready signal for load issue

It should remove the critical path from dcacheReq.ready to rs