### PR TITLE
ldu: optimize dcache hitvec wiring

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -356,10 +356,15 @@ class DCacheLoadIO(implicit p: Parameters) extends DCacheWordIO
   val s2_kill  = Output(Bool())
   // cycle 0: virtual address: req.addr
   // cycle 1: physical address: s1_paddr
-  val s1_paddr = Output(UInt(PAddrBits.W))
-  val s1_hit_way = Input(UInt(nWays.W))
+  val s1_paddr_dup_lsu = Output(UInt(PAddrBits.W)) // lsu side paddr
+  val s1_paddr_dup_dcache = Output(UInt(PAddrBits.W)) // dcache side paddr
   val s1_disable_fast_wakeup = Input(Bool())
   val s1_bank_conflict = Input(Bool())
+  // cycle 2: hit signal
+  val s2_hit = Input(Bool()) // hit signal for lsu, 
+
+  // debug
+  val debug_s1_hit_way = Input(UInt(nWays.W))
 }
 
 class DCacheLineIO(implicit p: Parameters) extends DCacheBundle
@@ -730,7 +735,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     case (a, u) =>
       a.valid := RegNext(u.io.lsu.req.fire()) && !u.io.lsu.s1_kill
       a.bits.idx := RegNext(get_idx(u.io.lsu.req.bits.addr))
-      a.bits.tag := get_tag(u.io.lsu.s1_paddr)
+      a.bits.tag := get_tag(u.io.lsu.s1_paddr_dup_dcache)
   }
   st_access.valid := RegNext(mainPipe.io.store_req.fire())
   st_access.bits.idx := RegNext(get_idx(mainPipe.io.store_req.bits.vaddr))

--- a/src/main/scala/xiangshan/cache/dcache/FakeDCache.scala
+++ b/src/main/scala/xiangshan/cache/dcache/FakeDCache.scala
@@ -34,7 +34,7 @@ class FakeDCache()(implicit p: Parameters) extends XSModule with HasDCacheParame
     val fakeRAM = Module(new RAMHelper(64L * 1024 * 1024 * 1024))
     fakeRAM.clk   := clock
     fakeRAM.en    := io.lsu.load(i).resp.valid && !reset.asBool
-    fakeRAM.rIdx  := RegNext((io.lsu.load(i).s1_paddr - "h80000000".U) >> 3)
+    fakeRAM.rIdx  := RegNext((io.lsu.load(i).s1_paddr_dup_dcache - "h80000000".U) >> 3)
     fakeRAM.wIdx  := 0.U
     fakeRAM.wdata := 0.U
     fakeRAM.wmask := 0.U
@@ -46,7 +46,7 @@ class FakeDCache()(implicit p: Parameters) extends XSModule with HasDCacheParame
     io.lsu.load(i).resp.bits.miss := false.B
     io.lsu.load(i).resp.bits.replay := false.B
     io.lsu.load(i).resp.bits.id := DontCare
-    io.lsu.load(i).s1_hit_way := 1.U
+    io.lsu.load(i).s2_hit := true.B
     io.lsu.load(i).s1_disable_fast_wakeup := false.B
   }
   // to LSQ

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -107,7 +107,8 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s1_valid = RegInit(false.B)
   val s1_req = RegEnable(s0_req, s0_fire)
   // in stage 1, load unit gets the physical address
-  val s1_addr = io.lsu.s1_paddr
+  val s1_paddr_dup_lsu = io.lsu.s1_paddr_dup_lsu
+  val s1_paddr_dup_dcache = io.lsu.s1_paddr_dup_dcache
   val s1_vaddr = s1_req.addr
   val s1_bank_oh = UIntToOH(addr_to_dcache_bank(s1_req.addr))
   val s1_nack = RegNext(io.nack)
@@ -124,15 +125,17 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val meta_resp = io.meta_resp
   val tag_resp = io.tag_resp.map(r => r(tagBits - 1, 0))
   def wayMap[T <: Data](f: Int => T) = VecInit((0 until nWays).map(f))
