### PR TITLE
ICache: fix ICache ECC function

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -127,6 +127,7 @@ case class XSCoreParameters
 
       (preds, ras.io.out)
     }),
+  ICacheECCForceError: Boolean = false,
   IBufSize: Int = 48,
   DecodeWidth: Int = 6,
   RenameWidth: Int = 6,
@@ -398,6 +399,7 @@ trait HasXSParameter {
   val CacheLineSize = coreParams.CacheLineSize
   val CacheLineHalfWord = CacheLineSize / 16
   val ExtHistoryLength = HistoryLength + 64
+  val ICacheECCForceError = coreParams.ICacheECCForceError
   val IBufSize = coreParams.IBufSize
   val DecodeWidth = coreParams.DecodeWidth
   val RenameWidth = coreParams.RenameWidth

--- a/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
@@ -71,12 +71,12 @@ trait HasCSRConst {
   val Slvpredctl    = 0x5C2
   val Smblockctl    = 0x5C3
   val Srnctl        = 0x5C4
-  val Scachebase    = 0x5C5
-  val Sfetchctl     = 0x5C6
-
   /** 0x5C5-0x5E5 for cache instruction register*/
+  val Scachebase    = 0x5C5
 
+  // Supervisor Custom Read/Write
   val Sdsid         = 0x9C0
+  val Sfetchctl     = 0x9e0
 
   // Machine Information Registers
   val Mvendorid     = 0xF11

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -439,6 +439,10 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray
     read_codes(i) := codeArray.io.r.resp.asTypeOf(Vec(nWays,UInt(dataCodeEntryBits.W)))
   }
 
+  if (ICacheECCForceError) {
+    read_codes.foreach(_.foreach(_ := 0.U)) // force ecc to fail
+  }
+
   //Parity Encode
   val write = io.write.bits
   val write_data = WireInit(write.data)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -490,8 +490,9 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     io.errors(i).opType           := DontCare
     io.errors(i).opType.fetch     := true.B
   }
-  XSError(s2_parity_error.reduce(_||_) && RegNext(RegNext(s1_fire)), "ICache has parity error in MainPaipe!")
-
+  if (!ICacheECCForceError) {
+    XSError(s2_parity_error.reduce(_||_) && RegNext(RegNext(s1_fire)), "ICache has parity error in MainPaipe!")
+  }
 
   /** exception and pmp logic **/
   val s2_tlb_valid = VecInit((0 until PortNumber).map(i => ValidHold(s1_tlb_valid(i) && s1_fire, s2_fire, false.B)))


### PR DESCRIPTION
ICache ECC control CSR overlapped with CacheInstruction such that ICache ECC check could not be enabled.

This commit fixed the overlapping issue and added ICache ECC error generation mechanism.