### PR TITLE
rv64v: add ignore oldvd judgement in issue queue

### DIFF
--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -163,6 +163,8 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   private val og1CancelOH: UInt = dataPath.io.og1CancelOH
   private val og0CancelOH: UInt = dataPath.io.og0CancelOH
   private val cancelToBusyTable = dataPath.io.cancelToBusyTable
+  private val vlIsZero = intExuBlock.io.vlIsZero.get
+  private val vlIsVlmax = intExuBlock.io.vlIsVlmax.get
 
   ctrlBlock.io.IQValidNumVec := intScheduler.io.IQValidNumVec
   ctrlBlock.io.fromTop.hartId := io.fromTop.hartId
@@ -199,6 +201,8 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   intScheduler.io.fromDataPath.og1Cancel := og1CancelOH
   intScheduler.io.ldCancel := io.mem.ldCancel
   intScheduler.io.fromDataPath.cancelToBusyTable := cancelToBusyTable
+  intScheduler.io.vlWriteBack.vlIsZero := false.B
+  intScheduler.io.vlWriteBack.vlIsVlmax := false.B
 
   memScheduler.io.fromTop.hartId := io.fromTop.hartId
   memScheduler.io.fromCtrlBlock.flush := ctrlBlock.io.toIssueBlock.flush
@@ -231,6 +235,8 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   memScheduler.io.fromDataPath.og1Cancel := og1CancelOH
   memScheduler.io.ldCancel := io.mem.ldCancel
   memScheduler.io.fromDataPath.cancelToBusyTable := cancelToBusyTable
+  memScheduler.io.vlWriteBack.vlIsZero := vlIsZero
+  memScheduler.io.vlWriteBack.vlIsVlmax := vlIsVlmax
 
   vfScheduler.io.fromTop.hartId := io.fromTop.hartId
   vfScheduler.io.fromCtrlBlock.flush := ctrlBlock.io.toIssueBlock.flush
@@ -244,6 +250,8 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   vfScheduler.io.fromDataPath.og1Cancel := og1CancelOH
   vfScheduler.io.ldCancel := io.mem.ldCancel
   vfScheduler.io.fromDataPath.cancelToBusyTable := cancelToBusyTable
