### PR TITLE
Timing optimization for MemScheduler

### DIFF
--- a/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
@@ -87,6 +87,10 @@ case class IssueBlockParams(
 
   def readVfRf: Boolean = numVfSrc > 0
 
+  def readV0Rf: Boolean = numV0Src > 0
+
+  def readVlRf: Boolean = numVlSrc > 0
+
   def writeIntRf: Boolean = exuBlockParams.map(_.writeIntRf).reduce(_ || _)
 
   def writeFpRf: Boolean = exuBlockParams.map(_.writeFpRf).reduce(_ || _)
@@ -252,15 +256,15 @@ case class IssueBlockParams(
 
   def hasIQWakeUp: Boolean = numWakeupFromIQ > 0 && numRegSrc > 0
 
-  def needWakeupFromIntWBPort = backendParam.allExuParams.filter(x => !wakeUpInExuSources.map(_.name).contains(x.name)).groupBy(x => x.getIntWBPort.getOrElse(IntWB(port = -1)).port).filter(_._1 != -1)
+  def needWakeupFromIntWBPort = backendParam.allExuParams.filter(x => !wakeUpInExuSources.map(_.name).contains(x.name) && this.readIntRf).groupBy(x => x.getIntWBPort.getOrElse(IntWB(port = -1)).port).filter(_._1 != -1)
 
-  def needWakeupFromFpWBPort = backendParam.allExuParams.filter(x => !wakeUpInExuSources.map(_.name).contains(x.name)).groupBy(x => x.getFpWBPort.getOrElse(FpWB(port = -1)).port).filter(_._1 != -1)
+  def needWakeupFromFpWBPort = backendParam.allExuParams.filter(x => !wakeUpInExuSources.map(_.name).contains(x.name) && this.readFpRf).groupBy(x => x.getFpWBPort.getOrElse(FpWB(port = -1)).port).filter(_._1 != -1)
 
-  def needWakeupFromVfWBPort = backendParam.allExuParams.filter(x => !wakeUpInExuSources.map(_.name).contains(x.name)).groupBy(x => x.getVfWBPort.getOrElse(VfWB(port = -1)).port).filter(_._1 != -1)
+  def needWakeupFromVfWBPort = backendParam.allExuParams.filter(x => !wakeUpInExuSources.map(_.name).contains(x.name) && this.readVecRf).groupBy(x => x.getVfWBPort.getOrElse(VfWB(port = -1)).port).filter(_._1 != -1)
 
-  def needWakeupFromV0WBPort = backendParam.allExuParams.filter(x => !wakeUpInExuSources.map(_.name).contains(x.name)).groupBy(x => x.getV0WBPort.getOrElse(V0WB(port = -1)).port).filter(_._1 != -1)
+  def needWakeupFromV0WBPort = backendParam.allExuParams.filter(x => !wakeUpInExuSources.map(_.name).contains(x.name) && this.readV0Rf).groupBy(x => x.getV0WBPort.getOrElse(V0WB(port = -1)).port).filter(_._1 != -1)
 
-  def needWakeupFromVlWBPort = backendParam.allExuParams.filter(x => !wakeUpInExuSources.map(_.name).contains(x.name)).groupBy(x => x.getVlWBPort.getOrElse(VlWB(port = -1)).port).filter(_._1 != -1)
+  def needWakeupFromVlWBPort = backendParam.allExuParams.filter(x => !wakeUpInExuSources.map(_.name).contains(x.name) && this.readVlRf).groupBy(x => x.getVlWBPort.getOrElse(VlWB(port = -1)).port).filter(_._1 != -1)
 
   def hasWakeupFromMem: Boolean = backendParam.allExuParams.filter(x => wakeUpInExuSources.map(_.name).contains(x.name)).map(_.isMemExeUnit).fold(false)(_ | _)
 

--- a/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
@@ -97,6 +97,10 @@ case class IssueBlockParams(
 
   def writeVecRf: Boolean = exuBlockParams.map(_.writeVecRf).reduce(_ || _)
 
+  def writeV0Rf: Boolean = exuBlockParams.map(_.writeV0Rf).reduce(_ || _)
+
+  def writeVlRf: Boolean = exuBlockParams.map(_.writeVlRf).reduce(_ || _)
+
   def exceptionOut: Seq[Int] = exuBlockParams.map(_.exceptionOut).reduce(_ ++ _).distinct.sorted
 
   def hasLoadError: Boolean = exuBlockParams.map(_.hasLoadError).reduce(_ || _)

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -1067,19 +1067,19 @@ class IssueQueueMemAddrImp(override val wrapper: IssueQueue)(implicit p: Paramet
       val uop = loadWakeUpIter.next()
 
       wakeup.valid := GatedValidRegNext(uop.fire)
-      wakeup.bits.rfWen  := GatedValidRegNext(uop.bits.rfWen  && uop.fire)
-      wakeup.bits.fpWen  := GatedValidRegNext(uop.bits.fpWen  && uop.fire)
-      wakeup.bits.vecWen := GatedValidRegNext(uop.bits.vecWen && uop.fire)
-      wakeup.bits.v0Wen  := GatedValidRegNext(uop.bits.v0Wen  && uop.fire)
-      wakeup.bits.vlWen  := GatedValidRegNext(uop.bits.vlWen  && uop.fire)
+      wakeup.bits.rfWen  := (if (params.writeIntRf) GatedValidRegNext(uop.bits.rfWen  && uop.fire) else false.B)
+      wakeup.bits.fpWen  := (if (params.writeFpRf)  GatedValidRegNext(uop.bits.fpWen  && uop.fire) else false.B)
+      wakeup.bits.vecWen := (if (params.writeVecRf) GatedValidRegNext(uop.bits.vecWen && uop.fire) else false.B)
+      wakeup.bits.v0Wen  := (if (params.writeV0Rf)  GatedValidRegNext(uop.bits.v0Wen  && uop.fire) else false.B)
+      wakeup.bits.vlWen  := (if (params.writeVlRf)  GatedValidRegNext(uop.bits.vlWen  && uop.fire) else false.B)
       wakeup.bits.pdest  := RegEnable(uop.bits.pdest, uop.fire)
       wakeup.bits.loadDependency.foreach(_ := 0.U) // this is correct for load only
 
-      wakeup.bits.rfWenCopy .foreach(_.foreach(_ := GatedValidRegNext(uop.bits.rfWen  && uop.fire)))
-      wakeup.bits.fpWenCopy .foreach(_.foreach(_ := GatedValidRegNext(uop.bits.fpWen  && uop.fire)))
-      wakeup.bits.vecWenCopy.foreach(_.foreach(_ := GatedValidRegNext(uop.bits.vecWen && uop.fire)))
-      wakeup.bits.v0WenCopy .foreach(_.foreach(_ := GatedValidRegNext(uop.bits.v0Wen  && uop.fire)))
-      wakeup.bits.vlWenCopy .foreach(_.foreach(_ := GatedValidRegNext(uop.bits.vlWen  && uop.fire)))
+      wakeup.bits.rfWenCopy .foreach(_.foreach(_ := (if (params.writeIntRf) GatedValidRegNext(uop.bits.rfWen  && uop.fire) else false.B)))
+      wakeup.bits.fpWenCopy .foreach(_.foreach(_ := (if (params.writeFpRf)  GatedValidRegNext(uop.bits.fpWen  && uop.fire) else false.B)))
+      wakeup.bits.vecWenCopy.foreach(_.foreach(_ := (if (params.writeVecRf) GatedValidRegNext(uop.bits.vecWen && uop.fire) else false.B)))
+      wakeup.bits.v0WenCopy .foreach(_.foreach(_ := (if (params.writeV0Rf)  GatedValidRegNext(uop.bits.v0Wen  && uop.fire) else false.B)))
+      wakeup.bits.vlWenCopy .foreach(_.foreach(_ := (if (params.writeVlRf)  GatedValidRegNext(uop.bits.vlWen  && uop.fire) else false.B)))
       wakeup.bits.pdestCopy .foreach(_.foreach(_ := RegEnable(uop.bits.pdest, uop.fire)))
       wakeup.bits.loadDependencyCopy.foreach(x => x := 0.U.asTypeOf(x)) // this is correct for load only
 


### PR DESCRIPTION
 - generate busytable read ports based on the actual number of read operands required
 - check the type of read operands when generating the WB waking up ports
 - only wen signals for data types that load IQ will write back can be sent out