### PR TITLE
LoadMissTable: add it and use constant control

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -19,6 +19,7 @@ jobs:
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
+          echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
           echo "WAVE_HOME=/nfs/home/ci-runner/xs-wave/${HEAD_SHA}" >> $GITHUB_ENV
           mkdir -p /nfs/home/ci-runner/xs-wave/${HEAD_SHA}
@@ -54,6 +55,7 @@ jobs:
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
+          echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
           echo "AM_HOME=/nfs/home/share/ci-workloads/nexus-am" >> $GITHUB_ENV
           echo "PERF_HOME=/nfs/home/ci-runner/xs-perf/${HEAD_SHA}" >> $GITHUB_ENV
@@ -110,6 +112,7 @@ jobs:
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
+          echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
           echo "AM_HOME=/nfs/home/share/ci-workloads/nexus-am" >> $GITHUB_ENV
           echo "PERF_HOME=/nfs/home/ci-runner/xs-perf/${HEAD_SHA}" >> $GITHUB_ENV
@@ -172,6 +175,7 @@ jobs:
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
+          echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
           echo "AM_HOME=/nfs/home/share/ci-workloads/nexus-am" >> $GITHUB_ENV
           echo "PERF_HOME=/nfs/home/ci-runner/xs-perf/${HEAD_SHA}" >> $GITHUB_ENV
@@ -205,6 +209,7 @@ jobs:
   #     - name: set env
   #       run: |
   #         export HEAD_SHA=${{ github.run_number }}
+  #         echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
   #         echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
   #         echo "AM_HOME=/nfs/home/share/ci-workloads/nexus-am" >> $GITHUB_ENV
   #         echo "PERF_HOME=/nfs/home/ci-runner/xs-perf/${HEAD_SHA}" >> $GITHUB_ENV

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -37,7 +37,7 @@ jobs:
       - name: build MinimalConfig Release emu
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
-            --threads 4 --config MinimalConfig --release
+            --threads 4 --config MinimalConfig --release --with-constantin
       - name: run MinimalConfig - Linux
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 4 --numa --ci linux-hello 2> perf.log
@@ -65,7 +65,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       - name: Build EMU
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --build --threads 8
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --build --threads 8 --with-constantin
       - name: Basic Test - cputest
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 8 --ci cputest 2> /dev/zero
@@ -123,7 +123,7 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3            \
-            --with-dramsim3 --threads 16
+            --with-dramsim3 --threads 16 --with-constantin
       - name: SPEC06 Test - mcf
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000 --numa --ci mcf 2> perf.log
@@ -186,7 +186,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --num-cores 2 \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 \
-            --with-dramsim3 --threads 16
+            --with-dramsim3 --threads 16 --with-constantin
       - name: MC Test
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --diff ./ready-to-run/riscv64-nemu-interpreter-dual-so --ci mc-tests 2> /dev/zero

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,7 @@ jobs:
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
+          echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "NEMU_HOME=/nfs/home/share/ci-workloads/NEMU" >> $GITHUB_ENV
           echo "PERF_HOME=/nfs/home/ci-runner/xs-perf/${HEAD_SHA}" >> $GITHUB_ENV
           echo "WAVE_HOME=/nfs/home/ci-runner/xs-wave/${HEAD_SHA}" >> $GITHUB_ENV

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3     \
-            --with-dramsim3 --threads 16 --spike
+            --with-dramsim3 --threads 16 --spike --with-constantin
       - name: Random Checkpoint 0
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \

--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -73,6 +73,7 @@ class XSArgs(object):
         # Makefile arguments
         self.threads = args.threads
         self.with_dramsim3 = 1 if args.with_dramsim3 else None
+        self.with_constantin = 1 if args.with_constantin else None
         self.is_release = 1 if args.release else None
         self.is_spike = "spike" if args.spike else None
         self.trace = 1 if args.trace or not args.disable_fork and not args.trace_fst else None
