### PR TITLE
rv64v: reduce the number of vector issue queue

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -315,7 +315,7 @@ case class XSCoreParameters
         ExeUnitParams("BJU2", Seq(BrhCfg), Seq(), Seq(Seq(IntRD(11, 0)), Seq(IntRD(7, 1)))),
       ), numEntries = IssueQueueSize / 2, numEnq = 1),
       IssueBlockParams(Seq(
-        ExeUnitParams("IMISC0", Seq(VSetRiWiCfg, I2fCfg, VSetRiWvfCfg, JmpCfg, CsrCfg, FenceCfg), Seq(IntWB(port = 5, 0), VfWB(2, 0)), Seq(Seq(IntRD(5, 1)), Seq(IntRD(3, 1)))),
+        ExeUnitParams("IMISC0", Seq(VSetRiWiCfg, I2fCfg, I2vCfg, VSetRiWvfCfg, JmpCfg, CsrCfg, FenceCfg), Seq(IntWB(port = 5, 0), VfWB(2, 0)), Seq(Seq(IntRD(5, 1)), Seq(IntRD(3, 1)))),
         ExeUnitParams("IDIV0", Seq(DivCfg), Seq(IntWB(port = 7, 1)), Seq(Seq(IntRD(1, Int.MaxValue)), Seq(IntRD(9, Int.MaxValue)))),
       ), numEntries = IssueQueueSize, numEnq = 2),
     ),

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -315,7 +315,7 @@ case class XSCoreParameters
         ExeUnitParams("BJU2", Seq(BrhCfg), Seq(), Seq(Seq(IntRD(11, 0)), Seq(IntRD(7, 1)))),
       ), numEntries = IssueQueueSize / 2, numEnq = 1),
       IssueBlockParams(Seq(
-        ExeUnitParams("IMISC0", Seq(VSetRiWiCfg, I2fCfg, VSetRiWvfCfg, JmpCfg, CsrCfg, FenceCfg), Seq(IntWB(port = 5, 0), VfWB(4, 0)), Seq(Seq(IntRD(5, 1)), Seq(IntRD(3, 1)))),
+        ExeUnitParams("IMISC0", Seq(VSetRiWiCfg, I2fCfg, VSetRiWvfCfg, JmpCfg, CsrCfg, FenceCfg), Seq(IntWB(port = 5, 0), VfWB(2, 0)), Seq(Seq(IntRD(5, 1)), Seq(IntRD(3, 1)))),
         ExeUnitParams("IDIV0", Seq(DivCfg), Seq(IntWB(port = 7, 1)), Seq(Seq(IntRD(1, Int.MaxValue)), Seq(IntRD(9, Int.MaxValue)))),
       ), numEntries = IssueQueueSize, numEnq = 2),
     ),
