### PR TITLE
LQ: fix LoadQueueReplay select fail

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -305,6 +305,8 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   loadQueueReplay.io.lqFull <> io.lqReplayFull
   loadQueueReplay.io.tlbReplayDelayCycleCtrl <> io.tlbReplayDelayCycleCtrl
   loadQueueReplay.io.ldWbPtr := virtualLoadQueue.io.ldWbPtr
+  loadQueueReplay.io.rarFull := loadQueueRAR.io.lqFull
+  loadQueueReplay.io.rawFull := loadQueueRAW.io.lqFull
 
   val full_mask = Cat(loadQueueRAR.io.lqFull, loadQueueRAW.io.lqFull, loadQueueReplay.io.lqFull)
   XSPerfAccumulate("full_mask_000", full_mask === 0.U)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -401,7 +401,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val pos = UInt(log2Up(LoadPipelineWidth).W)
   }
 
-  def balanceReOrder(sel: Seq[ValidIO[BalanceEntry]]): (Seq[ValidIO[BalanceEntry]]) = {
+  def balanceReOrder(sel: Seq[ValidIO[BalanceEntry]]): Seq[ValidIO[BalanceEntry]] = {
     val nullSel = WireInit(0.U.asTypeOf(Valid(new BalanceEntry)))
     val balancePick = sel.foldLeft(nullSel)((l, r) => {
       Mux(l.valid && r.valid, Mux(!l.bits.balance && r.bits.balance, r, l), Mux(!l.valid && r.valid, r, l))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -364,8 +364,8 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val oldestPtrExt = (0 until OldestSelectStride).map(i => io.ldWbPtr + i.U)
   val oldestMatchMaskVec = (0 until LoadQueueReplaySize).map(i => (0 until OldestSelectStride).map(j => loadReplaySelMask(i) && uop(i).lqIdx === oldestPtrExt(j)))
   val remReplaySelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemBits(loadReplaySelMask)(rem)))
-  val remOldsetMatchMaskVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => VecInit(getRemSeq(oldestMatchMaskVec.map(_(0)))(rem))))
-  val remOlderMatchMaskVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemSeq(VecInit(oldestMatchMaskVec.map(_.drop(1)))(rem))))
+  val remOldsetMatchMaskVec = Seq.tabulate(LoadPipelineWidth)(rem => VecInit(getRemSeq(oldestMatchMaskVec.map(_(0)))(rem)))
+  val remOlderMatchMaskVec = Seq.tabulate(LoadPipelineWidth)(rem => getRemSeq(oldestMatchMaskVec.map(_.drop(1)))(rem))
   val remOldestSelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => {
     VecInit((0 until LoadQueueReplaySize / LoadPipelineWidth).map(i => {
       remReplaySelVec(rem)(i) && Mux(remOldsetMatchMaskVec(rem).asUInt.orR, remOldsetMatchMaskVec(rem)(i), remOlderMatchMaskVec(rem)(i).asUInt.orR)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -343,9 +343,8 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val blocked = selBlocked(i) || blockByTlbMiss(i) || blockByForwardFail(i) || blockByCacheMiss(i) || blockByWaitStore(i) || blockByOthers(i)
     allocated(i) && sleep(i) && !blocked && !loadCancelSelMask(i)
   })).asUInt // use uint instead vec to reduce verilog lines
-  val oldestPtr = VecInit((0 until CommitWidth).map(x => io.ldWbPtr + x.U))
   val oldestSelMask = VecInit((0 until LoadQueueReplaySize).map(i => {
-    loadReplaySelMask(i) && VecInit(oldestPtr.map(_ === uop(i).lqIdx)).asUInt.orR
+    loadReplaySelMask(i) && (io.ldWbPtr === uop(i).lqIdx)
   })).asUInt // use uint instead vec to reduce verilog lines
   val remReplaySelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemBits(loadReplaySelMask)(rem)))
   val remOldestSelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemBits(oldestSelMask)(rem)))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -343,8 +343,9 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val blocked = selBlocked(i) || blockByTlbMiss(i) || blockByForwardFail(i) || blockByCacheMiss(i) || blockByWaitStore(i) || blockByOthers(i)
     allocated(i) && sleep(i) && !blocked && !loadCancelSelMask(i)
   })).asUInt // use uint instead vec to reduce verilog lines
