### PR TITLE
riscv-zicond: Add Zicond Extension

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -454,6 +454,13 @@ object HypervisorDecode extends DecodeConstants {
   )
 }
 
+object ZicondDecode extends DecodeConstants {
+  override val decodeArray: Array[(BitPat, XSDecodeBase)] = Array(
+    CZERO_EQZ   -> XSDecode(SrcType.reg, SrcType.reg, SrcType.X, FuType.alu, ALUOpType.czero_eqz, SelImm.X, xWen = T, canRobCompress = T),
+    CZERO_NEZ   -> XSDecode(SrcType.reg, SrcType.reg, SrcType.X, FuType.alu, ALUOpType.czero_nez, SelImm.X, xWen = T, canRobCompress = T),
+  )
+}
+
 /**
  * XiangShan Trap Decode constants
  */
@@ -672,7 +679,8 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
     CBODecode.table ++
     SvinvalDecode.table ++
     HypervisorDecode.table ++
-    VecDecoder.table
+    VecDecoder.table ++
+    ZicondDecode.table
 
   require(decode_table.map(_._2.length == 15).reduce(_ && _), "Decode tables have different column size")
   // assertion for LUI: only LUI should be assigned `selImm === SelImm.IMM_U && fuType === FuType.alu`

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -300,6 +300,10 @@ package object xiangshan {
     def bltu       = "b111_1100".U
     def bgeu       = "b111_1110".U
 
+    // Zicond
+    def czero_eqz  = "b111_0100".U
+    def czero_nez  = "b111_0110".U
+
     // misc optype
     def and        = "b100_0000".U
     def andn       = "b100_0001".U


### PR DESCRIPTION
This PR added RISC-V Integer Conditional Operations Extension, which is in the RVA23U64 Profile Mandatory Base. And the performance of conditional move instructions in micro-architecture is an interesting point to explore.

Zicond instructions added: czero.eqz, czero.nez

Changes based on spec:
https://github.com/riscvarchive/riscv-zicond/releases/download/v1.0.1/riscv-zicond_1.0.1.pdf