### PR TITLE
VLSU: fix bugs related to vector access exceptions

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -222,13 +222,14 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   }
   // vlsu exception!
   for (i <- 0 until VecLoadPipelineWidth) {
-    exceptionBuffer.io.req(LoadPipelineWidth + i).valid               := io.vecFeedback(i).valid && io.vecFeedback(i).bits.feedback(VecFeedbacks.FLUSH) // have exception
-    exceptionBuffer.io.req(LoadPipelineWidth + i).bits                := DontCare
-    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.vaddr          := io.vecFeedback(i).bits.vaddr
-    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.uopIdx     := io.vecFeedback(i).bits.uopidx
-    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.robIdx     := io.vecFeedback(i).bits.robidx
-    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.vpu.vstart := io.vecFeedback(i).bits.vstart
-    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.vpu.vl     := io.vecFeedback(i).bits.vl
+    exceptionBuffer.io.req(LoadPipelineWidth + i).valid                 := io.vecFeedback(i).valid && io.vecFeedback(i).bits.feedback(VecFeedbacks.FLUSH) // have exception
+    exceptionBuffer.io.req(LoadPipelineWidth + i).bits                  := DontCare
+    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.vaddr            := io.vecFeedback(i).bits.vaddr
+    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.uopIdx       := io.vecFeedback(i).bits.uopidx
+    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.robIdx       := io.vecFeedback(i).bits.robidx
+    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.vpu.vstart   := io.vecFeedback(i).bits.vstart
+    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.vpu.vl       := io.vecFeedback(i).bits.vl
+    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.exceptionVec := io.vecFeedback(i).bits.exceptionVec
   }
   // mmio non-data error exception
   exceptionBuffer.io.req.last := uncacheBuffer.io.exception

--- a/src/main/scala/xiangshan/mem/vector/VecCommon.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecCommon.scala
@@ -919,7 +919,15 @@ object genVUopOffset extends VLSUConstants {
 
 
 
-object searchVFirstUnMask extends VLSUConstants {
+object genVFirstUnmask extends VLSUConstants {
+  /**
+   * Find the lowest unmasked number of bits.
+   * example:
+   *   mask = 16'b1111_1111_1110_0000
+   *   return 5
+   * @param mask 16bits of mask.
+   * @return lowest unmasked number of bits.
+   */
   def apply(mask: UInt): UInt = {
     require(mask.getWidth == 16, "The mask width must be 16")
     val select = (0 until 16).zip(mask.asBools).map{case (i, v) =>


### PR DESCRIPTION
 fix the bug of vector unit-stride exception address calculation, as in (b43913a1a16065076728931e4945132851945197).


fix connection between vector exception and 'exceptionBuffer' in 'LoadQueue'. as in (2d1c7300228274e845948a94433933cf667bab11).

At present, the vector access exception processing still needs to wait for the modification of the back-end. We will test after the back-end is completed, and may also adapt the storage access side.