+  val oldestPtr = VecInit((0 until 4).map(x => io.ldWbPtr + x.U)) // make sure that the number of oldestPtr less than or equal the number of stage in load unit.
   val oldestSelMask = VecInit((0 until LoadQueueReplaySize).map(i => {
-    loadReplaySelMask(i) && (io.ldWbPtr === uop(i).lqIdx)
+    loadReplaySelMask(i) && VecInit(oldestPtr.map(_ === uop(i).lqIdx)).asUInt.orR
   })).asUInt // use uint instead vec to reduce verilog lines
   val remReplaySelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemBits(loadReplaySelMask)(rem)))
   val remOldestSelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemBits(oldestSelMask)(rem)))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -361,14 +361,14 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
    ******************************************************************************************
    */
   val OldestSelectStride = 4
-  val oldestPtrExt = (0 until OldestSelectStride).map(i => io.ldWbPtr + i.U)
+  val oldestPtrExt = (0 until OldestSelectStride).map(i => io.ldIssuePtr + i.U)
   val oldestMatchMaskVec = (0 until LoadQueueReplaySize).map(i => (0 until OldestSelectStride).map(j => loadReplaySelMask(i) && uop(i).lqIdx === oldestPtrExt(j)))
   val remReplaySelVec = VecInit((0 until LoadPipelineWidth).map(rem => getRemBits(loadReplaySelMask)(rem)))
-  val remOldsetMatchMaskVec = (0 until LoadPipelineWidth).map(rem => VecInit(getRemSeq(oldestMatchMaskVec.map(_(0)))(rem)))
+  val remOldsetMatchMaskVec = (0 until LoadPipelineWidth).map(rem => getRemSeq(oldestMatchMaskVec.map(_.take(1)))(rem))
   val remOlderMatchMaskVec = (0 until LoadPipelineWidth).map(rem => getRemSeq(oldestMatchMaskVec.map(_.drop(1)))(rem))
   val remOldestSelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => {
     VecInit((0 until LoadQueueReplaySize / LoadPipelineWidth).map(i => {
-      remReplaySelVec(rem)(i) && Mux(remOldsetMatchMaskVec(rem).asUInt.orR, remOldsetMatchMaskVec(rem)(i), VecInit(remOlderMatchMaskVec(rem)(i)).asUInt.orR)
+      remReplaySelVec(rem)(i) && Mux(VecInit(remOldsetMatchMaskVec(rem).map(_(0))).asUInt.orR, remOldsetMatchMaskVec(rem)(i)(0), remOlderMatchMaskVec(rem)(i).reduce(_|_))
     })).asUInt
   }))
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -343,9 +343,8 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val blocked = selBlocked(i) || blockByTlbMiss(i) || blockByForwardFail(i) || blockByCacheMiss(i) || blockByWaitStore(i) || blockByOthers(i)
     allocated(i) && sleep(i) && !blocked && !loadCancelSelMask(i)
   })).asUInt // use uint instead vec to reduce verilog lines
