### PR TITLE
MMU: LLPTW should report PF when pte is not leaf

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -544,7 +544,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
       ptw_resp.level.map(_ := 2.U)
       ptw_resp.perm.map(_ := pte_in.getPerm())
       ptw_resp.tag := vpn(vpnLen - 1, sectortlbwidth)
-      ptw_resp.pf := (if (af_first) !af else true.B) && pte_in.isPf(2.U)
+      ptw_resp.pf := (if (af_first) !af else true.B) && (pte_in.isPf(2.U) || !pte_in.isLeaf())
       ptw_resp.af := (if (!af_first) pte_in.isPf(2.U) else true.B) && (af || pte_in.isAf())
       ptw_resp.v := !ptw_resp.pf
       ptw_resp.prefetch := DontCare


### PR DESCRIPTION
When LLPTW looks for the last level of the page table (a 4KB page table), it must be a leaf node. The condition that the x w r bits of the page table cannot all be 0 needs to be satisfied. When this condition is not met, the LLPTW needs to report pf to the L1 TLB. (Although in practice the L1 TLB does a permission check as well, which does not result in an error from the MMU's overall perspective)