-  val s1_tag_eq_way = wayMap((w: Int) => tag_resp(w) === (get_tag(s1_addr))).asUInt
+
+  // dcache side tag match
+  val s1_tag_eq_way = wayMap((w: Int) => tag_resp(w) === (get_tag(s1_paddr_dup_dcache))).asUInt
   val s1_tag_match_way = wayMap((w: Int) => s1_tag_eq_way(w) && meta_resp(w).coh.isValid()).asUInt
   val s1_tag_match = s1_tag_match_way.orR
   assert(RegNext(!s1_valid || PopCount(s1_tag_match_way) <= 1.U), "tag should not match with more than 1 way")
 
   val s1_fake_meta = Wire(new Meta)
-//  s1_fake_meta.tag := get_tag(s1_addr)
+//  s1_fake_meta.tag := get_tag(s1_paddr_dup_dcache)
   s1_fake_meta.coh := ClientMetadata.onReset
-  val s1_fake_tag = get_tag(s1_addr)
+  val s1_fake_tag = get_tag(s1_paddr_dup_dcache)
 
   // when there are no tag match, we give it a Fake Meta
   // this simplifies our logic in s2 stage
@@ -149,7 +152,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s1_need_replacement = !s1_tag_match
   val s1_way_en = Mux(s1_need_replacement, s1_repl_way_en, s1_tag_match_way)
   val s1_coh = Mux(s1_need_replacement, s1_repl_coh, s1_hit_coh)
-  val s1_tag = Mux(s1_need_replacement, s1_repl_tag, get_tag(s1_addr))
+  val s1_tag = Mux(s1_need_replacement, s1_repl_tag, get_tag(s1_paddr_dup_dcache))
 
   // data read
   io.banked_data_read.valid := s1_fire && !s1_nack
@@ -174,7 +177,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // val s2_valid = RegEnable(next = s1_valid && !io.lsu.s1_kill, init = false.B, enable = s1_fire)
   val s2_valid = RegInit(false.B)
   val s2_req = RegEnable(s1_req, s1_fire)
-  val s2_addr = RegEnable(s1_addr, s1_fire)
+  val s2_paddr = RegEnable(s1_paddr_dup_dcache, s1_fire)
   val s2_vaddr = RegEnable(s1_vaddr, s1_fire)
   val s2_bank_oh = RegEnable(s1_bank_oh, s1_fire)
   s2_ready := true.B
@@ -187,13 +190,22 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   dump_pipeline_reqs("LoadPipe s2", s2_valid, s2_req)
 
   // hit, miss, nack, permission checking
+  // dcache side tag match
   val s2_tag_match_way = RegEnable(s1_tag_match_way, s1_fire)
   val s2_tag_match = RegEnable(s1_tag_match, s1_fire)
 
+  // lsu side tag match
+  val s2_tag_eq_way_dup_lsu = wayMap((w: Int) => RegNext(tag_resp(w)) === RegNext((get_tag(s1_paddr_dup_lsu)))).asUInt
+  val s2_tag_match_way_dup_lsu = wayMap((w: Int) => s2_tag_eq_way_dup_lsu(w) && RegNext(meta_resp(w).coh.isValid())).asUInt
+  val s2_tag_match_dup_lsu = s2_tag_match_way_dup_lsu.orR
+  val s2_hit_dup_lsu = s2_tag_match_dup_lsu
+
+  io.lsu.s2_hit := s2_hit_dup_lsu
+
   val s2_hit_meta = RegEnable(s1_hit_meta, s1_fire)
   val s2_hit_coh = RegEnable(s1_hit_coh, s1_fire)
-  val s2_has_permission = s2_hit_coh.onAccess(s2_req.cmd)._1
-  val s2_new_hit_coh = s2_hit_coh.onAccess(s2_req.cmd)._3
+  val s2_has_permission = s2_hit_coh.onAccess(s2_req.cmd)._1 // redundant
+  val s2_new_hit_coh = s2_hit_coh.onAccess(s2_req.cmd)._3 // redundant
 
   val s2_way_en = RegEnable(s1_way_en, s1_fire)
   val s2_repl_coh = RegEnable(s1_repl_coh, s1_fire)
