### PR TITLE
ldu: select data in load_s3

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -287,6 +287,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     // passdown to lsq (load s2)
     lsq.io.loadIn(i) <> loadUnits(i).io.lsq.loadIn
     lsq.io.ldout(i) <> loadUnits(i).io.lsq.ldout
+    lsq.io.ldRawDataOut(i) <> loadUnits(i).io.lsq.ldRawData
     lsq.io.s2_load_data_forwarded(i) <> loadUnits(i).io.lsq.s2_load_data_forwarded
     lsq.io.trigger(i) <> loadUnits(i).io.lsq.trigger
 

--- a/src/main/scala/xiangshan/mem/MemCommon.scala
+++ b/src/main/scala/xiangshan/mem/MemCommon.scala
@@ -162,9 +162,39 @@ class LoadViolationQueryIO(implicit p: Parameters) extends XSBundle {
   val resp = Flipped(Valid(new LoadViolationQueryResp))
 }
 
+// Store byte valid mask write bundle
+//
+// Store byte valid mask write to SQ takes 2 cycles
 class StoreMaskBundle(implicit p: Parameters) extends XSBundle {
   val sqIdx = new SqPtr
   val mask = UInt(8.W)
+}
+
+// Load writeback data from dcache
+class LoadDataFromDcacheBundle(implicit p: Parameters) extends XSBundle {
+  val dcacheData = UInt(64.W)
+  val forwardMask = Vec(8, Bool())
+  val forwardData = Vec(8, UInt(8.W))
+  val uop = new MicroOp // for data selection, only fwen and fuOpType are used
+  val addrOffset = UInt(3.W) // for data selection
+
+  def mergedData(): UInt = {
+    val rdataVec = VecInit((0 until XLEN / 8).map(j =>
+      Mux(forwardMask(j), forwardData(j), dcacheData(8*(j+1)-1, 8*j))
+    ))
+    rdataVec.asUInt
+  }
+}
+
+// Load writeback data from load queue (refill)
+class LoadDataFromLQBundle(implicit p: Parameters) extends XSBundle {
+  val lqData = UInt(64.W) // load queue has merged data
+  val uop = new MicroOp // for data selection, only fwen and fuOpType are used
+  val addrOffset = UInt(3.W) // for data selection
+
+  def mergedData(): UInt = {
+    lqData
+  }
 }
 
 // Bundle for load / store wait waking up

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -69,6 +69,7 @@ class LsqWrappper(implicit p: Parameters) extends XSModule with HasDCacheParamet
     val s3_replay_from_fetch = Vec(LoadPipelineWidth, Input(Bool()))
     val sbuffer = Vec(StorePipelineWidth, Decoupled(new DCacheWordReqWithVaddr))
     val ldout = Vec(2, DecoupledIO(new ExuOutput)) // writeback int load
+    val ldRawDataOut = Vec(2, Output(new LoadDataFromLQBundle))
     val mmioStout = DecoupledIO(new ExuOutput) // writeback uncached store
     val forward = Vec(LoadPipelineWidth, Flipped(new PipeLoadForwardQueryIO))
     val loadViolationQuery = Vec(LoadPipelineWidth, Flipped(new LoadViolationQueryIO))
@@ -125,6 +126,7 @@ class LsqWrappper(implicit p: Parameters) extends XSModule with HasDCacheParamet
   loadQueue.io.s2_dcache_require_replay <> io.s2_dcache_require_replay
   loadQueue.io.s3_replay_from_fetch <> io.s3_replay_from_fetch
   loadQueue.io.ldout <> io.ldout
+  loadQueue.io.ldRawDataOut <> io.ldRawDataOut
   loadQueue.io.rob <> io.rob
   loadQueue.io.rollback <> io.rollback
   loadQueue.io.dcache <> io.dcache

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -97,6 +97,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     val s2_dcache_require_replay = Vec(LoadPipelineWidth, Input(Bool()))
     val s3_replay_from_fetch = Vec(LoadPipelineWidth, Input(Bool()))
     val ldout = Vec(2, DecoupledIO(new ExuOutput)) // writeback int load
