### PR TITLE
Rob: fix misused `Mem` for multi-assigned array

### DIFF
--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -472,7 +472,7 @@ class RobImp(outer: Rob)(implicit p: Parameters) extends LazyModuleImp(outer)
   // instvalid field
   val valid = RegInit(VecInit(Seq.fill(RobSize)(false.B)))
   // writeback status
-  val writebacked = Mem(RobSize, Bool())
+  val writebacked = Reg(Vec(RobSize, Bool()))
   val store_data_writebacked = Mem(RobSize, Bool())
   val mmio = RegInit(VecInit(Seq.fill(RobSize)(false.B)))
   // data for redirect, exception, etc.


### PR DESCRIPTION
`writebacked` should be a RegVec instead of Mem, as it may be multi-written in a single cycle intentionally, when an exception happened on an atomic instruction.

> when multiple conflicting writes are performed on a Mem element, the result is undefined (unlike Vec, where the last assignment wins)