### PR TITLE
Rename table: fix width of rename table ports

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -176,8 +176,8 @@ class FPUCtrlSignals(implicit p: Parameters) extends XSBundle {
 class CtrlSignals(implicit p: Parameters) extends XSBundle {
   val debug_globalID = UInt(XLEN.W)
   val srcType = Vec(4, SrcType())
-  val lsrc = Vec(4, UInt(6.W))
-  val ldest = UInt(6.W)
+  val lsrc = Vec(4, UInt(LogicRegsWidth.W))
+  val ldest = UInt(LogicRegsWidth.W)
   val fuType = FuType()
   val fuOpType = FuOpType()
   val rfWen = Bool()
@@ -377,7 +377,7 @@ class RobCommitIO(implicit p: Parameters) extends XSBundle {
 }
 
 class RabCommitInfo(implicit p: Parameters) extends XSBundle {
-  val ldest = UInt(6.W)
+  val ldest = UInt(LogicRegsWidth.W)
   val pdest = UInt(PhyRegIdxWidth.W)
   val rfWen = Bool()
   val fpWen = Bool()

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -26,12 +26,12 @@ import xiangshan.backend.datapath.WbConfig._
 import xiangshan.backend.dispatch.DispatchParameters
 import xiangshan.backend.exu.ExeUnitParams
 import xiangshan.backend.fu.FuConfig._
-import xiangshan.backend.issue.{FpScheduler, IntScheduler, IssueBlockParams, MemScheduler, SchdBlockParams, SchedulerType, VfScheduler}
+import xiangshan.backend.issue.{IntScheduler, IssueBlockParams, MemScheduler, SchdBlockParams, SchedulerType, VfScheduler, FpScheduler}
 import xiangshan.backend.regfile._
 import xiangshan.backend.BackendParams
 import xiangshan.cache.DCacheParameters
 import xiangshan.cache.prefetch._
-import xiangshan.frontend.{BasePredictor, BranchPredictionResp, FTB, FakePredictor, FauFTB, ITTage, RAS, Tage, Tage_SC}
+import xiangshan.frontend.{BasePredictor, BranchPredictionResp, FTB, FakePredictor, ITTage, RAS, Tage, Tage_SC, FauFTB}
 import xiangshan.frontend.icache.ICacheParameters
 import xiangshan.cache.mmu.{L2TLBParameters, TLBParameters}
 import xiangshan.frontend._

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -26,17 +26,16 @@ import xiangshan.backend.datapath.WbConfig._
 import xiangshan.backend.dispatch.DispatchParameters
 import xiangshan.backend.exu.ExeUnitParams
 import xiangshan.backend.fu.FuConfig._
-import xiangshan.backend.issue.{IntScheduler, IssueBlockParams, MemScheduler, SchdBlockParams, SchedulerType, VfScheduler, FpScheduler}
+import xiangshan.backend.issue.{FpScheduler, IntScheduler, IssueBlockParams, MemScheduler, SchdBlockParams, SchedulerType, VfScheduler}
 import xiangshan.backend.regfile._
 import xiangshan.backend.BackendParams
 import xiangshan.cache.DCacheParameters
 import xiangshan.cache.prefetch._
-import xiangshan.frontend.{BasePredictor, BranchPredictionResp, FTB, FakePredictor, RAS, Tage, ITTage, Tage_SC, FauFTB}
+import xiangshan.frontend.{BasePredictor, BranchPredictionResp, FTB, FakePredictor, FauFTB, ITTage, RAS, Tage, Tage_SC}
 import xiangshan.frontend.icache.ICacheParameters
 import xiangshan.cache.mmu.{L2TLBParameters, TLBParameters}
 import xiangshan.frontend._
 import xiangshan.frontend.icache.ICacheParameters
-
 import freechips.rocketchip.diplomacy.AddressSet
 import freechips.rocketchip.tile.MaxHartIdBits
 import system.SoCParamsKey
@@ -47,7 +46,7 @@ import coupledL2._
 import xiangshan.backend.datapath.WakeUpConfig
 import xiangshan.mem.prefetch.{PrefetcherParams, SMSParams}
 
-import scala.math.min
+import scala.math.{max, min}
 
 case object XSTileKey extends Field[Seq[XSCoreParameters]]
 
@@ -671,6 +670,8 @@ trait HasXSParameter {
   def VecLogicRegs = coreParams.VecLogicRegs
   def V0LogicRegs = coreParams.V0LogicRegs
   def VlLogicRegs = coreParams.VlLogicRegs
+  def MaxLogicRegs = Set(IntLogicRegs, FpLogicRegs, VecLogicRegs, V0LogicRegs, VlLogicRegs).max
+  def LogicRegsWidth = log2Ceil(MaxLogicRegs)
   def V0_IDX = coreParams.V0_IDX
   def Vl_IDX = coreParams.Vl_IDX
   def IntPhyRegs = coreParams.intPreg.numEntries

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -31,7 +31,7 @@ import xiangshan.backend.regfile._
 import xiangshan.backend.BackendParams
 import xiangshan.cache.DCacheParameters
 import xiangshan.cache.prefetch._
-import xiangshan.frontend.{BasePredictor, BranchPredictionResp, FTB, FakePredictor, ITTage, RAS, Tage, Tage_SC, FauFTB}
+import xiangshan.frontend.{BasePredictor, BranchPredictionResp, FTB, FakePredictor, RAS, Tage, ITTage, Tage_SC, FauFTB}
 import xiangshan.frontend.icache.ICacheParameters
 import xiangshan.cache.mmu.{L2TLBParameters, TLBParameters}
 import xiangshan.frontend._

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -80,8 +80,8 @@ object Bundles {
     val ftqOffset       = UInt(log2Up(PredictWidth).W)
     // decoded
     val srcType         = Vec(numSrc, SrcType())
-    val lsrc            = Vec(numSrc, UInt(6.W))
-    val ldest           = UInt(6.W)
+    val lsrc            = Vec(numSrc, UInt(LogicRegsWidth.W))
+    val ldest           = UInt(LogicRegsWidth.W)
     val fuType          = FuType()
     val fuOpType        = FuOpType()
     val rfWen           = Bool()
@@ -155,7 +155,7 @@ object Bundles {
     val ftqOffset       = UInt(log2Up(PredictWidth).W)
     // passed from DecodedInst
     val srcType         = Vec(numSrc, SrcType())
-    val ldest           = UInt(6.W)
+    val ldest           = UInt(LogicRegsWidth.W)
     val fuType          = FuType()
     val fuOpType        = FuOpType()
     val rfWen           = Bool()

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -45,11 +45,11 @@ class DecodeStage(implicit p: Parameters) extends XSModule
     // to Rename
     val out = Vec(DecodeWidth, DecoupledIO(new DecodedInst))
     // RAT read
-    val intRat = Vec(RenameWidth, Vec(2, Flipped(new RatReadPort))) // Todo: make it configurable
-    val fpRat = Vec(RenameWidth, Vec(3, Flipped(new RatReadPort)))
-    val vecRat = Vec(RenameWidth, Vec(numVecRatPorts, Flipped(new RatReadPort)))
-    val v0Rat = Vec(RenameWidth, Flipped(new RatReadPort))
-    val vlRat = Vec(RenameWidth, Flipped(new RatReadPort))
+    val intRat = Vec(RenameWidth, Vec(2, Flipped(new RatReadPort(IntLogicRegs)))) // Todo: make it configurable
+    val fpRat = Vec(RenameWidth, Vec(3, Flipped(new RatReadPort(FpLogicRegs))))
+    val vecRat = Vec(RenameWidth, Vec(numVecRatPorts, Flipped(new RatReadPort(VecLogicRegs))))
+    val v0Rat = Vec(RenameWidth, Flipped(new RatReadPort(V0LogicRegs)))
+    val vlRat = Vec(RenameWidth, Flipped(new RatReadPort(VlLogicRegs)))
     // csr control
     val csrCtrl = Input(new CustomCSRCtrlIO)
     val fusion = Vec(DecodeWidth - 1, Input(Bool()))

--- a/src/main/scala/xiangshan/backend/decode/FusionDecoder.scala
+++ b/src/main/scala/xiangshan/backend/decode/FusionDecoder.scala
@@ -509,10 +509,10 @@ class FusionDecodeInfo extends Bundle {
   val rs2FromZero = Output(Bool())
 }
 
-class FusionDecodeReplace extends Bundle {
+class FusionDecodeReplace(implicit p: Parameters) extends XSBundle {
   val fuType = Valid(FuType())
   val fuOpType = Valid(FuOpType())
-  val lsrc2 = Valid(UInt(6.W))
+  val lsrc2 = Valid(UInt(LogicRegsWidth.W))
   val src2Type = Valid(SrcType())
   val selImm = Valid(SelImm())
 

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -55,11 +55,11 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     val vecReadPorts = Vec(RenameWidth, Vec(numVecRatPorts, Input(UInt(PhyRegIdxWidth.W))))
     val v0ReadPorts = Vec(RenameWidth, Vec(1, Input(UInt(PhyRegIdxWidth.W))))
     val vlReadPorts = Vec(RenameWidth, Vec(1, Input(UInt(PhyRegIdxWidth.W))))
-    val intRenamePorts = Vec(RenameWidth, Output(new RatWritePort))
-    val fpRenamePorts = Vec(RenameWidth, Output(new RatWritePort))
-    val vecRenamePorts = Vec(RenameWidth, Output(new RatWritePort))
-    val v0RenamePorts = Vec(RenameWidth, Output(new RatWritePort))
-    val vlRenamePorts = Vec(RenameWidth, Output(new RatWritePort))
+    val intRenamePorts = Vec(RenameWidth, Output(new RatWritePort(log2Ceil(IntLogicRegs))))
+    val fpRenamePorts = Vec(RenameWidth, Output(new RatWritePort(log2Ceil(FpLogicRegs))))
+    val vecRenamePorts = Vec(RenameWidth, Output(new RatWritePort(log2Ceil(VecLogicRegs))))
+    val v0RenamePorts = Vec(RenameWidth, Output(new RatWritePort(log2Ceil(V0LogicRegs))))
+    val vlRenamePorts = Vec(RenameWidth, Output(new RatWritePort(log2Ceil(VlLogicRegs))))
     // from rename table
     val int_old_pdest = Vec(RabCommitWidth, Input(UInt(PhyRegIdxWidth.W)))
     val fp_old_pdest = Vec(RabCommitWidth, Input(UInt(PhyRegIdxWidth.W)))
@@ -476,23 +476,23 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     // I. RAT Update
     // When redirect happens (mis-prediction), don't update the rename table
     io.intRenamePorts(i).wen  := intSpecWen(i)
-    io.intRenamePorts(i).addr := uops(i).ldest
+    io.intRenamePorts(i).addr := uops(i).ldest(log2Ceil(IntLogicRegs) - 1, 0)
     io.intRenamePorts(i).data := io.out(i).bits.pdest
 
     io.fpRenamePorts(i).wen  := fpSpecWen(i)
-    io.fpRenamePorts(i).addr := uops(i).ldest
+    io.fpRenamePorts(i).addr := uops(i).ldest(log2Ceil(FpLogicRegs) - 1, 0)
     io.fpRenamePorts(i).data := fpFreeList.io.allocatePhyReg(i)
 
     io.vecRenamePorts(i).wen := vecSpecWen(i)
-    io.vecRenamePorts(i).addr := uops(i).ldest
+    io.vecRenamePorts(i).addr := uops(i).ldest(log2Ceil(VecLogicRegs) - 1, 0)
     io.vecRenamePorts(i).data := vecFreeList.io.allocatePhyReg(i)
 
     io.v0RenamePorts(i).wen := v0SpecWen(i)
-    io.v0RenamePorts(i).addr := uops(i).ldest
+    io.v0RenamePorts(i).addr := uops(i).ldest(log2Ceil(V0LogicRegs) - 1, 0)
     io.v0RenamePorts(i).data := v0FreeList.io.allocatePhyReg(i)
 
     io.vlRenamePorts(i).wen := vlSpecWen(i)
-    io.vlRenamePorts(i).addr := uops(i).ldest
+    io.vlRenamePorts(i).addr := uops(i).ldest(log2Ceil(VlLogicRegs) - 1, 0)
     io.vlRenamePorts(i).data := vlFreeList.io.allocatePhyReg(i)
 
     // II. Free List Update

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -77,7 +77,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     // debug_begin
     val debug_pc = OptionWrapper(backendParams.debugEn, UInt(VAddrBits.W))
     val debug_instr = OptionWrapper(backendParams.debugEn, UInt(32.W))
-    val debug_ldest = OptionWrapper(backendParams.debugEn, UInt(6.W))
+    val debug_ldest = OptionWrapper(backendParams.debugEn, UInt(LogicRegsWidth.W))
     val debug_pdest = OptionWrapper(backendParams.debugEn, UInt(PhyRegIdxWidth.W))
     val debug_fuType = OptionWrapper(backendParams.debugEn, FuType())
     // debug_end
@@ -110,7 +110,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     // debug_begin
     val debug_pc = OptionWrapper(backendParams.debugEn, UInt(VAddrBits.W))
     val debug_instr = OptionWrapper(backendParams.debugEn, UInt(32.W))
-    val debug_ldest = OptionWrapper(backendParams.debugEn, UInt(6.W))
+    val debug_ldest = OptionWrapper(backendParams.debugEn, UInt(LogicRegsWidth.W))
     val debug_pdest = OptionWrapper(backendParams.debugEn, UInt(PhyRegIdxWidth.W))
     val debug_fuType = OptionWrapper(backendParams.debugEn, FuType())
     // debug_end


### PR DESCRIPTION
Different rename table has different numbers of entries, leading to differences in the width of read/write ports. In the code we see the widths of all read/write ports were set to 6, which works well but is not parameterized. Now these widths are modified to be controlled by parameters.