### PR TITLE
Reservation: Append writeback_valid to fastdata for bypass valid

### DIFF
--- a/src/main/scala/xiangshan/backend/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/Scheduler.scala
@@ -463,12 +463,14 @@ class SchedulerImp(outer: Scheduler) extends LazyModuleImp(outer) with HasXSPara
     val innerFpUop = outer.innerFpFastSources(i).map(_._2).map(rs_all(_).module.io.fastWakeup.get).fold(Seq())(_ ++ _)
     val innerUop = innerIntUop ++ innerFpUop
     val innerData = outer.innerFastPorts(i).map(io.writeback(_).bits.data)
-    node.connectFastWakeup(innerUop, innerData)
+    val innerDataValid = outer.innerFastPorts(i).map(io.writeback(_).valid)
+    node.connectFastWakeup(innerUop, innerData, innerDataValid)
     require(innerUop.length == innerData.length)
 
     val outerUop = outer.outFastPorts(i).map(io.fastUopIn(_))
     val outerData = outer.outFastPorts(i).map(io.writeback(_).bits.data)
-    node.connectFastWakeup(outerUop, outerData)
+    val outerDataValid = outer.outFastPorts(i).map(io.writeback(_).valid)
+    node.connectFastWakeup(outerUop, outerData, outerDataValid)
     require(outerUop.length == outerData.length)
   }
   require(issueIdx == io.issue.length)

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -209,6 +209,7 @@ class ReservationStationWrapper(implicit p: Parameters) extends LazyModule with 
     module.io.fastUopsIn(fastWakeupIdx) := uop
     module.io.fastDatas(fastWakeupIdx).valid := valid
     module.io.fastDatas(fastWakeupIdx).bits := data
+    fastWakeupIdx += 1
   }
   def connectFastWakeup(uop: Seq[ValidIO[MicroOp]], data: Seq[UInt], valid: Seq[Bool]): Unit = {
     for ((u, (d, v)) <- uop.zip(data.zip(valid))) {
@@ -767,7 +768,6 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
       bypassNetwork.io.hold := !s2_deq(i).ready || !s1_out(i).valid
       bypassNetwork.io.source := s1_out(i).bits.src.take(params.numSrc)
       bypassNetwork.io.bypass.zip(wakeupBypassMask.zip(io.fastDatas)).foreach { case (by, (m, d)) =>
-//        by.valid := m
         by.valid.zipWithIndex.foreach{
             case(v,i) => v := m(i) && d.valid
         }

--- a/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
+++ b/src/main/scala/xiangshan/backend/issue/ReservationStation.scala
@@ -205,14 +205,14 @@ class ReservationStationWrapper(implicit p: Parameters) extends LazyModule with 
   lazy val module = new RSWrapperImp(this)
 
   var fastWakeupIdx = 0
-  def connectFastWakeup(uop: ValidIO[MicroOp], data: UInt): Unit = {
+  def connectFastWakeup(uop: ValidIO[MicroOp], data: UInt, valid: Bool): Unit = {
     module.io.fastUopsIn(fastWakeupIdx) := uop
-    module.io.fastDatas(fastWakeupIdx) := data
-    fastWakeupIdx += 1
+    module.io.fastDatas(fastWakeupIdx).valid := valid
+    module.io.fastDatas(fastWakeupIdx).bits := data
   }
-  def connectFastWakeup(uop: Seq[ValidIO[MicroOp]], data: Seq[UInt]): Unit = {
-    for ((u, d) <- uop.zip(data)) {
-      connectFastWakeup(u, d)
+  def connectFastWakeup(uop: Seq[ValidIO[MicroOp]], data: Seq[UInt], valid: Seq[Bool]): Unit = {
+    for ((u, (d, v)) <- uop.zip(data.zip(valid))) {
+      connectFastWakeup(u, d, v)
     }
   }
 }
@@ -227,7 +227,7 @@ class ReservationStationIO(params: RSParams)(implicit p: Parameters) extends XSB
   val deq = Vec(params.numDeq, DecoupledIO(new ExuInput))
   // wakeup
   val fastUopsIn = Vec(params.numFastWakeup, Flipped(ValidIO(new MicroOp)))
-  val fastDatas = Vec(params.numFastWakeup, Input(UInt(params.dataBits.W)))
+  val fastDatas = Vec(params.numFastWakeup, Flipped(ValidIO(UInt(params.dataBits.W))))
   val slowPorts = Vec(params.numWakeup, Flipped(ValidIO(new ExuOutput)))
   // extra
   val fastWakeup = if (params.fixedLatency >= 0) Some(Vec(params.numDeq, ValidIO(new MicroOp))) else None
@@ -767,8 +767,12 @@ class ReservationStation(params: RSParams)(implicit p: Parameters) extends XSMod
       bypassNetwork.io.hold := !s2_deq(i).ready || !s1_out(i).valid
       bypassNetwork.io.source := s1_out(i).bits.src.take(params.numSrc)
       bypassNetwork.io.bypass.zip(wakeupBypassMask.zip(io.fastDatas)).foreach { case (by, (m, d)) =>
-        by.valid := m
-        by.data := d
+//        by.valid := m
+        by.valid.zipWithIndex.foreach{
+            case(v,i) => v := m(i) && d.valid
+        }
+
+        by.data := d.bits
       }
       bypassNetwork.io.target <> s2_deq(i).bits.src.take(params.numSrc)
 


### PR DESCRIPTION
Fastdata drops writeback_valid, bypass invalid data to alu, and finally visit ITLB. This result in IPC difference in differenct seed.

After this Commit, there is no Randomness with/without DRAMsim3, tested by SPEC_0.3coverage, 2000000 instruction.

However, Randomness is detected before Iprefetch disabled (#2277) . I will test again after Iprefetch fixed bug and re-enabled