-  val oldestPtr = VecInit((0 until 4).map(x => io.ldWbPtr + x.U)) // make sure that the number of oldestPtr less than or equal the number of stage in load unit.
   val oldestSelMask = VecInit((0 until LoadQueueReplaySize).map(i => {
-    loadReplaySelMask(i) && VecInit(oldestPtr.map(_ === uop(i).lqIdx)).asUInt.orR
+    loadReplaySelMask(i) && (io.ldWbPtr === uop(i).lqIdx)
   })).asUInt // use uint instead vec to reduce verilog lines
   val remReplaySelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemBits(loadReplaySelMask)(rem)))
   val remOldestSelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemBits(oldestSelMask)(rem)))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -372,7 +372,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val remOlderMatchMaskVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemSeq(VecInit(oldestMatchMaskVec.drop(1))(rem))))
   val remOldestSelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => {
     VecInit((0 until LoadQueueReplaySize / LoadPipelineWidth).map(i => {
-      loadReplaySelMask(i) && Mux(remOldsetMatchMaskVec(rem).asUInt.orR, remOldsetMatchMaskVec(rem)(i), remOlderMatchMaskVec(rem)(i).asUInt.orR)
+      remReplaySelVec(rem)(i) && Mux(remOldsetMatchMaskVec(rem).asUInt.orR, remOldsetMatchMaskVec(rem)(i), remOlderMatchMaskVec(rem)(i).asUInt.orR)
     })).asUInt
   }))
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -441,7 +441,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   })
   val s1_balanceOldestSel = balanceReOrder(s1_balanceOldestSelExt)
   (0 until LoadPipelineWidth).map(w => {
-    vaddrModule.io.raddr(w) := s1_balanceOldestSel(w).bits
+    vaddrModule.io.raddr(w) := s1_balanceOldestSel(w).bits.index
   })
 
   for (i <- 0 until LoadPipelineWidth) {

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -361,7 +361,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
    ******************************************************************************************
    */
   val OldestSelectStride = 4
-  val oldestPtrExt = (0 until OldestSelectStride).map(i => io.ldIssuePtr + i.U)
+  val oldestPtrExt = (0 until OldestSelectStride).map(i => io.ldWbPtr + i.U)
   val oldestMatchMaskVec = (0 until LoadQueueReplaySize).map(i => (0 until OldestSelectStride).map(j => loadReplaySelMask(i) && uop(i).lqIdx === oldestPtrExt(j)))
   val remReplaySelVec = VecInit((0 until LoadPipelineWidth).map(rem => getRemBits(loadReplaySelMask)(rem)))
   val remOldsetMatchMaskVec = (0 until LoadPipelineWidth).map(rem => getRemSeq(oldestMatchMaskVec.map(_.take(1)))(rem))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -363,12 +363,12 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val OldestSelectStride = 4
   val oldestPtrExt = (0 until OldestSelectStride).map(i => io.ldWbPtr + i.U)
   val oldestMatchMaskVec = (0 until LoadQueueReplaySize).map(i => (0 until OldestSelectStride).map(j => loadReplaySelMask(i) && uop(i).lqIdx === oldestPtrExt(j)))
-  val remReplaySelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemBits(loadReplaySelMask)(rem)))
-  val remOldsetMatchMaskVec = Seq.tabulate(LoadPipelineWidth)(rem => VecInit(getRemSeq(oldestMatchMaskVec.map(_(0)))(rem)))
-  val remOlderMatchMaskVec = Seq.tabulate(LoadPipelineWidth)(rem => getRemSeq(oldestMatchMaskVec.map(_.drop(1)))(rem))
+  val remReplaySelVec = VecInit((0 until LoadPipelineWidth).map(rem => getRemBits(loadReplaySelMask)(rem)))
+  val remOldsetMatchMaskVec = (0 until LoadPipelineWidth).map(rem => VecInit(getRemSeq(oldestMatchMaskVec.map(_(0)))(rem)))
+  val remOlderMatchMaskVec = (0 until LoadPipelineWidth).map(rem => getRemSeq(oldestMatchMaskVec.map(_.drop(1)))(rem))
   val remOldestSelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => {
     VecInit((0 until LoadQueueReplaySize / LoadPipelineWidth).map(i => {
-      remReplaySelVec(rem)(i) && Mux(remOldsetMatchMaskVec(rem).asUInt.orR, remOldsetMatchMaskVec(rem)(i), remOlderMatchMaskVec(rem)(i).asUInt.orR)
+      remReplaySelVec(rem)(i) && Mux(remOldsetMatchMaskVec(rem).asUInt.orR, remOldsetMatchMaskVec(rem)(i), VecInit(remOlderMatchMaskVec(rem)(i)).asUInt.orR)
     })).asUInt
   }))
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -309,8 +309,8 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
 
     when (blockByCacheMiss(i) && io.refill.valid && io.refill.bits.id === missMSHRId(i)) { creditUpdate(i) := 0.U }
     when (blockByCacheMiss(i) && creditUpdate(i) === 0.U) { blockByCacheMiss(i) := false.B }
