### PR TITLE
bpu: fix ittage reset init

### DIFF
--- a/src/main/scala/xiangshan/frontend/ITTAGE.scala
+++ b/src/main/scala/xiangshan/frontend/ITTAGE.scala
@@ -263,7 +263,7 @@ class ITTageTable
   // io.req.ready := !bank_conflict
   XSPerfAccumulate(f"ittage_table_bank_conflict", bank_conflict)
 
-  us.io.wen := io.update.uValid
+  us.io.wen := io.update.uValid && io.update.valid
   us.io.waddr := update_idx
   us.io.wdata := io.update.u
 
@@ -570,15 +570,15 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
 
 
   for (i <- 0 until ITTageNTables) {
-    tables(i).io.update.valid := RegNext(updateMask(i))
-    tables(i).io.update.reset_u := RegNext(updateResetU)
+    tables(i).io.update.valid := RegNext(updateMask(i), init = false.B)
+    tables(i).io.update.reset_u := RegNext(updateResetU, init = false.B)
     tables(i).io.update.correct := RegEnable(updateCorrect(i), updateMask(i))
     tables(i).io.update.target := RegEnable(updateTarget(i), updateMask(i))
     tables(i).io.update.old_target := RegEnable(updateOldTarget(i), updateMask(i))
     tables(i).io.update.alloc := RegEnable(updateAlloc(i), updateMask(i))
     tables(i).io.update.oldCtr := RegEnable(updateOldCtr(i), updateMask(i))
 
-    tables(i).io.update.uValid := RegEnable(updateUMask(i), updateMask(i))
+    tables(i).io.update.uValid := RegEnable(updateUMask(i), false.B, updateMask(i))
     tables(i).io.update.u := RegEnable(updateU(i), updateMask(i))
     tables(i).io.update.pc := RegEnable(update.pc, updateMask(i))
     // use fetch pc instead of instruction pc


### PR DESCRIPTION
update.uValid is X when reset, sometimes causing random bits written into ITTAGE useful array.
this commit fixes the useful array write condition and RegEnable reset init.

The figure below is the waveform of the same `emu` on the same workload (microbench) with a different seed.

<img width="1348" alt="Screenshot 2024-05-11 at 12 58 23" src="https://github.com/OpenXiangShan/XiangShan/assets/19954398/b7688181-8000-41c1-a285-cb15277aa7c4">

The X state will not propagate. However, it may already cause problems before it is stabilized by a valid signal from previous stages.

This PR will very likely fix the CI IPC fluctuation.