### PR TITLE
Trigger: Refactor

### DIFF
--- a/src/main/scala/device/RocketDebugWrapper.scala
+++ b/src/main/scala/device/RocketDebugWrapper.scala
@@ -62,7 +62,7 @@ class DebugModule(numCores: Int)(implicit p: Parameters) extends LazyModule {
     io.resetCtrl.hartResetReq.foreach { rcio => debug.module.io.hartResetReq.foreach { rcdm => rcio := rcdm }}
 
     io.debugIO.clockeddmi.foreach { dbg => debug.module.io.dmi.get <> dbg } // not connected in current case since we use dtm
-    debug.module.io.debug_reset := io.debugIO.reset
+    debug.module.io.debug_reset := io.debugIO.systemjtag.get.reset
     debug.module.io.debug_clock := io.debugIO.clock
     io.debugIO.ndreset := debug.module.io.ctrl.ndreset
     io.debugIO.dmactive := debug.module.io.ctrl.dmactive

--- a/src/main/scala/utils/BitUtils.scala
+++ b/src/main/scala/utils/BitUtils.scala
@@ -230,6 +230,41 @@ object OnesMoreThan {
   }
 }
 
+/** Scan an input signal with fixed length.
+  * Set 1 at the end of the length-fixed scan chain if the scanned bits meet the condition.
+  *
+  * @example {{{
+  * val data = Seq(false.B, true.B, true.B, false.B, true.B)
+  * def condition(input: Seq[Bool]) : Bool = input(0) && input(1)
+  * val onesLen2EndVec = FixLengthScanSetEnd(data, 2, condition)
+  * assert(VecInit(onesLen2EndVec).asUInt === VecInit(Seq(false.B, false.B, true.B, false.B, false.B)).asUInt)
+  * }}}
+  */
+object FixedLengthScanSetEnd {
+  def apply(input: Seq[Bool], scanLen: Int, condition: Seq[Bool] => Bool) : Seq[Bool] = {
+    require(scanLen > 0)
+    val res: Vec[Bool] = VecInit(Seq.fill(input.size)(false.B))
+    for (i <- (scanLen - 1) until input.size) {
+      res(i) := condition((1 - scanLen until 1).map(_ + i).map(input(_)))
+    }
+    res
+  }
+}
+
+object ConsecutiveOnesSetEnd {
+  def apply(input: Seq[Bool], thres: Int): Seq[Bool] = {
+    def condition(input: Seq[Bool]): Bool = input.reduce(_ && _)
+    FixedLengthScanSetEnd(input, thres, condition)
+  }
+}
+
+object ConsecutiveOnes {
+  def apply(input: Seq[Bool], thres: Int): Bool = {
+    require(thres > 0)
+    ConsecutiveOnesSetEnd(input, thres).reduce(_ || _)
+  }
+}
+
 abstract class SelectOne {
   def getNthOH(n: Int): (Bool, Vec[Bool])
 }

--- a/src/main/scala/utils/IntBuffer.scala
+++ b/src/main/scala/utils/IntBuffer.scala
@@ -4,6 +4,7 @@ import chisel3._
 import chipsalliance.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.interrupts.IntAdapterNode
