### PR TITLE
pararm: addr disable alwaysbasci db on pldm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 # emu for the release version
 RELEASE_ARGS += --disable-all --remove-assert --fpga-platform
 DEBUG_ARGS   += --enable-difftest
-PLDM_ARGS    += --fpga-platform --enable-difftest
+PLDM_ARGS    += --fpga-platform --enable-difftest --disable-alwaysdb
 ifeq ($(RELEASE),1)
 override SIM_ARGS += $(RELEASE_ARGS)
 else ifeq ($(PLDM),1)

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -101,6 +101,10 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(EnablePerfDebug = false)
           }), tail)
+        case "--disable-alwaysdb" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(AlwaysBasicDB = false)
+          }), tail)
         case "--xstop-prefix" :: value :: tail if chisel3.BuildInfo.version != "3.6.0" =>
           nextOption(config.alter((site, here, up) => {
             case SoCParamsKey => up(SoCParamsKey).copy(XSTopPrefix = Some(value))


### PR DESCRIPTION
To reduce invalid DPIC calls, you need to shut down DB. In addition to specifying WITH_CHISELDB=0 when generating verilog, you also need to turn off AlwaysBasicDB，Implement this parameter