@@ -210,7 +222,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s2_nack = s2_nack_hit || s2_nack_no_mshr || s2_nack_data
 
   val banked_data_resp = io.banked_data_resp
-  val s2_bank_addr = addr_to_dcache_bank(s2_addr)
+  val s2_bank_addr = addr_to_dcache_bank(s2_paddr)
   val banked_data_resp_word = Mux1H(s2_bank_oh, io.banked_data_resp) // io.banked_data_resp(s2_bank_addr)
   dontTouch(s2_bank_addr)
 
@@ -220,6 +232,8 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s2_flag_error = RegEnable(s1_flag_error, s1_fire)
 
   val s2_hit = s2_tag_match && s2_has_permission && s2_hit_coh === s2_new_hit_coh
+  assert(!RegNext(s2_valid && (s2_tag_match && !s2_hit)))
+  assert(!RegNext(s2_valid && (s2_hit_dup_lsu =/= s2_hit)))
 
   // only dump these signals when they are actually valid
   dump_pipeline_valids("LoadPipe s2", "s2_hit", s2_valid && s2_hit)
@@ -234,7 +248,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.miss_req.bits := DontCare
   io.miss_req.bits.source := s2_instrtype
   io.miss_req.bits.cmd := s2_req.cmd
-  io.miss_req.bits.addr := get_block_addr(s2_addr)
+  io.miss_req.bits.addr := get_block_addr(s2_paddr)
   io.miss_req.bits.vaddr := s2_vaddr
   io.miss_req.bits.way_en := s2_way_en
   io.miss_req.bits.req_coh := s2_hit_coh
@@ -254,7 +268,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // they can sit in load queue and wait for refill
   //
   // * report a miss if bank conflict is detected
-  val real_miss = !s2_hit
+  val real_miss = !s2_hit_dup_lsu
   resp.bits.miss := real_miss || io.bank_conflict_slow
   // load pipe need replay when there is a bank conflict
   resp.bits.replay := resp.bits.miss && (!io.miss_req.fire() || s2_nack) || io.bank_conflict_slow
@@ -270,7 +284,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
     resp.bits.dump()
   }
 
-  io.lsu.s1_hit_way := s1_tag_match_way
+  io.lsu.debug_s1_hit_way := s1_tag_match_way
   io.lsu.s1_disable_fast_wakeup := io.disable_ld_fast_wakeup
   io.lsu.s1_bank_conflict := io.bank_conflict_fast
   assert(RegNext(s1_ready && s2_ready), "load pipeline should never be blocked")
@@ -281,7 +295,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // report ecc error
 
   val s3_valid = RegNext(s2_valid)
-  val s3_addr = RegEnable(s2_addr, s2_fire)
+  val s3_paddr = RegEnable(s2_paddr, s2_fire)
   val s3_hit = RegEnable(s2_hit, s2_fire)
 
   val s3_data_error = io.read_error_delayed // banked_data_resp_word.error && !bank_conflict
@@ -295,7 +309,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // report tag / data / l2 error (with paddr) to bus error unit
   io.error := 0.U.asTypeOf(new L1CacheErrorInfo())
   io.error.report_to_beu := (s3_tag_error || s3_data_error) && s3_valid
-  io.error.paddr := s3_addr
+  io.error.paddr := s3_paddr
   io.error.source.tag := s3_tag_error
   io.error.source.data := s3_data_error
   io.error.source.l2 := s3_flag_error

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -169,6 +169,7 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
     val in = Flipped(Decoupled(new LsPipelineBundle))
     val out = Decoupled(new LsPipelineBundle)
     val dtlbResp = Flipped(DecoupledIO(new TlbResp(2)))
+    val lsuPAddr = Output(UInt(PAddrBits.W))
     val dcachePAddr = Output(UInt(PAddrBits.W))
     val dcacheKill = Output(Bool())
     val dcacheBankConflict = Input(Bool())
