### PR TITLE
AtomicsUnit: refactor FSM in AtomicsUnit

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -47,7 +47,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
   //-------------------------------------------------------
   // Atomics Memory Accsess FSM
   //-------------------------------------------------------
-  val s_invalid :: s_tlb :: s_pm :: s_flush_sbuffer_req :: s_flush_sbuffer_resp :: s_cache_req :: s_cache_resp :: s_cache_resp_latch :: s_finish :: Nil = Enum(9)
+  val s_invalid :: s_tlb_and_flush_sbuffer_req :: s_pm :: s_wait_flush_sbuffer_resp :: s_cache_req :: s_cache_resp :: s_finish :: Nil = Enum(7)
   val state = RegInit(s_invalid)
   val out_valid = RegInit(false.B)
   val data_valid = RegInit(false.B)
@@ -65,6 +65,8 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
   val resp_data = Reg(UInt())
   val resp_data_wire = WireInit(0.U)
   val is_lrsc_valid = Reg(Bool())
+  // sbuffer is empty or not
+  val sbuffer_empty = io.flush_sbuffer.empty
 
 
   // Difftest signals
@@ -96,7 +98,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
     when (io.in.fire) {
       in := io.in.bits
       in.src(1) := in.src(1) // leave src2 unchanged
-      state := s_tlb
+      state := s_tlb_and_flush_sbuffer_req
     }
   }
 
@@ -119,7 +121,8 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
   io.feedbackSlow.bits.dataInvalidSqIdx := DontCare
 
   // tlb translation, manipulating signals && deal with exception
