### PR TITLE
L2TLB, RVH: change ppnlen from 24 to 29 for the first stage translation in two stage translation

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -238,7 +238,7 @@ class TlbEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parameters) 
     this.tag := Mux(item.s2xlate === onlyStage2, s2tag, s1tag)
 
     val s1ppn = {
-      if (!pageNormal) item.s1.entry.ppn(sectorppnLen - 1, vpnnLen - sectortlbwidth)
+      if (!pageNormal) item.s1.entry.ppn(sectorgvpnLen - 1, vpnnLen - sectortlbwidth)
       else Cat(item.s1.entry.ppn, item.s1.ppn_low(OHToUInt(item.s1.pteidx)))
     }
     val s2ppn = {
@@ -427,7 +427,7 @@ class TlbSectorEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parame
     this.valididx := Mux(item.s2xlate === onlyStage2, s2_valid, item.s1.valididx)
     // if stage2 page is larger than stage1 page, need to merge s2tag and s2ppn to get a new s2ppn.
     val s1ppn = {
-      if (!pageNormal) item.s1.entry.ppn(sectorppnLen - 1, vpnnLen - sectortlbwidth) else item.s1.entry.ppn
+      if (!pageNormal) item.s1.entry.ppn(sectorgvpnLen - 1, vpnnLen - sectortlbwidth) else item.s1.entry.ppn
     }
     val s1ppn_low = item.s1.ppn_low
     val s2ppn = {
@@ -830,7 +830,9 @@ class PteBundle(implicit p: Parameters) extends PtwBundle{
     pm.r := perm.r
     pm
   }
-
+  def getPPN() = {
+    Cat(ppn_high, ppn)
+  }
   override def toPrintable: Printable = {
     p"ppn:0x${Hexadecimal(ppn)} perm:b${Binary(perm.asUInt)}"
   }
@@ -915,7 +917,7 @@ class PtwEntry(tagLen: Int, hasPerm: Boolean = false, hasLevel: Boolean = false)
 }
 
 class PtwSectorEntry(tagLen: Int, hasPerm: Boolean = false, hasLevel: Boolean = false)(implicit p: Parameters) extends PtwEntry(tagLen, hasPerm, hasLevel) {
-  override val ppn = UInt(sectorppnLen.W)
+  override val ppn = UInt(sectorgvpnLen.W)
 }
 
 class PtwMergeEntry(tagLen: Int, hasPerm: Boolean = false, hasLevel: Boolean = false)(implicit p: Parameters) extends PtwSectorEntry(tagLen, hasPerm, hasLevel) {
@@ -932,8 +934,8 @@ class PtwEntries(num: Int, tagLen: Int, level: Int, hasPerm: Boolean)(implicit p
 
   val tag  = UInt(tagLen.W)
   val asid = UInt(asidLen.W)
-  val vmid = if (HasHExtension) Some(UInt(vmidLen.W)) else None
-  val ppns = if (HasHExtension) Vec(num, UInt((vpnLen.max(ppnLen)).W)) else Vec(num, UInt(ppnLen.W))
+  val vmid = Some(UInt(vmidLen.W))
+  val ppns = Vec(num, UInt(gvpnLen.W))
   val vs   = Vec(num, Bool())
   val perms = if (hasPerm) Some(Vec(num, new PtePermBundle)) else None
   val prefetch = Bool()
@@ -1197,8 +1199,8 @@ class PtwMergeResp(implicit p: Parameters) extends PtwBundle {
     assert(tlbcontiguous == 8, "Only support tlbcontiguous = 8!")
     val resp_pte = Mux(af, 0.U.asTypeOf(pte), pte)
     val ptw_resp = Wire(new PtwMergeEntry(tagLen = sectorvpnLen, hasPerm = true, hasLevel = true))
-    ptw_resp.ppn := resp_pte.ppn(ppnLen - 1, sectortlbwidth)
-    ptw_resp.ppn_low := resp_pte.ppn(sectortlbwidth - 1, 0)
+    ptw_resp.ppn := resp_pte.getPPN()(gvpnLen - 1, sectortlbwidth)
+    ptw_resp.ppn_low := resp_pte.getPPN()(sectortlbwidth - 1, 0)
     ptw_resp.level.map(_ := level)
     ptw_resp.perm.map(_ := resp_pte.getPerm())
     ptw_resp.tag := vpn(vpnLen - 1, sectortlbwidth)
@@ -1225,62 +1227,6 @@ class PtwMergeResp(implicit p: Parameters) extends PtwBundle {
       1.U -> Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, vpnnLen - sectortlbwidth), tag(vpnnLen - 1, 0)),
       2.U -> Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, 0), entry(idx).ppn_low))
     )
