### PR TITLE
Exu,FuncUnit,Vialufix: Add parameterized delay for fixtiming

### DIFF
--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -70,20 +70,24 @@ class ExeUnitImp(
       val fuVld_en_reg = RegInit(false.B)
       val uncer_en_reg = RegInit(false.B)
 
-      val lat0 = FuType.isLat0(io.in.bits.fuType)
-      val latN = FuType.isLatN(io.in.bits.fuType)
-      val uncerLat = FuType.isUncerLat(io.in.bits.fuType)
-
       def lat: Int = cfg.latency.latencyVal.getOrElse(0)
+      def latfixtiming: Int = cfg.latfixtiming.latencyVal.getOrElse(0)
+      def latReal: Int = latfixtiming max lat
 
-      val fuVldVec = (io.in.valid && latN) +: Seq.fill(lat)(RegInit(false.B))
-      val fuRdyVec = Seq.fill(lat)(Wire(Bool())) :+ io.out.ready
+      val uncerLat = cfg.latency.uncertainLatencyVal.nonEmpty
+      val lat0 = (latReal == 0 && !uncerLat).asBool
+      val latN = (latReal > 0&& !uncerLat).asBool
 
-      for (i <- 0 until lat) {
+
+
+      val fuVldVec = (io.in.valid && latN) +: Seq.fill(latReal)(RegInit(false.B))
+      val fuRdyVec = Seq.fill(latReal)(Wire(Bool())) :+ io.out.ready
+
+      for (i <- 0 until latReal) {
         fuRdyVec(i) := !fuVldVec(i + 1) || fuRdyVec(i + 1)
       }
 
-      for (i <- 1 to lat) {
+      for (i <- 1 to latReal) {
         when(fuRdyVec(i - 1) && fuVldVec(i - 1)) {
           fuVldVec(i) := fuVldVec(i - 1)
         }.elsewhen(fuRdyVec(i)) {
@@ -93,9 +97,9 @@ class ExeUnitImp(
       fuVld_en := fuVldVec.map(v => v).reduce(_ || _)
       fuVld_en_reg := fuVld_en
 
-      when(uncerLat && io.in.fire) {
+      when(uncerLat.asBool && io.in.fire) {
         uncer_en_reg := true.B
-      }.elsewhen(uncerLat && io.out.fire) {
+      }.elsewhen(uncerLat.asBool && io.out.fire) {
         uncer_en_reg := false.B
       }
 
@@ -103,7 +107,7 @@ class ExeUnitImp(
         clk_en := true.B
       }.elsewhen(latN && fuVld_en || fuVld_en_reg) {
         clk_en := true.B
-      }.elsewhen(uncerLat && io.in.fire || uncer_en_reg) {
+      }.elsewhen(uncerLat.asBool && io.in.fire || uncer_en_reg) {
         clk_en := true.B
       }
 
@@ -226,10 +230,23 @@ class ExeUnitImp(
       sink.bits.perfDebugInfo    := source.bits.perfDebugInfo
   }
 
+  private val OutresVecs = funcUnits.map { fu =>
+    def lat: Int = fu.cfg.latency.latencyVal.getOrElse(0)
+    def latfixtiming: Int = fu.cfg.latfixtiming.latencyVal.getOrElse(0)
+    def latDiff :Int = if (latfixtiming < lat && latfixtiming != 0) lat - latfixtiming else 0
+    val OutresVec = fu.io.out.bits.res +: Seq.fill(latDiff)(Reg(chiselTypeOf(fu.io.out.bits.res)))
+    for (i <- 1 to latDiff) {
+      OutresVec(i) := OutresVec(i - 1)
+    }
+    OutresVec
+  }
+  OutresVecs.foreach(vec => vec.foreach(res =>dontTouch(res)))
+
   private val fuOutValidOH = funcUnits.map(_.io.out.valid)
   XSError(PopCount(fuOutValidOH) > 1.U, p"fuOutValidOH ${Binary(VecInit(fuOutValidOH).asUInt)} should be one-hot)\n")
   private val fuOutBitsVec = funcUnits.map(_.io.out.bits)
-  private val fuRedirectVec: Seq[Option[ValidIO[Redirect]]] = funcUnits.map(_.io.out.bits.res.redirect)
+  private val fuOutresVec = OutresVecs.map(_.last)
+  private val fuRedirectVec: Seq[Option[ValidIO[Redirect]]] = fuOutresVec.map(_.redirect)
 
   // Assume that one fu can only write int or fp or vec,
   // otherwise, wenVec should be assigned to wen in fu.
@@ -241,16 +258,16 @@ class ExeUnitImp(
   funcUnits.foreach(fu => fu.io.out.ready := io.out.ready)
 
   // select one fu's result
-  io.out.bits.data := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.res.data))
+  io.out.bits.data := Mux1H(fuOutValidOH, fuOutresVec.map(_.data))
   io.out.bits.robIdx := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.robIdx))
   io.out.bits.pdest := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.pdest))
   io.out.bits.intWen.foreach(x => x := Mux1H(fuOutValidOH, fuIntWenVec))
   io.out.bits.fpWen.foreach(x => x := Mux1H(fuOutValidOH, fuFpWenVec))
   io.out.bits.vecWen.foreach(x => x := Mux1H(fuOutValidOH, fuVecWenVec))
   io.out.bits.redirect.foreach(x => x := Mux1H((fuOutValidOH zip fuRedirectVec).filter(_._2.isDefined).map(x => (x._1, x._2.get))))
-  io.out.bits.fflags.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.res.fflags.getOrElse(0.U.asTypeOf(io.out.bits.fflags.get)))))
+  io.out.bits.fflags.foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.fflags.getOrElse(0.U.asTypeOf(io.out.bits.fflags.get)))))
   io.out.bits.wflags.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.fpu.getOrElse(0.U.asTypeOf(new FPUCtrlSignals)).wflags)))
