### PR TITLE
ci: use MFC for nightly regression

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3     \
-            --with-dramsim3 --threads 16 --spike
+            --with-dramsim3 --threads 16 --spike --mfc
       - name: Random Checkpoint 0
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \


### PR DESCRIPTION
It takes too long to compile emu using SFC. I propose using MFC instead.