### PR TITLE
LogUtils: remove the unused reset condition

### DIFF
--- a/src/main/scala/utils/LogUtils.scala
+++ b/src/main/scala/utils/LogUtils.scala
@@ -46,7 +46,7 @@ object XSLog {
       val ctrlInfo = ctrlInfoOpt.getOrElse(Module(new LogPerfHelper).io)
       val logEnable = ctrlInfo.logEnable
       val logTimestamp = ctrlInfo.timer
-      val check_cond = (if (debugLevel == XSLogLevel.ERROR) true.B else logEnable) && cond && RegNext(true.B, false.B)
+      val check_cond = (if (debugLevel == XSLogLevel.ERROR) true.B else logEnable) && cond
       when (check_cond) {
         val commonInfo = p"[$debugLevel][time=$logTimestamp] $MagicStr: "
         printf((if (prefix) commonInfo else p"") + pable)


### PR DESCRIPTION
Chisel Assertions are checked only when reset is deasserted.

This extra condition is introduced in https://github.com/OpenXiangShan/XiangShan/pull/2023. It seems to be asserted only after reset is deasserted. However, Chisel automatically generates a `~reset` condition for assertions. The simulation seems OK without this extra condition.