### PR TITLE
Switch to asynchronous reset for all modules

### DIFF
--- a/.github/workflows/check_verilog.py
+++ b/.github/workflows/check_verilog.py
@@ -9,6 +9,8 @@ def err(line, loc, msg):
 if __name__ == "__main__":
     in_decode = False
     in_dispatch = False
+    in_sync_always = False
+    always_depth = 0
     line_number = 0
     with open(sys.argv[1], "r") as f:
         for line in f:
@@ -25,5 +27,17 @@ if __name__ == "__main__":
                 err(line, line_number, "PC should not be in decode!!!\n")
             elif in_dispatch and "_lsrc" in line:
                 err(line, line_number, "lsrc should not be in dispatch!!!\n")
+            if "always @(posedge clock) begin" in line:
+                in_sync_always = True
+            if in_sync_always:
+                if " begin " in line or line.endswith(" begin"):
+                    always_depth += 1
+                if " end " in line or line.endswith(" end"):
+                    always_depth -= 1
+                if always_depth == 0:
+                    in_sync_always = False
+                if "if (reset) begin" in line:
+                    err(line, line_number, "should not use sync reset!!!\n")
             line_number += 1
     exit(0)
+

--- a/src/main/scala/device/RocketDebugWrapper.scala
+++ b/src/main/scala/device/RocketDebugWrapper.scala
@@ -54,7 +54,7 @@ class DebugModule(numCores: Int)(implicit p: Parameters) extends LazyModule {
       val resetCtrl = new ResetCtrlIO(numCores)(p)
       val debugIO = new DebugIO()(p)
       val clock = Input(Bool())
-      val reset = Input(Bool())
+      val reset = Input(Reset())
     })
     debug.module.io.tl_reset := io.reset // this should be TL reset
     debug.module.io.tl_clock := io.clock.asClock // this should be TL clock
@@ -112,13 +112,13 @@ class SimJTAG(tickDelay: Int = 50)(implicit val p: Parameters) extends ExtModule
   with HasExtModuleResource {
 
   val clock = IO(Input(Clock()))
-  val reset = IO(Input(Bool()))
+  val reset = IO(Input(Reset()))
   val jtag = IO(new JTAGIO(hasTRSTn = true))
   val enable = IO(Input(Bool()))
   val init_done = IO(Input(Bool()))
   val exit = IO(Output(UInt(32.W)))
 
-  def connect(dutio: JTAGIO, tbclock: Clock, tbreset: Bool, done: Bool, tbsuccess: Bool) = {
+  def connect(dutio: JTAGIO, tbclock: Clock, tbreset: Reset, done: Bool, tbsuccess: Bool) = {
     dutio.TCK := jtag.TCK
     dutio.TMS := jtag.TMS
     dutio.TDI := jtag.TDI

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -447,6 +447,6 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
     )
   )
 
-  ResetGen(resetTree, reset.asBool, !debugOpts.FPGAPlatform)
+  ResetGen(resetTree, reset, !debugOpts.FPGAPlatform)
 
 }

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -14,7 +14,7 @@ import top.BusPerfMonitor
 import utility.{DelayN, ResetGen, TLClientsMerger, TLEdgeBuffer}
 
 class L1BusErrorUnitInfo(implicit val p: Parameters) extends Bundle with HasSoCParameter {
-  val ecc_error = Valid(UInt(soc.PAddrBits.W)) 
+  val ecc_error = Valid(UInt(soc.PAddrBits.W))
 }
 
 class XSL1BusErrors()(implicit val p: Parameters) extends BusErrors {
@@ -174,6 +174,6 @@ class XSTile()(implicit p: Parameters) extends LazyModule
         l1d_to_l2_bufferOpt.map(_.module) ++
         l2cache.map(_.module)
     )
-    ResetGen(resetChain, reset.asBool || core_soft_rst.asBool, !debugOpts.FPGAPlatform)
+    ResetGen(resetChain, reset, !debugOpts.FPGAPlatform)
   }
 }

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -361,14 +361,14 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   val mipFixMask = ZeroExt(GenMask(9) | GenMask(5) | GenMask(1), XLEN)
   val mip = (mipWire.asUInt | mipReg).asTypeOf(new Interrupt)
 
-  def getMisaMxl(mxl: Int): UInt = {mxl.U << (XLEN-2)}.asUInt
-  def getMisaExt(ext: Char): UInt = {1.U << (ext.toInt - 'a'.toInt)}.asUInt
+  def getMisaMxl(mxl: BigInt): BigInt = mxl << (XLEN - 2)
+  def getMisaExt(ext: Char): Long = 1 << (ext.toInt - 'a'.toInt)
   var extList = List('a', 's', 'i', 'u')
   if (HasMExtension) { extList = extList :+ 'm' }
   if (HasCExtension) { extList = extList :+ 'c' }
   if (HasFPU) { extList = extList ++ List('f', 'd') }
-  val misaInitVal = getMisaMxl(2) | extList.foldLeft(0.U)((sum, i) => sum | getMisaExt(i)) //"h8000000000141105".U
-  val misa = RegInit(UInt(XLEN.W), misaInitVal)
+  val misaInitVal = getMisaMxl(2) | extList.foldLeft(0L)((sum, i) => sum | getMisaExt(i)) //"h8000000000141105".U
+  val misa = RegInit(UInt(XLEN.W), misaInitVal.U)
 
   // MXL = 2          | 0 | EXT = b 00 0000 0100 0001 0001 0000 0101
   // (XLEN-1, XLEN-2) |   |(25, 0)  ZY XWVU TSRQ PONM LKJI HGFE DCBA
@@ -376,7 +376,10 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   val mvendorid = RegInit(UInt(XLEN.W), 0.U) // this is a non-commercial implementation
   val marchid = RegInit(UInt(XLEN.W), 25.U) // architecture id for XiangShan is 25; see https://github.com/riscv/riscv-isa-manual/blob/master/marchid.md
   val mimpid = RegInit(UInt(XLEN.W), 0.U) // provides a unique encoding of the version of the processor implementation