-  io.out.bits.vxsat.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.res.vxsat.getOrElse(0.U.asTypeOf(io.out.bits.vxsat.get)))))
+  io.out.bits.vxsat.foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.vxsat.getOrElse(0.U.asTypeOf(io.out.bits.vxsat.get)))))
   io.out.bits.exceptionVec.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec.getOrElse(0.U.asTypeOf(io.out.bits.exceptionVec.get)))))
   io.out.bits.flushPipe.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.flushPipe.getOrElse(0.U.asTypeOf(io.out.bits.flushPipe.get)))))
   io.out.bits.replay.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.replay.getOrElse(0.U.asTypeOf(io.out.bits.replay.get)))))

--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -55,6 +55,12 @@ case class FuConfig (
   writeVxsat    : Boolean = false,
   dataBits      : Int = 64,
   latency       : HasFuLatency = CertainLatency(0),
+  /* latfixitming delay N cycles to fixtiming
+  * latency - latfixitming is the cycles to be delayed after the result generated
+  * if latfixtiming !=0 latfixtiming is the pre-latency of funcunit
+  * don't support uncertainlatency; fence, csr; branch, mul, std (Funcunit)
+  */
+  latfixtiming  : HasFuLatency = CertainLatency(0),
   hasInputBuffer: (Boolean, Int, Boolean) = (false, 0, false),
   exceptionOut  : Seq[Int] = Seq(),
   hasLoadError  : Boolean = false,

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -124,51 +124,89 @@ abstract class FuncUnit(val cfg: FuConfig)(implicit p: Parameters) extends XSMod
 trait HasPipelineReg { this: FuncUnit =>
   def latency: Int
 
-  require(latency >= 0)
+  val latfixtiming :Int = cfg.latfixtiming.latencyVal.get
+  val latdiff :Int = if (latfixtiming < latency && latfixtiming != 0) latency - latfixtiming else 0
+  val preLat :Int = latency - latdiff
 
-  val validVec = io.in.valid +: Seq.fill(latency)(RegInit(false.B))
-  val rdyVec = Seq.fill(latency)(Wire(Bool())) :+ io.out.ready
-  val ctrlVec = io.in.bits.ctrl +: Seq.fill(latency)(Reg(chiselTypeOf(io.in.bits.ctrl)))
-  val dataVec = io.in.bits.data +: Seq.fill(latency)(Reg(chiselTypeOf(io.in.bits.data)))
-  val perfVec = io.in.bits.perfDebugInfo +: Seq.fill(latency)(Reg(chiselTypeOf(io.in.bits.perfDebugInfo)))
+  require(latency >= 0 && latfixtiming >= 0 && latdiff >=0)
 
-  val robIdxVec = ctrlVec.map(_.robIdx)
-  val pcVec = dataVec.map(_.pc)
+  def pipelineReg(init: FuncUnitInput , valid:Bool, ready: Bool,latency: Int, flush:ValidIO[Redirect]): (Seq[FuncUnitInput],Seq[Bool],Seq[Bool])={
+    val rdyVec = Seq.fill(latency)(Wire(Bool())) :+ ready
+    val validVec = valid +: Seq.fill(latency)(RegInit(false.B))
+    val ctrlVec = init.ctrl +: Seq.fill(latency)(Reg(chiselTypeOf(io.in.bits.ctrl)))
+    val dataVec = init.data +: Seq.fill(latency)(Reg(chiselTypeOf(io.in.bits.data)))
+    val perfVec = init.perfDebugInfo +: Seq.fill(latency)(Reg(chiselTypeOf(io.in.bits.perfDebugInfo)))
 
-  // if flush(0), valid 0 will not given, so set flushVec(0) to false.B
-  val flushVec = validVec.zip(robIdxVec).map(x => x._1 && x._2.needFlush(io.flush))
 
-  for (i <- 0 until latency) {
-    rdyVec(i) := !validVec(i + 1) || rdyVec(i + 1)
-  }
 
-  for (i <- 1 to latency) {
-    when(rdyVec(i - 1) && validVec(i - 1) && !flushVec(i - 1)) {
-      validVec(i) := validVec(i - 1)
-      ctrlVec(i) := ctrlVec(i - 1)
-      dataVec(i) := dataVec(i - 1)
-      perfVec(i) := perfVec(i - 1)
-    }.elsewhen(flushVec(i) || rdyVec(i)) {
-      validVec(i) := false.B
+    val robIdxVec = ctrlVec.map(_.robIdx)
+
+    // if flush(0), valid 0 will not given, so set flushVec(0) to false.B
+    val flushVec = validVec.zip(robIdxVec).map(x => x._1 && x._2.needFlush(flush))
+
+    for (i <- 0 until latency) {
+      rdyVec(i) := !validVec(i + 1) || rdyVec(i + 1).asTypeOf(Bool())
     }
-  }
+    for (i <- 1 to latency) {
+      when(rdyVec(i - 1) && validVec(i - 1) && !flushVec(i - 1)) {
+        validVec(i) := validVec(i - 1)
+        ctrlVec(i) := ctrlVec(i - 1)
+        dataVec(i) := dataVec(i - 1)
+        perfVec(i) := perfVec(i - 1)
+      }.elsewhen(flushVec(i) || rdyVec(i)) {
+        validVec(i) := false.B
+      }
+    }
 
-  io.in.ready := rdyVec.head
-  io.out.valid := validVec.last
+    (ctrlVec.zip(dataVec).zip(perfVec).map{
+      case(( ctrl,data), perf) => {
+        val out = Wire(new FuncUnitInput(cfg))
+        out.ctrl := ctrl
+        out.data := data
+        out.perfDebugInfo := perf
+        out
+      }
+    },validVec, rdyVec)
+  }
+  val (pipeReg : Seq[FuncUnitInput],validVec ,rdyVec ) = pipelineReg(io.in.bits, io.in.valid,io.out.ready,preLat, io.flush)
+  val ctrlVec = pipeReg.map(_.ctrl)
+  val dataVec = pipeReg.map(_.data)
+  val perfVec = pipeReg.map(_.perfDebugInfo)
+  val robIdxVec = ctrlVec.map(_.robIdx)
+  val pipeflushVec = validVec.zip(robIdxVec).map(x => x._1 && x._2.needFlush(io.flush))
+
+
+  val fixtiminginit = Wire(new FuncUnitInput(cfg))
+  fixtiminginit.ctrl := ctrlVec.last
+  fixtiminginit.data := dataVec.last
+  fixtiminginit.perfDebugInfo := perfVec.last
+
+  // fixtiming pipelinereg
+  val (fixpipeReg : Seq[FuncUnitInput], fixValidVec, fixRdyVec) = pipelineReg(fixtiminginit, validVec.last,rdyVec.head ,latdiff, io.flush)
+  val fixCtrlVec = fixpipeReg.map(_.ctrl)
+  val fixDataVec = fixpipeReg.map(_.data)
+  val fixPerfVec = fixpipeReg.map(_.perfDebugInfo)
+  val fixrobIdxVec = ctrlVec.map(_.robIdx)
+  val fixflushVec = fixValidVec.zip(fixrobIdxVec).map(x => x._1 && x._2.needFlush(io.flush))
+  val flushVec = pipeflushVec ++ fixflushVec
+  val pcVec = fixDataVec.map(_.pc)
+
+  io.in.ready := fixRdyVec.head
+  io.out.valid := fixValidVec.last
   io.out.bits.res.pc.zip(pcVec.last).foreach { case (l, r) => l := r }
 
-  io.out.bits.ctrl.robIdx := ctrlVec.last.robIdx
-  io.out.bits.ctrl.pdest := ctrlVec.last.pdest
-  io.out.bits.ctrl.rfWen.foreach(_ := ctrlVec.last.rfWen.get)
-  io.out.bits.ctrl.fpWen.foreach(_ := ctrlVec.last.fpWen.get)
-  io.out.bits.ctrl.vecWen.foreach(_ := ctrlVec.last.vecWen.get)
-  io.out.bits.ctrl.fpu.foreach(_ := ctrlVec.last.fpu.get)
-  io.out.bits.ctrl.vpu.foreach(_ := ctrlVec.last.vpu.get)
-  io.out.bits.perfDebugInfo := perfVec.last
+  io.out.bits.ctrl.robIdx := fixCtrlVec.last.robIdx
+  io.out.bits.ctrl.pdest := fixCtrlVec.last.pdest
+  io.out.bits.ctrl.rfWen.foreach(_ := fixCtrlVec.last.rfWen.get)
+  io.out.bits.ctrl.fpWen.foreach(_ := fixCtrlVec.last.fpWen.get)
+  io.out.bits.ctrl.vecWen.foreach(_ := fixCtrlVec.last.vecWen.get)
+  io.out.bits.ctrl.fpu.foreach(_ := fixCtrlVec.last.fpu.get)
+  io.out.bits.ctrl.vpu.foreach(_ := fixCtrlVec.last.vpu.get)
+  io.out.bits.perfDebugInfo := fixPerfVec.last
 
   // vstart illegal
   if (cfg.exceptionOut.nonEmpty) {
-    val outVstart = ctrlVec.last.vpu.get.vstart
+    val outVstart = fixCtrlVec.last.vpu.get.vstart
     val vstartIllegal = outVstart =/= 0.U
     io.out.bits.ctrl.exceptionVec.get := 0.U.asTypeOf(io.out.bits.ctrl.exceptionVec.get)
     io.out.bits.ctrl.exceptionVec.get(illegalInstr) := vstartIllegal
@@ -176,10 +214,22 @@ trait HasPipelineReg { this: FuncUnit =>
 
   def regEnable(i: Int): Bool = validVec(i - 1) && rdyVec(i - 1) && !flushVec(i - 1)
 
-  def PipelineReg[TT <: Data](i: Int)(next: TT) = RegEnable(
-    next,
-    regEnable(i)
-  )
+  def PipelineReg[TT <: Data](i: Int)(next: TT) = {
+    val lat = preLat min i
+    RegEnable(
+      next,
+      regEnable(lat)
+    )
+  }
+
+  def SNReg[TT <: Data](in: TT, n: Int): TT ={
+    val lat = preLat min n
+    var next = in
+    for (i <- 1 to lat) {
+      next = PipelineReg[TT](i)(next)
+    }
+    next
+  }
 
   def S1Reg[TT <: Data](next: TT): TT = PipelineReg[TT](1)(next)
 

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VIAluFix.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VIAluFix.scala
@@ -251,7 +251,8 @@ class VIAluFix(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(c
   /**
    * [[mgu]]'s in connection
    */
-  private val outEewVs1 = DelayN(eewVs1, latency)
+  //private val outEewVs1 = DelayN(eewVs1, latency)
+  private val outEewVs1 = SNReg(eewVs1, latency)
 
   private val outVd = Cat(vIntFixpAlus.reverse.map(_.io.vd))
   private val outCmp = Mux1H(outEewVs1.oneHot, Seq(8, 4, 2, 1).map(
@@ -316,7 +317,7 @@ class VIAluFix(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(c
   mgu.io.in.info.ma := outVecCtrl.vma
   mgu.io.in.info.vl := Mux(outIsVmvsx, 1.U, outVl)
   mgu.io.in.info.vlmul := outVecCtrl.vlmul
-  mgu.io.in.info.valid := io.out.valid
+  mgu.io.in.info.valid := validVec.last
   mgu.io.in.info.vstart := outVecCtrl.vstart
   mgu.io.in.info.eew := outEew
   mgu.io.in.info.vsew := outVecCtrl.vsew


### PR DESCRIPTION
Add parameterized delay for fixtiming:
       Funcunit : add fixtiming pipereg
       exuunit : delay latdiff cycles
       Fuconfig : latfixitming delay N cycles to fixtiming
                       latency - latfixitming is the cycles to be delayed after the result generated
                       if latfixtiming !=0 latfixtiming is the pre-latency of funcunit
                       don't support uncertainlatency; fence, csr; branch, mul, std (Funcunit)
     vialufix outeew use new pipereg