### PR TITLE
lq: fix load load violation check logic

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -119,7 +119,6 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   val released = RegInit(VecInit(List.fill(LoadQueueSize)(false.B))) // load data has been released by dcache
   val error = RegInit(VecInit(List.fill(LoadQueueSize)(false.B))) // load data has been corrupted
   val miss = Reg(Vec(LoadQueueSize, Bool())) // load inst missed, waiting for miss queue to accept miss request
-  val need_refill_by_dcache = Reg(Vec(LoadQueueSize, Bool())) // load inst missed, the data should be refilled by dcache
   // val listening = Reg(Vec(LoadQueueSize, Bool())) // waiting for refill result
   val pending = Reg(Vec(LoadQueueSize, Bool())) // mmio pending: inst is an mmio inst, it will not be executed until it reachs the end of rob
   val refilling = WireInit(VecInit(List.fill(LoadQueueSize)(false.B))) // inst has been writebacked to CDB
@@ -165,7 +164,6 @@ class LoadQueue(implicit p: Parameters) extends XSModule
       writebacked(index) := false.B
       released(index) := false.B
       miss(index) := false.B
-      need_refill_by_dcache(index) := false.B
       pending(index) := false.B
       error(index) := false.B
       XSError(!io.enq.canAccept || !io.enq.sqCanAccept, s"must accept $i\n")
@@ -246,10 +244,8 @@ class LoadQueue(implicit p: Parameters) extends XSModule
       val dcacheMissed = io.loadIn(i).bits.miss && !io.loadIn(i).bits.mmio
       if(EnableFastForward){
         miss(loadWbIndex) := dcacheMissed && !io.loadDataForwarded(i) && !io.dcacheRequireReplay(i)
-        need_refill_by_dcache(loadWbIndex) := dcacheMissed && !io.loadDataForwarded(i) && !io.dcacheRequireReplay(i)
       } else {
         miss(loadWbIndex) := dcacheMissed && !io.loadDataForwarded(i)
-        need_refill_by_dcache(loadWbIndex) := dcacheMissed && !io.loadDataForwarded(i)
       }
       pending(loadWbIndex) := io.loadIn(i).bits.mmio
       released(loadWbIndex) := release2cycle.valid && 
@@ -307,7 +303,6 @@ class LoadQueue(implicit p: Parameters) extends XSModule
         // do not writeback if that inst will be resend from rs
         // rob writeback will not be triggered by a refill before inst replay
         miss(lastCycleLoadWbIndex) := false.B // disable refill listening
-        need_refill_by_dcache(lastCycleLoadWbIndex) := false.B // instr will replay, no need to be refilled by dcache for now 
         datavalid(lastCycleLoadWbIndex) := false.B // disable refill listening
         assert(!datavalid(lastCycleLoadWbIndex))
       }
@@ -722,12 +717,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   (0 until LoadQueueSize).map(i => {
     when(RegNext(dataModule.io.release_violation.takeRight(1)(0).match_mask(i) && 
       allocated(i) &&
-      (
-        // load has been writebacked
-        writebacked(i) || 
-        // or this load missed, refilled by dcache, but has not been writebacked to ROB
-        (need_refill_by_dcache(i) && datavalid(i) && !writebacked(i))
-      ) &&
+      datavalid(i) &&
       release1cycle.valid
     )){
       // Note: if a load has missed in dcache and is waiting for refill in load queue,


### PR DESCRIPTION
* when a load instruction missed in dcache and then refilled by dcache, waiting to be written back, if the block is released by dcache, it also needs to be marked as released