### PR TITLE
VPU: fix vfreduction bug; remove redundant logic for scalar compute

### DIFF
--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -246,6 +246,9 @@ class ExeUnitImp(
       sink.bits.ctrl.predictInfo .foreach(x => x := source.bits.predictInfo.get)
       sink.bits.ctrl.fpu         .foreach(x => x := source.bits.fpu.get)
       sink.bits.ctrl.vpu         .foreach(x => x := source.bits.vpu.get)
+      sink.bits.ctrl.vpu         .foreach(x => x.fpu.isFpToVecInst := 0.U)
+      sink.bits.ctrl.vpu         .foreach(x => x.fpu.isFP32Instr   := 0.U)
+      sink.bits.ctrl.vpu         .foreach(x => x.fpu.isFP64Instr   := 0.U)
       sink.bits.perfDebugInfo    := source.bits.perfDebugInfo
   }
 

--- a/src/main/scala/xiangshan/backend/fu/vector/VecPipedFuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/VecPipedFuncUnit.scala
@@ -77,6 +77,8 @@ class VecPipedFuncUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(c
   protected val outVl       = outVConfig.vl
   protected val outVstart   = outVecCtrl.vstart
   protected val outOldVd    = outData.src(2)
+  protected val outVlmul    = outCtrl.vpu.get.vlmul
+  protected val outLastUop  = outCtrl.vpu.get.lastUop
   // There is no difference between control-dependency or data-dependency for function unit,
   // but spliting these in ctrl or data bundles is easy to coding.
   protected val outSrcMask: UInt = if (!cfg.maskWakeUp) outCtrl.vpu.get.vmask else {


### PR DESCRIPTION
fix vfreduction bug:
    Unordered reduction only generates fflags in the first round of uops, with the fflags outputs of other rounds set to 0; 
    ordered reduction has only the lowest 5 bits of vfalu_0 valid in each uop, while all others are set to 0