### PR TITLE
CSR: Correct the behavior of `ebreak` when hart not in debug mode

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -541,7 +541,7 @@ class CustomCSRCtrlIO(implicit p: Parameters) extends XSBundle {
 
   // distribute csr write signal
   val distribute_csr = new DistributedCSRIO()
-
+  // TODO: move it to a new bundle, since single step is not a custom control signal
   val singlestep = Output(Bool())
   val frontend_trigger = new FrontendTdataDistributeIO()
   val mem_trigger = new MemTdataDistributeIO()

--- a/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
@@ -188,7 +188,7 @@ trait HasCSRConst {
   // Debug Mode Registers
   val Dcsr          = 0x7B0
   val Dpc           = 0x7B1
-  val Dscratch      = 0x7B2
+  val Dscratch0     = 0x7B2
   val Dscratch1     = 0x7B3
 
   def privEcall  = 0x000.U


### PR DESCRIPTION
* `ebreak` instruction will raise breakpoint exception when hart not in debug mode.
* Use the signals renamed with "has*" to specify the traps(exceptions/interrupts) are to be handled which were transported from ROB, while the signals renamed with "raise*" are being transported to ROB.

This commit is cherry-pick from nanhu and new-backend.

This PR is a part of migrating the Linux-hello test in CI from riscv-pk to OpenSBI.