### PR TITLE
CSR: initialize pmpaddr with 0 for difftest

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -431,6 +431,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   val pma = Wire(Vec(NumPMA, new PMPEntry())) // just used for method parameter
   val pmpMapping = pmp_gen_mapping(pmp_init, NumPMP, PmpcfgBase, PmpaddrBase, pmp)
   val pmaMapping = pmp_gen_mapping(pma_init, NumPMA, PmacfgBase, PmaaddrBase, pma)
+  // !WARNNING: pmp and pma CSRs are not checked in difftest.
 
   // Superviser-Level CSRs
 

--- a/src/main/scala/xiangshan/backend/fu/PMP.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMP.scala
@@ -288,10 +288,13 @@ class PMPEntry(implicit p: Parameters) extends PMPBase with PMPMatchMethod {
 trait PMPMethod extends PMPConst {
   def pmp_init() : (Vec[UInt], Vec[UInt], Vec[UInt])= {
     val cfg = WireInit(0.U.asTypeOf(Vec(NumPMP/8, UInt(PMXLEN.W))))
-    val addr = Wire(Vec(NumPMP, UInt((PMPAddrBits-PMPOffBits).W)))
-    val mask = Wire(Vec(NumPMP, UInt(PMPAddrBits.W)))
-    addr := DontCare
-    mask := DontCare
+    // val addr = Wire(Vec(NumPMP, UInt((PMPAddrBits-PMPOffBits).W)))
+    // val mask = Wire(Vec(NumPMP, UInt(PMPAddrBits.W)))
+    // addr := DontCare
+    // mask := DontCare
+    // INFO: these CSRs could be uninitialized, but for difftesting with NEMU, we opt to initialize them.
+    val addr = WireInit(0.U.asTypeOf(Vec(NumPMP, UInt((PMPAddrBits-PMPOffBits).W))))
+    val mask = WireInit(0.U.asTypeOf(Vec(NumPMP, UInt(PMPAddrBits.W))))
     (cfg, addr, mask)
   }
 


### PR DESCRIPTION
pmpaddr CSRs could be uninitialized, but for difftesting with NEMU, we opt to initialize them. However, pmp and pma CSRs are not checked in difftest, which should be fixed in feature.

This PR is a part of migrating the Linux-hello test in CI from riscv-pk to OpenSBI.