### PR TITLE
Backend: optimize og0 cancel signals

### DIFF
--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -208,8 +208,8 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   memScheduler.io.fromWbFuBusyTable.fuBusyTableRead := wbFuBusyTable.io.out.memRespRead
   dataPath.io.wbConfictRead := wbFuBusyTable.io.out.wbConflictRead
 
-  private val og1CancelOH: UInt = dataPath.io.og1CancelOH
-  private val og0CancelOH: UInt = dataPath.io.og0CancelOH
+  private val og1Cancel = dataPath.io.og1Cancel
+  private val og0Cancel = dataPath.io.og0Cancel
   private val vlIsZero = intExuBlock.io.vlIsZero.get
   private val vlIsVlmax = intExuBlock.io.vlIsVlmax.get
 
@@ -247,8 +247,8 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   intScheduler.io.vlWriteBack := 0.U.asTypeOf(intScheduler.io.vlWriteBack)
   intScheduler.io.fromDataPath.resp := dataPath.io.toIntIQ
   intScheduler.io.fromSchedulers.wakeupVec.foreach { wakeup => wakeup := iqWakeUpMappedBundle(wakeup.bits.exuIdx) }
-  intScheduler.io.fromDataPath.og0Cancel := og0CancelOH
-  intScheduler.io.fromDataPath.og1Cancel := og1CancelOH
+  intScheduler.io.fromDataPath.og0Cancel := og0Cancel
+  intScheduler.io.fromDataPath.og1Cancel := og1Cancel
   intScheduler.io.ldCancel := io.mem.ldCancel
   intScheduler.io.vlWriteBackInfo.vlIsZero := false.B
   intScheduler.io.vlWriteBackInfo.vlIsVlmax := false.B
@@ -264,8 +264,8 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   fpScheduler.io.vlWriteBack := 0.U.asTypeOf(fpScheduler.io.vlWriteBack)
   fpScheduler.io.fromDataPath.resp := dataPath.io.toFpIQ
   fpScheduler.io.fromSchedulers.wakeupVec.foreach { wakeup => wakeup := iqWakeUpMappedBundle(wakeup.bits.exuIdx) }
-  fpScheduler.io.fromDataPath.og0Cancel := og0CancelOH
-  fpScheduler.io.fromDataPath.og1Cancel := og1CancelOH
+  fpScheduler.io.fromDataPath.og0Cancel := og0Cancel
+  fpScheduler.io.fromDataPath.og1Cancel := og1Cancel
   fpScheduler.io.ldCancel := io.mem.ldCancel
   fpScheduler.io.vlWriteBackInfo.vlIsZero := false.B
   fpScheduler.io.vlWriteBackInfo.vlIsVlmax := false.B
@@ -300,8 +300,8 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   memScheduler.io.fromMem.get.vstuFeedback := io.mem.vstuIqFeedback
   memScheduler.io.fromMem.get.vlduFeedback := io.mem.vlduIqFeedback
   memScheduler.io.fromSchedulers.wakeupVec.foreach { wakeup => wakeup := iqWakeUpMappedBundle(wakeup.bits.exuIdx) }
-  memScheduler.io.fromDataPath.og0Cancel := og0CancelOH
-  memScheduler.io.fromDataPath.og1Cancel := og1CancelOH
+  memScheduler.io.fromDataPath.og0Cancel := og0Cancel
+  memScheduler.io.fromDataPath.og1Cancel := og1Cancel
   memScheduler.io.ldCancel := io.mem.ldCancel
   memScheduler.io.vlWriteBackInfo.vlIsZero := vlIsZero
   memScheduler.io.vlWriteBackInfo.vlIsVlmax := vlIsVlmax
@@ -317,8 +317,8 @@ class BackendImp(override val wrapper: Backend)(implicit p: Parameters) extends 
   vfScheduler.io.vlWriteBack := wbDataPath.io.toVlPreg
   vfScheduler.io.fromDataPath.resp := dataPath.io.toVfIQ
   vfScheduler.io.fromSchedulers.wakeupVec.foreach { wakeup => wakeup := iqWakeUpMappedBundle(wakeup.bits.exuIdx) }
