### PR TITLE
FPU: fix f2v boxing error when higher bits are not all zeros

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/fpu/IntFPToVec.scala
+++ b/src/main/scala/xiangshan/backend/fu/fpu/IntFPToVec.scala
@@ -38,11 +38,24 @@ class IntFPToVec(cfg: FuConfig)(implicit p: Parameters) extends PipedFuncUnit(cf
   // when isFmv is true, the high bits of the scalar data is 1
   private val isFmv = IF2VectorType.isFmv(in.ctrl.fuOpType(4, 2))
 
+  private val isFp = IF2VectorType.isFp(in.ctrl.fuOpType(4, 2))
+
   // imm use src(1), scalar use src(0)
   private val scalaData = Mux(isImm, in.data.src(1), in.data.src(0))
   // vsew is the lowest 2 bits of fuOpType
   private val vsew = in.ctrl.fuOpType(1, 0)
   private val dataWidth = cfg.dataBits
+
+  private val outNAN = Seq(
+    Cat(0.U, Fill(3, 1.U), 1.U, 0.U(3.W)),
+    Cat(0.U, Fill(5, 1.U), 1.U, 0.U(9.W)),
+    Cat(0.U, Fill(8, 1.U), 1.U, 0.U(22.W))
+  )
+  private val isFpCanonicalNAN = Seq(
+    !scalaData.head(56).andR,
+    !scalaData.head(48).andR,
+    !scalaData.head(32).andR
+  )
 
   private val fpData = Mux1H(Seq(
     (vsew === VSew.e8)  -> Cat(Fill(56, 1.U), scalaData( 7, 0)),
@@ -56,9 +69,9 @@ class IntFPToVec(cfg: FuConfig)(implicit p: Parameters) extends PipedFuncUnit(cf
   private val vecE32Data = Wire(Vec(dataWidth / 32, UInt(32.W)))
   private val vecE64Data = Wire(Vec(dataWidth / 64, UInt(64.W)))
 
-  vecE8Data   := VecInit(Seq.fill(dataWidth /  8)(scalaData( 7, 0)))
-  vecE16Data  := VecInit(Seq.fill(dataWidth / 16)(scalaData(15, 0)))
-  vecE32Data  := VecInit(Seq.fill(dataWidth / 32)(scalaData(31, 0)))
+  vecE8Data   := VecInit(Seq.fill(dataWidth /  8)(Mux(isFpCanonicalNAN(0) & isFp, outNAN(0), scalaData( 7, 0))))
+  vecE16Data  := VecInit(Seq.fill(dataWidth / 16)(Mux(isFpCanonicalNAN(1) & isFp, outNAN(1), scalaData(15, 0))))
+  vecE32Data  := VecInit(Seq.fill(dataWidth / 32)(Mux(isFpCanonicalNAN(2) & isFp, outNAN(2), scalaData(31, 0))))
   vecE64Data  := VecInit(Seq.fill(dataWidth / 64)(scalaData(63, 0)))
 
   out.res.data := Mux(needDup, Mux1H(Seq(

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -126,14 +126,15 @@ package object xiangshan {
   object IF2VectorType {
     // use last 2 bits for vsew
     def iDup2Vec   = "b1_00".U
-    def fDup2Vec   = "b1_00".U
+    def fDup2Vec   = "b1_01".U
     def immDup2Vec = "b1_10".U
     def i2Vec      = "b0_00".U
     def f2Vec      = "b0_01".U
     def imm2Vec    = "b0_10".U
     def needDup(bits: UInt): Bool = bits(2)
     def isImm(bits: UInt): Bool = bits(1)
-    def isFmv(bits: UInt): Bool = bits(0)
+    def isFp(bits: UInt): Bool = bits(0)
+    def isFmv(bits: UInt): Bool = bits(0) & !bits(2)
     def FMX_D_X    = "b0_01_11".U
     def FMX_W_X    = "b0_01_10".U
   }


### PR DESCRIPTION
FPU: fix f2v boxing error 
       set result as NAN when higher bit are not all zeros