### PR TITLE
ci: add basic ci for Hypervisor extension

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Basic Test - misc-tests
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --ci misc-tests 2> /dev/zero
+      - name: Extension Test - hypervisor
+        run: |
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --ci rvh-tests 2> /dev/zero
       - name: Simple Test - microbench
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --ci microbench 2> perf.log

--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -355,6 +355,15 @@ class XiangShan(object):
         ]
         misc_tests = map(lambda x: os.path.join(base_dir, x), workloads)
         return misc_tests
+    
+    def __get_ci_rvhtest(self, name=None):
+        base_dir = "/nfs/home/share/ci-workloads/H-extension-tests"
+        workloads = [
+            # "riscv-hyp-tests/rvh_test.bin",
+            "xvisor_wboxtest/checkpoint.gz",
+        ]
+        rvh_tests = map(lambda x: os.path.join(base_dir, x), workloads)
+        return rvh_tests
 
     def __get_ci_rvvbench(self, name=None):
         base_dir = "/nfs/home/share/ci-workloads"
@@ -464,6 +473,7 @@ class XiangShan(object):
             "misc-tests": self.__get_ci_misc,
             "mc-tests": self.__get_ci_mc,
             "nodiff-tests": self.__get_ci_nodiff,
+            "rvh-tests": self.__get_ci_rvhtest,
             "microbench": self.__am_apps_path,
             "coremark": self.__am_apps_path,
             "rvv-bench": self.__get_ci_rvvbench,
@@ -489,6 +499,7 @@ class XiangShan(object):
             "misc-tests": self.__get_ci_misc,
             "mc-tests": self.__get_ci_mc,
             "nodiff-tests": self.__get_ci_nodiff,
+            "rvh-tests": self.__get_ci_rvhtest,
             "microbench": self.__am_apps_path,
             "coremark": self.__am_apps_path,
             "rvv-bench": self.__get_ci_rvvbench,


### PR DESCRIPTION
This patch add xvisor_wboxtest to ci, which tests the nested mmu system. riscv-hyp-tests are still on the way.