### PR TITLE
rs,mem: optimize load-load forwarding timing

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -256,7 +256,6 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     loadUnits(i).io.feedbackFast <> io.rsfeedback(i).feedbackFast
     loadUnits(i).io.rsIdx := io.rsfeedback(i).rsIdx
     loadUnits(i).io.isFirstIssue := io.rsfeedback(i).isFirstIssue // NOTE: just for dtlb's perf cnt
-    loadUnits(i).io.loadFastMatch <> io.loadFastMatch(i)
     // get input form dispatch
     loadUnits(i).io.ldin <> io.issue(i)
     // dcache access
@@ -274,10 +273,15 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     // pmp
     loadUnits(i).io.pmp <> pmp_check(i).resp
 
-    // load to load fast forward
-    for (j <- 0 until exuParameters.LduCnt) {
-      loadUnits(i).io.fastpathIn(j) <> loadUnits(j).io.fastpathOut
-    }
+    // load to load fast forward: load(i) prefers data(i)
+    val fastPriority = (i until exuParameters.LduCnt) ++ (0 until i)
+    val fastValidVec = fastPriority.map(j => loadUnits(j).io.fastpathOut.valid)
+    val fastDataVec = fastPriority.map(j => loadUnits(j).io.fastpathOut.data)
+    val fastMatchVec = fastPriority.map(j => io.loadFastMatch(i)(j))
+    loadUnits(i).io.fastpathIn.valid := VecInit(fastValidVec).asUInt.orR
+    loadUnits(i).io.fastpathIn.data := ParallelPriorityMux(fastValidVec, fastDataVec)
+    val fastMatch = ParallelPriorityMux(fastValidVec, fastMatchVec)
+    loadUnits(i).io.loadFastMatch := fastMatch
 
     // Lsq to load unit's rs
 

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -713,6 +713,7 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
     s2_deq(i).ready := !s2_deq(i).valid || io.deq(i).ready
     io.deq(i).valid := s2_deq(i).valid
     io.deq(i).bits := s2_deq(i).bits
+    io.deq(i).bits.uop.debugInfo.issueTime := GTimer()
 
     // data: send to bypass network
     // TODO: these should be done outside RS
@@ -740,41 +741,11 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
       // we reduce its latency for one cycle since it does not need to read
       // from data array. Timing to be optimized later.
       if (params.isLoad) {
-        if (EnableLoadToLoadForward) {
-          val ldFastDeq = Wire(io.deq(i).cloneType)
-          // Condition: wakeup by load (to select load wakeup bits)
-          val ldCanBeFast = VecInit(
-            wakeupBypassMask.drop(exuParameters.AluCnt).take(exuParameters.LduCnt).map(_.asUInt.orR)
-          ).asUInt
-          ldFastDeq.valid := s1_issuePtrOH(i).valid && ldCanBeFast.orR
-          ldFastDeq.ready := true.B
-          ldFastDeq.bits.src := DontCare
-          ldFastDeq.bits.uop := s1_out(i).bits.uop
-          // when last cycle load has fast issue, cancel this cycle's normal issue and let it go
-          val lastCycleLdFire = RegNext(ldFastDeq.valid && !s2_deq(i).valid && io.deq(i).ready)
-          when (lastCycleLdFire) {
-            s2_deq(i).valid := false.B
-            s2_deq(i).ready := true.B
-          }
-          // For now, we assume deq.valid has higher priority than ldFastDeq.
-          when (!s2_deq(i).valid) {
-            io.deq(i).valid := ldFastDeq.valid
-            io.deq(i).bits := ldFastDeq.bits
-            s2_deq(i).ready := true.B
-          }
-          io.load.get.fastMatch(i) := Mux(s2_deq(i).valid, 0.U, ldCanBeFast)
-          when (!s2_deq(i).valid) {
-            io.feedback.get(i).rsIdx := s1_issuePtr(i)
-            io.feedback.get(i).isFirstIssue := s1_is_first_issue(i)
-          }
-          XSPerfAccumulate(s"fast_load_deq_valid_$i", !s2_deq(i).valid && ldFastDeq.valid)
-          XSPerfAccumulate(s"fast_load_deq_fire_$i", !s2_deq(i).valid && ldFastDeq.valid && io.deq(i).ready)
-        } else {
-          io.load.get.fastMatch(i) := DontCare
-        }
+        // Condition: wakeup by load (to select load wakeup bits)
+        io.load.get.fastMatch(i) := Mux(s1_issuePtrOH(i).valid, VecInit(
+          wakeupBypassMask.drop(exuParameters.AluCnt).take(exuParameters.LduCnt).map(_.asUInt.orR)
+        ).asUInt, 0.U)
       }
