### PR TITLE
PageCache: should not hit access fault ptes

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -616,7 +616,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     rfvOH.suggestName(s"l2_rfvOH")
   }
 
-  when (!flush_dup(2) && refill.levelOH.l3 && !memPte(2).isAf()) {
+  when (!flush_dup(2) && refill.levelOH.l3) {
     val refillIdx = genPtwL3SetIdx(refill.req_info_dup(2).vpn)
     val victimWay = replaceWrapper(getl3vSet(refill.req_info_dup(2).vpn), ptwl3replace.way(refillIdx))
     val victimWayOH = UIntToOH(victimWay)


### PR DESCRIPTION
In the previous design, even if an access fault occurs on a page table, the page cache is hit and information about the access fault is lost because the page cache truncates the ppn bit width. We have fixed this problem in this PR by determining whether af occurs when a page table refill occurs, and if it does, making it a forced miss.