### PR TITLE
top-down: move sc from FTB to redirect SRAM

### DIFF
--- a/src/main/scala/xiangshan/frontend/FTB.scala
+++ b/src/main/scala/xiangshan/frontend/FTB.scala
@@ -55,8 +55,6 @@ class FtbSlot(val offsetLen: Int, val subOffsetLen: Option[Int] = None)(implicit
   val sharing = Bool()
   val valid   = Bool()
 
-  val sc      = Bool() // set by sc in s3, perf use only
-
   def setLowerStatByTarget(pc: UInt, target: UInt, isShare: Boolean) = {
     def getTargetStatByHigher(pc_higher: UInt, target_higher: UInt) =
       Mux(target_higher > pc_higher, TAR_OVF,

--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -605,7 +605,7 @@ class BranchPredictionResp(implicit p: Parameters) extends XSBundle with HasBPUC
   val s3 = new BranchPredictionBundle
 
   val last_stage_meta = UInt(MaxMetaLength.W)
-  val last_stage_spec_info = new SpeculativeInfo
+  val last_stage_spec_info = new Ftq_Redirect_SRAMEntry
   val last_stage_ftb_entry = new FTBEntry
 
   val topdown_info = new FrontendTopDownBundle

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -144,7 +144,9 @@ class Ftq_pd_Entry(implicit p: Parameters) extends XSBundle {
 
 
 
-class Ftq_Redirect_SRAMEntry(implicit p: Parameters) extends SpeculativeInfo {}
+class Ftq_Redirect_SRAMEntry(implicit p: Parameters) extends SpeculativeInfo {
+  val sc_disagree = Vec(numBr, Bool())
+}
 
 class Ftq_1R_SRAMEntry(implicit p: Parameters) extends XSBundle with HasBPUConst {
   val meta = UInt(MaxMetaLength.W)
@@ -915,8 +917,9 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
 
   backendRedirectCfi.br_hit := r_ftb_entry.brIsSaved(r_ftqOffset)
   backendRedirectCfi.jr_hit := r_ftb_entry.isJalr && r_ftb_entry.tailSlot.offset === r_ftqOffset
+  // FIXME: not portable
   backendRedirectCfi.sc_hit := backendRedirectCfi.br_hit && Mux(r_ftb_entry.brSlots(0).offset === r_ftqOffset,
-      r_ftb_entry.brSlots(0).sc, r_ftb_entry.tailSlot.sc)
+    stage3CfiInfo.sc_disagree(0), stage3CfiInfo.sc_disagree(1))
 
   when (entry_hit_status(fromBackendRedirect.bits.ftqIdx.value) === h_hit) {
     backendRedirectCfi.shift := PopCount(r_ftb_entry.getBrMaskByOffset(r_ftqOffset)) +&

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -291,9 +291,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         )
 
       val s3_disagree = RegEnable(s2_disagree, io.s2_fire(3))
-      // FIXME: not portable
-      io.out.last_stage_ftb_entry.brSlots(0).sc := RegEnable(s2_disagree(0), io.s2_fire(3))
-      io.out.last_stage_ftb_entry.tailSlot.sc := RegEnable(s2_disagree(1), io.s2_fire(3))
+      io.out.last_stage_spec_info.sc_disagree := s3_disagree
 
       scMeta.tageTakens(w) := RegEnable(s2_tageTakens_dup(3)(w), io.s2_fire(3))
       scMeta.scUsed(w)     := RegEnable(s2_provideds(w), io.s2_fire(3))


### PR DESCRIPTION
`sc` is used for perf only (i.e. `TAGEMissBubble` counter and `SCMissBubble` counter), so it is better to be stored in Redirect SRAM instead of FTB