### PR TITLE
rf-after-issue: success for coremark, microbench, linux-hello

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -271,10 +271,10 @@ class CtrlBlockImp(outer: CtrlBlock)(implicit p: Parameters) extends LazyModuleI
 
   pcMem.io.wen.head   := RegNext(io.frontend.fromFtq.pc_mem_wen)
   pcMem.io.waddr.head := RegNext(io.frontend.fromFtq.pc_mem_waddr)
-  pcMem.io.wdata.head := RegNext(io.frontend.fromFtq.pc_mem_wdata)
+  pcMem.io.wdata.head := RegNext(io.frontend.fromFtq.pc_mem_wdata)                          // Ftq_RF_Components: startAddr nextLineAddr isNextMask fallThruError
   jalrTargetMem.io.wen.head   := RegNext(io.frontend.fromFtq.pc_mem_wen)
   jalrTargetMem.io.waddr.head := RegNext(io.frontend.fromFtq.pc_mem_waddr)
-  jalrTargetMem.io.wdata.head := RegNext(io.frontend.fromFtq.target)
+  jalrTargetMem.io.wdata.head := RegNext(io.frontend.fromFtq.target)                        // UInt(VAddrBits.W)
   jalrTargetMem.io.wen.tail.head   := RegNext(io.frontend.fromFtq.pd_redirect_waddr.valid)
   jalrTargetMem.io.waddr.tail.head := RegNext(io.frontend.fromFtq.pd_redirect_waddr.bits)
   jalrTargetMem.io.wdata.tail.head := RegNext(io.frontend.fromFtq.pd_redirect_target)

--- a/src/main/scala/xiangshan/backend/ExuBlock.scala
+++ b/src/main/scala/xiangshan/backend/ExuBlock.scala
@@ -35,7 +35,17 @@ class ExuBlock(
   val hasIntRf: Boolean,
   val hasFpRf: Boolean
 )(implicit p: Parameters) extends LazyModule with HasWritebackSource with HasExuWbHelper {
-  val scheduler = LazyModule(new Scheduler(configs, dpPorts, intRfWbPorts, fpRfWbPorts, outFastPorts, outIntRfReadPorts, outFpRfReadPorts, hasIntRf, hasFpRf))
+  val scheduler = LazyModule(new Scheduler(
+    configs           = configs, 
+    dpPorts           = dpPorts, 
+    intRfWbPorts      = intRfWbPorts, 
+    fpRfWbPorts       = fpRfWbPorts, 
+    outFastPorts      = outFastPorts, 
+    outIntRfReadPorts = outIntRfReadPorts, 
+    outFpRfReadPorts  = outFpRfReadPorts, 
+    hasIntRf          = hasIntRf, 
+    hasFpRf           = hasFpRf
+    ))
 
   val allRfWbPorts: Seq[Seq[ExuConfig]] = intRfWbPorts ++ fpRfWbPorts
   def getWbIndex(cfg: ExuConfig): Seq[Int] = allRfWbPorts.zipWithIndex.filter(_._1.contains(cfg)).map(_._2)

--- a/src/main/scala/xiangshan/backend/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/Scheduler.scala
@@ -210,10 +210,9 @@ class Scheduler(
   }
   val numSTDPorts: Int = reservationStations.filter(_.params.exuCfg.get == StdExeUnitCfg).map(_.params.numDeq).sum
 
-  val numDpPortIntRead: Seq[Int] = dpPorts.map(_.map(_.rsIdx).map(configs(_).exuConfig.intSrcCnt).max)
-  val numIntRfReadPorts: Int = numDpPortIntRead.sum + outIntRfReadPorts
-  val numDpPortFpRead: Seq[Int] = dpPorts.map(_.map(_.rsIdx).map(configs(_).exuConfig.fpSrcCnt).max)
-  val numFpRfReadPorts: Int = numDpPortFpRead.sum + outFpRfReadPorts
+  val numIntRfReadPorts: Int = reservationStations.map(p => (p.params.numDeq) * p.numIntRfPorts).sum + outIntRfReadPorts
+
+  val numFpRfReadPorts: Int = reservationStations.map(p => (p.params.numDeq) * p.numFpRfPorts).sum + outFpRfReadPorts
 
   lazy val module = new SchedulerImp(this)
 
@@ -373,13 +372,16 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
   } else None
   val allocate = dispatch2.flatMap(_.io.out)
 
