### PR TITLE
SoC: require the ReqSourceKey user bits at top

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -20,17 +20,17 @@ import chipsalliance.rocketchip.config.{Field, Parameters}
 import chisel3._
 import chisel3.util._
 import device.{DebugModule, TLPMA, TLPMAIO}
-import freechips.rocketchip.devices.tilelink.{CLINT, CLINTParams, DevNullParams, PLICParams, TLError, TLPLIC}
+import freechips.rocketchip.amba.axi4._
+import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy.{AddressSet, IdRange, InModuleBody, LazyModule, LazyModuleImp, MemoryDevice, RegionType, SimpleDevice, TransferSizes}
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
-import freechips.rocketchip.regmapper.{RegField, RegFieldAccessType, RegFieldDesc, RegFieldGroup}
-import utility.{BinaryArbiter, TLClientsMerger, TLEdgeBuffer, TLLogger}
-import xiangshan.{DebugOptionsKey, HasXSParameter, XSBundle, XSCore, XSCoreParameters, XSTileKey}
-import freechips.rocketchip.amba.axi4._
+import freechips.rocketchip.regmapper.{RegField, RegFieldDesc, RegFieldGroup}
 import freechips.rocketchip.tilelink._
-import top.BusPerfMonitor
-import xiangshan.backend.fu.PMAConst
 import huancun._
+import top.BusPerfMonitor
+import utility.{ReqSourceKey, TLClientsMerger, TLEdgeBuffer, TLLogger}
+import xiangshan.backend.fu.PMAConst
+import xiangshan.{DebugOptionsKey, XSTileKey}
 
 case object SoCParamsKey extends Field[SoCParameters]
 
@@ -142,12 +142,13 @@ trait HaveAXI4MemPort {
           resources = device.reg("mem")
         )
       ),
-      beatBytes = L3OuterBusWidth / 8
+      beatBytes = L3OuterBusWidth / 8,
+      requestKeys = if (debugOpts.FPGAPlatform) Seq() else Seq(ReqSourceKey),
     )
   ))
 
   val mem_xbar = TLXbar()
-  val l3_mem_pmu = BusPerfMonitor(name = "L3_Mem", enable = !debugOpts.FPGAPlatform, stat_latency = true, add_reqkey = true)
+  val l3_mem_pmu = BusPerfMonitor(name = "L3_Mem", enable = !debugOpts.FPGAPlatform, stat_latency = true)
   mem_xbar :=*
     TLBuffer.chainNode(2) :=
     TLCacheCork() :=

--- a/src/main/scala/top/BusPerfMonitor.scala
+++ b/src/main/scala/top/BusPerfMonitor.scala
@@ -17,28 +17,16 @@
 package top
 
 import chipsalliance.rocketchip.config.Parameters
-import freechips.rocketchip.diplomacy.{AdapterNode, LazyModule, LazyModuleImp}
-import freechips.rocketchip.tilelink._
 import chisel3._
 import chisel3.util._
-import utils.{XSPerfAccumulate, XSPerfPrint}
+import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.tilelink.TLMessages._
-import freechips.rocketchip.tilelink.TLPermissions._
-import utility.{MemReqSource, ReqSourceField, ReqSourceKey, GTimer}
+import freechips.rocketchip.tilelink._
+import utility.{GTimer, MemReqSource, ReqSourceKey}
+import utils.XSPerfAccumulate
 
-class BusPerfMonitor(name: String, stat_latency: Boolean, add_reqkey: Boolean)(implicit p: Parameters) extends LazyModule {
-  val node = if (add_reqkey) TLAdapterNode(managerFn = { m =>
-    TLSlavePortParameters.v1(
-      m.managers.map { m =>
-        m.v2copy()
-      },
-      requestKeys = Seq(ReqSourceKey),
-      beatBytes = 32,
-      endSinkId = m.endSinkId
-    )
-  }) else {
-    TLAdapterNode()
-  }
+class BusPerfMonitor(name: String, stat_latency: Boolean)(implicit p: Parameters) extends LazyModule {
+  val node = TLAdapterNode()
   lazy val module = new BusPerfMonitorImp(this, name, stat_latency)
 }
 
@@ -179,7 +167,7 @@ object BusPerfMonitor {
      add_reqkey: Boolean = false)(implicit p: Parameters) =
   {
     if(enable){
-      val busPMU = LazyModule(new BusPerfMonitor(name, stat_latency, add_reqkey))
+      val busPMU = LazyModule(new BusPerfMonitor(name, stat_latency))
       busPMU.node
     } else {
       TLTempNode()


### PR DESCRIPTION
The top-level memory port requires the ReqSourceKey user bits.

This would avoid adding an extra key through the BusPerfMonitor and also benefit SoC level optimizations, such as system caches.