### PR TITLE
L1Cache: L1CacheError must be valid to report to beu

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -608,7 +608,7 @@ class L1CacheErrorInfo(implicit p: Parameters) extends XSBundle {
 
   def toL1BusErrorUnitInfo(): L1BusErrorUnitInfo = {
     val beu_info = Wire(new L1BusErrorUnitInfo)
-    beu_info.ecc_error.valid := report_to_beu
+    beu_info.ecc_error.valid := valid && report_to_beu
     beu_info.ecc_error.bits := paddr
     beu_info
   }


### PR DESCRIPTION
`L1CacheErrorInfo.report_to_beu` is valid iff `L1CacheErrorInfo.valid === true.B`, therefore `beu_errors.[id]cache.valid` should be `valid && report_to_beu`.