### PR TITLE
issueQueue: fix vld cannot clear the validReg siganl after issued

### DIFF
--- a/src/main/scala/xiangshan/backend/datapath/DataPath.scala
+++ b/src/main/scala/xiangshan/backend/datapath/DataPath.scala
@@ -370,7 +370,7 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
           //            fuBusy      ->IQ entry issued set false, then re-issue
           // Only hyu, lda and sta are fuUncertain at OG1 stage
           og1resp.bits.resp             := Mux(!og1FailedVec2(iqIdx)(iuIdx),
-            if (toIU.issueQueueParams.isMemAddrIQ) RespType.uncertain else RespType.success,
+            if (toIU.issueQueueParams match { case x => x.isMemAddrIQ && !x.isVecMemIQ }) RespType.uncertain else RespType.success,
             RespType.block
           )
           og1resp.bits.fuType           := s1_toExuData(iqIdx)(iuIdx).fuType

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -991,8 +991,10 @@ class IssueQueueVecMemImp(override val wrapper: IssueQueue)(implicit p: Paramete
   val uopIdxVec = entries.io.uopIdx.get
   val allEntryOldestOH = selectOldUop(robIdxVec, uopIdxVec, validVec)
 
-  finalDeqSelValidVec.head := (allEntryOldestOH.asUInt & canIssueVec.asUInt).orR
-  finalDeqSelOHVec.head := allEntryOldestOH.asUInt & canIssueVec.asUInt
+  deqSelValidVec.head := (allEntryOldestOH.asUInt & canIssueVec.asUInt).orR
+  deqSelOHVec.head := allEntryOldestOH.asUInt & canIssueVec.asUInt
+  finalDeqSelValidVec.head := (allEntryOldestOH.asUInt & canIssueVec.asUInt).orR && deqBeforeDly.head.ready
+  finalDeqSelOHVec.head := deqSelOHVec.head
 
   s0_enqBits.foreach{ x =>
     x.srcType(3) := SrcType.vp // v0: mask src


### PR DESCRIPTION
* fix resp signal for vector load/store
* hold the canIssueVec when vector load/store instruction is not the oldest uop