### PR TITLE
build: specify output format in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ifeq ($(MFC),1)
 CHISEL_VERSION = chisel
 FPGA_MEM_ARGS = --firtool-opt "--repl-seq-mem --repl-seq-mem-file=$(TOP).v.conf"
 SIM_MEM_ARGS = --firtool-opt "--repl-seq-mem --repl-seq-mem-file=$(SIM_TOP).v.conf"
-MFC_ARGS = --dump-fir \
+MFC_ARGS = --dump-fir --target verilog \
            --firtool-opt "-O=release --disable-annotation-unknown --lowering-options=explicitBitcast,disallowLocalVariables,disallowPortDeclSharing,locationInfoStyle=none"
 RELEASE_ARGS += $(MFC_ARGS)
 DEBUG_ARGS += $(MFC_ARGS)

--- a/src/main/scala/top/Generator.scala
+++ b/src/main/scala/top/Generator.scala
@@ -28,7 +28,7 @@ object Generator {
         RunFirrtlTransformAnnotation(new PrintControl),
         RunFirrtlTransformAnnotation(new PrintModuleName)
       )
-      case _ => Seq(CIRCTTargetAnnotation(CIRCTTarget.Verilog)) ++ firtoolOpts.map(FirtoolOption.apply)
+      case _ => firtoolOpts.map(FirtoolOption.apply).toSeq
     }
 
     (new XiangShanStage).execute(args, ChiselGeneratorAnnotation(mod _) +: annotations)


### PR DESCRIPTION
This can make users to modify target format without recompiling scala.