### PR TITLE
StoreQueue: fix X  when write StoreBuffer

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -911,7 +911,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     io.sbuffer(i).bits.vaddr := dataBuffer.io.deq(i).bits.vaddr
     io.sbuffer(i).bits.data  := dataBuffer.io.deq(i).bits.data
     io.sbuffer(i).bits.mask  := dataBuffer.io.deq(i).bits.mask
-    io.sbuffer(i).bits.wline := dataBuffer.io.deq(i).bits.wline
+    io.sbuffer(i).bits.wline := dataBuffer.io.deq(i).bits.wline && dataBuffer.io.deq(i).bits.vecValid
     io.sbuffer(i).bits.prefetch := dataBuffer.io.deq(i).bits.prefetch
     io.sbuffer(i).bits.vecValid := dataBuffer.io.deq(i).bits.vecValid
     // io.sbuffer(i).fire is RegNexted, as sbuffer data write takes 2 cycles.


### PR DESCRIPTION
If there is an inactive element in a vector access instruction, it will not be sent to the sta pipeline, so the data in the corresponding entry in the StoreQueue is invalid, and we use `vecValid` to differentiate between valid and invalid data in table entries.

For StoreQueue entries, `vecValid` depends on `hasException`, `vecDataValid` (whether the data in the table entry is valid or not), and `isVec` (whether it is a table entry for a vector instruction or not). `vecDataValid` is initialized to false, and will be set to true when sta writes back to the entry and the entry is a vector instruction.

Only vector instructions have invalid data in table entries, because we can't determine how many table entries are needed for a vector access uop at dispatch time.