+  vfScheduler.io.vlWriteBack.vlIsZero := vlIsZero
+  vfScheduler.io.vlWriteBack.vlIsVlmax := vlIsVlmax
 
   dataPath.io.hartId := io.fromTop.hartId
   dataPath.io.flush := ctrlBlock.io.toDataPath.flush

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -365,6 +365,8 @@ class IssueQueueIQWakeUpBundle(
     val isOpMask  = Bool() // vmand, vmnand
     val isMove    = Bool() // vmv.s.x, vmv.v.v, vmv.v.x, vmv.v.i
 
+    val isDependOldvd = Bool() // some instruction's computation depends on oldvd
+
     def vtype: VType = {
       val res = Wire(VType())
       res.illegal := this.vill

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -812,9 +812,13 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
     decodedInst.vpu.veew := inst.WIDTH
     decodedInst.vpu.isReverse := needReverseInsts.map(_ === inst.ALL).reduce(_ || _)
     decodedInst.vpu.isExt := vextInsts.map(_ === inst.ALL).reduce(_ || _)
-    decodedInst.vpu.isNarrow := narrowInsts.map(_ === inst.ALL).reduce(_ || _)
-    decodedInst.vpu.isDstMask := maskDstInsts.map(_ === inst.ALL).reduce(_ || _)
-    decodedInst.vpu.isOpMask := maskOpInsts.map(_ === inst.ALL).reduce(_ || _)
+    val isNarrow = narrowInsts.map(_ === inst.ALL).reduce(_ || _)
+    val isDstMask = maskDstInsts.map(_ === inst.ALL).reduce(_ || _)
+    val isOpMask = maskOpInsts.map(_ === inst.ALL).reduce(_ || _)
+    decodedInst.vpu.isNarrow := isNarrow
+    decodedInst.vpu.isDstMask := isDstMask
+    decodedInst.vpu.isOpMask := isOpMask
+    decodedInst.vpu.isDependOldvd := isVppu || isVecOPF || isVStore || (isDstMask && !isOpMask) || isNarrow
   }
 
   decodedInst.vlsInstr := isVls
@@ -836,8 +840,8 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
   io.deq.decodedInst := decodedInst
   io.deq.decodedInst.rfWen := (decodedInst.ldest =/= 0.U) && decodedInst.rfWen
 
-  // when vta and vma are all set, no need to read old vd
-  decodedInst.srcType(2) := Mux(!isFpToVecInst && ((inst.VM === 0.U && !io.enq.vtype.vma) || !io.enq.vtype.vta || isVppu || isVecOPF || isVStore), SrcType.vp, SrcType.no) // old vd
+  // when instruction is not a vector instruction
+  decodedInst.srcType(2) := Mux(!isFpToVecInst, SrcType.vp, SrcType.no) // old vd
   //-------------------------------------------------------------
   // Debug Info
 //  XSDebug("in:  instr=%x pc=%x excepVec=%b crossPageIPFFix=%d\n",

--- a/src/main/scala/xiangshan/backend/decode/FPDecoder.scala
+++ b/src/main/scala/xiangshan/backend/decode/FPDecoder.scala
@@ -94,6 +94,7 @@ class FPToVecDecoder(implicit p: Parameters) extends XSModule {
   io.vpuCtrl.isNarrow  := false.B
   io.vpuCtrl.isDstMask := false.B
   io.vpuCtrl.isOpMask  := false.B
+  io.vpuCtrl.isDependOldvd := false.B
 }
 
 

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -37,6 +37,8 @@ class ExeUnitIO(params: ExeUnitParams)(implicit p: Parameters) extends XSBundle 
   val fenceio = if (params.hasFence) Some(new FenceIO) else None
   val frm = if (params.needSrcFrm) Some(Input(UInt(3.W))) else None
   val vxrm = if (params.needSrcVxrm) Some(Input(UInt(2.W))) else None
+  val vlIsZero = OptionWrapper(params.writeVConfig, Output(Bool()))
+  val vlIsVlmax = OptionWrapper(params.writeVConfig, Output(Bool()))
 }
 
 class ExeUnit(val exuParams: ExeUnitParams)(implicit p: Parameters) extends LazyModule {
@@ -261,6 +263,8 @@ class ExeUnitImp(
   io.fenceio.foreach(exuio => funcUnits.foreach(fu => fu.io.fenceio.foreach(fuio => fuio <> exuio)))
   io.frm.foreach(exuio => funcUnits.foreach(fu => fu.io.frm.foreach(fuio => fuio <> exuio)))
   io.vxrm.foreach(exuio => funcUnits.foreach(fu => fu.io.vxrm.foreach(fuio => fuio <> exuio)))
+  io.vlIsZero.foreach(exuio => funcUnits.foreach(fu => fu.io.vlIsZero.foreach(fuio => exuio := fuio)))
+  io.vlIsVlmax.foreach(exuio => funcUnits.foreach(fu => fu.io.vlIsVlmax.foreach(fuio => exuio := fuio)))
 
   // debug info
   io.out.bits.debug     := 0.U.asTypeOf(io.out.bits.debug)

--- a/src/main/scala/xiangshan/backend/exu/ExeUnitParams.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnitParams.scala
@@ -67,6 +67,7 @@ case class ExeUnitParams(
   val needSrcVxrm: Boolean = fuConfigs.map(_.needSrcVxrm).reduce(_ || _)
   val needFPUCtrl: Boolean = fuConfigs.map(_.needFPUCtrl).reduce(_ || _)
   val needVPUCtrl: Boolean = fuConfigs.map(_.needVecCtrl).reduce(_ || _)
+  val writeVConfig: Boolean = fuConfigs.map(_.writeVConfig).reduce(_ || _)
   val isHighestWBPriority: Boolean = wbPortConfigs.forall(_.priority == 0)
 
   val isIntExeUnit: Boolean = schdType.isInstanceOf[IntScheduler]

--- a/src/main/scala/xiangshan/backend/exu/ExuBlock.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExuBlock.scala
@@ -38,6 +38,8 @@ class ExuBlockImp(
     exu.io.fenceio.foreach(exuio => io.fenceio.get <> exuio)
     exu.io.frm.foreach(exuio => io.frm.get <> exuio)
     exu.io.vxrm.foreach(exuio => io.vxrm.get <> exuio)
+    exu.io.vlIsZero.foreach(exuio => io.vlIsZero.get := exuio)
+    exu.io.vlIsVlmax.foreach(exuio => io.vlIsVlmax.get := exuio)
     exu.io.in <> input
     output <> exu.io.out
     if (exu.wrapper.exuParams.fuConfigs.contains(AluCfg) || exu.wrapper.exuParams.fuConfigs.contains(BrhCfg)){
@@ -65,4 +67,6 @@ class ExuBlockIO(implicit p: Parameters, params: SchdBlockParams) extends XSBund
   val fenceio = if (params.hasFence) Some(new FenceIO) else None
   val frm = if (params.needSrcFrm) Some(Input(UInt(3.W))) else None
   val vxrm = if (params.needSrcVxrm) Some(Input(UInt(2.W))) else None
+  val vlIsZero = OptionWrapper(params.writeVConfig, Output(Bool()))
+  val vlIsVlmax = OptionWrapper(params.writeVConfig, Output(Bool()))
 }

--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -63,6 +63,7 @@ case class FuConfig (
   trigger       : Boolean = false,
   needSrcFrm    : Boolean = false,
   needSrcVxrm   : Boolean = false,
+  writeVConfig  : Boolean = false,
   immType       : Set[UInt] = Set(),
   // vector
   vconfigWakeUp : Boolean = false,
@@ -349,6 +350,7 @@ object FuConfig {
     ),
     piped = true,
     writeVecRf = true,
+    writeVConfig = true,
     latency = CertainLatency(0),
     immType = Set(SelImm.IMM_VSETVLI, SelImm.IMM_VSETIVLI),
   )
@@ -362,6 +364,7 @@ object FuConfig {
     ),
     piped = true,
     writeVecRf = true,
+    writeVConfig = true,
     latency = CertainLatency(0),
     immType = Set(SelImm.IMM_VSETVLI, SelImm.IMM_VSETIVLI),
   )

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -83,6 +83,8 @@ class FuncUnitIO(cfg: FuConfig)(implicit p: Parameters) extends XSBundle {
   val fenceio = if (cfg.isFence) Some(new FenceIO) else None
   val frm = if (cfg.needSrcFrm) Some(Input(UInt(3.W))) else None
   val vxrm = if (cfg.needSrcVxrm) Some(Input(UInt(2.W))) else None
+  val vlIsZero = OptionWrapper(cfg.writeVConfig, Output(Bool()))
+  val vlIsVlmax = OptionWrapper(cfg.writeVConfig, Output(Bool()))
 }
 
 abstract class FuncUnit(val cfg: FuConfig)(implicit p: Parameters) extends XSModule {

--- a/src/main/scala/xiangshan/backend/fu/Vsetu.scala
+++ b/src/main/scala/xiangshan/backend/fu/Vsetu.scala
@@ -33,6 +33,7 @@ class VsetModuleIO(implicit p: Parameters) extends XSBundle {
 
   val out = Output(new Bundle {
     val vconfig: VConfig = VConfig()
+    val vlmax  : UInt = UInt(vlWidth.W)
   })
 
   // test bundle for internal state
@@ -102,6 +103,8 @@ class VsetModule(implicit p: Parameters) extends XSModule {
   outVConfig.vtype.vma := Mux(illegal, 0.U, vtype.vma)
   outVConfig.vtype.vlmul := Mux(illegal, 0.U, vtype.vlmul)
   outVConfig.vtype.vsew := Mux(illegal, 0.U, vtype.vsew)
+
+  io.out.vlmax := vlmax
 
   io.testOut.vlmax := vlmax
   io.testOut.log2Vlmax := log2Vlmax

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VSet.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VSet.scala
@@ -71,8 +71,13 @@ class VSetRiWi(cfg: FuConfig)(implicit p: Parameters) extends VSetBase(cfg) {
 class VSetRiWvf(cfg: FuConfig)(implicit p: Parameters) extends VSetBase(cfg) {
   vsetModule.io.in.avl := avl
   vsetModule.io.in.vtype := vtype
+  val vl = vsetModule.io.out.vconfig.vl
+  val vlmax = vsetModule.io.out.vlmax
 
   out.res.data := ZeroExt(vsetModule.io.out.vconfig.asUInt, XLEN)
+
+  if (cfg.writeVConfig) io.vlIsZero.get := vl === 0.U
+  if (cfg.writeVConfig) io.vlIsVlmax.get := vl === vlmax
 
   debugIO.vconfig := vsetModule.io.out.vconfig
 }
@@ -92,11 +97,15 @@ class VSetRvfWvf(cfg: FuConfig)(implicit p: Parameters) extends VSetBase(cfg) {
 
   val oldVL = in.data.src(0).asTypeOf(VConfig()).vl
   val res = WireInit(0.U.asTypeOf(VConfig()))
+  val vlmax = vsetModule.io.out.vlmax
   res.vl := Mux(vsetModule.io.out.vconfig.vtype.illegal, 0.U,
               Mux(VSETOpType.isKeepVl(in.ctrl.fuOpType), oldVL, vsetModule.io.out.vconfig.vl))
   res.vtype := vsetModule.io.out.vconfig.vtype
 
   out.res.data := ZeroExt(res.asUInt, XLEN)
+
+  if (cfg.writeVConfig) io.vlIsZero.get := res.vl === 0.U
+  if (cfg.writeVConfig) io.vlIsVlmax.get := res.vl === vlmax
 
   debugIO.vconfig := res
 }

--- a/src/main/scala/xiangshan/backend/issue/Entries.scala
+++ b/src/main/scala/xiangshan/backend/issue/Entries.scala
@@ -409,6 +409,8 @@ class Entries(implicit p: Parameters, params: IssueBlockParams) extends XSModule
     in.flush                    := io.flush
     in.wakeUpFromWB             := io.wakeUpFromWB
     in.wakeUpFromIQ             := io.wakeUpFromIQ
+    in.vlIsZero                 := io.vlIsZero
+    in.vlIsVlmax                := io.vlIsVlmax
     in.og0Cancel                := io.og0Cancel
     in.og1Cancel                := io.og1Cancel
     in.ldCancel                 := io.ldCancel
@@ -492,6 +494,8 @@ class EntriesIO(implicit p: Parameters, params: IssueBlockParams) extends XSBund
   // wakeup
   val wakeUpFromWB: MixedVec[ValidIO[IssueQueueWBWakeUpBundle]] = Flipped(params.genWBWakeUpSinkValidBundle)
   val wakeUpFromIQ: MixedVec[ValidIO[IssueQueueIQWakeUpBundle]] = Flipped(params.genIQWakeUpSinkValidBundle)
+  val vlIsZero            = Input(Bool())
+  val vlIsVlmax           = Input(Bool())
   val og0Cancel           = Input(ExuOH(backendParams.numExu))
   val og1Cancel           = Input(ExuOH(backendParams.numExu))
   val ldCancel            = Vec(backendParams.LdExuCnt, Flipped(new LoadCancelIO))

--- a/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
@@ -106,6 +106,8 @@ case class IssueBlockParams(
 
   def needSrcVxrm: Boolean = exuBlockParams.map(_.needSrcVxrm).reduce(_ || _)
 
+  def writeVConfig: Boolean = exuBlockParams.map(_.writeVConfig).reduce(_ || _)
+
   def numPcReadPort: Int = (if (needPc) 1 else 0) * numEnq
 
   def numWriteIntRf: Int = exuBlockParams.count(_.writeIntRf)

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -56,6 +56,8 @@ class IssueQueueIO()(implicit p: Parameters, params: IssueBlockParams) extends X
   val wbBusyTableWrite = Output(params.genWbFuBusyTableWriteBundle())
   val wakeupFromWB: MixedVec[ValidIO[IssueQueueWBWakeUpBundle]] = Flipped(params.genWBWakeUpSinkValidBundle)
   val wakeupFromIQ: MixedVec[ValidIO[IssueQueueIQWakeUpBundle]] = Flipped(params.genIQWakeUpSinkValidBundle)
+  val vlIsZero = Input(Bool())
+  val vlIsVlmax = Input(Bool())
   val og0Cancel = Input(ExuOH(backendParams.numExu))
   val og1Cancel = Input(ExuOH(backendParams.numExu))
   val ldCancel = Vec(backendParams.LduCnt + backendParams.HyuCnt, Flipped(new LoadCancelIO))
@@ -304,6 +306,8 @@ class IssueQueueImp(override val wrapper: IssueQueue)(implicit p: Parameters, va
     }
     entriesIO.wakeUpFromWB                                      := io.wakeupFromWB
     entriesIO.wakeUpFromIQ                                      := io.wakeupFromIQ
+    entriesIO.vlIsZero                                          := io.vlIsZero
+    entriesIO.vlIsVlmax                                         := io.vlIsVlmax
     entriesIO.og0Cancel                                         := io.og0Cancel
     entriesIO.og1Cancel                                         := io.og1Cancel
     entriesIO.ldCancel                                          := io.ldCancel

--- a/src/main/scala/xiangshan/backend/issue/SchdBlockParams.scala
+++ b/src/main/scala/xiangshan/backend/issue/SchdBlockParams.scala
@@ -95,6 +95,8 @@ case class SchdBlockParams(
 
   def needSrcVxrm: Boolean = issueBlockParams.map(_.needSrcVxrm).reduce(_ || _)
 
+  def writeVConfig: Boolean = issueBlockParams.map(_.writeVConfig).reduce(_ || _)
+
   def numRedirect: Int = issueBlockParams.map(_.numRedirect).sum
 
   def pregIdxWidth: Int = log2Up(numPregs)


### PR DESCRIPTION
1. when the instruction depend on old vd, we cannot set the srctype to imm
2. when vl = 0, we cannot set the srctype to imm because the vd keep the old value
3. when vl = vlmax, we can set srctype to imm when vta is not se