### PR TITLE
Move one buffer in L1I - L2 path from L2Top to MemBlock

### DIFF
--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -80,7 +80,6 @@ class L2Top()(implicit p: Parameters) extends LazyModule
   val l1d_logger = TLLogger(s"L2_L1D_${coreParams.HartId}", enbale_tllog)
   val l1i_logger = TLLogger(s"L2_L1I_${coreParams.HartId}", enbale_tllog)
   val ptw_logger = TLLogger(s"L2_PTW_${coreParams.HartId}", enbale_tllog)
-  val l1i_to_l2_buffer = LazyModule(new TLBuffer)
   val ptw_to_l2_buffer = LazyModule(new TLBuffer)
   val i_mmio_buffer = LazyModule(new TLBuffer)
 

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -56,7 +56,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
       core.memBlock.l1d_to_l2_buffer.node := core.memBlock.dcache.clientNode
   }
 
-  l2top.misc_l2_pmu := l2top.l1i_logger := l2top.l1i_to_l2_buffer.node := core.memBlock.frontendBridge.icache_node
+  l2top.misc_l2_pmu := l2top.l1i_logger := core.memBlock.frontendBridge.icache_node
   if (!coreParams.softPTW) {
     l2top.misc_l2_pmu := l2top.ptw_logger := l2top.ptw_to_l2_buffer.node := core.memBlock.ptw_to_l2_buffer.node
   }


### PR DESCRIPTION
Now **Triple buffer in PTW - L2** (two in MemBlock, one in L2Top below xbar)
can reduce violation to less than 30ps