### PR TITLE
dcache: duplicate registers for better fanout

### DIFF
--- a/src/main/scala/xiangshan/cache/CacheInstruction.scala
+++ b/src/main/scala/xiangshan/cache/CacheInstruction.scala
@@ -142,6 +142,9 @@ class CSRCacheOpDecoder(decoder_name: String, id: Int)(implicit p: Parameters) e
     val csr = new L1CacheToCsrIO
     val cache = new L1CacheInnerOpIO
     val cache_req_dup_0 = Valid(new CacheCtrlReqInfo)
+    val cache_req_dup_1 = Valid(new CacheCtrlReqInfo)
+    val cacheOp_req_bits_opCode_dup_0 = Output(UInt(XLEN.W))
+    val cacheOp_req_bits_opCode_dup_1 = Output(UInt(XLEN.W))
     val error = Flipped(new L1CacheErrorInfo)
   })
 
@@ -157,6 +160,7 @@ class CSRCacheOpDecoder(decoder_name: String, id: Int)(implicit p: Parameters) e
   // Translate CSR write to cache op
   val translated_cache_req = Reg(new CacheCtrlReqInfo)
   val translated_cache_req_opCode_dup_0 = Reg(UInt(XLEN.W))
+  val translated_cache_req_opCode_dup_1 = Reg(UInt(XLEN.W))
   println("Cache op decoder (" + decoder_name + "):")
   println("  Id " + id)
   // CacheInsRegisterList.map{case (name, attribute) => {
@@ -179,6 +183,7 @@ class CSRCacheOpDecoder(decoder_name: String, id: Int)(implicit p: Parameters) e
 
   update_cache_req_when_write("CACHE_OP", translated_cache_req.opCode)
   update_cache_req_when_write("CACHE_OP", translated_cache_req_opCode_dup_0)
+  update_cache_req_when_write("CACHE_OP", translated_cache_req_opCode_dup_1)
   update_cache_req_when_write("CACHE_LEVEL", translated_cache_req.level)
   update_cache_req_when_write("CACHE_WAY", translated_cache_req.wayNum)
   update_cache_req_when_write("CACHE_IDX", translated_cache_req.index)
@@ -204,11 +209,16 @@ class CSRCacheOpDecoder(decoder_name: String, id: Int)(implicit p: Parameters) e
   // Send cache op to cache
   io.cache.req.valid := RegNext(cache_op_start)
   io.cache_req_dup_0.valid := RegNext(cache_op_start)
+  io.cache_req_dup_1.valid := RegNext(cache_op_start)
   io.cache.req.bits := translated_cache_req
   io.cache_req_dup_0.bits := translated_cache_req
+  io.cache_req_dup_1.bits := translated_cache_req
   when(io.cache.req.fire()){
     wait_cache_op_resp := true.B
   }
+
+  io.cacheOp_req_bits_opCode_dup_0 := translated_cache_req_opCode_dup_0
+  io.cacheOp_req_bits_opCode_dup_1 := translated_cache_req_opCode_dup_1
 
   // Receive cache op resp from cache
   val raw_cache_resp = Reg(new CacheCtrlRespInfo)

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -180,6 +180,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s2_paddr = RegEnable(s1_paddr_dup_dcache, s1_fire)
   val s2_vaddr = RegEnable(s1_vaddr, s1_fire)
   val s2_bank_oh = RegEnable(s1_bank_oh, s1_fire)
+  val s2_bank_oh_dup_0 = RegEnable(s1_bank_oh, s1_fire)
   s2_ready := true.B
 
   val s2_fire = s2_valid
@@ -224,6 +225,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val banked_data_resp = io.banked_data_resp
   val s2_bank_addr = addr_to_dcache_bank(s2_paddr)
   val banked_data_resp_word = Mux1H(s2_bank_oh, io.banked_data_resp) // io.banked_data_resp(s2_bank_addr)
+  val banked_data_resp_word_dup_0 = Mux1H(s2_bank_oh_dup_0, io.banked_data_resp) // io.banked_data_resp(s2_bank_addr)
   dontTouch(s2_bank_addr)
 
   val s2_instrtype = s2_req.instrtype
@@ -262,6 +264,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   resp.bits := DontCare
   // resp.bits.data := s2_word_decoded
   resp.bits.data := banked_data_resp_word.raw_data
+  resp.bits.data_dup_0 := banked_data_resp_word_dup_0.raw_data
   // * on miss or nack, upper level should replay request
   // but if we successfully sent the request to miss queue
   // upper level does not need to replay request

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -459,10 +459,10 @@ class MissQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule wi
     val mem_finish = DecoupledIO(new TLBundleE(edge.bundle))
 
     val refill_pipe_req = DecoupledIO(new RefillPipeReq)
