### PR TITLE
rename: fix unhandled instr page fault caused by move elimination

### DIFF
--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -150,7 +150,10 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   val needIntDest    = Wire(Vec(RenameWidth, Bool()))
   val hasValid = Cat(io.in.map(_.valid)).orR
 
-  val isMove = io.in.map(_.bits.isMove)
+  val isMove = Wire(Vec(RenameWidth, Bool()))
+  isMove zip io.in.map(_.bits) foreach {
+    case (move, in) => move := Mux(in.exceptionVec.asUInt.orR, false.B, in.isMove)
+  }
 
   val walkNeedIntDest = WireDefault(VecInit(Seq.fill(RenameWidth)(false.B)))
   val walkNeedFpDest = WireDefault(VecInit(Seq.fill(RenameWidth)(false.B)))


### PR DESCRIPTION
A move instruction can commit so fast that instr page fault or access fault cannot prevent it in time.
In order to fix this, we disable ME in rename stage when an instruction comes with exception.