### PR TITLE
LSU: trigger accessfault for vector mmio access request

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -954,8 +954,11 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   // will be force writebacked to rob
   val s2_exception_vec = WireInit(s2_in.uop.exceptionVec)
   when (!s2_in.delayedLoadError) {
-    s2_exception_vec(loadAccessFault) := (s2_in.uop.exceptionVec(loadAccessFault) || s2_pmp.ld ||
-                                       (io.dcache.resp.bits.tag_error && GatedValidRegNext(io.csrCtrl.cache_error_enable))) && s2_vecActive
+    s2_exception_vec(loadAccessFault) := (s2_in.uop.exceptionVec(loadAccessFault) ||
+                                         s2_pmp.ld ||
+                                         s2_isvec && s2_pmp.mmio && !s2_prf && !s2_in.tlbMiss ||
+                                         (io.dcache.resp.bits.tag_error && GatedValidRegNext(io.csrCtrl.cache_error_enable))
+                                         ) && s2_vecActive
   }
 
   // soft prefetch will not trigger any exception (but ecc error interrupt may

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -318,7 +318,10 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   s2_out.af     := s2_pmp.st && !s2_in.isvec
   s2_out.mmio   := s2_mmio && !s2_exception
   s2_out.atomic := s2_in.atomic || s2_pmp.atomic
-  s2_out.uop.exceptionVec(storeAccessFault) := (s2_in.uop.exceptionVec(storeAccessFault) || s2_pmp.st) && s2_vecActive
+  s2_out.uop.exceptionVec(storeAccessFault) := (s2_in.uop.exceptionVec(storeAccessFault) ||
+                                                s2_pmp.st ||
+                                                (s2_in.isvec && s2_pmp.mmio && RegNext(s1_feedback.bits.hit))
+                                                ) && s2_vecActive
 
   // kill dcache write intent request when mmio or exception
   io.dcache.s2_kill := (s2_mmio || s2_exception || s2_in.uop.robIdx.needFlush(io.redirect))


### PR DESCRIPTION
This commit is to ensure robustness when vector instructions are used to access MMIO regions by mistake. Currently, we do not support vector instruction access to MMIO regions, and in order to handle the situation when a vector instruction incorrectly accesses an MMIO region, an accessfault exception is triggered when the MMIO region is accessed using a vector instruction.