-  vfScheduler.io.fromDataPath.og0Cancel := og0CancelOH
-  vfScheduler.io.fromDataPath.og1Cancel := og1CancelOH
+  vfScheduler.io.fromDataPath.og0Cancel := og0Cancel
+  vfScheduler.io.fromDataPath.og1Cancel := og1Cancel
   vfScheduler.io.ldCancel := io.mem.ldCancel
   vfScheduler.io.vlWriteBackInfo.vlIsZero := vlIsZero
   vfScheduler.io.vlWriteBackInfo.vlIsVlmax := vlIsVlmax

--- a/src/main/scala/xiangshan/backend/datapath/DataPath.scala
+++ b/src/main/scala/xiangshan/backend/datapath/DataPath.scala
@@ -576,10 +576,10 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
       }
   }
 
-  io.og0CancelOH := VecInit(og0FailedVec2.flatten.zip(params.allExuParams).map{ case (cancel, params) => 
-                              if (params.hasLoadExu || !params.isIQWakeUpSource) false.B else cancel
-                            }).asUInt
-  io.og1CancelOH := VecInit(toFlattenExu.map(x => x.valid && !x.fire)).asUInt
+  io.og0Cancel := og0FailedVec2.flatten.zip(params.allExuParams).map{ case (cancel, params) => 
+                    if (params.isIQWakeUpSource && params.latencyCertain && params.wakeUpFuLatancySet.contains(0)) cancel else false.B
+                  }.toSeq
+  io.og1Cancel := toFlattenExu.map(x => x.valid && !x.fire)
 
 
   if (backendParams.debugEn){
@@ -763,9 +763,9 @@ class DataPathIO()(implicit p: Parameters, params: BackendParams) extends XSBund
 
   val toVfIQ = MixedVec(vfSchdParams.issueBlockParams.map(_.genOGRespBundle))
 
-  val og0CancelOH = Output(ExuOH(backendParams.numExu))
+  val og0Cancel = Output(ExuVec())
 
-  val og1CancelOH = Output(ExuOH(backendParams.numExu))
+  val og1Cancel = Output(ExuVec())
 
   val ldCancel = Vec(backendParams.LduCnt + backendParams.HyuCnt, Flipped(new LoadCancelIO))
 

--- a/src/main/scala/xiangshan/backend/issue/Entries.scala
+++ b/src/main/scala/xiangshan/backend/issue/Entries.scala
@@ -140,13 +140,13 @@ class Entries(implicit p: Parameters, params: IssueBlockParams) extends XSModule
     enqEntry.io.enqDelayIn1.wakeUpFromWB      := RegEnable(io.wakeUpFromWB, io.enq(entryIdx).valid)
     enqEntry.io.enqDelayIn1.wakeUpFromIQ      := RegEnable(io.wakeUpFromIQ, io.enq(entryIdx).valid)
     enqEntry.io.enqDelayIn1.srcLoadDependency := RegEnable(VecInit(io.enq(entryIdx).bits.payload.srcLoadDependency.take(params.numRegSrc)), io.enq(entryIdx).valid)
-    enqEntry.io.enqDelayIn1.og0Cancel         := RegNext(io.og0Cancel.asUInt)
+    enqEntry.io.enqDelayIn1.og0Cancel         := RegNext(io.og0Cancel)
     enqEntry.io.enqDelayIn1.ldCancel          := RegNext(io.ldCancel)
     // note: these signals with 2 cycle delay should not be enabled by io.enq.valid
     enqEntry.io.enqDelayIn2.wakeUpFromWB      := DelayN(io.wakeUpFromWB, 2)
     enqEntry.io.enqDelayIn2.wakeUpFromIQ      := DelayN(io.wakeUpFromIQ, 2)
     enqEntry.io.enqDelayIn2.srcLoadDependency := DelayN(VecInit(io.enq(entryIdx).bits.payload.srcLoadDependency.take(params.numRegSrc)), 2)
-    enqEntry.io.enqDelayIn2.og0Cancel         := DelayN(io.og0Cancel.asUInt, 2)
+    enqEntry.io.enqDelayIn2.og0Cancel         := DelayN(io.og0Cancel, 2)
     enqEntry.io.enqDelayIn2.ldCancel          := DelayN(io.ldCancel, 2)
     enqEntryTransVec(entryIdx)                := enqEntry.io.commonOut.transEntry
   }
@@ -533,8 +533,8 @@ class EntriesIO(implicit p: Parameters, params: IssueBlockParams) extends XSBund
   val wakeUpFromIQ: MixedVec[ValidIO[IssueQueueIQWakeUpBundle]] = Flipped(params.genIQWakeUpSinkValidBundle)
   val vlIsZero            = Input(Bool())
   val vlIsVlmax           = Input(Bool())
