### PR TITLE
sim: add bosc_trap signal in XSTop

### DIFF
--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -142,6 +142,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc() with HasSoCParameter
       val debug_reset = Output(Bool())
       val cacheable_check = new TLPMAIO()
       val riscv_halt = Output(Vec(NumCores, Bool()))
+      val bosc_trap = Output(Vec(NumCores, Bool()))
     })
 
     val reset_sync = withClockAndReset(io.clock.asClock, io.reset) { ResetGen() }
@@ -168,6 +169,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc() with HasSoCParameter
     for ((core, i) <- core_with_l2.zipWithIndex) {
       core.module.io.hartId := i.U
       io.riscv_halt(i) := core.module.io.cpu_halt
+      io.bosc_trap(i) := core.module.io.cpu_trap
     }
 
     if(l3cacheOpt.isEmpty || l3cacheOpt.get.rst_nodes.isEmpty){

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -246,6 +246,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   val io = IO(new Bundle {
     val hartId = Input(UInt(64.W))
     val cpu_halt = Output(Bool())
+    val cpu_trap = Output(Bool())
     val l2_pf_enable = Output(Bool())
     val perfEvents = Input(Vec(numPCntHc * coreParams.L2NBanks, new PerfEvent))
     val beu_errors = Output(new XSL1BusErrors())
@@ -267,6 +268,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   outer.wbArbiter.module.io.hartId := io.hartId
 
   io.cpu_halt := ctrlBlock.io.cpu_halt
+  io.cpu_trap := ctrlBlock.io.cpu_trap
 
   outer.wbArbiter.module.io.redirect <> ctrlBlock.io.redirect
   val allWriteback = exuBlocks.flatMap(_.io.fuWriteback) ++ memBlock.io.writeback

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -144,6 +144,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
     val io = IO(new Bundle {
       val hartId = Input(UInt(64.W))
       val cpu_halt = Output(Bool())
+      val cpu_trap = Output(Bool())
     })
 
     dontTouch(io.hartId)
@@ -152,6 +153,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
 
     core.module.io.hartId := io.hartId
     io.cpu_halt := core.module.io.cpu_halt
+    io.cpu_trap := core.module.io.cpu_trap
     if(l2cache.isDefined){
       core.module.io.perfEvents.zip(l2cache.get.module.io.perfEvents.flatten).foreach(x => x._1.value := x._2)
     }

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -202,6 +202,7 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
   val io = IO(new Bundle {
     val hartId = Input(UInt(8.W))
     val cpu_halt = Output(Bool())
+    val cpu_trap = Output(Bool())
     val frontend = Flipped(new FrontendToCtrlIO)
     // to exu blocks
     val allocPregs = Vec(RenameWidth, Output(new ResetPregStateReq))
@@ -502,6 +503,7 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
 
   rob.io.hartId := io.hartId
   io.cpu_halt := DelayN(rob.io.cpu_halt, 5)
+  io.cpu_trap := DelayN(rob.io.cpu_trap, 5)
   rob.io.redirect <> stage2Redirect
   outer.rob.generateWritebackIO(Some(outer), Some(this))
 

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -286,6 +286,7 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
     val csr = new RobCSRIO
     val robFull = Output(Bool())
     val cpu_halt = Output(Bool())
+    val cpu_trap = Output(Bool())
   })
 
   def selectWb(index: Int, func: Seq[ExuConfig] => Boolean): Seq[(Seq[ExuConfig], ValidIO[ExuOutput])] = {
@@ -1104,6 +1105,7 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
     difftest.io.cycleCnt := timer
     difftest.io.instrCnt := instrCnt
     difftest.io.hasWFI   := hasWFI
+    io.cpu_trap := RegNext(hitTrap)
   }
   else if (env.AlwaysBasicDiff) {
     val dt_isXSTrap = Mem(RobSize, Bool())
@@ -1120,6 +1122,7 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
     difftest.io.valid    := hitTrap
     difftest.io.cycleCnt := timer
     difftest.io.instrCnt := instrCnt
+    io.cpu_trap := RegNext(hitTrap)
   }
 
   val validEntries = PopCount((0 until RobSize).map(valid(_)))


### PR DESCRIPTION
bosc_trap signal is used in simulation to check if core has hit xstrap