### PR TITLE
Add the mill wrapper (millw)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "coupledL2"]
 	path = coupledL2
 	url = https://github.com/OpenXiangShan/coupledL2
+[submodule "tools/millw"]
+	path = tools/millw
+	url = https://github.com/lefou/millw.git

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ IMAGE  ?= temp
 CONFIG ?= DefaultConfig
 NUM_CORES ?= 1
 MFC ?= 0
+MILL ?= ./millw
 
 # common chisel args
 ifeq ($(MFC),1)
@@ -110,11 +111,11 @@ endif
 .DEFAULT_GOAL = verilog
 
 help:
-	mill -i xiangshan[$(CHISEL_VERSION)].runMain $(FPGATOP) --help
+	$(MILL) -i xiangshan[$(CHISEL_VERSION)].runMain $(FPGATOP) --help
 
 $(TOP_V): $(SCALA_FILE)
 	mkdir -p $(@D)
-	$(TIME_CMD) mill -i xiangshan[$(CHISEL_VERSION)].runMain $(FPGATOP)   \
+	$(TIME_CMD) $(MILL) -i xiangshan[$(CHISEL_VERSION)].runMain $(FPGATOP)   \
 		-td $(@D) --config $(CONFIG) $(FPGA_MEM_ARGS)                    \
 		--num-cores $(NUM_CORES) $(RELEASE_ARGS)
 ifeq ($(MFC),1)
@@ -136,7 +137,7 @@ $(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
 	mkdir -p $(@D)
 	@echo "\n[mill] Generating Verilog files..." > $(TIMELOG)
 	@date -R | tee -a $(TIMELOG)
-	$(TIME_CMD) mill -i xiangshan[$(CHISEL_VERSION)].test.runMain $(SIMTOP)    \
+	$(TIME_CMD) $(MILL) -i xiangshan[$(CHISEL_VERSION)].test.runMain $(SIMTOP)    \
 		-td $(@D) --config $(CONFIG) $(SIM_MEM_ARGS)                          \
 		--num-cores $(NUM_CORES) $(SIM_ARGS)
 ifeq ($(MFC),1)
@@ -175,10 +176,10 @@ bump:
 	git submodule foreach "git fetch origin&&git checkout master&&git reset --hard origin/master"
 
 bsp:
-	mill -i mill.bsp.BSP/install
+	$(MILL) -i mill.bsp.BSP/install
 
 idea:
-	mill -i mill.scalalib.GenIdea/idea
+	$(MILL) -i mill.scalalib.GenIdea/idea
 
 # verilator simulation
 emu: sim-verilog

--- a/Makefile.test
+++ b/Makefile.test
@@ -1,12 +1,12 @@
 # only generate a small module: example
 verilog-decode:
-	mill -i XiangShan.test.runMain xiangshan.DecodeMain -td build --output-file DecodeUnit.v
+	$(MILL) -i XiangShan.test.runMain xiangshan.DecodeMain -td build --output-file DecodeUnit.v
 
 # chiseltest
 # autorun all the chiselTest case
 test:
-	mill -i XiangShan.test.test
+	$(MILL) -i XiangShan.test.test
 
 # only run DecodeUnitTest
 test-DecodeUnit:
-	mill -i XiangShan.test.testOnly xiangshan.DecodeUnitTest
+	$(MILL) -i XiangShan.test.testOnly xiangshan.DecodeUnitTest

--- a/millw
+++ b/millw
@@ -1,0 +1,1 @@
+tools/millw/millw


### PR DESCRIPTION
To make the project easier to build add the mill wrapper (millw) submodule and make the mill executable selectable via the MILL Makefile variable. Furthermore, set ./millw as the default for the MILL Makefile variable, so that the wrapper is used as default.