### PR TITLE
DCache: Fix x-prop caused by l2_error

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -399,7 +399,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s2_banked_store_wmask = RegEnable(s1_banked_store_wmask, s1_fire)
   val s2_flag_error = RegEnable(s1_flag_error, s1_fire)
   val s2_tag_error = dcacheParameters.tagCode.decode(s2_encTag).error && s2_need_tag
-  val s2_l2_error = io.refill_info.bits.error
+  val s2_l2_error = Mux(io.refill_info.valid, io.refill_info.bits.error, false.B)
   val s2_error = s2_flag_error || s2_tag_error || s2_l2_error // data_error not included
 
   val s2_may_report_data_error = s2_need_data && s2_coh.state =/= ClientStates.Nothing


### PR DESCRIPTION
Add valid mux for s2_l2_error to fix X propagation.