### PR TITLE
Revert "ci: use checkout@v3 instead of v2 (#1942)"

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -13,7 +13,7 @@ jobs:
     continue-on-error: false
     name: Generate Verilog
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - name: set env
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - Basics
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - name: set env
@@ -106,7 +106,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - Performance
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - name: set env
@@ -169,7 +169,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - MC
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - name: set env
@@ -203,7 +203,7 @@ jobs:
   #   timeout-minutes: 900
   #   name: SIMV - Basics
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v2
   #       with:
   #         submodules: 'recursive'
   #     - name: set env

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
     # Build + 8 checkpoints * 1-hour timeout
     name: Nightly Regression - Checkpoints
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - name: set env


### PR DESCRIPTION
This reverts commit 33d13d4bd28246aab7d8ac58563d172047923ed2.

It may solve recent problems of invalid url in the checkout phase of CI.