### PR TITLE
resetGen: fix memblock reset on fpgaplatform

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -1413,7 +1413,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   if (p(DebugOptionsKey).FPGAPlatform) {
     val resetTree = ResetGenNode(
       Seq(
-        ResetGenNode(Seq(ResetGenNode(Seq(CellNode(reset_io_frontend))))),
+        CellNode(reset_io_frontend),
         CellNode(reset_io_backend),
         ModuleNode(itlbRepeater3),
         ModuleNode(dtlbRepeater),


### PR DESCRIPTION
When the fpgaplatform option is enabled ,We should synchronize the reset and release of frontend and backend to avoid the following errors caused by a multi-core boot on
`Assertion failedat L2TLB.scala:296 assertl!flush latch(i) ll waiting resp(i)) // when sfence latch wait for mem resp, waiting resp should be true`