### PR TITLE
LSQ: fix uncache req logic

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -202,7 +202,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
 
   switch(pendingstate){
     is(s_idle){
-      when(io.uncache.req.fire && !io.uncacheOutstanding){
+      when(io.uncache.req.fire){
         pendingstate := Mux(loadQueue.io.uncache.req.valid, s_load,
                           Mux(io.uncacheOutstanding, s_idle, s_store))
       }


### PR DESCRIPTION
Bug descriptions:
When an uncache load and _enableOutstanding_ is true (default false), the uncache fsm will transition to an incorrect state.

Bug fix:
remove _enableOutstanding_ from the condition