-    val refill_pipe_req_dup_0 = Output(new RefillPipeReq)
-    val refill_pipe_req_dup_1 = Output(new RefillPipeReq)
-    val refill_pipe_req_dup_2 = Output(new RefillPipeReq)
-    val refill_pipe_req_dup_3 = Output(new RefillPipeReq)
+    val refill_pipe_req_dup_0 = Output(Valid(new RefillPipeReq))
+    val refill_pipe_req_dup_1 = Output(Valid(new RefillPipeReq))
+    val refill_pipe_req_dup_2 = Output(Valid(new RefillPipeReq))
+    val refill_pipe_req_dup_3 = Output(Valid(new RefillPipeReq))
     val refill_pipe_resp = Flipped(ValidIO(UInt(log2Up(cfg.nMissEntries).W)))
 
     val replace_pipe_req = DecoupledIO(new MainPipeReq)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/RefillPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/RefillPipe.scala
@@ -43,10 +43,10 @@ class RefillPipeReq(implicit p: Parameters) extends DCacheBundle {
 class RefillPipe(implicit p: Parameters) extends DCacheModule {
   val io = IO(new Bundle() {
     val req = Flipped(DecoupledIO(new RefillPipeReq))
-    val req_dup_0 = Input(new RefillPipeReq)
-    val req_dup_1 = Input(new RefillPipeReq)
-    val req_dup_2 = Input(new RefillPipeReq)
-    val req_dup_3 = Input(new RefillPipeReq)
+    val req_dup_0 = Input(Valid(new RefillPipeReq))
+    val req_dup_1 = Input(Valid(new RefillPipeReq))
+    val req_dup_2 = Input(Valid(new RefillPipeReq))
+    val req_dup_3 = Input(Valid(new RefillPipeReq))
     val resp = ValidIO(UInt(log2Up(cfg.nMissEntries).W))
 
     val data_write = DecoupledIO(new L1BankedDataWriteReq)
@@ -65,10 +65,10 @@ class RefillPipe(implicit p: Parameters) extends DCacheModule {
   val refill_w_valid = io.req.valid
   val refill_w_req = io.req.bits
 
-  val req_dup_0 = io.req_dup_0
-  val req_dup_1 = io.req_dup_1
-  val req_dup_2 = io.req_dup_2
-  val req_dup_3 = io.req_dup_3
+  val req_dup_0 = io.req_dup_0.bits
+  val req_dup_1 = io.req_dup_1.bits
+  val req_dup_2 = io.req_dup_2.bits
+  val req_dup_3 = io.req_dup_3.bits
 
   io.req.ready := true.B
   io.resp.valid := io.req.fire()
@@ -77,23 +77,23 @@ class RefillPipe(implicit p: Parameters) extends DCacheModule {
   val idx = refill_w_req.idx
   val tag = get_tag(refill_w_req.addr)
 
-  io.data_write.valid := refill_w_valid
+  io.data_write.valid := io.req_dup_0.valid
   io.data_write.bits.addr := req_dup_0.paddrWithVirtualAlias
   io.data_write.bits.way_en := req_dup_0.way_en
   io.data_write.bits.wmask := refill_w_req.wmask
   io.data_write.bits.data := refill_w_req.data
 
-  io.meta_write.valid := refill_w_valid
+  io.meta_write.valid := io.req_dup_1.valid
   io.meta_write.bits.idx := req_dup_1.idx
   io.meta_write.bits.way_en := req_dup_1.way_en
   io.meta_write.bits.meta := refill_w_req.meta
 
-  io.error_flag_write.valid := refill_w_valid
+  io.error_flag_write.valid := io.req_dup_2.valid
   io.error_flag_write.bits.idx := req_dup_2.idx
   io.error_flag_write.bits.way_en := req_dup_2.way_en
   io.error_flag_write.bits.error := refill_w_req.error
 
-  io.tag_write.valid := refill_w_valid
+  io.tag_write.valid := io.req_dup_3.valid
   io.tag_write.bits.idx := req_dup_3.idx
   io.tag_write.bits.way_en := req_dup_3.way_en
   io.tag_write.bits.tag := tag

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -374,7 +374,12 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
 
   // data merge
   val rdataVec = VecInit((0 until XLEN / 8).map(j =>
-    Mux(forwardMask(j), forwardData(j), io.dcacheResp.bits.data(8*(j+1)-1, 8*j))))
+    if(j < XLEN / 16) {
+      Mux(forwardMask(j), forwardData(j), io.dcacheResp.bits.data(8*(j+1)-1, 8*j))
+    }else {
+      Mux(forwardMask(j), forwardData(j), io.dcacheResp.bits.data_dup_0(8*(j+1)-1, 8*j))
+    }
+    ))
   val rdata = rdataVec.asUInt
   val rdataSel = LookupTree(s2_paddr(2, 0), List(
     "b000".U -> rdata(63, 0),


### PR DESCRIPTION
* pipelineReg and pipelineReg_valid in miss queue
* translated_cache_req_opCode and io_cache_req_valid_reg in cacheOpDecoder
* r_way_en_reg in bankedDataArray
* s2_bank_oh_reg in loadPipe which wires to loadUnit