-  val og0Cancel           = Input(ExuOH(backendParams.numExu))
-  val og1Cancel           = Input(ExuOH(backendParams.numExu))
+  val og0Cancel           = Input(ExuVec())
+  val og1Cancel           = Input(ExuVec())
   val ldCancel            = Vec(backendParams.LdExuCnt, Flipped(new LoadCancelIO))
   //entries status
   val valid               = Output(UInt(params.numEntries.W))

--- a/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
+++ b/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
@@ -102,8 +102,8 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     val vlIsZero              = Input(Bool())
     val vlIsVlmax             = Input(Bool())
     //cancel
-    val og0Cancel             = Input(ExuOH(backendParams.numExu))
-    val og1Cancel             = Input(ExuOH(backendParams.numExu))
+    val og0Cancel             = Input(ExuVec())
+    val og1Cancel             = Input(ExuVec())
     val ldCancel              = Vec(backendParams.LdExuCnt, Flipped(new LoadCancelIO))
     //deq sel
     val deqSel                = Input(Bool())
@@ -480,7 +480,7 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     val wakeUpFromIQ: MixedVec[ValidIO[IssueQueueIQWakeUpBundle]] = Flipped(params.genIQWakeUpSinkValidBundle)
     //cancel
     val srcLoadDependency     = Input(Vec(params.numRegSrc, Vec(LoadPipelineWidth, UInt(LoadDependencyWidth.W))))
-    val og0Cancel             = Input(ExuOH(backendParams.numExu))
+    val og0Cancel             = Input(ExuVec())
     val ldCancel              = Vec(backendParams.LdExuCnt, Flipped(new LoadCancelIO))
   }
 

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -59,8 +59,8 @@ class IssueQueueIO()(implicit p: Parameters, params: IssueBlockParams) extends X
   val wakeupFromIQ: MixedVec[ValidIO[IssueQueueIQWakeUpBundle]] = Flipped(params.genIQWakeUpSinkValidBundle)
   val vlIsZero = Input(Bool())
   val vlIsVlmax = Input(Bool())
-  val og0Cancel = Input(ExuOH(backendParams.numExu))
-  val og1Cancel = Input(ExuOH(backendParams.numExu))
+  val og0Cancel = Input(ExuVec())
+  val og1Cancel = Input(ExuVec())
   val ldCancel = Vec(backendParams.LduCnt + backendParams.HyuCnt, Flipped(new LoadCancelIO))
 
   // Outputs

--- a/src/main/scala/xiangshan/backend/issue/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/issue/Scheduler.scala
@@ -93,9 +93,9 @@ class SchedulerIO()(implicit params: SchdBlockParams, p: Parameters) extends XSB
 
   val fromDataPath = new Bundle {
     val resp: MixedVec[MixedVec[OGRespBundle]] = MixedVec(params.issueBlockParams.map(x => Flipped(x.genOGRespBundle)))
-    val og0Cancel = Input(ExuOH(backendParams.numExu))
+    val og0Cancel = Input(ExuVec())
     // Todo: remove this after no cancel signal from og1
-    val og1Cancel = Input(ExuOH(backendParams.numExu))
+    val og1Cancel = Input(ExuVec())
     // just be compatible to old code
     def apply(i: Int)(j: Int) = resp(i)(j)
   }

--- a/src/main/scala/xiangshan/backend/rename/BusyTable.scala
+++ b/src/main/scala/xiangshan/backend/rename/BusyTable.scala
@@ -42,7 +42,7 @@ class BusyTable(numReadPorts: Int, numWritePorts: Int, numPhyPregs: Int, pregWB:
     // fast wakeup
     val wakeUp: MixedVec[ValidIO[IssueQueueIQWakeUpBundle]] = Flipped(params.genIQWakeUpInValidBundle)
     // cancelFromDatapath
-    val og0Cancel = Input(ExuOH(backendParams.numExu))
+    val og0Cancel = Input(ExuVec())
     // cancelFromMem
     val ldCancel = Vec(backendParams.LdExuCnt, Flipped(new LoadCancelIO))
     // read preg state


### PR DESCRIPTION
* use Vec[Bool] instead of UInt for og0Cancel
* only wakeup source Exus containing 0-latency function unit should send og0Cancel