+    val ldRawDataOut = Vec(2, Output(new LoadDataFromLQBundle))
     val load_s1 = Vec(LoadPipelineWidth, Flipped(new PipeLoadForwardQueryIO)) // TODO: to be renamed
     val loadViolationQuery = Vec(LoadPipelineWidth, Flipped(new LoadViolationQueryIO))
     val rob = Flipped(new RobLsqIO)
@@ -203,24 +204,22 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     // flag bits in lq needs to be updated accurately
     when(io.loadIn(i).fire()) {
       when(io.loadIn(i).bits.miss) {
-        XSInfo(io.loadIn(i).valid, "load miss write to lq idx %d pc 0x%x vaddr %x paddr %x data %x mask %x forwardData %x forwardMask: %x mmio %x\n",
+        XSInfo(io.loadIn(i).valid, "load miss write to lq idx %d pc 0x%x vaddr %x paddr %x mask %x forwardData %x forwardMask: %x mmio %x\n",
           io.loadIn(i).bits.uop.lqIdx.asUInt,
           io.loadIn(i).bits.uop.cf.pc,
           io.loadIn(i).bits.vaddr,
           io.loadIn(i).bits.paddr,
-          io.loadIn(i).bits.data,
           io.loadIn(i).bits.mask,
           io.loadIn(i).bits.forwardData.asUInt,
           io.loadIn(i).bits.forwardMask.asUInt,
           io.loadIn(i).bits.mmio
         )
       }.otherwise {
-        XSInfo(io.loadIn(i).valid, "load hit write to cbd lqidx %d pc 0x%x vaddr %x paddr %x data %x mask %x forwardData %x forwardMask: %x mmio %x\n",
+        XSInfo(io.loadIn(i).valid, "load hit write to cbd lqidx %d pc 0x%x vaddr %x paddr %x mask %x forwardData %x forwardMask: %x mmio %x\n",
         io.loadIn(i).bits.uop.lqIdx.asUInt,
         io.loadIn(i).bits.uop.cf.pc,
         io.loadIn(i).bits.vaddr,
         io.loadIn(i).bits.paddr,
-        io.loadIn(i).bits.data,
         io.loadIn(i).bits.mask,
         io.loadIn(i).bits.forwardData.asUInt,
         io.loadIn(i).bits.forwardMask.asUInt,
@@ -461,7 +460,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     // Int load writeback will finish (if not blocked) in one cycle
     io.ldout(i).bits.uop := seluop
     io.ldout(i).bits.uop.lqIdx := loadWbSel(i).asTypeOf(new LqPtr)
-    io.ldout(i).bits.data := rdataPartialLoad
+    io.ldout(i).bits.data := rdataPartialLoad // not used
     io.ldout(i).bits.redirectValid := false.B
     io.ldout(i).bits.redirect := DontCare
     io.ldout(i).bits.debug.isMMIO := debug_mmio(loadWbSel(i))
@@ -470,6 +469,11 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     io.ldout(i).bits.debug.vaddr := vaddrModule.io.rdata(i+1)
     io.ldout(i).bits.fflags := DontCare
     io.ldout(i).valid := loadWbSelV(i)
+    
+    // merged data, uop and offset for data sel in load_s3
+    io.ldRawDataOut(i).lqData := dataModule.io.wb.rdata(i).data
+    io.ldRawDataOut(i).uop := io.ldout(i).bits.uop
+    io.ldRawDataOut(i).addrOffset := dataModule.io.wb.rdata(i).paddr
 
     when(io.ldout(i).fire()) {
       XSInfo("int load miss write to cbd robidx %d lqidx %d pc 0x%x mmio %x\n",

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -30,6 +30,7 @@ class LoadToLsqIO(implicit p: Parameters) extends XSBundle {
   val loadIn = ValidIO(new LqWriteBundle)
   val loadPaddrIn = ValidIO(new LqPaddrWriteBundle)
   val ldout = Flipped(DecoupledIO(new ExuOutput))
+  val ldRawData = Input(new LoadDataFromLQBundle)
   val s2_load_data_forwarded = Output(Bool())
   val s3_delayed_load_error = Output(Bool())
   val s2_dcache_require_replay = Output(Bool())
@@ -291,6 +292,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
     val sentFastUop = Input(Bool())
     val static_pm = Input(Valid(Bool())) // valid for static, bits for mmio
     val s2_can_replay_from_fetch = Output(Bool()) // dirty code
+    val loadDataFromDcache = Output(new LoadDataFromDcacheBundle)
   })
 
   val pmp = WireInit(io.pmpResp)
@@ -375,12 +377,8 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
 
   // data merge
   val rdataVec = VecInit((0 until XLEN / 8).map(j =>
-    if(j < XLEN / 16) {
-      Mux(forwardMask(j), forwardData(j), io.dcacheResp.bits.data(8*(j+1)-1, 8*j))
-    }else {
-      Mux(forwardMask(j), forwardData(j), io.dcacheResp.bits.data_dup_0(8*(j+1)-1, 8*j))
-    }
-    ))
+    Mux(forwardMask(j), forwardData(j), io.dcacheResp.bits.data(8*(j+1)-1, 8*j))
+  )) // s2_rdataVec will be write to load queue
   val rdata = rdataVec.asUInt
   val rdataSel = LookupTree(s2_paddr(2, 0), List(
     "b000".U -> rdata(63, 0),
@@ -392,13 +390,14 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
     "b110".U -> rdata(63, 48),
     "b111".U -> rdata(63, 56)
   ))
-  val rdataPartialLoad = rdataHelper(s2_uop, rdataSel)
+  val rdataPartialLoad = rdataHelper(s2_uop, rdataSel) // s2_rdataPartialLoad is not used
 
   io.out.valid := io.in.valid && !s2_tlb_miss && !s2_data_invalid
   // Inst will be canceled in store queue / lsq,
   // so we do not need to care about flush in load / store unit's out.valid
   io.out.bits := io.in.bits
-  io.out.bits.data := rdataPartialLoad
+  // io.out.bits.data := rdataPartialLoad
+  io.out.bits.data := 0.U // data will be generated in load_s3
   // when exception occurs, set it to not miss and let it write back to rob (via int port)
   if (EnableFastForward) {
     io.out.bits.miss := s2_cache_miss &&
@@ -411,6 +410,13 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
       !s2_is_prefetch
   }
   io.out.bits.uop.ctrl.fpWen := io.in.bits.uop.ctrl.fpWen && !s2_exception
+
+  io.loadDataFromDcache.dcacheData := io.dcacheResp.bits.data
+  io.loadDataFromDcache.forwardMask := forwardMask
+  io.loadDataFromDcache.forwardData := forwardData
+  io.loadDataFromDcache.uop := io.out.bits.uop
+  io.loadDataFromDcache.addrOffset := s2_paddr(2, 0)
+
   io.s2_can_replay_from_fetch := !s2_mmio && !s2_is_prefetch && !s2_tlb_miss
   // if forward fail, replay this inst from fetch
   val debug_forwardFailReplay = s2_forward_fail && !s2_mmio && !s2_is_prefetch && !s2_tlb_miss
@@ -435,7 +441,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
     (fullForward || io.csrCtrl.cache_error_enable && s2_cache_tag_error)
   // io.out.bits.forwardX will be send to lq
   io.out.bits.forwardMask := forwardMask
-  // data retbrived from dcache is also included in io.out.bits.forwardData
+  // data retrived from dcache is also included in io.out.bits.forwardData
   io.out.bits.forwardData := rdataVec
 
   io.in.ready := io.out.ready || !io.in.valid
@@ -480,8 +486,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
 
   // fast load to load forward
   io.fastpath.valid := RegNext(io.out.valid) // for debug only
-  io.fastpath.data := RegNext(io.out.bits.data)
-
+  io.fastpath.data := RegNext(rdata) // fastpath is for ld only
 
   XSDebug(io.out.fire(), "[DCACHE LOAD RESP] pc %x rdata %x <- D$ %x + fwd %x(%b)\n",
     s2_uop.cf.pc, rdataPartialLoad, io.dcacheResp.bits.data,
@@ -654,12 +659,44 @@ class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper with 
   load_s2.io.out.ready := true.B
 
   // load s3
-  val load_wb_reg = RegNext(Mux(hitLoadOut.valid, hitLoadOut.bits, io.lsq.ldout.bits))
-  io.ldout.bits := load_wb_reg
+  val s3_load_wb_meta_reg = RegNext(Mux(hitLoadOut.valid, hitLoadOut.bits, io.lsq.ldout.bits))
+
+  // data from load queue refill
+  val s3_loadDataFromLQ = RegEnable(io.lsq.ldRawData, io.lsq.ldout.valid)
+  val s3_rdataLQ = s3_loadDataFromLQ.mergedData()
+  val s3_rdataSelLQ = LookupTree(s3_loadDataFromLQ.addrOffset, List(
+    "b000".U -> s3_rdataLQ(63, 0),
+    "b001".U -> s3_rdataLQ(63, 8),
+    "b010".U -> s3_rdataLQ(63, 16),
+    "b011".U -> s3_rdataLQ(63, 24),
+    "b100".U -> s3_rdataLQ(63, 32),
+    "b101".U -> s3_rdataLQ(63, 40),
+    "b110".U -> s3_rdataLQ(63, 48),
+    "b111".U -> s3_rdataLQ(63, 56)
+  ))
+  val s3_rdataPartialLoadLQ = rdataHelper(s3_loadDataFromLQ.uop, s3_rdataSelLQ)
+
+  // data from dcache hit
+  val s3_loadDataFromDcache = RegEnable(load_s2.io.loadDataFromDcache, load_s2.io.in.valid)
+  val s3_rdataDcache = s3_loadDataFromDcache.mergedData()
+  val s3_rdataSelDcache = LookupTree(s3_loadDataFromDcache.addrOffset, List(
+    "b000".U -> s3_rdataDcache(63, 0),
+    "b001".U -> s3_rdataDcache(63, 8),
+    "b010".U -> s3_rdataDcache(63, 16),
+    "b011".U -> s3_rdataDcache(63, 24),
+    "b100".U -> s3_rdataDcache(63, 32),
+    "b101".U -> s3_rdataDcache(63, 40),
+    "b110".U -> s3_rdataDcache(63, 48),
+    "b111".U -> s3_rdataDcache(63, 56)
+  ))
+  val s3_rdataPartialLoadDcache = rdataHelper(s3_loadDataFromDcache.uop, s3_rdataSelDcache)
+
+  io.ldout.bits := s3_load_wb_meta_reg
+  io.ldout.bits.data := Mux(RegNext(hitLoadOut.valid), s3_rdataPartialLoadDcache, s3_rdataPartialLoadLQ)
   io.ldout.valid := RegNext(hitLoadOut.valid) && !RegNext(load_s2.io.out.bits.uop.robIdx.needFlush(io.redirect)) ||
     RegNext(io.lsq.ldout.valid) && !RegNext(io.lsq.ldout.bits.uop.robIdx.needFlush(io.redirect)) && !RegNext(hitLoadOut.valid)
 
-  io.ldout.bits.uop.cf.exceptionVec(loadAccessFault) := load_wb_reg.uop.cf.exceptionVec(loadAccessFault) ||
+  io.ldout.bits.uop.cf.exceptionVec(loadAccessFault) := s3_load_wb_meta_reg.uop.cf.exceptionVec(loadAccessFault) ||
     RegNext(hitLoadOut.valid) && load_s2.io.s3_delayed_load_error
 
   // feedback tlb miss / dcache miss queue full


### PR DESCRIPTION
rdataVec (i.e. sram read result merge forward result) is still
generated in load_s2. It will be write to load queue in load_s2