### PR TITLE
Prevent XSTile duplication for new backend

### DIFF
--- a/.github/workflows/check_verilog.py
+++ b/.github/workflows/check_verilog.py
@@ -13,6 +13,7 @@ if __name__ == "__main__":
     in_sync_always = False
     always_depth = 0
     line_number = 0
+    count_xstile = 0
     with open(sys.argv[1], "r") as f:
         for line in f:
             if "$fatal" in line or "$fwrite" in line:
@@ -27,6 +28,12 @@ if __name__ == "__main__":
                 in_decode = False
                 in_dispatch = False
                 in_miss_entry = False
+            elif line.startswith("module XSTile"):
+                count_xstile += 1
+                if count_xstile > 1:
+                    err(line, line_number, "Found duplicated XSTile!\n" +
+                                           "Please convert Map, Set to Seq and sort it to generate RTL in Scala.\n" +
+                                           "And always use HartID from IO.\n")
             elif in_decode and "_pc" in line:
                 err(line, line_number, "PC should not be in decode!!!\n")
             elif in_dispatch and "_lsrc" in line:

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -953,7 +953,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
     println(f"$addr%#03x ${mapping(addr)._1}")
   }
 
-  val vs_s_csr_map = Map(
+  val vs_s_csr_map = List(
     Sstatus.U  -> Vsstatus.U,
     Sie.U      -> Vsie.U,
     Stvec.U    -> Vstvec.U,

--- a/src/main/scala/xiangshan/backend/issue/FuBusyTableWrite.scala
+++ b/src/main/scala/xiangshan/backend/issue/FuBusyTableWrite.scala
@@ -42,7 +42,7 @@ class FuBusyTableWrite(fuLatencyMap: Map[FuType.OHType, Int]) (implicit p: Param
     VecInit((0 until tableSize).map {
       lat =>
         Cat(
-          latMappedFuTypeSet.getOrElse(lat, Set()).map(
+          latMappedFuTypeSet.getOrElse(lat, Set()).toSeq.sorted.map(
             fuType => resp.bits.fuType(fuType.id)
           ).toSeq
         ).orR

--- a/src/main/scala/xiangshan/backend/issue/ImmExtractor.scala
+++ b/src/main/scala/xiangshan/backend/issue/ImmExtractor.scala
@@ -38,7 +38,7 @@ class ImmExtractor(dataBits: Int, immTypeSet: Set[BigInt]) extends Module {
     SelImm.IMM_VRORVI   .litValue -> SignExt(ImmUnion.VRORVI  .toImm32(io.in.imm), IntData().dataWidth),
   )
 
-  val usedMap: Map[BigInt, UInt] = extractMap.view.filterKeys(x => immTypeSet.contains(x)).toMap
+  val usedMap: Seq[(BigInt, UInt)] = extractMap.view.filterKeys(x => immTypeSet.contains(x)).toSeq.sortWith(_._1 < _._1)
   println(usedMap)
 
   io.out.imm := MuxLookup(io.in.immType, 0.U)(usedMap.map { case (k, v) => (k.U, v) }.toSeq)


### PR DESCRIPTION
XSTile will duplicated after the new backend is merged. This PR fixed this by preventing the direct use of Map and Set in Chisel and letting them convert to Seq and sorted by some fixed key. And add CI to prevent this from happening again. 

I suggest merging it with **rebase** mode since I have 2 commits, one for bug fixes and one for adding ci, to prevent it from happening again.