### PR TITLE
fix a bug: first uop of vrsub donot need reverse; delete uuid

### DIFF
--- a/src/main/scala/xiangshan/.uuid
+++ b/src/main/scala/xiangshan/.uuid
@@ -1,1 +1,0 @@
-6e38f88a-bdc4-4a21-bfeb-e9f997b49a9f

--- a/src/main/scala/xiangshan/.uuid
+++ b/src/main/scala/xiangshan/.uuid
@@ -1,0 +1,1 @@
+6e38f88a-bdc4-4a21-bfeb-e9f997b49a9f

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -142,6 +142,10 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   io.out.zipWithIndex.foreach { case (inst, i) =>
     inst.valid := finalDecodedInstValid(i) && !(hasVectorInst && io.isResumeVType)
     inst.bits := finalDecodedInst(i)
+    inst.bits.lsrc(0) := Mux(finalDecodedInst(i).vpu.isReverse, finalDecodedInst(i).lsrc(1), finalDecodedInst(i).lsrc(0))
+    inst.bits.lsrc(1) := Mux(finalDecodedInst(i).vpu.isReverse, finalDecodedInst(i).lsrc(0), finalDecodedInst(i).lsrc(1))
+    inst.bits.srcType(0) := Mux(finalDecodedInst(i).vpu.isReverse, finalDecodedInst(i).srcType(1), finalDecodedInst(i).srcType(0))
+    inst.bits.srcType(1) := Mux(finalDecodedInst(i).vpu.isReverse, finalDecodedInst(i).srcType(0), finalDecodedInst(i).srcType(1))
   }
 
   for (i <- 0 until DecodeWidth) {

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
@@ -260,6 +260,7 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).fuType := FuType.f2v.U
       csBundle(0).fuOpType := Cat(IF2VectorType.fDup2Vec(2, 0), vsewReg)
       csBundle(0).vecWen := true.B
+      csBundle(0).vpu.isReverse := false.B
       /*
       LMUL
        */

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
@@ -352,6 +352,7 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
       csBundle(0).fuType := FuType.i2v.U
       csBundle(0).fuOpType := Cat(Mux(src1IsImm, IF2VectorType.immDup2Vec(2, 0), IF2VectorType.iDup2Vec(2, 0)), vsewReg)
       csBundle(0).vecWen := true.B
+      csBundle(0).vpu.isReverse := false.B
       /*
       LMUL
        */

--- a/src/main/scala/xiangshan/backend/fu/vector/VecNonPipedFuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/VecNonPipedFuncUnit.scala
@@ -16,8 +16,8 @@ class VecNonPipedFuncUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUni
   private val src0 = inData.src(0)
   private val src1 = WireInit(inData.src(1)) // vs2 only
 
-  protected val vs2 = Mux(isReverse, src0, src1)
-  protected val vs1 = Mux(isReverse, src1, src0)
+  protected val vs2 = src1
+  protected val vs1 = src0
   protected val oldVd = inData.src(2)
 
   protected val outCtrl     = DataHoldBypass(io.in.bits.ctrl, io.in.fire)

--- a/src/main/scala/xiangshan/backend/fu/vector/VecPipedFuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/VecPipedFuncUnit.scala
@@ -72,8 +72,8 @@ class VecPipedFuncUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(c
     )
     src1 := Mux(vecCtrl.fpu.isFoldTo1_2 || vecCtrl.fpu.isFoldTo1_4 || vecCtrl.fpu.isFoldTo1_8, vs2Fold, inData.src(1))
   }
-  protected val vs2 = Mux(isReverse, src0, src1)
-  protected val vs1 = Mux(isReverse, src1, src0)
+  protected val vs2 = src1
+  protected val vs1 = src0
   protected val oldVd = inData.src(2)
 
   protected val outCtrl     = ctrlVec.last


### PR DESCRIPTION
fix a bug:
    first uop of vrsub donot need reverse: add isreverse = false in DecodeUnitComp
delete uuid