### PR TITLE
PTW: fix the bug that ppn is x status when accessfault happens

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -1088,10 +1088,11 @@ class HptwResp(implicit p: Parameters) extends PtwBundle {
   val gaf = Bool()
 
   def apply(gpf: Bool, gaf: Bool, level: UInt, pte: PteBundle, vpn: UInt, vmid: UInt) = {
+    val resp_pte = Mux(gaf, 0.U.asTypeOf(pte), pte)
     this.entry.level.map(_ := level)
     this.entry.tag := vpn
-    this.entry.perm.map(_ := pte.getPerm())
-    this.entry.ppn := pte.ppn
+    this.entry.perm.map(_ := resp_pte.getPerm())
+    this.entry.ppn := resp_pte.ppn
     this.entry.prefetch := DontCare
     this.entry.asid := DontCare
     this.entry.vmid.map(_ := vmid)
@@ -1194,12 +1195,12 @@ class PtwMergeResp(implicit p: Parameters) extends PtwBundle {
 
   def apply(pf: Bool, af: Bool, level: UInt, pte: PteBundle, vpn: UInt, asid: UInt, vmid:UInt, addr_low : UInt, not_super : Boolean = true) = {
     assert(tlbcontiguous == 8, "Only support tlbcontiguous = 8!")
-
+    val resp_pte = Mux(af, 0.U.asTypeOf(pte), pte)
     val ptw_resp = Wire(new PtwMergeEntry(tagLen = sectorvpnLen, hasPerm = true, hasLevel = true))
-    ptw_resp.ppn := pte.ppn(ppnLen - 1, sectortlbwidth)
-    ptw_resp.ppn_low := pte.ppn(sectortlbwidth - 1, 0)
+    ptw_resp.ppn := resp_pte.ppn(ppnLen - 1, sectortlbwidth)
+    ptw_resp.ppn_low := resp_pte.ppn(sectortlbwidth - 1, 0)
     ptw_resp.level.map(_ := level)
-    ptw_resp.perm.map(_ := pte.getPerm())
+    ptw_resp.perm.map(_ := resp_pte.getPerm())
     ptw_resp.tag := vpn(vpnLen - 1, sectortlbwidth)
     ptw_resp.pf := pf
     ptw_resp.af := af


### PR DESCRIPTION
When accessfault happens and PTW don‘t get resp from mem before this exception，PTW will resp ppn which is x status. It makes   L1TLB resp x status paddr. Then a assert in IcacheMainPipe will be triggered. This assert is following:
`assert(PopCount(s1_tag_match_vec(0)) <= 1.U && (PopCount(s1_tag_match_vec(1)) <= 1.U || !s1_double_line),
      "Multiple hit in main pipe, port0:is=%d,ptag=0x%x,vidx=0x%x,vaddr=0x%x port1:is=%d,ptag=0x%x,vidx=0x%x,vaddr=0x%x ",
      PopCount(s1_tag_match_vec(0)) > 1.U,s1_req_ptags(0), get_idx(s1_req_vaddr(0)), s1_req_vaddr(0),
      PopCount(s1_tag_match_vec(1)) > 1.U && s1_double_line, s1_req_ptags(1), get_idx(s1_req_vaddr(1)), s1_req_vaddr(1))`