### PR TITLE
lq: fix load load violation check logic

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -780,9 +780,9 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   }
 
   (0 until LoadQueueSize).map(i => {
-    when(RegNext(dataModule.io.release_violation.takeRight(1)(0).match_mask(i) &&
+    when(RegNext(dataModule.io.release_violation.takeRight(1)(0).match_mask(i) && 
       allocated(i) &&
-      writebacked(i) &&
+      datavalid(i) &&
       release1cycle.valid
     )){
       // Note: if a load has missed in dcache and is waiting for refill in load queue,


### PR DESCRIPTION
when a load instruction missed in dcache and then refilled by dcache, waiting to be written back, if the block is released by dcache, it also needs to be marked as released