### PR TITLE
Increase L3-clientDir ways

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -288,7 +288,7 @@ class WithNKBL3(n: Int, ways: Int = 8, inclusive: Boolean = true, banks: Int = 1
         inclusive = inclusive,
         clientCaches = tiles.map{ core =>
           val l2params = core.L2CacheParamsOpt.get.toCacheParams
-          l2params.copy(sets = 2 * clientDirBytes / core.L2NBanks / l2params.ways / 64)
+          l2params.copy(sets = 2 * clientDirBytes / core.L2NBanks / l2params.ways / 64, ways = l2params.ways + 2)
         },
         enablePerf = true,
         ctrl = Some(CacheCtrl(


### PR DESCRIPTION
For better performance under L2 Evict@Refill feature

L3 clientDir will keep meta of all L2 blocks, and used to have the same ways as L2

Previously L2 Release first then Acquire, therefore L3 clientDir is invalidated first and then allocated, 
so it will hardly exceed capacity

Now L2 will Acquire first then Release, which means L3 clientDir is required to allocate when all valid,
so it is often that L3 clientDir will have set-capacity-conflict

An additonal-2-way is sufficient for fully utilizing the performance advantages of Evict@Refill, 
as our experiment shows little difference between +2 ways and +8 ways