@@ -330,20 +330,11 @@ case class XSCoreParameters
     implicit val schdType: SchedulerType = VfScheduler()
     SchdBlockParams(Seq(
       IssueBlockParams(Seq(
-        ExeUnitParams("FEX0", Seq(F2fCfg, F2iCfg, VSetRvfWvfCfg), Seq(VfWB(port = 0, 0), IntWB(port = 4, 0)), Seq(Seq(VfRD(12, 0)), Seq(VfRD(13, 0)))),
+        ExeUnitParams("VFEX0", Seq(VfaluCfg, VfmaCfg, VialuCfg, VppuCfg, F2fCfg, F2iCfg, VSetRvfWvfCfg), Seq(VfWB(port = 0, 0), IntWB(port = 4, 0)), Seq(Seq(VfRD(1, 0)), Seq(VfRD(2, 0)), Seq(VfRD(3, 0)), Seq(VfRD(4, 0)), Seq(VfRD(5, 0)))),
+        ExeUnitParams("VFEX1", Seq(VfaluCfg, VfmaCfg, VimacCfg, VipuCfg, VfcvtCfg), Seq(VfWB(port = 1, 0), IntWB(port = 8, 0)), Seq(Seq(VfRD(7, 0)), Seq(VfRD(8, 0)), Seq(VfRD(9, 0)), Seq(VfRD(10, 0)), Seq(VfRD(11, 0)))),
       ), numEntries = IssueQueueSize, numEnq = 2),
       IssueBlockParams(Seq(
-        ExeUnitParams("VEX0", Seq(VialuCfg, VimacCfg, VppuCfg, VipuCfg), Seq(VfWB(port = 1, 0)), Seq(Seq(VfRD(1, 0)), Seq(VfRD(2, 0)), Seq(VfRD(3, 0)), Seq(VfRD(4, 0)), Seq(VfRD(5, 0)))),
-      ), numEntries = IssueQueueSize, numEnq = 2),
-      IssueBlockParams(Seq(
-        ExeUnitParams("VEX1", Seq(VfaluCfg, VfmaCfg), Seq(VfWB(port = 2, 0), IntWB(port = 8, 0)), Seq(Seq(VfRD(1, 0)), Seq(VfRD(2, 0)), Seq(VfRD(3, 0)), Seq(VfRD(4, 0)), Seq(VfRD(5, 0)))),
-        ExeUnitParams("VEX2", Seq(VfaluCfg, VfmaCfg), Seq(VfWB(port = 3, 0), IntWB(port = 9, 0)), Seq(Seq(VfRD(7, 0)), Seq(VfRD(8, 0)), Seq(VfRD(9, 0)), Seq(VfRD(10, 0)), Seq(VfRD(11, 0)))),
-      ), numEntries = IssueQueueSize, numEnq = 2),
-      IssueBlockParams(Seq(
-        ExeUnitParams("VEX3", Seq(VfdivCfg), Seq(VfWB(port = 5, 1)), Seq(Seq(VfRD(7, 0)), Seq(VfRD(8, 0)), Seq(VfRD(9, 0)), Seq(VfRD(10, 0)), Seq(VfRD(11, 0)))),
-      ), numEntries = IssueQueueSize, numEnq = 2),
-      IssueBlockParams(Seq(
-        ExeUnitParams("VEX4", Seq(VfcvtCfg), Seq(VfWB(port = 8, 0)), Seq(Seq(VfRD(7, 1)), Seq(VfRD(8, 1)), Seq(VfRD(9, 1)), Seq(VfRD(10, 1)), Seq(VfRD(11, 1)))),
+        ExeUnitParams("VFEX2", Seq(VfdivCfg), Seq(VfWB(port = 5, 1)), Seq(Seq(VfRD(7, 0)), Seq(VfRD(8, 0)), Seq(VfRD(9, 0)), Seq(VfRD(10, 0)), Seq(VfRD(11, 0)))),
       ), numEntries = IssueQueueSize, numEnq = 2),
     ),
       numPregs = vfPreg.numEntries,
@@ -360,20 +351,20 @@ case class XSCoreParameters
 
     SchdBlockParams(Seq(
       IssueBlockParams(Seq(
-        ExeUnitParams("LDU0", Seq(LduCfg), Seq(IntWB(6, 0), VfWB(6, 0)), Seq(Seq(IntRD(12, 0)))),
-        ExeUnitParams("LDU1", Seq(LduCfg), Seq(IntWB(7, 0), VfWB(7, 0)), Seq(Seq(IntRD(13, 0)))),
+        ExeUnitParams("LDU0", Seq(LduCfg), Seq(IntWB(6, 0), VfWB(3, 0)), Seq(Seq(IntRD(12, 0)))),
+        ExeUnitParams("LDU1", Seq(LduCfg), Seq(IntWB(7, 0), VfWB(4, 0)), Seq(Seq(IntRD(13, 0)))),
       ), numEntries = IssueQueueSize, numEnq = 2),
       IssueBlockParams(Seq(
-        ExeUnitParams("STA0", Seq(StaCfg, MouCfg), Seq(IntWB(10, 0)), Seq(Seq(IntRD(3, 1)))),
-        ExeUnitParams("STA1", Seq(StaCfg, MouCfg), Seq(IntWB(11, 0)), Seq(Seq(IntRD(1, 1)))),
+        ExeUnitParams("STA0", Seq(StaCfg, MouCfg), Seq(IntWB(9, 0)), Seq(Seq(IntRD(3, 1)))),
+        ExeUnitParams("STA1", Seq(StaCfg, MouCfg), Seq(IntWB(10, 0)), Seq(Seq(IntRD(1, 1)))),
       ), numEntries = IssueQueueSize, numEnq = 2),
       IssueBlockParams(Seq(
         ExeUnitParams("STD0", Seq(StdCfg, MoudCfg), Seq(), Seq(Seq(IntRD(13, 1), VfRD(12, Int.MaxValue)))),
         ExeUnitParams("STD1", Seq(StdCfg, MoudCfg), Seq(), Seq(Seq(IntRD(5, 1), VfRD(10, Int.MaxValue)))),
       ), numEntries = IssueQueueSize, numEnq = 2),
       IssueBlockParams(Seq(
-        ExeUnitParams("VLDU0", Seq(VlduCfg), Seq(VfWB(6, 1)), Seq(Seq(VfRD(0, 0)), Seq(VfRD(1, 0)), Seq(VfRD(2, 0)), Seq(VfRD(3, 0)), Seq(VfRD(4, 0)))),
-        ExeUnitParams("VLDU1", Seq(VlduCfg), Seq(VfWB(7, 1)), Seq(Seq(VfRD(5, 0)), Seq(VfRD(6, 0)), Seq(VfRD(7, 0)), Seq(VfRD(8, 0)), Seq(VfRD(9, 0)))),
+        ExeUnitParams("VLDU0", Seq(VlduCfg), Seq(VfWB(3, 1)), Seq(Seq(VfRD(0, 0)), Seq(VfRD(1, 0)), Seq(VfRD(2, 0)), Seq(VfRD(3, 0)), Seq(VfRD(4, 0)))),
+        ExeUnitParams("VLDU1", Seq(VlduCfg), Seq(VfWB(4, 1)), Seq(Seq(VfRD(5, 0)), Seq(VfRD(6, 0)), Seq(VfRD(7, 0)), Seq(VfRD(8, 0)), Seq(VfRD(9, 0)))),
       ), numEntries = IssueQueueSize, numEnq = 2),
     ),
       numPregs = intPreg.numEntries max vfPreg.numEntries,
@@ -392,7 +383,7 @@ case class XSCoreParameters
         Seq("ALU0", "ALU1", "MUL0", "MUL1", "BJU0", "LDU0", "LDU1") ->
         Seq("ALU0", "ALU1", "MUL0", "MUL1", "BJU0", "BJU1", "BJU2", "LDU0", "LDU1", "STA0", "STA1", "STD0", "STD1")
       ),
-      WakeUpConfig(Seq("IMISC0") -> Seq("FEX0")),
+      WakeUpConfig(Seq("IMISC0") -> Seq("VFEX0")),
     ).flatten
   }
 

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -344,9 +344,14 @@ object Bundles {
     p: Parameters
   ) extends Bundle {
     private val rfReadDataCfgSet: Seq[Set[DataConfig]] = exuParams.getRfReadDataCfgSet
+    // check which set both have fp and vec and remove fp
+    private val rfReadDataCfgSetFilterFp = rfReadDataCfgSet.map((set: Set[DataConfig]) =>
+      if (set.contains(FpData()) && set.contains(VecData())) set.filter(_ != FpData())
+      else set
+    )
 
     val rf: MixedVec[MixedVec[RfReadPortWithConfig]] = Flipped(MixedVec(
-      rfReadDataCfgSet.map((set: Set[DataConfig]) =>
+      rfReadDataCfgSetFilterFp.map((set: Set[DataConfig]) =>
         MixedVec(set.map((x: DataConfig) => new RfReadPortWithConfig(x, exuParams.rdPregIdxWidth)).toSeq)
       )
     ))

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
@@ -593,8 +593,8 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
           csBundle(2 * i + 2).uopIdx := (2 * i + 1).U
         }
       }
