### PR TITLE
LDU: fix load writeback twice

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -842,17 +842,10 @@ class LoadUnit(implicit p: Parameters) extends XSModule
                            !s2_raw_nack &&
                            s2_nuke
 
-  val s2_hint_fast_rep  = !s2_mq_nack &&
-                          s2_dcache_miss &&
-                          s2_cache_handled &&
-                          io.l2_hint.valid &&
-                          io.l2_hint.bits.sourceId === io.dcache.resp.bits.mshr_id
-
-
   val s2_fast_rep = !s2_mem_amb &&
                     !s2_tlb_miss &&
                     !s2_fwd_fail &&
-                    (s2_dcache_fast_rep || s2_hint_fast_rep || s2_nuke_fast_rep) &&
+                    (s2_dcache_fast_rep || s2_nuke_fast_rep) &&
                     s2_troublem
 
   // need allocate new entry
@@ -1096,14 +1089,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.lsq.stld_nuke_query.revoke := s3_revoke
 
   // feedback slow
-  val s3_dcache_fast_rep = RegNext(s2_dcache_fast_rep)
-  val s3_nuke_fast_rep   = RegNext(s2_nuke_fast_rep)
-  val s3_hint_fast_rep   = RegNext(s2_hint_fast_rep) && !s3_fwd_frm_d_chan_valid
-  s3_fast_rep := RegNext(!s2_mem_amb &&
-                    !s2_tlb_miss &&
-                    !s2_fwd_fail) &&
-                  (s3_dcache_fast_rep || s3_nuke_fast_rep || s3_hint_fast_rep) &&
-                  s3_troublem &&
+  s3_fast_rep := RegNext(s2_fast_rep) &&
                  !s3_in.feedbacked &&
                  !s3_in.lateKill &&
                  !s3_rep_frm_fetch &&

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1097,7 +1097,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   // feedback slow
   val s3_dcache_fast_rep = RegNext(s2_dcache_fast_rep)
-  val s3_nuke_fast_rep   = RegNext(s3_nuke_fast_rep)
+  val s3_nuke_fast_rep   = RegNext(s2_nuke_fast_rep)
   val s3_hint_fast_rep   = RegNext(s2_hint_fast_rep) && !s3_fwd_frm_d_chan_valid
   s3_fast_rep := RegNext(!s2_mem_amb &&
                     !s2_tlb_miss &&

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1103,6 +1103,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
                     !s2_tlb_miss &&
                     !s2_fwd_fail) &&
                   (s3_dcache_fast_rep || s3_nuke_fast_rep || s3_hint_fast_rep) &&
+                  s3_troublem &&
                  !s3_in.feedbacked &&
                  !s3_in.lateKill &&
                  !s3_rep_frm_fetch &&

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1097,7 +1097,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   // feedback slow
   val s3_dcache_fast_rep = RegNext(s2_dcache_fast_rep)
-  val s3_nuke_fast_rep   = RegNext(s2_dcache_fast_rep)
+  val s3_nuke_fast_rep   = RegNext(s3_nuke_fast_rep)
   val s3_hint_fast_rep   = RegNext(s2_hint_fast_rep) && !s3_fwd_frm_d_chan_valid
   s3_fast_rep := RegNext(!s2_mem_amb &&
                     !s2_tlb_miss &&

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -969,7 +969,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.prefetch_train.bits.miss          := io.dcache.resp.bits.miss // TODO: use trace with bank conflict?
   io.prefetch_train.bits.meta_prefetch := io.dcache.resp.bits.meta_prefetch
   io.prefetch_train.bits.meta_access   := io.dcache.resp.bits.meta_access
-  
+
 
   io.prefetch_train_l1.valid              := s2_valid && !s2_actually_mmio
   io.prefetch_train_l1.bits.fromLsPipelineBundle(s2_in)
@@ -1096,7 +1096,13 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.lsq.stld_nuke_query.revoke := s3_revoke
 
   // feedback slow
-  s3_fast_rep := RegNext(s2_fast_rep) &&
+  val s3_dcache_fast_rep = RegNext(s2_dcache_fast_rep)
+  val s3_nuke_fast_rep   = RegNext(s2_dcache_fast_rep)
+  val s3_hint_fast_rep   = RegNext(s2_hint_fast_rep) && !s3_fwd_frm_d_chan_valid
+  s3_fast_rep := RegNext(!s2_mem_amb &&
+                    !s2_tlb_miss &&
+                    !s2_fwd_fail) &&
+                  (s3_dcache_fast_rep || s3_nuke_fast_rep || s3_hint_fast_rep) &&
                  !s3_in.feedbacked &&
                  !s3_in.lateKill &&
                  !s3_rep_frm_fetch &&


### PR DESCRIPTION
Bug descriptions:
  An load inst will fast replay check at s2, if dcache miss occur, data is forwarded from the bus at the same time. The data will be forwarded at s3, but **_s2_hint_fast_rep_** still high level. Hence, load will fast replay even though the data is ready. And the load also writeback s3.

Bug fix:
  Update **_s2_hint_fast_rep_** at s3