### PR TITLE
MMU: Add L1TLB and L2TLB Resp difftest

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -312,7 +312,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
       val difftest = Module(new DifftestL2TLBEvent)
       difftest.io.clock := clock
       difftest.io.coreid := p(XSCoreParamsKey).HartId.asUInt
-      difftest.io.valid := io.tlb(i).resp.fire
+      difftest.io.valid := io.tlb(i).resp.fire && !io.tlb(i).resp.bits.af
       difftest.io.index := i.U
       difftest.io.satp := io.csr.tlb.satp.ppn
       difftest.io.vpn := io.tlb(i).resp.bits.entry.tag

--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -313,6 +313,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
       difftest.io.clock := clock
       difftest.io.coreid := p(XSCoreParamsKey).HartId.asUInt
       difftest.io.valid := io.tlb(i).resp.fire
+      difftest.io.index := i.U
       difftest.io.satp := io.csr.tlb.satp.ppn
       difftest.io.vpn := io.tlb(i).resp.bits.entry.tag
       difftest.io.ppn := io.tlb(i).resp.bits.entry.ppn

--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -307,6 +307,21 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
     difftest.io.data := refill_data.asTypeOf(difftest.io.data)
   }
 
+  if (env.EnableDifftest) {
+    for (i <- 0 until PtwWidth) {
+      val difftest = Module(new DifftestL2TLBEvent)
+      difftest.io.clock := clock
+      difftest.io.coreid := p(XSCoreParamsKey).HartId.asUInt
+      difftest.io.valid := io.tlb(i).resp.fire
+      difftest.io.satp := io.csr.tlb.satp.ppn
+      difftest.io.vpn := io.tlb(i).resp.bits.entry.tag
+      difftest.io.ppn := io.tlb(i).resp.bits.entry.ppn
+      difftest.io.perm := io.tlb(i).resp.bits.entry.perm.getOrElse(0.U.asTypeOf(new PtePermBundle)).asUInt
+      difftest.io.level := io.tlb(i).resp.bits.entry.level.getOrElse(0.U.asUInt)
+      difftest.io.pf := io.tlb(i).resp.bits.pf
+    }
+  }
+
   // pmp
   pmp_check(0).req <> ptw.io.pmp.req
   ptw.io.pmp.resp <> pmp_check(0).resp


### PR DESCRIPTION
When L2TLB resp is valid, we will check: ppn, perm and level.
When L1TLB resp is valid, we will check: ppn.
I consider that it is not necessary to do pmp_check or permission_check in difftest when TLB response so L1TLB resp will not be checked when access fault or page fault occurs.

Please also merge https://github.com/OpenXiangShan/difftest/pull/99 to master.