### PR TITLE
Config: set minimal hartid width to 6

### DIFF
--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -72,8 +72,7 @@ object ArgParser {
               up(XSTileKey).head.copy(HartId = i)
             }
             case MaxHartIdBits =>
-              require(log2Up(value.toInt) <= 10, "MaxHartIdBits should not be larger than 10.")
-              log2Up(value.toInt)
+              log2Up(value.toInt) max up(MaxHartIdBits)
           }), tail)
         case "--with-dramsim3" :: tail =>
           nextOption(config.alter((site, here, up) => {

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -34,6 +34,7 @@ object ArgParser {
       |--xs-help                  print this help message
       |--config <ConfigClassName>
       |--num-cores <Int>
+      |--hartidbits <Int>
       |--with-dramsim3
       |--fpga-platform
       |--enable-difftest
@@ -73,6 +74,10 @@ object ArgParser {
             }
             case MaxHartIdBits =>
               log2Up(value.toInt) max up(MaxHartIdBits)
+          }), tail)
+        case "--hartidbits" :: hartidbits :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case MaxHartIdBits => hartidbits
           }), tail)
         case "--with-dramsim3" :: tail =>
           nextOption(config.alter((site, here, up) => {

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -50,7 +50,7 @@ class BaseConfig(n: Int) extends Config((site, here, up) => {
   case ExportDebug => DebugAttachParams(protocols = Set(JTAG))
   case DebugModuleKey => Some(XSDebugModuleParams(site(XLen)))
   case JtagDTMKey => JtagDTMKey
-  case MaxHartIdBits => log2Up(n)
+  case MaxHartIdBits => log2Up(n) max 6
   case EnableJtag => true.B
 })
 


### PR DESCRIPTION
This can help users who only build one core but then manually instantiate more than two cores in the SoC.