+import freechips.rocketchip.util.AsyncResetSynchronizerShiftReg
 
 class IntBuffer(implicit p: Parameters) extends LazyModule {
 
@@ -11,7 +12,7 @@ class IntBuffer(implicit p: Parameters) extends LazyModule {
 
   lazy val module = new LazyModuleImp(this){
     for(((in, edgeIn), (out, edgeOut)) <- node.in.zip(node.out)){
-      out := RegNext(in, 0.U.asTypeOf(in))
+      out := AsyncResetSynchronizerShiftReg(in, 3)
     }
   }
 

--- a/src/main/scala/utils/Trigger.scala
+++ b/src/main/scala/utils/Trigger.scala
@@ -21,20 +21,6 @@ import chisel3.util._
 import xiangshan.MatchTriggerIO
 import chipsalliance.rocketchip.config.Parameters
 
-
-object TriggerCmp {
-  def apply(actual: UInt, tdata: UInt, matchType: UInt, enable: Bool) = {
-    val equal = actual === tdata
-    val greater = actual >= tdata
-    val less = actual <= tdata
-    val res = MuxLookup(matchType, false.B,
-      Array(0.U -> equal,
-          2.U -> greater,
-          3.U -> less))
-    res && enable
-  }
-}
-
 object ChainCheck {
   def TimingCheck(prevTiming: Bool, thisTiming: Bool, chain: Bool) = !((prevTiming ^ thisTiming) && chain)
   def HitCheck(prevHit: Bool, chain: Bool) = prevHit || !chain

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -449,4 +449,7 @@ trait HasXSParameter {
   val numCSRPCntLsu      = 8
   val numCSRPCntHc       = 5
   val printEventCoding   = true
+  // Parameters for Sdtrig extension
+  protected val TriggerNum = 10
+  protected val TriggerChainMaxLength = 2
 }

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -94,10 +94,10 @@ class XSTile()(implicit p: Parameters) extends LazyModule
   val beu_int_source = IntIdentityNode()
   val core_reset_sink = BundleBridgeSink(Some(() => Reset()))
 
-  core.clint_int_sink :*= IntBuffer() :*= IntBuffer() :*= clint_int_sink
-  core.plic_int_sink :*= IntBuffer() :*= IntBuffer() :*= plic_int_sink
-  core.debug_int_sink :*= IntBuffer() :*= IntBuffer() :*= debug_int_sink
-  beu_int_source :*= IntBuffer() :*= IntBuffer() :*= misc.beu.intNode
+  core.clint_int_sink :*= IntBuffer() :*= clint_int_sink
+  core.plic_int_sink :*= IntBuffer() :*= plic_int_sink
+  core.debug_int_sink :*= IntBuffer() :*= debug_int_sink
+  beu_int_source :*= IntBuffer() :*= misc.beu.intNode
 
 
 

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -27,6 +27,7 @@ import utils._
 import xiangshan._
 import xiangshan.backend.exu.StdExeUnit
 import xiangshan.backend.fu._
+import xiangshan.backend.fu.util.SdtrigExt
 import xiangshan.backend.rob.RobLsqIO
 import xiangshan.cache._
 import xiangshan.cache.mmu.{BTlbPtwIO, TLB, TlbReplace}
@@ -64,6 +65,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   with HasFPUParameters
   with HasWritebackSourceImp
   with HasPerfEvents
+  with SdtrigExt
 {
 
   val io = IO(new Bundle {
@@ -270,19 +272,22 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   )
   dtlb.foreach(_.ptw_replenish := pmp_check_ptw.io.resp)
 
-  val tdata = RegInit(VecInit(Seq.fill(6)(0.U.asTypeOf(new MatchTriggerIO))))
-  val tEnable = RegInit(VecInit(Seq.fill(6)(false.B)))
-  val en = csrCtrl.trigger_enable
-  tEnable := VecInit(en(2), en (3), en(4), en(5), en(7), en(9))
-  when(csrCtrl.mem_trigger.t.valid) {
-    tdata(csrCtrl.mem_trigger.t.bits.addr) := csrCtrl.mem_trigger.t.bits.tdata
+  val tdata = RegInit(VecInit(Seq.fill(TriggerNum)(0.U.asTypeOf(new MatchTriggerIO))))
+  val tEnable = RegInit(VecInit(Seq.fill(TriggerNum)(false.B)))
+  tEnable := csrCtrl.mem_trigger.tEnableVec
+  when(csrCtrl.mem_trigger.tUpdate.valid) {
+    tdata(csrCtrl.mem_trigger.tUpdate.bits.addr) := csrCtrl.mem_trigger.tUpdate.bits.tdata
   }
-  val lTriggerMapping = Map(0 -> 2, 1 -> 3, 2 -> 5)
-  val sTriggerMapping = Map(0 -> 0, 1 -> 1, 2 -> 4)
-  val lChainMapping = Map(0 -> 2)
-  val sChainMapping = Map(0 -> 1)
+
+  val backendTriggerTimingVec = tdata.map(_.timing)
+  val backendTriggerChainVec  = tdata.map(_.chain)
+
+  //  val lTriggerMapping = Map(0 -> 2, 1 -> 3, 2 -> 5)
+//  val sTriggerMapping = Map(0 -> 0, 1 -> 1, 2 -> 4)
+//  val lChainMapping = Map(0 -> 2)
+//  val sChainMapping = Map(0 -> 1)
   XSDebug(tEnable.asUInt.orR, "Debug Mode: At least one store trigger is enabled\n")
-  for(j <- 0 until 3)
+  for(j <- 0 until TriggerNum)
     PrintTriggerInfo(tEnable(j), tdata(j))
 
   // LoadUnit
@@ -350,39 +355,33 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     // update mem dependency predictor
     // io.memPredUpdate(i) := DontCare
 
-    // Trigger Regs
-    // addr: 0-2 for store, 3-5 for load
-//    for (j <- 0 until 10) {
-//      io.writeback(i).bits.uop.cf.trigger.triggerHitVec(j) := false.B
-//      io.writeback(i).bits.uop.cf.trigger.triggerTiming(j) := false.B
-//      if (lChainMapping.contains(j)) io.writeback(i).bits.uop.cf.trigger.triggerChainVec(j) := false.B
-//    }
-
     // --------------------------------
     // Load Triggers
     // --------------------------------
-    val hit = Wire(Vec(3, Bool()))
-    for (j <- 0 until 3) {
-      loadUnits(i).io.trigger(j).tdata2 := tdata(lTriggerMapping(j)).tdata2
-      loadUnits(i).io.trigger(j).matchType := tdata(lTriggerMapping(j)).matchType
-      loadUnits(i).io.trigger(j).tEnable := tEnable(lTriggerMapping(j))
+    val frontendTriggerTimingVec  = io.writeback(i).bits.uop.cf.trigger.frontendTiming
+    val frontendTriggerChainVec   = io.writeback(i).bits.uop.cf.trigger.frontendChain
+    val frontendTriggerHitVec     = io.writeback(i).bits.uop.cf.trigger.frontendHit
+    val loadTriggerHitVec         = Wire(Vec(TriggerNum, Bool()))
+
+    val triggerTimingVec  = VecInit(backendTriggerTimingVec.zip(frontendTriggerTimingVec).map { case (b, f) => b || f } )
+    val triggerChainVec   = VecInit(backendTriggerChainVec.zip(frontendTriggerChainVec).map { case (b, f) => b || f } )
+    val triggerHitVec     = VecInit(loadTriggerHitVec.zip(frontendTriggerHitVec).map { case (b, f) => b || f })
+
+    val triggerCanFireVec = Wire(Vec(TriggerNum, Bool()))
+
+    for (j <- 0 until TriggerNum) {
+      loadUnits(i).io.trigger(j).tdata2     := tdata(j).tdata2
+      loadUnits(i).io.trigger(j).matchType  := tdata(j).matchType
+      loadUnits(i).io.trigger(j).tEnable    := tEnable(j) && tdata(j).load
       // Just let load triggers that match data unavailable
-      hit(j) := loadUnits(i).io.trigger(j).addrHit && !tdata(lTriggerMapping(j)).select // Mux(tdata(j + 3).select, loadUnits(i).io.trigger(j).lastDataHit, loadUnits(i).io.trigger(j).addrHit)
-      io.writeback(i).bits.uop.cf.trigger.backendHit(lTriggerMapping(j)) := hit(j)
-//      io.writeback(i).bits.uop.cf.trigger.backendTiming(lTriggerMapping(j)) := tdata(lTriggerMapping(j)).timing
-      //      if (lChainMapping.contains(j)) io.writeback(i).bits.uop.cf.trigger.triggerChainVec(lChainMapping(j)) := hit && tdata(j+3).chain
+      loadTriggerHitVec(j) := loadUnits(i).io.trigger(j).addrHit && !tdata(j).select
     }
-    when(tdata(2).chain) {
-      io.writeback(i).bits.uop.cf.trigger.backendHit(2) := hit(0) && hit(1)
-      io.writeback(i).bits.uop.cf.trigger.backendHit(3) := hit(0) && hit(1)
-    }
-    when(!io.writeback(i).bits.uop.cf.trigger.backendEn(1)) {
-      io.writeback(i).bits.uop.cf.trigger.backendHit(5) := false.B
-    }
+    TriggerCheckCanFire(TriggerNum, triggerCanFireVec, triggerHitVec, triggerTimingVec, triggerChainVec)
 
-    XSDebug(io.writeback(i).bits.uop.cf.trigger.getHitBackend && io.writeback(i).valid, p"Debug Mode: Load Inst No.${i}" +
-    p"has trigger hit vec ${io.writeback(i).bits.uop.cf.trigger.backendHit}\n")
-
+    io.writeback(i).bits.uop.cf.trigger.backendHit      := triggerHitVec
+    io.writeback(i).bits.uop.cf.trigger.backendCanFire  := triggerCanFireVec
+    XSDebug(io.writeback(i).bits.uop.cf.trigger.getBackendCanFire && io.writeback(i).valid, p"Debug Mode: Load Inst No.${i}" +
+    p"has trigger fire vec ${io.writeback(i).bits.uop.cf.trigger.backendCanFire}\n")
   }
   // Prefetcher
   prefetcherOpt.foreach(pf => {
@@ -430,27 +429,32 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     // -------------------------
     // Store Triggers
     // -------------------------
-    when(stOut(i).fire()){
-      val hit = Wire(Vec(3, Bool()))
-      for (j <- 0 until 3) {
-         hit(j) := !tdata(sTriggerMapping(j)).select && TriggerCmp(
-           stOut(i).bits.debug.vaddr,
-           tdata(sTriggerMapping(j)).tdata2,
-           tdata(sTriggerMapping(j)).matchType,
-           tEnable(sTriggerMapping(j))
-         )
-       stOut(i).bits.uop.cf.trigger.backendHit(sTriggerMapping(j)) := hit(j)
-     }
+    val frontendTriggerTimingVec  = stOut(i).bits.uop.cf.trigger.frontendTiming
+    val frontendTriggerChainVec   = stOut(i).bits.uop.cf.trigger.frontendChain
+    val frontendTriggerHitVec     = stOut(i).bits.uop.cf.trigger.frontendHit
 
-     when(tdata(0).chain) {
-       io.writeback(i).bits.uop.cf.trigger.backendHit(0) := hit(0) && hit(1)
-       io.writeback(i).bits.uop.cf.trigger.backendHit(1) := hit(0) && hit(1)
-     }
+    val storeTriggerHitVec        = WireInit(VecInit(Seq.fill(TriggerNum)(false.B)))
 
-     when(!stOut(i).bits.uop.cf.trigger.backendEn(0)) {
-       stOut(i).bits.uop.cf.trigger.backendHit(4) := false.B
-     }
-   }
+    val triggerTimingVec  = VecInit(backendTriggerTimingVec.zip(frontendTriggerTimingVec).map { case (b, f) => b || f } )
+    val triggerChainVec   = VecInit(backendTriggerChainVec.zip(frontendTriggerChainVec).map { case (b, f) => b || f } )
+    val triggerHitVec     = VecInit(storeTriggerHitVec.zip(frontendTriggerHitVec).map { case (b, f) => b || f })
+
+    val triggerCanFireVec = WireInit(VecInit(Seq.fill(TriggerNum)(false.B)))
+
+    when(stOut(i).fire){
+      for (j <- 0 until TriggerNum) {
+        storeTriggerHitVec(j) := !tdata(j).select && TriggerCmp(
+          stOut(i).bits.debug.vaddr,
+          tdata(j).tdata2,
+          tdata(j).matchType,
+          tEnable(j) && tdata(j).store
+        )
+      }
+      TriggerCheckCanFire(TriggerNum, triggerCanFireVec, triggerHitVec, triggerTimingVec, triggerChainVec)
+
+      stOut(i).bits.uop.cf.trigger.backendHit := triggerHitVec
+      stOut(i).bits.uop.cf.trigger.backendCanFire := triggerCanFireVec
+    }
     // store data
 //    when(lsq.io.storeDataIn(i).fire()){
 //
@@ -494,7 +498,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
 
     // when atom inst writeback, surpress normal load trigger
     (0 until 2).map(i => {
-      io.writeback(i).bits.uop.cf.trigger.backendHit := VecInit(Seq.fill(6)(false.B))
+      io.writeback(i).bits.uop.cf.trigger.backendHit := VecInit(Seq.fill(TriggerNum)(false.B))
     })
   }
 

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -135,7 +135,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents {
     // update singleStep
     updatedUop(i).ctrl.singleStep := io.singleStep && (if (i == 0) singleStepStatus else true.B)
     when (io.fromRename(i).fire()) {
-      XSDebug(updatedUop(i).cf.trigger.getHitFrontend, s"Debug Mode: inst ${i} has frontend trigger exception\n")
+      XSDebug(updatedUop(i).cf.trigger.getFrontendCanFire, s"Debug Mode: inst ${i} has frontend trigger exception\n")
       XSDebug(updatedUop(i).ctrl.singleStep, s"Debug Mode: inst ${i} has single step exception\n")
     }
   }
@@ -166,7 +166,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents {
   // nextCanOut: next instructions can out (based on blockBackward)
   // notBlockedByPrevious: previous instructions can enqueue
   val hasException = VecInit(io.fromRename.map(
-    r => selectFrontend(r.bits.cf.exceptionVec).asUInt.orR || r.bits.ctrl.singleStep || r.bits.cf.trigger.getHitFrontend))
+    r => selectFrontend(r.bits.cf.exceptionVec).asUInt.orR || r.bits.ctrl.singleStep || r.bits.cf.trigger.getFrontendCanFire))
   val thisIsBlocked = VecInit((0 until RenameWidth).map(i => {
     // for i > 0, when Rob is empty but dispatch1 have valid instructions to enqueue, it's blocked
     if (i > 0) isNoSpecExec(i) && (!io.enqRob.isEmpty || Cat(io.fromRename.take(i).map(_.valid)).orR)

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -27,7 +27,6 @@ import xiangshan.ExceptionNO._
 import xiangshan._
 import xiangshan.backend.fu.util._
 import xiangshan.cache._
-import freechips.rocketchip.util.AsyncResetSynchronizerShiftReg
 
 // Trigger Tdata1 bundles
 trait HasTriggerConst {
@@ -928,8 +927,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   def priviledgedEnableDetect(x: Bool): Bool = Mux(x, ((priviledgeMode === ModeS) && mstatusStruct.ie.s) || (priviledgeMode < ModeS),
     ((priviledgeMode === ModeM) && mstatusStruct.ie.m) || (priviledgeMode < ModeM))
 
-  val debugIntrSync = AsyncResetSynchronizerShiftReg(csrio.externalInterrupt.debug, 3)
-  val debugIntr = debugIntrSync & debugIntrEnable
+  val debugIntr = csrio.externalInterrupt.debug & debugIntrEnable
   XSDebug(debugIntr, "Debug Mode: debug interrupt is asserted and valid!")
   // send interrupt information to ROB
   val intrVecEnable = Wire(Vec(12, Bool()))

--- a/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
@@ -271,3 +271,4 @@ trait HasCSRConst {
     Mux(!mModeCanWrite && isTriggerReg, debug, true.B)
   }
 }
+object CSRConst extends HasCSRConst

--- a/src/main/scala/xiangshan/backend/fu/util/DebugCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/DebugCSR.scala
@@ -1,0 +1,52 @@
+package xiangshan.backend.fu.util
+
+import chisel3._
+import chipsalliance.rocketchip.config.Parameters
+import CSRConst.ModeM
+
+trait DebugCSR {
+  implicit val p: Parameters
+  class DcsrStruct extends Bundle {
+    val debugver  = Output(UInt(4.W)) // [28:31]
+    val pad1      = Output(UInt(10.W))// [27:18]
+    val ebreakvs  = Output(Bool())    // [17] reserved for Hypervisor debug
+    val ebreakvu  = Output(Bool())    // [16] reserved for Hypervisor debug
+    val ebreakm   = Output(Bool())    // [15]
+    val pad0      = Output(Bool())    // [14] ebreakh has been removed
+    val ebreaks   = Output(Bool())    // [13]
+    val ebreaku   = Output(Bool())    // [12]
+    val stepie    = Output(Bool())    // [11]
+    val stopcount = Output(Bool())    // [10]
+    val stoptime  = Output(Bool())    // [9]
+    val cause     = Output(UInt(3.W)) // [8:6]
+    val v         = Output(Bool())    // [5]
+    val mprven    = Output(Bool())    // [4]
+    val nmip      = Output(Bool())    // [3]
+    val step      = Output(Bool())    // [2]
+    val prv       = Output(UInt(2.W)) // [1:0]
+    require(this.getWidth == 32)
+  }
+
+  object DcsrStruct extends DcsrStruct {
+    def DEBUGVER_NONE   = 0.U
+    def DEBUGVER_SPEC   = 4.U
+    def DEBUGVER_CUSTOM = 15.U
+    def CAUSE_EBREAK        = 1.U
+    def CAUSE_TRIGGER       = 2.U
+    def CAUSE_HALTREQ       = 3.U
+    def CAUSE_STEP          = 4.U
+    def CAUSE_RESETHALTREQ  = 5.U
+    private def debugver_offset   = 28
+    private def stopcount_offset  = 10
+    private def stoptime_offset   = 9
+    private def mprven_offset     = 5
+    private def prv_offset        = 0
+    def init: UInt = (
+      (DEBUGVER_SPEC.litValue << debugver_offset) | /* Debug implementation as it described in 0.13 draft */
+      (0L << stopcount_offset) |                    /* Stop count updating has not been supported */
+      (0L << stoptime_offset) |                     /* Stop time updating has not been supported */
+      (0L << mprven_offset) |                       /* Whether use mstatus.perven as mprven */
+      (ModeM.litValue << prv_offset)
+    ).U
+  }
+}

--- a/src/main/scala/xiangshan/backend/fu/util/Trigger.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/Trigger.scala
@@ -189,22 +189,22 @@ trait SdtrigExt {
 
   /**
     * Check if triggers can fire
-    * @param TriggerNum
+    * @param triggerNum
     * @param canFireVec
     * @param hitVec
     * @param timingVec
     * @param chainVec
     */
-  def TriggerCheckCanFire(TriggerNum: Int, canFireVec: Vec[Bool], hitVec: Vec[Bool], timingVec: Vec[Bool], chainVec: Vec[Bool]): Unit = {
-    val trigger2ChainVec = WireInit(VecInit(Seq.fill(TriggerNum)(false.B)))
-    val trigger2TimingSameVec = WireInit(VecInit(Seq.fill(TriggerNum)(true.B)))
-    val trigger2TimingOkVec = WireInit(VecInit(Seq.fill(TriggerNum)(true.B)))
-    val trigger2ChainOkVec = WireInit(VecInit(Seq.fill(TriggerNum)(true.B)))
-    for (i <- 1 until TriggerNum) { // the 0th trigger always chain ok
+  def TriggerCheckCanFire(triggerNum: Int, canFireVec: Vec[Bool], hitVec: Vec[Bool], timingVec: Vec[Bool], chainVec: Vec[Bool]): Unit = {
+    val trigger2ChainVec = WireInit(VecInit(Seq.fill(triggerNum)(false.B)))
+    val trigger2TimingSameVec = WireInit(VecInit(Seq.fill(triggerNum)(true.B)))
+    val trigger2TimingOkVec = WireInit(VecInit(Seq.fill(triggerNum)(true.B)))
+    val trigger2ChainOkVec = WireInit(VecInit(Seq.fill(triggerNum)(true.B)))
+    for (i <- 1 until triggerNum) { // the 0th trigger always chain ok
       trigger2ChainOkVec(i) := chainVec(i - 1) && hitVec(i - 1) || !chainVec(i - 1)
     }
 
-    for (i <- 1 until TriggerNum) { // the 0th trigger always timing same, not chain, timing ok
+    for (i <- 1 until triggerNum) { // the 0th trigger always timing same, not chain, timing ok
       trigger2TimingSameVec(i) := timingVec(i - 1) === timingVec(i)
       trigger2ChainVec(i) := chainVec(i - 1) && !chainVec(i)
       trigger2TimingOkVec(i) := trigger2ChainVec(i) && trigger2TimingSameVec(i) || !chainVec(i - 1)
@@ -220,8 +220,8 @@ trait SdtrigExt {
     * @param chainLen
     * @return true.B if the max length of chain don't exceed the permitted length
     */
-  def TriggerCheckChainLegal(chainVec: Vec[Bool], chainLen: Int): Bool = {
-    ConsecutiveOnes(chainVec, chainLen - 1)
+  def TriggerCheckChainLegal(chainVec: Seq[Bool], chainLen: Int): Bool = {
+    !ConsecutiveOnes(chainVec, chainLen)
   }
 
   /**

--- a/src/main/scala/xiangshan/backend/fu/util/Trigger.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/Trigger.scala
@@ -1,0 +1,215 @@
+package xiangshan.backend.fu.util
+
+import chisel3._
+import chisel3.util._
+import xiangshan.XSBundle
+import chipsalliance.rocketchip.config.Parameters
+
+trait SdtrigExt {
+  implicit val p: Parameters
+  class TDataRegs extends XSBundle {
+    val tdata1 = UInt(XLEN.W)
+    val tdata2 = UInt(XLEN.W)
+  }
+  object TDataRegs extends TDataRegs {
+    def apply() = new TDataRegs
+  }
+
+  class Tdata1Bundle extends XSBundle {
+    val type_ = TrigTypeEnum()    // [XLEN-1: XLEN-4]
+    val dmode = Bool()            // [XLEN-5]
+    val data  = new Tdata1Data    // [XLEN-6, 0]
+    require(this.getWidth == XLEN)
+    def getTriggerAction : TrigActionEnum = {
+      this.data.asTypeOf(new MControlData).action
+    }
+    def getTriggerChain: Bool = {
+      this.data.asTypeOf(new MControlData).chain
+    }
+    def getTiming: Bool = {
+      this.data.asTypeOf(new MControlData).timing
+    }
+  }
+  object Tdata1Bundle {
+    def apply(): Tdata1Bundle = new Tdata1Bundle
+    def Read(rdata: UInt) : UInt = rdata
+    def Write(wdata: UInt, tdata1: UInt, chainable: Bool) : UInt = {
+      val tdata1_old = WireInit(tdata1.asTypeOf(new Tdata1Bundle))
+      val tdata1_new = Wire(new Tdata1Bundle)
+      val wdata_new = WireInit(wdata.asTypeOf(new Tdata1Bundle))
+      tdata1_new.type_ := wdata_new.type_.legalize
+      tdata1_new.dmode := false.B // not support yet
+      when (wdata_new.type_.asUInt === TrigTypeEnum.MCONTROL) {
+        tdata1_new.data.value := MControlData.Write(wdata_new.data.asUInt, tdata1_old.data.asUInt, chainable)
+      }.otherwise {
+        tdata1_new.data.value := 0.U
+      }
+      tdata1_new.asUInt
+    }
+  }
+
+  class TrigTypeEnum extends Bundle {
+    val value         = UInt(4.W)
+    def NONE          = 0.U
+    def LEGACY        = 1.U
+    def MCONTROL      = 2.U
+    def ICOUNT        = 3.U
+    def ITRIGGER      = 4.U
+    def ETRIGGER      = 5.U
+    def MCONTROL6     = 6.U
+    def TMEXTTRIGGER  = 7.U
+    def disabled      = 15.U
+    /**
+      * XS supports part of trigger type of Sdtrig extension
+      * @param data trigger type checked
+      * @return true.B, If XS support this trigger type
+      */
+    def isLegal : Bool = {
+      this.asUInt === this.MCONTROL
+    }
+    def legalize : TrigTypeEnum = {
+      Mux(this.isLegal, this.asUInt, this.disabled).asTypeOf(new TrigTypeEnum)
+    }
+  }
+  object TrigTypeEnum extends TrigTypeEnum {
+    def apply()   = new TrigTypeEnum
+  }
+
+  protected class Tdata1Data extends XSBundle {
+    val value = UInt((XLEN-5).W)
+  }
+
+  class MControlData extends Tdata1Data {
+    override val value = null
+    val maskmax   = UInt(6.W)                           // [XLEN-6: XLEN-11]
+    val zero1     = if (XLEN==64) UInt(30.W) else null  // [XLEN-12: 23]
+    val sizehi    = if (XLEN==64) UInt(2.W) else null   // [22:21]
+    val hit       = Bool()                              // [20]
+    val select    = Bool()                              // [19]
+    val timing    = Bool()                              // [18]
+    val sizelo    = UInt(2.W)                           // [17:16]
+    val action    = TrigActionEnum()                    // [15:12]
+    val chain     = Bool()                              // [11]
+    val match_    = TrigMatchEnum()                     // [10:7]
+    val m         = Bool()                              // [6]
+    val zero2     = Bool()                              // [5]
+    val s         = Bool()                              // [4]
+    val u         = Bool()                              // [3]
+    val execute   = Bool()                              // [2]
+    val store     = Bool()                              // [1]
+    val load      = Bool()                              // [0]
+    require(this.getWidth == (new Tdata1Data).getWidth)
+
+    def isFetchTrigger: Bool = this.execute
+    def isMemAccTrigger: Bool = this.store || this.load
+  }
+  object MControlData {
+    def Read(rdata: UInt) : UInt = rdata
+    def Write(wdata: UInt, tdata1data: UInt, chainable: Bool) : UInt = {
+      val mcontrol_old = WireInit(tdata1data.asTypeOf(new MControlData))
+      val mcontrol_new = WireInit(wdata.asTypeOf(new MControlData))
+      val wdata_new = WireInit(wdata.asTypeOf(new MControlData))
+      mcontrol_new.maskmax  := 0.U
+      mcontrol_new.zero1    := 0.U
+      mcontrol_new.sizehi   := 0.U
+      mcontrol_new.hit      := false.B
+      mcontrol_new.select   := wdata_new.execute && wdata_new.select // not support rdata/wdata trigger
+      mcontrol_new.timing   := false.B // only support trigger fires before its execution
+      mcontrol_new.sizelo   := 0.U
+      mcontrol_new.action   := wdata_new.action.legalize
+      mcontrol_new.chain    := chainable && wdata_new.chain
+      mcontrol_new.match_   := wdata_new.match_.legalize
+      mcontrol_new.zero2    := 0.U
+      mcontrol_new.asUInt
+    }
+  }
+
+  class TrigActionEnum extends Bundle {
+    val value       = UInt(4.W)
+    def BKPT_EXCPT  = 0.U // raise breakpoint exception
+    def DEBUG_MODE  = 1.U // enter debug mode
+    def TRACE_ON    = 2.U
+    def TRACE_OFF   = 3.U
+    def TRACE_NOTIFY= 4.U
+    def default     = this.BKPT_EXCPT
+    /**
+      * XS supports part of trigger action type of Sdtrig extension
+      * @param data action checked
+      * @return true.B, If XS support such trigger action type
+      */
+    def isLegal : Bool = {
+      this.asUInt === this.BKPT_EXCPT || this.asUInt === this.DEBUG_MODE
+    }
+    def legalize : TrigActionEnum = {
+      Mux(this.isLegal, this.asUInt, this.default).asTypeOf(new TrigActionEnum)
+    }
+  }
+  object TrigActionEnum extends TrigActionEnum {
+    def apply() = new TrigActionEnum
+  }
+
+  class TrigMatchEnum extends Bundle {
+    val value     = UInt(4.W)
+    private def not_bit = 8.U
+    def EQ        = 0.U
+    def NAPOT     = 1.U
+    def GE        = 2.U
+    def LT        = 3.U
+    def MASK_LO   = 4.U
+    def MASK_HI   = 5.U
+    def NE        = EQ      | this.not_bit // not eq
+    def NNAPOT    = NAPOT   | this.not_bit // not napot
+    def NMASK_LO  = MASK_LO | this.not_bit // not mask low
+    def NMASK_HI  = MASK_HI | this.not_bit // not mask high
+    def default   = this.EQ
+    def isRVSpecLegal : Bool = {
+      this.asUInt === this.EQ || this.asUInt === this.NAPOT ||
+        this.asUInt === this.GE || this.asUInt === this.LT ||
+        this.asUInt === this.MASK_LO || this.asUInt === this.MASK_HI ||
+        this.asUInt === this.NE || this.asUInt === this.NNAPOT ||
+        this.asUInt === this.NMASK_LO || this.asUInt === this.NMASK_HI
+    }
+
+    /**
+      * XS supports part of trigger match type of Sdtrig extension
+      * @param data match type checked
+      * @return true.B, If XS support such trigger match type
+      */
+    def isLegal : Bool = {
+      this.asUInt === this.EQ || this.asUInt === this.GE || this.asUInt === this.LT
+    }
+    def legalize : TrigMatchEnum = {
+      Mux(this.isLegal, this.asUInt, this.default).asTypeOf(new TrigMatchEnum)
+    }
+  }
+  object TrigMatchEnum extends TrigMatchEnum {
+    def apply() = new TrigMatchEnum
+  }
+
+  /**
+    * Check if triggers can fire
+    * @param TriggerNum
+    * @param canFireVec
+    * @param hitVec
+    * @param timingVec
+    * @param chainVec
+    */
+  def TriggerCheckCanFire(TriggerNum: Int, canFireVec: Vec[Bool], hitVec: Vec[Bool], timingVec: Vec[Bool], chainVec: Vec[Bool]): Unit = {
+    val trigger2ChainVec = WireInit(VecInit(Seq.fill(TriggerNum)(false.B)))
+    val trigger2TimingSameVec = WireInit(VecInit(Seq.fill(TriggerNum)(true.B)))
+    val trigger2TimingOkVec = WireInit(VecInit(Seq.fill(TriggerNum)(true.B)))
+    val trigger2ChainOkVec = WireInit(VecInit(Seq.fill(TriggerNum)(true.B)))
+    for (i <- 1 until TriggerNum) { // the 0th trigger always chain ok
+      trigger2ChainOkVec(i) := chainVec(i - 1) && hitVec(i - 1) || !chainVec(i - 1)
+    }
+
+    for (i <- 1 until TriggerNum) { // the 0th trigger always timing same, not chain, timing ok
+      trigger2TimingSameVec(i) := timingVec(i - 1) === timingVec(i)
+      trigger2ChainVec(i) := chainVec(i - 1) && !chainVec(i)
+      trigger2TimingOkVec(i) := trigger2ChainVec(i) && trigger2TimingSameVec(i) || !chainVec(i - 1)
+    }
+    canFireVec.zipWithIndex.foreach {
+      case (canFire, i) => canFire := trigger2ChainOkVec(i) && trigger2TimingOkVec(i) && hitVec(i)
+    }
+  }
+}

--- a/src/main/scala/xiangshan/backend/fu/util/Trigger.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/Trigger.scala
@@ -210,7 +210,7 @@ trait SdtrigExt {
       trigger2TimingOkVec(i) := trigger2ChainVec(i) && trigger2TimingSameVec(i) || !chainVec(i - 1)
     }
     canFireVec.zipWithIndex.foreach {
-      case (canFire, i) => canFire := trigger2ChainOkVec(i) && trigger2TimingOkVec(i) && hitVec(i)
+      case (canFire, i) => canFire := trigger2ChainOkVec(i) && trigger2TimingOkVec(i) && hitVec(i) && !chainVec(i)
     }
   }
 

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -167,10 +167,10 @@ class RobExceptionInfo(implicit p: Parameters) extends XSBundle {
 
 //  def trigger_before = !trigger.getTimingBackend && trigger.getHitBackend
 //  def trigger_after = trigger.getTimingBackend && trigger.getHitBackend
-  def has_exception = exceptionVec.asUInt.orR || flushPipe || singleStep || replayInst || trigger.hit
-  def not_commit = exceptionVec.asUInt.orR || singleStep || replayInst || trigger.hit
+  def has_exception = exceptionVec.asUInt.orR || flushPipe || singleStep || replayInst || trigger.canFire
+  def not_commit = exceptionVec.asUInt.orR || singleStep || replayInst || trigger.canFire
   // only exceptions are allowed to writeback when enqueue
-  def can_writeback = exceptionVec.asUInt.orR || singleStep || trigger.hit
+  def can_writeback = exceptionVec.asUInt.orR || singleStep || trigger.canFire
 }
 
 class ExceptionGen(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelper {
@@ -418,22 +418,22 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
       when (enqUop.ctrl.noSpecExec) {
         hasNoSpecExec := true.B
       }
-      val enqHasTriggerHit = io.enq.req(i).bits.cf.trigger.getHitFrontend
+      val enqHasTriggerCanFire = io.enq.req(i).bits.cf.trigger.getFrontendCanFire
       val enqHasException = ExceptionNO.selectFrontend(enqUop.cf.exceptionVec).asUInt.orR
       // the begin instruction of Svinval enqs so mark doingSvinval as true to indicate this process
-      when(!enqHasTriggerHit && !enqHasException && FuType.isSvinvalBegin(enqUop.ctrl.fuType, enqUop.ctrl.fuOpType, enqUop.ctrl.flushPipe))
+      when(!enqHasTriggerCanFire && !enqHasException && FuType.isSvinvalBegin(enqUop.ctrl.fuType, enqUop.ctrl.fuOpType, enqUop.ctrl.flushPipe))
       {
         doingSvinval := true.B
       }
       // the end instruction of Svinval enqs so clear doingSvinval
-      when(!enqHasTriggerHit && !enqHasException && FuType.isSvinvalEnd(enqUop.ctrl.fuType, enqUop.ctrl.fuOpType, enqUop.ctrl.flushPipe))
+      when(!enqHasTriggerCanFire && !enqHasException && FuType.isSvinvalEnd(enqUop.ctrl.fuType, enqUop.ctrl.fuOpType, enqUop.ctrl.flushPipe))
       {
         doingSvinval := false.B
       }
       // when we are in the process of Svinval software code area , only Svinval.vma and end instruction of Svinval can appear
       assert(!doingSvinval || (FuType.isSvinval(enqUop.ctrl.fuType, enqUop.ctrl.fuOpType, enqUop.ctrl.flushPipe) ||
         FuType.isSvinvalEnd(enqUop.ctrl.fuType, enqUop.ctrl.fuOpType, enqUop.ctrl.flushPipe)))
-      when (enqUop.ctrl.isWFI && !enqHasException && !enqHasTriggerHit) {
+      when (enqUop.ctrl.isWFI && !enqHasException && !enqHasTriggerCanFire) {
         hasWFI := true.B
       }
     }
@@ -476,14 +476,14 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
   val intrEnable = intrBitSetReg && !hasNoSpecExec && interrupt_safe(deqPtr.value)
   val deqHasExceptionOrFlush = exceptionDataRead.valid && exceptionDataRead.bits.robIdx === deqPtr
   val deqHasException = deqHasExceptionOrFlush && (exceptionDataRead.bits.exceptionVec.asUInt.orR ||
-    exceptionDataRead.bits.singleStep || exceptionDataRead.bits.trigger.hit)
+    exceptionDataRead.bits.singleStep || exceptionDataRead.bits.trigger.canFire)
   val deqHasFlushPipe = deqHasExceptionOrFlush && exceptionDataRead.bits.flushPipe
   val deqHasReplayInst = deqHasExceptionOrFlush && exceptionDataRead.bits.replayInst
   val exceptionEnable = writebacked(deqPtr.value) && deqHasException
 
   XSDebug(deqHasException && exceptionDataRead.bits.singleStep, "Debug Mode: Deq has singlestep exception\n")
-  XSDebug(deqHasException && exceptionDataRead.bits.trigger.getHitFrontend, "Debug Mode: Deq has frontend trigger exception\n")
-  XSDebug(deqHasException && exceptionDataRead.bits.trigger.getHitBackend, "Debug Mode: Deq has backend trigger exception\n")
+  XSDebug(deqHasException && exceptionDataRead.bits.trigger.getFrontendCanFire, "Debug Mode: Deq has frontend trigger exception\n")
+  XSDebug(deqHasException && exceptionDataRead.bits.trigger.getBackendCanFire, "Debug Mode: Deq has backend trigger exception\n")
 
   val isFlushPipe = writebacked(deqPtr.value) && (deqHasFlushPipe || deqHasReplayInst)
 
@@ -769,9 +769,9 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
   for (i <- 0 until RenameWidth) {
     when (canEnqueue(i)) {
       val enqHasException = ExceptionNO.selectFrontend(io.enq.req(i).bits.cf.exceptionVec).asUInt.orR
-      val enqHasTriggerHit = io.enq.req(i).bits.cf.trigger.getHitFrontend
+      val enqHasTriggerCanFire = io.enq.req(i).bits.cf.trigger.getBackendCanFire
       val enqIsWritebacked = io.enq.req(i).bits.eliminatedMove
-      writebacked(allocatePtrVec(i).value) := enqIsWritebacked && !enqHasException && !enqHasTriggerHit
+      writebacked(allocatePtrVec(i).value) := enqIsWritebacked && !enqHasException && !enqHasTriggerCanFire
       val isStu = io.enq.req(i).bits.ctrl.fuType === FuType.stu
       store_data_writebacked(allocatePtrVec(i).value) := !isStu
     }
@@ -786,10 +786,10 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
     when (wb.valid) {
       val wbIdx = wb.bits.uop.robIdx.value
       val wbHasException = ExceptionNO.selectByExu(wb.bits.uop.cf.exceptionVec, cfgs).asUInt.orR
-      val wbHasTriggerHit = wb.bits.uop.cf.trigger.getHitBackend
+      val wbHasTriggerCanFire = wb.bits.uop.cf.trigger.getBackendCanFire
       val wbHasFlushPipe = cfgs.exists(_.flushPipe).B && wb.bits.uop.ctrl.flushPipe
       val wbHasReplayInst = cfgs.exists(_.replayInst).B && wb.bits.uop.ctrl.replayInst
-      val block_wb = wbHasException || wbHasFlushPipe || wbHasReplayInst || wbHasTriggerHit
+      val block_wb = wbHasException || wbHasFlushPipe || wbHasReplayInst || wbHasTriggerCanFire
       writebacked(wbIdx) := !block_wb
     }
   }
@@ -857,8 +857,9 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
     XSError(canEnqueue(i) && io.enq.req(i).bits.ctrl.replayInst, "enq should not set replayInst")
     exceptionGen.io.enq(i).bits.singleStep := io.enq.req(i).bits.ctrl.singleStep
     exceptionGen.io.enq(i).bits.crossPageIPFFix := io.enq.req(i).bits.cf.crossPageIPFFix
-    exceptionGen.io.enq(i).bits.trigger.clear()
+    exceptionGen.io.enq(i).bits.trigger.clear() // Don't care frontend timing and chain, backend hit and canFire
     exceptionGen.io.enq(i).bits.trigger.frontendHit := io.enq.req(i).bits.cf.trigger.frontendHit
+    exceptionGen.io.enq(i).bits.trigger.frontendCanFire := io.enq.req(i).bits.cf.trigger.frontendCanFire
   }
 
   println(s"ExceptionGen:")
@@ -873,8 +874,9 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
     exc_wb.bits.singleStep      := false.B
     exc_wb.bits.crossPageIPFFix := false.B
     // TODO: make trigger configurable
-    exc_wb.bits.trigger.clear()
+    exc_wb.bits.trigger.clear() // Don't care frontend timing, chain, hit and canFire
     exc_wb.bits.trigger.backendHit := wb.bits.uop.cf.trigger.backendHit
+    exc_wb.bits.trigger.backendCanFire := wb.bits.uop.cf.trigger.backendCanFire
     println(s"  [$i] ${configs.map(_.name)}: exception ${exceptionCases(i)}, " +
       s"flushPipe ${configs.exists(_.flushPipe)}, " +
       s"replayInst ${configs.exists(_.replayInst)}")

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -73,8 +73,6 @@ class FrontendImp (outer: Frontend) extends LazyModuleImp(outer)
 
   // trigger
   ifu.io.frontendTrigger := csrCtrl.frontend_trigger
-  val triggerEn = csrCtrl.trigger_enable
-  ifu.io.csrTriggerEnable := VecInit(triggerEn(0), triggerEn(1), triggerEn(6), triggerEn(8))
 
   // bpu ctrl
   bpu.io.ctrl := csrCtrl.bp_ctrl

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -64,7 +64,6 @@ class NewIFUIO(implicit p: Parameters) extends XSBundle {
   val toIbuffer       = Decoupled(new FetchToIBuffer)
   val uncacheInter   =  new UncacheInterface
   val frontendTrigger = Flipped(new FrontendTdataDistributeIO)
-  val csrTriggerEnable = Input(Vec(4, Bool()))
   val rob_commits = Flipped(Vec(CommitWidth, Valid(new RobCommitInfo)))
   val iTLBInter       = new BlockTlbRequestIO
   val pmp             =   new ICachePMPBundle
@@ -82,7 +81,6 @@ class LastHalfInfo(implicit p: Parameters) extends XSBundle {
 class IfuToPreDecode(implicit p: Parameters) extends XSBundle {
   val data                =  if(HasCExtension) Vec(PredictWidth + 1, UInt(16.W)) else Vec(PredictWidth, UInt(32.W))
   val frontendTrigger     = new FrontendTdataDistributeIO
-  val csrTriggerEnable    = Vec(4, Bool())
   val pc                  = Vec(PredictWidth, UInt(VAddrBits.W))
 }
 
@@ -313,7 +311,6 @@ class NewIFU(implicit p: Parameters) extends XSModule
     val preDecoderIn  = preDecoders(i).io.in
     preDecoderIn.data := f2_cut_data(i)
     preDecoderIn.frontendTrigger := io.frontendTrigger  
-    preDecoderIn.csrTriggerEnable := io.csrTriggerEnable
     preDecoderIn.pc  := f2_pc
   }
 
@@ -584,7 +581,6 @@ class NewIFU(implicit p: Parameters) extends XSModule
   frontendTrigger.io.data   := f3_cut_data
 
   frontendTrigger.io.frontendTrigger  := io.frontendTrigger
-  frontendTrigger.io.csrTriggerEnable := io.csrTriggerEnable
 
   val f3_triggered = frontendTrigger.io.triggered
 

--- a/src/main/scala/xiangshan/frontend/PreDecode.scala
+++ b/src/main/scala/xiangshan/frontend/PreDecode.scala
@@ -17,13 +17,14 @@
 package xiangshan.frontend
 
 import chipsalliance.rocketchip.config.Parameters
-import freechips.rocketchip.rocket.{RVCDecoder, ExpandedInstruction}
+import freechips.rocketchip.rocket.{ExpandedInstruction, RVCDecoder}
 import chisel3.{util, _}
 import chisel3.util._
 import utils._
 import xiangshan._
 import xiangshan.frontend.icache._
 import xiangshan.backend.decode.isa.predecode.PreDecodeInst
+import xiangshan.backend.fu.util.SdtrigExt
 
 trait HasPdConst extends HasXSParameter with HasICacheParameters with HasIFUConst{
   def isRVC(inst: UInt) = (inst(1,0) =/= 3.U)
@@ -269,11 +270,10 @@ class PredChecker(implicit p: Parameters) extends XSModule with HasPdConst {
 
 }
 
-class FrontendTrigger(implicit p: Parameters) extends XSModule {
+class FrontendTrigger(implicit p: Parameters) extends XSModule with SdtrigExt {
   val io = IO(new Bundle(){
     val frontendTrigger = Input(new FrontendTdataDistributeIO)
-    val csrTriggerEnable = Input(Vec(4, Bool()))
-    val triggered    = Output(Vec(PredictWidth, new TriggerCf))
+    val triggered     = Output(Vec(PredictWidth, new TriggerCf))
 
     val pds           = Input(Vec(PredictWidth, new PreDecodeInfo))
     val pc            = Input(Vec(PredictWidth, UInt(VAddrBits.W)))
@@ -286,40 +286,45 @@ class FrontendTrigger(implicit p: Parameters) extends XSModule {
   val rawInsts = if (HasCExtension) VecInit((0 until PredictWidth).map(i => Cat(data(i+1), data(i))))
                         else         VecInit((0 until PredictWidth).map(i => data(i)))
 
-  val tdata = RegInit(VecInit(Seq.fill(4)(0.U.asTypeOf(new MatchTriggerIO))))
-  when(io.frontendTrigger.t.valid) {
-    tdata(io.frontendTrigger.t.bits.addr) := io.frontendTrigger.t.bits.tdata
+  val tdata = RegInit(VecInit(Seq.fill(TriggerNum)(0.U.asTypeOf(new MatchTriggerIO))))
+  when(io.frontendTrigger.tUpdate.valid) {
+    tdata(io.frontendTrigger.tUpdate.bits.addr) := io.frontendTrigger.tUpdate.bits.tdata
   }
-  io.triggered.map{i => i := 0.U.asTypeOf(new TriggerCf)}
-  val triggerEnable = RegInit(VecInit(Seq.fill(4)(false.B))) // From CSR, controlled by priv mode, etc.
-  triggerEnable := io.csrTriggerEnable
-  XSDebug(triggerEnable.asUInt.orR, "Debug Mode: At least one frontend trigger is enabled\n")
+//  io.triggered.foreach{ i => i := 0.U.asTypeOf(new TriggerCf)}
+  val triggerEnableVec = RegInit(VecInit(Seq.fill(TriggerNum)(false.B))) // From CSR, controlled by priv mode, etc.
+  triggerEnableVec := io.frontendTrigger.tEnableVec
+  XSDebug(triggerEnableVec.asUInt.orR, "Debug Mode: At least one frontend trigger is enabled\n")
 
-  for (i <- 0 until 4) {PrintTriggerInfo(triggerEnable(i), tdata(i))}
+  val triggerTimingVec = VecInit(tdata.map(_.timing))
+  val triggerChainVec = VecInit(tdata.map(_.chain))
+
+  for (i <- 0 until TriggerNum) { PrintTriggerInfo(triggerEnableVec(i), tdata(i)) }
 
   for (i <- 0 until PredictWidth) {
     val currentPC = io.pc(i)
     val currentIsRVC = io.pds(i).isRVC
     val inst = WireInit(rawInsts(i))
-    val triggerHitVec = Wire(Vec(4, Bool()))
+    val triggerHitVec = Wire(Vec(TriggerNum, Bool()))
+    val triggerCanFireVec = Wire(Vec(TriggerNum, Bool()))
 
-    for (j <- 0 until 4) {
-      triggerHitVec(j) := Mux(tdata(j).select, TriggerCmp(Mux(currentIsRVC, inst(15, 0), inst), tdata(j).tdata2, tdata(j).matchType, triggerEnable(j)),
-        TriggerCmp(currentPC, tdata(j).tdata2, tdata(j).matchType, triggerEnable(j)))
+    for (j <- 0 until TriggerNum) {
+      triggerHitVec(j) := Mux(
+        tdata(j).select,
+        TriggerCmp(Mux(currentIsRVC, inst(15, 0), inst), tdata(j).tdata2, tdata(j).matchType, triggerEnableVec(j)),
+        TriggerCmp(currentPC, tdata(j).tdata2, tdata(j).matchType, triggerEnableVec(j))
+      )
     }
 
-    // fix chains this could be moved further into the pipeline
+    TriggerCheckCanFire(TriggerNum, triggerCanFireVec, triggerHitVec, triggerTimingVec, triggerChainVec)
+
+    // only hit, no matter fire or not
     io.triggered(i).frontendHit := triggerHitVec
-    val enableChain = tdata(0).chain
-    when(enableChain){
-      io.triggered(i).frontendHit(0) := triggerHitVec(0) && triggerHitVec(1) && (tdata(0).timing === tdata(1).timing)
-      io.triggered(i).frontendHit(1) := triggerHitVec(0) && triggerHitVec(1) && (tdata(0).timing === tdata(1).timing)
-    }
-    for(j <- 0 until 2) {
-      io.triggered(i).backendEn(j) := Mux(tdata(j+2).chain, triggerHitVec(j+2), true.B)
-      io.triggered(i).frontendHit(j+2) := !tdata(j+2).chain && triggerHitVec(j+2) // temporary workaround
-    }
-    XSDebug(io.triggered(i).getHitFrontend, p"Debug Mode: Predecode Inst No. ${i} has trigger hit vec ${io.triggered(i).frontendHit}" +
-      p"and backend en ${io.triggered(i).backendEn}\n")
-  }  
+    // can fire, exception will be handled at rob enq
+    io.triggered(i).frontendCanFire := triggerCanFireVec
+    io.triggered(i).frontendTiming  := triggerTimingVec.zip(triggerEnableVec).map{ case(timing, en) => timing && en}
+    io.triggered(i).frontendChain  := triggerChainVec.zip(triggerEnableVec).map{ case(chain, en) => chain && en}
+    XSDebug(io.triggered(i).getFrontendCanFire, p"Debug Mode: Predecode Inst No. ${i} has trigger fire vec ${io.triggered(i).frontendCanFire}\n")
+  }
+  io.triggered.foreach(_.backendCanFire := VecInit(Seq.fill(TriggerNum)(false.B)))
+  io.triggered.foreach(_.backendHit := VecInit(Seq.fill(TriggerNum)(false.B)))
 }

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -117,7 +117,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   // val data = Reg(Vec(LoadQueueSize, new LsRobEntry))
   val dataModule = Module(new LoadQueueDataWrapper(LoadQueueSize, wbNumRead = LoadPipelineWidth, wbNumWrite = LoadPipelineWidth))
   dataModule.io := DontCare
-  val vaddrModule = Module(new SyncDataModuleTemplate(UInt(VAddrBits.W), LoadQueueSize, numRead = TriggerNum, numWrite = LoadPipelineWidth, "LqVaddr"))
+  val vaddrModule = Module(new SyncDataModuleTemplate(UInt(VAddrBits.W), LoadQueueSize, numRead = LoadPipelineWidth + 1, numWrite = LoadPipelineWidth, "LqVaddr"))
   vaddrModule.io := DontCare
   val vaddrTriggerResultModule = Module(new SyncDataModuleTemplate(Vec(TriggerNum, Bool()), LoadQueueSize, numRead = LoadPipelineWidth, numWrite = LoadPipelineWidth, "LqTrigger"))
   vaddrTriggerResultModule.io := DontCare

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -75,8 +75,8 @@ class LqPaddrWriteBundle(implicit p: Parameters) extends XSBundle {
 }
 
 class LqTriggerIO(implicit p: Parameters) extends XSBundle {
-  val hitLoadAddrTriggerHitVec = Input(Vec(3, Bool()))
-  val lqLoadAddrTriggerHitVec = Output(Vec(3, Bool()))
+  val hitLoadAddrTriggerHitVec = Input(Vec(TriggerNum, Bool()))
+  val lqLoadAddrTriggerHitVec = Output(Vec(TriggerNum, Bool()))
 }
 
 // Load Queue
@@ -117,9 +117,9 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   // val data = Reg(Vec(LoadQueueSize, new LsRobEntry))
   val dataModule = Module(new LoadQueueDataWrapper(LoadQueueSize, wbNumRead = LoadPipelineWidth, wbNumWrite = LoadPipelineWidth))
   dataModule.io := DontCare
-  val vaddrModule = Module(new SyncDataModuleTemplate(UInt(VAddrBits.W), LoadQueueSize, numRead = 3, numWrite = LoadPipelineWidth, "LqVaddr"))
+  val vaddrModule = Module(new SyncDataModuleTemplate(UInt(VAddrBits.W), LoadQueueSize, numRead = TriggerNum, numWrite = LoadPipelineWidth, "LqVaddr"))
   vaddrModule.io := DontCare
-  val vaddrTriggerResultModule = Module(new SyncDataModuleTemplate(Vec(3, Bool()), LoadQueueSize, numRead = LoadPipelineWidth, numWrite = LoadPipelineWidth, "LqTrigger"))
+  val vaddrTriggerResultModule = Module(new SyncDataModuleTemplate(Vec(TriggerNum, Bool()), LoadQueueSize, numRead = LoadPipelineWidth, numWrite = LoadPipelineWidth, "LqTrigger"))
   vaddrTriggerResultModule.io := DontCare
   val allocated = RegInit(VecInit(List.fill(LoadQueueSize)(false.B))) // lq entry has been allocated
   val datavalid = RegInit(VecInit(List.fill(LoadQueueSize)(false.B))) // data is valid
@@ -880,7 +880,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     io.trigger(i).lqLoadAddrTriggerHitVec := Mux(
       loadWbSelV(i),
       vaddrTriggerResultModule.io.rdata(i),
-      VecInit(Seq.fill(3)(false.B))
+      VecInit(Seq.fill(TriggerNum)(false.B))
     )
   })
 

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -26,8 +26,9 @@ import xiangshan.cache.mmu.{TlbCmd, TlbRequestIO}
 import difftest._
 import xiangshan.ExceptionNO._
 import xiangshan.backend.fu.PMPRespBundle
+import xiangshan.backend.fu.util.SdtrigExt
 
-class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstants{
+class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstants with SdtrigExt{
   val io = IO(new Bundle() {
     val hartId = Input(UInt(8.W))
     val in            = Flipped(Decoupled(new ExuInput))
@@ -320,78 +321,60 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule with MemoryOpConstant
 
   // atomic trigger
   val csrCtrl = io.csrCtrl
-  val tdata = Reg(Vec(6, new MatchTriggerIO))
-  val tEnable = RegInit(VecInit(Seq.fill(6)(false.B)))
-  val en = csrCtrl.trigger_enable
-  tEnable := VecInit(en(2), en (3), en(7), en(4), en(5), en(9))
-  when(csrCtrl.mem_trigger.t.valid) {
-    tdata(csrCtrl.mem_trigger.t.bits.addr) := csrCtrl.mem_trigger.t.bits.tdata
+  val tdata = Reg(Vec(TriggerNum, new MatchTriggerIO))
+  val tEnableVec = RegInit(VecInit(Seq.fill(TriggerNum)(false.B)))
+  tEnableVec := csrCtrl.mem_trigger.tEnableVec
+  when(csrCtrl.mem_trigger.tUpdate.valid) {
+    tdata(csrCtrl.mem_trigger.tUpdate.bits.addr) := csrCtrl.mem_trigger.tUpdate.bits.tdata
   }
-  val lTriggerMapping = Map(0 -> 2, 1 -> 3, 2 -> 5)
-  val sTriggerMapping = Map(0 -> 0, 1 -> 1, 2 -> 4)
+//  val lTriggerMapping = Map(0 -> 2, 1 -> 3, 2 -> 5)
+//  val sTriggerMapping = Map(0 -> 0, 1 -> 1, 2 -> 4)
 
-  val backendTriggerHitReg = Reg(Vec(6, Bool()))
-  backendTriggerHitReg := VecInit(Seq.fill(6)(false.B))
+  val frontendTriggerTimingVec  = in.uop.cf.trigger.frontendTiming
+  val frontendTriggerChainVec   = in.uop.cf.trigger.frontendChain
+  val frontendTriggerHitVec     = in.uop.cf.trigger.frontendHit
 
+  val backendTriggerTimingVec   = tdata.map(_.timing)
+  val backendTriggerChainVec    = tdata.map(_.chain)
+  val backendTriggerHitVec      = WireInit(VecInit(Seq.fill(TriggerNum)(false.B)))
+
+  val triggerTimingVec  = VecInit(backendTriggerTimingVec.zip(frontendTriggerTimingVec).map { case (b, f) => b || f })
+  val triggerChainVec   = VecInit(backendTriggerChainVec.zip(frontendTriggerChainVec).map { case (b, f) => b || f })
+  val triggerHitVec     = Reg(Vec(TriggerNum, Bool()))
+  triggerHitVec         := VecInit(backendTriggerHitVec.zip(frontendTriggerHitVec).map { case (b, f) => b || f })
+
+  val triggerCanFireVec = Reg(Vec(TriggerNum, Bool()))
   when(state === s_cache_req){
     // store trigger
-    val store_hit = Wire(Vec(3, Bool()))
-    for (j <- 0 until 3) {
-        store_hit(j) := !tdata(sTriggerMapping(j)).select && TriggerCmp(
-          vaddr,
-          tdata(sTriggerMapping(j)).tdata2,
-          tdata(sTriggerMapping(j)).matchType,
-          tEnable(sTriggerMapping(j))
-        )
-       backendTriggerHitReg(sTriggerMapping(j)) := store_hit(j)
-     }
-
-    when(tdata(0).chain) {
-      backendTriggerHitReg(0) := store_hit(0) && store_hit(1)
-      backendTriggerHitReg(1) := store_hit(0) && store_hit(1)
-    }
-
-    when(!in.uop.cf.trigger.backendEn(0)) {
-      backendTriggerHitReg(4) := false.B
-    }
-
-    // load trigger
-    val load_hit = Wire(Vec(3, Bool()))
-    for (j <- 0 until 3) {
-
-      val addrHit = TriggerCmp(
+    val store_hit = Wire(Vec(TriggerNum, Bool()))
+    for (j <- 0 until TriggerNum) {
+      store_hit(j) := !tdata(j).select && TriggerCmp(
         vaddr,
-        tdata(lTriggerMapping(j)).tdata2,
-        tdata(lTriggerMapping(j)).matchType,
-        tEnable(lTriggerMapping(j))
+        tdata(j).tdata2,
+        tdata(j).matchType,
+        tEnableVec(j) && tdata(j).store
       )
-      load_hit(j) := addrHit && !tdata(lTriggerMapping(j)).select
-      backendTriggerHitReg(lTriggerMapping(j)) := load_hit(j)
     }
-    when(tdata(2).chain) {
-      backendTriggerHitReg(2) := load_hit(0) && load_hit(1)
-      backendTriggerHitReg(3) := load_hit(0) && load_hit(1)
+    // load trigger
+    val load_hit = Wire(Vec(TriggerNum, Bool()))
+    for (j <- 0 until TriggerNum) {
+      load_hit(j) := !tdata(j).select && TriggerCmp(
+        vaddr,
+        tdata(j).tdata2,
+        tdata(j).matchType,
+        tEnableVec(j) && tdata(j).load
+      )
     }
-    when(!in.uop.cf.trigger.backendEn(1)) {
-      backendTriggerHitReg(5) := false.B
-    }
+    backendTriggerHitVec := store_hit.zip(load_hit).map{ case(sh, lh) => sh || lh }
+    TriggerCheckCanFire(TriggerNum, triggerCanFireVec, triggerHitVec, triggerTimingVec, triggerChainVec)
   }
 
   // addr trigger do cmp at s_cache_req
   // trigger result is used at s_finish
   // thus we can delay it safely
-  io.out.bits.uop.cf.trigger.backendHit := VecInit(Seq.fill(6)(false.B))
-  when(isLr){
-    // enable load trigger
-    io.out.bits.uop.cf.trigger.backendHit(2) := backendTriggerHitReg(2)
-    io.out.bits.uop.cf.trigger.backendHit(3) := backendTriggerHitReg(3)
-    io.out.bits.uop.cf.trigger.backendHit(5) := backendTriggerHitReg(5)
-  }.otherwise{
-    // enable store trigger
-    io.out.bits.uop.cf.trigger.backendHit(0) := backendTriggerHitReg(0)
-    io.out.bits.uop.cf.trigger.backendHit(1) := backendTriggerHitReg(1)
-    io.out.bits.uop.cf.trigger.backendHit(4) := backendTriggerHitReg(4)
-  }
+
+  io.out.bits.uop.cf.trigger.backendHit     := RegNext(triggerHitVec)
+  io.out.bits.uop.cf.trigger.backendCanFire := triggerCanFireVec
 
   if (env.EnableDifftest) {
     val difftest = Module(new DifftestAtomicEvent)

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -23,6 +23,7 @@ import utils._
 import xiangshan.ExceptionNO._
 import xiangshan._
 import xiangshan.backend.fu.PMPRespBundle
+import xiangshan.backend.fu.util.SdtrigExt
 import xiangshan.cache._
 import xiangshan.cache.mmu.{TlbCmd, TlbReq, TlbRequestIO, TlbResp}
 
@@ -491,7 +492,7 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule with HasLoadHelper {
   XSPerfAccumulate("replay_from_fetch_load_vio", io.out.valid && debug_ldldVioReplay)
 }
 
-class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper with HasPerfEvents {
+class LoadUnit(implicit p: Parameters) extends XSModule with HasLoadHelper with HasPerfEvents with SdtrigExt {
   val io = IO(new Bundle() {
     val ldin = Flipped(Decoupled(new ExuInput))
     val ldout = Decoupled(new ExuOutput)

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -51,14 +51,15 @@ class SimTop(implicit p: Parameters) extends Module {
   }
 
   soc.io.clock := clock.asBool
-  soc.io.reset := reset.asAsyncReset
+  soc.io.reset := (reset.asBool || soc.io.debug_reset).asAsyncReset
   soc.io.extIntrs := simMMIO.io.interrupt.intrVec
   soc.io.sram_config := 0.U
   soc.io.pll0_lock := true.B
   soc.io.cacheable_check := DontCare
 
   val success = Wire(Bool())
-  val jtag = Module(new SimJTAG(tickDelay=3)(p)).connect(soc.io.systemjtag.jtag, clock, reset.asBool, ~reset.asBool, success)
+  val jtag = Module(new SimJTAG(tickDelay=3)(p))
+  jtag.connect(soc.io.systemjtag.jtag, clock, reset.asBool, !reset.asBool, success)
   soc.io.systemjtag.reset := reset.asAsyncReset
   soc.io.systemjtag.mfr_id := 0.U(11.W)
   soc.io.systemjtag.part_number := 0.U(16.W)


### PR DESCRIPTION
* Details
  + Set 10 general triggers, instead of 10 special triggers as before(4 fetch, 3 load and 3 store)
  + Remove trigger chain suppprt temporarily
  + Update fetch trigger will lead to pipe flush
* Attentions
  + Trigger update signal will assert 2 cycles after assertion csr.in.valid, since CSR write results has 1 cycle delay.
* Tests
  + Pass riscv-tests breakpoint, diff with NEMU
* Todo:
  + Support 2 triggers chain by enable chain check when setting trigger
  + Relocate load trigger, since it widens entry of LoadQueue
  + Remove useless comments and dead code