-  // extract each dispatch-rs port's psrc
-  def extractReadRf(numRead: Seq[Int]): Seq[UInt] = {
-    require(numRead.length == allocate.length)
-    allocate.map(_.bits.psrc).zip(numRead).flatMap{ case (src, num) => src.take(num) }
+  def extractReadRf(isInt: Boolean): Seq[UInt] = {
+    if (isInt) {
+      rs_all.flatMap(_.module.readIntRf_asyn).map(_.addr)
+    }
+    else {
+      rs_all.flatMap(_.module.readFpRf_asyn).map(_.addr)
+    }
   }
-  def readIntRf: Seq[UInt] = extractReadRf(outer.numDpPortIntRead) ++ io.extra.intRfReadOut.getOrElse(Seq()).map(_.addr)
-  def readFpRf: Seq[UInt] = extractReadRf(outer.numDpPortFpRead) ++ io.extra.fpRfReadOut.getOrElse(Seq()).map(_.addr)
+  def readIntRf: Seq[UInt] = extractReadRf(true) ++ io.extra.intRfReadOut.getOrElse(Seq()).map(_.addr)
+  def readFpRf: Seq[UInt] = extractReadRf(false) ++ io.extra.fpRfReadOut.getOrElse(Seq()).map(_.addr)
 
   def genRegfile(isInt: Boolean): Seq[UInt] = {
     val wbPorts = if (isInt) io.writeback.take(intRfWritePorts) else io.writeback.drop(intRfWritePorts)
@@ -397,8 +399,13 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
     }
   }
 
-  val intRfReadData = if (intRfConfig._1) genRegfile(true) else io.extra.intRfReadIn.getOrElse(Seq()).map(_.data)
-  val fpRfReadData = if (fpRfConfig._1) genRegfile(false) else VecInit(io.extra.fpRfReadIn.getOrElse(Seq()).map(_.data))
+  val intRfReadData_asyn = if (intRfConfig._1) genRegfile(true) else io.extra.intRfReadIn.getOrElse(Seq()).map(_.data)
+  val fpRfReadData_asyn = if (fpRfConfig._1) genRegfile(false) else VecInit(io.extra.fpRfReadIn.getOrElse(Seq()).map(_.data))
+
+  if(intRfReadData_asyn.length>0)  
+    rs_all.flatMap(_.module.readIntRf_asyn.map(_.data)).zip(intRfReadData_asyn).foreach{ case (a, b) => a := b}
+  if(fpRfReadData_asyn.length>0)  
+    rs_all.flatMap(_.module.readFpRf_asyn).map(_.data).zip(fpRfReadData_asyn).foreach{ case (a, b) => a := b}
 
   if (io.extra.intRfReadIn.isDefined) {
     io.extra.intRfReadIn.get.map(_.addr).zip(readIntRf).foreach{ case (r, addr) => r := addr}
@@ -412,13 +419,13 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
   }
 
   if (io.extra.intRfReadOut.isDefined) {
-    val extraIntReadData = intRfReadData.dropRight(32).takeRight(outer.outIntRfReadPorts)
+    val extraIntReadData = intRfReadData_asyn.dropRight(32).takeRight(outer.outIntRfReadPorts)
     io.extra.intRfReadOut.get.map(_.data).zip(extraIntReadData).foreach{ case (a, b) => a := b }
     require(io.extra.intRfReadOut.get.length == extraIntReadData.length)
   }
 
   if (io.extra.fpRfReadOut.isDefined) {
-    val extraFpReadData = fpRfReadData.dropRight(32).takeRight(outer.outFpRfReadPorts)
+    val extraFpReadData = fpRfReadData_asyn.dropRight(32).takeRight(outer.outFpRfReadPorts)
     io.extra.fpRfReadOut.get.map(_.data).zip(extraFpReadData).foreach{ case (a, b) => a := b }
     require(io.extra.fpRfReadOut.get.length == extraFpReadData.length)
   }
@@ -491,8 +498,6 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
     io.extra.loadFastImm.get := allLoadRS.map(_.map(_.fastImm)).fold(Seq())(_ ++ _)
   }
 
