### PR TITLE
IPrefetch: fix s2_miss(1) typo

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -380,7 +380,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
 
   val s2_hits = s2_waymasks.map(_.orR)
   val s2_miss = VecInit(Seq(!s2_itlbExcp(0) && !s2_pmpExcp(0) && !s2_hits(0) && !s2_MSHR_hits(0),
-                            !s2_itlbExcp(0) && !s2_pmpExcp(0) && !s2_itlbExcp(1) && s2_pmpExcp(1) && !s2_hits(1) && !s2_MSHR_hits(1) && s2_doubleline))
+                            !s2_itlbExcp(0) && !s2_pmpExcp(0) && !s2_itlbExcp(1) && !s2_pmpExcp(1) && !s2_hits(1) && !s2_MSHR_hits(1) && s2_doubleline))
 
   /**
     ******************************************************************************


### PR DESCRIPTION
Explained: (**NOT** has exception **AND NOT** hit) === miss === needs fetch

Performance change is expected, as prefetch is actually doing more work.