### PR TITLE
Frontend: refactor exceptions to labels

### DIFF
--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -114,11 +114,12 @@ class mmioCommitRead(implicit p: Parameters) extends XSBundle {
 
 object ExceptionType {
   def none  : UInt = "b00".U
-  def pf    : UInt = "b01".U
-  def gpf   : UInt = "b10".U
-  def af    : UInt = "b11".U
+  def pf    : UInt = "b01".U // instruction page fault
+  def gpf   : UInt = "b10".U // instruction guest page fault
+  def af    : UInt = "b11".U // instruction access fault
   def width : Int  = 2
 
+  // raise pf/gpf/af according to itlb response
   def fromTlbResp(resp: TlbResp, useDup: Int = 0): UInt = {
     require(useDup >= 0 && useDup < resp.excp.length)
     assert(
@@ -126,6 +127,7 @@ object ExceptionType {
       "tlb resp has more than 1 exception, af=%d, pf=%d, gpf=%d",
       resp.excp(useDup).af.instr, resp.excp(useDup).pf.instr, resp.excp(useDup).gpf.instr
     )
+    // itlb is guaranteed to respond at most one exception, so we don't worry about priority here.
     MuxCase(none, Seq(
       resp.excp(useDup).pf.instr  -> pf,
       resp.excp(useDup).gpf.instr -> gpf,
@@ -133,24 +135,78 @@ object ExceptionType {
     ))
   }
 
+  // raise af if pmp check failed
   def fromPMPResp(resp: PMPRespBundle): UInt = {
-    MuxCase(none, Seq(
-      resp.instr -> af
-    ))
+    Mux(resp.instr, af, none)
   }
 
+  // raise af if meta/data array ecc check failed or l2 cache respond with tilelink corrupt
   def fromECC(corrupt: Bool): UInt = {
     Mux(corrupt, af, none)
   }
 
-  def merge(high: UInt, low: UInt): UInt = {
-    require(high.getWidth == width)
-    require(low.getWidth == width)
-    Mux(high =/= none, high, low)
+  /**Generates exception mux tree
+   *
+   * Exceptions that are further to the left in the parameter list have higher priority
+   * @example
+   * {{{
+   *   val itlb_exception = ExceptionType.fromTlbResp(io.itlb.resp.bits)
+   *   // so as pmp_exception, meta_corrupt
+   *   // ExceptionType.merge(itlb_exception, pmp_exception, meta_corrupt) is equivalent to:
+   *   Mux(
+   *     itlb_exception =/= none,
+   *     itlb_exception,
+   *     Mux(pmp_exception =/= none, pmp_exception, meta_corrupt)
+   *   )
+   * }}}
+   */
+  def merge(exceptions: UInt*): UInt = {
+//    // recursively generate mux tree
+//    if (exceptions.length == 1) {
+//      require(exceptions.head.getWidth == width)
+//      exceptions.head
+//    } else {
+//      Mux(exceptions.head =/= none, exceptions.head, merge(exceptions.tail: _*))
+//    }
+    // use MuxCase with default
+    exceptions.foreach(e => require(e.getWidth == width))
+    val mapping = exceptions.init.map(e => (e =/= none) -> e)
+    val default = exceptions.last
+    MuxCase(default, mapping)
   }
-  def merge(highVec: Vec[UInt], lowVec: Vec[UInt]): Vec[UInt] = {
-    require(highVec.length == lowVec.length)
-    VecInit((highVec zip lowVec).map{ case (high, low) => merge(high, low) })
+
+  /**Generates exception mux tree for multi-port exception vectors
+   *
+   * Exceptions that are further to the left in the parameter list have higher priority
+   * @example
+   * {{{
+   *   val itlb_exception = VecInit((0 until PortNumber).map(i => ExceptionType.fromTlbResp(io.itlb(i).resp.bits)))
+   *   // so as pmp_exception, meta_corrupt
+   *   // ExceptionType.merge(itlb_exception, pmp_exception, meta_corrupt) is equivalent to:
+   *   VecInit((0 until PortNumber).map(i => Mux(
+   *     itlb_exception(i) =/= none,
+   *     itlb_exception(i),
+   *     Mux(pmp_exception(i) =/= none, pmp_exception(i), meta_corrupt(i))
+   *   ))
+   * }}}
+   */
+  def merge(exceptionVecs: Vec[UInt]*): Vec[UInt] = {
+//    // recursively generate mux tree
+//    if (exceptionVecs.length == 1) {
+//      exceptionVecs.head.foreach(e => require(e.getWidth == width))
+//      exceptionVecs.head
+//    } else {
+//      require(exceptionVecs.head.length == exceptionVecs.last.length)
+//      VecInit((exceptionVecs.head zip merge(exceptionVecs.tail: _*)).map{ case (high, low) =>
+//        Mux(high =/= none, high, low)
+//      })
+//    }
+    // merge port-by-port
+    val length = exceptionVecs.head.length
+    exceptionVecs.tail.foreach(vec => require(vec.length == length))
+    VecInit((0 until length).map{ i =>
+      merge(exceptionVecs.map(_(i)): _*)
+    })
   }
 }
 

--- a/src/main/scala/xiangshan/frontend/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/IBuffer.scala
@@ -87,9 +87,9 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
     cf.pc := pc
     cf.foldpc := foldpc
     cf.exceptionVec := 0.U.asTypeOf(ExceptionVec())
-    cf.exceptionVec(instrPageFault) := exceptionType === ExceptionType.ipf
-    cf.exceptionVec(instrGuestPageFault) := exceptionType === ExceptionType.igpf
-    cf.exceptionVec(instrAccessFault) := exceptionType === ExceptionType.acf
+    cf.exceptionVec(instrPageFault) := exceptionType === ExceptionType.pf
+    cf.exceptionVec(instrGuestPageFault) := exceptionType === ExceptionType.gpf
+    cf.exceptionVec(instrAccessFault) := exceptionType === ExceptionType.af
     cf.trigger := triggered
     cf.pd := pd
     cf.pred_taken := pred_taken

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -376,16 +376,12 @@ class NewIFU(implicit p: Parameters) extends XSModule
   .elsewhen(f1_fire && !f1_flush) {f2_valid := true.B }
   .elsewhen(f2_fire)              {f2_valid := false.B}
 
-  val f2_except_pf    = VecInit((0 until PortNumber).map(i => fromICache(i).bits.tlbExcp.pageFault))
-  val f2_except_gpf   = VecInit((0 until PortNumber).map(i => fromICache(i).bits.tlbExcp.guestPageFault))
-  val f2_except_af    = VecInit((0 until PortNumber).map(i => fromICache(i).bits.tlbExcp.accessFault))
+  val f2_exception    = VecInit((0 until PortNumber).map(i => fromICache(i).bits.exception))
   // paddr and gpaddr of [startAddr, nextLineAddr]
   val f2_paddrs       = VecInit((0 until PortNumber).map(i => fromICache(i).bits.paddr))
   val f2_gpaddr       = fromICache(0).bits.gpaddr
-  val f2_mmio         = fromICache(0).bits.tlbExcp.mmio &&
-    !fromICache(0).bits.tlbExcp.accessFault &&
-    !fromICache(0).bits.tlbExcp.pageFault   &&
-    !fromICache(0).bits.tlbExcp.guestPageFault
+  // cancel mmio fetch if exception occurs
+  val f2_mmio         = fromICache(0).bits.mmio && f2_exception(0) === ExceptionType.none
 
   /**
     * reduce the number of registers, origin code
@@ -411,9 +407,10 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f2_jump_range = Fill(PredictWidth, !f2_ftq_req.ftqOffset.valid) | Fill(PredictWidth, 1.U(1.W)) >> ~f2_ftq_req.ftqOffset.bits
   val f2_ftr_range  = Fill(PredictWidth,  f2_ftq_req.ftqOffset.valid) | Fill(PredictWidth, 1.U(1.W)) >> ~getBasicBlockIdx(f2_ftq_req.nextStartAddr, f2_ftq_req.startAddr)
   val f2_instr_range = f2_jump_range & f2_ftr_range
-  val f2_pf_vec = VecInit((0 until PredictWidth).map(i => (!isNextLine(f2_pc(i), f2_ftq_req.startAddr) && f2_except_pf(0)   ||  isNextLine(f2_pc(i), f2_ftq_req.startAddr) && f2_doubleLine &&  f2_except_pf(1))))
-  val f2_af_vec = VecInit((0 until PredictWidth).map(i => (!isNextLine(f2_pc(i), f2_ftq_req.startAddr) && f2_except_af(0)   ||  isNextLine(f2_pc(i), f2_ftq_req.startAddr) && f2_doubleLine && f2_except_af(1))))
-  val f2_gpf_vec = VecInit((0 until PredictWidth).map(i => (!isNextLine(f2_pc(i), f2_ftq_req.startAddr) && f2_except_gpf(0) || isNextLine(f2_pc(i), f2_ftq_req.startAddr) && f2_doubleLine && f2_except_gpf(1))))
+  val f2_exception_vec = VecInit((0 until PredictWidth).map( i => MuxCase(ExceptionType.none, Seq(
+      !isNextLine(f2_pc(i), f2_ftq_req.startAddr)                   -> f2_exception(0),
+      (isNextLine(f2_pc(i), f2_ftq_req.startAddr) && f2_doubleLine) -> f2_exception(1)
+  ))))
   val f2_perf_info    = io.icachePerfInfo
 
   def cut(cacheline: UInt, cutPtr: Vec[UInt]) : Vec[UInt] ={
@@ -458,8 +455,12 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f2_pd             = preDecoderOut.pd
   val f2_jump_offset    = preDecoderOut.jumpOffset
   val f2_hasHalfValid   =  preDecoderOut.hasHalfValid
-  val f2_crossPageFault = VecInit((0 until PredictWidth).map(i => isLastInLine(f2_pc(i)) && !f2_except_pf(0) && f2_doubleLine &&  f2_except_pf(1) && !f2_pd(i).isRVC ))
-  val f2_crossGuestPageFault = VecInit((0 until PredictWidth).map(i => isLastInLine(f2_pc(i)) && !f2_except_gpf(0) && f2_doubleLine && f2_except_gpf(1) && !f2_pd(i).isRVC ))
+  val f2_crossPageFault = VecInit((0 until PredictWidth).map( i =>
+    isLastInLine(f2_pc(i)) && (f2_exception(0) =/= ExceptionType.pf) && f2_doubleLine && (f2_exception(1) === ExceptionType.pf) && !f2_pd(i).isRVC
+  ))
+  val f2_crossGuestPageFault = VecInit((0 until PredictWidth).map( i =>
+    isLastInLine(f2_pc(i)) && (f2_exception(0) =/= ExceptionType.gpf) && f2_doubleLine && (f2_exception(1) === ExceptionType.gpf) && !f2_pd(i).isRVC
+  ))
   XSPerfAccumulate("fetch_bubble_icache_not_resp",   f2_valid && !icacheRespAllValid )
 
 
@@ -483,12 +484,10 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f3_doubleLine     = RegEnable(f2_doubleLine, f2_fire)
   val f3_fire           = io.toIbuffer.fire
 
-  val f3_cut_data       = RegEnable(f2_cut_data, f2_fire)
+  val f3_cut_data       = RegEnable(f2_cut_data,   f2_fire)
 
-  val f3_except_pf      = RegEnable(f2_except_pf,  f2_fire)
-  val f3_except_af      = RegEnable(f2_except_af,  f2_fire)
-  val f3_except_gpf     = RegEnable(f2_except_gpf,  f2_fire)
-  val f3_mmio           = RegEnable(f2_mmio   ,  f2_fire)
+  val f3_exception      = RegEnable(f2_exception,  f2_fire)
+  val f3_mmio           = RegEnable(f2_mmio,       f2_fire)
 
   //val f3_expd_instr     = RegEnable(f2_expd_instr,  f2_fire)
   val f3_instr          = RegEnable(f2_instr, f2_fire)
@@ -498,17 +497,15 @@ class NewIFU(implicit p: Parameters) extends XSModule
     expander.io.out.bits
   })
 
-  val f3_pd_wire        = RegEnable(f2_pd,          f2_fire)
-  val f3_pd             = WireInit(f3_pd_wire)
-  val f3_jump_offset    = RegEnable(f2_jump_offset, f2_fire)
-  val f3_af_vec         = RegEnable(f2_af_vec,      f2_fire)
-  val f3_pf_vec         = RegEnable(f2_pf_vec ,     f2_fire)
-  val f3_gpf_vec        = RegEnable(f2_gpf_vec,     f2_fire)
+  val f3_pd_wire         = RegEnable(f2_pd,            f2_fire)
+  val f3_pd              = WireInit(f3_pd_wire)
+  val f3_jump_offset     = RegEnable(f2_jump_offset,   f2_fire)
+  val f3_exception_vec   = RegEnable(f2_exception_vec, f2_fire)
 
-  val f3_pc_lower_result        = RegEnable(f2_pc_lower_result, f2_fire)
-  val f3_pc_high                = RegEnable(f2_pc_high, f2_fire)
-  val f3_pc_high_plus1          = RegEnable(f2_pc_high_plus1, f2_fire)
-  val f3_pc             = CatPC(f3_pc_lower_result, f3_pc_high, f3_pc_high_plus1)
+  val f3_pc_lower_result = RegEnable(f2_pc_lower_result, f2_fire)
+  val f3_pc_high         = RegEnable(f2_pc_high, f2_fire)
+  val f3_pc_high_plus1   = RegEnable(f2_pc_high_plus1, f2_fire)
+  val f3_pc              = CatPC(f3_pc_lower_result, f3_pc_high, f3_pc_high_plus1)
 
   val f3_pc_last_lower_result_plus2 = RegEnable(f2_pc_lower_result(PredictWidth - 1) + 2.U, f2_fire)
   val f3_pc_last_lower_result_plus4 = RegEnable(f2_pc_lower_result(PredictWidth - 1) + 4.U, f2_fire)
@@ -535,8 +532,6 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f3_crossPageFault = RegEnable(f2_crossPageFault,           f2_fire)
   val f3_crossGuestPageFault = RegEnable(f2_crossGuestPageFault, f2_fire)
   val f3_hasHalfValid   = RegEnable(f2_hasHalfValid,             f2_fire)
-  val f3_except         = VecInit((0 until 2).map{i => f3_except_pf(i) || f3_except_af(i) || f3_except_gpf(i)})
-  val f3_has_except     = f3_valid && (f3_except_af.reduce(_||_) || f3_except_pf.reduce(_||_) || f3_except_gpf.reduce(_||_))
   val f3_paddrs         = RegEnable(f2_paddrs,  f2_fire)
   val f3_gpaddr         = RegEnable(f2_gpaddr,  f2_fire)
   val f3_resend_vaddr   = RegEnable(f2_resend_vaddr,             f2_fire)
@@ -563,13 +558,11 @@ class NewIFU(implicit p: Parameters) extends XSModule
   }
 
   /*** MMIO State Machine***/
-  val f3_mmio_data       = Reg(Vec(2, UInt(16.W)))
-  val mmio_is_RVC        = RegInit(false.B)
-  val mmio_resend_addr   = RegInit(0.U(PAddrBits.W))
-  val mmio_resend_af     = RegInit(false.B)
-  val mmio_resend_pf     = RegInit(false.B)
-  val mmio_resend_gpf    = RegInit(false.B)
-  val mmio_resend_gpaddr = RegInit(0.U(GPAddrBits.W))
+  val f3_mmio_data          = Reg(Vec(2, UInt(16.W)))
+  val mmio_is_RVC           = RegInit(false.B)
+  val mmio_resend_addr      = RegInit(0.U(PAddrBits.W))
+  val mmio_resend_exception = RegInit(0.U(ExceptionType.width.W))
+  val mmio_resend_gpaddr    = RegInit(0.U(GPAddrBits.W))
 
   //last instuction finish
   val is_first_instr = RegInit(true.B)
@@ -661,24 +654,23 @@ class NewIFU(implicit p: Parameters) extends XSModule
       when(io.iTLBInter.resp.fire) {
         // we are using a blocked tlb, so resp.fire must have !resp.bits.miss
         assert(!io.iTLBInter.resp.bits.miss, "blocked mode iTLB miss when resp.fire")
-        val tlbExcp = io.iTLBInter.resp.bits.excp(0).pf.instr ||
-                      io.iTLBInter.resp.bits.excp(0).af.instr ||
-                      io.iTLBInter.resp.bits.excp(0).gpf.instr
+        val tlb_exception = ExceptionType.fromTlbResp(io.iTLBInter.resp.bits)
         // if tlb has exception, abort checking pmp, just send instr & exception to ibuffer and wait for commit
-        mmio_state         := Mux(tlbExcp, m_waitCommit, m_sendPMP)
+        mmio_state := Mux(tlb_exception === ExceptionType.none, m_sendPMP, m_waitCommit)
         // also save itlb response
-        mmio_resend_addr   := io.iTLBInter.resp.bits.paddr(0)
-        mmio_resend_af     := mmio_resend_af || io.iTLBInter.resp.bits.excp(0).af.instr
-        mmio_resend_pf     := mmio_resend_pf || io.iTLBInter.resp.bits.excp(0).pf.instr
-        mmio_resend_gpf    := mmio_resend_gpf || io.iTLBInter.resp.bits.excp(0).gpf.instr
-        mmio_resend_gpaddr := io.iTLBInter.resp.bits.gpaddr(0)
+        mmio_resend_addr      := io.iTLBInter.resp.bits.paddr(0)
+        mmio_resend_exception := tlb_exception
+        mmio_resend_gpaddr    := io.iTLBInter.resp.bits.gpaddr(0)
       }
     }
 
     is(m_sendPMP){
-      val pmpExcpAF = io.pmp.resp.instr || !io.pmp.resp.mmio
-      mmio_state     := Mux(pmpExcpAF, m_waitCommit, m_resendReq)
-      mmio_resend_af := mmio_resend_af || pmpExcpAF
+      // if pmp re-check does not respond mmio, must be access fault
+      val pmp_exception = Mux(io.pmp.resp.mmio, ExceptionType.fromPMPResp(io.pmp.resp), ExceptionType.af)
+      // if pmp has exception, abort sending request, just send instr & exception to ibuffer and wait for commit
+      mmio_state := Mux(pmp_exception === ExceptionType.none, m_resendReq, m_waitCommit)
+      // also save pmp response
+      mmio_resend_exception := pmp_exception
     }
 
     is(m_resendReq){
@@ -698,26 +690,22 @@ class NewIFU(implicit p: Parameters) extends XSModule
 
     //normal mmio instruction
     is(m_commited) {
-      mmio_state         := m_idle
-      mmio_is_RVC        := false.B
-      mmio_resend_addr   := 0.U
-      mmio_resend_af     := false.B
-      mmio_resend_pf     := false.B
-      mmio_resend_gpf    := false.B
-      mmio_resend_gpaddr := 0.U
+      mmio_state            := m_idle
+      mmio_is_RVC           := false.B
+      mmio_resend_addr      := 0.U
+      mmio_resend_exception := ExceptionType.none
+      mmio_resend_gpaddr    := 0.U
     }
   }
 
   // Exception or flush by older branch prediction
   // Condition is from RegNext(fromFtq.redirect), 1 cycle after backend rediect
   when(f3_ftq_flush_self || f3_ftq_flush_by_older) {
-    mmio_state         := m_idle
-    mmio_is_RVC        := false.B
-    mmio_resend_addr   := 0.U
-    mmio_resend_af     := false.B
-    mmio_resend_pf     := false.B
-    mmio_resend_gpf    := false.B
-    mmio_resend_gpaddr := 0.U
+    mmio_state            := m_idle
+    mmio_is_RVC           := false.B
+    mmio_resend_addr      := 0.U
+    mmio_resend_exception := ExceptionType.none
+    mmio_resend_gpaddr    := 0.U
     f3_mmio_data.map(_ := 0.U)
   }
 
@@ -814,11 +802,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   io.toIbuffer.bits.pc          := f3_pc
   io.toIbuffer.bits.ftqOffset.zipWithIndex.map{case(a, i) => a.bits := i.U; a.valid := checkerOutStage1.fixedTaken(i) && !f3_req_is_mmio}
   io.toIbuffer.bits.foldpc      := f3_foldpc
-  io.toIbuffer.bits.exceptionType := (0 until PredictWidth).map(i => MuxCase(ExceptionType.none, Seq(
-    (f3_pf_vec(i) || f3_crossPageFault(i)) -> ExceptionType.pf,
-    (f3_gpf_vec(i) || f3_crossGuestPageFault(i)) -> ExceptionType.gpf,
-    f3_af_vec(i) -> ExceptionType.af
-  )))
+  io.toIbuffer.bits.exceptionType := f3_exception_vec
   io.toIbuffer.bits.crossPageIPFFix := (0 until PredictWidth).map(i => f3_crossPageFault(i) || f3_crossGuestPageFault(i))
   io.toIbuffer.bits.triggered   := f3_triggered
 
@@ -831,8 +815,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
   // f3_gpaddr is valid iff gpf is detected
   io.toBackend.gpaddrMem_wen   := f3_toIbuffer_valid && Mux(
     f3_req_is_mmio,
-    mmio_resend_gpf,
-    f3_gpf_vec.asUInt.orR || f3_crossGuestPageFault.asUInt.orR
+    mmio_resend_exception === ExceptionType.gpf,
+    f3_exception.map(_ === ExceptionType.gpf).reduce(_||_)
   )
   io.toBackend.gpaddrMem_waddr := f3_ftq_req.ftqIdx.value
   io.toBackend.gpaddrMem_wdata := Mux(f3_req_is_mmio, mmio_resend_gpaddr, f3_gpaddr)
@@ -880,14 +864,10 @@ class NewIFU(implicit p: Parameters) extends XSModule
     io.toIbuffer.bits.pd(0).isCall  := isCall
     io.toIbuffer.bits.pd(0).isRet   := isRet
 
-    when (mmio_resend_af) {
-      io.toIbuffer.bits.exceptionType(0) := ExceptionType.af
-    } .elsewhen (mmio_resend_pf) {
-      io.toIbuffer.bits.exceptionType(0) := ExceptionType.pf
-    } .elsewhen (mmio_resend_gpf) {
-      io.toIbuffer.bits.exceptionType(0) := ExceptionType.gpf
-    }
-    io.toIbuffer.bits.crossPageIPFFix(0) := mmio_resend_pf
+    io.toIbuffer.bits.exceptionType(0)   := mmio_resend_exception
+    // resend must be cross-page
+    // FIXME: should gpf set crossPageIPFFix to true? See https://github.com/OpenXiangShan/XiangShan/blame/89c99ce9fd7fc54dd7e7521527e6099040868e4c/src/main/scala/xiangshan/frontend/IFU.scala#L822
+    io.toIbuffer.bits.crossPageIPFFix(0) := mmio_resend_exception === ExceptionType.pf // || mmio_resend_exception === ExceptionType.gpf
 
     io.toIbuffer.bits.enqEnable   := f3_mmio_range.asUInt
 

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -815,9 +815,9 @@ class NewIFU(implicit p: Parameters) extends XSModule
   io.toIbuffer.bits.ftqOffset.zipWithIndex.map{case(a, i) => a.bits := i.U; a.valid := checkerOutStage1.fixedTaken(i) && !f3_req_is_mmio}
   io.toIbuffer.bits.foldpc      := f3_foldpc
   io.toIbuffer.bits.exceptionType := (0 until PredictWidth).map(i => MuxCase(ExceptionType.none, Seq(
-    (f3_pf_vec(i) || f3_crossPageFault(i)) -> ExceptionType.ipf,
-    (f3_gpf_vec(i) || f3_crossGuestPageFault(i)) -> ExceptionType.igpf,
-    f3_af_vec(i) -> ExceptionType.acf
+    (f3_pf_vec(i) || f3_crossPageFault(i)) -> ExceptionType.pf,
+    (f3_gpf_vec(i) || f3_crossGuestPageFault(i)) -> ExceptionType.gpf,
+    f3_af_vec(i) -> ExceptionType.af
   )))
   io.toIbuffer.bits.crossPageIPFFix := (0 until PredictWidth).map(i => f3_crossPageFault(i) || f3_crossGuestPageFault(i))
   io.toIbuffer.bits.triggered   := f3_triggered
@@ -881,11 +881,11 @@ class NewIFU(implicit p: Parameters) extends XSModule
     io.toIbuffer.bits.pd(0).isRet   := isRet
 
     when (mmio_resend_af) {
-      io.toIbuffer.bits.exceptionType(0) := ExceptionType.acf
+      io.toIbuffer.bits.exceptionType(0) := ExceptionType.af
     } .elsewhen (mmio_resend_pf) {
-      io.toIbuffer.bits.exceptionType(0) := ExceptionType.ipf
+      io.toIbuffer.bits.exceptionType(0) := ExceptionType.pf
     } .elsewhen (mmio_resend_gpf) {
-      io.toIbuffer.bits.exceptionType(0) := ExceptionType.igpf
+      io.toIbuffer.bits.exceptionType(0) := ExceptionType.gpf
     }
     io.toIbuffer.bits.crossPageIPFFix(0) := mmio_resend_pf
 

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -209,7 +209,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   val s1_meta_ptags   = fromMeta.tags
   val s1_meta_valids  = fromMeta.entryValid
   // If error is found in either way, the tag_eq_vec is unreliable, so we do not use waymask, but directly .orR
-  val s1_meta_errors = VecInit(fromMeta.errors.map(_.asUInt.orR))
+  val s1_meta_corrupt = VecInit(fromMeta.errors.map(_.asUInt.orR))
 
   def get_waymask(paddrs: Vec[UInt]): Vec[UInt] = {
     val ptags         = paddrs.map(get_phy_tag)
@@ -267,8 +267,8 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   (0 until PortNumber).foreach { i =>
     val excpValid = (if (i == 0) true.B else s1_doubleline)  // exception in first line is always valid, in second line is valid iff is doubleline request
     // Send s1_itlb_exception to WayLookup (instead of s1_exception_out) for better timing. Will check pmp again in mainPipe
-    toWayLookup.bits.exception(i)   := Mux(excpValid, s1_itlb_exception(i), ExceptionType.none)
-    toWayLookup.bits.meta_errors(i) := excpValid && s1_meta_errors(i)
+    toWayLookup.bits.exception(i)    := Mux(excpValid, s1_itlb_exception(i), ExceptionType.none)
+    toWayLookup.bits.meta_corrupt(i) := excpValid && s1_meta_corrupt(i)
   }
 
   val s1_waymasks_vec = s1_waymasks.map(_.asTypeOf(Vec(nWays, Bool())))

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -267,8 +267,8 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   (0 until PortNumber).foreach { i =>
     val excpValid = (if (i == 0) true.B else s1_doubleline)  // exception in first line is always valid, in second line is valid iff is doubleline request
     // Send s1_itlb_exception to WayLookup (instead of s1_exception_out) for better timing. Will check pmp again in mainPipe
-    toWayLookup.bits.exception(i)    := Mux(excpValid, s1_itlb_exception(i), ExceptionType.none)
-    toWayLookup.bits.meta_corrupt(i) := excpValid && s1_meta_corrupt(i)
+    toWayLookup.bits.itlb_exception(i) := Mux(excpValid, s1_itlb_exception(i), ExceptionType.none)
+    toWayLookup.bits.meta_corrupt(i)   := excpValid && s1_meta_corrupt(i)
   }
 
   val s1_waymasks_vec = s1_waymasks.map(_.asTypeOf(Vec(nWays, Bool())))
@@ -362,7 +362,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   val s2_req_vaddr    = RegEnable(s1_req_vaddr,     0.U.asTypeOf(s1_req_vaddr),     s1_fire)
   val s2_doubleline   = RegEnable(s1_doubleline,    0.U.asTypeOf(s1_doubleline),    s1_fire)
   val s2_req_paddr    = RegEnable(s1_req_paddr,     0.U.asTypeOf(s1_req_paddr),     s1_fire)
-  val s2_exception    = RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_fire)
+  val s2_exception    = RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_fire)  // includes itlb/pmp exceptions
   val s2_mmio         = RegEnable(s1_mmio,          0.U.asTypeOf(s1_mmio),          s1_fire)
   val s2_waymasks     = RegEnable(s1_waymasks,      0.U.asTypeOf(s1_waymasks),      s1_fire)
 

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -394,6 +394,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
    * also, if port0 has exception, port1 should not be prefetched
    * miss = this port not hit && need this port && no exception found before and in this port
    */
+  // FIXME: maybe we should cancel fetch when meta error is detected, since hits (waymasks) can be invalid
   val s2_miss = VecInit((0 until PortNumber).map { i =>
     !s2_hits(i) && (if (i==0) true.B else s2_doubleline) &&
       s2_exception.take(i+1).map(_ === ExceptionType.none).reduce(_&&_) &&

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -32,7 +32,7 @@ import utility._
 abstract class IPrefetchBundle(implicit p: Parameters) extends ICacheBundle
 abstract class IPrefetchModule(implicit p: Parameters) extends ICacheModule
 
-class IPredfetchIO(implicit p: Parameters) extends IPrefetchBundle {
+class IPrefetchIO(implicit p: Parameters) extends IPrefetchBundle {
   // control
   val csr_pf_enable     = Input(Bool())
   val flush             = Input(Bool())
@@ -48,7 +48,7 @@ class IPredfetchIO(implicit p: Parameters) extends IPrefetchBundle {
 
 class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
 {
-  val io = IO(new IPredfetchIO)
+  val io: IPrefetchIO = IO(new IPrefetchIO)
 
   val fromFtq = io.ftqReq
   val (toITLB,  fromITLB) = (io.itlb.map(_.req), io.itlb.map(_.resp))
@@ -57,6 +57,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   val (toMSHR, fromMSHR)  = (io.MSHRReq, io.MSHRResp)
   val toWayLookup = io.wayLookupWrite
 
+  // FIXME: csr_pf_enable/enableBit is not used now
   val enableBit = RegInit(false.B)
   enableBit := io.csr_pf_enable
 
@@ -84,7 +85,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   val s0_req_vaddr    = VecInit(Seq(fromFtq.req.bits.startAddr, fromFtq.req.bits.nextlineStart))
   val s0_req_ftqIdx   = fromFtq.req.bits.ftqIdx
   val s0_doubleline   = fromFtq.req.bits.crossCacheline
-  val s0_req_vSetIdx  = s0_req_vaddr.map(get_idx(_))
+  val s0_req_vSetIdx  = s0_req_vaddr.map(get_idx)
 
   from_bpu_s0_flush := fromFtq.flushFromBpu.shouldFlushByStage2(s0_req_ftqIdx) ||
                        fromFtq.flushFromBpu.shouldFlushByStage3(s0_req_ftqIdx)
@@ -109,7 +110,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   val s1_req_vaddr    = RegEnable(s0_req_vaddr, 0.U.asTypeOf(s0_req_vaddr), s0_fire)
   val s1_doubleline   = RegEnable(s0_doubleline, 0.U.asTypeOf(s0_doubleline), s0_fire)
   val s1_req_ftqIdx   = RegEnable(s0_req_ftqIdx, 0.U.asTypeOf(s0_req_ftqIdx), s0_fire)
-  val s1_req_vSetIdx  = VecInit(s1_req_vaddr.map(get_idx(_)))
+  val s1_req_vSetIdx  = VecInit(s1_req_vaddr.map(get_idx))
 
   val m_idle :: m_itlbResend :: m_metaResend :: m_enqWay :: m_enterS2 :: Nil = Enum(5)
   val state = RegInit(m_idle)
@@ -158,20 +159,20 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
     * Receive resp from ITLB
     ******************************************************************************
     */
-  val s1_req_paddr_wire   = VecInit(fromITLB.map(_.bits.paddr(0)))
-  val s1_req_paddr_reg    = VecInit((0 until PortNumber).map(i =>
-                                RegEnable(s1_req_paddr_wire(i), 0.U(PAddrBits.W), tlb_valid_pulse(i))))
-  val s1_req_paddr        = VecInit((0 until PortNumber).map(i => 
-                                Mux(tlb_valid_pulse(i), s1_req_paddr_wire(i), s1_req_paddr_reg(i))))
-  val s1_req_gpaddr_tmp   = VecInit((0 until PortNumber).map(i =>
-                                ResultHoldBypass(valid = tlb_valid_pulse(i), init = 0.U.asTypeOf(fromITLB(i).bits.gpaddr(0)), data = fromITLB(i).bits.gpaddr(0))))
-  val itlbExcpPF          = VecInit((0 until PortNumber).map(i =>
-                                ResultHoldBypass(valid = tlb_valid_pulse(i), init = 0.U.asTypeOf(fromITLB(i).bits.excp(0).pf.instr), data = fromITLB(i).bits.excp(0).pf.instr)))
-  val itlbExcpGPF         = VecInit((0 until PortNumber).map(i =>
-                                ResultHoldBypass(valid = tlb_valid_pulse(i), init = 0.U.asTypeOf(fromITLB(i).bits.excp(0).gpf.instr), data = fromITLB(i).bits.excp(0).gpf.instr)))
-  val itlbExcpAF          = VecInit((0 until PortNumber).map(i =>
-                                ResultHoldBypass(valid = tlb_valid_pulse(i), init = 0.U.asTypeOf(fromITLB(i).bits.excp(0).af.instr), data = fromITLB(i).bits.excp(0).af.instr)))
-  val itlbExcp            = VecInit((0 until PortNumber).map(i => itlbExcpAF(i) || itlbExcpPF(i) || itlbExcpGPF(i)))
+  val s1_req_paddr_wire     = VecInit(fromITLB.map(_.bits.paddr(0)))
+  val s1_req_paddr_reg      = VecInit((0 until PortNumber).map( i =>
+    RegEnable(s1_req_paddr_wire(i), 0.U(PAddrBits.W), tlb_valid_pulse(i))
+  ))
+  val s1_req_paddr          = VecInit((0 until PortNumber).map( i =>
+    Mux(tlb_valid_pulse(i), s1_req_paddr_wire(i), s1_req_paddr_reg(i))
+  ))
+  val s1_req_gpaddr_tmp     = VecInit((0 until PortNumber).map( i =>
+    ResultHoldBypass(valid = tlb_valid_pulse(i), init = 0.U.asTypeOf(fromITLB(i).bits.gpaddr(0)), data = fromITLB(i).bits.gpaddr(0))
+  ))
+  val s1_itlb_exception     = VecInit((0 until PortNumber).map( i =>
+    ResultHoldBypass(valid = tlb_valid_pulse(i), init = 0.U(ExceptionType.width.W), data = ExceptionType.fromTlbResp(fromITLB(i).bits))
+  ))
+  val s1_itlb_exception_gpf = VecInit(s1_itlb_exception.map(_ === ExceptionType.gpf))
 
   /* Select gpaddr with the first gpf
    * Note: the backend wants the base guest physical address of a fetch block
@@ -180,7 +181,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
    *       see also: https://github.com/OpenXiangShan/XiangShan/blob/344cf5d55568dd40cd658a9ee66047a505eeb504/src/main/scala/xiangshan/frontend/IFU.scala#L374-L375
    */
   val s1_req_gpaddr = PriorityMuxDefault(
-    itlbExcpGPF zip (0 until PortNumber).map(i => s1_req_gpaddr_tmp(i) - (i << blockOffBits).U),
+    s1_itlb_exception_gpf zip (0 until PortNumber).map(i => s1_req_gpaddr_tmp(i) - (i << blockOffBits).U),
     0.U.asTypeOf(s1_req_gpaddr_tmp(0))
   )
 
@@ -203,17 +204,15 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
     * Receive resp from IMeta and check
     ******************************************************************************
     */
-  val s1_req_ptags    = VecInit(s1_req_paddr.map(get_phy_tag(_)))
+  val s1_req_ptags    = VecInit(s1_req_paddr.map(get_phy_tag))
 
   val s1_meta_ptags   = fromMeta.tags
   val s1_meta_valids  = fromMeta.entryValid
-  val s1_meta_errors = VecInit((0 until PortNumber).map( p =>
-    // If error is found in either way, the tag_eq_vec is unreliable, so we do not use waymask, but directly .orR
-    fromMeta.errors(p).asUInt.orR
-  ))
+  // If error is found in either way, the tag_eq_vec is unreliable, so we do not use waymask, but directly .orR
+  val s1_meta_errors = VecInit(fromMeta.errors.map(_.asUInt.orR))
 
   def get_waymask(paddrs: Vec[UInt]): Vec[UInt] = {
-    val ptags         = paddrs.map(get_phy_tag(_))
+    val ptags         = paddrs.map(get_phy_tag)
     val tag_eq_vec    = VecInit((0 until PortNumber).map( p => VecInit((0 until nWays).map( w => s1_meta_ptags(p)(w) === ptags(p)))))
     val tag_match_vec = VecInit((0 until PortNumber).map( k => VecInit(tag_eq_vec(k).zipWithIndex.map{ case(way_tag_eq, w) => way_tag_eq && s1_meta_valids(k)(w)})))
     val waymasks      = VecInit(tag_match_vec.map(_.asUInt))
@@ -236,7 +235,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
     val ptag_same = getPhyTagFromBlk(fromMSHR.bits.blkPaddr) === ptag
     val way_same  = fromMSHR.bits.waymask === mask
     when(valid && vset_same) {
-      when(ptag_same) { 
+      when(ptag_same) {
         new_mask := fromMSHR.bits.waymask
       }.elsewhen(way_same) {
         new_mask := 0.U
@@ -267,10 +266,9 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   toWayLookup.bits.gpaddr       := s1_req_gpaddr
   (0 until PortNumber).foreach { i =>
     val excpValid = (if (i == 0) true.B else s1_doubleline)  // exception in first line is always valid, in second line is valid iff is doubleline request
-    toWayLookup.bits.excp_tlb_af(i)  := excpValid && itlbExcpAF(i)
-    toWayLookup.bits.excp_tlb_pf(i)  := excpValid && itlbExcpPF(i)
-    toWayLookup.bits.excp_tlb_gpf(i) := excpValid && itlbExcpGPF(i)
-    toWayLookup.bits.meta_errors(i)  := excpValid && s1_meta_errors(i)
+    // Send s1_itlb_exception to WayLookup (instead of s1_exception_out) for better timing. Will check pmp again in mainPipe
+    toWayLookup.bits.exception(i)   := Mux(excpValid, s1_itlb_exception(i), ExceptionType.none)
+    toWayLookup.bits.meta_errors(i) := excpValid && s1_meta_errors(i)
   }
 
   val s1_waymasks_vec = s1_waymasks.map(_.asTypeOf(Vec(nWays, Bool())))
@@ -286,13 +284,18 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
     * PMP check
     ******************************************************************************
     */
-  toPMP.zipWithIndex.map { case (p, i) =>
-    p.valid     := s1_valid
+  toPMP.zipWithIndex.foreach { case (p, i) =>
+    // if itlb has exception, paddr can be invalid, therefore pmp check can be skipped
+    p.valid     := s1_valid // && s1_itlb_exception === ExceptionType.none
     p.bits.addr := s1_req_paddr(i)
     p.bits.size := 3.U // TODO
     p.bits.cmd  := TlbCmd.exec
   }
-  val pmpExcp = VecInit((0 until PortNumber).map( i => fromPMP(i).instr || fromPMP(i).mmio ))
+  val s1_pmp_exception = VecInit(fromPMP.map(ExceptionType.fromPMPResp))
+  val s1_mmio          = VecInit(fromPMP.map(_.mmio))
+
+  // merge s1 itlb/pmp exceptions, itlb has higher priority
+  val s1_exception_out = ExceptionType.merge(s1_itlb_exception, s1_pmp_exception)
 
   /**
     ******************************************************************************
@@ -356,16 +359,15 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
     */
   val s2_valid  = generatePipeControl(lastFire = s1_fire, thisFire = s2_fire, thisFlush = s2_flush, lastFlush = false.B)
 
-  val s2_req_vaddr    = RegEnable(s1_req_vaddr, 0.U.asTypeOf(s1_req_vaddr), s1_fire)
-  val s2_doubleline   = RegEnable(s1_doubleline, 0.U.asTypeOf(s1_doubleline), s1_fire)
-  val s2_req_paddr    = RegEnable(s1_req_paddr, 0.U.asTypeOf(s1_req_paddr), s1_fire)
+  val s2_req_vaddr    = RegEnable(s1_req_vaddr,     0.U.asTypeOf(s1_req_vaddr),     s1_fire)
+  val s2_doubleline   = RegEnable(s1_doubleline,    0.U.asTypeOf(s1_doubleline),    s1_fire)
+  val s2_req_paddr    = RegEnable(s1_req_paddr,     0.U.asTypeOf(s1_req_paddr),     s1_fire)
+  val s2_exception    = RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_fire)
+  val s2_mmio         = RegEnable(s1_mmio,          0.U.asTypeOf(s1_mmio),          s1_fire)
+  val s2_waymasks     = RegEnable(s1_waymasks,      0.U.asTypeOf(s1_waymasks),      s1_fire)
 
-  val s2_pmpExcp      = RegEnable(pmpExcp, 0.U.asTypeOf(pmpExcp), s1_fire)
-  val s2_itlbExcp     = RegEnable(itlbExcp, 0.U.asTypeOf(itlbExcp), s1_fire)
-  val s2_waymasks     = RegEnable(s1_waymasks, 0.U.asTypeOf(s1_waymasks), s1_fire)
-
-  val s2_req_vSetIdx  = s2_req_vaddr.map(get_idx(_))
-  val s2_req_ptags    = s2_req_paddr.map(get_phy_tag(_))
+  val s2_req_vSetIdx  = s2_req_vaddr.map(get_idx)
+  val s2_req_ptags    = s2_req_paddr.map(get_phy_tag)
 
   /**
     ******************************************************************************
@@ -387,12 +389,15 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   val s2_SRAM_hits = s2_waymasks.map(_.orR)
   val s2_hits = VecInit((0 until PortNumber).map(i => s2_MSHR_hits(i) || s2_SRAM_hits(i)))
 
-  // pmpExcp includes access fault and mmio, neither of which should be prefetched
-  // also, if port0 has exception, port1 should not be prefetched
-  // miss = this port not hit && need this port && no exception found before and in this port
+  /* s2_exception includes itlb pf/gpf/af and pmp af, neither of which should be prefetched
+   * mmio should not be prefetched
+   * also, if port0 has exception, port1 should not be prefetched
+   * miss = this port not hit && need this port && no exception found before and in this port
+   */
   val s2_miss = VecInit((0 until PortNumber).map { i =>
     !s2_hits(i) && (if (i==0) true.B else s2_doubleline) &&
-      !s2_itlbExcp.take(i+1).reduce(_||_) && !s2_pmpExcp.take(i+1).reduce(_||_)
+      s2_exception.take(i+1).map(_ === ExceptionType.none).reduce(_&&_) &&
+      s2_mmio.take(i+1).map(!_).reduce(_&&_)
   })
 
   /**

--- a/src/main/scala/xiangshan/frontend/icache/WayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/WayLookup.scala
@@ -33,7 +33,7 @@ class WayLookupEntry(implicit p: Parameters) extends ICacheBundle {
   val waymask      : Vec[UInt] = Vec(PortNumber, UInt(nWays.W))
   val ptag         : Vec[UInt] = Vec(PortNumber, UInt(tagBits.W))
   val exception    : Vec[UInt] = Vec(PortNumber, UInt(ExceptionType.width.W))
-  val meta_errors  : Vec[Bool] = Vec(PortNumber, Bool())
+  val meta_corrupt : Vec[Bool] = Vec(PortNumber, Bool())
 }
 
 class WayLookupGPFEntry(implicit p: Parameters) extends ICacheBundle {
@@ -45,12 +45,12 @@ class WayLookupInfo(implicit p: Parameters) extends ICacheBundle {
   val gpf   = new WayLookupGPFEntry
 
   // for compatibility
-  def vSetIdx     : Vec[UInt] = entry.vSetIdx
-  def waymask     : Vec[UInt] = entry.waymask
-  def ptag        : Vec[UInt] = entry.ptag
-  def exception   : Vec[UInt] = entry.exception
-  def meta_errors : Vec[Bool] = entry.meta_errors
-  def gpaddr      : UInt      = gpf.gpaddr
+  def vSetIdx      : Vec[UInt] = entry.vSetIdx
+  def waymask      : Vec[UInt] = entry.waymask
+  def ptag         : Vec[UInt] = entry.ptag
+  def exception    : Vec[UInt] = entry.exception
+  def meta_corrupt : Vec[Bool] = entry.meta_corrupt
+  def gpaddr       : UInt      = gpf.gpaddr
 }
 
 
@@ -137,7 +137,7 @@ class WayLookup(implicit p: Parameters) extends ICacheModule {
           // miss -> hit
           entry.waymask(i) := io.update.bits.waymask
           // also clear previously found errors since data/metaArray is refilled
-          entry.meta_errors(i) := false.B
+          entry.meta_corrupt(i) := false.B
         }.elsewhen(way_same) {
           // data is overwritten: hit -> miss
           entry.waymask(i) := 0.U


### PR DESCRIPTION
Combine `excp_pf`/`_gpf`/`_af` into `exception` to:
1. Reduce code redundancy and improve readability and maintainability
   e.g. `!itlb_excp_af && !itlb_excp_pf && !itlb_excp_gpf && !pmp_excp_af && !pmp_excp_mmio`
   -> `exception === ExcedptionType.none && !mmio`
2. Select exceptions as they are generated (e.g. from iTLB/PMP, or data/meta array ECC check) on a priority basis (e.g. iTLB over PMP), ensuring that there is at most one exception in the pipeline (and on the ports of iCache -> IFU)
3. Save a little bit of pipeline/WayLookup registers (i.e. 3 bit `excp_pf`/`_gpf`/`_af` -> 2bit `exception`)