-      csBundle(numOfUop - 1.U).srcType(0) := SrcType.fp
-      csBundle(numOfUop - 1.U).lsrc(0) := FP_TMP_REG_MV.U
+      csBundle(numOfUop - 1.U).srcType(0) := SrcType.vp
+      csBundle(numOfUop - 1.U).lsrc(0) := VECTOR_TMP_REG_LMUL.U
       csBundle(numOfUop - 1.U).ldest := dest + lmul - 1.U
     }
     is(UopSplitType.VEC_FSLIDE1DOWN) {

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
@@ -276,26 +276,40 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).srcType(0) := SrcType.reg
       csBundle(0).srcType(1) := SrcType.imm
       csBundle(0).lsrc(1) := 0.U
-      csBundle(0).ldest := FP_TMP_REG_MV.U
-      csBundle(0).fuType := FuType.i2f.U
-      csBundle(0).rfWen := false.B
-      csBundle(0).fpWen := true.B
-      csBundle(0).vecWen := false.B
-      csBundle(0).fpu.isAddSub := false.B
-      csBundle(0).fpu.typeTagIn := FPU.D
-      csBundle(0).fpu.typeTagOut := FPU.D
-      csBundle(0).fpu.fromInt := true.B
-      csBundle(0).fpu.wflags := false.B
-      csBundle(0).fpu.fpWen := true.B
-      csBundle(0).fpu.div := false.B
-      csBundle(0).fpu.sqrt := false.B
-      csBundle(0).fpu.fcvt := false.B
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
       /*
       LMUL
        */
       for (i <- 0 until MAX_VLMUL) {
-        csBundle(i + 1).srcType(0) := SrcType.fp
-        csBundle(i + 1).lsrc(0) := FP_TMP_REG_MV.U
+        csBundle(i + 1).srcType(0) := SrcType.vp
+        csBundle(i + 1).lsrc(0) := VECTOR_TMP_REG_LMUL.U
+        csBundle(i + 1).lsrc(1) := src2 + i.U
+        csBundle(i + 1).lsrc(2) := dest + i.U
+        csBundle(i + 1).ldest := dest + i.U
+        csBundle(i + 1).uopIdx := i.U
+      }
+    }
+    is(UopSplitType.VEC_VIV) {
+      /*
+      FMV.D.X
+       */
+      csBundle(0).srcType(0) := SrcType.imm
+      csBundle(0).srcType(1) := SrcType.imm
+      csBundle(0).lsrc(0) := 0.U
+      csBundle(0).lsrc(1) := 0.U
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
+      /*
+      LMUL
+       */
+      for (i <- 0 until MAX_VLMUL) {
+        csBundle(i + 1).srcType(0) := SrcType.vp
+        csBundle(i + 1).lsrc(0) := VECTOR_TMP_REG_LMUL.U
         csBundle(i + 1).lsrc(1) := src2 + i.U
         csBundle(i + 1).lsrc(2) := dest + i.U
         csBundle(i + 1).ldest := dest + i.U
@@ -351,30 +365,20 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).srcType(0) := SrcType.reg
       csBundle(0).srcType(1) := SrcType.imm
       csBundle(0).lsrc(1) := 0.U
-      csBundle(0).ldest := FP_TMP_REG_MV.U
-      csBundle(0).fuType := FuType.i2f.U
-      csBundle(0).rfWen := false.B
-      csBundle(0).fpWen := true.B
-      csBundle(0).vecWen := false.B
-      csBundle(0).fpu.isAddSub := false.B
-      csBundle(0).fpu.typeTagIn := FPU.D
-      csBundle(0).fpu.typeTagOut := FPU.D
-      csBundle(0).fpu.fromInt := true.B
-      csBundle(0).fpu.wflags := false.B
-      csBundle(0).fpu.fpWen := true.B
-      csBundle(0).fpu.div := false.B
-      csBundle(0).fpu.sqrt := false.B
-      csBundle(0).fpu.fcvt := false.B
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
 
       for (i <- 0 until MAX_VLMUL / 2) {
-        csBundle(2 * i + 1).srcType(0) := SrcType.fp
-        csBundle(2 * i + 1).lsrc(0) := FP_TMP_REG_MV.U
+        csBundle(2 * i + 1).srcType(0) := SrcType.vp
+        csBundle(2 * i + 1).lsrc(0) := VECTOR_TMP_REG_LMUL.U
         csBundle(2 * i + 1).lsrc(1) := src2 + i.U
         csBundle(2 * i + 1).lsrc(2) := dest + (2 * i).U
         csBundle(2 * i + 1).ldest := dest + (2 * i).U
         csBundle(2 * i + 1).uopIdx := (2 * i).U
-        csBundle(2 * i + 2).srcType(0) := SrcType.fp
-        csBundle(2 * i + 2).lsrc(0) := FP_TMP_REG_MV.U
+        csBundle(2 * i + 2).srcType(0) := SrcType.vp
+        csBundle(2 * i + 2).lsrc(0) := VECTOR_TMP_REG_LMUL.U
         csBundle(2 * i + 2).lsrc(1) := src2 + i.U
         csBundle(2 * i + 2).lsrc(2) := dest + (2 * i + 1).U
         csBundle(2 * i + 2).ldest := dest + (2 * i + 1).U
@@ -388,30 +392,20 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).srcType(0) := SrcType.reg
       csBundle(0).srcType(1) := SrcType.imm
       csBundle(0).lsrc(1) := 0.U
-      csBundle(0).ldest := FP_TMP_REG_MV.U
-      csBundle(0).fuType := FuType.i2f.U
-      csBundle(0).rfWen := false.B
-      csBundle(0).fpWen := true.B
-      csBundle(0).vecWen := false.B
-      csBundle(0).fpu.isAddSub := false.B
-      csBundle(0).fpu.typeTagIn := FPU.D
-      csBundle(0).fpu.typeTagOut := FPU.D
-      csBundle(0).fpu.fromInt := true.B
-      csBundle(0).fpu.wflags := false.B
-      csBundle(0).fpu.fpWen := true.B
-      csBundle(0).fpu.div := false.B
-      csBundle(0).fpu.sqrt := false.B
-      csBundle(0).fpu.fcvt := false.B
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
 
       for (i <- 0 until MAX_VLMUL / 2) {
-        csBundle(2 * i + 1).srcType(0) := SrcType.fp
-        csBundle(2 * i + 1).lsrc(0) := FP_TMP_REG_MV.U
+        csBundle(2 * i + 1).srcType(0) := SrcType.vp
+        csBundle(2 * i + 1).lsrc(0) := VECTOR_TMP_REG_LMUL.U
         csBundle(2 * i + 1).lsrc(1) := src2 + (2 * i).U
         csBundle(2 * i + 1).lsrc(2) := dest + (2 * i).U
         csBundle(2 * i + 1).ldest := dest + (2 * i).U
         csBundle(2 * i + 1).uopIdx := (2 * i).U
-        csBundle(2 * i + 2).srcType(0) := SrcType.fp
-        csBundle(2 * i + 2).lsrc(0) := FP_TMP_REG_MV.U
+        csBundle(2 * i + 2).srcType(0) := SrcType.vp
+        csBundle(2 * i + 2).lsrc(0) := VECTOR_TMP_REG_LMUL.U
         csBundle(2 * i + 2).lsrc(1) := src2 + (2 * i + 1).U
         csBundle(2 * i + 2).lsrc(2) := dest + (2 * i + 1).U
         csBundle(2 * i + 2).ldest := dest + (2 * i + 1).U
@@ -454,30 +448,20 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).srcType(0) := SrcType.reg
       csBundle(0).srcType(1) := SrcType.imm
       csBundle(0).lsrc(1) := 0.U
-      csBundle(0).ldest := FP_TMP_REG_MV.U
-      csBundle(0).fuType := FuType.i2f.U
-      csBundle(0).rfWen := false.B
-      csBundle(0).fpWen := true.B
-      csBundle(0).vecWen := false.B
-      csBundle(0).fpu.isAddSub := false.B
-      csBundle(0).fpu.typeTagIn := FPU.D
-      csBundle(0).fpu.typeTagOut := FPU.D
-      csBundle(0).fpu.fromInt := true.B
-      csBundle(0).fpu.wflags := false.B
-      csBundle(0).fpu.fpWen := true.B
-      csBundle(0).fpu.div := false.B
-      csBundle(0).fpu.sqrt := false.B
-      csBundle(0).fpu.fcvt := false.B
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
 
       for (i <- 0 until MAX_VLMUL / 2) {
-        csBundle(2 * i + 1).srcType(0) := SrcType.fp
-        csBundle(2 * i + 1).lsrc(0) := FP_TMP_REG_MV.U
+        csBundle(2 * i + 1).srcType(0) := SrcType.vp
+        csBundle(2 * i + 1).lsrc(0) := VECTOR_TMP_REG_LMUL.U
         csBundle(2 * i + 1).lsrc(1) := src2 + (2 * i).U
         csBundle(2 * i + 1).lsrc(2) := dest + i.U
         csBundle(2 * i + 1).ldest := dest + i.U
         csBundle(2 * i + 1).uopIdx := (2 * i).U
-        csBundle(2 * i + 2).srcType(0) := SrcType.fp
-        csBundle(2 * i + 2).lsrc(0) := FP_TMP_REG_MV.U
+        csBundle(2 * i + 2).srcType(0) := SrcType.vp
+        csBundle(2 * i + 2).lsrc(0) := VECTOR_TMP_REG_LMUL.U
         csBundle(2 * i + 2).lsrc(1) := src2 + (2 * i + 1).U
         csBundle(2 * i + 2).lsrc(2) := dest + i.U
         csBundle(2 * i + 2).ldest := dest + i.U
@@ -517,29 +501,19 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).srcType(0) := SrcType.reg
       csBundle(0).srcType(1) := SrcType.imm
       csBundle(0).lsrc(1) := 0.U
-      csBundle(0).ldest := FP_TMP_REG_MV.U
-      csBundle(0).fuType := FuType.i2f.U
-      csBundle(0).rfWen := false.B
-      csBundle(0).fpWen := true.B
-      csBundle(0).vecWen := false.B
-      csBundle(0).fpu.isAddSub := false.B
-      csBundle(0).fpu.typeTagIn := FPU.D
-      csBundle(0).fpu.typeTagOut := FPU.D
-      csBundle(0).fpu.fromInt := true.B
-      csBundle(0).fpu.wflags := false.B
-      csBundle(0).fpu.fpWen := true.B
-      csBundle(0).fpu.div := false.B
-      csBundle(0).fpu.sqrt := false.B
-      csBundle(0).fpu.fcvt := false.B
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
       //LMUL
-      csBundle(1).srcType(0) := SrcType.fp
-      csBundle(1).lsrc(0) := FP_TMP_REG_MV.U
+      csBundle(1).srcType(0) := SrcType.vp
+      csBundle(1).lsrc(0) := VECTOR_TMP_REG_LMUL.U
       csBundle(1).lsrc(2) := dest
       csBundle(1).ldest := dest
       csBundle(1).uopIdx := 0.U
       for (i <- 1 until MAX_VLMUL) {
-        csBundle(i + 1).srcType(0) := SrcType.fp
-        csBundle(i + 1).lsrc(0) := FP_TMP_REG_MV.U
+        csBundle(i + 1).srcType(0) := SrcType.vp
+        csBundle(i + 1).lsrc(0) := VECTOR_TMP_REG_LMUL.U
         csBundle(i + 1).lsrc(1) := src2 + i.U
         csBundle(i + 1).lsrc(2) := dest
         csBundle(i + 1).ldest := dest
@@ -554,23 +528,13 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).srcType(0) := SrcType.reg
       csBundle(0).srcType(1) := SrcType.imm
       csBundle(0).lsrc(1) := 0.U
-      csBundle(0).ldest := FP_TMP_REG_MV.U
-      csBundle(0).fuType := FuType.i2f.U
-      csBundle(0).rfWen := false.B
-      csBundle(0).fpWen := true.B
-      csBundle(0).vecWen := false.B
-      csBundle(0).fpu.isAddSub := false.B
-      csBundle(0).fpu.typeTagIn := FPU.D
-      csBundle(0).fpu.typeTagOut := FPU.D
-      csBundle(0).fpu.fromInt := true.B
-      csBundle(0).fpu.wflags := false.B
-      csBundle(0).fpu.fpWen := true.B
-      csBundle(0).fpu.div := false.B
-      csBundle(0).fpu.sqrt := false.B
-      csBundle(0).fpu.fcvt := false.B
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
       //LMUL
-      csBundle(1).srcType(0) := SrcType.fp
-      csBundle(1).lsrc(0) := FP_TMP_REG_MV.U
+      csBundle(1).srcType(0) := SrcType.vp
+      csBundle(1).lsrc(0) := VECTOR_TMP_REG_LMUL.U
       csBundle(1).lsrc(2) := dest
       csBundle(1).ldest := dest
       csBundle(1).uopIdx := 0.U
@@ -607,20 +571,10 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).srcType(0) := SrcType.reg
       csBundle(0).srcType(1) := SrcType.imm
       csBundle(0).lsrc(1) := 0.U
