### PR TITLE
sms: fix alias bug

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -226,6 +226,7 @@ trait HasDCacheParameters extends HasL1CacheParameters with HasL1PrefetchSourceP
   }
   
   def get_alias(vaddr: UInt): UInt ={
+    require(blockOffBits + idxBits > pgIdxBits)
     if(blockOffBits + idxBits > pgIdxBits){
       vaddr(blockOffBits + idxBits - 1, pgIdxBits)
     }else{

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -224,6 +224,14 @@ trait HasDCacheParameters extends HasL1CacheParameters with HasL1PrefetchSourceP
     require(data.getWidth >= (bank+1)*DCacheSRAMRowBytes)
     data(DCacheSRAMRowBytes * (bank + 1) - 1, DCacheSRAMRowBytes * bank)
   }
+  
+  def get_alias(vaddr: UInt): UInt ={
+    if(blockOffBits + idxBits > pgIdxBits){
+      vaddr(blockOffBits + idxBits - 1, pgIdxBits)
+    }else{
+      0.U
+    }
+  }
 
   def is_alias_match(vaddr0: UInt, vaddr1: UInt): Bool = {
     require(vaddr0.getWidth == VAddrBits && vaddr1.getWidth == VAddrBits)

--- a/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
@@ -103,7 +103,10 @@ trait HasSMSModuleHelper extends HasCircularQueuePtrHelper with HasDCacheParamet
     pc(PHT_INDEX_BITS + 2 + PHT_TAG_BITS - 1, PHT_INDEX_BITS + 2)
   }
 
-  def get_alias_bits(region_vaddr: UInt): UInt = region_vaddr(7, 6)
+  def get_alias_bits(region_vaddr: UInt): UInt = {
+    val offset = log2Up(REGION_SIZE)
+    get_alias(Cat(region_vaddr, 0.U(offset.W)))
+  }
 }
 
 class StridePF()(implicit p: Parameters) extends XSModule with HasSMSModuleHelper {


### PR DESCRIPTION
The wrong fixed index was used to get alias in `SMSPrefetcher`, and there is no API to get alias in `DCacheWrapper`. The PR is to solve these.