### PR TITLE
PTW, RVH: fix the bug that the last second stage translation continues after the first stage translation raises af

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -307,8 +307,8 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
         last_s2xlate := false.B
       }.otherwise{
         s_last_hptw_req := false.B
+        mem_addr_update := false.B
       }
-      mem_addr_update := false.B
     }.elsewhen(io.resp.valid){
       when(io.resp.fire) {
         idle := true.B

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -303,7 +303,11 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
       }
       finish := true.B
     }.elsewhen(s2xlate && last_s2xlate === true.B) {
-      s_last_hptw_req := false.B
+      when(accessFault || pageFault || ppn_af){
+        last_s2xlate := false.B
+      }.otherwise{
+        s_last_hptw_req := false.B
+      }
       mem_addr_update := false.B
     }.elsewhen(io.resp.valid){
       when(io.resp.fire) {

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -130,7 +130,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   val stage1 = RegEnable(io.req.bits.stage1, io.req.fire)
   val hptw_resp_stage2 = Reg(Bool()) 
 
-  val ppn_af = pte.isAf()
+  val ppn_af = Mux(s2xlate, false.B, pte.isAf())
   val find_pte = pte.isLeaf() || ppn_af || pageFault
   val to_find_pte = level === 1.U && find_pte === false.B
   val source = RegEnable(io.req.bits.req_info.source, io.req.fire)


### PR DESCRIPTION
1. ppn_af will check ppn_high because the paddrbits is 36. But when s2xlate is enabled, stage 1 ppn is 41 bits because stage 2 is sv39x4. ppn_af should not check ppn_high when s2xlate is enabled. 
2. when accessfault happens in stage 1 translation, PTW should resp rather than entering the last stage 2 translation.