### PR TITLE
DataPath, BusyTable: remove unnecessary cancel signals

### DIFF
--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -205,7 +205,6 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
 
   private val og1CancelOH: UInt = dataPath.io.og1CancelOH
   private val og0CancelOH: UInt = dataPath.io.og0CancelOH
-  private val cancelToBusyTable = dataPath.io.cancelToBusyTable
   private val vlIsZero = intExuBlock.io.vlIsZero.get
   private val vlIsVlmax = intExuBlock.io.vlIsVlmax.get
 
@@ -246,7 +245,6 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   intScheduler.io.fromDataPath.og0Cancel := og0CancelOH
   intScheduler.io.fromDataPath.og1Cancel := og1CancelOH
   intScheduler.io.ldCancel := io.mem.ldCancel
-  intScheduler.io.fromDataPath.cancelToBusyTable := cancelToBusyTable
   intScheduler.io.vlWriteBackInfo.vlIsZero := false.B
   intScheduler.io.vlWriteBackInfo.vlIsVlmax := false.B
 
@@ -264,7 +262,6 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   fpScheduler.io.fromDataPath.og0Cancel := og0CancelOH
   fpScheduler.io.fromDataPath.og1Cancel := og1CancelOH
   fpScheduler.io.ldCancel := io.mem.ldCancel
-  fpScheduler.io.fromDataPath.cancelToBusyTable := cancelToBusyTable
   fpScheduler.io.vlWriteBackInfo.vlIsZero := false.B
   fpScheduler.io.vlWriteBackInfo.vlIsVlmax := false.B
 
@@ -301,7 +298,6 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   memScheduler.io.fromDataPath.og0Cancel := og0CancelOH
   memScheduler.io.fromDataPath.og1Cancel := og1CancelOH
   memScheduler.io.ldCancel := io.mem.ldCancel
-  memScheduler.io.fromDataPath.cancelToBusyTable := cancelToBusyTable
   memScheduler.io.vlWriteBackInfo.vlIsZero := vlIsZero
   memScheduler.io.vlWriteBackInfo.vlIsVlmax := vlIsVlmax
 
@@ -319,7 +315,6 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   vfScheduler.io.fromDataPath.og0Cancel := og0CancelOH
   vfScheduler.io.fromDataPath.og1Cancel := og1CancelOH
   vfScheduler.io.ldCancel := io.mem.ldCancel
-  vfScheduler.io.fromDataPath.cancelToBusyTable := cancelToBusyTable
   vfScheduler.io.vlWriteBackInfo.vlIsZero := vlIsZero
   vfScheduler.io.vlWriteBackInfo.vlIsVlmax := vlIsVlmax
   vfScheduler.io.fromOg2.get := og2ForVector.io.toVfIQ

--- a/src/main/scala/xiangshan/backend/issue/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/issue/Scheduler.scala
@@ -96,7 +96,6 @@ class SchedulerIO()(implicit params: SchdBlockParams, p: Parameters) extends XSB
     val og0Cancel = Input(ExuOH(backendParams.numExu))
     // Todo: remove this after no cancel signal from og1
     val og1Cancel = Input(ExuOH(backendParams.numExu))
-    val cancelToBusyTable = Vec(backendParams.numExu, Flipped(ValidIO(new CancelSignal)))
     // just be compatible to old code
     def apply(i: Int)(j: Int) = resp(i)(j)
   }
@@ -204,7 +203,7 @@ abstract class SchedulerImpBase(wrapper: Scheduler)(implicit params: SchdBlockPa
         wb.bits := io.intWriteBack(i).addr
       }
       bt.io.wakeUp := io.fromSchedulers.wakeupVec
-      bt.io.cancel := io.fromDataPath.cancelToBusyTable
+      bt.io.og0Cancel := io.fromDataPath.og0Cancel
       bt.io.ldCancel := io.ldCancel
     case None =>
   }
@@ -220,7 +219,7 @@ abstract class SchedulerImpBase(wrapper: Scheduler)(implicit params: SchdBlockPa
         wb.bits := io.fpWriteBack(i).addr
       }
       bt.io.wakeUp := io.fromSchedulers.wakeupVec
-      bt.io.cancel := io.fromDataPath.cancelToBusyTable
+      bt.io.og0Cancel := io.fromDataPath.og0Cancel
       bt.io.ldCancel := io.ldCancel
     case None =>
   }
@@ -236,7 +235,7 @@ abstract class SchedulerImpBase(wrapper: Scheduler)(implicit params: SchdBlockPa
         wb.bits := io.vfWriteBack(i).addr
       }
       bt.io.wakeUp := io.fromSchedulers.wakeupVec
-      bt.io.cancel := io.fromDataPath.cancelToBusyTable
+      bt.io.og0Cancel := io.fromDataPath.og0Cancel
       bt.io.ldCancel := io.ldCancel
     case None =>
   }
@@ -252,7 +251,7 @@ abstract class SchedulerImpBase(wrapper: Scheduler)(implicit params: SchdBlockPa
         wb.bits := io.v0WriteBack(i).addr
       }
       bt.io.wakeUp := io.fromSchedulers.wakeupVec
-      bt.io.cancel := io.fromDataPath.cancelToBusyTable
+      bt.io.og0Cancel := io.fromDataPath.og0Cancel
       bt.io.ldCancel := io.ldCancel
     case None =>
   }
@@ -268,7 +267,7 @@ abstract class SchedulerImpBase(wrapper: Scheduler)(implicit params: SchdBlockPa
         wb.bits := io.vlWriteBack(i).addr
       }
       bt.io.wakeUp := io.fromSchedulers.wakeupVec
-      bt.io.cancel := io.fromDataPath.cancelToBusyTable
+      bt.io.og0Cancel := io.fromDataPath.og0Cancel
       bt.io.ldCancel := io.ldCancel
     case None =>
   }


### PR DESCRIPTION
* only non-load wakeup sources exu should send og0cancel
* og0cancel only works on the wakeup of 0 latency instructions