### PR TITLE
IPrefetch: do not pass exception(1) to WayLookup if !s1_doubleline

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -265,10 +265,13 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   toWayLookup.bits.waymask      := s1_waymasks
   toWayLookup.bits.ptag         := s1_req_ptags
   toWayLookup.bits.gpaddr       := s1_req_gpaddr
-  toWayLookup.bits.excp_tlb_af  := itlbExcpAF
-  toWayLookup.bits.excp_tlb_pf  := itlbExcpPF
-  toWayLookup.bits.excp_tlb_gpf := itlbExcpGPF
-  toWayLookup.bits.meta_errors  := s1_meta_errors
+  (0 until PortNumber).foreach { i =>
+    val excpValid = (if (i == 0) true.B else s1_doubleline)  // exception in first line is always valid, in second line is valid iff is doubleline request
+    toWayLookup.bits.excp_tlb_af(i)  := excpValid && itlbExcpAF(i)
+    toWayLookup.bits.excp_tlb_pf(i)  := excpValid && itlbExcpPF(i)
+    toWayLookup.bits.excp_tlb_gpf(i) := excpValid && itlbExcpGPF(i)
+    toWayLookup.bits.meta_errors(i)  := excpValid && s1_meta_errors(i)
+  }
 
   val s1_waymasks_vec = s1_waymasks.map(_.asTypeOf(Vec(nWays, Bool())))
   when(toWayLookup.fire) {


### PR DESCRIPTION
Fixes bug mentioned: https://github.com/OpenXiangShan/XiangShan/pull/3139#discussion_r1679178024

Analysis:
![image](https://github.com/user-attachments/assets/b45f56cb-8fea-4e82-a28b-9c80ac6b52f1)
1. (expected) In a doubleline request, port0 AND port1 finds guest page fault(`io_itlb_x_resp_bits_excp_0_gpf_instr`), it is stored in `itlbExcpGPF` register, enters WayLookup and is bypassed to ICacheMainPipe (WayLookup is `empty` and `io_write` fires with `io_read` fire). Finally it goes to backend
2. (expected) Backend send a redirect request and flushes IPrefetch/WayLookup/ICacheMainPipe
3. (WRONG) After flush, this is a singleline request, so port1 does not send request to itlb(`io_itlb_1_req_valid`) and thus not updated, `io_itlb_x_resp_bits_excp_0_gpf_instr` remains `true.B`
4. (WRONG) This false-positive gpf enters WayLookup and is bypassed to ICacheMainPipe
5. (expected) However, ICacheMainPipe finds `s2_doubleline` is `fasle.B`, so it drops results from port1, so no gpf goes to backend.
6. (expected) After so many requests, circular pointer in WayLookup overflows and returns to the location where the gpf was written to, so it reads gpd again
7. (expected) This time, `s2_doubleline` is `true.B`, so gpf goes to backend and finally causes error.

Solution:
1. Flush tlb results when `io_flush === true.B`. This might require modifications to both the IPrefetch and TLB, we may address it later.
2. **Drop port1 results before it enqueues into WayLookup, instead of when it is sent to IFU (after dequeues from WayLookup)**

