### PR TITLE
dcache: only update wbq addr when allocate

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -1224,8 +1224,6 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents {
     ) && need_wb
 
   io.wb.bits.addr := get_block_addr(Cat(s3_tag, get_untag(s3_req.vaddr)))
-  io.wb.bits.addr_dup_0 := get_block_addr(Cat(s3_tag, get_untag(s3_req_vaddr_dup_for_wb)))
-  io.wb.bits.addr_dup_1 := get_block_addr(Cat(s3_tag, get_untag(s3_req_vaddr_dup_for_wb)))
   io.wb.bits.param := writeback_param
   io.wb.bits.voluntary := s3_req_miss_dup(9) || s3_req_replace_dup(5)
   io.wb.bits.hasData := writeback_data

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
@@ -24,10 +24,7 @@ import freechips.rocketchip.tilelink.{TLArbiter, TLBundleC, TLBundleD, TLEdgeOut
 import huancun.DirtyKey
 import utils.{HasPerfEvents, HasTLDump, XSDebug, XSPerfAccumulate}
 
-class WritebackReqWodata(implicit p: Parameters) extends DCacheBundle {
-  val addr = UInt(PAddrBits.W)
-  val addr_dup_0 = UInt(PAddrBits.W)
-  val addr_dup_1 = UInt(PAddrBits.W)
+class WritebackReqCtrl(implicit p: Parameters) extends DCacheBundle {
   val param  = UInt(cWidth.W)
   val voluntary = Bool()
   val hasData = Bool()
@@ -35,6 +32,10 @@ class WritebackReqWodata(implicit p: Parameters) extends DCacheBundle {
 
   val delay_release = Bool()
   val miss_id = UInt(log2Up(cfg.nMissEntries).W)
+}
+
+class WritebackReqWodata(implicit p: Parameters) extends WritebackReqCtrl {
+  val addr = UInt(PAddrBits.W)
 
   def dump() = {
     XSDebug("WritebackReq addr: %x param: %d voluntary: %b hasData: %b\n",
@@ -57,8 +58,17 @@ class WritebackReq(implicit p: Parameters) extends WritebackReqWodata {
   def toWritebackReqWodata(): WritebackReqWodata = {
     val out = Wire(new WritebackReqWodata)
     out.addr := addr
-    out.addr_dup_0 := addr_dup_0
-    out.addr_dup_1 := addr_dup_1
+    out.param := param
+    out.voluntary := voluntary
+    out.hasData := hasData
+    out.dirty := dirty
+    out.delay_release := delay_release
+    out.miss_id := miss_id
+    out
+  }
+
+  def toWritebackReqCtrl(): WritebackReqCtrl = {
+    val out = Wire(new WritebackReqCtrl)
     out.param := param
     out.voluntary := voluntary
     out.hasData := hasData
@@ -146,6 +156,11 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
   // writeback queue data
   val data = Reg(UInt((cfg.blockBytes * 8).W))
 
+  // writeback queue paddr
+  val paddr_dup_0 = Reg(UInt(PAddrBits.W))
+  val paddr_dup_1 = Reg(UInt(PAddrBits.W))
+  val paddr_dup_2 = Reg(UInt(PAddrBits.W))
+
   // pending data write
   // !s_data_override means there is an in-progress data write
   val s_data_override = RegInit(true.B) 
@@ -155,7 +170,7 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
   // there are valid request that can be sent to release bus
   val busy = remain.orR && s_data_override && s_data_merge // have remain beats and data write finished
 
-  val req  = Reg(new WritebackReqWodata)
+  val req  = Reg(new WritebackReqCtrl)
 
   // assign default signals to output signals
   io.req.ready := false.B
@@ -163,7 +178,7 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
   io.mem_release.bits  := DontCare
   io.mem_grant.ready   := false.B
   io.block_addr.valid  := state =/= s_invalid
-  io.block_addr.bits   := req.addr
+  io.block_addr.bits   := paddr_dup_0
 
   s_data_override := true.B // data_override takes only 1 cycle
   s_data_merge := true.B // data_merge takes only 1 cycle
@@ -185,6 +200,10 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
     assert (remain === 0.U)
     req := io.req.bits
     s_data_override := false.B
+    // only update paddr when allocate a new missqueue entry
+    paddr_dup_0 := io.req.bits.addr
+    paddr_dup_1 := io.req.bits.addr
+    paddr_dup_2 := io.req.bits.addr
     when (io.req.bits.delay_release) {
       state := s_sleep
       state_dup_0 := s_sleep
@@ -207,7 +226,7 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
     // There shouldn't be a new Release with the same addr in sleep state
     assert(!(merge && io.req.bits.voluntary))
 
-    val update = io.release_update.valid && io.release_update.bits.addr === req.addr
+    val update = io.release_update.valid && io.release_update.bits.addr === paddr_dup_0
     when (update) {
       req.hasData := req.hasData || io.release_update.bits.mask_orr
       req.dirty := req.dirty || io.release_update.bits.mask_orr
@@ -252,14 +271,14 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
 
   val probeResponse = edge.ProbeAck(
     fromSource = io.id,
-    toAddress = req.addr_dup_0,
+    toAddress = paddr_dup_1,
     lgSize = log2Ceil(cfg.blockBytes).U,
     reportPermissions = req.param
   )
 
   val probeResponseData = edge.ProbeAck(
     fromSource = io.id,
-    toAddress = req.addr_dup_0,
+    toAddress = paddr_dup_1,
     lgSize = log2Ceil(cfg.blockBytes).U,
     reportPermissions = req.param,
     data = beat_data(beat)
@@ -267,14 +286,14 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
 
   val voluntaryRelease = edge.Release(
     fromSource = io.id,
-    toAddress = req.addr_dup_1,
+    toAddress = paddr_dup_2,
     lgSize = log2Ceil(cfg.blockBytes).U,
     shrinkPermissions = req.param
   )._2
 
   val voluntaryReleaseData = edge.Release(
     fromSource = io.id,
-    toAddress = req.addr_dup_1,
+    toAddress = paddr_dup_2,
     lgSize = log2Ceil(cfg.blockBytes).U,
     shrinkPermissions = req.param,
     data = beat_data(beat)
@@ -312,12 +331,8 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
     val delay_release = Bool()
     val miss_id = UInt(log2Up(cfg.nMissEntries).W)
 
-    def toWritebackReq = {
-      val r = Wire(new WritebackReq())
-      r.data := data
-      r.addr := req.addr
-      r.addr_dup_0 := req.addr_dup_0
-      r.addr_dup_1 := req.addr_dup_1
+    def toWritebackReqCtrl = {
+      val r = Wire(new WritebackReqCtrl())
       r.param := param
       r.voluntary := voluntary
       r.hasData := hasData
@@ -379,7 +394,7 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
         when (merge) {
           // Send the Release after ProbeAck
 //          state := s_release_req
-//          req := Mux(merge, io.req.bits, req_later.toWritebackReq)
+//          req := Mux(merge, io.req.bits, req_later.toWritebackReqCtrl)
 //          release_later := false.B
           state := s_sleep
           state_dup_0 := s_sleep
@@ -408,7 +423,7 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
             s_release_req,
             s_sleep
           ))
-          req := req_later.toWritebackReq
+          req := req_later.toWritebackReqCtrl
           when (io.release_wakeup.valid && io.release_wakeup.bits === req_later.miss_id) {
             req.delay_release := false.B
           }
@@ -456,7 +471,7 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
         state_dup_0 := s_release_req
         state_dup_1 := s_release_req
         state_dup_for_mp.foreach(_ := s_release_req)
-        req := req_later.toWritebackReq
+        req := req_later.toWritebackReqCtrl
         remain_set := Mux(req_later.hasData, ~0.U(refillCycles.W), 1.U(refillCycles.W))
         release_later := false.B
       }.otherwise {
@@ -476,7 +491,7 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
   //    handle this probe, so we don't need another release.
   io.primary_ready := state_dup_1 === s_invalid
   io.primary_ready_dup.zip(state_dup_for_mp).foreach { case (rdy, st) => rdy := st === s_invalid }
-  io.secondary_ready := state_dup_1 =/= s_invalid && io.req.bits.addr === req.addr
+  io.secondary_ready := state_dup_1 =/= s_invalid && io.req.bits.addr === paddr_dup_0
 
   // data update logic
   when (!s_data_merge) {


### PR DESCRIPTION
It will remove fanout from mem_release.valid releated logic