### PR TITLE
icache: reduce 1 cycle in mshr

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
@@ -87,7 +87,7 @@ class ICacheMissEntry(edge: TLEdgeOut, id: Int)(implicit p: Parameters) extends 
   io.meta_write.bits := DontCare
   io.data_write.bits := DontCare
 
-  val s_idle  :: s_send_mem_aquire :: s_wait_mem_grant :: s_write_back :: s_wait_resp :: Nil = Enum(5)
+  val s_idle  :: s_send_mem_aquire :: s_wait_mem_grant :: s_write_back_wait_resp :: s_write_back :: s_wait_resp :: Nil = Enum(6)
   val state = RegInit(s_idle)
   /** control logic transformation */
   //request register
@@ -146,19 +146,29 @@ class ICacheMissEntry(edge: TLEdgeOut, id: Int)(implicit p: Parameters) extends 
           req_corrupt := io.mem_grant.bits.corrupt // TODO: seems has bug
           when(readBeatCnt === (refillCycles - 1).U) {
             assert(refill_done, "refill not done!")
-            state := s_write_back
+            state := s_write_back_wait_resp
           }
         }
       }
     }
 
+    is(s_write_back_wait_resp) {
+      when((io.meta_write.fire && io.data_write.fire || needflush) && io.resp.fire) {
+        state := s_idle
+      }.elsewhen(io.meta_write.fire && io.data_write.fire || needflush) {
+        state := s_wait_resp
+      }.elsewhen(io.resp.fire) {
+        state := s_write_back
+      }
+    }
+
     is(s_write_back) {
-      state := Mux(io.meta_write.fire && io.data_write.fire || needflush, s_wait_resp, s_write_back)
+      when(io.meta_write.fire && io.data_write.fire || needflush) {
+        state := s_idle
+      }
     }
 
     is(s_wait_resp) {
-      io.resp.bits.data := respDataReg.asUInt
-      io.resp.bits.corrupt := req_corrupt
       when(io.resp.fire) {
         state := s_idle
       }
@@ -179,12 +189,15 @@ class ICacheMissEntry(edge: TLEdgeOut, id: Int)(implicit p: Parameters) extends 
   require(nSets <= 256) // icache size should not be more than 128KB
 
   //resp to ifu
-  io.resp.valid := state === s_wait_resp
+  io.resp.valid := (state === s_wait_resp) || (state === s_write_back_wait_resp)
 
-  io.meta_write.valid := (state === s_write_back && !needflush)
+  io.resp.bits.data := respDataReg.asUInt
+  io.resp.bits.corrupt := req_corrupt
+
+  io.meta_write.valid := (((state === s_write_back) || (state === s_write_back_wait_resp)) && !needflush)
   io.meta_write.bits.generate(tag = req_tag, idx = req_idx, waymask = req_waymask, bankIdx = req_idx(0))
 
-  io.data_write.valid := (state === s_write_back && !needflush)
+  io.data_write.valid := (((state === s_write_back) || (state === s_write_back_wait_resp)) && !needflush)
   io.data_write.bits.generate(data = respDataReg.asUInt,
                               idx  = req_idx,
                               waymask = req_waymask,


### PR DESCRIPTION
The previous scheme was as follows: After MSHR receiving data from L2, it was first written back to the ICache SRAM, and then the IFU was responded to. 
Now, both writing back to the ICache SRAM and responding to the IFU are done simultaneously.