### PR TITLE
MDP: fix mdp update logic

### DIFF
--- a/src/main/scala/xiangshan/backend/ctrlblock/RedirectGenerator.scala
+++ b/src/main/scala/xiangshan/backend/ctrlblock/RedirectGenerator.scala
@@ -82,6 +82,6 @@ class RedirectGenerator(implicit p: Parameters) extends XSModule
   // store pc is ready 1 cycle after s1_isReplay is judged
   io.memPredUpdate.stpc := RegEnable(XORFold(store_pc(VAddrBits - 1, 1), MemPredPCWidth), s1_isReplay && s1_redirect_valid_reg)
   // disle mdp
-  io.memPredUpdate := 0.U.asTypeOf(io.memPredUpdate)
+  // io.memPredUpdate := 0.U.asTypeOf(io.memPredUpdate)
 
 }

--- a/src/main/scala/xiangshan/mem/mdp/StoreSet.scala
+++ b/src/main/scala/xiangshan/mem/mdp/StoreSet.scala
@@ -199,6 +199,7 @@ class SSIT(implicit p: Parameters) extends XSModule {
   // for now we just use lowest bits of ldpc as store set id
   val s2_ldSsidAllocate = XORFold(s2_mempred_update_req.ldpc, SSIDWidth)
   val s2_stSsidAllocate = XORFold(s2_mempred_update_req.stpc, SSIDWidth)
+  val s2_allocSsid = Mux(s2_ldSsidAllocate < s2_stSsidAllocate, s2_ldSsidAllocate, s2_stSsidAllocate)
   // both the load and the store have already been assigned store sets
   // but load's store set ID is smaller
   val s2_winnerSSID = Mux(s2_loadOldSSID < s2_storeOldSSID, s2_loadOldSSID, s2_storeOldSSID)
@@ -237,13 +238,13 @@ class SSIT(implicit p: Parameters) extends XSModule {
         update_ld_ssit_entry(
           pc = s2_mempred_update_req.ldpc,
           valid = true.B,
-          ssid = s2_ldSsidAllocate,
+          ssid = s2_allocSsid,
           strict = false.B
         )
         update_st_ssit_entry(
           pc = s2_mempred_update_req.stpc,
           valid = true.B,
-          ssid = s2_stSsidAllocate,
+          ssid = s2_allocSsid,
           strict = false.B
         )
       }
@@ -253,7 +254,7 @@ class SSIT(implicit p: Parameters) extends XSModule {
         update_st_ssit_entry(
           pc = s2_mempred_update_req.stpc,
           valid = true.B,
-          ssid = s2_stSsidAllocate,
+          ssid = s2_loadOldSSID,
           strict = false.B
         )
       }
@@ -263,7 +264,7 @@ class SSIT(implicit p: Parameters) extends XSModule {
         update_ld_ssit_entry(
           pc = s2_mempred_update_req.ldpc,
           valid = true.B,
-          ssid = s2_ldSsidAllocate,
+          ssid = s2_storeOldSSID,
           strict = false.B
         )
       }


### PR DESCRIPTION
Bug description：
The update logic of store sets is inconsistent with the algorithm design of the paper(https://acg.cis.upenn.edu/milom/cis501-Fall10/papers/store-sets.pdf)

* "If neither the load nor the store has been assigned a store set, one is allocated and assigned to both instructions". The old update logic allocate two store set  and assigned to load and store.
* "If the load has been assigned a store set, but the store has not, the store is assigned the load’s store set". The old update logic store assigned to store's store set.
* "If the store has been assigned a store set, but the load has not, the load is assigned the store’s store set". The old update logic load assigned to load's store set.

Bug fix:
* If neither the load nor the store has been assigned a store set, use the winner SSID to assigned to load and store.
* If the load has been assigned a store set, but the store has not, use load's SSID to update.
* If the store has been assigned a store set, but the load has not, use store's SSID to update.