### PR TITLE
Some fixes on Tile Dedup for EMU

### DIFF
--- a/src/main/scala/xiangshan/backend/datapath/WbArbiter.scala
+++ b/src/main/scala/xiangshan/backend/datapath/WbArbiter.scala
@@ -25,7 +25,7 @@ class WbArbiterDispatcher[T <: Data](private val gen: T, n: Int, acceptCond: T =
 
   private val acceptVec: Vec[Bool] = VecInit(acceptCond(io.in.bits)._1)
 
-  XSError(io.in.valid && PopCount(acceptVec) > 1.U, s"[ExeUnit] accept vec should no more than 1, ${Binary(acceptVec.asUInt)} ")
+  XSError(io.in.valid && PopCount(acceptVec) > 1.U, p"[ExeUnit] accept vec should no more than 1, ${Binary(acceptVec.asUInt)} ")
 
   io.out.zipWithIndex.foreach { case (out, i) =>
     out.valid := acceptVec(i) && io.in.valid

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -297,7 +297,7 @@ class Dispatcher[T <: Data](private val gen: T, n: Int, acceptCond: T => Seq[Boo
 
   private val acceptVec: Vec[Bool] = VecInit(acceptCond(io.in.bits))
 
-  XSError(io.in.valid && PopCount(acceptVec) > 1.U, s"s[ExeUnit] accept vec should no more than 1, ${Binary(acceptVec.asUInt)} ")
+  XSError(io.in.valid && PopCount(acceptVec) > 1.U, p"[ExeUnit] accept vec should no more than 1, ${Binary(acceptVec.asUInt)} ")
   XSError(io.in.valid && PopCount(acceptVec) === 0.U, "[ExeUnit] there is a inst not dispatched to any fu")
 
   io.out.zipWithIndex.foreach { case (out, i) =>

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -148,7 +148,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   // Statistics on the frequency distribution of FTQ fire interval
   val cntFtqFireInterval = RegInit(0.U(32.W))
   cntFtqFireInterval := Mux(fromFtq.fire, 1.U, cntFtqFireInterval + 1.U)
-  XSPerfHistogram("ftq2icache_fire_" + p(XSCoreParamsKey).HartId.toString, 
+  XSPerfHistogram("ftq2icache_fire",
                   cntFtqFireInterval, fromFtq.fire,
                   1, 300, 1, right_strict = true)
 


### PR DESCRIPTION
Tile Dedup is essential to reduce the size of Verilog for RTL Simulation. However, some bugs and redundant information prevent tile dedup from being possible when generating multicore XiangShan. This PR gets this fixed.

The detailed message is in the commit. To save the commit messages, I recommend using the rebase method to merge this PR.