### PR TITLE
wbq: fix wbq's FSM logic

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
@@ -439,6 +439,12 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
             s_sleep
           ))
           req := req_later.toWritebackReqCtrl
+          when(io.release_wakeup.valid && io.release_wakeup.bits === req_later.miss_id || !req_later.delay_release) {
+            remain_set := Mux(req_later.hasData, ~0.U(refillCycles.W), 1.U(refillCycles.W))
+            remain_clr := 0.U
+          }.otherwise {
+            remain_set := 0.U
+          }
           when (io.release_wakeup.valid && io.release_wakeup.bits === req_later.miss_id) {
             req.delay_release := false.B
           }


### PR DESCRIPTION
* All the remain_set are set to the corresponding value before entering the s_release_req state
* set remain_clr to 0 when state change from s_release_req(probe) to s_release_req(release)