@@ -182,7 +183,8 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
   })
 
   val s1_uop = io.in.bits.uop
-  val s1_paddr = io.dtlbResp.bits.paddr(0)
+  val s1_paddr_dup_lsu = io.dtlbResp.bits.paddr(0)
+  val s1_paddr_dup_dcache = io.dtlbResp.bits.paddr(1)
   // af & pf exception were modified below.
   val s1_exception = ExceptionNO.selectByFu(io.out.bits.uop.cf.exceptionVec, lduCfg).asUInt.orR
   val s1_tlb_miss = io.dtlbResp.bits.miss
@@ -193,13 +195,14 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
 
   io.dtlbResp.ready := true.B
 
-  io.dcachePAddr := s1_paddr
+  io.lsuPAddr := s1_paddr_dup_lsu
+  io.dcachePAddr := s1_paddr_dup_dcache
   //io.dcacheKill := s1_tlb_miss || s1_exception || s1_mmio
   io.dcacheKill := s1_tlb_miss || s1_exception
   // load forward query datapath
   io.sbuffer.valid := io.in.valid && !(s1_exception || s1_tlb_miss)
   io.sbuffer.vaddr := io.in.bits.vaddr
-  io.sbuffer.paddr := s1_paddr
+  io.sbuffer.paddr := s1_paddr_dup_lsu
   io.sbuffer.uop := s1_uop
   io.sbuffer.sqIdx := s1_uop.sqIdx
   io.sbuffer.mask := s1_mask
@@ -207,7 +210,7 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
 
   io.lsq.valid := io.in.valid && !(s1_exception || s1_tlb_miss)
   io.lsq.vaddr := io.in.bits.vaddr
-  io.lsq.paddr := s1_paddr
+  io.lsq.paddr := s1_paddr_dup_lsu
   io.lsq.uop := s1_uop
   io.lsq.sqIdx := s1_uop.sqIdx
   io.lsq.sqIdxMask := DontCare // will be overwritten by sqIdxMask pre-generated in s0
@@ -216,7 +219,7 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
 
   // ld-ld violation query
   io.loadViolationQueryReq.valid := io.in.valid && !(s1_exception || s1_tlb_miss)
-  io.loadViolationQueryReq.bits.paddr := s1_paddr
+  io.loadViolationQueryReq.bits.paddr := s1_paddr_dup_lsu
   io.loadViolationQueryReq.bits.uop := s1_uop
 
   // Generate forwardMaskFast to wake up insts earlier
@@ -240,7 +243,7 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
   // if replay is detected in load_s1,
   // load inst will be canceled immediately
   io.out.valid := io.in.valid && !io.rsFeedback.valid
-  io.out.bits.paddr := s1_paddr
+  io.out.bits.paddr := s1_paddr_dup_lsu
   io.out.bits.tlbMiss := s1_tlb_miss
 
   // current ori test will cause the case of ldest == 0, below will be modifeid in the future.
@@ -539,7 +542,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper with 
   PipelineConnect(load_s0.io.out, load_s1.io.in, true.B, load_s0.io.out.bits.uop.robIdx.needFlush(io.redirect))
 
   load_s1.io.dtlbResp <> io.tlb.resp
-  io.dcache.s1_paddr <> load_s1.io.dcachePAddr
+  io.dcache.s1_paddr_dup_lsu <> load_s1.io.lsuPAddr
+  io.dcache.s1_paddr_dup_dcache <> load_s1.io.dcachePAddr
   io.dcache.s1_kill <> load_s1.io.dcacheKill
   load_s1.io.sbuffer <> io.sbuffer
   load_s1.io.lsq <> io.lsq.forward
@@ -570,10 +574,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper with 
   load_s2.io.csrCtrl <> io.csrCtrl
   load_s2.io.sentFastUop := io.fastUop.valid
 
