### PR TITLE
MissUnit: update replacer only when acuqire fire

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
@@ -372,7 +372,7 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
   val mshr_resp = allMSHRs_resp(id_r)
 
   // get waymask from replacer when acquire fire
-  io.victim.vSetIdx.valid := acquireArb.io.out.valid
+  io.victim.vSetIdx.valid := acquireArb.io.out.fire
   io.victim.vSetIdx.bits  := acquireArb.io.out.bits.vSetIdx
   val waymask = UIntToOH(mshr_resp.bits.waymask)
   val fetch_resp_valid = mshr_resp.valid && last_fire_r && !io.flush && !io.fencei


### PR DESCRIPTION
Each time `io.victim.vSetIdx.valid === true.B`, replacer will choose the LRU way as victim and access it to MRU position.

See: https://github.com/OpenXiangShan/XiangShan/blob/e3704ae5040ad97955501e3ec494c059d94f3826/src/main/scala/xiangshan/frontend/icache/ICache.scala#L438-L445

When `acquireArb.io.out.valid === true.B && acquireArb.io.out.ready === false.B`, replacer will be mistakenly updated, thus violates PLRU policy.

We want to update replacer only once per acquire request, so `io.victim.vSetIdx.valid := acquireArb.io.out.fire`.