### PR TITLE
ldu: update lq correctly when replay_from_fetch

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -127,9 +127,6 @@ class CtrlFlow(implicit p: Parameters) extends XSBundle {
   val ssid = UInt(SSIDWidth.W)
   val ftqPtr = new FtqPtr
   val ftqOffset = UInt(log2Up(PredictWidth).W)
-  // This inst will flush all the pipe when it is the oldest inst in ROB,
-  // then replay from this inst itself
-  val replayInst = Bool()
 }
 
 

--- a/src/main/scala/xiangshan/frontend/Ibuffer.scala
+++ b/src/main/scala/xiangshan/frontend/Ibuffer.scala
@@ -82,7 +82,6 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
     cf.ssid := DontCare
     cf.ftqPtr := ftqPtr
     cf.ftqOffset := ftqOffset
-    cf.replayInst := false.B
     cf
   }
 }

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -668,8 +668,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper with 
     RegNext(io.csrCtrl.ldld_vio_check_enable)
   )
   val s3_need_replay_from_fetch = s3_forward_fail || s3_ldld_violation
-  val s3_can_replay_from_fetch = RegEnable(load_s2.io.s2_can_replay_from_fetch, hitLoadOut.valid)
-  when (RegNext(hitLoadOut.valid)) {
+  val s3_can_replay_from_fetch = RegEnable(load_s2.io.s2_can_replay_from_fetch, load_s2.io.out.valid)
+  when (RegNext(load_s2.io.out.valid)) {
     io.ldout.bits.uop.ctrl.replayInst := s3_need_replay_from_fetch
   }
 


### PR DESCRIPTION
uop.ctrl.replayInst in lq should be replayed when load_s2 update lq
i.e. load_s2.io.out.valid

This commit fixes bug introduced by #1685 