-    when (blockByRARReject(i) && !io.rarFull) { blockByRARReject(i) := false.B }
-    when (blockByRAWReject(i) && !io.rawFull) { blockByRAWReject(i) := false.B }
+    when (blockByRARReject(i) && (!io.rarFull || !isAfter(uop(i).lqIdx, io.ldWbPtr))) { blockByRARReject(i) := false.B }
+    when (blockByRAWReject(i) && (!io.rawFull || !isAfter(uop(i).sqIdx, io.stAddrReadySqPtr))) { blockByRAWReject(i) := false.B }
     when (blockByTlbMiss(i) && creditUpdate(i) === 0.U) { blockByTlbMiss(i) := false.B }
     when (blockByOthers(i) && creditUpdate(i) === 0.U) { blockByOthers(i) := false.B }
   })  

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -408,7 +408,11 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val reorderSel = Wire(Vec(sel.length, ValidIO(new BalanceEntry)))
     (0 until sel.length).map(i =>
       if (i == 0) {
-        reorderSel(i) := balancePick
+        when (balancePick.valid && balancePick.bits.balance) {
+          reorderSel(i) := balancePick
+        } .otherwise {
+          reorderSel(i) := sel(i)
+        }
       } else {
         when (balancePick.valid && balancePick.bits.balance && i.U === balancePick.bits.port) {
           reorderSel(i) := sel(0)

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -53,13 +53,14 @@ class LoadToLsqReplayIO(implicit p: Parameters) extends XSBundle with HasDCacheP
   def tlbMiss       = cause(LoadReplayCauses.tlbMiss)
   def waitStore     = cause(LoadReplayCauses.waitStore)
   def schedError    = cause(LoadReplayCauses.schedError)
-  def rejectEnq     = cause(LoadReplayCauses.rejectEnq)
+  def rarReject     = cause(LoadReplayCauses.rarReject)
+  def rawReject     = cause(LoadReplayCauses.rawReject)
   def dcacheMiss    = cause(LoadReplayCauses.dcacheMiss)
   def bankConflict  = cause(LoadReplayCauses.bankConflict)
   def dcacheReplay  = cause(LoadReplayCauses.dcacheReplay)
   def forwardFail   = cause(LoadReplayCauses.forwardFail)
 
-  def forceReplay() = rejectEnq || schedError || waitStore || tlbMiss
+  def forceReplay() = rarReject || rawReject || schedError || waitStore || tlbMiss
   def needReplay()  = cause.asUInt.orR 
 }
 
@@ -614,7 +615,8 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule
 
   val s2_rarCanAccept = !io.loadLoadViolationQueryReq.valid || io.loadLoadViolationQueryReq.ready
   val s2_rawCanAccept = !io.storeLoadViolationQueryReq.valid || io.storeLoadViolationQueryReq.ready
-  val s2_rejectEnq = !s2_rarCanAccept || !s2_rawCanAccept
+  val s2_rarReject = !s2_rarCanAccept
+  val s2_rawReject = !s2_rawCanAccept
 
   // merge forward result
   // lsq has higher priority than sbuffer
@@ -754,7 +756,8 @@ class LoadUnit_S2(implicit p: Parameters) extends XSModule
     io.out.bits.replayInfo.cause(LoadReplayCauses.dcacheReplay) := !(!s2_cache_replay || s2_is_prefetch || s2_mmio || s2_exception || io.dataForwarded) 
   }
   io.out.bits.replayInfo.cause(LoadReplayCauses.forwardFail) := s2_data_invalid && !s2_mmio && !s2_is_prefetch
-  io.out.bits.replayInfo.cause(LoadReplayCauses.rejectEnq) := s2_rejectEnq && !s2_mmio && !s2_is_prefetch && !s2_exception
+  io.out.bits.replayInfo.cause(LoadReplayCauses.rarReject) := s2_rarReject && !s2_mmio && !s2_is_prefetch && !s2_exception
+  io.out.bits.replayInfo.cause(LoadReplayCauses.rawReject) := s2_rawReject && !s2_mmio && !s2_is_prefetch && !s2_exception
   io.out.bits.replayInfo.canForwardFullData := io.dataForwarded
   io.out.bits.replayInfo.dataInvalidSqIdx := io.dataInvalidSqIdx
   io.out.bits.replayInfo.addrInvalidSqIdx := io.addrInvalidSqIdx // io.in.bits.uop.sqIdx - io.oracleMDPQuery.resp.distance // io.addrInvalidSqIdx


### PR DESCRIPTION
- LoadQueueReplay: Worst case, all oldest instructions are allocated to the same bank. And the number of instructions is greater than the number of stages in load unit.