### PR TITLE
dtlb: merge duplicated tlb together: one ld-tlb and one st-tlb.

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -131,7 +131,7 @@ class MinimalConfig(n: Int = 1) extends Config(
           superNWays = 4,
           normalAsVictim = true,
           partialStaticPMP = true,
-          outReplace = true
+          outReplace = false
         ),
         sttlbParameters = TLBParameters(
           name = "sttlb",
@@ -142,7 +142,7 @@ class MinimalConfig(n: Int = 1) extends Config(
           normalAsVictim = true,
           superNWays = 4,
           partialStaticPMP = true,
-          outReplace = true
+          outReplace = false
         ),
         btlbParameters = TLBParameters(
           name = "btlb",

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -189,7 +189,7 @@ case class XSCoreParameters
     normalReplacer = Some("setplru"),
     superNWays = 8,
     normalAsVictim = true,
-    outReplace = true,
+    outReplace = false,
     partialStaticPMP = true,
     saveLevel = true
   ),
@@ -201,7 +201,7 @@ case class XSCoreParameters
     normalReplacer = Some("setplru"),
     superNWays = 8,
     normalAsVictim = true,
-    outReplace = true,
+    outReplace = false,
     partialStaticPMP = true,
     saveLevel = true
   ),
@@ -351,7 +351,7 @@ trait HasXSParameter {
     }.reduce(_++_) ++
       Set[FoldedHistoryInfo]((UbtbGHRLength, log2Ceil(UbtbSize)))
     ).toList
-  
+
 
 
   val CacheLineSize = coreParams.CacheLineSize
@@ -410,7 +410,7 @@ trait HasXSParameter {
   val dcacheParameters = coreParams.dcacheParametersOpt.getOrElse(DCacheParameters())
 
   // dcache block cacheline when lr for LRSCCycles - LRSCBackOff cycles
-  // for constrained LR/SC loop 
+  // for constrained LR/SC loop
   val LRSCCycles = 64
   // for lr storm
   val LRSCBackOff = 8

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -334,11 +334,11 @@ class ReplaceIO(Width: Int, nSets: Int, nWays: Int)(implicit p: Parameters) exte
   val chosen_set = Flipped(Output(UInt(log2Up(nSets).W)))
 
   def apply_sep(in: Seq[ReplaceIO], vpn: UInt): Unit = {
-    for (i <- 0 until Width) {
-      this.access(i) := in(i).access(0)
-      this.chosen_set := get_set_idx(vpn, nSets)
-      in(i).refillIdx := this.refillIdx
+    for ((ac_rep, ac_tlb) <- access.zip(in.map(a => a.access.map(b => b)).flatten)) {
+      ac_rep := ac_tlb
     }
+    this.chosen_set := get_set_idx(vpn, nSets)
+    in.map(a => a.refillIdx := this.refillIdx)
   }
 }
 

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -172,10 +172,9 @@ class TLBSA(
 
   io.r.req.map(_.ready :=  true.B)
   val v = RegInit(VecInit(Seq.fill(nSets)(VecInit(Seq.fill(nWays)(false.B)))))
+  val entries = Module(new SyncDataModuleTemplate(new TlbEntry(normalPage, superPage), nSets, ports, 1))
 
   for (i <- 0 until ports) { // duplicate sram
-    val entries = Module(new SyncDataModuleTemplate(new TlbEntry(normalPage, superPage), nSets, ports, 1))
-
     val req = io.r.req(i)
     val resp = io.r.resp(i)
     val access = io.access(i)
@@ -196,9 +195,7 @@ class TLBSA(
     resp.bits.perm := data.perm
     io.r.resp_hit_sameCycle(i) := DontCare
 
-    resp.valid := {
-      RegNext(req.valid)
-    }
+    resp.valid := { RegNext(req.valid) }
     resp.bits.hit.suggestName("hit")
     resp.bits.ppn.suggestName("ppn")
     resp.bits.perm.suggestName("perm")
@@ -206,15 +203,15 @@ class TLBSA(
     access.sets := get_set_idx(vpn_reg, nSets) // no use
     access.touch_ways.valid := resp.valid && hit
     access.touch_ways.bits := 1.U // TODO: set-assoc need no replacer when nset is 1
-
-    entries.io.wen(0) := io.w.valid || io.victim.in.valid
-    entries.io.waddr(0) := Mux(io.w.valid,
-      get_set_idx(io.w.bits.data.entry.tag, nSets),
-      get_set_idx(io.victim.in.bits.entry.tag, nSets))
-    entries.io.wdata(0) := Mux(io.w.valid,
-      (Wire(new TlbEntry(normalPage, superPage)).apply(io.w.bits.data, io.csr.satp.asid, io.w.bits.data_replenish)),
-      io.victim.in.bits.entry)
   }
+
+  entries.io.wen(0) := io.w.valid || io.victim.in.valid
+  entries.io.waddr(0) := Mux(io.w.valid,
+    get_set_idx(io.w.bits.data.entry.tag, nSets),
+    get_set_idx(io.victim.in.bits.entry.tag, nSets))
+  entries.io.wdata(0) := Mux(io.w.valid,
+    (Wire(new TlbEntry(normalPage, superPage)).apply(io.w.bits.data, io.csr.satp.asid, io.w.bits.data_replenish)),
+    io.victim.in.bits.entry)
 
   when (io.victim.in.valid) {
     v(get_set_idx(io.victim.in.bits.entry.tag, nSets))(io.w.bits.wayIdx) := true.B


### PR DESCRIPTION
Old Edition:
2 ld tlb but with same entries. 2 st tlb but wih the same entries.
The 'duplicate' is used for timing optimization that each tlb can
be placed close to mem access pipeline unit.

Problem:
The duplicate tlb takes more Power/Area.

New Edition:
Only 1 ld tlb and 1 st tlb now.
If the area is not ok, may merge ld and st together.

Fix: fix some syntax bugs when changing parameters