### PR TITLE
LLPTW, RVH: fix the mem_resp_hit when the new req's status is changed to last_hptw_req

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -506,7 +506,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     entries(enq_ptr).wait_id := Mux(to_wait, wait_id, enq_ptr)
     entries(enq_ptr).af := false.B
     entries(enq_ptr).hptw_resp := Mux(to_last_hptw_req, entries(last_hptw_req_id).hptw_resp, Mux(to_wait, entries(wait_id).hptw_resp, entries(enq_ptr).hptw_resp))
-    mem_resp_hit(enq_ptr) := to_mem_out
+    mem_resp_hit(enq_ptr) := to_mem_out || to_last_hptw_req
   }
 
   val enq_ptr_reg = RegNext(enq_ptr)


### PR DESCRIPTION
When the req is sent into LLPTW and its status need to be changed to last_hptw_req, the mem_resp_hit is not valid. It make L2TLB don't store the pte of the req. That is why L2TLB resp a wrong stage 1 pte. So the mem_resp_hit need to be valid when the new req's status is changed into last_hptw_req directly.