### PR TITLE
Fix constant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,16 @@ endif
 override SIM_ARGS += --with-dramsim3
 endif
 
+# dynamic switch CONSTANTIN
+ifeq ($(WITH_CONSTANTIN),0)
+$(info disable WITH_CONSTANTIN)
+else
+ifndef NOOP_HOME
+$(error NOOP_HOME is not set)
+endif
+override SIM_ARGS += --with-constantin
+endif
+
 # top-down
 ifeq ($(CONFIG),DefaultConfig)
 ENABLE_TOPDOWN ?= 1

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -72,6 +72,10 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(UseDRAMSim = true)
           }), tail)
+        case "--with-constantin" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(EnableConstantin = true)
+          }), tail)
         case "--fpga-platform" :: tail =>
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(FPGAPlatform = true)

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -206,7 +206,8 @@ object TopMain extends App with HasRocketChipStageUtils {
 
     // tools: init to close dpi-c when in fpga
     val envInFPGA = config(DebugOptionsKey).FPGAPlatform
-    Constantin.init(envInFPGA)
+    val enableConstantin = config(DebugOptionsKey).EnableConstantin
+    Constantin.init(enableConstantin && !envInFPGA)
     ChiselDB.init(envInFPGA)
 
     val soc = DisableMonitors(p => LazyModule(new XSTop()(p)))(config)

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -287,6 +287,7 @@ case class DebugOptions
   EnableDebug: Boolean = false,
   EnablePerfDebug: Boolean = true,
   UseDRAMSim: Boolean = false,
+  EnableConstantin: Boolean = false,
   EnableTopDown: Boolean = false
 )
 

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -112,7 +112,8 @@ object SimTop extends App {
 
     // tools: init to close dpi-c when in fpga
     val envInFPGA = config(DebugOptionsKey).FPGAPlatform
-    Constantin.init(envInFPGA)
+    val enableConstantin = config(DebugOptionsKey).EnableConstantin
+    Constantin.init(enableConstantin && !envInFPGA)
     ChiselDB.init(envInFPGA)
 
     Generator.execute(


### PR DESCRIPTION
fix bug:
- utility: if the `constantin.txt` does not exists, it defaults to 0.
- when making emu, use `WITH_CONSTANTIN=0` to close the constant control. In this situation, all ChiselDB switches controlled with constants recorded by Constantin will default to their initial valur. 
> Note that: `WITH_CONSTANT` defaults to 1.