### PR TITLE
LSU, Loadunit: Set all data to 0 when exception (#2888)

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1198,8 +1198,9 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   // FIXME: add 1 cycle delay ?
   io.lsq.uncache.ready := !s3_valid
+  val s3_outexception = ExceptionNO.selectByFu(s3_out.bits.uop.cf.exceptionVec, lduCfg).asUInt.orR
   io.ldout.bits        := s3_ld_wb_meta
-  io.ldout.bits.data   := Mux(s3_valid, s3_ld_data_frm_cache, s3_ld_data_frm_uncache)
+  io.ldout.bits.data   := Mux(s3_valid, Mux(!s3_outexception, s3_ld_data_frm_cache, 0.U), s3_ld_data_frm_uncache)
   io.ldout.valid       := s3_out.valid || (io.lsq.uncache.valid && !s3_valid)
 
   // s3 load fast replay


### PR DESCRIPTION
When an exception occurs, as s3_out is true, backend will still consider the data valid at this time (which is actually in X state) valid and bypass it. Although in real chips, this situation will be handled after 2 cycles of exception processing (flushing the pipeline and redirecting), when using vcs simulation, the simulation cannot continue due to the problem of X-state propagation. Therefore, when an exception occurs in load_s3, the output data will be forcibly set to 0.