### PR TITLE
exu: fix the definition/instance in multicore

### DIFF
--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -125,7 +125,9 @@ object ExeUnitDef {
       case JumpExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new JumpExeUnit))
       case AluExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new AluExeUnit))
       case MulDivExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new MulDivExeUnit))
-      case JumpCSRExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new JumpCSRExeUnit))
+      // TODO: CSR should also use instance. We need to fix difftest.
+      // We should not call DifftestModule in Definition/Instance for now.
+      case JumpCSRExeUnitCfg => Definition(new JumpCSRExeUnit)
       case FmacExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new FmacExeUnit))
       case FmiscExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new FmiscExeUnit))
       case StdExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new StdExeUnit))
@@ -136,4 +138,3 @@ object ExeUnitDef {
     }
   }
 }
-

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -19,7 +19,7 @@ package xiangshan.backend.exu
 
 import chipsalliance.rocketchip.config.Parameters
 import chisel3._
-import chisel3.experimental.hierarchy.{Definition, instantiable, public}
+import chisel3.experimental.hierarchy.{Definition, instantiable}
 import chisel3.util._
 import utils._
 import utility._
@@ -118,15 +118,17 @@ class FmacExeUnit(implicit p: Parameters) extends ExeUnit(FmacExeUnitCfg)
 class FmiscExeUnit(implicit p: Parameters) extends ExeUnit(FmiscExeUnitCfg)
 
 object ExeUnitDef {
+  val defMap = new scala.collection.mutable.HashMap[ExuConfig, Definition[ExeUnit]]()
+
   def apply(cfg: ExuConfig)(implicit p: Parameters): Definition[ExeUnit] = {
     cfg match {
-      case JumpExeUnitCfg => Definition(new JumpExeUnit)
-      case AluExeUnitCfg => Definition(new AluExeUnit)
-      case MulDivExeUnitCfg => Definition(new MulDivExeUnit)
-      case JumpCSRExeUnitCfg => Definition(new JumpCSRExeUnit)
-      case FmacExeUnitCfg => Definition(new FmacExeUnit)
-      case FmiscExeUnitCfg => Definition(new FmiscExeUnit)
-      case StdExeUnitCfg => Definition(new StdExeUnit)
+      case JumpExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new JumpExeUnit))
+      case AluExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new AluExeUnit))
+      case MulDivExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new MulDivExeUnit))
+      case JumpCSRExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new JumpCSRExeUnit))
+      case FmacExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new FmacExeUnit))
+      case FmiscExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new FmiscExeUnit))
+      case StdExeUnitCfg => defMap.getOrElseUpdate(cfg, Definition(new StdExeUnit))
       case _ => {
         println(s"cannot generate exeUnit from $cfg")
         null


### PR DESCRIPTION
Currently the definitions are instantiated every time when FUBlock is called. Though it addresses the dedup issue for multiple ExeUnits in one FUBlock, it still causes non-dedup modules across various FUBlocks and multiple CPU cores.