### PR TITLE
CSR: modify *counteren mask for emulation support

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -282,7 +282,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   val mtvec = RegInit(UInt(XLEN.W), 0.U)
   val mcounteren = RegInit(UInt(XLEN.W), 0.U)
   // Currently, XiangShan don't support Unprivileged Counter/Timers CSRs ("Zicntr" and "Zihpm")
-  val mcounterenMask = 0.U(XLEN.W)
+  val mcounterenMask = 7.U(XLEN.W)
   val mcause = RegInit(UInt(XLEN.W), 0.U)
   val mtval = RegInit(UInt(XLEN.W), 0.U)
   val mtval2 = RegInit(UInt(XLEN.W), 0.U)
@@ -469,7 +469,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   val scounteren = RegInit(UInt(XLEN.W), 0.U)
   val senvcfg = RegInit(UInt(XLEN.W), 0.U)  // !WARNING: there is no logic about this CSR.
   // Currently, XiangShan don't support Unprivileged Counter/Timers CSRs ("Zicntr" and "Zihpm")
-  val scounterenMask = 0.U(XLEN.W)
+  val scounterenMask = 7.U(XLEN.W)
 
   // sbpctl
   // Bits 0-7: {LOOP, RAS, SC, TAGE, BIM, BTB, uBTB}
@@ -596,7 +596,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   // val htimedelta = RegInit(UInt(XLEN.W), 0.U)
   val hcounteren = RegInit(UInt(XLEN.W), 0.U)
   // Currently, XiangShan don't support Unprivileged Counter/Timers CSRs ("Zicntr" and "Zihpm")
-  val hcounterenMask = 0.U(XLEN.W)
+  val hcounterenMask = 7.U(XLEN.W)
 
   val vsstatus = RegInit("h200002000".U(XLEN.W))
   val vsstatusStruct = vsstatus.asTypeOf(new MstatusStruct)


### PR DESCRIPTION
*counteren were changed to read-only zero before, which prevent machine-level program to emulate access to unprivileged counters. This patch changed the mask to 7, to allow emulated access to cycle, time and instret. Actually, openSBI would not check permission of time CSR for performance reason.

This is just a workaround. The new CSR will provide real unprivileged counters.