### PR TITLE
Dispatch2Iq: fix store not using store's special select policy

### DIFF
--- a/src/main/scala/xiangshan/backend/issue/Dispatch2Iq.scala
+++ b/src/main/scala/xiangshan/backend/issue/Dispatch2Iq.scala
@@ -931,6 +931,7 @@ class Dispatch2IqMemImp(override val wrapper: Dispatch2Iq)(implicit p: Parameter
 
   finalFuDeqMap.zipWithIndex.foreach {
     case ((Seq(FuType.ldu), deqPortIdSeq), i) =>
+      println(s"[Dispatch2IqMemImp] deqPort $deqPortIdSeq use ldu policy")
       val maxSelNum = wrapper.numIn
       val selNum = deqPortIdSeq.length
       val portReadyVec = loadReadyDecoder.map(Mux1H(_, deqPortIdSeq.map(outs(_).ready).toSeq))
@@ -945,7 +946,8 @@ class Dispatch2IqMemImp(override val wrapper: Dispatch2Iq)(implicit p: Parameter
           selIdxOH(i)(OHToUInt(Mux1H(selPortIdxOH, loadReadyDecoder))).bits := Mux1H(selectIdxOH, loadValidDecoder)
         }
       }
-    case ((Seq(FuType.stu, FuType.mou), deqPortIdSeq), i) =>
+    case ((fuTypeSeq, deqPortIdSeq), i) if fuTypeSeq.contains(FuType.stu) =>
+      println(s"[Dispatch2IqMemImp] deqPort $deqPortIdSeq use stu policy")
       val maxSelNum = wrapper.numIn
       val selNum = deqPortIdSeq.length
       val portReadyVec = storeReadyDecoder.map(Mux1H(_, deqPortIdSeq.map(outs(_).ready).toSeq))


### PR DESCRIPTION
The pattern matching may not success because the sequence of a `Set` is not determined.