-  var intReadPort = 0
-  var fpReadPort = 0
   for ((dp, i) <- outer.dpPorts.zipWithIndex) {
     // dp connects only one rs: don't use arbiter
     if (dp.length == 1) {
@@ -506,50 +511,20 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
       rsIn <> arbiterOut
     }
 
-    val numIntRfPorts = dp.map(_.rsIdx).map(rs_all(_).intSrcCnt).max
-    if (numIntRfPorts > 0) {
-      val intRfPorts = VecInit(intRfReadData.slice(intReadPort, intReadPort + numIntRfPorts))
-      for (m <- dp) {
-        val target = rs_all(m.rsIdx).module.io.srcRegValue(m.dpIdx)
-        target := intRfPorts.take(target.length)
-      }
-      intReadPort += numIntRfPorts
-    }
 
-    val numFpRfPorts = dp.map(_.rsIdx).map(rs_all(_).fpSrcCnt).max
-    if (numFpRfPorts > 0) {
-      val fpRfPorts = VecInit(fpRfReadData.slice(fpReadPort, fpReadPort + numFpRfPorts))
-      for (m <- dp) {
-        val rs_mod = rs_all(m.rsIdx).module
-        if (numIntRfPorts > 0) {
-          require(numFpRfPorts == 1 && numIntRfPorts == 1)
-          // dirty code for store
-          rs_mod.extra.fpRegValue(m.dpIdx) := fpRfPorts.head
-        }
-        else {
-          val target = rs_mod.io.srcRegValue(m.dpIdx)
-          val isFp = RegNext(rs_mod.io.fromDispatch(m.dpIdx).bits.ctrl.srcType(0) === SrcType.fp)
-          val fromFp = if (numIntRfPorts > 0) isFp else false.B
-          when (fromFp) {
-            target := fpRfPorts.take(target.length)
-          }
-        }
-      }
-      fpReadPort += numFpRfPorts
-    }
   }
 
   if ((env.AlwaysBasicDiff || env.EnableDifftest) && intRfConfig._1) {
     val difftest = Module(new DifftestArchIntRegState)
     difftest.io.clock := clock
     difftest.io.coreid := io.hartId
-    difftest.io.gpr := RegNext(RegNext(VecInit(intRfReadData.takeRight(32))))
+    difftest.io.gpr := RegNext(RegNext(VecInit(intRfReadData_asyn.takeRight(32))))
   }
   if ((env.AlwaysBasicDiff || env.EnableDifftest) && fpRfConfig._1) {
     val difftest = Module(new DifftestArchFpRegState)
     difftest.io.clock := clock
     difftest.io.coreid := io.hartId
-    difftest.io.fpr := RegNext(RegNext(VecInit(fpRfReadData.takeRight(32))))
+    difftest.io.fpr := RegNext(RegNext(VecInit(fpRfReadData_asyn.takeRight(32))))
   }
 
   XSPerfAccumulate("allocate_valid", PopCount(allocate.map(_.valid)))

--- a/src/main/scala/xiangshan/backend/dispatch/DispatchQueue.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/DispatchQueue.scala
@@ -35,7 +35,7 @@ class DispatchQueueIO(enqnum: Int, deqnum: Int)(implicit p: Parameters) extends 
   val deq = Vec(deqnum, DecoupledIO(new MicroOp))
   val redirect = Flipped(ValidIO(new Redirect))
   val dqFull = Output(Bool())
-  val deqNext = Vec(deqnum, Output(new MicroOp))
+  val deqNext = Vec(deqnum, Output(new MicroOp))  // deqNext >> deq
 }
 
 // dispatch queue: accepts at most enqnum uops from dispatch1 and dispatches deqnum uops at every clock cycle

--- a/src/main/scala/xiangshan/backend/issue/ReservationStationALU.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStationALU.scala
@@ -20,10 +20,13 @@ import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
+import xiangshan._
 
 case class ALURSParams()
 
 class ALURSWrapper(modGen: RSMod)(implicit p: Parameters) extends BaseReservationStationWrapper(modGen) {
+  params.exuCfg = Some(AluExeUnitCfg)
+
   override lazy val module = new ALURSImp(params, this)
 }
 

--- a/src/main/scala/xiangshan/backend/issue/ReservationStationBase.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStationBase.scala
@@ -25,6 +25,7 @@ import xiangshan._
 import xiangshan.backend.exu.ExuConfig
 import xiangshan.backend.fu.FuConfig
 import xiangshan.mem.{MemWaitUpdateReq, SqPtr}
+import xiangshan.backend.regfile.RfReadPort
 
 import scala.math.max
 import com.fasterxml.jackson.databind.JsonSerializable.Base
@@ -152,7 +153,8 @@ class BaseReservationStationWrapper(modGen: RSMod)(implicit p: Parameters) exten
   // duplicate with ModuleImp, fix it later
   val maxRsDeq = 2
   def numRS = (params.numDeq + (maxRsDeq - 1)) / maxRsDeq
-
+  def numIntRfPorts = params.exuCfg.get.fuConfigs.map(_.numIntSrc).max
+  def numFpRfPorts = params.exuCfg.get.fuConfigs.map(_.numFpSrc).max
   lazy val module = new BaseReservationStationImp(params, this)
 }
 