-      csBundle(0).ldest := FP_TMP_REG_MV.U
-      csBundle(0).fuType := FuType.i2f.U
-      csBundle(0).rfWen := false.B
-      csBundle(0).fpWen := true.B
-      csBundle(0).vecWen := false.B
-      csBundle(0).fpu.isAddSub := false.B
-      csBundle(0).fpu.typeTagIn := FPU.D
-      csBundle(0).fpu.typeTagOut := FPU.D
-      csBundle(0).fpu.fromInt := true.B
-      csBundle(0).fpu.wflags := false.B
-      csBundle(0).fpu.fpWen := true.B
-      csBundle(0).fpu.div := false.B
-      csBundle(0).fpu.sqrt := false.B
-      csBundle(0).fpu.fcvt := false.B
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
       //LMUL
       for (i <- 0 until MAX_VLMUL) {
         csBundle(2 * i + 1).srcType(0) := SrcType.vp
@@ -628,13 +582,13 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
         csBundle(2 * i + 1).lsrc(0) := src2 + (i + 1).U
         csBundle(2 * i + 1).lsrc(1) := src2 + i.U
         csBundle(2 * i + 1).lsrc(2) := dest + i.U
-        csBundle(2 * i + 1).ldest := VECTOR_TMP_REG_LMUL.U
+        csBundle(2 * i + 1).ldest := VECTOR_TMP_REG_LMUL.U + 1.U
         csBundle(2 * i + 1).uopIdx := (2 * i).U
         if (2 * i + 2 < MAX_VLMUL * 2) {
-          csBundle(2 * i + 2).srcType(0) := SrcType.fp
-          csBundle(2 * i + 2).lsrc(0) := FP_TMP_REG_MV.U
+          csBundle(2 * i + 2).srcType(0) := SrcType.vp
+          csBundle(2 * i + 2).lsrc(0) := VECTOR_TMP_REG_LMUL.U
           // csBundle(2 * i + 2).lsrc(1) := src2 + i.U         // DontCare
-          csBundle(2 * i + 2).lsrc(2) := VECTOR_TMP_REG_LMUL.U
+          csBundle(2 * i + 2).lsrc(2) := VECTOR_TMP_REG_LMUL.U + 1.U
           csBundle(2 * i + 2).ldest := dest + i.U
           csBundle(2 * i + 2).uopIdx := (2 * i + 1).U
         }
@@ -1192,31 +1146,21 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).srcType(0) := SrcType.reg
       csBundle(0).srcType(1) := SrcType.imm
       csBundle(0).lsrc(1) := 0.U