-  val mhartid = RegInit(UInt(XLEN.W), csrio.hartId) // the hardware thread running the code
+  val mhartid = Reg(UInt(XLEN.W)) // the hardware thread running the code
+  when (RegNext(RegNext(reset.asBool) && !reset.asBool)) {
+    mhartid := csrio.hartId
+  }
   val mconfigptr = RegInit(UInt(XLEN.W), 0.U) // the read-only pointer pointing to the platform config structure, 0 for not supported.
   val mstatus = RegInit("ha00002000".U(XLEN.W))
 
@@ -518,12 +521,12 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   //  Others    : Reserved.
 
   val smblockctl_init_val =
-    ("hf".U & StoreBufferThreshold.U) |
-    (EnableLdVioCheckAfterReset.B.asUInt << 4) |
-    (EnableSoftPrefetchAfterReset.B.asUInt << 5) |
-    (EnableCacheErrorAfterReset.B.asUInt << 6) |
-    (EnableUncacheWriteOutstanding.B.asUInt << 7)
-  val smblockctl = RegInit(UInt(XLEN.W), smblockctl_init_val)
+    (0xf & StoreBufferThreshold) |
+    (EnableLdVioCheckAfterReset.toInt << 4) |
+    (EnableSoftPrefetchAfterReset.toInt << 5) |
+    (EnableCacheErrorAfterReset.toInt << 6)
+    (EnableUncacheWriteOutstanding.toInt << 7)
+  val smblockctl = RegInit(UInt(XLEN.W), smblockctl_init_val.U)
   csrio.customCtrl.sbuffer_threshold := smblockctl(3, 0)
   // bits 4: enable load load violation check
   csrio.customCtrl.ldld_vio_check_enable := smblockctl(4)
@@ -537,7 +540,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   println("  Enable soft prefetch after reset: " + EnableSoftPrefetchAfterReset)
   println("  Enable cache error after reset: " + EnableCacheErrorAfterReset)
   println("  Enable uncache write outstanding: " + EnableUncacheWriteOutstanding)
-  
+
   val srnctl = RegInit(UInt(XLEN.W), "h7".U)
   csrio.customCtrl.fusion_enable := srnctl(0)
   csrio.customCtrl.svinval_enable := srnctl(1)
@@ -1172,7 +1175,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
 
   // Implicit add reset values for mepc[0] and sepc[0]
   // TODO: rewrite mepc and sepc using a struct-like style with the LSB always being 0
-  when (reset.asBool) {
+  when (RegNext(RegNext(reset.asBool) && !reset.asBool)) {
     mepc := Cat(mepc(XLEN - 1, 1), 0.U(1.W))
     sepc := Cat(sepc(XLEN - 1, 1), 0.U(1.W))
   }

--- a/src/main/scala/xiangshan/backend/fu/PMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMA.scala
@@ -19,8 +19,10 @@ package xiangshan.backend.fu
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.regmapper.{RegField, RegFieldDesc, RegReadFn, RegWriteFn}
-import utility.{ParallelPriorityMux, ZeroExt, ValidHold}
+import utility.{ParallelPriorityMux, ValidHold, ZeroExt}
 import xiangshan.cache.mmu.TlbCmd
+
+import scala.collection.mutable.ListBuffer
 
 /* Memory Mapped PMA */
 case class MMPMAConfig
@@ -120,100 +122,67 @@ trait PMAMethod extends PMAConst {
    */
 
   def pma_init() : (Vec[UInt], Vec[UInt], Vec[UInt]) = {
-    // the init value is zero
-    // from 0 to num(default 16) - 1, lower priority
-    // according to simple map, 9 entries is needed, pick 6-14, leave 0-5 & 15 unusedcfgMerged.map(_ := 0.U)
+    def genAddr(init_addr: BigInt) = {
+      init_addr.U((PMPAddrBits - PMPOffBits).W)
+    }
+    def genMask(init_addr: BigInt, a: BigInt) = {
+      val match_mask_addr = (init_addr << 1) | (a & 0x1) | (((1 << PlatformGrain) - 1) >> PMPOffBits)
+      val mask = ((match_mask_addr & ~(match_mask_addr + 1)) << PMPOffBits) | ((1 << PMPOffBits) - 1)
+      mask.U(PMPAddrBits.W)
+    }
 
     val num = NumPMA
     require(num >= 16)
-    val cfg = WireInit(0.U.asTypeOf(Vec(num, new PMPConfig())))
 
-    val addr = Wire(Vec(num, UInt((PMPAddrBits-PMPOffBits).W)))
-    val mask = Wire(Vec(num, UInt(PMPAddrBits.W)))
-    addr := DontCare
-    mask := DontCare
+    val cfg_list = ListBuffer[UInt]()
+    val addr_list = ListBuffer[UInt]()
+    val mask_list = ListBuffer[UInt]()
+    def addPMA(base_addr: BigInt,
+               range: BigInt = 0L, // only use for napot mode
+               l: Boolean = false,
+               c: Boolean = false,
+               atomic: Boolean = false,
+               a: Int = 0,
+               x: Boolean = false,
+               w: Boolean = false,
+               r: Boolean = false) = {
+      val addr = if (a < 2) { shift_addr(base_addr) }
+        else { get_napot(base_addr, range) }
+      cfg_list.append(PMPConfigUInt(l, c, atomic, a, x, w, r))
+      addr_list.append(genAddr(addr))
+      mask_list.append(genMask(addr, a))
+    }
 
-    var idx = num-1
+    addPMA(0x0L, range = 0x1000000000L, c = true, atomic = true, a = 3, x = true, w = true, r = true)
+    addPMA(0x0L, range = 0x80000000L, a = 3, w = true, r = true)
+    addPMA(0x3C000000L, a = 1)
+    addPMA(0x3A001000L, a = 1, w = true, r = true)
+    addPMA(0x3A000000L, a = 1)
+    addPMA(0x39002000L, a = 1, w = true, r = true)
+    addPMA(0x39000000L, a = 1)
+    addPMA(0x38022000L, a = 1, w = true, r = true)
+    addPMA(0x38021000L, a = 1, x = true, w = true, r = true)
+    addPMA(0x38020000L, a = 1, w = true, r = true)
+    addPMA(0x30050000L, a = 1, w = true, r = true) // FIXME: GPU space is cacheable?
+    addPMA(0x30010000L, a = 1, w = true, r = true)
+    addPMA(0x20000000L, a = 1, x = true, w = true, r = true)
+    addPMA(0x10000000L, a = 1, w = true, r = true)
+    addPMA(0)
+    while (cfg_list.length < 16) {
+      addPMA(0)
+    }
 
-    // TODO: turn to napot to save entries
-    // use tor instead of napot, for napot may be confusing and hard to understand
-    // NOTE: all the addr space are default set to DDR, RWXCA
-    idx = idx - 1
-    addr(idx) := shift_addr(0xFFFFFFFFFL) // all the addr are default ddr, whicn means rwxca
-    cfg(idx).a := 3.U; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).x := true.B; cfg(idx).c := true.B;cfg(idx).atomic := true.B
-    mask(idx) := match_mask(addr(idx), cfg(idx))
-    idx = idx - 1
-
-    // NOTE: (0x0_0000_0000L, 0x0_8000_0000L) are default set to MMIO, only RWA
-    addr(idx) := get_napot(0x00000000L, 0x80000000L)
-    cfg(idx).a := 3.U; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).atomic := true.B
-    mask(idx) := match_mask(addr(idx), cfg(idx))
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x3C000000)
-    cfg(idx).a := 1.U; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x3A001000)
-    cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x3A000000)
-    cfg(idx).a := 1.U; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x39002000)
-    cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x39000000)
-    cfg(idx).a := 1.U; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x38022000)
-    cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x38021000)
-    cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).x := true.B; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x38020000)
-    cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x310D0000)
-    cfg(idx).a := 1.U; cfg(idx).c := false.B; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).atomic := false.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x310B0000)
-    cfg(idx).a := 1.U;cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    // addr(idx) := shift_addr(0x30050000)
-    // cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B
-    // idx = idx - 1
-    
-    addr(idx) := shift_addr(0x30010000)
-    cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x20000000)
-    cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).x := true.B; cfg(idx).atomic := true.B
-    idx = idx - 1
-
-    addr(idx) := shift_addr(0x10000000)
-    cfg(idx).a := 1.U; cfg(idx).r := true.B; cfg(idx).w := true.B; cfg(idx).atomic := true.B
-    // idx = idx - 1
-
-    require(idx >= 0)
-    addr(idx) := shift_addr(0)
-
-    val cfgInitMerge = cfg.asTypeOf(Vec(num/8, UInt(PMXLEN.W)))
-    (cfgInitMerge, addr, mask)
+    val cfgInitMerge = Seq.tabulate(num / 8)(i => {
+      cfg_list.reverse.drop(8 * i).take(8).foldRight(BigInt(0L)) { case (a, result) =>
+        (result << a.getWidth) | a.litValue
+      }.U(PMXLEN.W)
+    })
+    val addr = addr_list.reverse
+    val mask = mask_list.reverse
+    (VecInit(cfgInitMerge), VecInit(addr), VecInit(mask))
   }
 
