### PR TITLE
ftq: fix predecode redirect use RAS condition

### DIFF
--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -945,7 +945,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
 
   val toBpuCfi = ifuRedirectToBpu.bits.cfiUpdate
   toBpuCfi.fromFtqRedirectSram(ftq_redirect_sram.io.rdata.head)
-  when (ifuRedirectReg.bits.cfiUpdate.pd.isRet) {
+  when (ifuRedirectReg.bits.cfiUpdate.pd.isRet && ifuRedirectReg.bits.cfiUpdate.pd.valid) {
     toBpuCfi.target := toBpuCfi.rasEntry.retAddr
   }
 


### PR DESCRIPTION
This PR fixes redirection target error when:
1. FTB falseHit
2. Predecode stage detects falseHit but coincidently sets pd.isRet while the pd(ftqOffset) is not a RVC instruction.