### PR TITLE
Memblock: Merge memblock timing fixes into master

### DIFF
--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -82,6 +82,9 @@ class L2Top()(implicit p: Parameters) extends LazyModule
   val ptw_logger = TLLogger(s"L2_PTW_${coreParams.HartId}", enbale_tllog)
   val ptw_to_l2_buffer = LazyModule(new TLBuffer)
   val i_mmio_buffer = LazyModule(new TLBuffer)
+  // channel C alone requires another buffer
+  val noBufParam = BufferParams.none
+  val chnC_buffer = LazyModule(new TLBuffer(noBufParam, noBufParam, BufferParams.default, noBufParam, noBufParam))
 
   val clint_int_node = IntIdentityNode()
   val debug_int_node = IntIdentityNode()

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -225,7 +225,7 @@ case class XSCoreParameters
   EnableLdVioCheckAfterReset: Boolean = true,
   EnableSoftPrefetchAfterReset: Boolean = true,
   EnableCacheErrorAfterReset: Boolean = true,
-  EnableAccurateLoadError: Boolean = true,
+  EnableAccurateLoadError: Boolean = false,
   EnableUncacheWriteOutstanding: Boolean = false,
   EnableStorePrefetchAtIssue: Boolean = false,
   EnableStorePrefetchAtCommit: Boolean = false,

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -52,8 +52,8 @@ class XSTile()(implicit p: Parameters) extends LazyModule
   // =========== Components' Connection ============
   // L1 to l1_xbar
   coreParams.dcacheParametersOpt.map { _ =>
-    l2top.misc_l2_pmu := l2top.l1d_logger := core.memBlock.dcache_port :=
-      core.memBlock.l1d_to_l2_buffer.node := core.memBlock.dcache.clientNode
+    l2top.misc_l2_pmu := l2top.l1d_logger := l2top.chnC_buffer.node :=
+      core.memBlock.dcache_port := core.memBlock.l1d_to_l2_buffer.node := core.memBlock.dcache.clientNode
   }
 
   l2top.misc_l2_pmu := l2top.l1i_logger := core.memBlock.frontendBridge.icache_node

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -322,8 +322,8 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   }
 
   val loadUnits = Seq.fill(LduCnt)(Module(new LoadUnit))
-  val storeUnits = Seq.fill(StaCnt)(Module(new StoreUnit))
-  val stdExeUnits = Seq.fill(StdCnt)(Module(new MemExeUnit(backendParams.memSchdParams.get.issueBlockParams.find(_.StdCnt != 0).get.exuBlockParams.head)))
+  val storeUnits = Seq.fill(StaCnt)(Module(new StoreAddrUnit))
+  val stdExeUnits = Seq.fill(StdCnt)(Module(new StoreDataUnit))
   val hybridUnits = Seq.fill(HyuCnt)(Module(new HybridUnit)) // Todo: replace it with HybridUnit
   val stData = stdExeUnits.map(_.io.out)
   val exeUnits = loadUnits ++ storeUnits
