### PR TITLE
ldu: remove dcache sram data from forwardData

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -432,8 +432,8 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
     (fullForward || io.csrCtrl.cache_error_enable && s2_cache_tag_error)
   // io.out.bits.forwardX will be send to lq
   io.out.bits.forwardMask := forwardMask
-  // data retrived from dcache is also included in io.out.bits.forwardData
-  io.out.bits.forwardData := rdataVec
+  // data from dcache is not included in io.out.bits.forwardData
+  io.out.bits.forwardData := forwardData
 
   io.in.ready := io.out.ready || !io.in.valid
 


### PR DESCRIPTION
`forwardData` for load queue does not need data from dcache sram.
In this way, we remove load queue data wdata fanin from all dcache
data srams