### PR TITLE
args: modify the optional configuration of the run command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,9 @@ override SIM_ARGS += --with-constantin
 endif
 
 # emu for the release version
-RELEASE_ARGS += --fpga-platform --disable-all --remove-assert
+RELEASE_ARGS += --fpga-platform --disable-all --remove-assert --reset-gen
 DEBUG_ARGS   += --enable-difftest
 PLDM_ARGS    += --fpga-platform --enable-difftest
-FPGA_ARGS    += --fpga-platform --enable-difftest --reset-gen
 ifeq ($(GOALS),verilog)
 RELEASE_ARGS += --disable-always-basic-diff
 endif
@@ -117,8 +116,6 @@ ifeq ($(RELEASE),1)
 override SIM_ARGS += $(RELEASE_ARGS)
 else ifeq ($(PLDM),1)
 override SIM_ARGS += $(PLDM_ARGS)
-else ifeq ($(FPGA),1)
-override SIM_ARGS += $(FPGA_ARGS)
 else
 override SIM_ARGS += $(DEBUG_ARGS)
 endif

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,11 @@ ifeq ($(WITH_RESETGEN),1)
 override SIM_ARGS += --reset-gen
 endif
 
+# run with disable all perf
+ifeq ($(DISABLE_PERF),1)
+override SIM_ARGS += --disable-perf
+endif
+
 # run with disable all db
 ifeq ($(DISABLE_ALWAYSDB),1)
 override SIM_ARGS += --disable-alwaysdb

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ ifeq ($(WITH_ROLLINGDB),1)
 override SIM_ARGS += --with-rollingdb
 endif
 
+# enable ResetGen
 ifeq ($(WITH_RESETGEN),1)
 override SIM_ARGS += --reset-gen
 endif

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ ifeq ($(WITH_ROLLINGDB),1)
 override SIM_ARGS += --with-rollingdb
 endif
 
+ifeq ($(WITH_RESETGEN),1)
+override SIM_ARGS += --reset-gen
+endif
+
 # run with disable all db
 ifeq ($(DISABLE_ALWAYSDB),1)
 override SIM_ARGS += --disable-alwaysdb
@@ -99,6 +103,7 @@ endif
 RELEASE_ARGS += --fpga-platform --disable-all --remove-assert
 DEBUG_ARGS   += --enable-difftest
 PLDM_ARGS    += --fpga-platform --enable-difftest
+FPGA_ARGS    += --fpga-platform --enable-difftest --reset-gen
 ifeq ($(GOALS),verilog)
 RELEASE_ARGS += --disable-always-basic-diff
 endif
@@ -106,6 +111,8 @@ ifeq ($(RELEASE),1)
 override SIM_ARGS += $(RELEASE_ARGS)
 else ifeq ($(PLDM),1)
 override SIM_ARGS += $(PLDM_ARGS)
+else ifeq ($(FPGA),1)
+override SIM_ARGS += $(FPGA_ARGS)
 else
 override SIM_ARGS += $(DEBUG_ARGS)
 endif

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -36,6 +36,7 @@ object ArgParser {
       |--num-cores <Int>
       |--with-dramsim3
       |--fpga-platform
+      |--reset-gen
       |--enable-difftest
       |--enable-log
       |--with-chiseldb
@@ -94,6 +95,10 @@ object ArgParser {
         case "--fpga-platform" :: tail =>
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(FPGAPlatform = true)
+          }), tail)
+        case "--reset-gen" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(ResetGen = true)
           }), tail)
         case "--enable-difftest" :: tail =>
           nextOption(config.alter((site, here, up) => {

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -255,7 +255,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc() with HasSoCParameter
       // Modules are reset one by one
       // reset ----> SYNC --> {SoCMisc, L3 Cache, Cores}
       val resetChain = Seq(Seq(misc.module) ++ l3cacheOpt.map(_.module) ++ core_with_l2.map(_.module))
-      ResetGen(resetChain, reset_sync, !debugOpts.FPGAPlatform)
+      ResetGen(resetChain, reset_sync, !debugOpts.ResetGen)
     }
 
   }

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -452,6 +452,7 @@ case object DebugOptionsKey extends Field[DebugOptions]
 case class DebugOptions
 (
   FPGAPlatform: Boolean = false,
+  ResetGen: Boolean = false,
   EnableDifftest: Boolean = false,
   AlwaysBasicDiff: Boolean = true,
   EnableDebug: Boolean = false,

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -249,7 +249,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   )
 
   // ResetGen(resetTree, reset, !debugOpts.FPGAPlatform)
-  if (debugOpts.FPGAPlatform) {
+  if (debugOpts.ResetGen) {
     frontend.reset := memBlock.reset_io_frontend
     backend.reset := memBlock.reset_io_backend
   }

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -1429,7 +1429,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   io.outer_l2_pf_enable := io.inner_l2_pf_enable
   // io.inner_hc_perfEvents <> io.outer_hc_perfEvents
 
-  if (p(DebugOptionsKey).FPGAPlatform) {
+  if (p(DebugOptionsKey).ResetGen) {
     val resetTree = ResetGenNode(
       Seq(
         CellNode(reset_io_frontend),
@@ -1440,7 +1440,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
         ModuleNode(ptw_to_l2_buffer)
       )
     )
-    ResetGen(resetTree, reset, !p(DebugOptionsKey).FPGAPlatform)
+    ResetGen(resetTree, reset, !p(DebugOptionsKey).ResetGen)
   } else {
     reset_io_frontend := DontCare
     reset_io_backend := DontCare


### PR DESCRIPTION
Separate FPGAplatform from resetgen. Configure restgen as an optional option. RESETGEN is disabled by default on Paladin.
It should be noted that multi-core XIANGSHAN cannot be started after enabling RESETGEN, which may still be bug