### PR TITLE
build: fix vcs simulation workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ emu-run: emu
 	$(MAKE) -C ./difftest emu-run SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES)
 
 # vcs simulation
-simv:
+simv: sim-verilog
 	$(MAKE) -C ./difftest simv SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES)
 
 # palladium simulation

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -260,6 +260,8 @@ class WithNKBL2
         echoField = Seq(huancun.DirtyField()),
         prefetch = Some(coupledL2.prefetch.PrefetchReceiverParams()),
         enablePerf = !site(DebugOptionsKey).FPGAPlatform,
+        enableRollingDB = site(DebugOptionsKey).EnableRollingDB,
+        enableMonitor = site(DebugOptionsKey).AlwaysBasicDB,
         elaboratedTopDown = !site(DebugOptionsKey).FPGAPlatform
       )),
       L2NBanks = banks


### PR DESCRIPTION
To run vcs simulation, you need to:

1. change `AlwaysBasicDB` in `Parameters.scala` to `false`

2. `make simv WITH_CONSTANTIN=0 WITH_CHISELDB=0 CONSIDER_FSDB=1 MFC=1`

3. `./build/simv +workload=<workload> +diff=<ref-so>`