### PR TITLE
LQ: Fixed the bug that the load did not detect RAR violation

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
@@ -219,9 +219,9 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
   val lastAllocIndexOH = lastAllocIndex.map(UIntToOH(_))
   val lastReleasePAddrMatch = VecInit((0 until LoadPipelineWidth).map(i => {
     (bypassPAddr(i)(PAddrBits-1, DCacheLineOffset) === release1Cycle.bits.paddr(PAddrBits-1, DCacheLineOffset))
-  })).asUInt.orR
+  }))
   (0 until LoadQueueRARSize).map(i => {
-    val bypassMatch = VecInit((0 until LoadPipelineWidth).map(j => lastAllocIndexOH(j)(i))).asUInt.orR && lastReleasePAddrMatch
+    val bypassMatch = VecInit((0 until LoadPipelineWidth).map(j => lastCanAccept(j) && lastAllocIndexOH(j)(i) && lastReleasePAddrMatch(j))).asUInt.orR
     when (RegNext((paddrModule.io.releaseMmask.takeRight(1)(0)(i) || bypassMatch) && allocated(i) && release1Cycle.valid)) {
       // Note: if a load has missed in dcache and is waiting for refill in load queue,
       // its released flag still needs to be set as true if addr matches.

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
@@ -72,6 +72,7 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
   ))
   paddrModule.io := DontCare
   val released = RegInit(VecInit(List.fill(LoadQueueRARSize)(false.B)))
+  val bypassPAddr = Reg(Vec(LoadPipelineWidth, UInt(PAddrBits.W)))
 
   // freeliset: store valid entries index.
   // +---+---+--------------+-----+-----+
@@ -134,6 +135,7 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
       paddrModule.io.wen(w) := true.B
       paddrModule.io.waddr(w) := enqIndex
       paddrModule.io.wdata(w) := enq.bits.paddr
+      bypassPAddr(w) := enq.bits.paddr
 
       //  Fill info
       uop(enqIndex) := enq.bits.uop
@@ -214,8 +216,13 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
     paddrModule.io.releaseMdata.takeRight(1)(0) := release1Cycle.bits.paddr
   }
 
+  val lastAllocIndexOH = lastAllocIndex.map(UIntToOH(_))
+  val lastReleasePAddrMatch = VecInit((0 until LoadPipelineWidth).map(i => {
+    (bypassPAddr(i)(PAddrBits-1, DCacheLineOffset) === release1Cycle.bits.paddr(PAddrBits-1, DCacheLineOffset))
+  })).asUInt.orR
   (0 until LoadQueueRARSize).map(i => {
-    when (RegNext(paddrModule.io.releaseMmask.takeRight(1)(0)(i) && allocated(i) && release1Cycle.valid)) {
+    val bypassMatch = VecInit((0 until LoadPipelineWidth).map(j => lastAllocIndexOH(j)(i))).asUInt.orR && lastReleasePAddrMatch
+    when (RegNext((paddrModule.io.releaseMmask.takeRight(1)(0)(i) || bypassMatch) && allocated(i) && release1Cycle.valid)) {
       // Note: if a load has missed in dcache and is waiting for refill in load queue,
       // its released flag still needs to be set as true if addr matches.
       released(i) := true.B


### PR DESCRIPTION
Bugs description:
LoadQueueRAR requires 2 cycles to store paddr，when a probe request comes in the previous cycle，_released_ will not be updated in correctly.

Bugs fix:
Add a bypass register, store paddr temporary.