### PR TITLE
soc: remove extra assignment to rtcTick

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -320,12 +320,6 @@ class SoCMisc()(implicit p: Parameters) extends BaseSoC
     rtcTick := Cat(rtcTick(1, 0), rtc_clock)
     clint.module.io.rtcTick := rtcTick(1) && !rtcTick(2)
 
-    val freq = 100
-    val cnt = RegInit(freq.U)
-    val tick = cnt === 0.U
-    cnt := Mux(tick, freq.U, cnt - 1.U)
-    clint.module.io.rtcTick := tick
-
     val pll_ctrl_regs = Seq.fill(6){ RegInit(0.U(32.W)) }
     val pll_lock = RegNext(next = pll0_lock, init = false.B)
 


### PR DESCRIPTION
`clint.module.io.rtcTick` is assigned twice in `SoCMiscImp`, it should be driven using `rtc_clock` (in #1565), remove the extra fix frequency assignment.