### PR TITLE
DCache: Replay refill_req when the evict_addr matching a valid mshr

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -886,6 +886,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   missQueue.io.l2_hint <> RegNext(io.l2_hint)
   missQueue.io.mainpipe_info := mainPipe.io.mainpipe_info
   mainPipe.io.refill_info := missQueue.io.refill_info
+  mainPipe.io.replace_block := missQueue.io.replace_block
   mainPipe.io.sms_agt_evict_req <> io.sms_agt_evict_req
   io.memSetPattenDetected := missQueue.io.memSetPattenDetected
 
@@ -1303,7 +1304,6 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   wb.io.miss_req.valid := missReqArb.io.out.valid
   wb.io.miss_req.bits  := missReqArb.io.out.bits.addr
-  wb.io.mshr_block := missQueue.io.release_block
 
   // block_decoupled(missReqArb.io.out, missQueue.io.req, wb.io.block_miss_req)
   missReqArb.io.out <> missQueue.io.req
@@ -1331,7 +1331,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   bus.a <> missQueue.io.mem_acquire
   bus.e <> missQueue.io.mem_finish
   missQueue.io.probe_addr := bus.b.bits.address
-  missQueue.io.release_addr := mainPipe.io.evict_addr
+  missQueue.io.replace_addr := mainPipe.io.replace_addr
 
   missQueue.io.main_pipe_resp.valid := RegNext(mainPipe.io.atomic_resp.valid)
   missQueue.io.main_pipe_resp.bits := RegEnable(mainPipe.io.atomic_resp.bits, mainPipe.io.atomic_resp.valid)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -166,7 +166,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     val replace_way = new ReplacementWayReqIO
 
     // writeback addr to be replaced
-    val evict_addr = ValidIO(UInt(PAddrBits.W))
+    val replace_addr = ValidIO(UInt(PAddrBits.W))
+    val replace_block = Input(Bool())
 
     // sms prefetch
     val sms_agt_evict_req = DecoupledIO(new AGTEvictReq)
@@ -351,7 +352,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s1_repl_way_raw = WireInit(0.U(log2Up(nWays).W))
   s1_repl_way_raw := Mux(GatedValidRegNext(s0_fire), io.replace_way.way, RegEnable(s1_repl_way_raw, s1_valid))
 
-  val s1_need_replacement = (s1_req.miss || s1_req.isStore && !s1_req.probe) && !s1_tag_match
+  val s1_need_replacement = s1_req.miss && !s1_tag_match
+  val s1_need_eviction = s1_req.miss && !s1_tag_match && s1_repl_coh.state =/= ClientStates.Nothing
 
   val s1_way_en = Mux(s1_need_replacement, s1_repl_way_en, s1_tag_match_way)
   assert(!RegNext(s1_fire && PopCount(s1_way_en) > 1.U))
@@ -379,6 +381,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s2_repl_coh = RegEnable(s1_repl_coh, s1_fire)
   val s2_repl_pf  = RegEnable(s1_repl_pf, s1_fire)
   val s2_need_replacement = RegEnable(s1_need_replacement, s1_fire)
+  val s2_need_eviction = RegEnable(s1_need_eviction, s1_fire)
   val s2_need_data = RegEnable(s1_need_data, s1_fire)
   val s2_need_tag = RegEnable(s1_need_tag, s1_fire)
   val s2_encTag = RegEnable(s1_encTag, s1_fire)
@@ -422,8 +425,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
 
   // For a store req, it either hits and goes to s3, or miss and enter miss queue immediately
   val s2_req_miss_without_data = Mux(s2_valid, s2_req.miss && !io.refill_info.valid, false.B)
-  val s2_can_go_to_mq_replay = s2_req_miss_without_data && RegEnable(s2_req_miss_without_data && !io.mainpipe_info.s2_replay_to_mq, false.B, s2_valid) // miss_req in s2 but refill data is invalid, can block 1 cycle
-  val s2_can_go_to_s3 = (s2_req_replace_dup_1 || s2_req.probe || (s2_req.miss && io.refill_info.valid) || (s2_req.isStore || s2_req.isAMO) && s2_hit) && s3_ready
+  val s2_can_go_to_mq_replay = (s2_req_miss_without_data && RegEnable(s2_req_miss_without_data && !io.mainpipe_info.s2_replay_to_mq, false.B, s2_valid)) || io.replace_block // miss_req in s2 but refill data is invalid, can block 1 cycle
+  val s2_can_go_to_s3 = (s2_req_replace_dup_1 || s2_req.probe || (s2_req.miss && io.refill_info.valid && !io.replace_block) || (s2_req.isStore || s2_req.isAMO) && s2_hit) && s3_ready
   val s2_can_go_to_mq = RegEnable(s1_pregen_can_go_to_mq, s1_fire)
   assert(RegNext(!(s2_valid && s2_can_go_to_s3 && s2_can_go_to_mq && s2_can_go_to_mq_replay)))
   val s2_can_go = s2_can_go_to_s3 || s2_can_go_to_mq || s2_can_go_to_mq_replay
