### PR TITLE
RAS: reduce entry to improve timing

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -72,7 +72,7 @@ case class XSCoreParameters
   EnableCommitGHistDiff: Boolean = true,
   UbtbSize: Int = 256,
   FtbSize: Int = 2048,
-  RasSize: Int = 32,
+  RasSize: Int = 16,
   RasSpecSize: Int = 32,
   RasCtrSize: Int = 8,
   CacheLineSize: Int = 512,

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -73,7 +73,7 @@ case class XSCoreParameters
   UbtbSize: Int = 256,
   FtbSize: Int = 2048,
   RasSize: Int = 32,
-  RasSpecSize: Int = 64,
+  RasSpecSize: Int = 32,
   RasCtrSize: Int = 8,
   CacheLineSize: Int = 512,
   FtbWays: Int = 4,


### PR DESCRIPTION
Speculative entry number should be 32 rather than 64

Redundant MUX of RAS has proven to be essential for ITTAGE result to work so no fixup for that