### PR TITLE
DCache: Fix valid signal of refill_info and error_flag_write

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -744,7 +744,7 @@ class MissEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule
   io.req_addr.valid := req_valid
   io.req_addr.bits := req.addr
 
-  io.refill_info.valid := w_grantlast
+  io.refill_info.valid := req_valid && w_grantlast
   io.refill_info.bits.store_data := refill_and_store_data.asUInt
   io.refill_info.bits.store_mask := ~0.U(blockBytes.W)
   io.refill_info.bits.miss_param := grant_param


### PR DESCRIPTION
- Fix refill_info valid signal in MissQueue. `refill_info.valid` is set only when the req in mshr is valid and the req in MainPipe stage s2 is refill req with `s2_req.miss`.
- Enable `error_flag_write.valid` for every refill req in Mainpipe to fix the problem that the error_flag never being updated.