### PR TITLE
ICache: fix cacheop waymask width

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -297,7 +297,7 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray
         tagArrays(i).io.w.req.bits.apply(
           data = io.cacheOp.req.bits.write_tag_low,
           setIdx = io.cacheOp.req.bits.index,
-          waymask = UIntToOH(io.cacheOp.req.bits.wayNum(4, 0))
+          waymask = UIntToOH(io.cacheOp.req.bits.wayNum(log2Ceil(nWays) - 1, 0))
         )
       }
       cacheOpShouldResp := true.B

--- a/src/main/scala/xiangshan/frontend/icache/ICacheBankedArray.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheBankedArray.scala
@@ -276,7 +276,7 @@ class ICacheMetaArrayNoBanked()(implicit p: Parameters) extends ICacheArray
       tagArray.io.w.req.bits.apply(
         data = io.cacheOp.req.bits.write_tag_low,
         setIdx = io.cacheOp.req.bits.index,
-        waymask = UIntToOH(io.cacheOp.req.bits.wayNum(4, 0))
+        waymask = UIntToOH(io.cacheOp.req.bits.wayNum(log2Ceil(nWays) - 1, 0))
       )
       cacheOpShouldResp := true.B
     }


### PR DESCRIPTION
CacheOp is deprecated, but this fix is required to make the compiler happy.

The related PR is the change in SRAMTemplate OpenXiangShan/Utility#50 
https://github.com/OpenXiangShan/Utility/pull/50/files#diff-a473eaad7802dde422ddef37a671d197b04af03e62f0c9c37a79d4c2daf24637R63-R64