### PR TITLE
Sbuffer: fix input logic

### DIFF
--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -295,7 +295,6 @@ class Sbuffer(implicit p: Parameters) extends DCacheModule with HasSbufferConst 
   val sameTag = inptags(0) === inptags(1)
   val firstWord = getWord(io.in(0).bits.addr)
   val secondWord = getWord(io.in(1).bits.addr)
-  val sameWord = firstWord === secondWord
 
   // merge condition
   val mergeMask = Wire(Vec(EnsbufferWidth, Vec(StoreBufferSize, Bool())))
@@ -362,7 +361,7 @@ class Sbuffer(implicit p: Parameters) extends DCacheModule with HasSbufferConst 
   XSPerfAccumulate("do_uarch_drain", do_uarch_drain)
 
   io.in(0).ready := firstCanInsert
-  io.in(1).ready := secondCanInsert && !sameWord && io.in(0).ready
+  io.in(1).ready := secondCanInsert && io.in(0).ready
 
   def wordReqToBufLine( // allocate a new line in sbuffer
     req: DCacheWordReq,


### PR DESCRIPTION
This is a historical legacy issue where the minimum granularity for writing into the sbuffer used to be 8 bytes. Therefore, when two write requests to the sbuffer were located within the same 8 bytes, the second request (io.in(1)) had to be blocked. Now, with the minimum granularity for writing into the sbuffer being 1 byte, there is no need to block the second request in this situation.