### PR TITLE
rv64v: fix 'segmentUnit' was not connected to 'sbufferDifftestInfo' port and fix timing problem caused by bit width in 'Dispatch2iq'.

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -705,6 +705,7 @@ trait HasXSParameter {
   def LoadUncacheBufferSize = coreParams.LoadUncacheBufferSize
   def LoadQueueNWriteBanks = coreParams.LoadQueueNWriteBanks
   def StoreQueueSize = coreParams.StoreQueueSize
+  def VirtualLoadQueueMaxStoreQueueSize = VirtualLoadQueueSize max StoreQueueSize
   def StoreQueueNWriteBanks = coreParams.StoreQueueNWriteBanks
   def StoreQueueForwardWithMask = coreParams.StoreQueueForwardWithMask
   def VlsQueueSize = coreParams.VlsQueueSize

--- a/src/main/scala/xiangshan/backend/issue/Dispatch2Iq.scala
+++ b/src/main/scala/xiangshan/backend/issue/Dispatch2Iq.scala
@@ -856,9 +856,11 @@ class Dispatch2IqMemImp(override val wrapper: Dispatch2Iq)(implicit p: Parameter
   //  1) The lsq has enough entris.
   //  2) The number of flows accumulated does not exceed VecMemDispatchMaxNumber.
   //  3) Vector instructions other than 'unit-stride' can only be issued on the first port.
-  private val allowDispatch = Wire(Vec(numLsElem.length, Bool()))
+  private val allowDispatch = Wire(Vec(enqLsqIO.req.length, Bool()))
+
   for (index <- allowDispatch.indices) {
-    val flowTotal = conserveFlows.take(index + 1).reduce(_ +& _)
+    val flowTotal = Wire(UInt(log2Up(VirtualLoadQueueMaxStoreQueueSize + 1).W))
+    flowTotal := conserveFlows.take(index + 1).reduce(_ +& _)
     if(index == 0){
       when(isStoreVec(index) || isVStoreVec(index)) {
         allowDispatch(index) := sqFreeCount > flowTotal

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -165,7 +165,7 @@ trait HasDCacheParameters extends HasL1CacheParameters with HasL1PrefetchSourceP
   val DCacheLineOffset = DCacheSetOffset
 
   // uncache
-  val uncacheIdxBits = log2Up(StoreQueueSize + 1) max log2Up(VirtualLoadQueueSize + 1)
+  val uncacheIdxBits = log2Up(VirtualLoadQueueMaxStoreQueueSize + 1)
   // hardware prefetch parameters
   // high confidence hardware prefetch port
   val HighConfHWPFLoadPort = LoadPipelineWidth - 1 // use the last load port by default

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -620,14 +620,7 @@ class TlbReplaceIO(Width: Int, q: TLBParameters)(implicit p: Parameters) extends
 class MemBlockidxBundle(implicit p: Parameters) extends TlbBundle {
   val is_ld = Bool()
   val is_st = Bool()
-  val idx =
-    if (VirtualLoadQueueSize >= StoreQueueSize) {
-      val idx = UInt(log2Ceil(VirtualLoadQueueSize).W)
-      idx
-    } else {
-      val idx = UInt(log2Ceil(StoreQueueSize).W)
-      idx
-    }
+  val idx = UInt(log2Ceil(VirtualLoadQueueMaxStoreQueueSize).W)
 }
 
 class TlbReq(implicit p: Parameters) extends TlbBundle {

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -971,18 +971,11 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     vecExceptionFlag.valid  := false.B
     vecExceptionFlag.bits   := 0.U.asTypeOf(new DynInst)
   }
-  val vecExceptionFlagAssertReg = RegInit(0.U(8.W))
 
   // A dumb defensive code. The flag should not be placed for a long period of time.
-  when(vecExceptionFlag.valid){
-    vecExceptionFlagAssertReg := vecExceptionFlagAssertReg + 1.U
-  }.otherwise{
-    vecExceptionFlagAssertReg := 0.U
-  }
   // A relatively large timeout period, not have any special meaning.
   // If an assert appears and you confirm that it is not a Bug: Increase the timeout or remove the assert.
-  assert(vecExceptionFlagAssertReg <= 150.U, s"vecExceptionFlag Timeout.")
-
+  TimeOutAssert(vecExceptionFlag.valid, 3000, "vecExceptionFlag timeout, Plase check for bugs or add timeouts.")
 
   // Initialize when unenabled difftest.
   for (i <- 0 until EnsbufferWidth) {

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -509,6 +509,9 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
   io.sbuffer.bits.id               := DontCare
   io.sbuffer.bits.addr             := instMicroOp.paddr
 
+  io.vecDifftestInfo.valid         := state === s_send_data && segmentActive
+  io.vecDifftestInfo.bits          := uopq(deqPtr.value).uop
+
   /**
    * update ptr
    * */

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -233,6 +233,7 @@ class VSegmentUnitIO(implicit p: Parameters) extends VLSUBundle{
   val uopwriteback        = DecoupledIO(new MemExuOutput(isVector = true)) // writeback data
   val rdcache             = new DCacheLoadIO // read dcache port
   val sbuffer             = Decoupled(new DCacheWordReqWithVaddrAndPfFlag)
+  val vecDifftestInfo     = Decoupled(new DynInst) // to sbuffer
   val dtlb                = new TlbRequestIO(2)
   val pmpResp             = Flipped(new PMPRespBundle())
   val flush_sbuffer       = new SbufferFlushBundle


### PR DESCRIPTION
Fix the timing problem in dispatch2iq caused by wrong bit width calculation is fixed, as described in (401631ccb66daaf5b5a7b1f67ae5402e26be95b7), and unified parameters in (eebd01f8b876d1529595ebded6cdc45d611be759).

Fix an issue where 'segmentUnit' was not connected to 'sbufferVecDifftestInfo' port, as described in (96c35ec3dbed9762cbced86c79ce0bdc550bcb56).

Figured out that we could use an already implemented API to check the 'timeout'. as described in (468eda665c20b26570967bdfb1611edebcd021f2).
