### PR TITLE
DCache: Block the writeback req when the addr matching a valid req in mshr

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1331,7 +1331,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   bus.a <> missQueue.io.mem_acquire
   bus.e <> missQueue.io.mem_finish
   missQueue.io.probe_addr := bus.b.bits.address
-  missQueue.io.release_addr := wb.io.req.bits.addr
+  missQueue.io.release_addr := mainPipe.io.evict_addr
 
   missQueue.io.main_pipe_resp.valid := RegNext(mainPipe.io.atomic_resp.valid)
   missQueue.io.main_pipe_resp.bits := RegEnable(mainPipe.io.atomic_resp.bits, mainPipe.io.atomic_resp.valid)

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1303,6 +1303,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   wb.io.miss_req.valid := missReqArb.io.out.valid
   wb.io.miss_req.bits  := missReqArb.io.out.bits.addr
+  wb.io.mshr_block := missQueue.io.release_block
 
   // block_decoupled(missReqArb.io.out, missQueue.io.req, wb.io.block_miss_req)
   missReqArb.io.out <> missQueue.io.req
@@ -1330,6 +1331,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   bus.a <> missQueue.io.mem_acquire
   bus.e <> missQueue.io.mem_finish
   missQueue.io.probe_addr := bus.b.bits.address
+  missQueue.io.release_addr := wb.io.req.bits.addr
 
   missQueue.io.main_pipe_resp.valid := RegNext(mainPipe.io.atomic_resp.valid)
   missQueue.io.main_pipe_resp.bits := RegEnable(mainPipe.io.atomic_resp.bits, mainPipe.io.atomic_resp.valid)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -165,6 +165,9 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     // find the way to be replaced
     val replace_way = new ReplacementWayReqIO
 
+    // writeback addr to be replaced
+    val evict_addr = ValidIO(UInt(PAddrBits.W))
+
     // sms prefetch
     val sms_agt_evict_req = DecoupledIO(new AGTEvictReq)
 
@@ -1542,6 +1545,9 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.tag_write_intend := s3_req_miss_dup(7) && s3_valid_dup(11)
   XSPerfAccumulate("fake_tag_write_intend", io.tag_write_intend && !io.tag_write.valid)
   XSPerfAccumulate("mainpipe_tag_write", io.tag_write.valid)
+
+  io.evict_addr.valid := io.wb.valid && s3_need_replacement
+  io.evict_addr.bits  := io.wb.bits.addr
 
   assert(!RegNext(io.tag_write.valid && !io.tag_write_intend))
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -831,7 +831,7 @@ class MissQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule
     val probe_block = Output(Bool())
 
     // block release
-    val release_addr = Input(UInt(PAddrBits.W))
+    val release_addr = Flipped(ValidIO(UInt(PAddrBits.W)))
     val release_block = Output(Bool())
 
     val full = Output(Bool())
@@ -1020,7 +1020,7 @@ class MissQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule
 
   io.probe_block := Cat(probe_block_vec).orR
 
-  io.release_block := Cat(entries.map(e => e.io.req_addr.valid && e.io.req_addr.bits === io.release_addr) ++ Seq(miss_req_pipe_reg.block_match(io.release_addr))).orR
+  io.release_block := io.release_addr.valid && Cat(entries.map(e => e.io.req_addr.valid && e.io.req_addr.bits === io.release_addr.bits) ++ Seq(miss_req_pipe_reg.block_match(io.release_addr.bits))).orR
 
   io.full := ~Cat(entries.map(_.io.primary_ready)).andR
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
@@ -315,6 +315,8 @@ class WritebackQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
 
     val miss_req = Flipped(Valid(UInt()))
     val block_miss_req = Output(Bool()) 
+
+    val mshr_block = Input(Bool())
   })
 
   require(cfg.nReleaseEntries > cfg.nMissEntries)
@@ -325,7 +327,7 @@ class WritebackQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
   val req = io.req
   val block_conflict = Wire(Bool())
 
-  req.ready := alloc && !block_conflict
+  req.ready := alloc && !block_conflict && !io.mshr_block
 
   // assign default values to output signals
   io.mem_release.valid := false.B

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
@@ -327,7 +327,7 @@ class WritebackQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
   val req = io.req
   val block_conflict = Wire(Bool())
 
-  req.ready := alloc && !block_conflict && !io.mshr_block
+  req.ready := alloc && !block_conflict
 
   // assign default values to output signals
   io.mem_release.valid := false.B
@@ -351,7 +351,7 @@ class WritebackQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
       entry.io.id := entry_id
 
       // entry req
-      entry.io.req.valid := req.valid && !block_conflict
+      entry.io.req.valid := req.valid && !block_conflict && !io.mshr_block
       primary_ready_vec(i)   := entry.io.primary_ready
       entry.io.req.bits  := req.bits
       entry.io.req_data  := req_data


### PR DESCRIPTION
Bug: 
- When two req with different addr x and y enter MissQueue together, req y is real miss req, while req x is **AcquireBlock BtoT**. Req y receive the resp from L2 first and complete the refill operation by replacing the data block with addr x (decided by plru algorithm). MainPipe will release the data block with addr in writeback queue through req **Release BtoN** to L2. Addr x receive GrantData with permission toT at last.
- From the view of L2, the req sequence of addr x is: Acquire BtoT -> GrantData toT -> Release BtoN, which is abnormal.

Fix: When a valid req reaches wbq, check if there is any valid mshr with same block_addr. If a mshr is found, block current wbq_req.