@@ -986,10 +986,8 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
 
   // StoreUnit
   for (i <- 0 until StdCnt) {
-    stdExeUnits(i).io.flush <> redirect
-    stdExeUnits(i).io.in.valid := io.ooo_to_mem.issueStd(i).valid
-    io.ooo_to_mem.issueStd(i).ready := stdExeUnits(i).io.in.ready
-    stdExeUnits(i).io.in.bits := io.ooo_to_mem.issueStd(i).bits
+    stdExeUnits(i).io.redirect <> redirect
+    stdExeUnits(i).io.in <> io.ooo_to_mem.issueStd(i)
   }
 
   for (i <- 0 until StaCnt) {

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -625,7 +625,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   val pmp = Module(new PMP())
   pmp.io.distribute_csr <> csrCtrl.distribute_csr
 
-  val pmp_check = VecInit(Seq.fill(LduCnt + HyuCnt + 1 + StaCnt + 1)(Module(new PMPChecker(3)).io))
+  val pmp_check = VecInit(Seq.fill(LduCnt + HyuCnt + 1 + StaCnt + 1)(Module(new PMPChecker(3, leaveHitMux = true)).io))
   for ((p,d) <- pmp_check zip dtlb_pmps) {
     p.apply(tlbcsr.priv.dmode, pmp.io.pmp, pmp.io.pma, d)
     require(p.req.bits.size.getWidth == d.bits.size.getWidth)

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -380,7 +380,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   }
   // load prefetch to l1 Dcache
   l1PrefetcherOpt match {
-    case Some(pf) => l1_pf_req <> Pipeline(in = pf.io.l1_req, depth = 1, pipe = true, name = Some("pf_queue_to_ldu_reg"))
+    case Some(pf) => l1_pf_req <> Pipeline(in = pf.io.l1_req, depth = 1, pipe = false, name = Some("pf_queue_to_ldu_reg"))
     case None =>
       l1_pf_req.valid := false.B
       l1_pf_req.bits := DontCare

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -1303,14 +1303,12 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
 
   for (i <- 0 until StaCnt) when(st_atomics(i)) {
     io.ooo_to_mem.issueSta(i).ready := atomicsUnit.io.in.ready
-    storeUnits(i).io.stin.valid := false.B
 
     state := s_atomics(i)
     assert(!st_atomics.zipWithIndex.filterNot(_._2 == i).unzip._1.reduce(_ || _))
   }
   for (i <- 0 until HyuCnt) when(st_atomics(StaCnt + i)) {
     io.ooo_to_mem.issueHya(i).ready := atomicsUnit.io.in.ready
-    hybridUnits(i).io.lsin.valid := false.B
 
     state := s_atomics(StaCnt + i)
     assert(!st_atomics.zipWithIndex.filterNot(_._2 == StaCnt + i).unzip._1.reduce(_ || _))

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -167,13 +167,14 @@ class fetch_to_mem(implicit p: Parameters) extends XSBundle{
 
 // triple buffer applied in i-mmio path (two at MemBlock, one at L2Top)
 class InstrUncacheBuffer()(implicit p: Parameters) extends LazyModule with HasInstrMMIOConst {
-  val node = new TLBufferNode(BufferParams.default, BufferParams.default, BufferParams.default, BufferParams.default, BufferParams.default)
+  val bufParam = BufferParams.default
+  val node = new TLBufferNode(bufParam, bufParam, bufParam, bufParam, bufParam)
   lazy val module = new InstrUncacheBufferImpl
 
   class InstrUncacheBufferImpl extends LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
-      out.a <> BufferParams.default(BufferParams.default(in.a))
-      in.d <> BufferParams.default(BufferParams.default(out.d))
+      out.a <> bufParam(bufParam(in.a))
+      in.d <> bufParam(bufParam(out.d))
 
       // only a.valid, a.ready, a.address can change
       // hoping that the rest would be optimized to keep MemBlock port unchanged after adding buffer

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -54,7 +54,9 @@ case class DCacheParameters
   blockBytes: Int = 64,
   nMaxPrefetchEntry: Int = 1,
   alwaysReleaseData: Boolean = false,
-  isKeywordBitsOpt: Option[Boolean] = Some(true)
+  isKeywordBitsOpt: Option[Boolean] = Some(true),
+  enableDataEcc: Boolean = false,
+  enableTagEcc: Boolean = true
 ) extends L1CacheParameters {
   // if sets * blockBytes > 4KB(page size),
   // cache alias will happen,
@@ -127,6 +129,8 @@ trait HasDCacheParameters extends HasL1CacheParameters with HasL1PrefetchSourceP
   require(cfg.nMissEntries < cfg.nReleaseEntries)
   val nEntries = cfg.nMissEntries + cfg.nReleaseEntries
   val releaseIdBase = cfg.nMissEntries
+  val EnableDataEcc = cacheParams.enableDataEcc
+  val EnableTagEcc = cacheParams.enableTagEcc
 
   // banked dcache support
   val DCacheSetDiv = 1
@@ -228,7 +232,7 @@ trait HasDCacheParameters extends HasL1CacheParameters with HasL1PrefetchSourceP
     require(data.getWidth >= (bank+1)*DCacheSRAMRowBytes)
     data(DCacheSRAMRowBytes * (bank + 1) - 1, DCacheSRAMRowBytes * bank)
   }
-  
+
   def get_alias(vaddr: UInt): UInt ={
     require(blockOffBits + idxBits > pgIdxBits)
     if(blockOffBits + idxBits > pgIdxBits){
@@ -362,7 +366,7 @@ class DCacheWordReq(implicit p: Parameters) extends DCacheBundle
   val isFirstIssue = Bool()
   val replayCarry = new ReplayCarry(nWays)
   val lqIdx = new LqPtr
-  
+
   val debug_robIdx = UInt(log2Ceil(RobSize).W)
   def dump() = {
     XSDebug("DCacheWordReq: cmd: %x vaddr: %x data: %x mask: %x id: %d\n",

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -56,7 +56,7 @@ case class DCacheParameters
   alwaysReleaseData: Boolean = false,
   isKeywordBitsOpt: Option[Boolean] = Some(true),
   enableDataEcc: Boolean = false,
-  enableTagEcc: Boolean = true
+  enableTagEcc: Boolean = false
 ) extends L1CacheParameters {
   // if sets * blockBytes > 4KB(page size),
   // cache alias will happen,

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -506,15 +506,18 @@ class SramedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   val read_result_delayed = RegNext(read_result)
   (0 until LoadPipelineWidth).map(i => {
     // io.read_resp(i) := read_result(RegNext(bank_addrs(i)))(RegNext(OHToUInt(way_en(i))))
-    val rr_read_fire = RegNext(RegNext(io.read(i).fire))
-    val rr_div_addr = RegNext(RegNext(div_addrs(i)))
-    val rr_bank_addr = RegNext(RegNext(bank_addrs(i)))
-    val rr_way_addr = RegNext(RegNext(OHToUInt(way_en(i))))
+    val rr_read_fire = RegNext(io.read(i).fire)
+    val rr_div_addr = RegNext(div_addrs(i))
+    val rr_div_addr_next = RegNext(rr_div_addr)
+    val rr_bank_addr = RegNext(bank_addrs(i))
+    val rr_bank_addr_next = RegNext(rr_bank_addr)
+    val rr_way_addr = RegNext(OHToUInt(way_en(i)))
+    val rr_way_addr_next = RegNext(rr_way_addr)
     (0 until VLEN/DCacheSRAMRowBits).map( j =>{
-      io.read_resp_delayed(i)(j) := read_result_delayed(rr_div_addr)(rr_bank_addr(j))(rr_way_addr)
+      io.read_resp_delayed(i)(j) := read_result(rr_div_addr)(rr_bank_addr(j))(rr_way_addr)
       // error detection
       // normal read ports
-      io.read_error_delayed(i)(j) := rr_read_fire && read_error_delayed_result(rr_div_addr)(rr_bank_addr(j))(rr_way_addr) && !RegNext(io.bank_conflict_slow(i))
+      io.read_error_delayed(i)(j) := RegNext(rr_read_fire) && read_error_delayed_result(rr_div_addr_next)(rr_bank_addr_next(j))(rr_way_addr_next) && !RegNext(io.bank_conflict_slow(i))
     })
   })
 
@@ -894,14 +897,17 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
 
   val bank_result_delayed = RegNext(bank_result)
   (0 until LoadPipelineWidth).map(i => {
-    val rr_read_fire = RegNext(RegNext(io.read(i).fire))
-    val rr_div_addr = RegNext(RegNext(div_addrs(i)))
-    val rr_bank_addr = RegNext(RegNext(bank_addrs(i)))
-    val rr_way_addr = RegNext(RegNext(OHToUInt(way_en(i))))
+    val rr_read_fire = RegNext(io.read(i).fire)
+    val rr_div_addr = RegNext(div_addrs(i))
+    val rr_div_addr_next = RegNext(rr_div_addr)
+    val rr_bank_addr = RegNext(bank_addrs(i))
+    val rr_bank_addr_next = RegNext(rr_bank_addr)
+    val rr_way_addr = RegNext(OHToUInt(way_en(i)))
     (0 until VLEN/DCacheSRAMRowBits).map( j =>{
-      io.read_resp_delayed(i)(j) := bank_result_delayed(rr_div_addr)(rr_bank_addr(j))
+      io.read_resp_delayed(i)(j) := bank_result(rr_div_addr)(rr_bank_addr(j))
       // error detection
-      io.read_error_delayed(i)(j) := rr_read_fire && read_bank_error_delayed(rr_div_addr)(rr_bank_addr(j)) && !RegNext(io.bank_conflict_slow(i))
+      // normal read ports
+      io.read_error_delayed(i)(j) := RegNext(rr_read_fire) && read_bank_error_delayed(rr_div_addr_next)(rr_bank_addr_next(j)) && !RegNext(io.bank_conflict_slow(i))
     })
   })
 

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -241,7 +241,6 @@ case object HasDataEccParam
 // -----------------------------------------------------------------
 abstract class AbstractBankedDataArray(implicit p: Parameters) extends DCacheModule
 {
-  val EnableDataEcc = false
   val DataEccParam = if(EnableDataEcc) Some(HasDataEccParam) else None
   val ReadlinePortErrorIndex = LoadPipelineWidth
   val io = IO(new DCacheBundle {

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -364,7 +364,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
   val s2_instrtype = s2_req.instrtype
 
-  val s2_tag_error = dcacheParameters.tagCode.decode(s2_encTag).error // error reported by tag ecc check
+  val s2_tag_error = WireInit(false.B)
   val s2_flag_error = RegEnable(s1_flag_error, s1_fire)
 
   val s2_hit_prefetch = RegEnable(s1_hit_prefetch, s1_fire)
@@ -379,6 +379,12 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   dump_pipeline_valids("LoadPipe s2", "s2_nack_no_mshr", s2_valid && s2_nack_no_mshr)
 
   val s2_can_send_miss_req = RegEnable(s1_will_send_miss_req, s1_fire)
+
+  if(EnableTagEcc) {
+    s2_tag_error := dcacheParameters.tagCode.decode(s2_encTag).error // error reported by tag ecc check
+  }else {
+    s2_tag_error := false.B
+  }
 
   // send load miss to miss queue
   io.miss_req.valid := s2_valid && s2_can_send_miss_req

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -406,7 +406,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s2_coh = RegEnable(s1_coh, s1_fire)
   val s2_banked_store_wmask = RegEnable(s1_banked_store_wmask, s1_fire)
   val s2_flag_error = RegEnable(s1_flag_error, s1_fire)
-  val s2_tag_error = dcacheParameters.tagCode.decode(s2_encTag).error && s2_need_tag
+  val s2_tag_error = WireInit(false.B)
   val s2_l2_error = s2_req.error
   val s2_error = s2_flag_error || s2_tag_error || s2_l2_error // data_error not included
 
@@ -415,6 +415,12 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s2_hit = s2_tag_match && s2_has_permission
   val s2_amo_hit = s2_hit && !s2_req.probe && !s2_req.miss && s2_req.isAMO
   val s2_store_hit = s2_hit && !s2_req.probe && !s2_req.miss && s2_req.isStore
+
+  if(EnableTagEcc) {
+    s2_tag_error := dcacheParameters.tagCode.decode(s2_encTag).error && s2_need_tag
+  }else {
+    s2_tag_error := false.B
+  }
 
   s2_s0_set_conlict := s2_valid_dup(0) && s0_idx === s2_idx
   s2_s0_set_conlict_store := s2_valid_dup(1) && store_idx === s2_idx

--- a/src/main/scala/xiangshan/cache/dcache/meta/TagArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/meta/TagArray.scala
@@ -37,7 +37,13 @@ class TagEccWriteReq(implicit p: Parameters) extends TagReadReq {
   val ecc = UInt(eccTagBits.W)
 }
 
-class TagArray(implicit p: Parameters) extends DCacheModule {
+case object HasTagEccParam
+
+abstract class AbstractTagArray(implicit p: Parameters) extends DCacheModule {
+  val TagEccParam = if(EnableTagEcc) Some(HasTagEccParam) else None
+}
+
+class TagArray(implicit p: Parameters) extends AbstractTagArray {
   val io = IO(new Bundle() {
     val read = Flipped(DecoupledIO(new TagReadReq))
     val resp = Output(Vec(nWays, UInt(tagBits.W)))
@@ -62,8 +68,12 @@ class TagArray(implicit p: Parameters) extends DCacheModule {
   val tag_array = Module(new SRAMTemplate(UInt(tagBits.W), set = nSets, way = nWays,
     shouldReset = false, holdRead = false, singlePort = true))
 
-  val ecc_array = Module(new SRAMTemplate(UInt(eccTagBits.W), set = nSets, way = nWays,
-    shouldReset = false, holdRead = false, singlePort = true))
+  val ecc_array = TagEccParam.map {
+    case _ =>
+      val ecc = Module(new SRAMTemplate(UInt(eccTagBits.W), set = nSets, way = nWays,
+      shouldReset = false, holdRead = false, singlePort = true))
+    ecc
+  }
 
   val wen = rst || io.write.valid
   tag_array.io.w.req.valid := wen
@@ -77,12 +87,16 @@ class TagArray(implicit p: Parameters) extends DCacheModule {
   val ecc_waddr = Mux(rst, rst_cnt, io.ecc_write.bits.idx)
   val ecc_wdata = Mux(rst, rstVal, io.ecc_write.bits.ecc)
   val ecc_wmask = Mux(rst || (nWays == 1).B, (-1).asSInt, io.ecc_write.bits.way_en.asSInt).asBools
-  ecc_array.io.w.req.valid := ecc_wen
-  ecc_array.io.w.req.bits.apply(
-    setIdx = ecc_waddr,
-    data = ecc_wdata,
-    waymask = VecInit(ecc_wmask).asUInt
-  )
+  ecc_array match {
+    case Some(ecc) =>
+      ecc.io.w.req.valid := ecc_wen
+      ecc.io.w.req.bits.apply(
+        setIdx = ecc_waddr,
+        data = ecc_wdata,
+        waymask = VecInit(ecc_wmask).asUInt
+      )
+    case None =>
+  }
 
   // tag read
   val ren = io.read.fire
@@ -93,17 +107,28 @@ class TagArray(implicit p: Parameters) extends DCacheModule {
   XSPerfAccumulate("part_tag_read_counter", tag_array.io.r.req.valid)
 
   val ecc_ren = io.ecc_read.fire
-  ecc_array.io.r.req.valid := ecc_ren
-  ecc_array.io.r.req.bits.apply(setIdx = io.ecc_read.bits.idx)
-  io.ecc_resp := ecc_array.io.r.resp.data
+  ecc_array match {
+    case Some(ecc) =>
+      ecc.io.r.req.valid := ecc_ren
+      ecc.io.r.req.bits.apply(setIdx = io.ecc_read.bits.idx)
+      io.ecc_resp := ecc.io.r.resp.data
+    case None =>
+      io.ecc_resp := 0.U.asTypeOf(io.ecc_resp)
+  }
 
   io.write.ready := !rst
   io.read.ready := !wen
-  io.ecc_write.ready := !rst
-  io.ecc_read.ready := !ecc_wen
+  ecc_array match {
+    case Some(ecc) =>
+      io.ecc_write.ready := !rst
+      io.ecc_read.ready := !ecc_wen
+    case None =>
+      io.ecc_write.ready := true.B
+      io.ecc_read.ready := true.B
+  }
 }
 
-class DuplicatedTagArray(readPorts: Int)(implicit p: Parameters) extends DCacheModule {
+class DuplicatedTagArray(readPorts: Int)(implicit p: Parameters) extends AbstractTagArray {
   val io = IO(new Bundle() {
     val read = Vec(readPorts, Flipped(DecoupledIO(new TagReadReq)))
     val resp = Output(Vec(readPorts, Vec(nWays, UInt(encTagBits.W))))

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -142,10 +142,10 @@ class TLBFA(
       }
     } else {
       for (d <- 0 until nDups) {
-        resp.bits.ppn(d) := ParallelMux(hitVecReg zip ppn_reg)
-        resp.bits.perm(d) := ParallelMux(hitVecReg zip perm_reg)
-        resp.bits.g_perm(d) := ParallelMux(hitVec zip g_perm_reg)
-        resp.bits.s2xlate(d) := ParallelMux(hitVec zip s2xlate_reg)
+        resp.bits.ppn(d) := Mux1H(hitVecReg zip ppn_reg)
+        resp.bits.perm(d) := Mux1H(hitVecReg zip perm_reg)
+        resp.bits.g_perm(d) := Mux1H(hitVec zip g_perm_reg)
+        resp.bits.s2xlate(d) := Mux1H(hitVec zip s2xlate_reg)
       }
     }
 

--- a/src/main/scala/xiangshan/mem/MemCommon.scala
+++ b/src/main/scala/xiangshan/mem/MemCommon.scala
@@ -124,6 +124,7 @@ class LsPipelineBundle(implicit p: Parameters) extends XSBundle
   val isLoadReplay = Bool()
   val isFastPath = Bool()
   val isFastReplay = Bool()
+  val isMMIO = Bool()
   val replayCarry = new ReplayCarry(nWays)
 
   // For dcache miss load
@@ -186,6 +187,7 @@ class LdPrefetchTrainBundle(implicit p: Parameters) extends LsPipelineBundle {
     isLoadReplay := DontCare
     isFastPath := DontCare
     isFastReplay := DontCare
+    isMMIO := DontCare
     handledByMSHR := DontCare
     replacementUpdated := DontCare
     missDbUpdated := DontCare
@@ -238,6 +240,7 @@ class LqWriteBundle(implicit p: Parameters) extends LsPipelineBundle {
     if(latch) isLoadReplay := RegNext(input.isLoadReplay) else isLoadReplay := input.isLoadReplay
     if(latch) isFastPath := RegNext(input.isFastPath) else isFastPath := input.isFastPath
     if(latch) isFastReplay := RegNext(input.isFastReplay) else isFastReplay := input.isFastReplay
+    if(latch) isMMIO := RegNext(input.isMMIO) else isMMIO := input.isMMIO
     if(latch) mshrid := RegNext(input.mshrid) else mshrid := input.mshrid
     if(latch) forward_tlDchannel := RegNext(input.forward_tlDchannel) else forward_tlDchannel := input.forward_tlDchannel
     if(latch) replayCarry := RegNext(input.replayCarry) else replayCarry := input.replayCarry

--- a/src/main/scala/xiangshan/mem/MemCommon.scala
+++ b/src/main/scala/xiangshan/mem/MemCommon.scala
@@ -338,14 +338,15 @@ class LoadNukeQueryIO(implicit p: Parameters) extends XSBundle {
 }
 
 class StoreNukeQueryIO(implicit p: Parameters) extends XSBundle {
+  val s1_valid = Output(Bool())
   //  robIdx: Requestor's (a store instruction) rob index for match logic.
-  val robIdx = new RobPtr
-
+  val s1_robIdx = Output(new RobPtr)
   //  paddr: requestor's (a store instruction) physical address for match logic.
-  val paddr  = UInt(PAddrBits.W)
-
+  val s1_paddr  = Output(UInt(PAddrBits.W))
   //  mask: requestor's (a store instruction) data width mask for match logic.
-  val mask = UInt((VLEN/8).W)
+  val s1_mask = Output(UInt((VLEN/8).W))
+  //
+  val s3_nuke = Input(Bool())
 }
 
 // Store byte valid mask write bundle

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -72,6 +72,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
       val storeAddrInRe = Vec(StorePipelineWidth, Input(new LsPipelineBundle())) // from store_s2
       val vecStoreAddrIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle))) //from store_s2
       val vecStoreFlowAddrIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle))) // from vsFlowQueue last element issue
+      val storeNuke = Vec(StorePipelineWidth, Output(Bool())) // from store s1
     }
     val std = new Bundle() {
       val storeDataIn = Vec(StorePipelineWidth, Flipped(Valid(new MemExuOutput))) // from store_s0, store data, send to sq from rs
@@ -201,6 +202,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   loadQueue.io.sq.sqEmpty          <> storeQueue.io.sqEmpty
   loadQueue.io.sta.storeAddrIn     <> io.sta.storeAddrIn // store_s1
   loadQueue.io.sta.vecStoreAddrIn  <> io.sta.vecStoreAddrIn // store_s1
+  loadQueue.io.sta.storeNuke       <> io.sta.storeNuke // store_s1
   loadQueue.io.std.storeDataIn     <> io.std.storeDataIn // store_s0
   loadQueue.io.lqFull              <> io.lqFull
   loadQueue.io.lq_rep_full         <> io.lq_rep_full

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -127,6 +127,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     val sta = new Bundle() {
       val storeAddrIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle))) // from store_s1
       val vecStoreAddrIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle))) // from store_s1
+      val storeNuke = Vec(StorePipelineWidth, Output(Bool()))
     }
     val std = new Bundle() {
       val storeDataIn = Vec(StorePipelineWidth, Flipped(Valid(new MemExuOutput))) // from store_s0, store data, send to sq from rs
@@ -192,6 +193,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   loadQueueRAW.io.redirect         <> io.redirect
   loadQueueRAW.io.storeIn          <> io.sta.storeAddrIn
   loadQueueRAW.io.vecStoreIn       <> io.sta.vecStoreAddrIn
+  loadQueueRAW.io.storeNuke        <> io.sta.storeNuke
   loadQueueRAW.io.stAddrReadySqPtr <> io.sq.stAddrReadySqPtr
   loadQueueRAW.io.stIssuePtr       <> io.sq.stIssuePtr
   for (w <- 0 until LoadPipelineWidth) {

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
@@ -260,31 +260,8 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
     val numSelectGroups = scala.math.ceil(valid.length.toFloat / SelectGroupSize).toInt
 
     // group info
-    val selectValidGroups =
-      if (valid.length <= SelectGroupSize) {
-        Seq(valid)
-      } else {
-        (0 until numSelectGroups).map(g => {
-          if (valid.length < (g + 1) * SelectGroupSize) {
-            valid.takeRight(valid.length - g * SelectGroupSize)
-          } else {
-            (0 until SelectGroupSize).map(j => valid(g * SelectGroupSize + j))
-          }
-        })
-      }
-    val selectBitsGroups =
-      if (bits.length <= SelectGroupSize) {
-        Seq(bits)
-      } else {
-        (0 until numSelectGroups).map(g => {
-          if (bits.length < (g + 1) * SelectGroupSize) {
-            bits.takeRight(bits.length - g * SelectGroupSize)
-          } else {
-            (0 until SelectGroupSize).map(j => bits(g * SelectGroupSize + j))
-          }
-        })
-      }
-
+    val selectValidGroups = valid.sliding(SelectGroupSize, numSelectGroups).toList
+    val selectBitsGroups = bits.sliding(SelectGroupSize, numSelectGroups).toList
     // select logic
     if (valid.length <= SelectGroupSize) {
       val (selValid, selBits) = selectPartialOldest(valid, bits)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
@@ -43,6 +43,7 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
 
     // from store unit s1
     val storeIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle)))
+    val storeNuke = Vec(StorePipelineWidth, Output(Bool()))
     val vecStoreIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle)))
 
     // global rollback flush
@@ -300,7 +301,7 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
       wrapper.uop := uop
       wrapper
     })
-
+    io.storeNuke(i) := ParallelORR(lqViolationSelVec)
     // select logic
     val lqSelect = selectOldest(lqViolationSelVec, lqViolationSelUopExts)
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
@@ -260,8 +260,8 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
     val numSelectGroups = scala.math.ceil(valid.length.toFloat / SelectGroupSize).toInt
 
     // group info
-    val selectValidGroups = valid.sliding(SelectGroupSize, numSelectGroups).toList
-    val selectBitsGroups = bits.sliding(SelectGroupSize, numSelectGroups).toList
+    val selectValidGroups = valid.grouped(SelectGroupSize).toList
+    val selectBitsGroups = bits.grouped(SelectGroupSize).toList
     // select logic
     if (valid.length <= SelectGroupSize) {
       val (selValid, selBits) = selectPartialOldest(valid, bits)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -571,6 +571,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     needEnqueue(i) && !io.enq(i).bits.isLoadReplay
   })
 
+  val canAcceptCount = PopCount(freeList.io.canAllocate)
   for ((enq, w) <- io.enq.zipWithIndex) {
     vaddrModule.io.wen(w) := false.B
     freeList.io.doAllocate(w) := false.B
@@ -579,7 +580,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
 
     //  Allocated ready
     val offset = PopCount(newEnqueue.take(w))
-    val canAccept = freeList.io.canAllocate(offset)
+    val canAccept = canAcceptCount >= (w+1).U
     val enqIndex = Mux(enq.bits.isLoadReplay, enq.bits.schedIndex, freeList.io.allocateSlot(offset))
     enqIndexOH(w) := UIntToOH(enqIndex)
     enq.ready := Mux(enq.bits.isLoadReplay, true.B, canAccept)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueueData.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueueData.scala
@@ -236,14 +236,13 @@ class SQData8Module(numEntries: Int, numRead: Int, numWrite: Int, numForward: In
       val needCheck1 = io.needForward(i)(1)(j)
       val needCheck0Reg = RegNext(needCheck0)
       val needCheck1Reg = RegNext(needCheck1)
-      (0 until XLEN / 8).foreach(k => {
-        matchResultVec(j).validFast := needCheck0 && data(j).valid
-        matchResultVec(j).valid := needCheck0Reg && data(j).valid
-        matchResultVec(j).data := data(j).data
-        matchResultVec(numEntries + j).validFast := needCheck1 && data(j).valid
-        matchResultVec(numEntries + j).valid := needCheck1Reg && data(j).valid
-        matchResultVec(numEntries + j).data := data(j).data
-      })
+
+      matchResultVec(j).validFast := needCheck0 && data(j).valid
+      matchResultVec(j).valid := needCheck0Reg && data(j).valid
+      matchResultVec(j).data := data(j).data
+      matchResultVec(numEntries + j).validFast := needCheck1 && data(j).valid
+      matchResultVec(numEntries + j).valid := needCheck1Reg && data(j).valid
+      matchResultVec(numEntries + j).data := data(j).data
     }
 
     val parallelFwdResult = parallelFwd(matchResultVec).asTypeOf(new FwdEntry)

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -1212,10 +1212,12 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   } .otherwise {
     io.ldu_io.lsq.ldin.bits.rep_info.cause := VecInit(s3_sel_rep_cause.asBools)
   }
+  val s3_no_need_rep = !RegNext(s2_out.rep_info.need_rep) && !s3_in.mmio
+  val s3_safe_writeback = (s3_exception || s3_dly_ld_err || s3_no_need_rep)
 
   // Int flow, if hit, will be writebacked at s3
   s3_out.valid                := s3_valid &&
-                                (!s3_ld_flow && !s3_in.feedbacked || !io.ldu_io.lsq.ldin.bits.rep_info.need_rep) && !s3_in.mmio
+                                (!s3_ld_flow && !s3_in.feedbacked && !s3_in.mmio || s3_safe_writeback)
   s3_out.bits.uop             := s3_in.uop
   s3_out.bits.uop.exceptionVec(loadAccessFault) := (s3_dly_ld_err  || s3_in.uop.exceptionVec(loadAccessFault)) && s3_ld_flow
   s3_out.bits.uop.replayInst := s3_rep_frm_fetch

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -599,7 +599,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   val s1_ld_flow    = RegNext(s0_ld_flow)
   val s1_isvec      = RegEnable(s0_out.isvec, false.B, s0_fire)
   val s1_isLastElem = RegEnable(s0_out.isLastElem, false.B, s0_fire)
-  val s1_st_amo     = FuType.storeIsAMO(s1_in.uop.ctrl.fuType) && !s1_ld_flow && !s1_isvec
+  val s1_st_amo     = FuType.storeIsAMO(s1_in.uop.fuType) && !s1_ld_flow && !s1_isvec
 
   s1_ready := true.B
   when (s0_fire) { s1_valid := true.B }

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -597,7 +597,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   val s1_isvec      = RegEnable(s0_out.isvec, false.B, s0_fire)
   val s1_isLastElem = RegEnable(s0_out.isLastElem, false.B, s0_fire)
 
-  s1_ready := !s1_valid || s1_kill || s2_ready
+  s1_ready := true.B
   when (s0_fire) { s1_valid := true.B }
   .elsewhen (s1_fire) { s1_valid := false.B }
   .elsewhen (s1_kill) { s1_valid := false.B }
@@ -838,7 +838,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   val s2_paddr  = RegEnable(s1_paddr_dup_lsu, s1_fire)
 
   s2_kill := s2_in.uop.robIdx.needFlush(io.redirect)
-  s2_ready := !s2_valid || s2_kill || s3_ready
+  s2_ready := true.B
   when (s1_fire) { s2_valid := true.B }
   .elsewhen (s2_fire) { s2_valid := false.B }
   .elsewhen (s2_kill) { s2_valid := false.B }

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -1092,14 +1092,8 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   io.ldu_io.ldCancel.ld1Cancel := false.B
 
   // fast wakeup
-  io.ldu_io.fast_uop.valid := RegNext(
-    !io.ldu_io.dcache.s1_disable_fast_wakeup &&
-    s1_valid &&
-    !s1_kill &&
-    !io.tlb.resp.bits.miss &&
-    !io.ldu_io.lsq.forward.dataInvalidFast
-  ) && (s2_valid && !s2_out.rep_info.need_rep && !s2_ld_mmio && s2_ld_flow) && !s2_isvec
-  io.ldu_io.fast_uop.bits := RegNext(s1_out.uop)
+  io.ldu_io.fast_uop.valid := false.B
+  io.ldu_io.fast_uop.bits := DontCare
 
   //
   io.ldu_io.s2_ptr_chasing                    := RegEnable(s1_try_ptr_chasing && !s1_cancel_ptr_chasing, false.B, s1_fire)

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -487,12 +487,13 @@ class HybridUnit(implicit p: Parameters) extends XSModule
 
   // set default
   s0_uop := DontCare
-  when (s0_super_ld_rep_select)      { fromNormalReplaySource(io.ldu_io.replay.bits)     }
-  .elsewhen (s0_ld_fast_rep_select)  { fromFastReplaySource(io.ldu_io.fast_rep_in.bits)  }
-  .elsewhen (s0_ld_rep_select)       { fromNormalReplaySource(io.ldu_io.replay.bits)     }
-  .elsewhen (s0_hw_prf_select)       { fromPrefetchSource(io.ldu_io.prefetch_req.bits)   }
-  .elsewhen (s0_int_iss_select)      { fromIntIssueSource(io.lsin.bits)                  }
-  .elsewhen (s0_vec_iss_select)      { fromVecIssueSource(io.vec_stu_io.in.bits)         }
+  when (s0_super_ld_rep_valid)      { fromNormalReplaySource(io.ldu_io.replay.bits)     }
+  .elsewhen (s0_ld_fast_rep_valid)  { fromFastReplaySource(io.ldu_io.fast_rep_in.bits)  }
+  .elsewhen (s0_ld_rep_valid)       { fromNormalReplaySource(io.ldu_io.replay.bits)     }
+  .elsewhen (s0_high_conf_prf_valid){ fromPrefetchSource(io.ldu_io.prefetch_req.bits)   }
+  .elsewhen (s0_int_iss_valid)      { fromIntIssueSource(io.lsin.bits)                  }
+  .elsewhen (s0_vec_iss_valid)      { fromVecIssueSource(io.vec_stu_io.in.bits)         }
+  .elsewhen (s0_low_conf_prf_valid) { fromPrefetchSource(io.ldu_io.prefetch_req.bits)   }
   .otherwise {
     if (EnableLoadToLoadForward) {
       fromLoadToLoadSource(io.ldu_io.l2l_fwd_in)

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -702,7 +702,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s1_vecActive        = RegEnable(s0_out.vecActive, true.B, s0_fire)
   val s1_vec_alignedType = RegEnable(io.vecldin.bits.alignedType, s0_fire)
 
-  s1_ready := !s1_valid || s1_kill || s2_ready
+  s1_ready := true.B
   when (s0_fire) { s1_valid := true.B }
   .elsewhen (s1_fire) { s1_valid := false.B }
   .elsewhen (s1_kill) { s1_valid := false.B }
@@ -901,7 +901,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s2_vec_alignedType = RegEnable(s1_vec_alignedType, s1_fire)
 
   s2_kill := s2_in.uop.robIdx.needFlush(io.redirect)
-  s2_ready := !s2_valid || s2_kill || s3_ready
+  s2_ready := true.B
   when (s1_fire) { s2_valid := true.B }
   .elsewhen (s2_fire) { s2_valid := false.B }
   .elsewhen (s2_kill) { s2_valid := false.B }
@@ -1168,7 +1168,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s3_isvec        = RegEnable(s2_out.isvec, false.B, s2_fire)
   val s3_vec_alignedType = RegEnable(s2_vec_alignedType, s2_fire)
   val s3_mmio         = Wire(Valid(new MemExuOutput))
-  s3_ready := !s3_valid || s3_kill || io.ldout.ready
+  s3_ready := true.B
   s3_mmio.valid := RegNextN(io.lsq.uncache.fire, 3, Some(false.B))
   s3_mmio.bits  := RegNextN(io.lsq.uncache.bits, 3)
 

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -588,14 +588,15 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   // set default
   val s0_src_selector = Seq(
-    s0_super_ld_rep_select,
-    s0_ld_fast_rep_select,
-    s0_ld_mmio_select,
-    s0_ld_rep_select,
-    s0_hw_prf_select,
-    s0_int_iss_select,
-    s0_vec_iss_select,
-    (if (EnableLoadToLoadForward) s0_l2l_fwd_select else true.B)
+    s0_super_ld_rep_valid,
+    s0_ld_fast_rep_valid,
+    s0_ld_mmio_valid,
+    s0_ld_rep_valid,
+    s0_high_conf_prf_valid,
+    s0_int_iss_valid,
+    s0_vec_iss_valid,
+    s0_low_conf_prf_valid,
+    (if (EnableLoadToLoadForward) s0_l2l_fwd_valid else true.B)
   )
   val s0_src_format = Seq(
     fromNormalReplaySource(io.replay.bits),
@@ -605,6 +606,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     fromPrefetchSource(io.prefetch_req.bits),
     fromIntIssueSource(io.ldin.bits),
     fromVecIssueSource(io.vecldin.bits),
+    fromPrefetchSource(io.prefetch_req.bits),
     (if (EnableLoadToLoadForward) fromLoadToLoadSource(io.l2l_fwd_in) else fromNullSource())
   )
   s0_sel_src := ParallelPriorityMux(s0_src_selector, s0_src_format)

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1113,14 +1113,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.ldCancel.ld1Cancel := false.B
 
   // fast wakeup
-  io.fast_uop.valid := RegNext(
-    !io.dcache.s1_disable_fast_wakeup &&
-    s1_valid &&
-    !s1_kill &&
-    !io.tlb.resp.bits.miss &&
-    !io.lsq.forward.dataInvalidFast
-  ) && (s2_valid && !s2_out.rep_info.need_rep && !s2_mmio) && !s2_isvec
-  io.fast_uop.bits := RegNext(s1_out.uop)
+  io.fast_uop.valid := false.B
+  io.fast_uop.bits := DontCare
 
   //
   io.s2_ptr_chasing                    := RegEnable(s1_try_ptr_chasing && !s1_cancel_ptr_chasing, false.B, s1_fire)

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1174,9 +1174,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   io.stld_nuke_query.map(x => x.s3_nuke := false.B)
   // forwrad last beat
-  val (s3_fwd_frm_d_chan, s3_fwd_data_frm_d_chan) = io.tl_d_channel.forward(s2_valid && s2_out.forward_tlDchannel, s2_out.mshrid, s2_out.paddr)
-  val s3_fwd_data_valid = RegEnable(s2_fwd_data_valid, false.B, s2_valid)
-  val s3_fwd_frm_d_chan_valid = (s3_fwd_frm_d_chan && s3_fwd_data_valid && s3_in.handledByMSHR)
   val s3_fast_rep_canceled = io.replay.valid && io.replay.bits.forward_tlDchannel || !io.dcache.req.ready && !s3_isvec
 
   // s3 load fast replay
@@ -1187,7 +1184,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   // TODO: check this --by hx
   // io.lsq.ldin.valid := s3_valid && (!s3_fast_rep || !io.fast_rep_out.ready) && !s3_in.feedbacked && !s3_in.lateKill
   io.lsq.ldin.bits := s3_in
-  io.lsq.ldin.bits.miss := s3_in.miss && !s3_fwd_frm_d_chan_valid
 
   /* <------- DANGEROUS: Don't change sequence here ! -------> */
   io.lsq.ldin.bits.data_wen_dup := s3_ld_valid_dup.asBools
@@ -1213,7 +1209,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s3_flushPipe = s3_ldld_rep_inst
 
   val s3_rep_info = WireInit(s3_in.rep_info)
-  s3_rep_info.dcache_miss   := s3_in.rep_info.dcache_miss && !s3_fwd_frm_d_chan_valid
   val s3_sel_rep_cause = PriorityEncoderOH(s3_rep_info.cause.asUInt)
 
   val s3_exception = ExceptionNO.selectByFu(s3_in.uop.exceptionVec, LduCfg).asUInt.orR && s3_vecActive
@@ -1306,13 +1301,13 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   // data from dcache hit
   val s3_ld_raw_data_frm_cache = Wire(new LoadDataFromDcacheBundle)
-  s3_ld_raw_data_frm_cache.respDcacheData       := io.dcache.resp.bits.data_delayed
+  s3_ld_raw_data_frm_cache.respDcacheData       := RegNext(io.dcache.resp.bits.data_delayed)
   s3_ld_raw_data_frm_cache.forwardMask          := RegEnable(s2_fwd_mask, s2_valid)
   s3_ld_raw_data_frm_cache.forwardData          := RegEnable(s2_fwd_data, s2_valid)
   s3_ld_raw_data_frm_cache.uop                  := RegEnable(s2_out.uop, s2_valid)
   s3_ld_raw_data_frm_cache.addrOffset           := RegEnable(s2_out.paddr(3, 0), s2_valid)
-  s3_ld_raw_data_frm_cache.forward_D            := RegEnable(s2_fwd_frm_d_chan, false.B, s2_valid) || s3_fwd_frm_d_chan_valid
-  s3_ld_raw_data_frm_cache.forwardData_D        := Mux(s3_fwd_frm_d_chan_valid, s3_fwd_data_frm_d_chan, RegEnable(s2_fwd_data_frm_d_chan, s2_valid))
+  s3_ld_raw_data_frm_cache.forward_D            := RegEnable(s2_fwd_frm_d_chan, false.B, s2_valid)
+  s3_ld_raw_data_frm_cache.forwardData_D        := RegEnable(s2_fwd_data_frm_d_chan, s2_valid)
   s3_ld_raw_data_frm_cache.forward_mshr         := RegEnable(s2_fwd_frm_mshr, false.B, s2_valid)
   s3_ld_raw_data_frm_cache.forwardData_mshr     := RegEnable(s2_fwd_data_frm_mshr, s2_valid)
   s3_ld_raw_data_frm_cache.forward_result_valid := RegEnable(s2_fwd_data_valid, false.B, s2_valid)
@@ -1492,7 +1487,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("s2_successfully_forward_channel_D", s2_fire && s2_fwd_frm_d_chan && s2_fwd_data_valid)
   XSPerfAccumulate("s2_successfully_forward_mshr",      s2_fire && s2_fwd_frm_mshr && s2_fwd_data_valid)
 
-  XSPerfAccumulate("s3_fwd_frm_d_chan",            s3_valid && s3_fwd_frm_d_chan_valid)
 
   XSPerfAccumulate("load_to_load_forward",                      s1_try_ptr_chasing && !s1_ptr_chasing_canceled)
   XSPerfAccumulate("load_to_load_forward_try",                  s1_try_ptr_chasing)

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1225,8 +1225,11 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     io.lsq.ldin.bits.rep_info.cause := VecInit(s3_sel_rep_cause.asBools)
   }
 
+  val s3_no_need_rep = !RegNext(s2_out.rep_info.need_rep) && !s3_in.mmio
+  val s3_safe_writeback = (s3_exception || s3_dly_ld_err || s3_no_need_rep)
+
   // Int load, if hit, will be writebacked at s3
-  s3_out.valid                := s3_valid && !io.lsq.ldin.bits.rep_info.need_rep && !s3_in.mmio
+  s3_out.valid                := s3_valid && s3_safe_writeback
   s3_out.bits.uop             := s3_in.uop
   s3_out.bits.uop.exceptionVec(loadAccessFault) := (s3_dly_ld_err || s3_in.uop.exceptionVec(loadAccessFault)) && s3_vecActive
   s3_out.bits.uop.flushPipe   := false.B

--- a/src/main/scala/xiangshan/mem/pipeline/StoreAddrUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreAddrUnit.scala
@@ -31,7 +31,7 @@ import xiangshan.backend.ctrlblock.DebugLsInfoBundle
 import xiangshan.cache.mmu.{TlbCmd, TlbReq, TlbRequestIO, TlbResp}
 import xiangshan.cache.{DcacheStoreRequestIO, DCacheStoreIO, MemoryOpConstants, HasDCacheParameters, StorePrefetchReq}
 
-class StoreUnit(implicit p: Parameters) extends XSModule with HasDCacheParameters {
+class StoreAddrUnit(implicit p: Parameters) extends XSModule with HasDCacheParameters {
   val io = IO(new Bundle() {
     val redirect        = Flipped(ValidIO(new Redirect))
     val stin            = Flipped(Decoupled(new MemExuInput))

--- a/src/main/scala/xiangshan/mem/pipeline/StoreAddrUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreAddrUnit.scala
@@ -24,6 +24,7 @@ import utility._
 import xiangshan.ExceptionNO._
 import xiangshan._
 import xiangshan.backend.Bundles.{MemExuInput, MemExuOutput}
+import xiangshan.backend.fu._
 import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.backend.fu.FuConfig._
 import xiangshan.backend.fu.FuType._
@@ -217,7 +218,8 @@ class StoreAddrUnit(implicit p: Parameters) extends XSModule with HasDCacheParam
   val s1_exception = ExceptionNO.selectByFu(s1_out.uop.exceptionVec, StaCfg).asUInt.orR
   val s1_isvec     = RegEnable(s0_out.isvec, false.B, s0_fire)
   val s1_isLastElem = RegEnable(s0_isLastElem, false.B, s0_fire)
-  s1_kill := s1_in.uop.robIdx.needFlush(io.redirect) || s1_tlb_miss
+  val s1_amo       = FuType.storeIsAMO(s1_in.uop.fuType)
+  s1_kill := s1_in.uop.robIdx.needFlush(io.redirect) || s1_tlb_miss || s1_amo
 
   s1_ready := true.B
   io.tlb.resp.ready := true.B // TODO: why dtlbResp needs a ready?
@@ -239,7 +241,7 @@ class StoreAddrUnit(implicit p: Parameters) extends XSModule with HasDCacheParam
   // Send TLB feedback to store issue queue
   // Store feedback is generated in store_s1, sent to RS in store_s2
   val s1_feedback = Wire(Valid(new RSFeedback))
-  s1_feedback.valid                 := s1_valid & !s1_in.isHWPrefetch && !s1_isvec
+  s1_feedback.valid                 := s1_valid & !s1_in.isHWPrefetch && !s1_isvec && !s1_amo
   s1_feedback.bits.hit              := !s1_tlb_miss
   s1_feedback.bits.flushState       := io.tlb.resp.bits.ptwBack
   s1_feedback.bits.robIdx           := s1_out.uop.robIdx
@@ -284,7 +286,7 @@ class StoreAddrUnit(implicit p: Parameters) extends XSModule with HasDCacheParam
   s1_out.uop.exceptionVec(storeGuestPageFault) := io.tlb.resp.bits.excp(0).gpf.st && s1_vecActive
 
   // scalar store and scalar load nuke check, and also other purposes
-  io.lsq.valid     := s1_valid && !s1_in.isHWPrefetch && !s1_isvec
+  io.lsq.valid     := s1_valid && !s1_in.isHWPrefetch && !s1_isvec && !s1_amo
   io.lsq.bits      := s1_out
   io.lsq.bits.miss := s1_tlb_miss
   // vector store and scalar load nuke check
@@ -294,7 +296,7 @@ class StoreAddrUnit(implicit p: Parameters) extends XSModule with HasDCacheParam
   io.lsq_vec.bits.isLastElem := s1_isLastElem
 
   // kill dcache write intent request when tlb miss or exception
-  io.dcache.s1_kill  := (s1_tlb_miss || s1_exception || s1_mmio || s1_in.uop.robIdx.needFlush(io.redirect))
+  io.dcache.s1_kill  := (s1_kill || s1_exception || s1_mmio)
   io.dcache.s1_paddr := s1_paddr
 
   // write below io.out.bits assign sentence to prevent overwriting values

--- a/src/main/scala/xiangshan/mem/pipeline/StoreDataUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreDataUnit.scala
@@ -1,0 +1,87 @@
+/***************************************************************************************
+* Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2021 Peng Cheng Laboratory
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+
+package xiangshan.mem
+
+import org.chipsalliance.cde.config.Parameters
+import chisel3._
+import chisel3.util._
+import utils._
+import utility._
+import xiangshan._
+import xiangshan.backend.Bundles.{MemExuInput, MemExuOutput}
+
+
+class StoreDataUnit(regOut: Boolean = false)(implicit p: Parameters) extends XSModule {
+  val io = IO(new Bundle() {
+    val redirect = Flipped(ValidIO(new Redirect))
+    val in = Flipped(DecoupledIO(new MemExuInput))
+    val out = DecoupledIO(new MemExuOutput)
+  })
+
+  if (regOut) {
+    val s1_ready = WireInit(false.B)
+
+    // Pipeline
+    // --------------------------------------------------------------------------------
+    // stage 0
+    // --------------------------------------------------------------------------------
+    val s0_valid = io.in.valid
+    val s0_out = io.in.bits
+    val s0_can_go = s1_ready
+    val s0_fire = s0_valid && s0_can_go
+
+
+    // Pipeline
+    // --------------------------------------------------------------------------------
+    // stage 1
+    // --------------------------------------------------------------------------------
+    val s1_valid = RegInit(false.B)
+    val s1_can_go = io.out.ready
+    val s1_fire = s1_valid && s1_can_go
+    val s1_in = RegEnable(s0_out, s0_fire)
+    val s1_out = Wire(new MemExuOutput)
+    s1_ready := io.out.ready
+
+    when (s0_fire) { s1_valid := true.B }
+    .elsewhen (s1_fire) { s1_valid := false.B }
+
+    s1_out := DontCare
+    s1_out.uop := s1_in.uop
+    s1_out.data := s1_in.src(0)
+
+    io.out.valid := s1_valid
+    io.out.bits := s1_out
+  } else {
+    // Pipeline
+    // --------------------------------------------------------------------------------
+    // stage 0
+    // --------------------------------------------------------------------------------
+    val s0_valid = io.in.valid
+    val s0_out = Wire(new MemExuOutput)
+
+    s0_out := DontCare
+    s0_out.uop := io.in.bits.uop
+    s0_out.data := io.in.bits.src(0)
+
+    io.out.valid := s0_valid
+    io.out.bits := s0_out
+
+    io.in.ready := io.out.ready
+  }
+
+}

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -118,9 +118,9 @@ trait HasTrainFilterHelper extends HasCircularQueuePtrHelper {
       res
     }else if(source.length == 3) {
       // TODO: generalize
-      val res_0_1 = Wire(source.cloneType)
-      val res_1_2 = Wire(source.cloneType)
-      val res = Wire(source.cloneType)
+      val res_0_1 = Reg(source.cloneType)
+      val res_1_2 = Reg(source.cloneType)
+      val res = Reg(source.cloneType)
 
       val tmp = reorder(VecInit(source.slice(0, 2)))
       res_0_1(0) := tmp(0)


### PR DESCRIPTION
Completed:
✅ Disable fast wakeup for new-backend (unsupport)
✅ Physically disable DCache Tag/Data ECC 
✅ Prefetcher support 3Load
✅ Optimize pmp timing (#2546)
✅ Use valid instead of select for source selector
✅ Optimize vaddr generate logic

WIP:
❌ Move loadPc buffer from Memblock to Backend (need backend support)
❌ Perform signed ext in RS (need backend support)
❌ Add detailed model to replace sim model (need backend support)