### PR TITLE
IFU: pass mmio gpf to ibuffer & gpaddr to gpaMem

### DIFF
--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -567,12 +567,13 @@ class NewIFU(implicit p: Parameters) extends XSModule
   }
 
   /*** MMIO State Machine***/
-  val f3_mmio_data    = Reg(Vec(2, UInt(16.W)))
-  val mmio_is_RVC     = RegInit(false.B)
-  val mmio_resend_addr =RegInit(0.U(PAddrBits.W))
-  val mmio_resend_af  = RegInit(false.B)
-  val mmio_resend_pf  = RegInit(false.B)
-  val mmio_resend_gpf = RegInit(false.B)
+  val f3_mmio_data       = Reg(Vec(2, UInt(16.W)))
+  val mmio_is_RVC        = RegInit(false.B)
+  val mmio_resend_addr   = RegInit(0.U(PAddrBits.W))
+  val mmio_resend_af     = RegInit(false.B)
+  val mmio_resend_pf     = RegInit(false.B)
+  val mmio_resend_gpf    = RegInit(false.B)
+  val mmio_resend_gpaddr = RegInit(0.U(GPAddrBits.W))
 
   //last instuction finish
   val is_first_instr = RegInit(true.B)
@@ -606,7 +607,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
     **********************************************************************************
     */
   when(is_first_instr && f3_fire){
-    is_first_instr  := false.B
+    is_first_instr := false.B
   }
 
   when(f3_flush && !f3_req_is_mmio)                                                 {f3_valid := false.B}
@@ -629,7 +630,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   switch(mmio_state){
     is(m_idle){
       when(f3_req_is_mmio){
-        mmio_state :=  m_waitLastCmt
+        mmio_state := m_waitLastCmt
       }
     }
 
@@ -642,24 +643,23 @@ class NewIFU(implicit p: Parameters) extends XSModule
     }
 
     is(m_sendReq){
-      mmio_state :=  Mux(toUncache.fire, m_waitResp, m_sendReq )
+      mmio_state := Mux(toUncache.fire, m_waitResp, m_sendReq)
     }
 
     is(m_waitResp){
       when(fromUncache.fire){
-          val isRVC =  fromUncache.bits.data(1,0) =/= 3.U
+          val isRVC = fromUncache.bits.data(1,0) =/= 3.U
           val needResend = !isRVC && f3_paddrs(0)(2,1) === 3.U
-          mmio_state :=  Mux(needResend, m_sendTLB , m_waitCommit)
-
-          mmio_is_RVC := isRVC
-          f3_mmio_data(0)   :=  fromUncache.bits.data(15,0)
-          f3_mmio_data(1)   :=  fromUncache.bits.data(31,16)
+          mmio_state      := Mux(needResend, m_sendTLB, m_waitCommit)
+          mmio_is_RVC     := isRVC
+          f3_mmio_data(0) := fromUncache.bits.data(15,0)
+          f3_mmio_data(1) := fromUncache.bits.data(31,16)
       }
     }
 
     is(m_sendTLB){
       when( io.iTLBInter.req.valid && !io.iTLBInter.resp.bits.miss ){
-        mmio_state :=  m_tlbResp
+        mmio_state := m_tlbResp
       }
     }
 
@@ -667,40 +667,41 @@ class NewIFU(implicit p: Parameters) extends XSModule
       val tlbExept = io.iTLBInter.resp.bits.excp(0).pf.instr ||
                      io.iTLBInter.resp.bits.excp(0).af.instr ||
                      io.iTLBInter.resp.bits.excp(0).gpf.instr
-      mmio_state :=  Mux(tlbExept,m_waitCommit,m_sendPMP)
-      mmio_resend_addr := io.iTLBInter.resp.bits.paddr(0)
-      mmio_resend_af := mmio_resend_af || io.iTLBInter.resp.bits.excp(0).af.instr
-      mmio_resend_pf := mmio_resend_pf || io.iTLBInter.resp.bits.excp(0).pf.instr
-      mmio_resend_gpf := mmio_resend_gpf || io.iTLBInter.resp.bits.excp(0).gpf.instr
+      mmio_state         := Mux(tlbExept, m_waitCommit, m_sendPMP)
+      mmio_resend_addr   := io.iTLBInter.resp.bits.paddr(0)
+      mmio_resend_af     := mmio_resend_af || io.iTLBInter.resp.bits.excp(0).af.instr
+      mmio_resend_pf     := mmio_resend_pf || io.iTLBInter.resp.bits.excp(0).pf.instr
+      mmio_resend_gpf    := mmio_resend_gpf || io.iTLBInter.resp.bits.excp(0).gpf.instr
+      mmio_resend_gpaddr := io.iTLBInter.resp.bits.gpaddr(0)
     }
 
     is(m_sendPMP){
       val pmpExcpAF = io.pmp.resp.instr || !io.pmp.resp.mmio
-      mmio_state :=  Mux(pmpExcpAF, m_waitCommit , m_resendReq)
+      mmio_state     := Mux(pmpExcpAF, m_waitCommit, m_resendReq)
       mmio_resend_af := pmpExcpAF
     }
 
     is(m_resendReq){
-      mmio_state :=  Mux(toUncache.fire, m_waitResendResp, m_resendReq )
+      mmio_state := Mux(toUncache.fire, m_waitResendResp, m_resendReq)
     }
 
     is(m_waitResendResp){
       when(fromUncache.fire){
-          mmio_state :=  m_waitCommit
-          f3_mmio_data(1)   :=  fromUncache.bits.data(15,0)
+          mmio_state      := m_waitCommit
+          f3_mmio_data(1) := fromUncache.bits.data(15,0)
       }
     }
 
     is(m_waitCommit){
       when(mmio_commit){
-          mmio_state  :=  m_commited
+          mmio_state := m_commited
       }
     }
 
     //normal mmio instruction
     is(m_commited){
-      mmio_state := m_idle
-      mmio_is_RVC := false.B
+      mmio_state       := m_idle
+      mmio_is_RVC      := false.B
       mmio_resend_addr := 0.U
     }
   }
