### PR TITLE
AXI4UART: dynamically adjust txDataPos using beatBytes

### DIFF
--- a/src/main/scala/device/AXI4UART.scala
+++ b/src/main/scala/device/AXI4UART.scala
@@ -36,8 +36,10 @@ class AXI4UART
     val stat = RegInit(0.U(32.W))
     val ctrl = RegInit(0.U(32.W))
 
+    val txDataPos = (4 % node.portParams.head.beatBytes) * 8;
+
     io.extra.get.out.valid := (waddr(3,0) === 4.U && in.w.fire)
-    io.extra.get.out.ch := in.w.bits.data(7,0)
+    io.extra.get.out.ch := in.w.bits.data(7 + txDataPos, txDataPos)
     io.extra.get.in.valid := (raddr(3,0) === 0.U && in.r.fire)
 
     val mapping = Map(


### PR DESCRIPTION
txData is not always on wdata(7,0) when AXI4 DataWidth >= 32 bits, we should adjust it dynamically.