### PR TITLE
bpu: ittage table change write priority to read priority.

### DIFF
--- a/src/main/scala/xiangshan/frontend/BPU.scala
+++ b/src/main/scala/xiangshan/frontend/BPU.scala
@@ -169,7 +169,7 @@ class BasePredictorIO (implicit p: Parameters) extends XSBundle with HasBPUConst
   val s2_ready = Output(Bool())
   val s3_ready = Output(Bool())
 
-  val update = Flipped(Valid(new BranchPredictionUpdate))
+  val update = Flipped(DecoupledIO(new BranchPredictionUpdate))
   val redirect = Flipped(Valid(new BranchPredictionRedirect))
   val redirectFromIFU = Input(Bool())
 }
@@ -193,6 +193,8 @@ abstract class BasePredictor(implicit p: Parameters) extends XSModule
   io.s1_ready := true.B
   io.s2_ready := true.B
   io.s3_ready := true.B
+
+  io.update.ready := true.B
 
   val s0_pc_dup   = WireInit(io.in.bits.s0_pc) // fetchIdx(io.f0_pc)
   val s1_pc_dup   = s0_pc_dup.zip(io.s0_fire).map {case (s0_pc, s0_fire) => RegEnable(s0_pc, s0_fire)}
@@ -442,6 +444,8 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
     s3_fire_dup(2) && s3_redirect_dup(2)
   io.bpu_to_ftq.resp.bits  := predictors.io.out
   io.bpu_to_ftq.resp.bits.last_stage_spec_info.histPtr     := s3_ghist_ptr_dup(2)
+
+  io.ftq_to_bpu.update.ready := predictors.io.update.ready
 
   val full_pred_diff = WireInit(false.B)
   val full_pred_diff_stage = WireInit(0.U)

--- a/src/main/scala/xiangshan/frontend/Composer.scala
+++ b/src/main/scala/xiangshan/frontend/Composer.scala
@@ -73,9 +73,12 @@ class Composer(implicit p: Parameters) extends BasePredictor with HasBPUConst wi
   require(meta_sz <= MaxMetaLength)
   io.out.last_stage_meta := metas
 
+  io.update.ready := components.map(_.io.update.ready).reduce(_ && _)
+
   var update_meta = io.update.bits.meta
   for (c <- components.reverse) {
-    c.io.update := io.update
+    c.io.update.valid := io.update.valid
+    c.io.update.bits := io.update.bits
     c.io.update.bits.meta := update_meta
     update_meta = update_meta >> c.meta_size
   }

--- a/src/main/scala/xiangshan/frontend/ITTAGE.scala
+++ b/src/main/scala/xiangshan/frontend/ITTAGE.scala
@@ -299,9 +299,12 @@ class ITTageTable
   // only when ctr is null
   update_wdata.target := Mux(io.update.bits.alloc || ctr_null(old_ctr), update_target, io.update.bits.old_target)
 
+  io.update.ready := !update_buff_valid
   XSPerfAccumulate("ittage_table_updates", io.update.valid)
   XSPerfAccumulate("ittage_table_hits", io.resp.valid)
   XSPerfAccumulate("ittage_us_tick_reset", io.update.bits.reset_u)