@@ -169,7 +171,7 @@ class BaseReservationStationImp(params: RSParams, wrapper: BaseReservationStatio
   require(params.numEnq < params.numDeq || params.numEnq % params.numDeq == 0)
   require(params.numEntries % params.numDeq == 0)
   val rsParams = (0 until numRS).map(i => {
-    val numDeq = Seq(params.numDeq - maxRsDeq * i, maxRsDeq).min
+    val numDeq = Seq(params.numDeq - maxRsDeq * i, maxRsDeq).min // params.numDeq: sum of RS's numDeq
     val numEnq = params.numEnq / numRS
     val numEntries = numDeq * params.numEntries / params.numDeq
     val rsParam = params.copy(numEnq = numEnq, numDeq = numDeq, numEntries = numEntries)
@@ -190,11 +192,16 @@ class BaseReservationStationImp(params: RSParams, wrapper: BaseReservationStatio
   })
   val io = IO(new ReservationStationIO(params)(updatedP))
   val extra = IO(new RSExtraIO(params)(updatedP))
+  val numIntRfPorts = params.exuCfg.get.fuConfigs.map(_.numIntSrc).max
+  val numFpRfPorts = params.exuCfg.get.fuConfigs.map(_.numFpSrc).max
+  val readIntRf_asyn = IO(Vec((params.numDeq) * numIntRfPorts, Flipped(new RfReadPort(params.dataBits))))
+  val readFpRf_asyn = IO(Vec((params.numDeq) * numFpRfPorts, Flipped(new RfReadPort(params.dataBits))))
   extra <> DontCare
+  readIntRf_asyn <> rs.flatMap(_.readIntRf_asyn)
+  readFpRf_asyn <> rs.flatMap(_.readFpRf_asyn)
 
   rs.foreach(_.io.redirect := RegNextWithEnable(io.redirect))
   io.fromDispatch <> rs.flatMap(_.io.fromDispatch)
-  io.srcRegValue <> rs.flatMap(_.io.srcRegValue)
   io.deq <> rs.flatMap(_.io.deq)
   rs.foreach(_.io.fastUopsIn <> io.fastUopsIn)
   rs.foreach(_.io.fastDatas <> io.fastDatas)
@@ -211,7 +218,6 @@ class ReservationStationIO(params: RSParams)(implicit p: Parameters) extends XSB
   val redirect = Flipped(ValidIO(new Redirect))
   // enq
   val fromDispatch = Vec(params.numEnq, Flipped(DecoupledIO(new MicroOp)))
-  val srcRegValue = Vec(params.numEnq, Input(Vec(params.numSrc, UInt(params.dataBits.W))))
   // deq
   val deq = Vec(params.numDeq, DecoupledIO(new ExuInput))
   // wakeup
@@ -231,7 +237,6 @@ class RSExtraIO(params: RSParams)(implicit p: Parameters) extends XSBundle {
     val fastMatch = Output(UInt(exuParameters.LduCnt.W))
     val fastImm = Output(UInt(12.W))
   })
-  val fpRegValue = Vec(params.numEnq, Input(UInt(params.dataBits.W)))
   val feedback = Vec(params.numDeq, Flipped(new MemRSFeedbackIO))
   val checkwait = new Bundle {
     val stIssuePtr = Input(new SqPtr)
@@ -245,12 +250,15 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
 {
   val io = IO(new ReservationStationIO(params)(p))
   val extra = IO(new RSExtraIO(params))
+  val numIntRfPorts = params.exuCfg.get.fuConfigs.map(_.numIntSrc).max
+  val numFpRfPorts = params.exuCfg.get.fuConfigs.map(_.numFpSrc).max
+  val readIntRf_asyn = IO(Vec((params.numDeq) * numIntRfPorts, Flipped(new RfReadPort(params.dataBits))))
+  val readFpRf_asyn = IO(Vec((params.numDeq) * numFpRfPorts, Flipped(new RfReadPort(params.dataBits))))
   // DontCare here
   extra <> DontCare
 
   val statusArray = Module(new StatusArray(params))
   val select = Module(new SelectPolicy(params))
-  val dataArray = Module(new DataArray(params))
   val payloadArray = Module(new PayloadArray(new MicroOp, params))
 
   val s2_deq = Wire(io.deq.cloneType)
@@ -363,16 +371,17 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
   // For better timing, we add one more read port to data array when oldestFirst is enabled,
   // and select data after the arbiter decides which one to issue.
   // In this way, selection and data read happen simultaneously.
-  for (i <- 0 until params.numDeq) {
-    dataArray.io.read(i).addr := select.io.grant(i).bits
-  }
-  dataArray.io.read.last.addr := s1_oldestSel.bits
+  // val dataArrayReadAddr = Wire(Vec(params.numDeq, UInt(params.numEntries.W)))
+  // for (i <- 0 until params.numDeq) {
+  //   dataArrayReadAddr(i) := select.io.grant(i).bits
+  // }
 
   def enqReverse[T <: Data](in: Seq[T]): Seq[T] = {
-    if (params.numDeq == 2) {
-      in.take(params.numDeq).reverse ++ in.drop(params.numDeq)
-    }
-    else in
+    // if (params.numDeq == 2) {
+    //   in.take(params.numDeq).reverse ++ in.drop(params.numDeq)
+    // }
+    // else in
+    in
   }
   /**
     * S1: read uop and data
@@ -384,7 +393,6 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
   val s1_allocatePtrOH_dup = RegNext(VecInit.fill(3)(VecInit(enqReverse(s0_allocatePtrOH))))
   val s1_allocatePtr = RegNext(VecInit(enqReverse(s0_allocatePtr)))
   val s1_enqWakeup = RegNext(VecInit(enqReverse(s0_enqWakeup)))
-  val s1_enqRfDataSel = WireInit(VecInit(enqReverse(io.srcRegValue)))
   val s1_enqDataCapture = RegNext(VecInit(enqReverse(s0_enqDataCapture)))
   val s1_fastWakeup = RegNext(VecInit(enqReverse(s0_fastWakeup)))
   val s1_in_selectPtr = select.io.grant
@@ -477,6 +485,16 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
   // Do the read data arbitration
   val s1_is_first_issue = Wire(Vec(params.numDeq, Bool()))
   val s1_all_src_ready = Wire(Vec(params.numDeq, Bool()))
+  val s1_out_addr = Wire(Vec(params.numDeq, UInt(params.numEntries.W)))
+  val dataArrayWrite = Wire(Vec(params.numEnq, new Bundle{
+    val enable = Bool()
+    val addr   = UInt(params.numEntries.W)
+  }))
+  for (i <- 0 until params.numEnq) {
+    dataArrayWrite(i).enable := s1_dispatchUops_dup(2)(i).valid
+    dataArrayWrite(i).addr := s1_allocatePtrOH_dup(2)(i)
+  }
+
   for (i <- 0 until params.numDeq) {
     val canBypass = s1_dispatchUops_dup.head(i).valid && statusArray.io.update(i).data.canIssue
     s1_issue_dispatch(i) := canBypass && !s1_issue_oldest(i) && !s1_in_selectPtrValid(i)
@@ -487,6 +505,10 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
 
     s1_out(i).bits.uop := Mux(s1_issue_oldest(i), payloadArray.io.read.last.data,
       Mux(s1_in_selectPtrValid(i), payloadArray.io.read(i).data, s1_dispatchUops_dup.head(i).bits))
+
+    s1_out_addr(i) := Mux(s1_issue_oldest(i), s1_oldestSel.bits,
+      Mux(s1_in_selectPtrValid(i), select.io.grant(i).bits, dataArrayWrite(i).addr))
+  
     s1_is_first_issue(i) := Mux(s1_issue_oldest(i), statusArray.io.isFirstIssue.last,
       Mux(s1_in_selectPtrValid(i), statusArray.io.isFirstIssue(params.numEnq + i),
         statusArray.io.update(i).data.isFirstIssue))
@@ -536,31 +558,12 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
   statusArray.io.deqResp.last.bits.resptype := DontCare
   statusArray.io.deqResp.last.bits.dataInvalidSqIdx := DontCare
 
-  // select whether the source is from (whether slowPorts, regfile or imm)
-  // for read-after-issue, it's done over the selected uop
-  // for read-before-issue, it's done over the enqueue uop (and store the imm in dataArray to save space)
-  // TODO: need to bypass data here.
-  val immBypassedData = Wire(Vec(params.numEnq, Vec(params.numSrc, UInt(params.dataBits.W))))
-  val immExts = s1_dispatchUops_dup(2).map(_.bits)
-    .zip(s1_enqRfDataSel)
-    .zip(immBypassedData).map{ case ((uop, data), bypass) =>
-    val immExt = ImmExtractor(params, uop, data)
-    bypass := immExt.io.data_out
-    immExt
-  }
-
   /**
     * S1: Data broadcast (from Regfile and FUs) and read
     *
     * Note: this is only needed when read-before-issue
     */
   // dispatch data: the next cycle after enqueue
-  for (i <- 0 until params.numEnq) {
-    dataArray.io.write(i).enable := s1_dispatchUops_dup(2)(i).valid
-    dataArray.io.write(i).mask := s1_dispatchUops_dup(2)(i).bits.srcIsReady.take(params.numSrc)
-    dataArray.io.write(i).addr := s1_allocatePtrOH_dup(2)(i)
-    dataArray.io.write(i).data := immBypassedData(i)
-  }
   // data broadcast: from function units (only slow wakeup date are needed)
   val broadcastValid = io.slowPorts.map(_.valid)
   val broadcastValue = VecInit(io.slowPorts.map(_.bits.data))
@@ -572,7 +575,13 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
       slowWakeupMatchVec(i)(j) := statusArray.io.wakeupMatch(i)(j)(params.allWakeup - 1, params.numFastWakeup)
     }
   }
-  dataArray.io.multiWrite.zipWithIndex.foreach { case (w, i) =>
+
+  val dataArrayMultiWrite = Wire(Vec(params.numWakeup, new Bundle{
+    val enable = Bool()
+    val addr   = Vec(params.numSrc, UInt(params.numEntries.W))
+    val data   = UInt(params.dataBits.W)
+  }))
+  dataArrayMultiWrite.zipWithIndex.foreach { case (w, i) =>
     w.enable := RegNext(broadcastValid(i))
     for (j <- 0 until params.numSrc) {
       val allocateValid = s1_enqDataCapture.zip(s1_dispatchUops_dup(2)).map(x => x._1(j)(i) && x._2.valid)
@@ -589,33 +598,34 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
   class DataSelect(implicit p: Parameters) extends XSModule {
     val io = IO(new Bundle {
       // one for override data, the others for original data
-      val doOverride = Vec(params.numDeq, Input(Bool()))
-      val readData = Vec(dataArray.io.read.length, Vec(params.numSrc, Input(UInt(params.dataBits.W))))
+      // val doOverride = Vec(params.numDeq, Input(Bool()))
+      val readData = Vec(params.numDeq, Vec(params.numSrc, Input(UInt(params.dataBits.W))))
       // for data bypass from slowPorts
-      val fromSlowPorts = Vec(dataArray.io.read.length + params.numEnq, Vec(params.numSrc, Input(UInt(dataArray.io.multiWrite.length.W))))
-      val slowData = Vec(dataArray.io.multiWrite.length, Input(UInt(params.dataBits.W)))
+      val fromSlowPorts = Vec(params.numDeq, Vec(params.numSrc, Input(UInt(params.numWakeup.W))))
+      val slowData = Vec(params.numWakeup, Input(UInt(params.dataBits.W)))
       // for enq data
-      val enqBypass = Vec(params.numDeq, Vec(params.numEnq, Input(Bool())))
-      val enqData = Vec(params.numEnq, Vec(params.numSrc, Flipped(ValidIO(UInt(params.dataBits.W)))))
+      // val enqBypass = Vec(params.numDeq, Vec(params.numEnq, Input(Bool())))
+      // val enqData = Vec(params.numEnq, Vec(params.numSrc, Flipped(ValidIO(UInt(params.dataBits.W)))))
       // deq data
       val deqData = Vec(params.numDeq, Vec(params.numSrc, Output(UInt(params.dataBits.W))))
     })
 
     val slowCapture = io.fromSlowPorts.map(_.map(bySlow => (bySlow.orR, Mux1H(bySlow, io.slowData))))
-    val realEnqData = io.enqData.zip(slowCapture.takeRight(params.numEnq)).map{ case (e, c) =>
-      e.zip(c).map(x => Mux(x._2._1, x._2._2, x._1.bits))
-    }
+    // val realEnqData = io.enqData.zip(slowCapture.takeRight(params.numEnq)).map{ case (e, c) =>
+    //   e.zip(c).map(x => Mux(x._2._1, x._2._2, x._1.bits))
+    // }
 
     for ((deq, i) <- io.deqData.zipWithIndex) {
       for (j <- 0 until params.numSrc) {
         // default deq data is selected from data array or from slow
         val normalData = Mux(slowCapture(i)(j)._1, slowCapture(i)(j)._2, io.readData(i)(j))
-        val oldestData = Mux(slowCapture(params.numDeq)(j)._1, slowCapture(params.numDeq)(j)._2, io.readData.last(j))
-        deq(j) := Mux(io.doOverride(i), oldestData, normalData)
+        deq(j) := normalData
+        // val oldestData = Mux(slowCapture(params.numDeq)(j)._1, slowCapture(params.numDeq)(j)._2, io.readData.last(j))
+        // deq(j) := Mux(io.doOverride(i), oldestData, normalData)
         // when instructions are selected for dequeue after enq, we need to bypass data.
-        when (io.enqBypass(i).asUInt.orR) {
-          deq(j) := Mux1H(io.enqBypass(i), realEnqData.map(_(j)))
-        }
+        // when (io.enqBypass(i).asUInt.orR) {
+        //   deq(j) := Mux1H(io.enqBypass(i), realEnqData.map(_(j)))
+        // }
       }
     }
   }
@@ -624,6 +634,7 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
   // for read-after-issue, we need to bypass the imm here
   s1_out.foreach(_.bits.src := DontCare)
   // check enq data bypass (another form of broadcast except that we know where it hits) here
+  // just for ReservationStationJump
   val s1_select_bypass_s0 = Wire(Vec(params.numDeq, Vec(params.numEnq, Bool())))
   for ((bypass, i) <- s1_select_bypass_s0.zipWithIndex) {
     // bypass: Vec(config.numEnq, Bool())
@@ -632,22 +643,51 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
   }
 
   val dataSelect = Module(new DataSelect)
-  dataSelect.io.doOverride := s1_issue_oldest
-  dataSelect.io.readData := dataArray.io.read.map(_.data)
-  val dataSlowCaptureAddr = dataArray.io.read.map(_.addr) ++ dataArray.io.write.map(_.addr)
+  val immBypassedData2 = Wire(Vec(params.numDeq, Vec(params.numSrc, UInt(params.dataBits.W))))
+  dataSelect.io.readData := immBypassedData2
+
+  val s1_payloadUops = Wire(Vec(params.numDeq, new MicroOp))
+  s1_payloadUops.zip(s1_out.map(_.bits.uop)).map{case (a,b) => a := b}
+
+  val s1_deqRfDataSel = Wire(Vec(params.numDeq, Vec(params.numSrc, UInt(params.dataBits.W))))
+  s1_deqRfDataSel.foreach(_.foreach(_ := DontCare))
+
+  for(((readData, readAddr), i)<-(s1_deqRfDataSel.zip(s1_out)).zipWithIndex){
+    println(s"params.numSrc == numIntRfPorts + numFpRfPorts : ${params.numSrc} ${numIntRfPorts} ${numFpRfPorts} ")
+    // require(params.numSrc == numIntRfPorts + numFpRfPorts)
+    if(params.numSrc == numIntRfPorts + numFpRfPorts){
+      readData := readIntRf_asyn.slice(i*numIntRfPorts,(i+1)*numIntRfPorts).map(_.data) ++ readFpRf_asyn.slice(i*numFpRfPorts,(i+1)*numFpRfPorts).map(_.data)
+      val readAddr0 = readIntRf_asyn.slice(i*numIntRfPorts,(i+1)*numIntRfPorts).map(_.addr) ++ readFpRf_asyn.slice(i*numFpRfPorts,(i+1)*numFpRfPorts).map(_.addr)
+      readAddr0.zip(readAddr.bits.uop.psrc).foreach{
+        case (a,b) =>
+          a := b
+      }
+    }else{
+      readData := readIntRf_asyn.slice(i*numIntRfPorts,(i+1)*numIntRfPorts).map(_.data)
+      val readAddr0 = readIntRf_asyn.slice(i*numIntRfPorts,(i+1)*numIntRfPorts).map(_.addr)
+      val readAddr1 = readFpRf_asyn.slice(i*numFpRfPorts,(i+1)*numFpRfPorts).map(_.addr)
+      (readAddr0.zip(readAddr1)).zip(readAddr.bits.uop.psrc).foreach{
+        case ((a0,a1),b) =>
+          a0 := b
+          a1 := b
+      }
+    }
+  }
+  val immExts = s1_payloadUops                   
+    .zip(s1_deqRfDataSel)
+    .zip(immBypassedData2).map{ case ((uop, data), bypass) =>
+    val immExt = ImmExtractor(params, uop, data)
+    bypass := immExt.io.data_out
+    immExt
+  }
+
+  val dataSlowCaptureAddr = s1_out_addr
   for ((port, addr) <- dataSelect.io.fromSlowPorts.zip(dataSlowCaptureAddr)) {
     for (j <- 0 until params.numSrc) {
-      port(j) := VecInit(dataArray.io.multiWrite.map(w => w.enable && (addr & w.addr(j)).asUInt.orR)).asUInt
+      port(j) := VecInit(dataArrayMultiWrite.map(w => w.enable && (addr & w.addr(j)).asUInt.orR)).asUInt
     }
   }
-  dataSelect.io.slowData := dataArray.io.multiWrite.map(_.data)
-  dataSelect.io.enqBypass := s1_select_bypass_s0
-  for ((enq, i) <- dataSelect.io.enqData.zipWithIndex) {
-    for (j <- 0 until params.numSrc) {
-      enq(j).valid := RegNext(enqReverse(io.fromDispatch)(i).bits.srcIsReady(j))
-      enq(j).bits := immBypassedData(i)(j)
-    }
-  }
+  dataSelect.io.slowData := dataArrayMultiWrite.map(_.data)
   for (i <- 0 until params.numDeq) {
     for (j <- 0 until params.numSrc) {
       s1_out(i).bits.src(j) := dataSelect.io.deqData(i)(j)
@@ -690,8 +730,8 @@ class BaseReservationStation(params: RSParams)(implicit p: Parameters) extends R
       val normalIssuePtrOH = Mux(s1_issue_oldest(i), s1_in_oldestPtrOH.bits, s1_in_selectPtrOH(i))
       val normalFastWakeupMatch = Mux1H(normalIssuePtrOH, fastWakeupMatch)
       val wakeupBypassMask = Wire(Vec(params.numFastWakeup, Vec(params.numSrc, Bool())))
-      for (j <- 0 until params.numFastWakeup) {
-        for (k <- 0 until params.numSrc) {
+      for (j <- 0 until params.numFastWakeup) { // 5
+        for (k <- 0 until params.numSrc) {      // 2
           wakeupBypassMask(j)(k) := Mux(isNormalIssue, normalFastWakeupMatch(k)(j), s1_fastWakeup(i)(k)(j))
         }
       }

--- a/src/main/scala/xiangshan/backend/issue/ReservationStationFMA.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStationFMA.scala
@@ -21,11 +21,13 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utils._
+import xiangshan._
 
 case class FMARSParams()
 
 class FMARSWrapper(modGen: RSMod)(implicit p: Parameters) extends BaseReservationStationWrapper(modGen) {
   params.needScheduledBit = true
+  params.exuCfg = Some(FmacExeUnitCfg)
 
   override lazy val module = new FMARSImp(params, this)
 }

--- a/src/main/scala/xiangshan/backend/issue/ReservationStationFMisc.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStationFMisc.scala
@@ -20,10 +20,13 @@ import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
+import xiangshan._
 
 case class FMiscRSParams()
 
 class FMiscRSWrapper(modGen: RSMod)(implicit p: Parameters) extends BaseReservationStationWrapper(modGen) {
+  params.exuCfg = Some(FmiscExeUnitCfg)
+  
   override lazy val module = new FMiscRSImp(params, this)
 }
 

--- a/src/main/scala/xiangshan/backend/issue/ReservationStationLoad.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStationLoad.scala
@@ -21,11 +21,14 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utils._
+import xiangshan._
 
 case class LoadRSParams()
 
 class LoadRSWrapper(modGen: RSMod)(implicit p: Parameters) extends BaseReservationStationWrapper(modGen) {
   params.needScheduledBit = true
+  params.exuCfg = Some(LdExeUnitCfg)
+
   override lazy val module = new LoadRSImp(params, this)
 }
 

--- a/src/main/scala/xiangshan/backend/issue/ReservationStationMul.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStationMul.scala
@@ -20,10 +20,12 @@ import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
+import xiangshan._
 
 case class MulRSParams()
 
 class MulRSWrapper(modGen: RSMod)(implicit p: Parameters) extends BaseReservationStationWrapper(modGen) {
+  params.exuCfg = Some(MulDivExeUnitCfg)
   override lazy val module = new MulRSImp(params, this)
 }
 

--- a/src/main/scala/xiangshan/backend/issue/ReservationStationSta.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStationSta.scala
@@ -20,11 +20,13 @@ import chipsalliance.rocketchip.config.Parameters
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
+import xiangshan._
 
 case class StaRSParams()
 
 class StaRSWrapper(modGen: RSMod)(implicit p: Parameters) extends BaseReservationStationWrapper(modGen) {
   params.needScheduledBit = true
+  params.exuCfg = Some(StaExeUnitCfg)
   override lazy val module = new StaRSImp(params, this)
 }
 

--- a/src/main/scala/xiangshan/backend/regfile/Regfile.scala
+++ b/src/main/scala/xiangshan/backend/regfile/Regfile.scala
@@ -51,7 +51,7 @@ class Regfile
   val mem = Reg(Vec(NRPhyRegs, UInt(len.W)))
   for (r <- io.readPorts) {
     val rdata = if (hasZero) Mux(r.addr === 0.U, 0.U, mem(r.addr)) else mem(r.addr)
-    r.data := RegNext(rdata)
+    r.data := rdata
   }
   for (w <- io.writePorts) {
     when(w.wen) {


### PR DESCRIPTION
arch: success for coremark, microbench, linux-hello

finished:
1. read Regfile : syn -> asyn
2. Scheduler.scala : add parameter( numIntRfReadPorts, numFpRfReadPorts)
3. Scheduler.scala : fix extractReadRf
4. Scheduler.scala : connect between rs_all and intRfReadData_asyn/fpRfReadData_asyn
5. add params.exuCfg for all BaseReservationStationWrapper
6. ReservationStationJump.scala : add jalrMem and fix immExts connect
7. ReservationStationStd.scala : fix connect between s1_deqRfDataSel and readFpRf_asyn(i).data
8. ReservationStationBase.scala : add parameter( numIntRfPorts, numFpRfPorts )
9. ReservationStationBase.scala : connect between readIntRf_asyn/readFpRf_asyn and
s1_deqRfDataSel[readData]+s1_out[readAddr]
10. ReservationStationBase.scala : add s1_out_addr, dataArrayWrite, dataArrayMultiWrite,
11. ReservationStationBase.scala : fix DataSelect
12. ReservationStationBase.scala : add immBypassedData2 for bypass

todo:
1. debug for povray/_3400001000_.gz