### PR TITLE
SoC: add buffer between AXI4Xbar and CLINT

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -259,6 +259,7 @@ trait HaveAXI4PeripheralPort { this: BaseSoC =>
       AXI4Deinterleaver(8) :=
       TLToAXI4() :=
       error_xbar.get :=
+      TLBuffer.chainNode(2, Some("llc_to_peripheral_buffer")) :=
       TLFIFOFixer() :=
       TLWidthWidget(L3OuterBusWidth / 8) :=
       AXI4ToTL() :=


### PR DESCRIPTION
CLINT for simulation echoes response in the same cycle as the request. However, AXI4Xbar is unable to handle synchronous response because AXI4Xbar must track id flow.