@@ -1546,8 +1549,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   XSPerfAccumulate("fake_tag_write_intend", io.tag_write_intend && !io.tag_write.valid)
   XSPerfAccumulate("mainpipe_tag_write", io.tag_write.valid)
 
-  io.evict_addr.valid := io.wb.valid && s3_need_replacement
-  io.evict_addr.bits  := io.wb.bits.addr
+  io.replace_addr.valid := s2_valid && s2_need_eviction
+  io.replace_addr.bits  := get_block_addr(Cat(s2_tag, get_untag(s2_req.vaddr)))
 
   assert(!RegNext(io.tag_write.valid && !io.tag_write_intend))
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -741,7 +741,7 @@ class MissEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule
   io.block_addr.valid := req_valid && w_grantlast 
   io.block_addr.bits := req.addr
 
-  io.req_addr.valid := req_valid
+  io.req_addr.valid := req_valid && !s_grantack
   io.req_addr.bits := req.addr
 
   io.refill_info.valid := req_valid && w_grantlast
@@ -830,9 +830,9 @@ class MissQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule
     val probe_addr = Input(UInt(PAddrBits.W))
     val probe_block = Output(Bool())
 
-    // block release
-    val release_addr = Flipped(ValidIO(UInt(PAddrBits.W)))
-    val release_block = Output(Bool())
+    // block replace when release an addr valid in mshr
+    val replace_addr = Flipped(ValidIO(UInt(PAddrBits.W)))
+    val replace_block = Output(Bool())
 
     val full = Output(Bool())
 
@@ -1023,7 +1023,7 @@ class MissQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule
 
   io.probe_block := Cat(probe_block_vec).orR
 
-  io.release_block := io.release_addr.valid && Cat(entries.map(e => e.io.req_addr.valid && e.io.req_addr.bits === io.release_addr.bits) ++ Seq(miss_req_pipe_reg.block_match(io.release_addr.bits))).orR
+  io.replace_block := io.replace_addr.valid && Cat(entries.map(e => e.io.req_addr.valid && e.io.req_addr.bits === io.replace_addr.bits) ++ Seq(miss_req_pipe_reg.block_match(io.replace_addr.bits))).orR
 
   io.full := ~Cat(entries.map(_.io.primary_ready)).andR
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -741,7 +741,7 @@ class MissEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule
   io.block_addr.valid := req_valid && w_grantlast 
   io.block_addr.bits := req.addr
 
-  io.req_addr.valid := req_valid && !s_grantack
+  io.req_addr.valid := req_valid
   io.req_addr.bits := req.addr
 
   io.refill_info.valid := req_valid && w_grantlast

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
@@ -317,8 +317,6 @@ class WritebackQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
 
     val miss_req = Flipped(Valid(UInt()))
     val block_miss_req = Output(Bool()) 
-
-    val mshr_block = Input(Bool())
   })
 
   require(cfg.nReleaseEntries > cfg.nMissEntries)
@@ -353,7 +351,7 @@ class WritebackQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
       entry.io.id := entry_id
 
       // entry req
-      entry.io.req.valid := req.valid && !block_conflict && !io.mshr_block
+      entry.io.req.valid := req.valid && !block_conflict
       primary_ready_vec(i)   := entry.io.primary_ready
       entry.io.req.bits  := req.bits
       entry.io.req_data  := req_data


### PR DESCRIPTION
**Bug:** According to the Tilelink Specification, Chapter 9.2, "A master should not issue a Release if there is a pending Grant on the block." However, in dcache, this situation can occur when refill_req selects an evicted block whose address matches a valid MSHR.

**Solution:** Replay the refill_req if the address selected by the replacement policy matches a valid MSHR, and do not generate a current release request to L2.