### PR TITLE
IFU: remove duplicate assignment for f3_ready

### DIFF
--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -580,7 +580,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   when(RegNext(f2_fire && !f2_flush) && f3_req_is_mmio)        { f3_mmio_use_seq_pc := true.B  }
   .elsewhen(redirect_mmio_req)                                 { f3_mmio_use_seq_pc := false.B }
 
-  f3_ready := Mux(f3_req_is_mmio, io.toIbuffer.ready && f3_mmio_req_commit || !f3_valid , io.toIbuffer.ready || !f3_valid)
+  f3_ready := (io.toIbuffer.ready && (f3_mmio_req_commit || !f3_req_is_mmio)) || !f3_valid
 
   // mmio state machine
   switch(mmio_state){

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -468,8 +468,6 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f3_doubleLine     = RegEnable(f2_doubleLine, f2_fire)
   val f3_fire           = io.toIbuffer.fire
 
-  f3_ready := f3_fire || !f3_valid
-
   val f3_cut_data       = RegEnable(f2_cut_data, f2_fire)
 
   val f3_except_pf      = RegEnable(f2_except_pf,  f2_fire)


### PR DESCRIPTION
f3_ready is assigned twice under the identical condition:
- https://github.com/OpenXiangShan/XiangShan/blob/182b7ece8ba898233f30d6cd83bbed50825943de/src/main/scala/xiangshan/frontend/IFU.scala\#L471
- https://github.com/OpenXiangShan/XiangShan/blob/182b7ece8ba898233f30d6cd83bbed50825943de/src/main/scala/xiangshan/frontend/IFU.scala\#L585

and the former one:
```scala
f3_ready := f3_fire || !f3_valid
//       := (io.toIbuffer.ready && f3_valid && (!f3_req_is_mmio || f3_mmio_can_go) && !f3_flush) || !f3_valid
```
might not ideal since the previous mmio request may be not commited (i.e. `mmio_state === m_waitCommit`)

therefore, remove the former assignment