### PR TITLE
DCache: Remove useless data_read when miss in LoadPipe

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -231,8 +231,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     in = Seq(
       io.probe_req,
       io.refill_req,
+      store_req, // Note: store_req.ready is now manually assigned for better timing
       io.atomic_req,
-      store_req // Note: store_req.ready is now manually assigned for better timing
     ),
     out = req,
     name = Some("main_pipe_req")


### PR DESCRIPTION
- Remove useless data_read when DCache miss in LoadPipe
- Fix req priority in DCache MainPipe