### PR TITLE
ci: use checkout@v3 instead of v2

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -13,7 +13,7 @@ jobs:
     continue-on-error: false
     name: Generate Verilog
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
       - name: set env
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - Basics
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
       - name: set env
@@ -104,7 +104,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - Performance
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
       - name: set env
@@ -166,7 +166,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - MC
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
       - name: set env
@@ -199,7 +199,7 @@ jobs:
   #   timeout-minutes: 900
   #   name: SIMV - Basics
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v3
   #       with:
   #         submodules: 'recursive'
   #     - name: set env

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
     # Build + 8 checkpoints * 1-hour timeout
     name: Nightly Regression - Checkpoints
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
       - name: set env


### PR DESCRIPTION
This commit should solve deprecation warnings in workflows.
See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ and https://github.com/actions/checkout#whats-new.