### PR TITLE
ci: use PGO for nightly regression

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,9 +30,11 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       - name: Build EMU with DRAMsim3 and Spike-Diff
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
-            --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3     \
-            --with-dramsim3 --threads 16 --spike --mfc
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build          \
+            --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3              \
+            --with-dramsim3 --threads 16 --spike --mfc                    \
+            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin \
+            --llvm-profdata llvm-profdata
       - name: Random Checkpoint 0
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py           \


### PR DESCRIPTION
Enable PGO for nightly regression to reduce the running time.