### PR TITLE
L1Prefetch: fix x problem in l1 prefetch (#2862)

### DIFF
--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -103,8 +103,11 @@ trait HasTrainFilterHelper extends HasCircularQueuePtrHelper {
     }else if(source.length == 2) {
       val source_v = source.map(_.valid)
       val res = Wire(source.cloneType)
-      // source 1 is older than source 0
-      val source_1_older = isBefore(source(1).bits.uop.robIdx, source(0).bits.uop.robIdx)
+      // source 1 is older than source 0 (only when source0/1 are both valid)
+      val source_1_older = Mux(Cat(source_v).andR,
+        isBefore(source(1).bits.uop.robIdx, source(0).bits.uop.robIdx),
+        false.B
+      )
       when(source_1_older) {
         res(0) := source(1)
         res(1) := source(0)


### PR DESCRIPTION
Since it is not controlled by the valid signal, source_1_older may become the x state, causing all prefetched training signals to become the x state.