### PR TITLE
LDU: fix rar flush logic

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -301,6 +301,7 @@ class MicroOpRbExt(implicit p: Parameters) extends XSBundleWithMicroOp {
 
 class Redirect(implicit p: Parameters) extends XSBundle {
   val isRVC = Bool()
+  val rawNuke = Bool()
   val robIdx = new RobPtr
   val ftqIdx = new FtqPtr
   val ftqOffset = UInt(log2Up(PredictWidth).W)

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -180,7 +180,7 @@ class RedirectGenerator(implicit p: Parameters) extends XSModule
   val brTarget = real_pc + SignExt(ImmUnion.B.toImm32(s1_imm12_reg), XLEN)
   val snpc = real_pc + Mux(s1_pd.isRVC, 2.U, 4.U)
   val target = Mux(s1_isReplay,
-    real_pc + Mux(s1_redirect_bits_reg.isRVC, 2.U, 4.U),
+    Mux(s1_redirect_bits_reg.rawNuke, real_pc, real_pc + Mux(s1_redirect_bits_reg.isRVC, 2.U, 4.U)),
     Mux(s1_redirect_bits_reg.cfiUpdate.taken,
       Mux(s1_isJump, s1_jumpTarget, brTarget),
       snpc

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -180,7 +180,7 @@ class RedirectGenerator(implicit p: Parameters) extends XSModule
   val brTarget = real_pc + SignExt(ImmUnion.B.toImm32(s1_imm12_reg), XLEN)
   val snpc = real_pc + Mux(s1_pd.isRVC, 2.U, 4.U)
   val target = Mux(s1_isReplay,
-    real_pc, // replay from itself
+    real_pc + Mux(s1_redirect_bits_reg.isRVC, 2.U, 4.U),
     Mux(s1_redirect_bits_reg.cfiUpdate.taken,
       Mux(s1_isJump, s1_jumpTarget, brTarget),
       snpc
@@ -209,7 +209,7 @@ class RedirectGenerator(implicit p: Parameters) extends XSModule
   val store_pc = io.memPredPcRead(s1_redirect_bits_reg.stFtqIdx, s1_redirect_bits_reg.stFtqOffset)
 
   // update load violation predictor if load violation redirect triggered
-  io.memPredUpdate.valid := RegNext(s1_isReplay && s1_redirect_valid_reg, init = false.B)
+  io.memPredUpdate.valid := RegNext(s1_isReplay && s1_redirect_valid_reg && s2_redirect_bits_reg.rawNuke, init = false.B)
   // update wait table
   io.memPredUpdate.waddr := RegNext(XORFold(real_pc(VAddrBits-1, 1), MemPredPCWidth))
   io.memPredUpdate.wdata := true.B

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -821,12 +821,36 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   lsq.io.rob.commit              := io.ooo_to_mem.lsqio.commit
   lsq.io.rob.pendingPtr          := io.ooo_to_mem.lsqio.pendingPtr
 
-//  lsq.io.rob            <> io.lsqio.rob
+  //  lsq.io.rob            <> io.lsqio.rob
   lsq.io.enq            <> io.ooo_to_mem.enqLsq
   lsq.io.brqRedirect    <> redirect
-  io.mem_to_ooo.memoryViolation    <> lsq.io.rollback
+
+  //  violation rollback
+  def selectOldest[T <: Redirect](valid: Seq[Bool], bits: Seq[T]): (Seq[Bool], Seq[T]) = {
+    assert(valid.length == bits.length)
+    if (valid.length == 0 || valid.length == 1) {
+      (valid, bits)
+    } else if (valid.length == 2) {
+      val res = Seq.fill(2)(Wire(ValidIO(chiselTypeOf(bits(0)))))
+      for (i <- res.indices) {
+        res(i).valid := valid(i)
+        res(i).bits := bits(i)
+      }
+      val oldest = Mux(valid(0) && valid(1), Mux(isAfter(bits(0).uop.obIdx, bits(1).uop.robIdx), res(1), res(0)), Mux(valid(0) && !valid(1), res(0), res(1)))
+      (Seq(oldest.valid), Seq(oldest.bits))
+    } else {
+      val left = selectOldest(valid.take(valid.length / 2), bits.take(bits.length / 2))
+      val right = selectOldest(valid.takeRight(valid.length - (valid.length / 2)), bits.takeRight(bits.length - (bits.length / 2)))
+      selectOldest(left._1 ++ right._1, left._2 ++ right._2)
+    }
+  }
+  val rollback = lsq.io.rollback +: loadUnits.map(_.io.rollback)
+  val rollbackSel = selectOldest(rollback.map(_.valid), rollback.map(_.bits))
+  io.mem_to_ooo.memoryViolation.valid := rollbackSel._1(0)
+  io.mem_to_ooo.memoryViolation.bits  := rollbackSel._2(0)
   io.mem_to_ooo.lsqio.lqCanAccept  := lsq.io.lqCanAccept
   io.mem_to_ooo.lsqio.sqCanAccept  := lsq.io.sqCanAccept
+
   // lsq.io.uncache        <> uncache.io.lsq
   AddPipelineReg(lsq.io.uncache.req, uncache.io.lsq.req, false.B)
   AddPipelineReg(uncache.io.lsq.resp, lsq.io.uncache.resp, false.B)

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -162,6 +162,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   with HasWritebackSourceImp
   with HasPerfEvents
   with HasL1PrefetchSourceParameter
+  with HasCircularQueuePtrHelper
 {
 
   val io = IO(new Bundle {

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -837,7 +837,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
         res(i).valid := valid(i)
         res(i).bits := bits(i)
       }
-      val oldest = Mux(valid(0) && valid(1), Mux(isAfter(bits(0).uop.obIdx, bits(1).uop.robIdx), res(1), res(0)), Mux(valid(0) && !valid(1), res(0), res(1)))
+      val oldest = Mux(valid(0) && valid(1), Mux(isAfter(bits(0).robIdx, bits(1).robIdx), res(1), res(0)), Mux(valid(0) && !valid(1), res(0), res(1)))
       (Seq(oldest.valid), Seq(oldest.bits))
     } else {
       val left = selectOldest(valid.take(valid.length / 2), bits.take(bits.length / 2))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
@@ -375,7 +375,7 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
 
   // check if rollback request is still valid in parallel
   io.rollback.bits             := DontCare
-  io.rollback.bits.isRVC       := rollbackUop.cf.isRVC
+  io.rollback.bits.isRVC       := rollbackUop.cf.pd.isRVC
   io.rollback.bits.rawNuke     := true.B
   io.rollback.bits.robIdx      := rollbackUop.robIdx
   io.rollback.bits.ftqIdx      := rollbackUop.cf.ftqPtr

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
@@ -375,6 +375,8 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
 
   // check if rollback request is still valid in parallel
   io.rollback.bits             := DontCare
+  io.rollback.bits.isRVC       := rollbackUop.cf.isRVC
+  io.rollback.bits.rawNuke     := true.B
   io.rollback.bits.robIdx      := rollbackUop.robIdx
   io.rollback.bits.ftqIdx      := rollbackUop.cf.ftqPtr
   io.rollback.bits.stFtqIdx    := rollbackStFtqIdx

--- a/src/main/scala/xiangshan/mem/lsqueue/UncacheBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/UncacheBuffer.scala
@@ -458,6 +458,8 @@ class UncacheBuffer(implicit p: Parameters) extends XSModule with HasCircularQue
 
   val (rollbackValid, rollbackUop) = detectRollback()
   io.rollback.bits           := DontCare
+  io.rollback.bits.rawNuke   := false.B
+  io.rollback.bits.isRVC     := rollbackUop.cf.isRVC
   io.rollback.bits.robIdx    := rollbackUop.robIdx
   io.rollback.bits.ftqIdx    := rollbackUop.cf.ftqPtr
   io.rollback.bits.ftqOffset := rollbackUop.cf.ftqOffset

--- a/src/main/scala/xiangshan/mem/lsqueue/UncacheBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/UncacheBuffer.scala
@@ -459,7 +459,7 @@ class UncacheBuffer(implicit p: Parameters) extends XSModule with HasCircularQue
   val (rollbackValid, rollbackUop) = detectRollback()
   io.rollback.bits           := DontCare
   io.rollback.bits.rawNuke   := false.B
-  io.rollback.bits.isRVC     := rollbackUop.cf.isRVC
+  io.rollback.bits.isRVC     := rollbackUop.cf.pd.isRVC
   io.rollback.bits.robIdx    := rollbackUop.robIdx
   io.rollback.bits.ftqIdx    := rollbackUop.cf.ftqPtr
   io.rollback.bits.ftqOffset := rollbackUop.cf.ftqOffset

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1049,7 +1049,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   s3_out.valid                := s3_valid && !io.lsq.ldin.bits.rep_info.need_rep && !s3_in.mmio
   s3_out.bits.uop             := s3_in.uop
   s3_out.bits.uop.cf.exceptionVec(loadAccessFault) := s3_dly_ld_err  || s3_in.uop.cf.exceptionVec(loadAccessFault)
-  s3_out.bits.uop.ctrl.replayInst := s3_rep_frm_fetch
+  s3_out.bits.uop.ctrl.flushPipe := s3_rep_frm_fetch
   s3_out.bits.data            := s3_in.data
   s3_out.bits.redirectValid   := false.B
   s3_out.bits.redirect        := DontCare

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1070,14 +1070,14 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   io.rollback.valid := s3_out.valid && !s3_rep_frm_fetch && s3_flushPipe
   io.rollback.bits             := DontCare
-  io.rollback.bits.isRVC       := s3_out.uop.cf.pd.isRVC
+  io.rollback.bits.isRVC       := s3_out.bits.uop.cf.pd.isRVC
   io.rollback.bits.rawNuke     := false.B
-  io.rollback.bits.robIdx      := s3_out.uop.robIdx
-  io.rollback.bits.ftqIdx      := s3_out.uop.cf.ftqPtr
-  io.rollback.bits.ftqOffset   := s3_out.uop.cf.ftqOffset
+  io.rollback.bits.robIdx      := s3_out.bits.uop.robIdx
+  io.rollback.bits.ftqIdx      := s3_out.bits.uop.cf.ftqPtr
+  io.rollback.bits.ftqOffset   := s3_out.bits.uop.cf.ftqOffset
   io.rollback.bits.level       := RedirectLevel.flushAfter
-  io.rollback.bits.cfiUpdate.target := s3_out.uop.cf.pc
-  io.rollback.bits.debug_runahead_checkpoint_id := s3_out.uop.debugInfo.runahead_checkpoint_id
+  io.rollback.bits.cfiUpdate.target := s3_out.bits.uop.cf.pc
+  io.rollback.bits.debug_runahead_checkpoint_id := s3_out.bits.uop.debugInfo.runahead_checkpoint_id
   /* <------- DANGEROUS: Don't change sequence here ! -------> */
 
   io.lsq.ldin.bits.uop := s3_out.bits.uop

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1043,7 +1043,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
                          s3_troublem
 
   val s3_exception = ExceptionNO.selectByFu(s3_in.uop.cf.exceptionVec, lduCfg).asUInt.orR
-  when ((s3_exception || s3_dly_ld_err || s3_rep_frm_fetch || s3_flushPipe) && !s3_force_rep) {
+  when ((s3_exception || s3_dly_ld_err || s3_rep_frm_fetch) && !s3_force_rep) {
     io.lsq.ldin.bits.rep_info.cause := 0.U.asTypeOf(s3_rep_info.cause.cloneType)
   } .otherwise {
     io.lsq.ldin.bits.rep_info.cause := VecInit(s3_sel_rep_cause.asBools)

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1032,7 +1032,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   val s3_rep_info = WireInit(s3_in.rep_info)
   s3_rep_info.dcache_miss   := s3_in.rep_info.dcache_miss && !s3_fwd_frm_d_chan_valid && s3_troublem
-  val s3_rep_frm_fetch = s3_vp_match_fail || s3_ldld_rep_inst
+  val s3_flushPipe = s3_ldld_rep_inst
+  val s3_rep_frm_fetch = s3_vp_match_fail
   val s3_sel_rep_cause = PriorityEncoderOH(s3_rep_info.cause.asUInt)
   val s3_force_rep     = s3_sel_rep_cause(LoadReplayCauses.C_TM) &&
                          !s3_in.uop.cf.exceptionVec(loadAddrMisaligned) &&
@@ -1049,7 +1050,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   s3_out.valid                := s3_valid && !io.lsq.ldin.bits.rep_info.need_rep && !s3_in.mmio
   s3_out.bits.uop             := s3_in.uop
   s3_out.bits.uop.cf.exceptionVec(loadAccessFault) := s3_dly_ld_err  || s3_in.uop.cf.exceptionVec(loadAccessFault)
-  s3_out.bits.uop.ctrl.flushPipe := s3_rep_frm_fetch
+  s3_out.bits.uop.ctrl.flushPipe := s3_flushPipe
+  s3_out.bits.uop.ctrl.replayInst := s3_rep_frm_fetch
   s3_out.bits.data            := s3_in.data
   s3_out.bits.redirectValid   := false.B
   s3_out.bits.redirect        := DontCare


### PR DESCRIPTION
Bugs description:
When a **read-after-read** violation occur, **ROB** incorrect flushing can lead to livelock.

Bugs fix:
Use **flushPipe** instead of **replayInst** to control flushing