### PR TITLE
UncacheBuffer: fix mmio data writeback logic

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/UncacheBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/UncacheBuffer.scala
@@ -384,7 +384,7 @@ class UncacheBuffer(implicit p: Parameters) extends XSModule with HasCircularQue
   // uncache RAW data
   // FIXME: remove it?
   io.ld_raw_data(0) := RegEnable(ld_raw_data, ldout.fire)
-  io.trigger(0).lqLoadAddrTriggerHitVec := RegNext(lqLoadAddrTriggerHitVec)
+  io.trigger(0).lqLoadAddrTriggerHitVec := RegEnable(lqLoadAddrTriggerHitVec, ldout.fire)
 
   for (i <- 0 until LoadPipelineWidth) {
     io.rob.mmio(i) := RegNext(s1_valid(i) && s1_req(i).mmio)

--- a/src/main/scala/xiangshan/mem/lsqueue/UncacheBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/UncacheBuffer.scala
@@ -381,7 +381,9 @@ class UncacheBuffer(implicit p: Parameters) extends XSModule with HasCircularQue
   // uncache Writeback
   AddPipelineReg(ldout, io.ldout(0), false.B)
 
-  io.ld_raw_data(0)      := RegNext(ld_raw_data)
+  // uncache RAW data
+  // FIXME: remove it?
+  io.ld_raw_data(0) := RegEnable(ld_raw_data, ldout.fire)
   io.trigger(0).lqLoadAddrTriggerHitVec := RegNext(lqLoadAddrTriggerHitVec)
 
   for (i <- 0 until LoadPipelineWidth) {


### PR DESCRIPTION
Bugs description:
mmio load writeback data by _ld_raw_data_, _ld_raw_data_ is not synchronized when data is written back.

Bugs fix:
use _RegEnable_ to synchronize

@good-circle orz