### PR TITLE
rob: support info collection for TIP analysis

### DIFF
--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -234,6 +234,35 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val s_idle :: s_walk :: Nil = Enum(2)
   val state = RegInit(s_idle)
 
+  val tip_computing :: tip_stalled :: tip_walk :: tip_drained :: Nil = Enum(4)
+  val tip_state = WireInit(0.U(4.W))
+  when(!isEmpty) {  // One or more inst in ROB
+    when(state === s_walk || io.redirect.valid) {
+      tip_state := tip_walk
+    }.elsewhen(io.commits.isCommit && PopCount(io.commits.commitValid) =/= 0.U) {
+      tip_state := tip_computing
+    }.otherwise {
+      tip_state := tip_stalled
+    }
+  }.otherwise {
+    tip_state := tip_drained
+  }
+  class TipEntry()(implicit p: Parameters) extends XSBundle {
+    val state = UInt(4.W)
+    val commits = new RobCommitIO()      // info of commit
+    val redirect = Valid(new Redirect)   // info of redirect
+    val redirect_pc = UInt(VAddrBits.W)  // PC of the redirect uop
+    val debugLsInfo = new DebugLsInfo()
+  }
+  val tip_table = ChiselDB.createTable("Tip_" + p(XSCoreParamsKey).HartId.toString, new TipEntry)
+  val tip_data = Wire(new TipEntry())
+  tip_data.state := tip_state
+  tip_data.commits := io.commits
+  tip_data.redirect := io.redirect
+  tip_data.redirect_pc := debug_microOp(io.redirect.bits.robIdx.value).pc
+  tip_data.debugLsInfo := debug_lsInfo(io.commits.robIdx(0).value)
+  tip_table.log(tip_data, true.B, "", clock, reset)
+
   val exceptionGen = Module(new ExceptionGen(params))
   val exceptionDataRead = exceptionGen.io.state
   val fflagsDataRead = Wire(Vec(CommitWidth, UInt(5.W)))


### PR DESCRIPTION
This PR support cycle-accurate information collection for TIP analysis, which can be used to identify performance abnormaly in terms of instructions. Size of information collected can be large because sampling is not implemented yet