-  // actually load s3
-  io.lsq.dcacheRequireReplay := load_s2.io.dcacheRequireReplay
-  io.lsq.delayedLoadError := load_s2.io.delayedLoadError
-
   // feedback tlb miss / dcache miss queue full
   io.feedbackSlow.bits := RegNext(load_s2.io.rsFeedback.bits)
   io.feedbackSlow.valid := RegNext(load_s2.io.rsFeedback.valid && !load_s2.io.out.bits.uop.robIdx.needFlush(io.redirect))
@@ -592,19 +592,20 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper with 
   val sqIdxMaskReg = RegNext(UIntToMask(load_s0.io.in.bits.uop.sqIdx.value, StoreQueueSize))
   io.lsq.forward.sqIdxMask := sqIdxMaskReg
 
-  // // use s2_hit_way to select data received in s1
-  // load_s2.io.dcacheResp.bits.data := Mux1H(RegNext(io.dcache.s1_hit_way), RegNext(io.dcache.s1_data))
-  // assert(load_s2.io.dcacheResp.bits.data === io.dcache.resp.bits.data)
-
+  // generate io.fastUop.valid for RS
   // now io.fastUop.valid is sent to RS in load_s2
+  val s2_dcache_hit = io.dcache.s2_hit // dcache hit dup in lsu side
+
   io.fastUop.valid := RegNext(
-    io.dcache.s1_hit_way.orR && // dcache hit
-    !io.dcache.s1_disable_fast_wakeup &&  // load fast wakeup should be disabled when dcache data read is not ready
-    load_s1.io.in.valid && // valid laod request
-    !load_s1.io.dtlbResp.bits.fast_miss && // not mmio or tlb miss, pf / af not included here
-    !io.lsq.forward.dataInvalidFast && // forward failed
-    !load_s1.io.needLdVioCheckRedo // load-load violation check: load paddr cam struct hazard
-  ) && !RegNext(load_s1.io.out.bits.uop.robIdx.needFlush(io.redirect))
+      !io.dcache.s1_disable_fast_wakeup &&  // load fast wakeup should be disabled when dcache data read is not ready
+      load_s1.io.in.valid && // valid load request
+      !load_s1.io.dtlbResp.bits.fast_miss && // not mmio or tlb miss, pf / af not included here
+      !io.lsq.forward.dataInvalidFast && // forward failed
+      !load_s1.io.needLdVioCheckRedo // load-load violation check: load paddr cam struct hazard
+    ) && 
+    !RegNext(load_s1.io.out.bits.uop.robIdx.needFlush(io.redirect)) &&
+    s2_dcache_hit // dcache hit in lsu side
+  
   io.fastUop.bits := RegNext(load_s1.io.out.bits.uop)
 
   XSDebug(load_s0.io.out.valid,
@@ -637,6 +638,10 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper with 
   hitLoadOut.bits.fflags := DontCare
 
   load_s2.io.out.ready := true.B
+
+  // load s3
+  io.lsq.dcacheRequireReplay := load_s2.io.dcacheRequireReplay
+  io.lsq.delayedLoadError := load_s2.io.delayedLoadError
 
   val load_wb_reg = RegNext(Mux(hitLoadOut.valid, hitLoadOut.bits, io.lsq.ldout.bits))
   io.ldout.bits := load_wb_reg


### PR DESCRIPTION
In previous design, hitvec is generated in load s1, then send to dcache
and lsu (rs) side separately. As dcache and lsu (rs side) is far in real
chip, it caused severe wiring problem.

Now we generate 2 hitvec in parallel:

* hitvec 1 is generated near dcache.
To generate that signal, paddr from dtlb is sent to dcache in load_s1
to geerate hitvec. The hitvec is then sent to dcache to generate
data array read_way_en.

* hitvec 2 is generated near lsu and rs in load_s2, tag read result
from dcache, as well as coh_state, is sent to lsu in load_s1,
then it is used to calcuate hitvec in load_s2.  hitvec 2 is used
to generate hit/miss signal used by lsu.

It should fix the wiring problem caused by hitvec