### PR TITLE
L1CacheErrorInfo: code refactor for correct and convenient clockgate

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -602,11 +602,7 @@ class L1CacheErrorInfo(implicit p: Parameters) extends XSBundle {
   // bus error unit will receive error info iff ecc_error.valid
   val report_to_beu = Output(Bool())
 
-  // there is an valid error
-  // l1 cache error will always be report to CACHE_ERROR csr
-  val valid = Output(Bool())
-
-  def toL1BusErrorUnitInfo(): L1BusErrorUnitInfo = {
+  def toL1BusErrorUnitInfo(valid: Bool): L1BusErrorUnitInfo = {
     val beu_info = Wire(new L1BusErrorUnitInfo)
     beu_info.ecc_error.valid := valid && report_to_beu
     beu_info.ecc_error.bits := paddr

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -176,7 +176,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   memBlock.io.hartId := io.hartId
   memBlock.io.outer_reset_vector := io.reset_vector
   // frontend -> memBlock
-  memBlock.io.inner_beu_errors_icache <> frontend.io.error.toL1BusErrorUnitInfo()
+  memBlock.io.inner_beu_errors_icache <> frontend.io.error.bits.toL1BusErrorUnitInfo(frontend.io.error.valid)
   memBlock.io.inner_l2_pf_enable := backend.io.csrCustomCtrl.l2_pf_enable
   memBlock.io.inner_cpu_halt := backend.io.toTop.cpuHalted
   memBlock.io.ooo_to_mem.issueLda <> backend.io.mem.issueLda
@@ -233,7 +233,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
 
   io.cpu_halt := memBlock.io.outer_cpu_halt
   io.beu_errors.icache <> memBlock.io.outer_beu_errors_icache
-  io.beu_errors.dcache <> memBlock.io.error.toL1BusErrorUnitInfo()
+  io.beu_errors.dcache <> memBlock.io.error.bits.toL1BusErrorUnitInfo(memBlock.io.error.valid)
   io.beu_errors.l2 <> DontCare
   io.l2_pf_enable := memBlock.io.outer_l2_pf_enable
   // Modules are reset one by one

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -260,7 +260,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     val fetch_to_mem = new fetch_to_mem
 
     // misc
-    val error = new L1CacheErrorInfo
+    val error = ValidIO(new L1CacheErrorInfo)
     val memInfo = new Bundle {
       val sqFull = Output(Bool())
       val lqFull = Output(Bool())
@@ -320,9 +320,9 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   dcache.io.csr.distribute_csr <> csrCtrl.distribute_csr
   dcache.io.l2_pf_store_only := RegNext(io.ooo_to_mem.csrCtrl.l2_pf_store_only, false.B)
   io.mem_to_ooo.csrUpdate := RegNext(dcache.io.csr.update)
-  io.error <> RegNext(RegNext(dcache.io.error))
+  io.error <> DelayNWithValid(dcache.io.error, 2)
   when(!csrCtrl.cache_error_enable){
-    io.error.report_to_beu := false.B
+    io.error.bits.report_to_beu := false.B
     io.error.valid := false.B
   }
 

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -887,7 +887,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   io.error.bits <> RegEnable(
     Mux1H(errors.map(e => RegNext(e.valid) -> RegEnable(e.bits, e.valid))),
     RegNext(error_valid))
-  io.error.valid := RegNext(RegNext(error_valid), init = false.B)
+  io.error.valid := RegNext(RegNext(error_valid, init = false.B), init = false.B)
 
   //----------------------------------------
   // meta array

--- a/src/main/scala/xiangshan/cache/dcache/data/AbstractDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/AbstractDataArray.scala
@@ -46,7 +46,7 @@ abstract class AbstractDataArray(implicit p: Parameters) extends DCacheModule {
     val write = Flipped(DecoupledIO(new L1DataWriteReq))
     val resp = Output(Vec(3, Vec(blockRows, Bits(encRowBits.W))))
     val nacks = Output(Vec(3, Bool()))
-    val errors = Output(Vec(3, new L1CacheErrorInfo))
+    val errors = Output(Vec(3, ValidIO(new L1CacheErrorInfo)))
   })
 
   def pipeMap[T <: Data](f: Int => T) = VecInit((0 until 3).map(f))

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -259,7 +259,7 @@ abstract class AbstractBankedDataArray(implicit p: Parameters) extends DCacheMod
     val read_resp_delayed = Output(Vec(LoadPipelineWidth, Vec(VLEN/DCacheSRAMRowBits, new L1BankedDataReadResult())))
     val read_error_delayed = Output(Vec(LoadPipelineWidth,Vec(VLEN/DCacheSRAMRowBits, Bool())))
     // val nacks = Output(Vec(LoadPipelineWidth, Bool()))
-    // val errors = Output(Vec(LoadPipelineWidth + 1, new L1CacheErrorInfo)) // read ports + readline port
+    // val errors = Output(Vec(LoadPipelineWidth + 1, ValidIO(new L1CacheErrorInfo))) // read ports + readline port
     // when bank_conflict, read (1) port should be ignored
     val bank_conflict_slow = Output(Vec(LoadPipelineWidth, Bool()))
     val disable_ld_fast_wakeup = Output(Vec(LoadPipelineWidth, Bool()))

--- a/src/main/scala/xiangshan/cache/dcache/data/DuplicatedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/DuplicatedDataArray.scala
@@ -162,8 +162,8 @@ class DuplicatedDataArray(implicit p: Parameters) extends AbstractDataArray {
           data
         }
       })
-      io.errors(j).report_to_beu := RegNext(io.read(j).fire) && Cat(row_error.flatten).orR
-      io.errors(j).paddr := RegNext(io.read(j).bits.addr)
+      io.errors(j).bits.report_to_beu := RegNext(io.read(j).fire) && Cat(row_error.flatten).orR
+      io.errors(j).bits.paddr := RegNext(io.read(j).bits.addr)
     }
 
     io.nacks(j) := false.B

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -75,7 +75,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
     val disable_ld_fast_wakeup = Input(Bool())
 
     // ecc error
