### PR TITLE
CI: enable PGO when building emu for CI

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -91,7 +91,8 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       - name: Build EMU
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --build --threads 16 --mfc
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --build --threads 16 --mfc \
+            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata
       - name: Basic Test - cputest
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --ci cputest 2> /dev/zero
@@ -152,7 +153,8 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3            \
-            --with-dramsim3 --threads 16 --mfc
+            --with-dramsim3 --threads 16 --mfc \
+            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata
       - name: SPEC06 Test - mcf
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000 --numa --ci mcf 2> perf.log
@@ -218,7 +220,8 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --num-cores 2 --emu-optimize "" \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 \
-            --with-dramsim3 --threads 16 --mfc
+            --with-dramsim3 --threads 16 --mfc \
+            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata
       - name: MC Test
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --diff ./ready-to-run/riscv64-nemu-interpreter-dual-so --ci mc-tests 2> /dev/zero

--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -25,7 +25,7 @@ import signal
 import subprocess
 import sys
 import time
-
+import shlex
 import psutil
 
 
@@ -94,6 +94,10 @@ class XSArgs(object):
         self.fork = not args.disable_fork
         self.disable_diff = args.no_diff
         self.disable_db = args.no_db
+        self.pgo = args.pgo
+        self.pgo_max_cycle = args.pgo_max_cycle
+        self.pgo_emu_args = args.pgo_emu_args
+        self.llvm_profdata = args.llvm_profdata
         # wave dump path
         if args.wave_dump is not None:
             self.set_wave_home(args.wave_dump)
@@ -133,9 +137,14 @@ class XSArgs(object):
             (self.is_mfc,        "MFC"),
             (self.emu_optimize,  "EMU_OPTIMIZE"),
             (self.xprop,         "ENABLE_XPROP"),
-            (self.with_chiseldb, "WITH_CHISELDB")
+            (self.with_chiseldb, "WITH_CHISELDB"),
+            (self.pgo,           "PGO_WORKLOAD"),
+            (self.pgo_max_cycle, "PGO_MAX_CYCLE"),
+            (self.pgo_emu_args,  "PGO_EMU_ARGS"),
+            (self.llvm_profdata, "LLVM_PROFDATA"),
         ]
         args = filter(lambda arg: arg[0] is not None, makefile_args)
+        args = [(shlex.quote(str(arg[0])), arg[1]) for arg in args] # shell escape
         return args
 
     def get_emu_args(self):
@@ -511,6 +520,10 @@ if __name__ == "__main__":
     parser.add_argument('--ram-size', nargs='?', type=str, help='manually set simulation memory size (8GB by default)')
     # both makefile and emu arguments
     parser.add_argument('--no-db', action='store_true', help='disable chiseldb dump')
+    parser.add_argument('--pgo', nargs='?', type=str, help='workload for pgo (null to disable pgo)')
+    parser.add_argument('--pgo-max-cycle', nargs='?', default=400000, type=int, help='maximun cycle to train pgo')
+    parser.add_argument('--pgo-emu-args', nargs='?', default='--no-diff', type=str, help='emu arguments for pgo')
+    parser.add_argument('--llvm-profdata', nargs='?', type=str, help='corresponding llvm-profdata command of clang to compile emu, do not set with GCC')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR adds PGO when building emu for CI. The workload used for training is coremark-2-iteration. To avoid CPU bugs causing PGO workload fails, this PR uses `--no-diff` for PGO.

Preliminary Result is shown below:

Item | [Run 7059(s)](https://github.com/OpenXiangShan/XiangShan/actions/runs/9519739280) | [Run 7051(s)](https://github.com/OpenXiangShan/XiangShan/actions/runs/9516292340) | Speed Up %
-- | -- | -- | --
Set up job | 2 | 2 |  
Run actions/checkout@v2 | 41 | 40 |  
set env | 31 | 31 |  
clean up | 31 | 32 |  
Build EMU | 5193 | 3568 | -31.29
Basic Test - cputest | 179 | 255 | 42.46
Basic Test - riscv-tests | 413 | 649 | 57.14
Basic Test - misc-tests | 1052 | 1916 | 82.13
Basic Test - nodiff-tests | 38 | 42 | 10.53
Simple Test - microbench | 141 | 188 | 33.33
Simple Test - CoreMark | 492 | 897 | 82.32
System Test - Linux | 2180 | 3793 | 73.99
Floating-point Test - povray | 785 | 1402 | 78.60
Uncache Fetch Test - copy and run | 703 | 555 | -21.05
Post Run actions/checkout@v2 | 33 | 32 |  
Complete job | 1 | 0 |  
All - EMU - Basic | 11315 | 13402 | 18.44
Set up job | 3 | 2 |  
Run actions/checkout@v2 | 44 | 44 |  
set env | 31 | 31 |  
clean up | 31 | 32 |  
Build EMU | 4707 | 3536 | -24.88
SPEC06 Test - mcf | 3076 | 6037 | 96.26
SPEC06 Test - xalancbmk | 744 | 1320 | 77.42
SPEC06 Test - gcc | 1658 | 2946 | 77.68
SPEC06 Test - namd | 798 | 1036 | 29.82
SPEC06 Test - milc | 1809 | 2836 | 56.77
SPEC06 Test - Ibm | 941 | 1617 | 71.84
SPEC06 Test - gromacs | 754 | 1303 | 72.81
SPEC06 Test - wrf | 945 | 1631 | 72.59
SPEC06 Test - astar | 1200 | 1993 | 66.08
Post Run actions/checkout@v2 | 34 | 32 |  
Complete job | 0 | 1 |  
All - EMU - Performance | 16775 | 24397 | 45.44
Set up job | 2 | 2 |  
Run actions/checkout@v2 | 42 | 15 |  
set env | 32 | 31 |  
clean up | 30 | 31 |  
Build MC EMU | 6166 | 5497 | -10.85
MC Test | 102 | 110 | 7.84
SMP Linux | 10530 | 13139 | 24.78
Post Run actions/checkout@v2 | 33 | 32 |  
Complete job | 1 | 2 |  
All - EMU - MC | 16938 | 18859 | 11.34

Since the CI server now is AMD Zen 2, the performance of Verilator is still bound to a lack of L3 cache and cores per CCX (4 for Zen 2), which needs some inter-CCX cache line transfer for 8 threads EMU. I suggest switching CI to run on an AMD Zen 3 server with doubled L3 Size per CCX and doubled core count per CCX.