### PR TITLE
CoupledL2: support for MCP2 SRAM, CHILog and CHI Issue E.b

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ endif
 FPGA_MEM_ARGS = --firtool-opt "--repl-seq-mem --repl-seq-mem-file=$(TOP).$(RTL_SUFFIX).conf"
 SIM_MEM_ARGS = --firtool-opt "--repl-seq-mem --repl-seq-mem-file=$(SIM_TOP).$(RTL_SUFFIX).conf"
 MFC_ARGS = --dump-fir --target systemverilog --split-verilog \
-           --firtool-binary-path /nfs/home/share/firtool-1.74.0/bin/firtool \
            --firtool-opt "-O=release --disable-annotation-unknown --lowering-options=explicitBitcast,disallowLocalVariables,disallowPortDeclSharing,locationInfoStyle=none"
 RELEASE_ARGS += $(MFC_ARGS)
 DEBUG_ARGS += $(MFC_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ endif
 FPGA_MEM_ARGS = --firtool-opt "--repl-seq-mem --repl-seq-mem-file=$(TOP).$(RTL_SUFFIX).conf"
 SIM_MEM_ARGS = --firtool-opt "--repl-seq-mem --repl-seq-mem-file=$(SIM_TOP).$(RTL_SUFFIX).conf"
 MFC_ARGS = --dump-fir --target systemverilog --split-verilog \
+           --firtool-binary-path /nfs/home/share/firtool-1.74.0/bin/firtool \
            --firtool-opt "-O=release --disable-annotation-unknown --lowering-options=explicitBitcast,disallowLocalVariables,disallowPortDeclSharing,locationInfoStyle=none"
 RELEASE_ARGS += $(MFC_ARGS)
 DEBUG_ARGS += $(MFC_ARGS)

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -27,6 +27,7 @@ import system.HasSoCParameter
 import utils._
 import utility._
 import xiangshan.backend._
+import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.cache.mmu._
 import xiangshan.frontend._
 import xiangshan.mem.L1PrefetchFuzzer
@@ -86,6 +87,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
     val beu_errors = Output(new XSL1BusErrors())
     val l2_hint = Input(Valid(new L2ToL1Hint()))
     val l2_tlb_req = Flipped(new TlbRequestIO(nRespDups = 2))
+    val l2_pmp_resp = new PMPRespBundle
     val l2PfqBusy = Input(Bool())
     val debugTopDown = new Bundle {
       val robTrueCommit = Output(UInt(64.W))
@@ -217,6 +219,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   memBlock.io.l2_hint.valid := io.l2_hint.valid
   memBlock.io.l2_hint.bits.sourceId := io.l2_hint.bits.sourceId
   memBlock.io.l2_tlb_req <> io.l2_tlb_req
+  memBlock.io.l2_pmp_resp <> io.l2_pmp_resp
   memBlock.io.l2_hint.bits.isKeyword := io.l2_hint.bits.isKeyword
   memBlock.io.l2PfqBusy := io.l2PfqBusy
 

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -136,6 +136,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
       core.module.io.debugTopDown.l2MissMatch := l2top.module.debugTopDown.l2MissMatch
       l2top.module.debugTopDown.robHeadPaddr := core.module.io.debugTopDown.robHeadPaddr
       l2top.module.debugTopDown.robTrueCommit := core.module.io.debugTopDown.robTrueCommit
+      l2top.module.l2_pmp_resp := core.module.io.l2_pmp_resp
       core.module.io.l2_tlb_req <> l2top.module.l2_tlb_req
     } else {
 

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -272,6 +272,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     val l2_hint = Input(Valid(new L2ToL1Hint()))
     val l2PfqBusy = Input(Bool())
     val l2_tlb_req = Flipped(new TlbRequestIO(nRespDups = 2))
+    val l2_pmp_resp = new PMPRespBundle
 
     val debugTopDown = new Bundle {
       val robHeadVaddr = Flipped(Valid(UInt(VAddrBits.W)))
@@ -1055,6 +1056,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   }
   dtlb_reqs(L2toL1DLBPortIndex) <> io.l2_tlb_req
   dtlb_reqs(L2toL1DLBPortIndex).resp.ready := true.B
+  io.l2_pmp_resp := pmp_check(L2toL1DLBPortIndex).resp
 
   // StoreUnit
   for (i <- 0 until StdCnt) {


### PR DESCRIPTION
This pull request includes important new features about CoupledL2 as follows:

1. [SRAM: implement real MCP2](https://github.com/OpenXiangShan/CoupledL2/pull/200)
2. [**Support for CHILog**](https://github.com/OpenXiangShan/CoupledL2/pull/207)
3. [**Support for configurable CHI issue E.b interface**](https://github.com/OpenXiangShan/CoupledL2/pull/209)

For bug fixes on CoupledL2:

1. [BOP: add pmp check to avoid illegal prefetch](https://github.com/OpenXiangShan/CoupledL2/pull/205)
2. [TL2TLCoupledL2, SinkB: do not accept Probe when same-addr waiting for ReleaseAck](https://github.com/OpenXiangShan/CoupledL2/pull/208)
3. [TL2CHICoupledL2, MSHR: fix bug when SnpRespFwded nestedwb the same MSHR](https://github.com/OpenXiangShan/CoupledL2/pull/211)

In addition, this pr bumps the latest version of [OpenLLC](https://github.com/OpenXiangShan/OpenLLC), which also supports optional CHI issue between B and E.b. DummyLLC still works as the default HN for now.