### PR TITLE
Backend,Frontend: pass flag of FtqPtr to TargetMem to avoid read out-of-date pred target

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -524,7 +524,7 @@ class CtrlBlockImp(
   io.toIssueBlock.flush   <> s2_s4_redirect
 
   pcMem.io.wen.head   := GatedValidRegNext(io.frontend.fromFtq.pc_mem_wen)
-  pcMem.io.waddr.head := RegEnable(io.frontend.fromFtq.pc_mem_waddr, io.frontend.fromFtq.pc_mem_wen)
+  pcMem.io.waddr.head := RegEnable(io.frontend.fromFtq.pc_mem_waddr.value, io.frontend.fromFtq.pc_mem_wen)
   pcMem.io.wdata.head := RegEnable(io.frontend.fromFtq.pc_mem_wdata, io.frontend.fromFtq.pc_mem_wen)
 
   io.toDataPath.flush := s2_s4_redirect

--- a/src/main/scala/xiangshan/backend/datapath/PcTargetMem.scala
+++ b/src/main/scala/xiangshan/backend/datapath/PcTargetMem.scala
@@ -24,26 +24,43 @@ class PcTargetMemImp(override val wrapper: PcTargetMem)(implicit p: Parameters, 
   private val readValid = io.toDataPath.fromDataPathValid
 
   private def hasRen: Boolean = true
-  private val targetMem = Module(new SyncDataModuleTemplate(new Ftq_RF_Components, FtqSize, numTargetMemRead, 1, hasRen = hasRen))
+  private val targetMem = Module(new SyncDataModuleTemplate(new PcTargetMemEntry, FtqSize, numTargetMemRead, 1, hasRen = hasRen))
   private val targetPCVec : Vec[UInt] = Wire(Vec(params.numTargetReadPort, UInt(VAddrData().dataWidth.W)))
   private val pcVec       : Vec[UInt] = Wire(Vec(params.numPcMemReadPort, UInt(VAddrData().dataWidth.W)))
 
+  private val wdata = Wire(new PcTargetMemEntry)
+  wdata.addr := io.fromFrontendFtq.pc_mem_wdata
+  wdata.flag := io.fromFrontendFtq.pc_mem_waddr.flag
+
   targetMem.io.wen.head := GatedValidRegNext(io.fromFrontendFtq.pc_mem_wen)
-  targetMem.io.waddr.head := RegEnable(io.fromFrontendFtq.pc_mem_waddr, io.fromFrontendFtq.pc_mem_wen)
-  targetMem.io.wdata.head := RegEnable(io.fromFrontendFtq.pc_mem_wdata, io.fromFrontendFtq.pc_mem_wen)
+  targetMem.io.waddr.head := RegEnable(io.fromFrontendFtq.pc_mem_waddr.value, io.fromFrontendFtq.pc_mem_wen)
+  targetMem.io.wdata.head := RegEnable(wdata, io.fromFrontendFtq.pc_mem_wen)
+  private val rdataVec = targetMem.io.rdata
 
   private val newestEn: Bool = io.fromFrontendFtq.newest_entry_en
   private val newestTarget: UInt = io.fromFrontendFtq.newest_entry_target
+
+  // The FtqPtr is used to compare with read ptr since its arrival(T), so it needs to be holded and bypassed.
+  private val currentNewestFtqPtr = DataHoldBypass(io.fromFrontendFtq.newest_entry_ptr, newestEn)
+  // The newest target will be used at T+1, so there is no need to bypass it.
+  private val currentNewestTarget = RegEnable(io.fromFrontendFtq.newest_entry_target, newestEn)
+  private val targetReadPtrVec = 0 until params.numTargetReadPort map { i =>
+    RegEnable(io.toDataPath.fromDataPathFtqPtr(i), io.toDataPath.fromDataPathValid(i))
+  }
+
   for (i <- 0 until params.numTargetReadPort) {
     val targetPtr = io.toDataPath.fromDataPathFtqPtr(i)
     // target pc stored in next entry
     targetMem.io.ren.get(i) := readValid(i)
     targetMem.io.raddr(i) := (targetPtr + 1.U).value
-    val needNewestTarget = RegEnable(targetPtr === io.fromFrontendFtq.newest_entry_ptr && newestEn, false.B, readValid(i))
-    targetPCVec(i) := Mux(
-      needNewestTarget,
-      RegEnable(newestTarget, newestEn),
-      targetMem.io.rdata(i).startAddr
+
+    val hitNewestFtqPtr = RegEnable(targetPtr === currentNewestFtqPtr, false.B, readValid(i))
+    targetPCVec(i) := MuxCase(
+      default = Fill(VAddrBits, 1.U(1.W)), // use all 1s as invalid predict jump target
+      mapping = Seq(
+        hitNewestFtqPtr -> currentNewestTarget,
+        (rdataVec(i).flag === targetReadPtrVec(i).flag) -> rdataVec(i).addr.startAddr,
+      )
     )
   }
 
@@ -53,7 +70,7 @@ class PcTargetMemImp(override val wrapper: PcTargetMem)(implicit p: Parameters, 
     // pc stored in this entry
     targetMem.io.ren.get(i + params.numTargetReadPort) := readValid(i)
     targetMem.io.raddr(i + params.numTargetReadPort) := pcAddr.value
-    pcVec(i) := targetMem.io.rdata(i + params.numTargetReadPort).getPc(RegEnable(offset, readValid(i)))
+    pcVec(i) := targetMem.io.rdata(i + params.numTargetReadPort).addr.getPc(RegEnable(offset, readValid(i)))
   }
 
   io.toDataPath.toDataPathTargetPC := targetPCVec
@@ -76,4 +93,9 @@ class PcTargetMemIO()(implicit p: Parameters, params: BackendParams) extends XSB
   val fromFrontendFtq = Flipped(new FtqToCtrlIO)
   //to backend
   val toDataPath = new PcToDataPathIO(params)
+}
+
+class PcTargetMemEntry(implicit p: Parameters) extends XSBundle {
+  val addr = new Ftq_RF_Components
+  val flag = Bool()
 }

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -164,7 +164,7 @@ class FrontendImp (outer: Frontend) extends LazyModuleImp(outer)
 
   val checkPcMem = Reg(Vec(FtqSize, new Ftq_RF_Components))
   when (ftq.io.toBackend.pc_mem_wen) {
-    checkPcMem(ftq.io.toBackend.pc_mem_waddr) := ftq.io.toBackend.pc_mem_wdata
+    checkPcMem(ftq.io.toBackend.pc_mem_waddr.value) := ftq.io.toBackend.pc_mem_wdata
   }
 
   val checkTargetIdx = Wire(Vec(DecodeWidth, UInt(log2Up(FtqSize).W)))

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -214,14 +214,13 @@ trait HasBackendRedirectInfo extends HasXSParameter {
 class FtqToCtrlIO(implicit p: Parameters) extends XSBundle with HasBackendRedirectInfo {
   // write to backend pc mem
   val pc_mem_wen = Output(Bool())
-  val pc_mem_waddr = Output(UInt(log2Ceil(FtqSize).W))
+  val pc_mem_waddr = Output(new FtqPtr)
   val pc_mem_wdata = Output(new Ftq_RF_Components)
   // newest target
   val newest_entry_en = Output(Bool())
   val newest_entry_target = Output(UInt(VAddrBits.W))
   val newest_entry_ptr = Output(new FtqPtr)
 }
-
 
 class FTBEntryGen(implicit p: Parameters) extends XSModule with HasBackendRedirectInfo with HasBPUParameter {
   val io = IO(new Bundle {
@@ -1014,7 +1013,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   // **********************************************************************
   // to backend pc mem / target
   io.toBackend.pc_mem_wen := RegNext(last_cycle_bpu_in)
-  io.toBackend.pc_mem_waddr := RegEnable(last_cycle_bpu_in_idx, last_cycle_bpu_in)
+  io.toBackend.pc_mem_waddr := RegEnable(last_cycle_bpu_in_ptr, last_cycle_bpu_in)
   io.toBackend.pc_mem_wdata := RegEnable(bpu_in_bypass_buf_for_ifu, last_cycle_bpu_in)
 
   // num cycle is fixed


### PR DESCRIPTION
* Hold newest predict target everytime it updated by frontend.
* Don't use out-of-date predict value even if FtqIdx match.