### PR TITLE
CSR: remove useless sdsid custom-CSR

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -525,8 +525,6 @@ class CustomCSRCtrlIO(implicit p: Parameters) extends XSBundle {
   val l2_pf_store_only = Output(Bool())
   // ICache
   val icache_parity_enable = Output(Bool())
-  // Labeled XiangShan
-  val dsid = Output(UInt(8.W)) // TODO: DsidWidth as parameter
   // Load violation predictor
   val lvpred_disable = Output(Bool())
   val no_spec_load = Output(Bool())

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -528,10 +528,6 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   val sfetchctl = RegInit(UInt(XLEN.W), "b0".U)
   csrio.customCtrl.icache_parity_enable := sfetchctl(0)
 
-  // sdsid: Differentiated Services ID
-  val sdsid = RegInit(UInt(XLEN.W), 0.U)
-  csrio.customCtrl.dsid := sdsid
-
   // slvpredctl: load violation predict settings
   // Default reset period: 2^16
   // Why this number: reset more frequently while keeping the overhead low
@@ -816,7 +812,6 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
     MaskedRegMap(Sbpctl, sbpctl),
     MaskedRegMap(Spfctl, spfctl),
     MaskedRegMap(Sfetchctl, sfetchctl),
-    MaskedRegMap(Sdsid, sdsid),
     MaskedRegMap(Slvpredctl, slvpredctl),
     MaskedRegMap(Smblockctl, smblockctl),
     MaskedRegMap(Srnctl, srnctl),

--- a/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
@@ -116,7 +116,6 @@ trait HasCSRConst {
   val Scachebase    = 0x5C5
 
   // Supervisor Custom Read/Write
-  val Sdsid         = 0x9C0
   val Sfetchctl     = 0x9e0
 
   // Hypervisor Trap Setup


### PR DESCRIPTION
Custom-CSR sdsid is a legacy from labeled XiangShan, which is no longer in use. Remove this Custom-CSR.

This patch fixes OpenXiangShan/NEMU#329