### PR TITLE
ICache: shrink to 64K

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -34,7 +34,7 @@ import difftest._
 
 case class ICacheParameters(
     nSets: Int = 256,
-    nWays: Int = 8,
+    nWays: Int = 4,
     rowBits: Int = 64,
     nTLBEntries: Int = 32,
     tagECC: Option[String] = None,
@@ -86,7 +86,7 @@ trait HasICacheParameters extends HasL1CacheParameters with HasInstrMMIOConst wi
 
   def PortNumber = 2
 
-  def partWayNum = 4
+  def partWayNum = 2
   def pWay = nWays/partWayNum
 
   def nPrefetchEntries = cacheParams.nPrefetchEntries


### PR DESCRIPTION
For timing evaluation purpose, should cause some performance drop.