### PR TITLE
ci: Do not enable difftest when building PGO profile

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build EMU
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --build --threads 16 \
-            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata
+            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --pgo-emu-args '--no-diff' --llvm-profdata llvm-profdata
       - name: Basic Test - cputest
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --ci cputest 2> /dev/zero
@@ -208,7 +208,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3            \
             --with-dramsim3 --threads 16 \
-            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata
+            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --pgo-emu-args '--no-diff' --llvm-profdata llvm-profdata
       - name: SPEC06 Test - mcf
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --max-instr 5000000 --numa --ci mcf --gcpt-restore-bin $GCPT_RESTORE_BIN 2> perf.log
@@ -275,7 +275,7 @@ jobs:
             --num-cores 2 --emu-optimize "" \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 \
             --with-dramsim3 --threads 16 \
-            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata
+            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --pgo-emu-args '--no-diff' --llvm-profdata llvm-profdata
       - name: MC Test
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --diff ./ready-to-run/riscv64-nemu-interpreter-dual-so --ci mc-tests 2> /dev/zero


### PR DESCRIPTION
Some changes in the RTL / configurations may result in the PGO profile failing to build due to difftest failures and even make this error hard to debug. So, turn off difftest when building a PGO profile to avoid this issue.