-      csBundle(0).ldest := FP_TMP_REG_MV.U
-      csBundle(0).fuType := FuType.i2f.U
-      csBundle(0).rfWen := false.B
-      csBundle(0).fpWen := true.B
-      csBundle(0).vecWen := false.B
-      csBundle(0).fpu.isAddSub := false.B
-      csBundle(0).fpu.typeTagIn := FPU.D
-      csBundle(0).fpu.typeTagOut := FPU.D
-      csBundle(0).fpu.fromInt := true.B
-      csBundle(0).fpu.wflags := false.B
-      csBundle(0).fpu.fpWen := true.B
-      csBundle(0).fpu.div := false.B
-      csBundle(0).fpu.sqrt := false.B
-      csBundle(0).fpu.fcvt := false.B
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
       // LMUL
       for (i <- 0 until MAX_VLMUL)
         for (j <- 0 to i) {
           val old_vd = if (j == 0) {
             dest + i.U
-          } else (VECTOR_TMP_REG_LMUL + j - 1).U
+          } else (VECTOR_TMP_REG_LMUL + j).U
           val vd = if (j == i) {
             dest + i.U
-          } else (VECTOR_TMP_REG_LMUL + j).U
-          csBundle(i * (i + 1) / 2 + j + 1).srcType(0) := SrcType.fp
-          csBundle(i * (i + 1) / 2 + j + 1).lsrc(0) := FP_TMP_REG_MV.U
+          } else (VECTOR_TMP_REG_LMUL + j + 1).U
+          csBundle(i * (i + 1) / 2 + j + 1).srcType(0) := SrcType.vp
+          csBundle(i * (i + 1) / 2 + j + 1).lsrc(0) := VECTOR_TMP_REG_LMUL.U
           csBundle(i * (i + 1) / 2 + j + 1).lsrc(1) := src2 + j.U
           csBundle(i * (i + 1) / 2 + j + 1).lsrc(2) := old_vd
           csBundle(i * (i + 1) / 2 + j + 1).ldest := vd
