### PR TITLE
tlb: fix portTranslateEnable

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -73,7 +73,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   // val vmEnable = satp.mode === 8.U // && (mode < ModeM) // FIXME: fix me when boot xv6/linux...
   val vmEnable = if (EnbaleTlbDebug) (satp.mode === 8.U)
     else (satp.mode === 8.U && (mode < ModeM))
-  val portTranslateEnable = (0 until Width).map(i => vmEnable && !req(i).bits.no_translate)
+  val portTranslateEnable = (0 until Width).map(i => vmEnable && RegNext(!req(i).bits.no_translate))
 
   val req_in = req
   val req_out = req.map(a => RegEnable(a.bits, a.fire()))


### PR DESCRIPTION
req(i).bits.no_translate is generated in s0, but used in s1, so regnext it otherwise hw prefetch will be translated