### PR TITLE
CI: switch to opensbi for linux-hello & switch to mfc for MC

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -41,7 +41,7 @@ jobs:
             --threads 4 --config MinimalConfig --release
       - name: run MinimalConfig - Linux
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 4 --numa --ci linux-hello 2> perf.log
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 4 --numa --ci linux-hello-opensbi 2> perf.log
           cat perf.log | sort
   emu-basics:
     runs-on: bosc
@@ -93,7 +93,7 @@ jobs:
           cat perf.log | sort | tee $PERF_HOME/coremark.log
       - name: System Test - Linux
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 8 --numa --ci linux-hello 2> perf.log
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 8 --numa --ci linux-hello-opensbi 2> perf.log
           cat perf.log | sort | tee $PERF_HOME/linux.log
       - name: Floating-point Test - povray
         run: |
@@ -199,7 +199,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --diff ./ready-to-run/riscv64-nemu-interpreter-dual-so --ci mc-tests 2> /dev/zero
       - name: SMP Linux
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --diff ./ready-to-run/riscv64-nemu-interpreter-dual-so --ci linux-hello-smp 2> /dev/zero
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --diff ./ready-to-run/riscv64-nemu-interpreter-dual-so --ci linux-hello-smp-opensbi 2> /dev/zero
   # simv-basics:
   #   runs-on: bosc
   #   continue-on-error: false
@@ -239,4 +239,4 @@ jobs:
   #         ssh -tt 172.28.10.101 "python3 `echo $GITHUB_WORKSPACE`/scripts/xiangshan.py --ci-vcs coremark --am=/nfs/home/share/ci-workloads/nexus-am/ --timeout 1800" 2> /dev/zero
   #     - name: System Test - Linux
   #       run: |
-  #         ssh -tt 172.28.10.101 "python3 `echo $GITHUB_WORKSPACE`/scripts/xiangshan.py --ci-vcs linux-hello --timeout 7200" 2> /dev/zero
+  #         ssh -tt 172.28.10.101 "python3 `echo $GITHUB_WORKSPACE`/scripts/xiangshan.py --ci-vcs linux-hello-opensbi --timeout 7200" 2> /dev/zero

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -193,7 +193,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --num-cores 2 \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 \
-            --with-dramsim3 --threads 16
+            --with-dramsim3 --threads 16 --mfc
       - name: MC Test
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --diff ./ready-to-run/riscv64-nemu-interpreter-dual-so --ci mc-tests 2> /dev/zero

--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -359,6 +359,8 @@ class XiangShan(object):
         workloads = {
             "linux-hello": "bbl.bin",
             "linux-hello-smp": "bbl.bin",
+            "linux-hello-opensbi": "fw_payload.bin",
+            "linux-hello-smp-opensbi": "fw_payload.bin",
             "povray": "_700480000000_.gz",
             "mcf": "_17520000000_.gz",
             "xalancbmk": "_266100000000_.gz",


### PR DESCRIPTION
We have discoverd that the older version of riscv-pk crashes on harts that support H-ext due to issues with checking mideleg. Although this issue was fixed back in 2021 (commit 4ae5a88), considering that riscv-pk has been replaced by opensbi, we deciede to gradually transition our testing workloads to utilize opensbi instead.

Using MFC for "EMU - MC" test may decrease the total ci time.

This PR might be the last part of migrating the Linux-hello test in CI from riscv-pk to OpenSBI.