### PR TITLE
ICache: fence.i should flush mainPipe

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -588,6 +588,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   mainPipe.io.respStall             := io.stop
   mainPipe.io.csr_parity_enable     := io.csr_parity_enable
   mainPipe.io.hartId                := io.hartId
+  mainPipe.io.fencei                := io.fencei
 
   io.pmp(0) <> mainPipe.io.pmp(0)
   io.pmp(1) <> mainPipe.io.pmp(1)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -244,7 +244,9 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   val s1_wait_itlb  = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
 
   (0 until PortNumber).foreach { i =>
-    when(RegNext(s0_fire) && fromITLB(i).bits.miss) {
+    when(io.fencei) {
+      s1_wait_itlb(i) := false.B
+    }.elsewhen(RegNext(s0_fire) && fromITLB(i).bits.miss) {
       s1_wait_itlb(i) := true.B
     }.elsewhen(s1_wait_itlb(i) && !fromITLB(i).bits.miss) {
       s1_wait_itlb(i) := false.B
@@ -294,7 +296,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
                         ResultHoldBypass(valid = tlb_valid_tmp(i), data = fromITLB(i).bits.excp(0).af.instr)))
   val tlbExcp       = VecInit((0 until PortNumber).map(i => tlbExcpAF(i) || tlbExcpPF(i) || tlbExcpGPF(i)))
 
-  val s1_tlb_valid = VecInit((0 until PortNumber).map(i => ValidHoldBypass(tlb_valid_tmp(i), s1_fire)))
+  val s1_tlb_valid = VecInit((0 until PortNumber).map(i => ValidHoldBypass(tlb_valid_tmp(i), s1_fire, io.fencei)))
   val tlbRespAllValid = s1_tlb_valid(0) && (!s1_double_line || s1_double_line && s1_tlb_valid(1))
 
 

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
@@ -100,7 +100,8 @@ class ICacheMissEntry(edge: TLEdgeOut, id: Int)(implicit p: Parameters) extends 
 
   val needflush_r = RegInit(false.B)
   when (state === s_idle) { needflush_r := false.B }
-  when (state =/= s_idle && io.fencei) { needflush_r := true.B }
+  // if a miss request is fired or is about to fire in next cycle, store needflush to cancel response to data/meta SRAM
+  when ((state =/= s_idle || io.req.fire) && io.fencei) { needflush_r := true.B }
   val needflush = needflush_r | io.fencei
 
   //cacheline register


### PR DESCRIPTION
Flush mainPipe, invalidate missSlot, and cancle request to MSHR when receive `fence.i` to prevent fake-valid data from sending to IFU.

This was fixed in kunminghu (#2632), but not in master.

Note that the miss handling state machine is re-designed in master. Instead of marking `missStateQueue` as `m_invalid`, we set `missSlot.valid = false.B` to do invalidate reserved data.