@@ -1246,32 +1190,22 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).srcType(0) := SrcType.reg
       csBundle(0).srcType(1) := SrcType.imm
       csBundle(0).lsrc(1) := 0.U
-      csBundle(0).ldest := FP_TMP_REG_MV.U
-      csBundle(0).fuType := FuType.i2f.U
-      csBundle(0).rfWen := false.B
-      csBundle(0).fpWen := true.B
-      csBundle(0).vecWen := false.B
-      csBundle(0).fpu.isAddSub := false.B
-      csBundle(0).fpu.typeTagIn := FPU.D
-      csBundle(0).fpu.typeTagOut := FPU.D
-      csBundle(0).fpu.fromInt := true.B
-      csBundle(0).fpu.wflags := false.B
-      csBundle(0).fpu.fpWen := true.B
-      csBundle(0).fpu.div := false.B
-      csBundle(0).fpu.sqrt := false.B
-      csBundle(0).fpu.fcvt := false.B
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
       // LMUL
       for (i <- 0 until MAX_VLMUL)
         for (j <- (0 to i).reverse) {
           when(i.U < lmul) {
             val old_vd = if (j == 0) {
               dest + lmul - 1.U - i.U
-            } else (VECTOR_TMP_REG_LMUL + j - 1).U
+            } else (VECTOR_TMP_REG_LMUL + j).U
             val vd = if (j == i) {
               dest + lmul - 1.U - i.U
-            } else (VECTOR_TMP_REG_LMUL + j).U
-            csBundle(numOfUop - (i * (i + 1) / 2 + i - j + 1).U).srcType(0) := SrcType.fp
-            csBundle(numOfUop - (i * (i + 1) / 2 + i - j + 1).U).lsrc(0) := FP_TMP_REG_MV.U
+            } else (VECTOR_TMP_REG_LMUL + j + 1).U
+            csBundle(numOfUop - (i * (i + 1) / 2 + i - j + 1).U).srcType(0) := SrcType.vp
+            csBundle(numOfUop - (i * (i + 1) / 2 + i - j + 1).U).lsrc(0) := VECTOR_TMP_REG_LMUL.U
             csBundle(numOfUop - (i * (i + 1) / 2 + i - j + 1).U).lsrc(1) := src2 + lmul - 1.U - j.U
             csBundle(numOfUop - (i * (i + 1) / 2 + i - j + 1).U).lsrc(2) := old_vd
             csBundle(numOfUop - (i * (i + 1) / 2 + i - j + 1).U).ldest := vd
@@ -1440,14 +1374,14 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       def genCsBundle_RGATHER_VX(len:Int): Unit ={
         for (i <- 0 until len)
           for (j <- 0 until len) {
-            csBundle(i * len + j + 1).srcType(0) := SrcType.fp
+            csBundle(i * len + j + 1).srcType(0) := SrcType.vp
             // csBundle(i * len + j + 1).srcType(1) := SrcType.vp
             // csBundle(i * len + j + 1).srcType(2) := SrcType.vp
-            csBundle(i * len + j + 1).lsrc(0) := FP_TMP_REG_MV.U
+            csBundle(i * len + j + 1).lsrc(0) := VECTOR_TMP_REG_LMUL.U
             csBundle(i * len + j + 1).lsrc(1) := src2 + j.U
-            val vd_old = if(j==0) (dest + i.U) else (VECTOR_TMP_REG_LMUL + j - 1).U
+            val vd_old = if(j==0) (dest + i.U) else (VECTOR_TMP_REG_LMUL + j).U
             csBundle(i * len + j + 1).lsrc(2) := vd_old
-            val vd = if(j==len-1) (dest + i.U) else (VECTOR_TMP_REG_LMUL + j).U
+            val vd = if(j==len-1) (dest + i.U) else (VECTOR_TMP_REG_LMUL + j + 1).U
             csBundle(i * len + j + 1).ldest := vd
             csBundle(i * len + j + 1).uopIdx := (i * len + j).U
           }
@@ -1456,20 +1390,10 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).srcType(0) := SrcType.reg
       csBundle(0).srcType(1) := SrcType.imm
       csBundle(0).lsrc(1) := 0.U
