### PR TITLE
TLB: Direct-asso tlb will not use sector

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -444,6 +444,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
     ptw_sector_resp.af := pte.entry(OHToUInt(pte.pteidx)).af
     ptw_sector_resp.pf := pte.entry(OHToUInt(pte.pteidx)).pf
     ptw_sector_resp.addr_low := OHToUInt(pte.pteidx)
+    ptw_sector_resp.pteidx := pte.pteidx
     for (i <- 0 until tlbcontiguous) {
       val ppn_equal = pte.entry(i).ppn === pte.entry(OHToUInt(pte.pteidx)).ppn
       val perm_equal = pte.entry(i).perm.getOrElse(0.U.asTypeOf(new PtePermBundle)).asUInt === pte.entry(OHToUInt(pte.pteidx)).perm.getOrElse(0.U.asTypeOf(new PtePermBundle)).asUInt

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -81,6 +81,41 @@ class TlbPermBundle(implicit p: Parameters) extends TlbBundle {
   val w = Bool()
   val r = Bool()
 
+  val pm = new TlbPMBundle
+
+  def apply(item: PtwSectorResp, pm: PMPConfig) = {
+    val ptePerm = item.entry.perm.get.asTypeOf(new PtePermBundle().cloneType)
+    this.pf := item.pf
+    this.af := item.af
+    this.d := ptePerm.d
+    this.a := ptePerm.a
+    this.g := ptePerm.g
+    this.u := ptePerm.u
+    this.x := ptePerm.x
+    this.w := ptePerm.w
+    this.r := ptePerm.r
+
+    this.pm.assign_ap(pm)
+    this
+  }
+  override def toPrintable: Printable = {
+    p"pf:${pf} af:${af} d:${d} a:${a} g:${g} u:${u} x:${x} w:${w} r:${r} " +
+    p"pm:${pm}"
+  }
+}
+
+class TlbSectorPermBundle(implicit p: Parameters) extends TlbBundle {
+  val pf = Bool() // NOTE: if this is true, just raise pf
+  val af = Bool() // NOTE: if this is true, just raise af
+  // pagetable perm (software defined)
+  val d = Bool()
+  val a = Bool()
+  val g = Bool()
+  val u = Bool()
+  val x = Bool()
+  val w = Bool()
+  val r = Bool()
+
   // static pmp & pma check has a minimum grain size of 4K
   // So sector tlb will use eight static pm entries
   val pm = Vec(tlbcontiguous, new TlbPMBundle)
@@ -141,6 +176,95 @@ class TlbEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parameters) 
   require(pageNormal || pageSuper)
 
   val tag = if (!pageNormal) UInt((vpnLen - vpnnLen).W)
+  else UInt(vpnLen.W)
+  val asid = UInt(asidLen.W)
+  val level = if (!pageNormal) Some(UInt(1.W))
+  else if (!pageSuper) None
+  else Some(UInt(2.W))
+  val ppn = if (!pageNormal) UInt((ppnLen - vpnnLen).W)
+  else UInt(ppnLen.W)
+  val perm = new TlbPermBundle
+
+  /** level usage:
+    *  !PageSuper: page is only normal, level is None, match all the tag
+    *  !PageNormal: page is only super, level is a Bool(), match high 9*2 parts
+    *  bits0  0: need mid 9bits
+    *         1: no need mid 9bits
+    *  PageSuper && PageNormal: page hold all the three type,
+    *  bits0  0: need low 9bits
+    *  bits1  0: need mid 9bits
+    */
+
+  def hit(vpn: UInt, asid: UInt, nSets: Int = 1, ignoreAsid: Boolean = false): Bool = {
+    val asid_hit = if (ignoreAsid) true.B else (this.asid === asid)
+
+    // NOTE: for timing, dont care low set index bits at hit check
+    //       do not need store the low bits actually
+    if (!pageSuper) asid_hit && drop_set_equal(vpn, tag, nSets)
+    else if (!pageNormal) {
+      val tag_match_hi = tag(vpnnLen*2-1, vpnnLen) === vpn(vpnnLen*3-1, vpnnLen*2)
+      val tag_match_mi = tag(vpnnLen-1, 0) === vpn(vpnnLen*2-1, vpnnLen)
+      val tag_match = tag_match_hi && (level.get.asBool() || tag_match_mi)
+      asid_hit && tag_match
+    }
+    else {
+      val tmp_level = level.get
+      val tag_match_hi = tag(vpnnLen*3-1, vpnnLen*2) === vpn(vpnnLen*3-1, vpnnLen*2)
+      val tag_match_mi = tag(vpnnLen*2-1, vpnnLen) === vpn(vpnnLen*2-1, vpnnLen)
+      val tag_match_lo = tag(vpnnLen-1, 0) === vpn(vpnnLen-1, 0) // if pageNormal is false, this will always be false
+      val tag_match = tag_match_hi && (tmp_level(1) || tag_match_mi) && (tmp_level(0) || tag_match_lo)
+      asid_hit && tag_match
+    }
+  }
+
+  def apply(item: PtwSectorResp, asid: UInt, pm: PMPConfig): TlbEntry = {
+    this.tag := {if (pageNormal) Cat(item.entry.tag, OHToUInt(item.pteidx)) else item.entry.tag(sectorvpnLen - 1, vpnnLen - sectortlbwidth)}
+    this.asid := asid
+    val inner_level = item.entry.level.getOrElse(0.U)
+    this.level.map(_ := { if (pageNormal && pageSuper) MuxLookup(inner_level, 0.U, Seq(
+      0.U -> 3.U,
+      1.U -> 1.U,
+      2.U -> 0.U ))
+    else if (pageSuper) ~inner_level(0)
+    else 0.U })
+    this.ppn := { if (!pageNormal) item.entry.ppn(sectorppnLen - 1, vpnnLen - sectortlbwidth)
+                  else Cat(item.entry.ppn, item.ppn_low(OHToUInt(item.pteidx))) }
+    this.perm.apply(item, pm)
+    this
+  }
+
+  // 4KB is normal entry, 2MB/1GB is considered as super entry
+  def is_normalentry(): Bool = {
+    if (!pageSuper) { true.B }
+    else if (!pageNormal) { false.B }
+    else { level.get === 0.U }
+  }
+
+  def genPPN(saveLevel: Boolean = false, valid: Bool = false.B)(vpn: UInt) : UInt = {
+    val inner_level = level.getOrElse(0.U)
+    val ppn_res = if (!pageSuper) ppn
+    else if (!pageNormal) Cat(ppn(ppnLen-vpnnLen-1, vpnnLen),
+      Mux(inner_level(0), vpn(vpnnLen*2-1, vpnnLen), ppn(vpnnLen-1,0)),
+      vpn(vpnnLen-1, 0))
+    else Cat(ppn(ppnLen-1, vpnnLen*2),
+      Mux(inner_level(1), vpn(vpnnLen*2-1, vpnnLen), ppn(vpnnLen*2-1, vpnnLen)),
+      Mux(inner_level(0), vpn(vpnnLen-1, 0), ppn(vpnnLen-1, 0)))
+
+    if (saveLevel) Cat(ppn(ppn.getWidth-1, vpnnLen*2), RegEnable(ppn_res(vpnnLen*2-1, 0), valid))
+    else ppn_res
+  }
+
+  override def toPrintable: Printable = {
+    val inner_level = level.getOrElse(2.U)
+    p"asid: ${asid} level:${inner_level} vpn:${Hexadecimal(tag)} ppn:${Hexadecimal(ppn)} perm:${perm}"
+  }
+
+}
+
+class TlbSectorEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parameters) extends TlbBundle {
+  require(pageNormal || pageSuper)
+
+  val tag = if (!pageNormal) UInt((vpnLen - vpnnLen).W)
             else UInt(sectorvpnLen.W)
   val asid = UInt(asidLen.W)
   val level = if (!pageNormal) Some(UInt(1.W))
@@ -148,8 +272,9 @@ class TlbEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parameters) 
               else Some(UInt(2.W))
   val ppn = if (!pageNormal) UInt((ppnLen - vpnnLen).W)
             else UInt(sectorppnLen.W)
