### PR TITLE
Decode: execute inst will raise EX_II when rm is reserved value

### DIFF
--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -109,6 +109,7 @@ object Bundles {
     val numUops         = UInt(log2Up(MaxUopSize).W) // rob need this
     val numWB           = UInt(log2Up(MaxUopSize).W) // rob need this
     val commitType      = CommitType() // Todo: remove it
+    val needFrm         = new NeedFrmBundle
 
     val debug_fuType    = OptionWrapper(backendParams.debugEn, FuType())
 
@@ -451,6 +452,11 @@ object Bundles {
       this.vsew  := source.vsew
       this.vlmul := source.vlmul
     }
+  }
+
+  class NeedFrmBundle(implicit p: Parameters) extends XSBundle {
+    val scalaNeedFrm = Bool()
+    val vectorNeedFrm = Bool()
   }
 
   // DynInst --[IssueQueue]--> DataPath

--- a/src/main/scala/xiangshan/backend/fu/FuType.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuType.scala
@@ -132,6 +132,8 @@ object FuType extends OHEnumeration {
   val vecArithOrMem = vecArith ++ vecMem
   val vecAll = vecVSET ++ vecArithOrMem
   val fpOP = fpArithAll ++ Seq(i2f, i2v)
+  val scalaNeedFrm = Seq(i2f, fmac, fDivSqrt)
+  val vectorNeedFrm = Seq(vfalu, vfma, vfdiv, vfcvt)
 
   def X = BitPat.N(num) // Todo: Don't Care
 
@@ -202,6 +204,10 @@ object FuType extends OHEnumeration {
   def storeIsAMO(fuType: UInt): Bool = FuTypeOrR(fuType, mou)
 
   def isVppu(fuType: UInt): Bool = FuTypeOrR(fuType, vppu)
+
+  def isScalaNeedFrm(fuType: UInt): Bool = FuTypeOrR(fuType, scalaNeedFrm)
+
+  def isVectorNeedFrm(fuType: UInt): Bool = FuTypeOrR(fuType, vectorNeedFrm)
 
   object FuTypeOrR {
     def apply(fuType: UInt, fu0: OHType, fus: OHType*): Bool = {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -732,9 +732,16 @@ class NewCSR(implicit val p: Parameters) extends Module
     vstart.w.wdata =/= 0.U && vstart.regOut.vstart.asUInt === 0.U
   )
 
+  // flush pipe when write frm and data > 4 or write fcsr and data[7:5] > 4 or write frm/fcsr and frm is reserved
+  val frmIsReserved = fcsr.frm(2) && fcsr.frm(1, 0).orR
+  val frmWdataReserved = fcsr.wAliasFfm.wdata(2) && fcsr.wAliasFfm.wdata(1, 0).orR
+  val fcsrWdataReserved = fcsr.w.wdata(7) && fcsr.w.wdata(6, 5).orR
+  val frmChange = fcsr.wAliasFfm.wen && (!frmIsReserved && frmWdataReserved || frmIsReserved && !frmWdataReserved) ||
+    fcsr.w.wen && (!frmIsReserved && fcsrWdataReserved || frmIsReserved && !fcsrWdataReserved)
+
   val flushPipe = resetSatp ||
     triggerFrontendChange || floatStatusOnOff || vectorStatusOnOff ||
-    vstartChange
+    vstartChange || frmChange
 
   private val rdata = Mux1H(csrRwMap.map { case (id, (_, rdata)) =>
     if (vsMapS.contains(id)) {
@@ -1080,6 +1087,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   io.toDecode.illegalInst.vsIsOff    := mstatus.regOut.VS === ContextStatus.Off || (isModeVS || isModeVU) && vsstatus.regOut.VS === ContextStatus.Off
   io.toDecode.illegalInst.wfi        := isModeHU || !isModeM && mstatus.regOut.TW
   io.toDecode.virtualInst.wfi        := isModeVS && !mstatus.regOut.TW && hstatus.regOut.VTW || isModeVU && !mstatus.regOut.TW
+  io.toDecode.illegalInst.frm        := frmIsReserved
 
   // Always instantiate basic difftest modules.
   if (env.AlwaysBasicDiff || env.EnableDifftest) {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/Unprivileged.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/Unprivileged.scala
@@ -21,7 +21,7 @@ trait Unprivileged { self: NewCSR with MachineLevel with SupervisorLevel =>
     val OF = WARL(2, wNoFilter)
     val DZ = WARL(3, wNoFilter)
     val NV = WARL(4, wNoFilter)
-    val FRM = WARL(7, 5, wNoFilter)
+    val FRM = WARL(7, 5, wNoFilter).withReset(0.U)
   }) with HasRobCommitBundle {
     val wAliasFflags = IO(Input(new CSRAddrWriteBundle(new CSRFFlagsBundle)))
     val wAliasFfm = IO(Input(new CSRAddrWriteBundle(new CSRFrmBundle)))

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -345,6 +345,12 @@ class CSRToDecode(implicit p: Parameters) extends XSBundle {
      * raise EX_II when isModeHU || !isModeM && mstatus.TW=1
      */
     val wfi = Bool()
+
+    /**
+     * frm reserved
+     * raise EX_II when frm.data > 4
+     */
+    val frm = Bool()
   }
   val virtualInst = new Bundle {
     /**


### PR DESCRIPTION
    * When 0 <= inst.rm <= 4, execute inst as usual.
    * When inst.rm = 5/6, execute inst will raise EX_II.
    * When inst.rm = 7, rm = frm.data. if frm.data > 4 will raise EX_II.
    * rm = frm.data for vf* inst.

    * Meanwhile, flush pipe when wen frm/fcsr CSR
        *       1. frm rdata is Reserved and wdata is normal
        *       2. frm rdata is normal and wdata is Reserved

    * inst rely on Spike.