-  }
-}
-
-class HptwMergeResp(implicit p: Parameters) extends PtwBundle {
-  val entry = Vec(tlbcontiguous, new HptwMergeEntry(tagLen = sectorvpnLen, hasPerm = true, hasLevel = true))
-  val pteidx = Vec(tlbcontiguous, Bool())
-  val not_super = Bool()
-
-  def genPPN(): UInt = {
-    val idx = OHToUInt(pteidx)
-    MuxLookup(entry(idx).level.get, 0.U)(Seq(
-      0.U -> Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, vpnnLen * 2 - sectortlbwidth), entry(idx).tag(vpnnLen * 2 - 1, 0)),
-      1.U -> Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, vpnnLen - sectortlbwidth), entry(idx).tag(vpnnLen - 1, 0)),
-      2.U -> Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, 0), entry(idx).ppn_low))
-    )
-  }
-
-  def isAf(): Bool = {
-    val idx = OHToUInt(pteidx)
-    entry(idx).af
-  }
-
-  def isPf(): Bool = {
-    val idx = OHToUInt(pteidx)
-    entry(idx).pf
-  }
-
-  def MergeRespToPte(): PteBundle = {
-    val idx = OHToUInt(pteidx)
-    val resp = Wire(new PteBundle())
-    resp.ppn := Cat(entry(idx).ppn, entry(idx).ppn_low)
-    resp.perm := entry(idx).perm.getOrElse(0.U)
-    resp
-  }
-
-  def apply(pf: Bool, af: Bool, level: UInt, pte: PteBundle, vpn: UInt, vmid: UInt, addr_low: UInt, not_super: Boolean = true) = {
-    assert(tlbcontiguous == 8, "Only support tlbcontiguous = 8!")
-
-    val ptw_resp = Wire(new HptwMergeEntry(tagLen = sectorvpnLen, hasPerm = true, hasLevel = true))
-    ptw_resp.ppn := pte.ppn(ppnLen - 1, sectortlbwidth)
-    ptw_resp.ppn_low := pte.ppn(sectortlbwidth - 1, 0)
-    ptw_resp.level.map(_ := level)
-    ptw_resp.perm.map(_ := pte.getPerm())
-    ptw_resp.tag := vpn(vpnLen - 1, sectortlbwidth)
-    ptw_resp.pf := pf
-    ptw_resp.af := af
-    ptw_resp.v := !pf
-    ptw_resp.prefetch := DontCare
-    ptw_resp.vmid.map(_ := vmid)
-    this.pteidx := UIntToOH(addr_low).asBools
-    this.not_super := not_super.B
-
-
-    for (i <- 0 until tlbcontiguous) {
-      this.entry(i) := ptw_resp
-    }
   }
 }
 

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -815,6 +815,10 @@ class PteBundle(implicit p: Parameters) extends PtwBundle{
     !(ppn_high === 0.U)
   }
 
+  def isStage1Af() = {
+    !((Cat(ppn_high, ppn) >> gvpnLen) === 0.U)
+  }
+
   def isLeaf() = {
     perm.r || perm.x || perm.w
   }

--- a/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
@@ -91,10 +91,12 @@ trait HasTlbConst extends HasXSParameter {
   val flagLen = 8
   val pteResLen = XLEN - 44 - 2 - flagLen
   val ppnHignLen = 44 - ppnLen
+  val gvpnLen = GPAddrBits - offLen
 
   val tlbcontiguous = 8
   val sectortlbwidth = log2Up(tlbcontiguous)
   val sectorppnLen = ppnLen - sectortlbwidth
+  val sectorgvpnLen = gvpnLen - sectortlbwidth
   val sectorvpnLen = vpnLen - sectortlbwidth
 
   val loadfiltersize = 16 // 4*3(LduCnt:2 + HyuCnt:1) + 4(prefetch:1)

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -130,7 +130,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   val stage1 = RegEnable(io.req.bits.stage1, io.req.fire)
   val hptw_resp_stage2 = Reg(Bool()) 
 
-  val ppn_af = Mux(s2xlate, false.B, pte.isAf()) // In two-stage address translation, stage 1 ppn is a vpn for host, so don't need to check ppn_high
+  val ppn_af = Mux(s2xlate, pte.isStage1Af(), pte.isAf()) // In two-stage address translation, stage 1 ppn is a vpn for host, so don't need to check ppn_high
   val find_pte = pte.isLeaf() || ppn_af || pageFault
   val to_find_pte = level === 1.U && find_pte === false.B
   val source = RegEnable(io.req.bits.req_info.source, io.req.fire)


### PR DESCRIPTION
The first stage is sv39 and the second stage is sv39x4. Before Xiangshan realizes H extension, the paddr is 36 bits, so ppnlen is 24 bits. After Xiangshan realizes H extension, the ppnlen of stage 1 should be 29 bits because the paddr of stage 1 is gpaddr for host and gpaddr is 41 bits. I add the gvpnlen to replace the ppnlen of stage 1 in L2TLB.