-  when (state === s_tlb) {
+  // at the same time, flush sbuffer
+  when (state === s_tlb_and_flush_sbuffer_req) {
     // send req to dtlb
     // keep firing until tlb hit
     io.dtlb.req.valid       := true.B
@@ -129,6 +132,9 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
     io.dtlb.req.bits.debug.robIdx := in.uop.robIdx
     io.dtlb.req.bits.debug.pc := in.uop.cf.pc
     io.dtlb.req.bits.debug.isFirstIssue := false.B
+
+    // send req to sbuffer to flush it if it is not empty
+    io.flush_sbuffer.valid := Mux(sbuffer_empty, false.B, true.B)
 
     when(io.dtlb.resp.fire){
       paddr := io.dtlb.resp.bits.paddr
@@ -179,17 +185,13 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
       out_valid := true.B
       atom_override_xtval := true.B
     }.otherwise {
-      state := s_flush_sbuffer_req
+      // if sbuffer has been flushed, go to query dcache, otherwise wait for sbuffer.
+      state := Mux(sbuffer_empty, s_cache_req, s_wait_flush_sbuffer_resp);
     }
   }
 
-  when (state === s_flush_sbuffer_req) {
-    io.flush_sbuffer.valid := true.B
-    state := s_flush_sbuffer_resp
-  }
-
-  when (state === s_flush_sbuffer_resp) {
-    when (io.flush_sbuffer.empty) {
+  when (state === s_wait_flush_sbuffer_resp) {
+    when (sbuffer_empty) {
       state := s_cache_req
     }
   }
@@ -236,7 +238,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
     io.dcache.req.valid := Mux(
       io.dcache.req.bits.cmd === M_XLR,
       !io.dcache.block_lr, // block lr to survive in lr storm
-      true.B
+      data_valid // wait until src(1) is ready
     )
 
     when(io.dcache.req.fire){
@@ -248,9 +250,9 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
     }
   }
 
-  val dcache_resp_data  = Reg(UInt())
-  val dcache_resp_id    = Reg(UInt())
-  val dcache_resp_error = Reg(Bool())
+  // val dcache_resp_data  = Reg(UInt())
+  // val dcache_resp_id    = Reg(UInt())
+  // val dcache_resp_error = Reg(Bool())
 
   when (state === s_cache_resp) {
     // when not miss
@@ -268,65 +270,60 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
           state := s_cache_req
         }
       } .otherwise {
-        // latch response
-        dcache_resp_data := io.dcache.resp.bits.data
-        dcache_resp_id := io.dcache.resp.bits.id
-        dcache_resp_error := io.dcache.resp.bits.error
-        state := s_cache_resp_latch
+        is_lrsc_valid :=  io.dcache.resp.bits.id
+        val rdataSel = LookupTree(paddr(2, 0), List(
+          "b000".U -> io.dcache.resp.bits.data(63, 0),
+          "b001".U -> io.dcache.resp.bits.data(63, 8),
+          "b010".U -> io.dcache.resp.bits.data(63, 16),
+          "b011".U -> io.dcache.resp.bits.data(63, 24),
+          "b100".U -> io.dcache.resp.bits.data(63, 32),
+          "b101".U -> io.dcache.resp.bits.data(63, 40),
+          "b110".U -> io.dcache.resp.bits.data(63, 48),
+          "b111".U -> io.dcache.resp.bits.data(63, 56)
+        ))
+
+        resp_data_wire := LookupTree(in.uop.ctrl.fuOpType, List(
+          LSUOpType.lr_w      -> SignExt(rdataSel(31, 0), XLEN),
+          LSUOpType.sc_w      -> io.dcache.resp.bits.data,
+          LSUOpType.amoswap_w -> SignExt(rdataSel(31, 0), XLEN),
+          LSUOpType.amoadd_w  -> SignExt(rdataSel(31, 0), XLEN),
+          LSUOpType.amoxor_w  -> SignExt(rdataSel(31, 0), XLEN),
+          LSUOpType.amoand_w  -> SignExt(rdataSel(31, 0), XLEN),
+          LSUOpType.amoor_w   -> SignExt(rdataSel(31, 0), XLEN),
+          LSUOpType.amomin_w  -> SignExt(rdataSel(31, 0), XLEN),
+          LSUOpType.amomax_w  -> SignExt(rdataSel(31, 0), XLEN),
+          LSUOpType.amominu_w -> SignExt(rdataSel(31, 0), XLEN),
+          LSUOpType.amomaxu_w -> SignExt(rdataSel(31, 0), XLEN),
+
+          LSUOpType.lr_d      -> SignExt(rdataSel(63, 0), XLEN),
+          LSUOpType.sc_d      -> io.dcache.resp.bits.data,
+          LSUOpType.amoswap_d -> SignExt(rdataSel(63, 0), XLEN),
+          LSUOpType.amoadd_d  -> SignExt(rdataSel(63, 0), XLEN),
+          LSUOpType.amoxor_d  -> SignExt(rdataSel(63, 0), XLEN),
+          LSUOpType.amoand_d  -> SignExt(rdataSel(63, 0), XLEN),
+          LSUOpType.amoor_d   -> SignExt(rdataSel(63, 0), XLEN),
+          LSUOpType.amomin_d  -> SignExt(rdataSel(63, 0), XLEN),
+          LSUOpType.amomax_d  -> SignExt(rdataSel(63, 0), XLEN),
+          LSUOpType.amominu_d -> SignExt(rdataSel(63, 0), XLEN),
+          LSUOpType.amomaxu_d -> SignExt(rdataSel(63, 0), XLEN)
+        ))
+
+        when (io.dcache.resp.bits.error && io.csrCtrl.cache_error_enable) {
+          exceptionVec(loadAccessFault)  := isLr
+          exceptionVec(storeAccessFault) := !isLr
+          assert(!exceptionVec(loadAccessFault))
+          assert(!exceptionVec(storeAccessFault))
+        }
+
+        resp_data := resp_data_wire
+        state := s_finish
+        out_valid := true.B
+
+        // dcache_resp_data := io.dcache.resp.bits.data
+        // dcache_resp_id := io.dcache.resp.bits.id
+        // dcache_resp_error := io.dcache.resp.bits.error
+        // state := s_cache_resp_latch
       }
-    }
-  }
-
-  when(state === s_cache_resp_latch) {
-    when(data_valid) {
-      is_lrsc_valid :=  dcache_resp_id
-      val rdataSel = LookupTree(paddr(2, 0), List(
-        "b000".U -> dcache_resp_data(63, 0),
-        "b001".U -> dcache_resp_data(63, 8),
-        "b010".U -> dcache_resp_data(63, 16),
-        "b011".U -> dcache_resp_data(63, 24),
-        "b100".U -> dcache_resp_data(63, 32),
-        "b101".U -> dcache_resp_data(63, 40),
-        "b110".U -> dcache_resp_data(63, 48),
-        "b111".U -> dcache_resp_data(63, 56)
-      ))
-
-      resp_data_wire := LookupTree(in.uop.ctrl.fuOpType, List(
-        LSUOpType.lr_w      -> SignExt(rdataSel(31, 0), XLEN),
-        LSUOpType.sc_w      -> dcache_resp_data,
-        LSUOpType.amoswap_w -> SignExt(rdataSel(31, 0), XLEN),
-        LSUOpType.amoadd_w  -> SignExt(rdataSel(31, 0), XLEN),
-        LSUOpType.amoxor_w  -> SignExt(rdataSel(31, 0), XLEN),
-        LSUOpType.amoand_w  -> SignExt(rdataSel(31, 0), XLEN),
-        LSUOpType.amoor_w   -> SignExt(rdataSel(31, 0), XLEN),
-        LSUOpType.amomin_w  -> SignExt(rdataSel(31, 0), XLEN),
-        LSUOpType.amomax_w  -> SignExt(rdataSel(31, 0), XLEN),
-        LSUOpType.amominu_w -> SignExt(rdataSel(31, 0), XLEN),
-        LSUOpType.amomaxu_w -> SignExt(rdataSel(31, 0), XLEN),
-
-        LSUOpType.lr_d      -> SignExt(rdataSel(63, 0), XLEN),
-        LSUOpType.sc_d      -> dcache_resp_data,
-        LSUOpType.amoswap_d -> SignExt(rdataSel(63, 0), XLEN),
-        LSUOpType.amoadd_d  -> SignExt(rdataSel(63, 0), XLEN),
-        LSUOpType.amoxor_d  -> SignExt(rdataSel(63, 0), XLEN),
-        LSUOpType.amoand_d  -> SignExt(rdataSel(63, 0), XLEN),
-        LSUOpType.amoor_d   -> SignExt(rdataSel(63, 0), XLEN),
-        LSUOpType.amomin_d  -> SignExt(rdataSel(63, 0), XLEN),
-        LSUOpType.amomax_d  -> SignExt(rdataSel(63, 0), XLEN),
-        LSUOpType.amominu_d -> SignExt(rdataSel(63, 0), XLEN),
-        LSUOpType.amomaxu_d -> SignExt(rdataSel(63, 0), XLEN)
-      ))
-
-      when (dcache_resp_error && io.csrCtrl.cache_error_enable) {
-        exceptionVec(loadAccessFault)  := isLr
-        exceptionVec(storeAccessFault) := !isLr
-        assert(!exceptionVec(loadAccessFault))
-        assert(!exceptionVec(storeAccessFault))
-      }
-
-      resp_data := resp_data_wire
-      state := s_finish
-      out_valid := true.B
     }
   }
 
@@ -432,7 +429,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
     val difftest = Module(new DifftestAtomicEvent)
     difftest.io.clock      := clock
     difftest.io.coreid     := io.hartId
-    difftest.io.atomicResp := (state === s_cache_resp_latch && data_valid)
+    difftest.io.atomicResp := (state === s_cache_resp && io.dcache.resp.fire() && !io.dcache.resp.bits.miss)
     difftest.io.atomicAddr := paddr_reg
     difftest.io.atomicData := data_reg
     difftest.io.atomicMask := mask_reg


### PR DESCRIPTION
* send tlb req and sbuffer flush req at the same time
* remove s_cache_resp_latch state
* change `data_valid` logic: do not send dcache req until `data_valid` is true