### PR TITLE
device(uartlite): fix wrong stat register

### DIFF
--- a/src/main/scala/device/AXI4UART.scala
+++ b/src/main/scala/device/AXI4UART.scala
@@ -33,7 +33,7 @@ class AXI4UART
   override lazy val module = new AXI4SlaveModuleImp[UARTIO](this){
     val rxfifo = RegInit(0.U(32.W))
     val txfifo = Reg(UInt(32.W))
-    val stat = RegInit(1.U(32.W))
+    val stat = RegInit(0.U(32.W))
     val ctrl = RegInit(0.U(32.W))
 
     io.extra.get.out.valid := (waddr(3,0) === 4.U && in.w.fire)


### PR DESCRIPTION
At present, there will be no input from uart. Thus, the "Rx FIFO Valid Data bit" of stat reg should be 0 rather than 1. Also, hardware side cannot get any valid indication from software side, this bit could only be 1 or 0 staticly. 

This solves the stuck issuse of xvisor boot-up.
This is just a temporary solution. uart module for emu should be refactored. 
