### PR TITLE
NewCSR: skip *ip difftest

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -688,7 +688,8 @@ class NewCSR(implicit val p: Parameters) extends Module
     (addr >= CSRs.mcycle.U) && (addr <= CSRs.mhpmcounter31.U) ||
     (addr >= mcountinhibit.addr.U) && (addr <= mhpmevents.last.addr.U) ||
     (addr >= CSRs.cycle.U) && (addr <= CSRs.hpmcounter31.U) ||
-    (addr === CSRs.mip.U) ||
+    (addr === CSRs.mip.U) || (addr === CSRs.sip.U) || (addr === CSRs.vsip.U) ||
+    (addr === CSRs.hip.U) || (addr === CSRs.mvip.U) || (addr === CSRs.hvip.U) ||
     Cat(aiaSkipCSRs.map(_.addr.U === addr)).orR ||
     (addr === CSRs.stimecmp.U) ||
     (addr === CSRs.mcounteren.U) ||


### PR DESCRIPTION
* Due to support Sscofpmf extension, the local counter overflow interrupt LCOFI(13) is RW
* While NEMU cannot get the value of the counter, so it temporarily skips *ip CSRs