-
-      io.deq(i).bits.uop.debugInfo.issueTime := GTimer()
 
       for (j <- 0 until params.numFastWakeup) {
         XSPerfAccumulate(s"source_bypass_${j}_$i", s1_out(i).fire && wakeupBypassMask(j).asUInt.orR)

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -108,8 +108,9 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s1_req = RegEnable(s0_req, s0_fire)
   // in stage 1, load unit gets the physical address
   val s1_addr = io.lsu.s1_paddr
-  val s1_vaddr = s1_req.addr
-  val s1_bank_oh = UIntToOH(addr_to_dcache_bank(s1_req.addr))
+  // LSU may update the address from io.lsu.s1_paddr, which affects the bank read enable only.
+  val s1_vaddr = Cat(s1_req.addr(PAddrBits - 1, blockOffBits), io.lsu.s1_paddr(blockOffBits - 1, 0))
+  val s1_bank_oh = UIntToOH(addr_to_dcache_bank(s1_vaddr))
   val s1_nack = RegNext(io.nack)
   val s1_nack_data = !io.banked_data_read.ready
   val s1_fire = s1_valid && s2_ready

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -394,6 +394,7 @@ class TlbResp(implicit p: Parameters) extends TlbBundle {
 
 class TlbRequestIO()(implicit p: Parameters) extends TlbBundle {
   val req = DecoupledIO(new TlbReq)
+  val req_kill = Output(Bool())
   val resp = Flipped(DecoupledIO(new TlbResp))
 }
 

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -188,6 +188,9 @@ class TLB(Width: Int, Block: Seq[Boolean], q: TLBParameters)(implicit p: Paramet
 
     val ptw_just_back = ptw.resp.fire && ptw.resp.bits.entry.hit(get_pn(req_out(idx).vaddr), asid = io.csr.satp.asid, allType = true)
     io.ptw.req(idx).valid :=  RegNext(req_out_v(idx) && missVec(idx) && !ptw_just_back, false.B) // TODO: remove the regnext, timing
+    when (RegEnable(io.requestor(idx).req_kill, RegNext(io.requestor(idx).req.fire))) {
+      io.ptw.req(idx).valid := false.B
+    }
     io.ptw.req(idx).bits.vpn := RegNext(get_pn(req_out(idx).vaddr))
   }
 

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -123,6 +123,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val (preDecoderIn, preDecoderOut)   = (preDecoder.io.in, preDecoder.io.out)
   val (checkerIn, checkerOut)         = (predChecker.io.in, predChecker.io.out)
 
+  io.iTLBInter.req_kill := false.B
   io.iTLBInter.resp.ready := true.B
 
   /**

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -113,6 +113,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   val (toMSHR, fromMSHR)  = (io.mshr.map(_.toMSHR), io.mshr.map(_.fromMSHR))
   val (toITLB, fromITLB)  = (io.itlb.map(_.req), io.itlb.map(_.resp))
   val (toPMP,  fromPMP)   = (io.pmp.map(_.req), io.pmp.map(_.resp))
+  io.itlb.foreach(_.req_kill := false.B)
 
   /** pipeline control signal */
   val s1_ready, s2_ready = Wire(Bool())
@@ -335,7 +336,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   val s2_meta_errors    = RegEnable(s1_meta_errors,    s1_fire)
   val s2_data_errorBits = RegEnable(s1_data_errorBits, s1_fire)
   val s2_data_cacheline = RegEnable(s1_data_cacheline, s1_fire)
-  
+
   val s2_data_errors    = Wire(Vec(PortNumber,Vec(nWays, Bool())))
 
   (0 until PortNumber).map{ i =>

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -77,6 +77,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
 
   val fromFtq = io.fromFtq
   val (toITLB,  fromITLB) = (io.iTLBInter.req, io.iTLBInter.resp)
+  io.iTLBInter.req_kill := false.B
   val (toIMeta, fromIMeta) = (io.toIMeta, io.fromIMeta.metaData(0))
   val (toPMP,  fromPMP)   = (io.pmp.req, io.pmp.resp)
   val toMissUnit = io.toMissUnit

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -86,6 +86,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
 
   io.dtlb.req.valid    := false.B
   io.dtlb.req.bits     := DontCare
+  io.dtlb.req_kill     := false.B
   io.dtlb.resp.ready   := true.B
 
   io.flush_sbuffer.valid := false.B

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -57,40 +57,28 @@ class LoadUnit_S0(implicit p: Parameters) extends XSModule with HasDCacheParamet
   val io = IO(new Bundle() {
     val in = Flipped(Decoupled(new ExuInput))
     val out = Decoupled(new LsPipelineBundle)
-    val fastpath = Input(Vec(LoadPipelineWidth, new LoadToLoadIO))
     val dtlbReq = DecoupledIO(new TlbReq)
     val dcacheReq = DecoupledIO(new DCacheWordReq)
     val rsIdx = Input(UInt(log2Up(IssQueSize).W))
     val isFirstIssue = Input(Bool())
-    val loadFastMatch = Input(UInt(exuParameters.LduCnt.W))
+    val fastpath = Input(new LoadToLoadIO)
+    val s0_kill = Input(Bool())
   })
   require(LoadPipelineWidth == exuParameters.LduCnt)
 
-  val s0_uop = io.in.bits.uop
-  val imm12 = WireInit(s0_uop.ctrl.imm(11,0))
-
-  val s0_vaddr = WireInit(io.in.bits.src(0) + SignExt(s0_uop.ctrl.imm(11,0), VAddrBits))
-  val s0_mask = WireInit(genWmask(s0_vaddr, s0_uop.ctrl.fuOpType(1,0)))
+  val imm12 = io.in.bits.uop.ctrl.imm(11, 0)
+  val s0_vaddr = WireInit(io.in.bits.src(0) + SignExt(imm12, VAddrBits))
+  val s0_mask = WireInit(genWmask(s0_vaddr, io.in.bits.uop.ctrl.fuOpType(1,0)))
+  val s0_uop = WireInit(io.in.bits.uop)
 
   if (EnableLoadToLoadForward) {
-    // slow vaddr from non-load insts
-    val slowpath_vaddr = io.in.bits.src(0) + SignExt(s0_uop.ctrl.imm(11,0), VAddrBits)
-    val slowpath_mask = genWmask(slowpath_vaddr, s0_uop.ctrl.fuOpType(1,0))
-
-    // fast vaddr from load insts
-    val fastpath_vaddrs = WireInit(VecInit(List.tabulate(LoadPipelineWidth)(i => {
-      io.fastpath(i).data + SignExt(s0_uop.ctrl.imm(11,0), VAddrBits)
-    })))
-    val fastpath_masks = WireInit(VecInit(List.tabulate(LoadPipelineWidth)(i => {
-      genWmask(fastpath_vaddrs(i), s0_uop.ctrl.fuOpType(1,0))
-    })))
-    val fastpath_vaddr = Mux1H(io.loadFastMatch, fastpath_vaddrs)
-    val fastpath_mask  = Mux1H(io.loadFastMatch, fastpath_masks)
-
-    // select vaddr from 2 alus
-    s0_vaddr := Mux(io.loadFastMatch.orR, fastpath_vaddr, slowpath_vaddr)
-    s0_mask  := Mux(io.loadFastMatch.orR, fastpath_mask, slowpath_mask)
-    XSPerfAccumulate("load_to_load_forward", io.loadFastMatch.orR && io.in.fire())
+    // When there's no valid instruction from RS, we try the load-to-load forwarding.
+    when (!io.in.valid) {
+      s0_vaddr := io.fastpath.data
+      // Assume the pointer chasing is always ld.
+      s0_uop.ctrl.fuOpType := LSUOpType.ld
+      s0_mask := genWmask(0.U, LSUOpType.ld)
+    }
   }
 
   val isSoftPrefetch = LSUOpType.isPrefetch(s0_uop.ctrl.fuOpType)
@@ -98,17 +86,17 @@ class LoadUnit_S0(implicit p: Parameters) extends XSModule with HasDCacheParamet
   val isSoftPrefetchWrite = s0_uop.ctrl.fuOpType === LSUOpType.prefetch_w
 
   // query DTLB
-  io.dtlbReq.valid := io.in.valid
+  io.dtlbReq.valid := io.in.valid || io.fastpath.valid
   io.dtlbReq.bits.vaddr := s0_vaddr
   io.dtlbReq.bits.cmd := TlbCmd.read
-  io.dtlbReq.bits.size := LSUOpType.size(io.in.bits.uop.ctrl.fuOpType)
+  io.dtlbReq.bits.size := LSUOpType.size(s0_uop.ctrl.fuOpType)
   io.dtlbReq.bits.kill := DontCare
   io.dtlbReq.bits.debug.robIdx := s0_uop.robIdx
   io.dtlbReq.bits.debug.pc := s0_uop.cf.pc
   io.dtlbReq.bits.debug.isFirstIssue := io.isFirstIssue
 
   // query DCache
-  io.dcacheReq.valid := io.in.valid
+  io.dcacheReq.valid := io.in.valid || io.fastpath.valid
   when (isSoftPrefetchRead) {
     io.dcacheReq.bits.cmd  := MemoryOpConstants.M_PFR
   }.elsewhen (isSoftPrefetchWrite) {
@@ -135,7 +123,7 @@ class LoadUnit_S0(implicit p: Parameters) extends XSModule with HasDCacheParamet
     "b11".U   -> (s0_vaddr(2, 0) === 0.U)  //d
   ))
 
-  io.out.valid := io.in.valid && io.dcacheReq.ready
+  io.out.valid := (io.in.valid || io.fastpath.valid) && io.dcacheReq.ready && !io.s0_kill
 
   io.out.bits := DontCare
   io.out.bits.vaddr := s0_vaddr
@@ -148,7 +136,7 @@ class LoadUnit_S0(implicit p: Parameters) extends XSModule with HasDCacheParamet
 
   io.in.ready := !io.in.valid || (io.out.ready && io.dcacheReq.ready)
 
-  XSDebug(io.dcacheReq.fire(),
+  XSDebug(io.dcacheReq.fire,
     p"[DCACHE LOAD REQ] pc ${Hexadecimal(s0_uop.cf.pc)}, vaddr ${Hexadecimal(s0_vaddr)}\n"
   )
   XSPerfAccumulate("in_valid", io.in.valid)
@@ -156,10 +144,10 @@ class LoadUnit_S0(implicit p: Parameters) extends XSModule with HasDCacheParamet
   XSPerfAccumulate("in_fire_first_issue", io.in.valid && io.isFirstIssue)
   XSPerfAccumulate("stall_out", io.out.valid && !io.out.ready && io.dcacheReq.ready)
   XSPerfAccumulate("stall_dcache", io.out.valid && io.out.ready && !io.dcacheReq.ready)
-  XSPerfAccumulate("addr_spec_success", io.out.fire() && s0_vaddr(VAddrBits-1, 12) === io.in.bits.src(0)(VAddrBits-1, 12))
-  XSPerfAccumulate("addr_spec_failed", io.out.fire() && s0_vaddr(VAddrBits-1, 12) =/= io.in.bits.src(0)(VAddrBits-1, 12))
-  XSPerfAccumulate("addr_spec_success_once", io.out.fire() && s0_vaddr(VAddrBits-1, 12) === io.in.bits.src(0)(VAddrBits-1, 12) && io.isFirstIssue)
-  XSPerfAccumulate("addr_spec_failed_once", io.out.fire() && s0_vaddr(VAddrBits-1, 12) =/= io.in.bits.src(0)(VAddrBits-1, 12) && io.isFirstIssue)
+  XSPerfAccumulate("addr_spec_success", io.out.fire && s0_vaddr(VAddrBits-1, 12) === io.in.bits.src(0)(VAddrBits-1, 12))
+  XSPerfAccumulate("addr_spec_failed", io.out.fire && s0_vaddr(VAddrBits-1, 12) =/= io.in.bits.src(0)(VAddrBits-1, 12))
+  XSPerfAccumulate("addr_spec_success_once", io.out.fire && s0_vaddr(VAddrBits-1, 12) === io.in.bits.src(0)(VAddrBits-1, 12) && io.isFirstIssue)
+  XSPerfAccumulate("addr_spec_failed_once", io.out.fire && s0_vaddr(VAddrBits-1, 12) =/= io.in.bits.src(0)(VAddrBits-1, 12) && io.isFirstIssue)
 }
 
 
@@ -168,6 +156,7 @@ class LoadUnit_S0(implicit p: Parameters) extends XSModule with HasDCacheParamet
 class LoadUnit_S1(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
     val in = Flipped(Decoupled(new LsPipelineBundle))
+    val s1_kill = Input(Bool())
     val out = Decoupled(new LsPipelineBundle)
     val dtlbResp = Flipped(DecoupledIO(new TlbResp))
     val dcachePAddr = Output(UInt(PAddrBits.W))
@@ -196,9 +185,9 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
 
   io.dcachePAddr := s1_paddr
   //io.dcacheKill := s1_tlb_miss || s1_exception || s1_mmio
-  io.dcacheKill := s1_tlb_miss || s1_exception
+  io.dcacheKill := s1_tlb_miss || s1_exception || io.s1_kill
   // load forward query datapath
-  io.sbuffer.valid := io.in.valid && !(s1_exception || s1_tlb_miss)
+  io.sbuffer.valid := io.in.valid && !(s1_exception || s1_tlb_miss || io.s1_kill)
   io.sbuffer.vaddr := io.in.bits.vaddr
   io.sbuffer.paddr := s1_paddr
   io.sbuffer.uop := s1_uop
@@ -206,7 +195,7 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
   io.sbuffer.mask := s1_mask
   io.sbuffer.pc := s1_uop.cf.pc // FIXME: remove it
 
-  io.lsq.valid := io.in.valid && !(s1_exception || s1_tlb_miss)
+  io.lsq.valid := io.in.valid && !(s1_exception || s1_tlb_miss || io.s1_kill)
   io.lsq.vaddr := io.in.bits.vaddr
   io.lsq.paddr := s1_paddr
   io.lsq.uop := s1_uop
@@ -216,13 +205,13 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
   io.lsq.pc := s1_uop.cf.pc // FIXME: remove it
 
   // ld-ld violation query
-  io.loadViolationQueryReq.valid := io.in.valid && !(s1_exception || s1_tlb_miss)
+  io.loadViolationQueryReq.valid := io.in.valid && !(s1_exception || s1_tlb_miss || io.s1_kill)
   io.loadViolationQueryReq.bits.paddr := s1_paddr
   io.loadViolationQueryReq.bits.uop := s1_uop
 
   // Generate forwardMaskFast to wake up insts earlier
   val forwardMaskFast = io.lsq.forwardMaskFast.asUInt | io.sbuffer.forwardMaskFast.asUInt
-  io.fullForwardFast := (~forwardMaskFast & s1_mask) === 0.U
+  io.fullForwardFast := ((~forwardMaskFast).asUInt & s1_mask) === 0.U
 
   // Generate feedback signal caused by:
   // * dcache bank conflict
@@ -231,7 +220,7 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
     !io.loadViolationQueryReq.ready &&
     RegNext(io.csrCtrl.ldld_vio_check_enable)
   io.needLdVioCheckRedo := needLdVioCheckRedo
-  io.rsFeedback.valid := io.in.valid && (s1_bank_conflict || needLdVioCheckRedo)
+  io.rsFeedback.valid := io.in.valid && (s1_bank_conflict || needLdVioCheckRedo) && !io.s1_kill
   io.rsFeedback.bits.hit := false.B // we have found s1_bank_conflict / re do ld-ld violation check
   io.rsFeedback.bits.rsIdx := io.in.bits.rsIdx
   io.rsFeedback.bits.flushState := io.in.bits.ptwBack
@@ -240,7 +229,7 @@ class LoadUnit_S1(implicit p: Parameters) extends XSModule {
 
   // if replay is detected in load_s1,
   // load inst will be canceled immediately
-  io.out.valid := io.in.valid && !io.rsFeedback.valid
+  io.out.valid := io.in.valid && !io.rsFeedback.valid && !io.s1_kill
   io.out.bits.paddr := s1_paddr
   io.out.bits.tlbMiss := s1_tlb_miss
 
@@ -351,7 +340,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
   val forwardMask = Wire(Vec(8, Bool()))
   val forwardData = Wire(Vec(8, UInt(8.W)))
 
-  val fullForward = (~forwardMask.asUInt & s2_mask) === 0.U && !io.lsq.dataInvalid
+  val fullForward = ((~forwardMask.asUInt).asUInt & s2_mask) === 0.U && !io.lsq.dataInvalid
   io.lsq := DontCare
   io.sbuffer := DontCare
   io.fullForward := fullForward
@@ -362,7 +351,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
     forwardData(i) := Mux(io.lsq.forwardMask(i), io.lsq.forwardData(i), io.sbuffer.forwardData(i))
   }
 
-  XSDebug(io.out.fire(), "[FWD LOAD RESP] pc %x fwd %x(%b) + %x(%b)\n",
+  XSDebug(io.out.fire, "[FWD LOAD RESP] pc %x fwd %x(%b) + %x(%b)\n",
     s2_uop.cf.pc,
     io.lsq.forwardData.asUInt, io.lsq.forwardMask.asUInt,
     io.in.bits.forwardData.asUInt, io.in.bits.forwardMask.asUInt
@@ -479,7 +468,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
   io.fastpath.data := RegNext(io.out.bits.data)
 
 
-  XSDebug(io.out.fire(), "[DCACHE LOAD RESP] pc %x rdata %x <- D$ %x + fwd %x(%b)\n",
+  XSDebug(io.out.fire, "[DCACHE LOAD RESP] pc %x rdata %x <- D$ %x + fwd %x(%b)\n",
     s2_uop.cf.pc, rdataPartialLoad, io.dcacheResp.bits.data,
     forwardData.asUInt, forwardMask.asUInt
   )
@@ -523,8 +512,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     val pmp = Flipped(new PMPRespBundle()) // arrive same to tlb now
 
     val fastpathOut = Output(new LoadToLoadIO)
-    val fastpathIn = Input(Vec(LoadPipelineWidth, new LoadToLoadIO))
-    val loadFastMatch = Input(UInt(exuParameters.LduCnt.W))
+    val fastpathIn = Input(new LoadToLoadIO)
+    val loadFastMatch = Input(Bool())
 
     val delayedLoadError = Output(Bool()) // load ecc error
     // Note that io.delayedLoadError and io.lsq.delayedLoadError is different
@@ -542,20 +531,63 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   load_s0.io.rsIdx := io.rsIdx
   load_s0.io.isFirstIssue := io.isFirstIssue
   load_s0.io.fastpath := io.fastpathIn
-  load_s0.io.loadFastMatch := io.loadFastMatch
+  load_s0.io.s0_kill := false.B
+  val s0_tryPointerChasing = !io.ldin.valid && io.fastpathIn.valid
 
-  PipelineConnect(load_s0.io.out, load_s1.io.in, true.B, load_s0.io.out.bits.uop.robIdx.needFlush(io.redirect))
+  PipelineConnect(load_s0.io.out, load_s1.io.in, true.B,
+    load_s0.io.out.bits.uop.robIdx.needFlush(io.redirect) && !s0_tryPointerChasing)
 
+  load_s1.io.s1_kill := RegEnable(load_s0.io.s0_kill, false.B, load_s0.io.in.valid || io.fastpathIn.valid)
   load_s1.io.dtlbResp <> io.tlb.resp
   io.dcache.s1_paddr <> load_s1.io.dcachePAddr
-  io.dcache.s1_kill <> load_s1.io.dcacheKill
+  io.dcache.s1_kill := load_s1.io.dcacheKill
   load_s1.io.sbuffer <> io.sbuffer
   load_s1.io.lsq <> io.lsq.forward
   load_s1.io.loadViolationQueryReq <> io.lsq.loadViolationQuery.req
   load_s1.io.dcacheBankConflict <> io.dcache.s1_bank_conflict
   load_s1.io.csrCtrl <> io.csrCtrl
 
-  PipelineConnect(load_s1.io.out, load_s2.io.in, true.B, load_s1.io.out.bits.uop.robIdx.needFlush(io.redirect))
+  val s1_tryPointerChasing = RegNext(s0_tryPointerChasing && load_s0.io.in.ready && load_s0.io.dcacheReq.ready, false.B)
+  val cancelPointerChasing = WireInit(false.B)
+  if (EnableLoadToLoadForward) {
+    // Sometimes, we need to cancel the load-load forwarding.
+    // These can be put at S0 if timing is bad at S1.
+    // Case 0: CACHE_SET(base + offset) != CACHE_SET(base) (lowest 6-bit addition has an overflow)
+    val speculativeAddress = RegEnable(load_s0.io.fastpath.data(5, 0), s0_tryPointerChasing)
+    val realPointerAddress = Cat(speculativeAddress(5, 3), 0.U(3.W)) +& io.ldin.bits.uop.ctrl.imm(5, 0)
+    val addressMisMatch = realPointerAddress(6) || io.ldin.bits.uop.ctrl.imm(11, 6).orR
+    // Case 1: the address is not 64-bit aligned or the fuOpType is not LD
+    val addressNotAligned = speculativeAddress(2, 0).orR
+    val fuOpTypeIsNotLd = io.ldin.bits.uop.ctrl.fuOpType =/= LSUOpType.ld
+    // Case 2: this is not a valid load-load pair
+    val notFastMatch = RegEnable(!io.loadFastMatch, s0_tryPointerChasing)
+    // Case 3: this load-load uop is cancelled
+    val isCancelled = RegNext(io.loadFastMatch) && !io.ldin.valid
+    when (s1_tryPointerChasing) {
+      cancelPointerChasing := addressMisMatch || addressNotAligned || fuOpTypeIsNotLd || notFastMatch || isCancelled
+      load_s1.io.in.bits.uop := io.ldin.bits.uop
+      val spec_vaddr = load_s1.io.in.bits.vaddr
+      val vaddr = Cat(spec_vaddr(VAddrBits - 1, 6), realPointerAddress(5, 3), spec_vaddr(2, 0))
+      io.sbuffer.vaddr := vaddr
+      io.lsq.forward.vaddr := vaddr
+      load_s1.io.in.bits.rsIdx := io.rsIdx
+      load_s1.io.in.bits.isFirstIssue := io.isFirstIssue
+      // We need to replace vaddr(5, 3).
+      val spec_paddr = io.tlb.resp.bits.paddr
+      load_s1.io.dtlbResp.bits.paddr := Cat(spec_paddr(PAddrBits - 1, 6), realPointerAddress(5, 3), spec_paddr(2, 0))
+    }
+    when (cancelPointerChasing) {
+      load_s1.io.s1_kill := true.B
+    }.otherwise {
+      load_s0.io.s0_kill := s1_tryPointerChasing
+      when (s1_tryPointerChasing) {
+        io.ldin.ready := true.B
+      }
+    }
+    XSPerfAccumulate("load_to_load_forward", load_s1.io.out.valid && s1_tryPointerChasing && !cancelPointerChasing)
+  }
+  PipelineConnect(load_s1.io.out, load_s2.io.in, true.B,
+    load_s1.io.out.bits.uop.robIdx.needFlush(io.redirect) || cancelPointerChasing)
 
   io.dcache.s2_kill := load_s2.io.dcache_kill // to kill mmio resp which are redirected
   load_s2.io.dcacheResp <> io.dcache.resp
@@ -603,7 +635,15 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   // pre-calcuate sqIdx mask in s0, then send it to lsq in s1 for forwarding
   val sqIdxMaskReg = RegNext(UIntToMask(load_s0.io.in.bits.uop.sqIdx.value, StoreQueueSize))
+  // to enable load-load, sqIdxMask must be calculated based on ldin.uop
+  // If the timing here is not OK, load-load forwarding has to be disabled.
+  // Or we calculate sqIdxMask at RS??
   io.lsq.forward.sqIdxMask := sqIdxMaskReg
+  if (EnableLoadToLoadForward) {
+    when (s1_tryPointerChasing) {
+      io.lsq.forward.sqIdxMask := UIntToMask(io.ldin.bits.uop.sqIdx.value, StoreQueueSize)
+    }
+  }
 
   // // use s2_hit_way to select data received in s1
   // load_s2.io.dcacheResp.bits.data := Mux1H(RegNext(io.dcache.s1_hit_way), RegNext(io.dcache.s1_data))
@@ -613,7 +653,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.fastUop.valid := RegNext(
     io.dcache.s1_hit_way.orR && // dcache hit
     !io.dcache.s1_disable_fast_wakeup &&  // load fast wakeup should be disabled when dcache data read is not ready
-    load_s1.io.in.valid && // valid laod request
+    load_s1.io.in.valid && // valid load request
+    !load_s1.io.s1_kill && // killed by load-load forwarding
     !load_s1.io.dtlbResp.bits.fast_miss && // not mmio or tlb miss, pf / af not included here
     !io.lsq.forward.dataInvalidFast && // forward failed
     !load_s1.io.needLdVioCheckRedo // load-load violation check: load paddr cam struct hazard
@@ -674,7 +715,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     assert(RegNext(!io.lsq.loadIn.valid) || RegNext(load_s2.io.dcacheRequireReplay))
   }
 
-  val lastValidData = RegEnable(io.ldout.bits.data, io.ldout.fire())
+  val lastValidData = RegEnable(io.ldout.bits.data, io.ldout.fire)
   val hitLoadAddrTriggerHitVec = Wire(Vec(3, Bool()))
   val lqLoadAddrTriggerHitVec = io.lsq.trigger.lqLoadAddrTriggerHitVec
   (0 until 3).map{i => {
@@ -689,7 +730,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.lsq.trigger.hitLoadAddrTriggerHitVec := hitLoadAddrTriggerHitVec
 
   val perfEvents = Seq(
-    ("load_s0_in_fire         ", load_s0.io.in.fire()                                                                                                            ),
+    ("load_s0_in_fire         ", load_s0.io.in.fire                                                                                                              ),
+    ("load_to_load_forward    ", load_s1.io.out.valid && s1_tryPointerChasing && !cancelPointerChasing                                                           ),
     ("stall_dcache            ", load_s0.io.out.valid && load_s0.io.out.ready && !load_s0.io.dcacheReq.ready                                                     ),
     ("load_s1_in_fire         ", load_s1.io.in.fire                                                                                                              ),
     ("load_s1_tlb_miss        ", load_s1.io.in.fire && load_s1.io.dtlbResp.bits.miss                                                                             ),
@@ -701,10 +743,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   )
   generatePerfEvent()
 
-  // Will cause timing problem:
-  // ("load_to_load_forward    ", load_s0.io.loadFastMatch.orR && load_s0.io.in.fire()),
-
-  when(io.ldout.fire()){
+  when(io.ldout.fire){
     XSDebug("ldout %x\n", io.ldout.bits.uop.cf.pc)
   }
 }

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -302,14 +302,14 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
   // writeback access fault caused by ecc error / bus error
   //
   // * ecc data error is slow to generate, so we will not use it until load stage 3
-  // * in load stage 3, an extra signal io.load_error will be used to 
+  // * in load stage 3, an extra signal io.load_error will be used to
 
   // now cache ecc error will raise an access fault
   // at the same time, error info (including error paddr) will be write to
   // an customized CSR "CACHE_ERROR"
   if (EnableAccurateLoadError) {
     io.delayedLoadError := io.dcacheResp.bits.error_delayed &&
-      io.csrCtrl.cache_error_enable && 
+      io.csrCtrl.cache_error_enable &&
       RegNext(io.out.valid)
   } else {
     io.delayedLoadError := false.B
@@ -488,7 +488,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
   XSPerfAccumulate("replay_from_fetch_load_vio", io.out.valid && ldldVioReplay)
 }
 
-class LoadUnit(implicit p: Parameters) extends XSModule 
+class LoadUnit(implicit p: Parameters) extends XSModule
   with HasLoadHelper
   with HasPerfEvents
   with HasDCacheParameters
@@ -538,6 +538,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     load_s0.io.out.bits.uop.robIdx.needFlush(io.redirect) && !s0_tryPointerChasing)
 
   load_s1.io.s1_kill := RegEnable(load_s0.io.s0_kill, false.B, load_s0.io.in.valid || io.fastpathIn.valid)
+  io.tlb.req_kill := load_s1.io.s1_kill
   load_s1.io.dtlbResp <> io.tlb.resp
   io.dcache.s1_paddr <> load_s1.io.dcachePAddr
   io.dcache.s1_kill := load_s1.io.dcacheKill
@@ -620,7 +621,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s3_replay_for_mshrfull = RegNext(!load_s2.io.rsFeedback.bits.hit && load_s2.io.rsFeedback.bits.sourceType === RSFeedbackType.mshrFull)
   val s3_refill_hit_load_paddr = refill_addr_hit(RegNext(load_s2.io.out.bits.paddr), io.refill.bits.addr)
   // update replay request
-  io.feedbackSlow.bits.hit := RegNext(load_s2.io.rsFeedback.bits).hit || 
+  io.feedbackSlow.bits.hit := RegNext(load_s2.io.rsFeedback.bits).hit ||
     s3_refill_hit_load_paddr && s3_replay_for_mshrfull
 
   // feedback bank conflict / ld-vio check struct hazard to rs
@@ -694,7 +695,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   val load_wb_reg = RegNext(Mux(hitLoadOut.valid, hitLoadOut.bits, io.lsq.ldout.bits))
   io.ldout.bits := load_wb_reg
-  io.ldout.valid := RegNext(hitLoadOut.valid) && !RegNext(load_s2.io.out.bits.uop.robIdx.needFlush(io.redirect)) || 
+  io.ldout.valid := RegNext(hitLoadOut.valid) && !RegNext(load_s2.io.out.bits.uop.robIdx.needFlush(io.redirect)) ||
     RegNext(io.lsq.ldout.valid) && !RegNext(io.lsq.ldout.bits.uop.robIdx.needFlush(io.redirect)) && !RegNext(hitLoadOut.valid)
 
   // io.ldout.bits.uop.cf.exceptionVec(loadAccessFault) := load_wb_reg.uop.cf.exceptionVec(loadAccessFault) ||

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -218,6 +218,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule {
 
   store_s0.io.in <> io.stin
   store_s0.io.dtlbReq <> io.tlb.req
+  io.tlb.req_kill := false.B
   store_s0.io.rsIdx := io.rsIdx
   store_s0.io.isFirstIssue := io.isFirstIssue
 
@@ -228,7 +229,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule {
   io.lsq <> store_s1.io.lsq
 
   PipelineConnect(store_s1.io.out, store_s2.io.in, true.B, store_s1.io.out.bits.uop.robIdx.needFlush(io.redirect))
-  
+
   // feedback tlb miss to RS in store_s2
   io.feedbackSlow.bits := RegNext(store_s1.io.rsFeedback.bits)
   io.feedbackSlow.valid := RegNext(store_s1.io.rsFeedback.valid && !store_s1.io.out.bits.uop.robIdx.needFlush(io.redirect))


### PR DESCRIPTION
This commit optimizes the timing of load-load forwarding by making
it speculatively issue requests to TLB/dcache.

When load_s0 does not have a valid instruction and load_s3 writes
a valid instruction back, we speculatively bypass the writeback
data to load_s0 and assume there will be a pointer chasing instruction
following it. A pointer chasing instruction has a base address that
comes from a previous instruction with a small offset. To avoid timing
issues, now only when the offset does not change the cache set index,
we reduce its latency by speculatively issuing it.