### PR TITLE
Remove unused ALUOpType branch ops from package.scalar

### DIFF
--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -309,14 +309,6 @@ package object xiangshan {
     def max        = "b011_0110".U
     def min        = "b011_0111".U
 
-    // branch
-    def beq        = "b111_0000".U
-    def bne        = "b111_0010".U
-    def blt        = "b111_1000".U
-    def bge        = "b111_1010".U
-    def bltu       = "b111_1100".U
-    def bgeu       = "b111_1110".U
-
     // Zicond
     def czero_eqz  = "b111_0100".U
     def czero_nez  = "b111_0110".U


### PR DESCRIPTION
I noticed that ALUOpType still defines the beq/bne/blt/bge/bltu/bgeu/ operations, that have been moved to BRUOpType, when experimenting with adding custom instructions to XiangShan.

To make sure that this doesn't break anything I tracked the changes that lead to having the instructions under ALUOpType and BRUOpType:

* [originally the branch ops were implemented in the ALU](https://github.com/OpenXiangShan/XiangShan/commit/675acc6894dd86f75adfa0d6a7c1182a0e48de99#diff-2ac16079a402bdc9ac9074de2e0255c01d8ca901bd07e56c80f87e0cb8477db1)
* [later they were moved to the BRU](https://github.com/OpenXiangShan/XiangShan/commit/3b739f49c5a26805be859c7231717ecc38aade30#diff-2ac16079a402bdc9ac9074de2e0255c01d8ca901bd07e56c80f87e0cb8477db1R370)
* [however the ALUOpType was accidentally still used, which was then fixed](https://github.com/OpenXiangShan/XiangShan/commit/3a93c817fd11305aebdfd86b92e9aa6adadb3eef)

So now they should be completely unused.