### PR TITLE
StoreUnit: fix bug when `lsq_replenish` of s2 fails to redirect

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -336,6 +336,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
 
   // mmio and exception
   io.lsq_replenish := s2_out
+  io.lsq_replenish.af := s2_out.af && !s2_kill
 
   // prefetch related
   io.lsq_replenish.miss := io.dcache.resp.fire && io.dcache.resp.bits.miss // miss info


### PR DESCRIPTION
When access fault exception is reported on s2 of StoreUnit, the exception address will be written into exception buffer of StoreQueue. If the store is flushed on s2, the exception buffer must not be updated otherwise mtval csr might be of false value.