@@ -118,6 +119,7 @@ class XSArgs(object):
         makefile_args = [
             (self.threads,       "EMU_THREADS"),
             (self.with_dramsim3, "WITH_DRAMSIM3"),
+            (self.with_constantin, "WITH_CONSTANTIN"),
             (self.is_release,    "RELEASE"),
             (self.is_spike,      "REF"),
             (self.trace,         "EMU_TRACE"),
@@ -477,6 +479,7 @@ if __name__ == "__main__":
     parser.add_argument('--release', action='store_true', help='enable release')
     parser.add_argument('--spike', action='store_true', help='enable spike diff')
     parser.add_argument('--with-dramsim3', action='store_true', help='enable dramsim3')
+    parser.add_argument('--with-constantin', action='store_true', help='enable constantin')
     parser.add_argument('--threads', nargs='?', type=int, help='number of emu threads')
     parser.add_argument('--trace', action='store_true', help='enable vcd waveform')
     parser.add_argument('--trace-fst', action='store_true', help='enable fst waveform')

--- a/src/main/resources/constantin.txt
+++ b/src/main/resources/constantin.txt
@@ -1,0 +1,1 @@
+is_first_hit_write 0

--- a/src/main/resources/constantin.txt
+++ b/src/main/resources/constantin.txt
@@ -1,1 +1,1 @@
-is_first_hit_write 0
+is_first_hit_write 1

--- a/src/main/resources/constantin.txt
+++ b/src/main/resources/constantin.txt
@@ -1,1 +1,13 @@
-is_first_hit_write 1
+isWriteBankConflictTable 0
+isWriteFetchToIBufferTable 0
+isWriteFTQTable 0
+isWriteIfuWbToFtqTable 0
+isWriteInstInfoTable 0
+isWriteL1MissQMissTable 0
+isWriteL1TlbTable 0
+isWriteL2TlbMissQueueTable 0
+isWriteL2TlbPrefetchTable 0
+isWriteLoadMissTable 1
+isWritePageCacheTable 0
+
+isFirstHitWrite 0

--- a/src/main/resources/constantin.txt
+++ b/src/main/resources/constantin.txt
@@ -9,5 +9,6 @@ isWriteL2TlbMissQueueTable 0
 isWriteL2TlbPrefetchTable 0
 isWriteLoadMissTable 1
 isWritePageCacheTable 0
+isWritePTWTable 0
 
 isFirstHitWrite 0

--- a/src/main/scala/xiangshan/DbEntry.scala
+++ b/src/main/scala/xiangshan/DbEntry.scala
@@ -6,9 +6,10 @@ import xiangshan.cache.DCacheBundle
 
 /** Mem */
 class LoadMissEntry(implicit p: Parameters) extends DCacheBundle {
-  val time = UInt(XLEN.W)
+  val timeCnt = UInt(XLEN.W)
   val paddr = UInt(PAddrBits.W)
   val vaddr = UInt(VAddrBits.W)
   // 1:first hit, 2:first miss, 3:second miss
   val missState = UInt(3.W)
+  val debug_isFirstHitWrite = UInt(XLEN.W)
 }

--- a/src/main/scala/xiangshan/DbEntry.scala
+++ b/src/main/scala/xiangshan/DbEntry.scala
@@ -11,5 +11,4 @@ class LoadMissEntry(implicit p: Parameters) extends DCacheBundle {
   val vaddr = UInt(VAddrBits.W)
   // 1:first hit, 2:first miss, 3:second miss
   val missState = UInt(3.W)
-  val debug_isFirstHitWrite = UInt(XLEN.W)
 }

--- a/src/main/scala/xiangshan/DbEntry.scala
+++ b/src/main/scala/xiangshan/DbEntry.scala
@@ -2,13 +2,34 @@ package xiangshan
 
 import chipsalliance.rocketchip.config.Parameters
 import chisel3._
+import chisel3.util.log2Ceil
+import xiangshan.backend.rob.{DebugLsInfo, DebugMdpInfo}
 import xiangshan.cache.DCacheBundle
 
 /** Mem */
 class LoadMissEntry(implicit p: Parameters) extends DCacheBundle {
   val timeCnt = UInt(XLEN.W)
+  val robIdx = UInt(log2Ceil(RobSize).W)
   val paddr = UInt(PAddrBits.W)
   val vaddr = UInt(VAddrBits.W)
   // 1:first hit, 2:first miss, 3:second miss
   val missState = UInt(3.W)
+}
+
+class InstInfoEntry(implicit p: Parameters) extends XSBundle{
+  val globalID = UInt(XLEN.W)
+  val robIdx = UInt(log2Ceil(RobSize).W)
+  val instType = FuType()
+  val exceptType = UInt(ExceptionVec.ExceptionVecSize.W)
+  val ivaddr = UInt(VAddrBits.W)
+  val dvaddr = UInt(VAddrBits.W) // the l/s access address
+  val dpaddr = UInt(VAddrBits.W) // need the physical address when the TLB is valid
+  val tlbLatency = UInt(XLEN.W)  // original requirements is L1toL2TlbLatency
+  val accessLatency = UInt(XLEN.W)  // RS out time --> write back time
+  val executeLatency = UInt(XLEN.W)
+  val issueLatency = UInt(XLEN.W)
+  val lsInfo = new DebugLsInfo
+  val mdpInfo = new DebugMdpInfo
+  val issueTime = UInt(XLEN.W)
+  val writebackTime = UInt(XLEN.W)
 }

--- a/src/main/scala/xiangshan/DbEntry.scala
+++ b/src/main/scala/xiangshan/DbEntry.scala
@@ -1,0 +1,14 @@
+package xiangshan
+
+import chipsalliance.rocketchip.config.Parameters
+import chisel3._
+import xiangshan.cache.DCacheBundle
+
+/** Mem */
+class LoadMissEntry(implicit p: Parameters) extends DCacheBundle {
+  val time = UInt(XLEN.W)
+  val paddr = UInt(PAddrBits.W)
+  val vaddr = UInt(VAddrBits.W)
+  // 1:first hit, 2:first miss, 3:second miss
+  val missState = UInt(3.W)
+}

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -96,7 +96,7 @@ class DebugLSIO(implicit p: Parameters) extends XSBundle {
   val debugLsInfo = Vec(exuParameters.LduCnt + exuParameters.StuCnt, Output(new DebugLsInfoBundle))
 }
 
-class DebugInstDB(implicit p: Parameters) extends XSBundle{
+class InstInfoTable(implicit p: Parameters) extends XSBundle{
   val globalID = UInt(XLEN.W)
   val robIdx = UInt(log2Ceil(RobSize).W)
   val instType = FuType()
@@ -1102,13 +1102,14 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
     * log trigger is at writeback valid
     * */
   if(!env.FPGAPlatform){
-    val instTableName = "InstDB" + p(XSCoreParamsKey).HartId.toString
+    val isWriteInstInfoTable = Constantin.createRecord("isWriteInstInfoTable")
+    val instTableName = "InstTable" + p(XSCoreParamsKey).HartId.toString
     val instSiteName = "Rob" + p(XSCoreParamsKey).HartId.toString
-    val debug_instTable = ChiselDB.createTable(instTableName, new DebugInstDB)
+    val debug_instTable = ChiselDB.createTable(instTableName, new InstInfoTable)
     // FIXME lyq: only get inst (alu, bj, ls) in exuWriteback
     for (wb <- exuWriteback) {
       when(wb.valid) {
-        val debug_instData = Wire(new DebugInstDB)
+        val debug_instData = Wire(new InstInfoTable)
         val idx = wb.bits.uop.robIdx.value
         debug_instData.globalID := wb.bits.uop.ctrl.debug_globalID
         debug_instData.robIdx := idx

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -96,24 +96,6 @@ class DebugLSIO(implicit p: Parameters) extends XSBundle {
   val debugLsInfo = Vec(exuParameters.LduCnt + exuParameters.StuCnt, Output(new DebugLsInfoBundle))
 }
 
-class InstInfoTable(implicit p: Parameters) extends XSBundle{
-  val globalID = UInt(XLEN.W)
-  val robIdx = UInt(log2Ceil(RobSize).W)
-  val instType = FuType()
-  val exceptType = ExceptionVec()
-  val ivaddr = UInt(VAddrBits.W)
-  val dvaddr = UInt(VAddrBits.W) // the l/s access address
-  val dpaddr = UInt(VAddrBits.W) // need the physical address when the TLB is valid
-  val tlbLatency = UInt(XLEN.W)  // original requirements is L1toL2TlbLatency
-  // val levelTlbHit = UInt(2.W) // 01, 10, 11(memory)
-  // val otherPerfNoteThing // FIXME: how much?
-  val accessLatency = UInt(XLEN.W)  // RS out time --> write back time
-  val executeLatency = UInt(XLEN.W)
-  val issueLatency = UInt(XLEN.W)
-  val lsInfo = new DebugLsInfo
-  val mdpInfo = new DebugMdpInfo
-}
-
 class RobPtr(implicit p: Parameters) extends CircularQueuePtr[RobPtr](
   p => p(XSCoreParamsKey).RobSize
 ) with HasCircularQueuePtrHelper {
@@ -1105,11 +1087,11 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
     val isWriteInstInfoTable = WireInit(Constantin.createRecord("isWriteInstInfoTable" + p(XSCoreParamsKey).HartId.toString))
     val instTableName = "InstTable" + p(XSCoreParamsKey).HartId.toString
     val instSiteName = "Rob" + p(XSCoreParamsKey).HartId.toString
-    val debug_instTable = ChiselDB.createTable(instTableName, new InstInfoTable)
+    val debug_instTable = ChiselDB.createTable(instTableName, new InstInfoEntry)
     // FIXME lyq: only get inst (alu, bj, ls) in exuWriteback
     for (wb <- exuWriteback) {
       when(wb.valid) {
-        val debug_instData = Wire(new InstInfoTable)
+        val debug_instData = Wire(new InstInfoEntry)
         val idx = wb.bits.uop.robIdx.value
         debug_instData.globalID := wb.bits.uop.ctrl.debug_globalID
         debug_instData.robIdx := idx
@@ -1121,10 +1103,12 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
         debug_instData.accessLatency := wb.bits.uop.debugInfo.writebackTime - wb.bits.uop.debugInfo.issueTime
         debug_instData.executeLatency := wb.bits.uop.debugInfo.writebackTime - wb.bits.uop.debugInfo.issueTime
         debug_instData.issueLatency := wb.bits.uop.debugInfo.issueTime - wb.bits.uop.debugInfo.selectTime
-        debug_instData.exceptType := wb.bits.uop.cf.exceptionVec
+        debug_instData.exceptType := Cat(wb.bits.uop.cf.exceptionVec)
         debug_instData.lsInfo := debug_lsInfo(idx)
         debug_instData.mdpInfo.ssid := wb.bits.uop.cf.ssid
         debug_instData.mdpInfo.waitAllStore := wb.bits.uop.cf.loadWaitStrict && wb.bits.uop.cf.loadWaitBit
+        debug_instData.issueTime := wb.bits.uop.debugInfo.issueTime
+        debug_instData.writebackTime := wb.bits.uop.debugInfo.writebackTime
         debug_instTable.log(
           data = debug_instData,
           en = wb.valid,

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1102,7 +1102,7 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
     * log trigger is at writeback valid
     * */
   if(!env.FPGAPlatform){
-    val isWriteInstInfoTable = Constantin.createRecord("isWriteInstInfoTable")
+    val isWriteInstInfoTable = WireInit(Constantin.createRecord("isWriteInstInfoTable" + p(XSCoreParamsKey).HartId.toString))
     val instTableName = "InstTable" + p(XSCoreParamsKey).HartId.toString
     val instSiteName = "Rob" + p(XSCoreParamsKey).HartId.toString
     val debug_instTable = ChiselDB.createTable(instTableName, new InstInfoTable)

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -43,6 +43,7 @@ case class DCacheParameters
   tagECC: Option[String] = None,
   dataECC: Option[String] = None,
   replacer: Option[String] = Some("setplru"),
+  updateReplaceOn2ndmiss: Boolean = true,
   nMissEntries: Int = 1,
   nProbeEntries: Int = 1,
   nReleaseEntries: Int = 1,
@@ -865,7 +866,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   missReqArb.io.in(MainPipeMissReqPort) <> mainPipe.io.miss_req
   for (w <- 0 until LoadPipelineWidth) { missReqArb.io.in(w + 1) <> ldu(w).io.miss_req }
 
-  for (w <- 0 until LoadPipelineWidth) { ldu(w).io.miss_resp.id := missQueue.io.resp.id }
+  for (w <- 0 until LoadPipelineWidth) { ldu(w).io.miss_resp := missQueue.io.resp }
+  mainPipe.io.miss_resp := missQueue.io.resp
 
   wb.io.miss_req.valid := missReqArb.io.out.valid
   wb.io.miss_req.bits  := missReqArb.io.out.bits.addr

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -850,8 +850,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   }
 
   /** LoadMissDB: record load miss state */
-  val isWriteLoadMissTable = Constantin.createRecord("isWriteLoadMissTable")
-  val isFirstHitWrite = Constantin.createRecord("isFirstHitWrite")
+  val isWriteLoadMissTable = WireInit(Constantin.createRecord("isWriteLoadMissTable" + p(XSCoreParamsKey).HartId.toString))
+  val isFirstHitWrite = WireInit(Constantin.createRecord("isFirstHitWrite" + p(XSCoreParamsKey).HartId.toString))
   val tableName = "LoadMissDB" + p(XSCoreParamsKey).HartId.toString
   val siteName = "DcacheWrapper" + p(XSCoreParamsKey).HartId.toString
   val loadMissTable = ChiselDB.createTable(tableName, new LoadMissEntry)

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -583,9 +583,10 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     bankConflictData.fake_rr_bank_conflict := false.B
   }
 
+  val isWriteBankConflictTable = Constantin.createRecord("isWriteBankConflictTable")
   bankConflictTable.log(
     data = bankConflictData,
-    en = rr_bank_conflict(0)(1),
+    en = isWriteBankConflictTable.orR && rr_bank_conflict(0)(1),
     site = siteName,
     clock = clock,
     reset = reset

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -583,7 +583,7 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     bankConflictData.fake_rr_bank_conflict := false.B
   }
 
-  val isWriteBankConflictTable = Constantin.createRecord("isWriteBankConflictTable")
+  val isWriteBankConflictTable = WireInit(Constantin.createRecord("isWriteBankConflictTable" + p(XSCoreParamsKey).HartId.toString))
   bankConflictTable.log(
     data = bankConflictData,
     en = isWriteBankConflictTable.orR && rr_bank_conflict(0)(1),

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -338,6 +338,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   resp.bits.meta_access := s2_hit_access
   resp.bits.tag_error := s2_tag_error // report tag_error in load s2
   resp.bits.mshr_id := io.miss_resp.id
+  resp.bits.debug_robIdx := s2_req.debug_robIdx
 
   XSPerfAccumulate("wpu_pred_fail", s2_wpu_pred_fail && s2_valid)
   XSPerfAccumulate("dcache_read_bank_conflict", io.bank_conflict_slow && s2_valid)

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -271,6 +271,8 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // Bank conflict on data arrays
   val s2_nack_data = RegEnable(!io.banked_data_read.ready, s1_fire)
   val s2_nack = s2_nack_hit || s2_nack_no_mshr || s2_nack_data
+  // s2 miss merged
+  val s2_miss_merged = io.miss_req.valid && io.miss_resp.merged
 
   val s2_bank_addr = addr_to_dcache_bank(s2_paddr)
   dontTouch(s2_bank_addr)
@@ -387,9 +389,35 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.error.valid := s3_error && s3_valid
 
   // update plru in s3
-  io.replace_access.valid := RegNext(RegNext(RegNext(io.meta_read.fire()) && s1_valid && !io.lsu.s1_kill) && !s2_nack_no_mshr)
-  io.replace_access.bits.set := RegNext(RegNext(get_idx(s1_req.addr)))
-  io.replace_access.bits.way := RegNext(RegNext(Mux(s1_tag_match_dup_dc, OHToUInt(s1_tag_match_way_dup_dc), io.replace_way.way)))
+  if (!cfg.updateReplaceOn2ndmiss) {
+    // replacement is only updated on 1st miss
+    io.replace_access.valid := RegNext(RegNext(
+      RegNext(io.meta_read.fire()) && s1_valid && !io.lsu.s1_kill) && 
+      !s2_nack_no_mshr &&
+      !s2_miss_merged
+    )
+    io.replace_access.bits.set := RegNext(RegNext(get_idx(s1_req.addr)))
+    io.replace_access.bits.way := RegNext(RegNext(Mux(s1_tag_match_dup_dc, OHToUInt(s1_tag_match_way_dup_dc), io.replace_way.way)))
+  } else {
+    // replacement is updated on both 1st and 2nd miss
+    // timing is worse than !cfg.updateReplaceOn2ndmiss
+    io.replace_access.valid := RegNext(RegNext(
+      RegNext(io.meta_read.fire()) && s1_valid && !io.lsu.s1_kill) &&
+      !s2_nack_no_mshr
+    )
+    io.replace_access.bits.set := RegNext(RegNext(get_idx(s1_req.addr)))
+    io.replace_access.bits.way := RegNext(
+      Mux(
+        RegNext(s1_tag_match_dup_dc),
+        RegNext(OHToUInt(s1_tag_match_way_dup_dc)), // if hit, access hit way in plru
+        Mux( // if miss
+          !s2_miss_merged,
+          RegNext(io.replace_way.way), // 1st fire: access new selected replace way
+          OHToUInt(io.miss_resp.repl_way_en) // 2nd fire: access replace way selected at miss queue allocate time
+        )
+      )
+    )
+  }
 
   // update access bit
   io.access_flag_write.valid := s3_valid && s3_hit

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -323,12 +323,13 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // * report a miss if bank conflict is detected
   val real_miss = Wire(Bool())
   when (wpu.io.resp.valid){
-    real_miss := s2_real_way_en.orR
+    real_miss := !s2_real_way_en.orR
   }.otherwise{
     real_miss := !s2_hit_dup_lsu
   }
   // io.debug_s2_cache_miss := real_miss
   resp.bits.miss := real_miss || io.bank_conflict_slow || s2_wpu_pred_fail
+  resp.bits.firstHit := s2_req.isFirstIssue && s2_hit
   // load pipe need replay when there is a bank conflict or wpu predict fail
   resp.bits.replay := (resp.bits.miss && (!io.miss_req.fire() || s2_nack)) || io.bank_conflict_slow || s2_wpu_pred_fail
   resp.bits.replayCarry.valid := resp.bits.miss

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -329,7 +329,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   }
   // io.debug_s2_cache_miss := real_miss
   resp.bits.miss := real_miss || io.bank_conflict_slow || s2_wpu_pred_fail
-  resp.bits.firstHit := s2_req.isFirstIssue && s2_hit
+  io.lsu.s2_first_hit := s2_req.isFirstIssue && s2_hit
   // load pipe need replay when there is a bank conflict or wpu predict fail
   resp.bits.replay := (resp.bits.miss && (!io.miss_req.fire() || s2_nack)) || io.bank_conflict_slow || s2_wpu_pred_fail
   resp.bits.replayCarry.valid := resp.bits.miss

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -102,6 +102,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents {
     val probe_req = Flipped(DecoupledIO(new MainPipeReq))
     // store miss go to miss queue
     val miss_req = DecoupledIO(new MissReq)
+    val miss_resp = Input(new MissResp) // miss resp is used to support plru update
     // store buffer
     val store_req = Flipped(DecoupledIO(new DCacheLineReq))
     val store_replay_resp = ValidIO(new DCacheLineResp)
@@ -1544,9 +1545,45 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents {
   io.wb.bits.delay_release := s3_req_replace_dup_for_wb_valid
   io.wb.bits.miss_id := s3_req.miss_id
 
-  io.replace_access.valid := RegNext(s1_fire && (s1_req.isAMO || s1_req.isStore) && !s1_req.probe)
-  io.replace_access.bits.set := s2_idx_dup_for_replace_access
-  io.replace_access.bits.way := RegNext(OHToUInt(s1_way_en))
+  // update plru in main pipe s3
+  if (!cfg.updateReplaceOn2ndmiss) {
+  // replacement is only updated on 1st miss
+    io.replace_access.valid := RegNext(
+      // generated in mainpipe s1
+      RegNext(s1_fire && (s1_req.isAMO || s1_req.isStore) && !s1_req.probe) &&
+      // generated in mainpipe s2
+      Mux(
+        io.miss_req.valid, 
+        !io.miss_resp.merged && io.miss_req.ready, // if store miss, only update plru for the first miss
+        true.B // normal store access
+      )
+    )
+    io.replace_access.bits.set := RegNext(s2_idx_dup_for_replace_access)
+    io.replace_access.bits.way := RegNext(RegNext(OHToUInt(s1_way_en)))
+  } else {
+    // replacement is updated on both 1st and 2nd miss
+    // timing is worse than !cfg.updateReplaceOn2ndmiss
+    io.replace_access.valid := RegNext(
+      // generated in mainpipe s1
+      RegNext(s1_fire && (s1_req.isAMO || s1_req.isStore) && !s1_req.probe) &&
+      // generated in mainpipe s2
+      Mux(
+        io.miss_req.valid, 
+        io.miss_req.ready, // if store miss, do not update plru if that req needs to be replayed
+        true.B // normal store access
+      )
+    )
+    io.replace_access.bits.set := RegNext(s2_idx_dup_for_replace_access)
+    io.replace_access.bits.way := RegNext(
+      Mux(
+        io.miss_req.valid && io.miss_resp.merged,
+        // miss queue 2nd fire: access replace way selected at miss queue allocate time
+        OHToUInt(io.miss_resp.repl_way_en),
+        // new selected replace way or hit way
+        RegNext(OHToUInt(s1_way_en))
+      )
+    )
+  }
 
   io.replace_way.set.valid := RegNext(s0_fire)
   io.replace_way.set.bits := s1_idx_dup_for_replace_way

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -748,8 +748,9 @@ class MissQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule wi
   debug_miss_trace.source := io.req.bits.source
   debug_miss_trace.pc := io.req.bits.pc
 
+  val isWriteL1MissQMissTable = Constantin.createRecord("isWriteL1MissQMissTable")
   val table = ChiselDB.createTable("L1MissQMissTrace_hart"+ p(XSCoreParamsKey).HartId.toString, new L1MissTrace)
-  table.log(debug_miss_trace, io.req.valid && !io.req.bits.cancel && alloc, "MissQueue", clock, reset)
+  table.log(debug_miss_trace, isWriteL1MissQMissTable.orR && io.req.valid && !io.req.bits.cancel && alloc, "MissQueue", clock, reset)
 
   // Difftest
   if (env.EnableDifftest) {

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -748,7 +748,7 @@ class MissQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule wi
   debug_miss_trace.source := io.req.bits.source
   debug_miss_trace.pc := io.req.bits.pc
 
-  val isWriteL1MissQMissTable = Constantin.createRecord("isWriteL1MissQMissTable")
+  val isWriteL1MissQMissTable = WireInit(Constantin.createRecord("isWriteL1MissQMissTable" + p(XSCoreParamsKey).HartId.toString))
   val table = ChiselDB.createTable("L1MissQMissTrace_hart"+ p(XSCoreParamsKey).HartId.toString, new L1MissTrace)
   table.log(debug_miss_trace, isWriteL1MissQMissTable.orR && io.req.valid && !io.req.bits.cancel && alloc, "MissQueue", clock, reset)
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -116,6 +116,10 @@ class MissReq(implicit p: Parameters) extends MissReqWoStoreData {
 
 class MissResp(implicit p: Parameters) extends DCacheBundle {
   val id = UInt(log2Up(cfg.nMissEntries).W)
+  // cache req missed, merged into one of miss queue entries
+  // i.e. !miss_merged means this access is the first miss for this cacheline
+  val merged = Bool()
+  val repl_way_en = UInt(DCacheWays.W)
 }
 
 class MissEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule {
@@ -136,13 +140,16 @@ class MissEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule {
     val secondary_ready = Output(Bool())
     // this entry is busy and it can not merge the new req
     val secondary_reject = Output(Bool())
-
-    val refill_to_ldq = ValidIO(new Refill)
+    // way selected for replacing, used to support plru update
+    val repl_way_en = Output(UInt(DCacheWays.W))
 
     // bus
     val mem_acquire = DecoupledIO(new TLBundleA(edge.bundle))
     val mem_grant = Flipped(DecoupledIO(new TLBundleD(edge.bundle)))
     val mem_finish = DecoupledIO(new TLBundleE(edge.bundle))
+
+    // send refill info to load queue 
+    val refill_to_ldq = ValidIO(new Refill)
 
     // refill pipe
     val refill_pipe_req = DecoupledIO(new RefillPipeReq)
@@ -420,6 +427,7 @@ class MissEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule {
   io.primary_ready := !req_valid
   io.secondary_ready := should_merge(io.req.bits)
   io.secondary_reject := should_reject(io.req.bits)
+  io.repl_way_en := req.way_en
 
   // should not allocate, merge or reject at the same time
   assert(RegNext(PopCount(Seq(io.primary_ready, io.secondary_ready, io.secondary_reject)) <= 1.U))
@@ -635,6 +643,8 @@ class MissQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule wi
   val req_handled_vec = entries.map(_.io.req_handled_by_this_entry)
   assert(PopCount(req_handled_vec) <= 1.U, "Only one mshr can handle a req")
   io.resp.id := OHToUInt(req_handled_vec)
+  io.resp.merged := merge
+  io.resp.repl_way_en := Mux1H(secondary_ready_vec, entries.map(_.io.repl_way_en))
 
   val forwardInfo_vec = VecInit(entries.map(_.io.forwardInfo))
   (0 until LoadPipelineWidth).map(i => {

--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -136,7 +136,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
     prefetch.io.csr := csr_dup(0)
     arb2.io.in(InArbPrefetchPort) <> prefetch.io.out
 
-    val isWriteL2TlbPrefetchTable = Constantin.createRecord("isWriteL2TlbPrefetchTable")
+    val isWriteL2TlbPrefetchTable = WireInit(Constantin.createRecord("isWriteL2TlbPrefetchTable" + p(XSCoreParamsKey).HartId.toString))
     val L2TlbPrefetchTable = ChiselDB.createTable("L2TlbPrefetch_hart" + p(XSCoreParamsKey).HartId.toString, new L2TlbPrefetchDB)
     val L2TlbPrefetchDB = Wire(new L2TlbPrefetchDB)
     L2TlbPrefetchDB.vpn := prefetch.io.out.bits.vpn
@@ -497,7 +497,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   val perfEvents  = Seq(llptw, cache, ptw).flatMap(_.getPerfEvents)
   generatePerfEvent()
 
-  val isWriteL1TlbTable = Constantin.createRecord("isWriteL1TlbTable")
+  val isWriteL1TlbTable = WireInit(Constantin.createRecord("isWriteL1TlbTable" + p(XSCoreParamsKey).HartId.toString))
   val L1TlbTable = ChiselDB.createTable("L1Tlb_hart" + p(XSCoreParamsKey).HartId.toString, new L1TlbDB)
   val ITlbReqDB, DTlbReqDB, ITlbRespDB, DTlbRespDB = Wire(new L1TlbDB)
   ITlbReqDB.vpn := io.tlb(0).req(0).bits.vpn
@@ -509,7 +509,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   L1TlbTable.log(ITlbRespDB, isWriteL1TlbTable.orR && io.tlb(0).resp.fire, "ITlbResp", clock, reset)
   L1TlbTable.log(DTlbRespDB, isWriteL1TlbTable.orR && io.tlb(1).resp.fire, "DTlbResp", clock, reset)
 
-  val isWritePageCacheTable = Constantin.createRecord("isWritePageCacheTable")
+  val isWritePageCacheTable = WireInit(Constantin.createRecord("isWritePageCacheTable" + p(XSCoreParamsKey).HartId.toString))
   val PageCacheTable = ChiselDB.createTable("PageCache_hart" + p(XSCoreParamsKey).HartId.toString, new PageCacheDB)
   val PageCacheDB = Wire(new PageCacheDB)
   PageCacheDB.vpn := Cat(cache.io.resp.bits.toTlb.entry(0).tag, OHToUInt(cache.io.resp.bits.toTlb.pteidx))
@@ -523,7 +523,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   PageCacheDB.hit := cache.io.resp.bits.hit
   PageCacheTable.log(PageCacheDB, isWritePageCacheTable.orR && cache.io.resp.fire, "PageCache", clock, reset)
 
-  val isWritePTWTable = Constantin.createRecord("isWritePTWTable")
+  val isWritePTWTable = WireInit(Constantin.createRecord("isWritePTWTable" + p(XSCoreParamsKey).HartId.toString))
   val PTWTable = ChiselDB.createTable("PTW_hart" + p(XSCoreParamsKey).HartId.toString, new PTWDB)
   val PTWReqDB, PTWRespDB, LLPTWReqDB, LLPTWRespDB = Wire(new PTWDB)
   PTWReqDB.vpn := ptw.io.req.bits.req_info.vpn
@@ -539,7 +539,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   PTWTable.log(LLPTWReqDB, isWritePTWTable.orR && llptw.io.in.fire, "LLPTWReq", clock, reset)
   PTWTable.log(LLPTWRespDB, isWritePTWTable.orR && llptw.io.mem.resp.fire, "LLPTWResp", clock, reset)
 
-  val isWriteL2TlbMissQueueTable = Constantin.createRecord("isWriteL2TlbMissQueueTable")
+  val isWriteL2TlbMissQueueTable = WireInit(Constantin.createRecord("isWriteL2TlbMissQueueTable" + p(XSCoreParamsKey).HartId.toString))
   val L2TlbMissQueueTable = ChiselDB.createTable("L2TlbMissQueue_hart" + p(XSCoreParamsKey).HartId.toString, new L2TlbMissQueueDB)
   val L2TlbMissQueueInDB, L2TlbMissQueueOutDB = Wire(new L2TlbMissQueueDB)
   L2TlbMissQueueInDB.vpn := missQueue.io.in.bits.vpn

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -827,8 +827,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("except_0",   f3_perf_info.except_0 && io.toIbuffer.fire() )
   XSPerfHistogram("ifu2ibuffer_validCnt", PopCount(io.toIbuffer.bits.valid & io.toIbuffer.bits.enqEnable), io.toIbuffer.fire, 0, PredictWidth + 1, 1)
 
-  val isWriteFetchToIBufferTable = Constantin.createRecord("isWriteFetchToIBufferTable")
-  val isWriteIfuWbToFtqTable = Constantin.createRecord("isWriteIfuWbToFtqTable")
+  val isWriteFetchToIBufferTable = WireInit(Constantin.createRecord("isWriteFetchToIBufferTable" + p(XSCoreParamsKey).HartId.toString))
+  val isWriteIfuWbToFtqTable = WireInit(Constantin.createRecord("isWriteIfuWbToFtqTable" + p(XSCoreParamsKey).HartId.toString))
   val fetchToIBufferTable = ChiselDB.createTable("FetchToIBuffer" + p(XSCoreParamsKey).HartId.toString, new FetchToIBufferDB)
   val ifuWbToFtqTable = ChiselDB.createTable("IfuWbToFtq" + p(XSCoreParamsKey).HartId.toString, new IfuWbToFtqDB)
 

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -827,6 +827,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("except_0",   f3_perf_info.except_0 && io.toIbuffer.fire() )
   XSPerfHistogram("ifu2ibuffer_validCnt", PopCount(io.toIbuffer.bits.valid & io.toIbuffer.bits.enqEnable), io.toIbuffer.fire, 0, PredictWidth + 1, 1)
 
+  val isWriteFetchToIBufferTable = Constantin.createRecord("isWriteFetchToIBufferTable")
+  val isWriteIfuWbToFtqTable = Constantin.createRecord("isWriteIfuWbToFtqTable")
   val fetchToIBufferTable = ChiselDB.createTable("FetchToIBuffer" + p(XSCoreParamsKey).HartId.toString, new FetchToIBufferDB)
   val ifuWbToFtqTable = ChiselDB.createTable("IfuWbToFtq" + p(XSCoreParamsKey).HartId.toString, new IfuWbToFtqDB)
 
@@ -848,14 +850,14 @@ class NewIFU(implicit p: Parameters) extends XSModule
 
   fetchToIBufferTable.log(
     data = fetchIBufferDumpData,
-    en = io.toIbuffer.fire(),
+    en = isWriteFetchToIBufferTable.orR && io.toIbuffer.fire,
     site = "IFU" + p(XSCoreParamsKey).HartId.toString,
     clock = clock,
     reset = reset
   )
   ifuWbToFtqTable.log(
     data = ifuWbToFtqDumpData,
-    en = checkFlushWb.valid,
+    en = isWriteIfuWbToFtqTable.orR && checkFlushWb.valid,
     site = "IFU" + p(XSCoreParamsKey).HartId.toString,
     clock = clock,
     reset = reset

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -1220,7 +1220,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   io.bpuInfo.bpRight := PopCount(mbpRights)
   io.bpuInfo.bpWrong := PopCount(mbpWrongs)
 
-  val isWriteFTQTable = Constantin.createRecord("isWriteFTQTable")
+  val isWriteFTQTable = WireInit(Constantin.createRecord("isWriteFTQTable" + p(XSCoreParamsKey).HartId.toString))
   val ftqBranchTraceDB = ChiselDB.createTable("FTQTable" + p(XSCoreParamsKey).HartId.toString, new FtqDebugBundle)
   // Cfi Info
   for (i <- 0 until PredictWidth) {

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -1219,7 +1219,8 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
 
   io.bpuInfo.bpRight := PopCount(mbpRights)
   io.bpuInfo.bpWrong := PopCount(mbpWrongs)
-  
+
+  val isWriteFTQTable = Constantin.createRecord("isWriteFTQTable")
   val ftqBranchTraceDB = ChiselDB.createTable("FTQTable" + p(XSCoreParamsKey).HartId.toString, new FtqDebugBundle)
   // Cfi Info
   for (i <- 0 until PredictWidth) {
@@ -1256,7 +1257,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
 
     ftqBranchTraceDB.log(
       data = logbundle /* hardware of type T */,
-      en = v && do_commit && isCfi,
+      en = isWriteFTQTable.orR && v && do_commit && isCfi,
       site = "FTQ" + p(XSCoreParamsKey).HartId.toString,
       clock = clock,
       reset = reset

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -944,6 +944,7 @@ def detectRollback(i: Int) = {
 
   dataModule.io.uncache.raddr := deqPtrExtNext.value
 
+  io.uncache.req.bits := DontCare
   io.uncache.req.bits.cmd  := MemoryOpConstants.M_XRD
   io.uncache.req.bits.addr := dataModule.io.uncache.rdata.paddr
   io.uncache.req.bits.data := DontCare

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -477,6 +477,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   }
   io.uncache.req.valid := uncacheState === s_req
 
+  io.uncache.req.bits := DontCare
   io.uncache.req.bits.cmd  := MemoryOpConstants.M_XWR
   io.uncache.req.bits.addr := paddrModule.io.rdata(0) // data(deqPtr) -> rdata(0)
   io.uncache.req.bits.data := dataModule.io.rdata(0).data
@@ -493,9 +494,6 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     io.uncache.req.bits.mask := DontCare // TODO
   }
 
-  io.uncache.req.bits.id   := DontCare
-  io.uncache.req.bits.instrtype   := DontCare
-  io.uncache.req.bits.replayCarry := DontCare
   io.uncache.req.bits.atomic := atomic(RegNext(rdataPtrExtNext(0)).value)
 
   when(io.uncache.req.fire()){
@@ -582,15 +580,13 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     dataBuffer.io.deq(i).ready := io.sbuffer(i).ready
     // Write line request should have all 1 mask
     assert(!(io.sbuffer(i).valid && io.sbuffer(i).bits.wline && !io.sbuffer(i).bits.mask.andR))
+    io.sbuffer(i).bits := DontCare
     io.sbuffer(i).bits.cmd   := MemoryOpConstants.M_XWR
     io.sbuffer(i).bits.addr  := dataBuffer.io.deq(i).bits.addr
     io.sbuffer(i).bits.vaddr := dataBuffer.io.deq(i).bits.vaddr
     io.sbuffer(i).bits.data  := dataBuffer.io.deq(i).bits.data
     io.sbuffer(i).bits.mask  := dataBuffer.io.deq(i).bits.mask
     io.sbuffer(i).bits.wline := dataBuffer.io.deq(i).bits.wline
-    io.sbuffer(i).bits.id    := DontCare
-    io.sbuffer(i).bits.instrtype    := DontCare
-    io.sbuffer(i).bits.replayCarry := DontCare
 
     // io.sbuffer(i).fire() is RegNexted, as sbuffer data write takes 2 cycles.
     // Before data write finish, sbuffer is unable to provide store to load

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -247,6 +247,7 @@ class LoadUnit_S0(implicit p: Parameters) extends XSModule with HasDCacheParamet
   }
   io.dcacheReq.bits.isFirstIssue := s0_isFirstIssue
   io.dcacheReq.bits.replayCarry := s0_replayCarry
+  io.dcacheReq.bits.debug_robIdx := s0_uop.robIdx.value
 
   // TODO: update cache meta
   io.dcacheReq.bits.id := DontCare

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -245,6 +245,7 @@ class LoadUnit_S0(implicit p: Parameters) extends XSModule with HasDCacheParamet
   }.otherwise {
     io.dcacheReq.bits.instrtype := LOAD_SOURCE.U
   }
+  io.dcacheReq.bits.isFirstIssue := s0_isFirstIssue
   io.dcacheReq.bits.replayCarry := s0_replayCarry
 
   // TODO: update cache meta

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -149,7 +149,8 @@ package object xiangshan {
   }
 
   object ExceptionVec {
-    def apply() = Vec(16, Bool())
+    val ExceptionVecSize = 16
+    def apply() = Vec(ExceptionVecSize, Bool())
   }
 
   object PMAMode {


### PR DESCRIPTION
- add `LoadMissTable` to record different load miss state
    > 0: first issue and hit
    > 1: first miss and get miss entry
    > 2: second miss and get miss entry
- add constant control of all databases
- fix some bug and rationalize the code of `constantIn`