### PR TITLE
load: update s1_vaddr when load-load forwarding

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -534,8 +534,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   load_s0.io.s0_kill := false.B
   val s0_tryPointerChasing = !io.ldin.valid && io.fastpathIn.valid
 
-  PipelineConnect(load_s0.io.out, load_s1.io.in, true.B,
-    load_s0.io.out.bits.uop.robIdx.needFlush(io.redirect) && !s0_tryPointerChasing)
+  val s1_data = PipelineConnect(load_s0.io.out, load_s1.io.in, true.B,
+    load_s0.io.out.bits.uop.robIdx.needFlush(io.redirect) && !s0_tryPointerChasing).get
 
   load_s1.io.s1_kill := RegEnable(load_s0.io.s0_kill, false.B, load_s0.io.in.valid || io.fastpathIn.valid)
   io.tlb.req_kill := load_s1.io.s1_kill
@@ -567,10 +567,9 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     when (s1_tryPointerChasing) {
       cancelPointerChasing := addressMisMatch || addressNotAligned || fuOpTypeIsNotLd || notFastMatch || isCancelled
       load_s1.io.in.bits.uop := io.ldin.bits.uop
-      val spec_vaddr = load_s1.io.in.bits.vaddr
+      val spec_vaddr = s1_data.vaddr
       val vaddr = Cat(spec_vaddr(VAddrBits - 1, 6), realPointerAddress(5, 3), spec_vaddr(2, 0))
-      io.sbuffer.vaddr := vaddr
-      io.lsq.forward.vaddr := vaddr
+      load_s1.io.in.bits.vaddr := vaddr
       load_s1.io.in.bits.rsIdx := io.rsIdx
       load_s1.io.in.bits.isFirstIssue := io.isFirstIssue
       // We need to replace vaddr(5, 3).


### PR DESCRIPTION
Load_S1 requires vaddr not only for lsq.forward and sbuffer.forward.
It also sends vaddr to S2, which sends lsq.loadIn when exceptions
and cache misses. We need to update the vaddr for S1 to avoid the wrong
vaddr when exceptions.