### PR TITLE
top-down: remove 'sc_disagree' from redirect SRAM for FPGAPlatform

### DIFF
--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -148,7 +148,7 @@ class PrefetchPtrDB(implicit p: Parameters) extends Bundle {
 }
 
 class Ftq_Redirect_SRAMEntry(implicit p: Parameters) extends SpeculativeInfo {
-  val sc_disagree = Vec(numBr, Bool())
+  val sc_disagree = if (!env.FPGAPlatform) Some(Vec(numBr, Bool())) else None
 }
 
 class Ftq_1R_SRAMEntry(implicit p: Parameters) extends XSBundle with HasBPUConst {
@@ -920,8 +920,9 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   backendRedirectCfi.br_hit := r_ftb_entry.brIsSaved(r_ftqOffset)
   backendRedirectCfi.jr_hit := r_ftb_entry.isJalr && r_ftb_entry.tailSlot.offset === r_ftqOffset
   // FIXME: not portable
+  val sc_disagree = stage3CfiInfo.sc_disagree.getOrElse(VecInit(Seq.fill(numBr)(false.B)))
   backendRedirectCfi.sc_hit := backendRedirectCfi.br_hit && Mux(r_ftb_entry.brSlots(0).offset === r_ftqOffset,
-    stage3CfiInfo.sc_disagree(0), stage3CfiInfo.sc_disagree(1))
+    sc_disagree(0), sc_disagree(1))
 
   when (entry_hit_status(fromBackendRedirect.bits.ftqIdx.value) === h_hit) {
     backendRedirectCfi.shift := PopCount(r_ftb_entry.getBrMaskByOffset(r_ftqOffset)) +&

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -291,7 +291,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         )
 
       val s3_disagree = RegEnable(s2_disagree, io.s2_fire(3))
-      io.out.last_stage_spec_info.sc_disagree := s3_disagree
+      io.out.last_stage_spec_info.sc_disagree.map(_ := s3_disagree)
 
       scMeta.tageTakens(w) := RegEnable(s2_tageTakens_dup(3)(w), io.s2_fire(3))
       scMeta.scUsed(w)     := RegEnable(s2_provideds(w), io.s2_fire(3))


### PR DESCRIPTION
Avoid increasing SRAM area with unnecessary signal