### PR TITLE
CSR: add menvcfg and senvcfg CSR without function

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -426,6 +426,8 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   val mideleg = RegInit(UInt(XLEN.W), 0.U)
   val mscratch = RegInit(UInt(XLEN.W), 0.U)
 
+  val menvcfg = RegInit(UInt(XLEN.W), 0.U)  // !WARNING: there is no logic about this CSR.
+
   // PMP Mapping
   val pmp = Wire(Vec(NumPMP, new PMPEntry())) // just used for method parameter
   val pma = Wire(Vec(NumPMA, new PMPEntry())) // just used for method parameter
@@ -464,6 +466,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   val stval = Reg(UInt(XLEN.W))
   val sscratch = RegInit(UInt(XLEN.W), 0.U)
   val scounteren = RegInit(UInt(XLEN.W), 0.U)
+  val senvcfg = RegInit(UInt(XLEN.W), 0.U)  // !WARNING: there is no logic about this CSR.
 
   // sbpctl
   // Bits 0-7: {LOOP, RAS, SC, TAGE, BIM, BTB, uBTB}
@@ -692,6 +695,9 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     MaskedRegMap(Stvec, stvec, stvecMask, MaskedRegMap.NoSideEffect, stvecMask),
     MaskedRegMap(Scounteren, scounteren),
 
+    //--- Supervisor Configuration ---
+    MaskedRegMap(Senvcfg, senvcfg),
+
     //--- Supervisor Trap Handling ---
     MaskedRegMap(Sscratch, sscratch),
     MaskedRegMap(Sepc, sepc, sepcMask, MaskedRegMap.NoSideEffect, sepcMask),
@@ -733,6 +739,9 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
     MaskedRegMap(Mcause, mcause),
     MaskedRegMap(Mtval, mtval),
     MaskedRegMap(Mip, mip.asUInt, 0.U(XLEN.W), MaskedRegMap.Unwritable),
+
+    //--- Machine Configuration ---
+    MaskedRegMap(Menvcfg, menvcfg),
 
     //--- Trigger ---
     MaskedRegMap(Tselect, tselectPhy, WritableMask, WriteTselect),

--- a/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
@@ -55,6 +55,9 @@ trait HasCSRConst {
   val Stvec         = 0x105
   val Scounteren    = 0x106
 
+  // Supervisor Configuration
+  val Senvcfg       = 0x10A
+
   // Supervisor Trap Handling
   val Sscratch      = 0x140
   val Sepc          = 0x141
@@ -100,6 +103,9 @@ trait HasCSRConst {
   val Mcause        = 0x342
   val Mtval         = 0x343
   val Mip           = 0x344
+
+  // Machine Configuration
+  val Menvcfg       = 0x30A
 
   // Machine Memory Protection
   // TBD


### PR DESCRIPTION
The CSRs menvcfg and senvcfg are required by ISA and openSBI. To run openSBI, we merely include them without any functionality. The functionality around these should be added in the feature.

This PR is a part of migrating the Linux-hello test in CI from riscv-pk to OpenSBI.