+  XSPerfAccumulate("ittage_table_read_write_conflict", read_write_conflict)
+  XSPerfAccumulate("ittage_table_update_buff_valid", update_buff_valid)
 
   if (BPUDebug && debug) {
     val u = io.update.bits

--- a/src/main/scala/xiangshan/frontend/ITTAGE.scala
+++ b/src/main/scala/xiangshan/frontend/ITTAGE.scala
@@ -90,7 +90,6 @@ class ITTageUpdate(implicit p: Parameters) extends ITTageBundle {
   val pc = UInt(VAddrBits.W)
   val ghist = UInt(HistoryLength.W)
   // update tag and ctr
-  val valid = Bool()
   val correct = Bool()
   val alloc = Bool()
   val oldCtr = UInt(ITTageCtrBits.W)
@@ -144,7 +143,7 @@ class ITTageTable
   val io = IO(new Bundle() {
     val req = Flipped(DecoupledIO(new ITTageReq))
     val resp = Output(Valid(new ITTageResp))
-    val update = Input(new ITTageUpdate)
+    val update = Flipped(DecoupledIO(new ITTageUpdate))
   })
 
   val SRAM_SIZE=128
@@ -221,7 +220,7 @@ class ITTageTable
   val read_write_conflict = io.update.valid && io.req.valid
   val s1_read_write_conflict = RegEnable(read_write_conflict, io.req.valid)
 
-  io.resp.valid := (if (tagLen != 0) s1_req_rhit && !s1_read_write_conflict else true.B) && s1_valid // && s1_mask(b)
+  io.resp.valid := (if (tagLen != 0) s1_req_rhit else true.B) && s1_valid // && s1_mask(b)
   io.resp.bits.ctr := table_read_data.ctr
   io.resp.bits.u := table_read_data.useful
   io.resp.bits.target := table_read_data.target
@@ -229,12 +228,12 @@ class ITTageTable
   // Use fetchpc to compute hash
   val update_folded_hist = WireInit(0.U.asTypeOf(new AllFoldedHistories(foldedGHistInfos)))
 
-  update_folded_hist.getHistWithInfo(idxFhInfo).folded_hist := compute_folded_ghist(io.update.ghist, log2Ceil(nRows))
-  update_folded_hist.getHistWithInfo(tagFhInfo).folded_hist := compute_folded_ghist(io.update.ghist, tagLen)
-  update_folded_hist.getHistWithInfo(altTagFhInfo).folded_hist := compute_folded_ghist(io.update.ghist, tagLen-1)
+  update_folded_hist.getHistWithInfo(idxFhInfo).folded_hist := compute_folded_ghist(io.update.bits.ghist, log2Ceil(nRows))
+  update_folded_hist.getHistWithInfo(tagFhInfo).folded_hist := compute_folded_ghist(io.update.bits.ghist, tagLen)
+  update_folded_hist.getHistWithInfo(altTagFhInfo).folded_hist := compute_folded_ghist(io.update.bits.ghist, tagLen-1)
   dontTouch(update_folded_hist)
-  val (update_idx, update_tag) = compute_tag_and_hash(getUnhashedIdx(io.update.pc), update_folded_hist)
-  val update_target = io.update.target
+  val (update_idx, update_tag) = compute_tag_and_hash(getUnhashedIdx(io.update.bits.pc), update_folded_hist)
+  val update_target = io.update.bits.target
   val update_wdata = Wire(new ITTageEntry)
 
 
@@ -242,27 +241,36 @@ class ITTageTable
   val updateNoBitmask = VecInit.fill(ittageEntrySz)(0.U).asUInt                         //update no
   val updateNoUsBitmask = VecInit.tabulate(ittageEntrySz)(_.U >= ITTageUsBits.U).asUInt //update others besides useful bit
   val updateUsBitmask = VecInit.tabulate(ittageEntrySz)(_.U < ITTageUsBits.U).asUInt    //update useful bit
-
+  val update_buff_valid = RegInit(false.B)
   val needReset = RegInit(false.B)
-  val useful_can_reset = !(io.req.fire || io.update.valid) && needReset
+  val useful_can_reset = !(io.req.fire || io.update.valid || update_buff_valid) && needReset
   val (resetSet, resetFinish) = Counter(useful_can_reset, nRows)
-  when (io.update.reset_u) {
+  when (io.update.bits.reset_u) {
     needReset := true.B
   }.elsewhen (resetFinish) {
     needReset := false.B
   }
-  val update_bitmask =  Mux(io.update.uValid && io.update.valid,
+  val update_bitmask =  Mux(io.update.bits.uValid && io.update.valid,
                           updateAllBitmask,
                           Mux(io.update.valid, updateNoUsBitmask,
                             Mux(useful_can_reset, updateUsBitmask, updateNoBitmask)
                           ))
 
+  val update_buff_data    = RegEnable(update_wdata, read_write_conflict)
+  val update_buff_idx     = RegEnable(update_idx, read_write_conflict)
+  val update_buff_bitmask = RegEnable(update_bitmask(ITTageUsBits - 1, 0), read_write_conflict) //for update bitmask only need store bitmask(0)
+  when(read_write_conflict){
+    update_buff_valid := true.B
+  }.elsewhen(!io.req.fire){
+    update_buff_valid := false.B
+  }
+
   table.io.w.apply(
-    valid   = io.update.valid || useful_can_reset,
-    data    = update_wdata,
-    setIdx  = Mux(useful_can_reset, resetSet, update_idx),
+    valid   = (io.update.valid || update_buff_valid) && !io.req.fire || useful_can_reset, //read first
+    data    = Mux(update_buff_valid, update_buff_data, update_wdata),
+    setIdx  = Mux(useful_can_reset, resetSet, Mux(update_buff_valid, update_buff_idx, update_idx)),
     waymask = true.B,
-    bitmask = update_bitmask
+    bitmask = Mux(update_buff_valid, Cat(Fill(ittageEntrySz - ITTageUsBits, 1.U), update_buff_bitmask), update_bitmask)
   )
 
   // Power-on reset
@@ -283,22 +291,20 @@ class ITTageTable
   wrbypass.io.write_idx := update_idx
   wrbypass.io.write_data.map(_ := update_wdata.ctr)
 
-  val old_ctr = Mux(wrbypass.io.hit, wrbypass.io.hit_data(0).bits, io.update.oldCtr)
+  val old_ctr = Mux(wrbypass.io.hit, wrbypass.io.hit_data(0).bits, io.update.bits.oldCtr)
   update_wdata.valid := true.B
-  update_wdata.ctr   := Mux(io.update.alloc, 2.U, inc_ctr(old_ctr, io.update.correct))
+  update_wdata.ctr   := Mux(io.update.bits.alloc, 2.U, inc_ctr(old_ctr, io.update.bits.correct))
   update_wdata.tag   := update_tag
-  update_wdata.useful:= Mux(useful_can_reset, false.B, io.update.u)
+  update_wdata.useful:= Mux(useful_can_reset, false.B, io.update.bits.u)
   // only when ctr is null
-  update_wdata.target := Mux(io.update.alloc || ctr_null(old_ctr), update_target, io.update.old_target)
-
+  update_wdata.target := Mux(io.update.bits.alloc || ctr_null(old_ctr), update_target, io.update.bits.old_target)
 
   XSPerfAccumulate("ittage_table_updates", io.update.valid)
   XSPerfAccumulate("ittage_table_hits", io.resp.valid)
-  XSPerfAccumulate("ittage_us_tick_reset", io.update.reset_u)
-  XSPerfAccumulate("ittage_table_read_write_conflict", read_write_conflict)
+  XSPerfAccumulate("ittage_us_tick_reset", io.update.bits.reset_u)
 
   if (BPUDebug && debug) {
-    val u = io.update
+    val u = io.update.bits
     val idx = s0_idx
     val tag = s0_tag
     XSDebug(io.req.fire,
@@ -576,22 +582,25 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
 
   for (i <- 0 until ITTageNTables) {
     tables(i).io.update.valid := RegNext(updateMask(i), init = false.B)
-    tables(i).io.update.reset_u := RegNext(updateResetU, init = false.B)
-    tables(i).io.update.correct := RegEnable(updateCorrect(i), updateMask(i))
-    tables(i).io.update.target := RegEnable(updateTarget(i), updateMask(i))
-    tables(i).io.update.old_target := RegEnable(updateOldTarget(i), updateMask(i))
-    tables(i).io.update.alloc := RegEnable(updateAlloc(i), updateMask(i))
-    tables(i).io.update.oldCtr := RegEnable(updateOldCtr(i), updateMask(i))
+    tables(i).io.update.bits.reset_u := RegNext(updateResetU, init = false.B)
+    tables(i).io.update.bits.correct := RegEnable(updateCorrect(i), updateMask(i))
+    tables(i).io.update.bits.target := RegEnable(updateTarget(i), updateMask(i))
+    tables(i).io.update.bits.old_target := RegEnable(updateOldTarget(i), updateMask(i))
+    tables(i).io.update.bits.alloc := RegEnable(updateAlloc(i), updateMask(i))
+    tables(i).io.update.bits.oldCtr := RegEnable(updateOldCtr(i), updateMask(i))
 
-    tables(i).io.update.uValid := RegEnable(updateUMask(i), false.B, updateMask(i))
-    tables(i).io.update.u := RegEnable(updateU(i), updateMask(i))
-    tables(i).io.update.pc := RegEnable(update.pc, updateMask(i))
+    tables(i).io.update.bits.uValid := RegEnable(updateUMask(i), false.B, updateMask(i))
+    tables(i).io.update.bits.u := RegEnable(updateU(i), updateMask(i))
+    tables(i).io.update.bits.pc := RegEnable(update.pc, updateMask(i))
     // use fetch pc instead of instruction pc
-    tables(i).io.update.ghist := RegEnable(update.ghist, updateMask(i))
+    tables(i).io.update.bits.ghist := RegEnable(update.ghist, updateMask(i))
   }
 
   // all should be ready for req
   io.s1_ready := tables.map(_.io.req.ready).reduce(_&&_)
+  //if ittage table has conflict need block ftq update req
+  io.update.ready := tables.map(_.io.update.ready).reduce(_&&_)
+  XSPerfAccumulate("ittage_update_not_ready", io.update.ready)
 
   // Debug and perf info
   XSPerfAccumulate("ittage_reset_u", updateResetU)

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -179,7 +179,7 @@ class FtqRead[T <: Data](private val gen: T)(implicit p: Parameters) extends XSB
 
 class FtqToBpuIO(implicit p: Parameters) extends XSBundle {
   val redirect = Valid(new BranchPredictionRedirect)
-  val update = Valid(new BranchPredictionUpdate)
+  val update = DecoupledIO(new BranchPredictionUpdate)
   val enq_ptr = Output(new FtqPtr)
   val redirctFromIFU = Output(Bool())
 }
@@ -1279,6 +1279,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   // ****************************************************************
   // **************************** to bpu ****************************
   // ****************************************************************
+  val bpu_update_ready = io.toBpu.update.ready
 
   io.toBpu.redirctFromIFU := ifuRedirectToBpu.valid
   io.toBpu.redirect := Mux(fromBackendRedirect.valid, fromBackendRedirect, ifuRedirectToBpu)
@@ -1291,7 +1292,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
 
   val may_have_stall_from_bpu = Wire(Bool())
   val bpu_ftb_update_stall = RegInit(0.U(2.W)) // 2-cycle stall, so we need 3 states
-  may_have_stall_from_bpu := bpu_ftb_update_stall =/= 0.U
+  may_have_stall_from_bpu := bpu_ftb_update_stall =/= 0.U || !bpu_update_ready
 
   val validInstructions = commitStateQueueReg(commPtr.value).map(s => s === c_toCommit || s === c_committed)
   val lastInstructionStatus = PriorityMux(validInstructions.reverse.zip(commitStateQueueReg(commPtr.value).reverse))

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -1279,7 +1279,8 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   // ****************************************************************
   // **************************** to bpu ****************************
   // ****************************************************************
-  val bpu_update_ready = io.toBpu.update.ready
+  // val bpu_update_ready = io.toBpu.update.ready
+  val do_commit_ready = WireInit(false.B)
 
   io.toBpu.redirctFromIFU := ifuRedirectToBpu.valid
   io.toBpu.redirect := Mux(fromBackendRedirect.valid, fromBackendRedirect, ifuRedirectToBpu)
@@ -1292,12 +1293,12 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
 
   val may_have_stall_from_bpu = Wire(Bool())
   val bpu_ftb_update_stall = RegInit(0.U(2.W)) // 2-cycle stall, so we need 3 states
-  may_have_stall_from_bpu := bpu_ftb_update_stall =/= 0.U || !bpu_update_ready
+  may_have_stall_from_bpu := bpu_ftb_update_stall =/= 0.U || !do_commit_ready
 
   val validInstructions = commitStateQueueReg(commPtr.value).map(s => s === c_toCommit || s === c_committed)
   val lastInstructionStatus = PriorityMux(validInstructions.reverse.zip(commitStateQueueReg(commPtr.value).reverse))
   val firstInstructionFlushed = commitStateQueueReg(commPtr.value)(0) === c_flushed
-  canCommit := commPtr =/= ifuWbPtr && !may_have_stall_from_bpu &&
+  canCommit := commPtr =/= ifuWbPtr && !may_have_stall_from_bpu && do_commit_ready &&
     (isAfter(robCommPtr, commPtr) ||
       validInstructions.reduce(_ || _) && lastInstructionStatus === c_committed)
   val canMoveCommPtr = commPtr =/= ifuWbPtr && !may_have_stall_from_bpu &&
@@ -1342,7 +1343,12 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
 
   // need one cycle to read mem and srams
   val do_commit_ptr = RegEnable(commPtr, canCommit)
-  val do_commit = RegNext(canCommit, init=false.B)
+  // val do_commit = RegNext(canCommit, init=false.B)
+  val do_commit = RegInit(false.B)
+  val do_commit_fire = do_commit && io.toBpu.update.ready
+  when(canCommit)             { do_commit := true.B  }
+    .elsewhen(do_commit_fire) { do_commit := false.B }
+  do_commit_ready := do_commit_fire || !do_commit
   when (canMoveCommPtr) {
     commPtr_write := commPtrPlus1
     commPtrPlus1_write := commPtrPlus1 + 1.U
@@ -1386,15 +1392,22 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   }
 
   // TODO: remove this
-  XSError(do_commit && diff_commit_target =/= commit_target, "\ncommit target should be the same as update target\n")
+  // XSError(do_commit && diff_commit_target =/= commit_target, "\ncommit target should be the same as update target\n")
+  XSError(do_commit_fire && diff_commit_target =/= io.toBpu.update.bits.full_target, "\ncommit target should be the same as update target\n")
 
   // update latency stats
   val update_latency = GTimer() - pred_s1_cycle.getOrElse(dummy_s1_pred_cycle_vec)(do_commit_ptr.value) + 1.U
   XSPerfHistogram("bpu_update_latency", update_latency, io.toBpu.update.valid, 0, 64, 2)
 
-  io.toBpu.update := DontCare
-  io.toBpu.update.valid := commit_valid && do_commit
-  val update = io.toBpu.update.bits
+  // io.toBpu.update := DontCare
+  // io.toBpu.update.valid := commit_valid && do_commit
+  // val update = io.toBpu.update.bits
+  val debug_cfi_buffer = RegInit(false.B)
+  val update = WireInit(0.U.asTypeOf(new BranchPredictionUpdate()))
+  val update_buffer_valid = RegInit(false.B)
+  val update_buffer = RegInit(0.U.asTypeOf(new BranchPredictionUpdate()))
+  io.toBpu.update.bits := Mux(update_buffer_valid, update_buffer, update)
+  io.toBpu.update.valid := commit_valid && do_commit_fire
   update.false_hit   := commit_hit === h_false_hit
   update.pc          := commit_pc_bundle.startAddr
   update.meta        := commit_meta
@@ -1402,7 +1415,17 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   update.full_target := commit_target
   update.from_stage  := commit_stage
   update.spec_info   := commit_spec_meta
-  XSError(commit_valid && do_commit && debug_cfi, "\ncommit cfi can be non c_commited\n")
+  XSError(Mux(update_buffer_valid, commit_valid && do_commit_fire && debug_cfi_buffer, commit_valid && do_commit_fire && debug_cfi), "\ncommit cfi can be non c_commited\n")
+  // XSError(commit_valid && do_commit && debug_cfi, "\ncommit cfi can be non c_commited\n")
+
+  when(do_commit && !do_commit_fire && !update_buffer_valid){
+    update_buffer_valid := true.B
+    update_buffer := update
+    debug_cfi_buffer := debug_cfi
+  }.elsewhen(do_commit_fire){
+    update_buffer_valid := false.B
+  }
+  XSPerfAccumulate("ftq_update_stall_due_to_not_ready", do_commit && !do_commit_fire)
 
   val commit_real_hit = commit_hit === h_hit
   val update_ftb_entry = update.ftb_entry
@@ -1504,6 +1527,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
 
   XSPerfAccumulate("entry", validEntries)
   XSPerfAccumulate("bpu_to_ftq_stall", enq.valid && !enq.ready)
+  XSPerfAccumulate("bpu_to_ftq_stall_due_to_update_stall", enq.valid && !enq.ready && !do_commit_ready)
   XSPerfAccumulate("mispredictRedirect", perf_redirect.valid && RedirectLevel.flushAfter === perf_redirect.bits.level)
   XSPerfAccumulate("replayRedirect", perf_redirect.valid && RedirectLevel.flushItself(perf_redirect.bits.level))
   XSPerfAccumulate("predecodeRedirect", fromIfuRedirect.valid)


### PR DESCRIPTION
Change the write priority of the current ittage table to read priority. 
When a read/write conflict occurs, temporarily store the update data in update_buff and block FTQ from sending new updates to BPU.