### PR TITLE
L2TLB, RVH: fix the bug that L2TLB resp wrong stage1 pte when gpf/gaf happens in LLPTW

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -228,7 +228,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   llptw.io.in.bits.ppn := cache.io.resp.bits.toFsm.ppn
   llptw.io.sfence := sfence_dup(1)
   llptw.io.csr := csr_dup(1)
-  val llptw_stage1 = RegEnable(cache.io.resp.bits.toTlb, llptw.io.in.fire)
+  val llptw_stage1 = RegEnable(cache.io.resp.bits.stage1, llptw.io.in.fire)
 
   cache.io.req.valid := arb2.io.out.valid
   cache.io.req.bits.req_info := arb2.io.out.bits.req_info
@@ -257,7 +257,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   ptw.io.req.bits.l1Hit := cache.io.resp.bits.toFsm.l1Hit
   ptw.io.req.bits.ppn := cache.io.resp.bits.toFsm.ppn
   ptw.io.req.bits.stage1Hit := cache.io.resp.bits.toFsm.stage1Hit
-  ptw.io.req.bits.stage1 := cache.io.resp.bits.toTlb
+  ptw.io.req.bits.stage1 := cache.io.resp.bits.stage1
   ptw.io.sfence := sfence_dup(7)
   ptw.io.csr := csr_dup(6)
   ptw.io.resp.ready := outReady(ptw.io.resp.bits.source, outArbFsmPort)
@@ -480,7 +480,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   for (i <- 0 until PtwWidth) {
     mergeArb(i).in(outArbCachePort).valid := cache.io.resp.valid && cache.io.resp.bits.hit && cache.io.resp.bits.req_info.source===i.U && !cache.io.resp.bits.isHptwReq 
     mergeArb(i).in(outArbCachePort).bits.s2xlate := cache.io.resp.bits.req_info.s2xlate
-    mergeArb(i).in(outArbCachePort).bits.s1 := cache.io.resp.bits.toTlb
+    mergeArb(i).in(outArbCachePort).bits.s1 := cache.io.resp.bits.stage1
     mergeArb(i).in(outArbCachePort).bits.s2 := cache.io.resp.bits.toHptw.resp
     mergeArb(i).in(outArbFsmPort).valid := ptw.io.resp.valid && ptw.io.resp.bits.source===i.U
     mergeArb(i).in(outArbFsmPort).bits.s2xlate := ptw.io.resp.bits.s2xlate
@@ -640,11 +640,11 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   val isWritePageCacheTable = Constantin.createRecord(s"isWritePageCacheTable$hartId")
   val PageCacheTable = ChiselDB.createTable(s"PageCache_hart$hartId", new PageCacheDB)
   val PageCacheDB = Wire(new PageCacheDB)
-  PageCacheDB.vpn := Cat(cache.io.resp.bits.toTlb.entry(0).tag, OHToUInt(cache.io.resp.bits.toTlb.pteidx))
+  PageCacheDB.vpn := Cat(cache.io.resp.bits.stage1.entry(0).tag, OHToUInt(cache.io.resp.bits.stage1.pteidx))
   PageCacheDB.source := cache.io.resp.bits.req_info.source
   PageCacheDB.bypassed := cache.io.resp.bits.bypassed
   PageCacheDB.is_first := cache.io.resp.bits.isFirst
-  PageCacheDB.prefetched := cache.io.resp.bits.toTlb.entry(0).prefetch
+  PageCacheDB.prefetched := cache.io.resp.bits.stage1.entry(0).prefetch
   PageCacheDB.prefetch := cache.io.resp.bits.prefetch
   PageCacheDB.l2Hit := cache.io.resp.bits.toFsm.l2Hit
   PageCacheDB.l1Hit := cache.io.resp.bits.toFsm.l1Hit

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -509,7 +509,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   io.resp.bits.toTlb.entry.map(_.tag := stageResp.bits.req_info.vpn(vpnLen - 1, 3))
   io.resp.bits.toTlb.entry.map(_.asid := Mux(stageResp.bits.req_info.hasS2xlate(), io.csr_dup(0).vsatp.asid, io.csr_dup(0).satp.asid)) // DontCare
   io.resp.bits.toTlb.entry.map(_.vmid.map(_ := io.csr_dup(0).hgatp.asid))
-  io.resp.bits.toTlb.entry.map(_.level.map(_ := Mux(resp_res.l3.hit, 2.U, resp_res.sp.level)))
+  io.resp.bits.toTlb.entry.map(_.level.map(_ := Mux(resp_res.l3.hit, 2.U, Mux(resp_res.l2.hit, 1.U, Mux(resp_res.l1.hit, 0.U, resp_res.sp.level)))))
   io.resp.bits.toTlb.entry.map(_.prefetch := from_pre(stageResp.bits.req_info.source))
   for (i <- 0 until tlbcontiguous) {
     io.resp.bits.toTlb.entry(i).ppn := Mux(resp_res.l3.hit, resp_res.l3.ppn(i)(gvpnLen - 1, sectortlbwidth), resp_res.sp.ppn(gvpnLen - 1, sectortlbwidth))

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -131,7 +131,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   val hptw_resp_stage2 = Reg(Bool()) 
 
   val ppn_af = Mux(s2xlate, pte.isStage1Af(), pte.isAf()) // In two-stage address translation, stage 1 ppn is a vpn for host, so don't need to check ppn_high
-  val find_pte = pte.isLeaf() || ppn_af || pageFault
+  val find_pte = pte.isLeaf() || ppn_af || pageFault || hptw_pageFault || hptw_accessFault
   val to_find_pte = level === 1.U && find_pte === false.B
   val source = RegEnable(io.req.bits.req_info.source, io.req.fire)
 

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -514,6 +514,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     entries(enq_ptr).wait_id := Mux(to_wait, wait_id, enq_ptr)
     entries(enq_ptr).af := false.B
     entries(enq_ptr).hptw_resp := Mux(to_last_hptw_req, entries(last_hptw_req_id).hptw_resp, Mux(to_wait, entries(wait_id).hptw_resp, entries(enq_ptr).hptw_resp))
+    entries(enq_ptr).first_s2xlate_fault := false.B
     mem_resp_hit(enq_ptr) := to_mem_out || to_last_hptw_req
   }
 
@@ -599,7 +600,6 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
           state(i) := Mux(Cat(need_to_waiting_vec).orR, state_mem_waiting, state_addr_check)
           entries(i).hptw_resp := io.hptw.resp.bits.h_resp
           entries(i).wait_id := Mux(Cat(need_to_waiting_vec).orR, waiting_index, entries(i).wait_id)
-          entries(i).first_s2xlate_fault := false.B
           //To do: change the entry that is having the same hptw req
         }
       }


### PR DESCRIPTION
When gaf or gpf happens in the first stage2 translation in LLPTW, L2TLB will resp. But LLPTW doesn't save the stage1 pte because LLPTW performs the first stage2 translation. So this pr saves the stage1 pte coresponding to the first stage2 translation.