-  val perm = new TlbPermBundle
+  val perm = new TlbSectorPermBundle
   val valididx = Vec(tlbcontiguous, Bool())
+  val pteidx = Vec(tlbcontiguous, Bool())
   val ppn_low = Vec(tlbcontiguous, UInt(sectortlbwidth.W))
 
   /** level usage:
@@ -224,7 +349,7 @@ class TlbEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parameters) 
     vpn_hit && index_hit.reduce(_ || _) && PopCount(data.valididx) === 1.U
   }
 
-  def apply(item: PtwSectorResp, asid: UInt, pm: Seq[PMPConfig]): TlbEntry = {
+  def apply(item: PtwSectorResp, asid: UInt, pm: Seq[PMPConfig]): TlbSectorEntry = {
     this.tag := {if (pageNormal) item.entry.tag else item.entry.tag(sectorvpnLen - 1, vpnnLen - sectortlbwidth)}
     this.asid := asid
     val inner_level = item.entry.level.getOrElse(0.U)
@@ -239,6 +364,7 @@ class TlbEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parameters) 
     this.perm.apply(item, pm)
     this.ppn_low := item.ppn_low
     this.valididx := item.valididx
+    this.pteidx := item.pteidx
     this
   }
 
@@ -302,7 +428,7 @@ class TlbStorageIO(nSets: Int, nWays: Int, ports: Int, nDups: Int = 1)(implicit 
     val resp = Vec(ports, ValidIO(new Bundle{
       val hit = Output(Bool())
       val ppn = Vec(nDups, Output(UInt(ppnLen.W)))
-      val perm = Vec(nDups, Output(new TlbPermBundle()))
+      val perm = Vec(nDups, Output(new TlbSectorPermBundle()))
     }))
   }
   val w = Flipped(ValidIO(new Bundle {
@@ -866,6 +992,7 @@ class PtwSectorResp(implicit p: Parameters) extends PtwBundle {
   val addr_low = UInt(sectortlbwidth.W)
   val ppn_low = Vec(tlbcontiguous, UInt(sectortlbwidth.W))
   val valididx = Vec(tlbcontiguous, Bool())
+  val pteidx = Vec(tlbcontiguous, Bool())
   val pf = Bool()
   val af = Bool()
 

--- a/src/main/scala/xiangshan/cache/mmu/Repeater.scala
+++ b/src/main/scala/xiangshan/cache/mmu/Repeater.scala
@@ -247,6 +247,7 @@ class PTWFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameters) 
   io.tlb.resp.bits.data.addr_low := ptwResp.addr_low
   io.tlb.resp.bits.data.ppn_low := ptwResp.ppn_low
   io.tlb.resp.bits.data.valididx := ptwResp.valididx
+  io.tlb.resp.bits.data.pteidx := ptwResp.pteidx
   io.tlb.resp.bits.data.pf := ptwResp.pf
   io.tlb.resp.bits.data.af := ptwResp.af
   io.tlb.resp.bits.data.memidx := memidx(OHToUInt(ptwResp_OldMatchVec))

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -98,7 +98,7 @@ class TLBFA(
   io.r.req.map(_.ready := true.B)
 
   val v = RegInit(VecInit(Seq.fill(nWays)(false.B)))
-  val entries = Reg(Vec(nWays, new TlbEntry(normalPage, superPage)))
+  val entries = Reg(Vec(nWays, new TlbSectorEntry(normalPage, superPage)))
   val g = entries.map(_.perm.g)
 
   for (i <- 0 until ports) {
@@ -186,14 +186,21 @@ class TLBFA(
   io.victim.out.valid := v(victim_idx) && io.w.valid && entries(victim_idx).is_normalentry()
   io.victim.out.bits.entry := ns_to_n(entries(victim_idx))
 
-  def ns_to_n(ns: TlbEntry): TlbEntry = {
+  def ns_to_n(ns: TlbSectorEntry): TlbEntry = {
     val n = Wire(new TlbEntry(pageNormal = true, pageSuper = false))
-    n.perm := ns.perm
-    n.ppn := ns.ppn
-    n.tag := ns.tag
+    n.perm.af := ns.perm.af
+    n.perm.pf := ns.perm.pf
+    n.perm.d := ns.perm.d
+    n.perm.a := ns.perm.a
+    n.perm.g := ns.perm.g
+    n.perm.u := ns.perm.u
+    n.perm.x := ns.perm.x
+    n.perm.w := ns.perm.w
+    n.perm.r := ns.perm.r
+    n.perm.pm := ns.perm.pm(OHToUInt(ns.pteidx))
+    n.ppn := Cat(ns.ppn, ns.ppn_low(OHToUInt(ns.pteidx)))
+    n.tag := Cat(ns.tag, OHToUInt(ns.pteidx))
     n.asid := ns.asid
-    n.valididx := ns.valididx
-    n.ppn_low := ns.ppn_low
     n
   }
 
@@ -249,10 +256,10 @@ class TLBSA(
     val vpn = req.bits.vpn
     val vpn_reg = RegEnable(vpn, req.fire())
 
-    val ridx = get_set_idx(vpn(vpn.getWidth - 1, sectortlbwidth), nSets)
+    val ridx = get_set_idx(vpn, nSets)
     val v_resize = v.asTypeOf(Vec(VPRE_SELECT, Vec(VPOST_SELECT, UInt(nWays.W))))
-    val vidx_resize = RegNext(v_resize(get_set_idx(drop_set_idx(vpn(vpn.getWidth - 1, sectortlbwidth), VPOST_SELECT), VPRE_SELECT)))
-    val vidx = vidx_resize(get_set_idx(vpn_reg(vpn_reg.getWidth - 1, sectortlbwidth), VPOST_SELECT)).asBools.map(_ && RegNext(req.fire()))
+    val vidx_resize = RegNext(v_resize(get_set_idx(drop_set_idx(vpn, VPOST_SELECT), VPRE_SELECT)))
+    val vidx = vidx_resize(get_set_idx(vpn_reg, VPOST_SELECT)).asBools.map(_ && RegNext(req.fire()))
     val vidx_bypass = RegNext((entries.io.waddr === ridx) && entries.io.wen)
     entries.io.raddr(i) := ridx
 
@@ -261,7 +268,18 @@ class TLBSA(
     resp.bits.hit := hit
     for (d <- 0 until nDups) {
       resp.bits.ppn(d) := data(d).genPPN()(vpn_reg)
-      resp.bits.perm(d) := data(d).perm
+      resp.bits.perm(d).pf := data(d).perm.pf
+      resp.bits.perm(d).af := data(d).perm.af
+      resp.bits.perm(d).d := data(d).perm.d
+      resp.bits.perm(d).a := data(d).perm.a
+      resp.bits.perm(d).g := data(d).perm.g
+      resp.bits.perm(d).u := data(d).perm.u
+      resp.bits.perm(d).x := data(d).perm.x
+      resp.bits.perm(d).w := data(d).perm.w
+      resp.bits.perm(d).r := data(d).perm.r
+      for (i <- 0 until tlbcontiguous) {
+        resp.bits.perm(d).pm(i) := data(d).perm.pm
+      }
     }
 
     resp.valid := { RegNext(req.valid) }
@@ -269,7 +287,7 @@ class TLBSA(
     resp.bits.ppn.suggestName("ppn")
     resp.bits.perm.suggestName("perm")
 
-    access.sets := get_set_idx(vpn_reg(vpn_reg.getWidth - 1, sectortlbwidth), nSets) // no use
+    access.sets := get_set_idx(vpn_reg, nSets) // no use
     access.touch_ways.valid := resp.valid && hit
     access.touch_ways.bits := 1.U // TODO: set-assoc need no replacer when nset is 1
   }
@@ -280,7 +298,7 @@ class TLBSA(
     get_set_idx(io.w.bits.data.entry.tag, nSets),
     get_set_idx(io.victim.in.bits.entry.tag, nSets))
   entries.io.wdata := Mux(io.w.valid,
-    (Wire(new TlbEntry(normalPage, superPage)).apply(io.w.bits.data, io.csr.satp.asid, io.w.bits.data_replenish)),
+    (Wire(new TlbEntry(normalPage, superPage)).apply(io.w.bits.data, io.csr.satp.asid, io.w.bits.data_replenish(OHToUInt(io.w.bits.data.pteidx)))),
     io.victim.in.bits.entry)
 
   when (io.victim.in.valid) {
@@ -303,13 +321,12 @@ class TLBSA(
 
   val sfence = io.sfence
   val sfence_vpn = sfence.bits.addr.asTypeOf(new VaBundle().cloneType).vpn
-  // Sfence will flush all sectors of an entry when hit
   when (io.sfence.valid) {
     when (sfence.bits.rs1) { // virtual address *.rs1 <- (rs1===0.U)
         v.map(a => a.map(b => b := false.B))
     }.otherwise {
         // specific addr but all asid
-        v(get_set_idx(sfence_vpn(sfence_vpn.getWidth - 1, sectortlbwidth), nSets)).map(_ := false.B)
+        v(get_set_idx(sfence_vpn, nSets)).map(_ := false.B)
     }
   }
 
@@ -327,7 +344,7 @@ class TLBSA(
 
   for (i <- 0 until nSets) {
     XSPerfAccumulate(s"hit${i}", io.r.resp.map(a => a.valid & a.bits.hit)
-      .zip(io.r.req.map(a => RegNext(get_set_idx(a.bits.vpn(a.bits.vpn.getWidth - 1, sectortlbwidth), nSets)) === i.U))
+      .zip(io.r.req.map(a => RegNext(get_set_idx(a.bits.vpn, nSets)) === i.U))
       .map{a => (a._1 && a._2).asUInt()}
       .fold(0.U)(_ + _)
     )
@@ -335,7 +352,7 @@ class TLBSA(
 
   for (i <- 0 until nSets) {
     XSPerfAccumulate(s"access${i}", io.r.resp.map(_.valid)
-      .zip(io.r.req.map(a => RegNext(get_set_idx(a.bits.vpn(a.bits.vpn.getWidth - 1, sectortlbwidth), nSets)) === i.U))
+      .zip(io.r.req.map(a => RegNext(get_set_idx(a.bits.vpn, nSets)) === i.U))
       .map{a => (a._1 && a._2).asUInt()}
       .fold(0.U)(_ + _)
     )
@@ -508,11 +525,20 @@ class TlbStorageWrapper(ports: Int, q: TLBParameters, nDups: Int = 1)(implicit p
     rp.bits.hit := np.bits.hit || sp.bits.hit
     for (d <- 0 until nDups) {
       rp.bits.ppn(d) := Mux(sp.bits.hit, sp.bits.ppn(0), np.bits.ppn(d))
-      rp.bits.perm(d) := Mux(sp.bits.hit, sp.bits.perm(0), np.bits.perm(d))
+      rp.bits.perm(d).pf := Mux(sp.bits.hit, sp.bits.perm(0).pf, np.bits.perm(d).pf)
+      rp.bits.perm(d).af := Mux(sp.bits.hit, sp.bits.perm(0).af, np.bits.perm(d).af)
+      rp.bits.perm(d).d := Mux(sp.bits.hit, sp.bits.perm(0).d, np.bits.perm(d).d)
+      rp.bits.perm(d).a := Mux(sp.bits.hit, sp.bits.perm(0).a, np.bits.perm(d).a)
+      rp.bits.perm(d).g := Mux(sp.bits.hit, sp.bits.perm(0).g, np.bits.perm(d).g)
+      rp.bits.perm(d).u := Mux(sp.bits.hit, sp.bits.perm(0).u, np.bits.perm(d).u)
+      rp.bits.perm(d).x := Mux(sp.bits.hit, sp.bits.perm(0).x, np.bits.perm(d).x)
+      rp.bits.perm(d).w := Mux(sp.bits.hit, sp.bits.perm(0).w, np.bits.perm(d).w)
+      rp.bits.perm(d).r := Mux(sp.bits.hit, sp.bits.perm(0).r, np.bits.perm(d).r)
+      rp.bits.perm(d).pm := DontCare
     }
     rp.bits.super_hit := sp.bits.hit
     rp.bits.super_ppn := sp.bits.ppn(0)
-    rp.bits.spm := np.bits.perm(0).pm(RegNext(io.r.req(i).bits.vpn(sectortlbwidth - 1, 0)))
+    rp.bits.spm := np.bits.perm(0).pm(0)
     // Sector tlb may trigger multi-hit, see def "wbhit"
     XSPerfAccumulate(s"port${i}_np_sp_multi_hit", !(!np.bits.hit || !sp.bits.hit || !rp.valid))
     //assert(!np.bits.hit || !sp.bits.hit || !rp.valid, s"${q.name} storage ports${i} normal and super multi-hit")


### PR DESCRIPTION
This commit is a repair for the decline of  cactusADM.

Submodule difftest will also be updated because l2 tlb check will only report warning when it fails. ( Errors will be reported until regs are wrong)