-    val error = Output(new L1CacheErrorInfo())
+    val error = Output(ValidIO(new L1CacheErrorInfo))
 
     val prefetch_info = new Bundle {
       val naive = new Bundle {
@@ -489,13 +489,13 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   resp.bits.replacementUpdated := io.replace_access.valid
 
   // report tag / data / l2 error (with paddr) to bus error unit
-  io.error := 0.U.asTypeOf(new L1CacheErrorInfo())
-  io.error.report_to_beu := (s3_tag_error || s3_data_error) && s3_valid
-  io.error.paddr := s3_paddr
-  io.error.source.tag := s3_tag_error
-  io.error.source.data := s3_data_error
-  io.error.source.l2 := s3_flag_error
-  io.error.opType.load := true.B
+  io.error := 0.U.asTypeOf(ValidIO(new L1CacheErrorInfo))
+  io.error.bits.report_to_beu := (s3_tag_error || s3_data_error) && s3_valid
+  io.error.bits.paddr := s3_paddr
+  io.error.bits.source.tag := s3_tag_error
+  io.error.bits.source.data := s3_data_error
+  io.error.bits.source.l2 := s3_flag_error
+  io.error.bits.opType.load := true.B
   // report tag error / l2 corrupted to CACHE_ERROR csr
   io.error.valid := s3_error && s3_valid
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -183,7 +183,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     val block_lr = Output(Bool())
 
     // ecc error
-    val error = Output(new L1CacheErrorInfo())
+    val error = Output(ValidIO(new L1CacheErrorInfo))
     // force write
     val force_write = Input(Bool())
 
@@ -1622,20 +1622,20 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.mainpipe_info.s3_refill_resp := RegNext(s2_valid && s2_req.miss && s2_fire_to_s3)
 
   // report error to beu and csr, 1 cycle after read data resp
-  io.error := 0.U.asTypeOf(new L1CacheErrorInfo())
+  io.error := 0.U.asTypeOf(ValidIO(new L1CacheErrorInfo))
   // report error, update error csr
   io.error.valid := s3_error && RegNext(s2_fire)
   // only tag_error and data_error will be reported to beu
   // l2_error should not be reported (l2 will report that)
-  io.error.report_to_beu := (RegEnable(s2_tag_error, s2_fire) || s3_data_error) && RegNext(s2_fire)
-  io.error.paddr := RegEnable(s2_req.addr, s2_fire)
-  io.error.source.tag := RegEnable(s2_tag_error, s2_fire)
-  io.error.source.data := s3_data_error
-  io.error.source.l2 := RegEnable(s2_flag_error || s2_l2_error, s2_fire)
-  io.error.opType.store := RegEnable(s2_req.isStore && !s2_req.probe, s2_fire)
-  io.error.opType.probe := RegEnable(s2_req.probe, s2_fire)
-  io.error.opType.release := RegEnable(s2_req.replace, s2_fire)
-  io.error.opType.atom := RegEnable(s2_req.isAMO && !s2_req.probe, s2_fire)
+  io.error.bits.report_to_beu := (RegEnable(s2_tag_error, s2_fire) || s3_data_error) && RegNext(s2_fire)
+  io.error.bits.paddr := RegEnable(s2_req.addr, s2_fire)
+  io.error.bits.source.tag := RegEnable(s2_tag_error, s2_fire)
+  io.error.bits.source.data := s3_data_error
+  io.error.bits.source.l2 := RegEnable(s2_flag_error || s2_l2_error, s2_fire)
+  io.error.bits.opType.store := RegEnable(s2_req.isStore && !s2_req.probe, s2_fire)
+  io.error.bits.opType.probe := RegEnable(s2_req.probe, s2_fire)
+  io.error.bits.opType.release := RegEnable(s2_req.replace, s2_fire)
+  io.error.bits.opType.atom := RegEnable(s2_req.isAMO && !s2_req.probe, s2_fire)
 
   val perfEvents = Seq(
     ("dcache_mp_req          ", s0_fire                                                      ),

--- a/src/main/scala/xiangshan/cache/dcache/storepipe/StorePipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/storepipe/StorePipe.scala
@@ -79,11 +79,11 @@ class StorePipe(id: Int)(implicit p: Parameters) extends DCacheModule{
     val replace_way = new ReplacementWayReqIO
 
     // ecc error
-    val error = Output(new L1CacheErrorInfo())
+    val error = Output(ValidIO(new L1CacheErrorInfo))
   })
 
   // TODO: error
-  io.error := DontCare
+  io.error := 0.U.asTypeOf(ValidIO(new L1CacheErrorInfo))
 
 /** S0:
   *   send tag and meta read req

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -51,7 +51,7 @@ class FrontendImp (outer: Frontend) extends LazyModuleImp(outer)
     val tlbCsr = Input(new TlbCsrBundle)
     val csrCtrl = Input(new CustomCSRCtrlIO)
     val csrUpdate = new DistributedCSRUpdateReq
-    val error  = new L1CacheErrorInfo
+    val error  = ValidIO(new L1CacheErrorInfo)
     val frontendInfo = new Bundle {
       val ibufFull  = Output(Bool())
       val bpuInfo = new Bundle {

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -492,7 +492,7 @@ class ICacheIO(implicit p: Parameters) extends ICacheBundle
   val pmp         = Vec(PortNumber + prefetchPipeNum, new ICachePMPBundle)
   val itlb        = Vec(PortNumber + prefetchPipeNum, new TlbRequestIO)
   val perfInfo    = Output(new ICachePerfInfo)
-  val error       = new L1CacheErrorInfo
+  val error       = ValidIO(new L1CacheErrorInfo)
   /* Cache Instruction */
   val csr         = new L1CacheToCsrIO
   /* CSR control signal */
@@ -629,7 +629,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
 
   //Parity error port
   val errors = mainPipe.io.errors
-  io.error <> RegEnable(Mux1H(errors.map(e => e.valid -> e)),errors.map(e => e.valid).reduce(_|_))
+  io.error.bits <> RegEnable(Mux1H(errors.map(e => e.valid -> e.bits)),errors.map(e => e.valid).reduce(_|_))
   io.error.valid := RegNext(errors.map(e => e.valid).reduce(_|_),init = false.B)
 
 


### PR DESCRIPTION
change the valid in the Bundle to the valid out of Bundle used `ValidIO`.