-  def get_napot(base: BigInt, range: BigInt) = {
+  def get_napot(base: BigInt, range: BigInt): BigInt = {
     val PlatformGrainBytes = (1 << PlatformGrain)
     if ((base % PlatformGrainBytes) != 0) {
       println("base:%x", base)
@@ -224,7 +193,7 @@ trait PMAMethod extends PMAConst {
     require((base % PlatformGrainBytes) == 0)
     require((range % PlatformGrainBytes) == 0)
 
-    ((base + (range/2 - 1)) >> PMPOffBits).U
+    ((base + (range/2 - 1)) >> PMPOffBits)
   }
 
   def match_mask(paddr: UInt, cfg: PMPConfig) = {
@@ -233,7 +202,7 @@ trait PMAMethod extends PMAConst {
   }
 
   def shift_addr(addr: BigInt) = {
-    (addr >> 2).U
+    addr >> 2
   }
 }
 

--- a/src/main/scala/xiangshan/backend/fu/PMP.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMP.scala
@@ -61,6 +61,26 @@ class PMPConfig(implicit p: Parameters) extends PMPBundle {
   def addr_locked(next: PMPConfig): Bool = locked || (next.locked && next.tor)
 }
 
+object PMPConfigUInt {
+  def apply(
+    l: Boolean = false,
+    c: Boolean = false,
+    atomic: Boolean = false,
+    a: Int = 0,
+    x: Boolean = false,
+    w: Boolean = false,
+    r: Boolean = false)(implicit p: Parameters): UInt = {
+    var config = 0
+    if (l) { config += (1 << 7) }
+    if (c) { config += (1 << 6) }
+    if (atomic) { config += (1 << 5) }
+    if (a > 0) { config += (a << 3) }
+    if (x) { config += (1 << 2) }
+    if (w) { config += (1 << 1) }
+    if (r) { config += (1 << 0) }
+    config.U(8.W)
+  }
+}
 trait PMPReadWriteMethodBare extends PMPConst {
   def match_mask(cfg: PMPConfig, paddr: UInt) = {
     val match_mask_c_addr = Cat(paddr, cfg.a(0)) | (((1 << PlatformGrain) - 1) >> PMPOffBits).U((paddr.getWidth + 1).W)

--- a/src/main/scala/xiangshan/backend/fu/SRT16Divider.scala
+++ b/src/main/scala/xiangshan/backend/fu/SRT16Divider.scala
@@ -51,7 +51,7 @@ class SRT16DividerDataModule(len: Int) extends Module {
   val quot_neg_2 :: quot_neg_1 :: quot_0 :: quot_pos_1 :: quot_pos_2 :: Nil = Enum(5)
 
 
-  val state = RegInit(UIntToOH(s_idle, 7))
+  val state = RegInit((1 << s_idle.litValue.toInt).U(7.W))
 
   // reused wires
 //  val aNormAbs = Wire(UInt((len + 1).W)) // Inputs of xNormAbs regs below

--- a/src/main/scala/xiangshan/backend/fu/fpu/FMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/fpu/FMA.scala
@@ -88,16 +88,6 @@ class FMUL_pipe(val mulLat: Int = 2)(implicit p: Parameters)
 
   val outSel = S2Reg(S1Reg(typeSel))
 
-  val s_mul :: d_mul :: Nil = FPU.ftypes.zipWithIndex.map{ case (ftype, i) =>
-    val mul = Module(new FMUL(ftype.expWidth, ftype.precision))
-    val in1 = src1
-    val in2 = Mux(fpCtrl.fmaCmd(1), invert_sign(src2, ftype.len), src2)
-    mul.io.a := in1
-    mul.io.b := in2
-    mul.io.rm := rm
-    mul
-  }
-
   toAdd.addend := S2Reg(S1Reg(io.in.bits.src(2)))
   toAdd.mul_out.zip(s3.map(_.io.to_fadd)).foreach(x => x._1 := x._2)
   toAdd.uop := uopVec.last
@@ -129,7 +119,7 @@ class FADD_pipe(val addLat: Int = 2)(implicit p: Parameters) extends FPUPipeline
   val stages = FPU.ftypes.zipWithIndex.map{
     case (t, i) =>
       val s1 = Module(new FCMA_ADD_s1(t.expWidth, 2*t.precision, t.precision))
-      val s2 = Module(new FCMA_ADD_s2(t.expWidth, t.precision))
+      val s2 = Module(new FCMA_ADD_s2(t.expWidth, 2*t.precision, t.precision))
       val in1 = Mux(fma,
         mulProd(i).fp_prod.asUInt,
         Cat(src1(t.len - 1, 0), 0.U(t.precision.W))

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -357,7 +357,6 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
   // Option 1: normal selection (do not care about the age)
   select.io.request := statusArray.io.canIssue
 
-  select.io.balance
   // Option 2: select the oldest
   val enqVec = VecInit(s0_doEnqueue.zip(s0_allocatePtrOH).map{ case (d, b) => RegNext(Mux(d, b, 0.U)) })
   val s1_oldestSel = AgeDetector(params.numEntries, enqVec, statusArray.io.flushed, statusArray.io.canIssue)
@@ -445,7 +444,6 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
     }
     statusUpdate.enable := uop.valid
     statusUpdate.addr := s1_allocatePtrOH_dup.head(i)
-    statusUpdate.data.valid := true.B
     statusUpdate.data.scheduled := s1_delayedSrc(i).asUInt.orR
     statusUpdate.data.blocked := params.checkWaitBit.B && uop.bits.cf.loadWaitBit
     val credit = if (params.delayedFpRf) 2 else 1

--- a/src/main/scala/xiangshan/backend/issue/StatusArray.scala
+++ b/src/main/scala/xiangshan/backend/issue/StatusArray.scala
@@ -36,7 +36,6 @@ class StatusArrayUpdateIO(params: RSParams)(implicit p: Parameters) extends Bund
 
 class StatusEntry(params: RSParams)(implicit p: Parameters) extends XSBundle {
   // states
-  val valid = Bool()
   val scheduled = Bool()
   val blocked = Bool()
   val credit = UInt(4.W)
@@ -68,7 +67,7 @@ class StatusEntry(params: RSParams)(implicit p: Parameters) extends XSBundle {
   }
 
   override def toPrintable: Printable = {
-    p"$valid, $scheduled, ${Binary(srcState.asUInt)}, $psrc, $robIdx"
+    p"$scheduled, ${Binary(srcState.asUInt)}, $psrc, $robIdx"
   }
 }
 
@@ -103,19 +102,18 @@ class StatusArray(params: RSParams)(implicit p: Parameters) extends XSModule
     val rsFeedback = Output(Vec(5, Bool()))
   })
 
+  val statusArrayValid = RegInit(VecInit(Seq.fill(params.numEntries)(false.B)))
+  val statusArrayValidNext = WireInit(statusArrayValid)
   val statusArray = Reg(Vec(params.numEntries, new StatusEntry(params)))
-  val replayArray = Reg(Vec(params.numEntries, UInt(3.W))) // for perf-eval only
+  val replayArray = RegInit(VecInit.fill(params.numEntries)(RSFeedbackType.feedbackInvalid)) // for perf-eval only
   val statusArrayNext = WireInit(statusArray)
-  val replayArrayNext = WireInit(replayArray)
+  statusArrayValid := statusArrayValidNext
   statusArray := statusArrayNext
+  val replayArrayNext = WireInit(replayArray)
   replayArray := replayArrayNext
-  when (reset.asBool) {
-    statusArray.map(_.valid := false.B)
-    replayArray.foreach(_ := RSFeedbackType.feedbackInvalid)
-  }
-  (statusArrayNext zip replayArrayNext).foreach { case (status, replay) => when(status.valid === 0.B) { replay := RSFeedbackType.feedbackInvalid } }
-  io.rsFeedback := VecInit((0 until 5).map(index => statusArray.zip(replayArray).map {
-    case (status, replay) => status.valid && replay === index.U
+  (statusArrayValid zip replayArrayNext).foreach { case (valid, replay) => when(valid === 0.B) { replay := RSFeedbackType.feedbackInvalid } }
+  io.rsFeedback := VecInit((0 until 5).map(index => statusArrayValid.zip(replayArray).map {
+    case (valid, replay) => valid && replay === index.U
   }.reduce(_ || _)))
 
   // instruction is ready for issue
@@ -159,16 +157,16 @@ class StatusArray(params: RSParams)(implicit p: Parameters) extends XSModule
   val deqResp = statusArray.indices.map(deqRespSel)
 
   val is_issued = Wire(Vec(params.numEntries, Bool()))
-  for ((((status, statusNext), replayNext), i) <- statusArray.zip(statusArrayNext).zip(replayArrayNext).zipWithIndex) {
+  for (((((statusValid, status), (statusNextValid, statusNext)), replayNext), i) <- statusArrayValid.zip(statusArray).zip(statusArrayValidNext.zip(statusArrayNext)).zip(replayArrayNext).zipWithIndex) {
     // valid: when the entry holds a valid instruction, mark it true.
     // Set when (1) not (flushed or deq); AND (2) update.
-    val realValid = updateValid(i) || status.valid
+    val realValid = updateValid(i) || statusValid
     val (deqRespValid, deqRespSucc, deqRespType, deqRespDataInvalidSqIdx) = deqResp(i)
     val isFlushed = statusNext.robIdx.needFlush(io.redirect)
-    flushedVec(i) := RegNext(realValid && isFlushed) || deqRespSucc
+    flushedVec(i) := (realValid && isFlushed) || (deqRespValid && deqRespSucc)
     when(updateValid(i)) { replayNext := RSFeedbackType.feedbackInvalid }
-    statusNext.valid := realValid && !(isFlushed || deqRespSucc)
-    XSError(updateValid(i) && status.valid, p"should not update a valid entry $i\n")
+    statusNextValid := realValid && !(isFlushed || (deqRespValid && deqRespSucc))
+    XSError(updateValid(i) && statusValid, p"should not update a valid entry $i\n")
     XSError(deqRespValid && !realValid, p"should not deq an invalid entry $i\n")
     if (params.hasFeedback) {
       XSError(deqRespValid && !statusArray(i).scheduled, p"should not deq an un-scheduled entry $i\n")
@@ -179,17 +177,17 @@ class StatusArray(params: RSParams)(implicit p: Parameters) extends XSModule
     // Reset when (1) deq is not granted (it needs to be scheduled again); (2) only one credit left.
     val hasIssued = VecInit(io.issueGranted.map(iss => iss.valid && iss.bits(i))).asUInt.orR
     val deqNotGranted = deqRespValid && !deqRespSucc
-    when(deqNotGranted && statusNext.valid) { replayNext := deqRespType }
+    when(deqNotGranted && statusNextValid) { replayNext := deqRespType }
     statusNext.scheduled := false.B
     if (params.needScheduledBit) {
       // An entry keeps in the scheduled state until its credit comes to zero or deqFailed.
-      val noCredit = status.valid && status.credit === 1.U
+      val noCredit = statusValid && status.credit === 1.U
       val keepScheduled = status.scheduled && !deqNotGranted && !noCredit
       // updateValid may arrive at the same cycle as hasIssued.
       statusNext.scheduled := hasIssued || Mux(updateValid(i), updateVal(i).scheduled, keepScheduled)
     }
     XSError(hasIssued && !realValid, p"should not issue an invalid entry $i\n")
-    is_issued(i) := status.valid && hasIssued
+    is_issued(i) := statusValid && hasIssued
 
     // blocked: indicate whether the entry is blocked for issue until certain conditions meet.
     statusNext.blocked := false.B
@@ -217,7 +215,7 @@ class StatusArray(params: RSParams)(implicit p: Parameters) extends XSModule
         statusNext.blocked := true.B
         statusNext.waitForSqIdx := deqRespDataInvalidSqIdx
         statusNext.waitForStoreData := true.B
-        XSError(status.valid && !isAfter(status.sqIdx, RegNext(RegNext(io.stIssuePtr))),
+        XSError(statusValid && !isAfter(status.sqIdx, RegNext(RegNext(io.stIssuePtr))),
           "Previous store instructions are all issued. Should not trigger dataInvalid.\n")
       }
     }
@@ -225,12 +223,12 @@ class StatusArray(params: RSParams)(implicit p: Parameters) extends XSModule
     // credit: the number of cycles this entry needed until it can be scheduled
     val creditStep = Mux(status.credit > 0.U, status.credit - 1.U, status.credit)
     statusNext.credit := Mux(updateValid(i), updateVal(i).credit, creditStep)
-    XSError(status.valid && status.credit > 0.U && !status.scheduled,
+    XSError(statusValid && status.credit > 0.U && !status.scheduled,
       p"instructions $i with credit ${status.credit} must not be scheduled\n")
 
     // srcState: indicate whether the operand is ready for issue
     val (stateWakeupEn, dataWakeupEnVec) = statusNext.psrc.zip(statusNext.srcType).map(wakeupMatch).unzip
-    io.wakeupMatch(i) := dataWakeupEnVec.map(en => Mux(updateValid(i) || status.valid, en, 0.U))
+    io.wakeupMatch(i) := dataWakeupEnVec.map(en => Mux(updateValid(i) || statusValid, en, 0.U))
     // For best timing of srcState, we don't care whether the instruction is valid or not.
     // We also don't care whether the instruction can really enqueue.
     statusNext.srcState := VecInit(status.srcState.zip(updateVal(i).srcState).zip(stateWakeupEn).map {
@@ -251,24 +249,24 @@ class StatusArray(params: RSParams)(implicit p: Parameters) extends XSModule
     // When the entry is not granted to issue, set isFirstIssue to false.B
     statusNext.isFirstIssue := Mux(hasIssued, false.B, updateValid(i) || status.isFirstIssue)
 
-    XSDebug(status.valid, p"entry[$i]: $status\n")
+    XSDebug(statusValid, p"entry[$i]: $status\n")
   }
 
-  io.isValid := VecInit(statusArray.map(_.valid)).asUInt
-  io.isValidNext := VecInit(statusArrayNext.map(_.valid)).asUInt
-  io.canIssue := VecInit(statusArrayNext.map(_.valid).zip(readyVecNext).map{ case (v, r) => RegNext(v && r) }).asUInt
+  io.isValid := statusArrayValid.asUInt
+  io.isValidNext := statusArrayValidNext.asUInt
+  io.canIssue := VecInit(statusArrayValidNext.zip(readyVecNext).map{ case (v, r) => RegNext(v && r) }).asUInt
   io.isFirstIssue := VecInit(io.issueGranted.map(iss => Mux1H(iss.bits, statusArray.map(_.isFirstIssue))))
   io.allSrcReady := VecInit(io.issueGranted.map(iss => Mux1H(iss.bits, statusArray.map(_.allSrcReady))))
   io.flushed := flushedVec.asUInt
 
-  val validEntries = PopCount(statusArray.map(_.valid))
+  val validEntries = PopCount(statusArrayValid)
   XSPerfHistogram("valid_entries", validEntries, true.B, 0, params.numEntries, 1)
   for (i <- 0 until params.numSrc) {
     val waitSrc = statusArray.map(_.srcState).map(s => Cat(s.zipWithIndex.filter(_._2 != i).map(_._1)).andR && !s(i))
-    val srcBlockIssue = statusArray.zip(waitSrc).map{ case (s, w) => s.valid && !s.scheduled && !s.blocked && w }
+    val srcBlockIssue = statusArrayValid.zip(statusArray).zip(waitSrc).map{ case ((v, s), w) => v && !s.scheduled && !s.blocked && w }
     XSPerfAccumulate(s"wait_for_src_$i", PopCount(srcBlockIssue))
     for (j <- 0 until params.allWakeup) {
-      val wakeup_j_i = io.wakeupMatch.map(_(i)(j)).zip(statusArray.map(_.valid)).map(p => p._1 && p._2)
+      val wakeup_j_i = io.wakeupMatch.map(_(i)(j)).zip(statusArrayValid).map(p => p._1 && p._2)
       XSPerfAccumulate(s"wakeup_${j}_$i", PopCount(wakeup_j_i).asUInt)
       val criticalWakeup = srcBlockIssue.zip(wakeup_j_i).map(x => x._1 && x._2)
       XSPerfAccumulate(s"critical_wakeup_${j}_$i", PopCount(criticalWakeup))
@@ -281,9 +279,9 @@ class StatusArray(params: RSParams)(implicit p: Parameters) extends XSModule
   }
   val canIssueEntries = PopCount(io.canIssue)
   XSPerfHistogram("can_issue_entries", canIssueEntries, true.B, 0, params.numEntries, 1)
-  val isBlocked = PopCount(statusArray.map(s => s.valid && s.blocked))
+  val isBlocked = PopCount(statusArrayValid.zip(statusArray).map(s => s._1 && s._2.blocked))
   XSPerfAccumulate("blocked_entries", isBlocked)
-  val isScheduled = PopCount(statusArray.map(s => s.valid && s.scheduled))
+  val isScheduled = PopCount(statusArrayValid.zip(statusArray).map(s => s._1 && s._2.scheduled))
   XSPerfAccumulate("scheduled_entries", isScheduled)
   val notSelected = PopCount(io.canIssue) - PopCount(is_issued)
   XSPerfAccumulate("not_selected_entries", notSelected)

--- a/src/main/scala/xiangshan/backend/rename/freelist/MEFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/MEFreeList.scala
@@ -25,7 +25,9 @@ import utility._
 
 
 class MEFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) with HasPerfEvents {
-  val freeList = Reg(Vec(size, UInt(PhyRegIdxWidth.W)))
+  val freeList = RegInit(VecInit(
+    // originally {1, 2, ..., size - 1} are free. Register 0-31 are mapped to x0.
+    Seq.tabulate(size - 1)(i => (i + 1).U(PhyRegIdxWidth.W)) :+ 0.U(PhyRegIdxWidth.W)))
 
   // head and tail pointer
   val headPtr = RegInit(FreeListPtr(false, 0))
@@ -81,11 +83,6 @@ class MEFreeList(size: Int)(implicit p: Parameters) extends BaseFreeList(size) w
     when (io.freeReq(i)) {
       val freePtr = tailPtr + PopCount(io.freeReq.take(i))
       freeList(freePtr.value) := io.freePhyReg(i)
-    }
-  }
-  when (reset.asBool) {
-    for (i <- 0 until size - 1) {
-      freeList(i) := (i + 1).U
     }
   }
 

--- a/src/main/scala/xiangshan/backend/rename/freelist/RefCounter.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/RefCounter.scala
@@ -117,8 +117,8 @@ class RefCounter(size: Int)(implicit p: Parameters) extends XSModule {
   }
 
   // assertion of consistancy between arch rename table and refCounter
-  val archRefCounterFromRAT = RegNext(VecInit((0 until size).map(i => PopCount(io.debug_int_rat.map(_ === i.U)))),
-                                      VecInit.fill(size)(0.U(IntRefCounterWidth.W)))
+  val archRefCounterFromRAT = RegInit(VecInit.fill(size)(0.U(IntRefCounterWidth.W)))
+  archRefCounterFromRAT := (0 until size).map(i => PopCount(io.debug_int_rat.map(_ === i.U)))
   (1 until size).foreach(i =>
     XSError(archRefCounter(i) =/= archRefCounterFromRAT(i),
             p"archRefCounter_$i: ${archRefCounter(i)} =/= archRefCounterFromRAT_$i: ${archRefCounterFromRAT(i)}\n")
@@ -133,4 +133,3 @@ class RefCounter(size: Int)(implicit p: Parameters) extends XSModule {
     XSPerfAccumulate(s"free_reg_$i", VecInit(isFreed).asUInt.orR)
   }
 }
-

--- a/src/main/scala/xiangshan/cache/dcache/meta/AsynchronousMetaArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/meta/AsynchronousMetaArray.scala
@@ -108,7 +108,7 @@ class ErrorArray(readPorts: Int, writePorts: Int)(implicit p: Parameters) extend
     val read = Vec(readPorts, Flipped(DecoupledIO(new MetaReadReq)))
     val resp = Output(Vec(readPorts, Vec(nWays, Bool())))
     val write = Vec(writePorts, Flipped(DecoupledIO(new ErrorWriteReq)))
-    // customized cache op port 
+    // customized cache op port
     // val cacheOp = Flipped(new L1CacheInnerOpIO)
   })
 

--- a/src/main/scala/xiangshan/frontend/BPU.scala
+++ b/src/main/scala/xiangshan/frontend/BPU.scala
@@ -183,7 +183,7 @@ class BasePredictorIO (implicit p: Parameters) extends XSBundle with HasBPUConst
   val redirect = Flipped(Valid(new BranchPredictionRedirect))
 }
 
-abstract class BasePredictor(implicit p: Parameters) extends XSModule 
+abstract class BasePredictor(implicit p: Parameters) extends XSModule
   with HasBPUConst with BPUUtils with HasPerfEvents {
   val meta_size = 0
   val spec_meta_size = 0
@@ -213,7 +213,7 @@ abstract class BasePredictor(implicit p: Parameters) extends XSModule
   io.out.s1.pc := s1_pc
   io.out.s2.pc := s2_pc
   io.out.s3.pc := s3_pc
-  
+
   val perfEvents: Seq[(String, UInt)] = Seq()
 
 
@@ -299,13 +299,13 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
   println(f"history buffer length ${HistoryLength}")
   val ghv_write_datas = Wire(Vec(HistoryLength, Bool()))
   val ghv_wens = Wire(Vec(HistoryLength, Bool()))
-  
+
   val s0_ghist_ptr = Wire(new CGHPtr)
   val s0_ghist_ptr_reg = RegNext(s0_ghist_ptr, 0.U.asTypeOf(new CGHPtr))
   val s1_ghist_ptr = RegEnable(s0_ghist_ptr, 0.U.asTypeOf(new CGHPtr), s0_fire)
   val s2_ghist_ptr = RegEnable(s1_ghist_ptr, 0.U.asTypeOf(new CGHPtr), s1_fire)
   val s3_ghist_ptr = RegEnable(s2_ghist_ptr, 0.U.asTypeOf(new CGHPtr), s2_fire)
-  
+
   def getHist(ptr: CGHPtr): UInt = (Cat(ghv_wire.asUInt, ghv_wire.asUInt) >> (ptr.value+1.U))(HistoryLength-1, 0)
   s0_ghist := getHist(s0_ghist_ptr)
 
@@ -341,7 +341,7 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
 
   s1_components_ready := predictors.io.s1_ready
   s1_ready := s1_fire || !s1_valid
-  s0_fire := RegNext(!reset.asBool) && s1_components_ready && s1_ready
+  s0_fire := s1_components_ready && s1_ready
   predictors.io.s0_fire := s0_fire
 
   s2_components_ready := predictors.io.s2_ready
@@ -665,9 +665,6 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
   // ghistPtrGen.register(need_reset, 0.U.asTypeOf(new CGHPtr), Some("reset_GHPtr"), 1)
 
   s0_pc         := npcGen()
-  when (!(RegNext(RegNext(reset.asBool) && !reset.asBool) )) {
-    s0_pc_reg     := s0_pc
-  }
   s0_folded_gh  := foldedGhGen()
   s0_ghist_ptr  := ghistPtrGen()
   s0_ahead_fh_oldest_bits := aheadFhObGen()

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -117,10 +117,10 @@ class SCTable(val nRows: Int, val ctrBits: Int, val histLen: Int)(implicit p: Pa
 
   val update_unhashed_idx = io.update.pc >> instOffsetBits
   for (pi <- 0 until numBr) {
-    updateWayMask(2*pi)   := Seq.tabulate(numBr)(li => 
+    updateWayMask(2*pi)   := Seq.tabulate(numBr)(li =>
       io.update.mask(li) && get_phy_br_idx(update_unhashed_idx, li) === pi.U && !io.update.tagePreds(li)
     ).reduce(_||_)
-    updateWayMask(2*pi+1) := Seq.tabulate(numBr)(li => 
+    updateWayMask(2*pi+1) := Seq.tabulate(numBr)(li =>
       io.update.mask(li) && get_phy_br_idx(update_unhashed_idx, li) === pi.U &&  io.update.tagePreds(li)
     ).reduce(_||_)
   }
@@ -141,7 +141,7 @@ class SCTable(val nRows: Int, val ctrBits: Int, val histLen: Int)(implicit p: Pa
 
   for (pi <- 0 until numBr) {
     val br_lidx = get_lgc_br_idx(update_unhashed_idx, pi.U(log2Ceil(numBr).W))
-    
+
     val wrbypass_io = Mux1H(UIntToOH(br_lidx, numBr), wrbypasses.map(_.io))
 
     val ctrPos = Mux1H(UIntToOH(br_lidx, numBr), io.update.tagePreds)
@@ -181,7 +181,7 @@ class SCThreshold(val ctrBits: Int = 6)(implicit p: Parameters) extends SCBundle
   val ctr = UInt(ctrBits.W)
   def satPos(ctr: UInt = this.ctr) = ctr === ((1.U << ctrBits) - 1.U)
   def satNeg(ctr: UInt = this.ctr) = ctr === 0.U
-  def neutralVal = (1.U << (ctrBits - 1))
+  def neutralVal = (1 << (ctrBits - 1)).U
   val thres = UInt(8.W)
   def initVal = 6.U
   def minThres = 6.U
@@ -226,7 +226,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
       }
     }
     sc_fh_info = scTables.map(_.getFoldedHistoryInfo).reduce(_++_).toSet
-  
+
     val scThresholds = List.fill(TageBanks)(RegInit(SCThreshold(5)))
     val useThresholds = VecInit(scThresholds map (_.thres))
 
@@ -241,9 +241,9 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
       (scSum < -signedThres - tagePvdr) && neg(totalSum)
     }
     val updateThresholds = VecInit(useThresholds map (t => (t << 3) +& 21.U))
-  
+
     val s1_scResps = VecInit(scTables.map(t => t.io.resp))
-  
+
     val scUpdateMask = WireInit(0.U.asTypeOf(Vec(numBr, Vec(SCNTables, Bool()))))
     val scUpdateTagePreds = Wire(Vec(TageBanks, Bool()))
     val scUpdateTakens = Wire(Vec(TageBanks, Bool()))
@@ -251,21 +251,21 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
     scUpdateTagePreds := DontCare
     scUpdateTakens := DontCare
     scUpdateOldCtrs := DontCare
-  
+
     val updateSCMeta = updateMeta.scMeta.get
-  
+
     val s2_sc_used, s2_conf, s2_unconf, s2_agree, s2_disagree =
       WireInit(0.U.asTypeOf(Vec(TageBanks, Bool())))
     val update_sc_used, update_conf, update_unconf, update_agree, update_disagree =
       WireInit(0.U.asTypeOf(Vec(TageBanks, Bool())))
     val sc_misp_tage_corr, sc_corr_tage_misp =
       WireInit(0.U.asTypeOf(Vec(TageBanks, Bool())))
-  
+
     // for sc ctrs
     def getCentered(ctr: SInt): SInt = Cat(ctr, 1.U(1.W)).asSInt
     // for tage ctrs, (2*(ctr-4)+1)*8
     def getPvdrCentered(ctr: UInt): SInt = Cat(ctr ^ (1 << (TageCtrBits-1)).U, 1.U(1.W), 0.U(3.W)).asSInt
-    
+
     val scMeta = resp_meta.scMeta.get
     scMeta := DontCare
     for (w <- 0 until TageBanks) {
@@ -295,7 +295,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
       scMeta.scUsed(w)     := RegEnable(s2_provideds(w), io.s2_fire)
       scMeta.scPreds(w)    := RegEnable(s2_scPreds(s2_chooseBit), io.s2_fire)
       scMeta.ctrs(w)       := RegEnable(s2_scCtrs, io.s2_fire)
-  
+
       when (s2_provideds(w)) {
         s2_sc_used(w) := true.B
         s2_unconf(w) := !s2_sumAboveThresholds(s2_chooseBit)
@@ -316,7 +316,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
       when (io.ctrl.sc_enable) {
         io.out.s3.full_pred.br_taken_mask(w) := RegEnable(s2_pred, io.s2_fire)
       }
-  
+
       val updateTageMeta = updateMeta
       when (updateValids(w) && updateSCMeta.scUsed(w)) {
         val scPred = updateSCMeta.scPreds(w)
@@ -331,7 +331,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         scUpdateTagePreds(w) := tagePred
         scUpdateTakens(w) := taken
         (scUpdateOldCtrs(w) zip scOldCtrs).foreach{case (t, c) => t := c}
-  
+
         update_sc_used(w) := true.B
         update_unconf(w) := !sumAboveThreshold
         update_conf(w) := sumAboveThreshold
@@ -339,14 +339,14 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         update_disagree(w) := scPred =/= tagePred
         sc_corr_tage_misp(w) := scPred === taken && tagePred =/= taken && update_conf(w)
         sc_misp_tage_corr(w) := scPred =/= taken && tagePred === taken && update_conf(w)
-  
+
         val thres = useThresholds(w)
         when (scPred =/= tagePred && sumAbs >= thres - 4.U && sumAbs <= thres - 2.U) {
           val newThres = scThresholds(w).update(scPred =/= taken)
           scThresholds(w) := newThres
           XSDebug(p"scThres $w update: old ${useThresholds(w)} --> new ${newThres.thres}\n")
         }
-  
+
         when (scPred =/= taken || !sumAboveThreshold) {
           scUpdateMask(w).foreach(_ := true.B)
           XSDebug(sum < 0.S,
@@ -363,8 +363,8 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         }
       }
     }
-  
-    
+
+
     for (b <- 0 until TageBanks) {
       for (i <- 0 until SCNTables) {
         scTables(i).io.update.mask(b) := RegNext(scUpdateMask(b)(i))
@@ -375,7 +375,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         scTables(i).io.update.folded_hist := RegNext(updateFHist)
       }
     }
-    
+
     tage_perf("sc_conf", PopCount(s2_conf), PopCount(update_conf))
     tage_perf("sc_unconf", PopCount(s2_unconf), PopCount(update_unconf))
     tage_perf("sc_agree", PopCount(s2_agree), PopCount(update_agree))
@@ -385,7 +385,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
     XSPerfAccumulate("sc_update_on_unconf", PopCount(update_on_unconf))
     XSPerfAccumulate("sc_mispred_but_tage_correct", PopCount(sc_misp_tage_corr))
     XSPerfAccumulate("sc_correct_and_tage_wrong", PopCount(sc_corr_tage_misp))
-    
+
   }
 
   override def getFoldedHistoryInfo = Some(tage_fh_info ++ sc_fh_info)

--- a/src/main/scala/xiangshan/frontend/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/Tage.scala
@@ -512,8 +512,7 @@ class TageTable
   }
 
   // ------------------------------Debug-------------------------------------
-  val valids = Reg(Vec(nRows, Bool()))
-  when (reset.asBool) { valids.foreach(r => r := false.B) }
+  val valids = RegInit(VecInit(Seq.fill(nRows)(false.B)))
   when (io.update.mask.reduce(_||_)) { valids(update_idx) := true.B }
   XSDebug("Table usage:------------------------\n")
   XSDebug("%d out of %d rows are valid\n", PopCount(valids), nRows.U)

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -53,7 +53,7 @@ class SimTop(implicit p: Parameters) extends Module {
   l_simAXIMem.io_axi4 <> soc.memory
 
   soc.io.clock := clock.asBool
-  soc.io.reset := reset.asBool
+  soc.io.reset := reset.asAsyncReset
   soc.io.extIntrs := simMMIO.io.interrupt.intrVec
   soc.io.sram_config := 0.U
   soc.io.pll0_lock := true.B
@@ -73,7 +73,7 @@ class SimTop(implicit p: Parameters) extends Module {
 
   val success = Wire(Bool())
   val jtag = Module(new SimJTAG(tickDelay=3)(p)).connect(soc.io.systemjtag.jtag, clock, reset.asBool, !reset.asBool, success)
-  soc.io.systemjtag.reset := reset
+  soc.io.systemjtag.reset := reset.asAsyncReset
   soc.io.systemjtag.mfr_id := 0.U(11.W)
   soc.io.systemjtag.part_number := 0.U(16.W)
   soc.io.systemjtag.version := 0.U(4.W)


### PR DESCRIPTION
This commit changes the reset of all modules to asynchronous style, including changes on the initialization values of some registers. For async registers, they must have constant reset values.