### PR TITLE
HPTW, RVH: fix the bug that non-leaf and level >= 2 pte doesn't raise pagefault.

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -754,7 +754,7 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
   val finish = WireInit(false.B)
 
   val sent_to_pmp = !idle && (!s_pmp_check || mem_addr_update) && !finish
-  val pageFault = pte.isPf(level)
+  val pageFault = pte.isPf(level) || (!pte.isLeaf() && level >= 2.U)
   val accessFault = RegEnable(io.pmp.resp.ld || io.pmp.resp.mmio, sent_to_pmp)
 
   val ppn_af = pte.isAf()


### PR DESCRIPTION
HPTW can translate three levels page. This bug is about non-leaf pte that pte level >= 2. When HPTW gets a level 2 pte and the pte is valid but RWX are zero, it does't raise pagefault. That's wrong.