@@ -708,10 +709,10 @@ class NewIFU(implicit p: Parameters) extends XSModule
   // Exception or flush by older branch prediction
   // Condition is from RegNext(fromFtq.redirect), 1 cycle after backend rediect
   when(f3_ftq_flush_self || f3_ftq_flush_by_older)  {
-    mmio_state := m_idle
-    mmio_is_RVC := false.B
-    mmio_resend_addr := 0.U
-    mmio_resend_af := false.B
+    mmio_state         := m_idle
+    mmio_is_RVC        := false.B
+    mmio_resend_addr   := 0.U
+    mmio_resend_af     := false.B
     f3_mmio_data.map(_ := 0.U)
   }
 
@@ -818,10 +819,13 @@ class NewIFU(implicit p: Parameters) extends XSModule
 
   /** to backend */
   // f3_gpaddr is valid iff gpf is detected
-  io.toBackend.gpaddrMem_wen   := f3_toIbuffer_valid && (f3_gpf_vec.asUInt.orR || f3_crossGuestPageFault.asUInt.orR)
+  io.toBackend.gpaddrMem_wen   := f3_toIbuffer_valid && Mux(
+    f3_req_is_mmio,
+    mmio_resend_gpf,
+    f3_gpf_vec.asUInt.orR || f3_crossGuestPageFault.asUInt.orR
+  )
   io.toBackend.gpaddrMem_waddr := f3_ftq_req.ftqIdx.value
-  io.toBackend.gpaddrMem_wdata := f3_gpaddr
-
+  io.toBackend.gpaddrMem_wdata := Mux(f3_req_is_mmio, mmio_resend_gpaddr, f3_gpaddr)
 
   //Write back to Ftq
   val f3_cache_fetch = f3_valid && !(f2_fire && !f2_flush)
@@ -870,6 +874,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
       io.toIbuffer.bits.exceptionType(0) := ExceptionType.acf
     } .elsewhen (mmio_resend_pf) {
       io.toIbuffer.bits.exceptionType(0) := ExceptionType.ipf
+    } .elsewhen (mmio_resend_gpf) {
+      io.toIbuffer.bits.exceptionType(0) := ExceptionType.igpf
     }
     io.toIbuffer.bits.crossPageIPFFix(0) := mmio_resend_pf
 

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -700,9 +700,13 @@ class NewIFU(implicit p: Parameters) extends XSModule
 
     //normal mmio instruction
     is(m_commited){
-      mmio_state       := m_idle
-      mmio_is_RVC      := false.B
-      mmio_resend_addr := 0.U
+      mmio_state         := m_idle
+      mmio_is_RVC        := false.B
+      mmio_resend_addr   := 0.U
+      mmio_resend_af     := false.B
+      mmio_resend_pf     := false.B
+      mmio_resend_gpf    := false.B
+      mmio_resend_gpaddr := 0.U
     }
   }
 
@@ -713,6 +717,9 @@ class NewIFU(implicit p: Parameters) extends XSModule
     mmio_is_RVC        := false.B
     mmio_resend_addr   := 0.U
     mmio_resend_af     := false.B
+    mmio_resend_pf     := false.B
+    mmio_resend_gpf    := false.B
+    mmio_resend_gpaddr := 0.U
     f3_mmio_data.map(_ := 0.U)
   }
 


### PR DESCRIPTION
also reset `mmio_resend_(a|p|gp)f` registers when mmio instr is commited or flush happens

Ref: discussion here https://github.com/OpenXiangShan/XiangShan/pull/3104#discussion_r1653865072 and https://github.com/OpenXiangShan/XiangShan/pull/3104#pullrequestreview-2146994731