### PR TITLE
L2Top, MemBlock, Backend: reconstruct reset tree

### DIFF
--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -157,6 +157,7 @@ class L2Top()(implicit p: Parameters) extends LazyModule
     val l2_tlb_req = IO(new TlbRequestIO(nRespDups = 2))
     val l2_pmp_resp = IO(Flipped(new PMPRespBundle))
     val l2_hint = IO(ValidIO(new L2ToL1Hint()))
+    val reset_core = IO(Output(Reset()))
 
     val resetDelayN = Module(new DelayN(UInt(PAddrBits.W), 5))
 
@@ -213,6 +214,13 @@ class L2Top()(implicit p: Parameters) extends LazyModule
       l2_tlb_req.req.bits := DontCare
       l2_tlb_req.req_kill := DontCare
       l2_tlb_req.resp.ready := true.B
+    }
+
+    if (debugOpts.ResetGen) {
+      val resetTree = ResetGenNode(Seq(CellNode(reset_core)))
+      ResetGen(resetTree, reset, sim = false)
+    } else {
+      reset_core := DontCare
     }
   }
 

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -237,24 +237,9 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   io.beu_errors.dcache <> memBlock.io.error.bits.toL1BusErrorUnitInfo(memBlock.io.error.valid)
   io.beu_errors.l2 <> DontCare
   io.l2_pf_enable := memBlock.io.outer_l2_pf_enable
-  // Modules are reset one by one
-  val resetTree = ResetGenNode(
-    Seq(
-      ModuleNode(memBlock),
-      ResetGenNode(Seq(
-        ModuleNode(backend),
-        ResetGenNode(Seq(
-          ResetGenNode(Seq(
-            ModuleNode(frontend)
-          ))
-        ))
-      ))
-    )
-  )
 
-  // ResetGen(resetTree, reset, !debugOpts.FPGAPlatform)
   if (debugOpts.ResetGen) {
-    frontend.reset := memBlock.reset_io_frontend
-    backend.reset := memBlock.reset_io_backend
+    backend.reset := memBlock.reset_backend
+    frontend.reset := backend.io.frontendReset
   }
 }

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -160,15 +160,9 @@ class XSTile()(implicit p: Parameters) extends LazyModule
     io.chi.foreach(_ <> l2top.module.chi.get)
     l2top.module.nodeID.foreach(_ := io.nodeID.get)
 
-    // Modules are reset one by one
-    // io_reset ----
-    //             |
-    //             v
-    // reset ----> OR_SYNC --> {Misc, L2 Cache, Cores}
-    // val resetChain = Seq(
-    //   Seq(l2top.module, core.module)
-    // )
-    // ResetGen(resetChain, reset, !debugOpts.FPGAPlatform)
+    if (debugOpts.ResetGen && enableL2) {
+      core.module.reset := l2top.module.reset_core
+    }
   }
 
   lazy val module = new XSTileImp(this)


### PR DESCRIPTION
Modules in XSTile are reset in the order of L2, MemBlock, Backend and Frontend.

<img src="https://github.com/user-attachments/assets/ae927496-9d4d-45fc-a924-78be181d4fa7" width="40%">
