### PR TITLE
dcache: use arbiter_with_pipereg for replace_pipe_req

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -556,7 +556,7 @@ class MissQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule wi
 
   arbiter_with_pipereg(entries.map(_.io.refill_pipe_req), io.refill_pipe_req, Some("refill_pipe_req"))
 
-  fastArbiter(entries.map(_.io.replace_pipe_req), io.replace_pipe_req, Some("replace_pipe_req"))
+  arbiter_with_pipereg(entries.map(_.io.replace_pipe_req), io.replace_pipe_req, Some("replace_pipe_req"))
 
   fastArbiter(entries.map(_.io.main_pipe_req), io.main_pipe_req, Some("main_pipe_req"))
 


### PR DESCRIPTION
replace_pipe_req is causing timing problem as vaddr in it is used to
generate mainpipe block signal. Unfortunately, vaddr from
replace_pipe_req is selected form all miss queue entries
(16 by default), which caused timing problem

refill_pipe_req will not be scheduled until dcache main pipe s3 reports
that replace_pipe_req has been finished. Thus it is legal to add a
pipe reg for replace_pipe_req

Now ALL mainpipe req candidates come from pipe reg. At the entry of
main pipe, 1 req is selected from 4 main pipe reqs, and its vaddr is
used to calcuate set block condition