-      csBundle(0).ldest := FP_TMP_REG_MV.U
-      csBundle(0).fuType := FuType.i2f.U
-      csBundle(0).rfWen := false.B
-      csBundle(0).fpWen := true.B
-      csBundle(0).vecWen := false.B
-      csBundle(0).fpu.isAddSub := false.B
-      csBundle(0).fpu.typeTagIn := FPU.D
-      csBundle(0).fpu.typeTagOut := FPU.D
-      csBundle(0).fpu.fromInt := true.B
-      csBundle(0).fpu.wflags := false.B
-      csBundle(0).fpu.fpWen := true.B
-      csBundle(0).fpu.div := false.B
-      csBundle(0).fpu.sqrt := false.B
-      csBundle(0).fpu.fcvt := false.B
+      csBundle(0).ldest := VECTOR_TMP_REG_LMUL.U
+      csBundle(0).fuType := FuType.i2v.U
+      csBundle(0).fuOpType := vsewReg
+      csBundle(0).vecWen := true.B
       switch(vlmulReg) {
         is("b000".U ){
           genCsBundle_RGATHER_VX(1)

--- a/src/main/scala/xiangshan/backend/decode/UopInfoGen.scala
+++ b/src/main/scala/xiangshan/backend/decode/UopInfoGen.scala
@@ -116,6 +116,7 @@ class UopInfoGen (implicit p: Parameters) extends XSModule {
     UopSplitType.VEC_VFREDOSUM -> numOfUopVFREDOSUM,
     UopSplitType.VEC_VXM -> (lmul +& 1.U),
     UopSplitType.VEC_VXV -> (lmul +& 1.U),
+    UopSplitType.VEC_VIV -> (lmul +& 1.U),
     UopSplitType.VEC_VFW -> Cat(lmul, 0.U(1.W)), // lmul <= 4
     UopSplitType.VEC_WFW -> Cat(lmul, 0.U(1.W)), // lmul <= 4
     UopSplitType.VEC_VVW -> Cat(lmul, 0.U(1.W)), // lmul <= 4

--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -6,7 +6,7 @@ import utils.EnumUtils.OHEnumeration
 import xiangshan.ExceptionNO._
 import xiangshan.SelImm
 import xiangshan.backend.Std
-import xiangshan.backend.fu.fpu.{FDivSqrt, FMA, FPToFP, FPToInt, IntToFP}
+import xiangshan.backend.fu.fpu.{FDivSqrt, FMA, FPToFP, FPToInt, IntToFP, IntToVec}
 import xiangshan.backend.fu.wrapper.{Alu, BranchUnit, DivUnit, JumpUnit, MulUnit, VFAlu, VFMA, VFDivSqrt, VIAluFix, VIMacU, VPPU, VIPU, VSetRiWi, VSetRiWvf, VSetRvfWvf, VCVT}
 import xiangshan.backend.Bundles.ExuInput
 import xiangshan.backend.datapath.DataConfig._
@@ -223,6 +223,19 @@ object FuConfig {
     writeFflags = true,
     latency = CertainLatency(2),
     needSrcFrm = true,
+  )
+
+  val I2vCfg: FuConfig = FuConfig (
+    name = "i2v",
+    FuType.i2v,
+    fuGen = (p: Parameters, cfg: FuConfig) => Module(new IntToVec(cfg)(p).suggestName("i2v")),
+    srcData = Seq(
+      Seq(IntData(), IntData()),
+    ),
+    piped = true,
+    writeVecRf = true,
+    latency = CertainLatency(1),
+    dataBits = 128,
   )
 
   val CsrCfg: FuConfig = FuConfig (
@@ -632,7 +645,7 @@ object FuConfig {
   // def VstuCfg = FuConfig ()
 
   def allConfigs = Seq(
-    JmpCfg, BrhCfg, I2fCfg, CsrCfg, AluCfg, MulCfg, DivCfg, FenceCfg, BkuCfg, VSetRvfWvfCfg, VSetRiWvfCfg, VSetRiWiCfg,
+    JmpCfg, BrhCfg, I2fCfg, I2vCfg, CsrCfg, AluCfg, MulCfg, DivCfg, FenceCfg, BkuCfg, VSetRvfWvfCfg, VSetRiWvfCfg, VSetRiWiCfg,
     FmacCfg, F2iCfg, F2fCfg, FDivSqrtCfg, LduCfg, StaCfg, StdCfg, MouCfg, MoudCfg, VialuCfg, VipuCfg, VlduCfg,
     VfaluCfg, VfmaCfg
   )

--- a/src/main/scala/xiangshan/backend/fu/FuType.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuType.scala
@@ -29,6 +29,7 @@ object FuType extends OHEnumeration {
   val jmp = addType(name = "jmp")
   val brh = addType(name = "brh")
   val i2f = addType(name = "i2f")
+  val i2v = addType(name = "i2v")
   val csr = addType(name = "csr")
   val alu = addType(name = "alu")
   val mul = addType(name = "mul")
@@ -64,7 +65,7 @@ object FuType extends OHEnumeration {
   val vldu = addType(name = "vldu")
   val vstu = addType(name = "vstu")
 
-  val intArithAll = Seq(jmp, brh, i2f, csr, alu, mul, div, fence, bku)
+  val intArithAll = Seq(jmp, brh, i2f, i2v, csr, alu, mul, div, fence, bku)
   val fpArithAll = Seq(fmac, fmisc, fDivSqrt)
   val scalaMemAll = Seq(ldu, stu, mou)
   val vecOPI = Seq(vipu, vialuF, vppu, vimac)
@@ -133,6 +134,7 @@ object FuType extends OHEnumeration {
     jmp -> "jmp",
     brh -> "brh",
     i2f -> "int_to_float",
+    i2v -> "int_to_vector",
     csr -> "csr",
     alu -> "alu",
     mul -> "mul",

--- a/src/main/scala/xiangshan/backend/fu/fpu/IntToVec.scala
+++ b/src/main/scala/xiangshan/backend/fu/fpu/IntToVec.scala
@@ -1,0 +1,76 @@
+/***************************************************************************************
+* Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2021 Peng Cheng Laboratory
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+// See LICENSE.Berkeley for license details.
+// See LICENSE.SiFive for license details.
+
+package xiangshan.backend.fu.fpu
+
+import org.chipsalliance.cde.config.Parameters
+import chisel3._
+import chisel3.util._
+import utility.{SignExt, ZeroExt}
+import xiangshan.backend.fu.{FuConfig, FuncUnit, PipedFuncUnit}
+import xiangshan.backend.fu.vector.Bundles.VSew
+
+// class IntToVecDataModule(vlen: Int)(implicit p: Parameters) extends FPUDataModule {
+//   protected val in = io.in.bits
+//   private val scalaData = in.data.src(0)
+//   private val vsew = in.ctrl.fuOpType
+
+//   private val vecE8Data  = Wire(Vec(vlen /  8, UInt( 8.W)))
+//   private val vecE16Data = Wire(Vec(vlen / 16, UInt(16.W)))
+//   private val vecE32Data = Wire(Vec(vlen / 32, UInt(32.W)))
+//   private val vecE64Data = Wire(Vec(vlen / 64, UInt(64.W)))
+
+//   vecE8Data   := VecInit(Seq.fill(vlen /  8)(scalaData( 7, 0)))
+//   vecE16Data  := VecInit(Seq.fill(vlen / 16)(scalaData(15, 0)))
+//   vecE32Data  := VecInit(Seq.fill(vlen / 32)(scalaData(31, 0)))
+//   vecE64Data  := VecInit(Seq.fill(vlen / 64)(scalaData(63, 0)))
+
+//   io.out.data := Mux1H(Seq(
+//     (vsew === VSew.e8)  -> vecE8Data.asUInt,
+//     (vsew === VSew.e16) -> vecE16Data.asUInt,
+//     (vsew === VSew.e32) -> vecE32Data.asUInt,
+//     (vsew === VSew.e64) -> vecE64Data.asUInt,
+//   ))
+// }
+
+class IntToVec(cfg: FuConfig)(implicit p: Parameters) extends PipedFuncUnit(cfg) {
+  protected val in = io.in.bits
+  protected val out = io.out.bits
+
+  private val scalaData = in.data.src(0)
+  private val vsew = in.ctrl.fuOpType
+  private val dataWidth = cfg.dataBits
+
+  private val vecE8Data  = Wire(Vec(dataWidth /  8, UInt( 8.W)))
+  private val vecE16Data = Wire(Vec(dataWidth / 16, UInt(16.W)))
+  private val vecE32Data = Wire(Vec(dataWidth / 32, UInt(32.W)))
+  private val vecE64Data = Wire(Vec(dataWidth / 64, UInt(64.W)))
+
+  vecE8Data   := VecInit(Seq.fill(dataWidth /  8)(scalaData( 7, 0)))
+  vecE16Data  := VecInit(Seq.fill(dataWidth / 16)(scalaData(15, 0)))
+  vecE32Data  := VecInit(Seq.fill(dataWidth / 32)(scalaData(31, 0)))
+  vecE64Data  := VecInit(Seq.fill(dataWidth  / 64)(scalaData(63, 0)))
+
+  out.res.data := Mux1H(Seq(
+    (vsew === VSew.e8)  -> vecE8Data.asUInt,
+    (vsew === VSew.e16) -> vecE16Data.asUInt,
+    (vsew === VSew.e32) -> vecE32Data.asUInt,
+    (vsew === VSew.e64) -> vecE64Data.asUInt,
+  ))
+}

--- a/src/main/scala/xiangshan/backend/fu/vector/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/Bundles.scala
@@ -144,7 +144,7 @@ object Bundles {
     def OPMVX : UInt = "b110".U(width.W)
     def OPCFG : UInt = "b111".U(width.W)
     def needScalaSrc(category: UInt) : Bool = {
-      Seq(OPIVI, OPIVX, OPFVF, OPMVX).map(_ === category).reduce(_ || _)
+      Seq(OPIVI, OPFVF).map(_ === category).reduce(_ || _)
     }
     def permImmTruncate(category: UInt) : Bool = {
       Seq(OPIVI).map(_ === category).reduce(_ || _)

--- a/src/main/scala/xiangshan/backend/rename/BusyTable.scala
+++ b/src/main/scala/xiangshan/backend/rename/BusyTable.scala
@@ -68,13 +68,13 @@ class BusyTable(numReadPorts: Int, numWritePorts: Int, numPhyPregs: Int, pregWB:
   val wbMask = reqVecToMask(io.wbPregs)
   val allocMask = reqVecToMask(io.allocPregs)
   val wakeUpMask = pregWB match {
-    case _: IntWB => ParallelOR(wakeUpFilterLS.map(x => Mux(x.valid && x.bits.rfWen && !x.bits.loadDependency.asUInt.orR, UIntToOH(x.bits.pdest), 0.U)).toSeq) //TODO: dont implement "load -> wakeUp other -> wakeUp BusyTable" now
-    case _: VfWB => ParallelOR(wakeUpFilterLS.map(x => Mux(x.valid && (x.bits.fpWen || x.bits.vecWen) && !x.bits.loadDependency.asUInt.orR, UIntToOH(x.bits.pdest), 0.U)).toSeq)
+    case _: IntWB => wakeUpFilterLS.map(x => Mux(x.valid && x.bits.rfWen && !x.bits.loadDependency.asUInt.orR, UIntToOH(x.bits.pdest), 0.U)).toSeq.fold(0.U)(_ | _) //TODO: dont implement "load -> wakeUp other -> wakeUp BusyTable" now
+    case _: VfWB => wakeUpFilterLS.map(x => Mux(x.valid && (x.bits.fpWen || x.bits.vecWen) && !x.bits.loadDependency.asUInt.orR, UIntToOH(x.bits.pdest), 0.U)).toSeq.fold(0.U)(_ | _)
     case _: NoWB => throw new IllegalArgumentException("NoWB is not permitted")
   }
   val cancelMask = pregWB match {
-    case _: IntWB => ParallelOR(io.cancel.map(x => Mux(x.valid && x.bits.rfWen, UIntToOH(x.bits.pdest), 0.U)))
-    case _: VfWB => ParallelOR(io.cancel.map(x => Mux(x.valid && (x.bits.fpWen || x.bits.vecWen), UIntToOH(x.bits.pdest), 0.U)))
+    case _: IntWB => io.cancel.map(x => Mux(x.valid && x.bits.rfWen, UIntToOH(x.bits.pdest), 0.U)).fold(0.U)(_ | _)
+    case _: VfWB => io.cancel.map(x => Mux(x.valid && (x.bits.fpWen || x.bits.vecWen), UIntToOH(x.bits.pdest), 0.U)).fold(0.U)(_ | _)
     case _: NoWB => throw new IllegalArgumentException("NoWB is not permitted")
   }
 

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -598,6 +598,7 @@ package object xiangshan {
     def DIR              = "b010001".U // dirty: vset
     def VEC_VVV          = "b010010".U // VEC_VVV
     def VEC_VXV          = "b010011".U // VEC_VXV
+    def VEC_VIV          = "b000011".U // VEC_VXV
     def VEC_0XV          = "b010100".U // VEC_0XV
     def VEC_VVW          = "b010101".U // VEC_VVW
     def VEC_WVW          = "b010110".U // VEC_WVW


### PR DESCRIPTION
* Depend on the vector instruction whether can be unblocked/blocked on pipeline, use different three issuequeue
* Use i2vector module for opivv and opmvv instructions