### PR TITLE
LDU, Decode: add support for software prefetch (Zicbop)

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -349,6 +349,10 @@ class DebugBundle(implicit p: Parameters) extends XSBundle {
   // val levelTlbHit = UInt(2.W)
 }
 
+class SoftIfetchPrefetchBundle(implicit p: Parameters) extends XSBundle {
+  val vaddr = UInt(VAddrBits.W)
+}
+
 class ExternalInterruptIO(implicit p: Parameters) extends XSBundle {
   val mtip = Input(Bool())
   val msip = Input(Bool())

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -260,7 +260,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     val mem_to_ooo = new mem_to_ooo
     val fetch_to_mem = new fetch_to_mem
 
-    val IfetchPrefetch = ValidIO(new SoftIfetchPrefetchBundle)
+    val IfetchPrefetch = Vec(LduCnt, ValidIO(new SoftIfetchPrefetchBundle))
     
     // misc
     val error = ValidIO(new L1CacheErrorInfo)
@@ -725,7 +725,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     loadUnits(i).io.fast_rep_in <> loadUnits(i).io.fast_rep_out
     
     // SoftPrefetch to frontend (prefetch.i)
-    loadUnits(i).io.IfetchPrefetch <> io.IfetchPrefetch
+    loadUnits(i).io.IfetchPrefetch <> io.IfetchPrefetch(i)
 
     // dcache access
     loadUnits(i).io.dcache <> dcache.io.lsu.load(i)

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -260,6 +260,8 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     val mem_to_ooo = new mem_to_ooo
     val fetch_to_mem = new fetch_to_mem
 
+    val IfetchPrefetch = ValidIO(new SoftIfetchPrefetchBundle)
+    
     // misc
     val error = ValidIO(new L1CacheErrorInfo)
     val memInfo = new Bundle {
@@ -721,6 +723,9 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
 
     // fast replay
     loadUnits(i).io.fast_rep_in <> loadUnits(i).io.fast_rep_out
+    
+    // SoftPrefetch to frontend (prefetch.i)
+    loadUnits(i).io.IfetchPrefetch <> io.IfetchPrefetch
 
     // dcache access
     loadUnits(i).io.dcache <> dcache.io.lsu.load(i)

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -982,24 +982,19 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
     decodedInst.exceptionVec(illegalInstr) := io.fromCSR.illegalInst.vsIsOff
   }
 
-  // val isSoftPrefetch = decodedInst.isSoftPrefetch
+  // decode for SoftPrefetch instructions (prefetch.w / prefetch.r / prefetch.i)
   val isSoftPrefetch = inst.OPCODE === BitPat("b0010011") && inst.FUNCT3 === BitPat("b110") && inst.RD === 0.U
   val isPreW = isSoftPrefetch && inst.RS2 === 3.U(5.W)
   val isPreR = isSoftPrefetch && inst.RS2 === 1.U(5.W)
   val isPreI = isSoftPrefetch && inst.RS2 === 0.U(5.W)
 
-  when(isSoftPrefetch){
+  when(isPreW || isPreR || isPreI){
     decodedInst.selImm := SelImm.IMM_S
     decodedInst.fuType := FuType.ldu.U
     decodedInst.canRobCompress := false.B
-    // decodedInst.xWen := false.B
-    when(isPreW){
-      decodedInst.fuOpType := LSUOpType.prefetch_w
-    }.elsewhen(isPreR){
-      decodedInst.fuOpType := LSUOpType.prefetch_r
-    }.elsewhen(isPreI){
-      decodedInst.fuOpType := LSUOpType.prefetch_i
-    }
+    decodedInst.fuOpType := Mux(isPreW,
+                                LSUOpType.prefetch_w,
+                                Mux(isPreR, LSUOpType.prefetch_r, LSUOpType.prefetch_i))
   }
 
   io.deq.decodedInst := decodedInst

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1439,7 +1439,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s3_outexception = ExceptionNO.selectByFu(s3_out.bits.uop.exceptionVec, LduCfg).asUInt.orR && s3_vecActive
   io.ldout.bits        := s3_ld_wb_meta
   io.ldout.bits.data   := Mux(s3_valid, s3_ld_data_frm_cache, s3_ld_data_frm_uncache)
-  io.ldout.valid       := (s3_out.valid && !s3_vecout.isvec || (s3_mmio.valid && !s3_valid) || (s3_in.isPrefetch && !s3_in.isHWPrefetch && s3_valid))
+  io.ldout.valid       := (s3_out.valid && !s3_vecout.isvec || (s3_mmio.valid && !s3_valid))
   io.ldout.bits.uop.exceptionVec := ExceptionNO.selectByFu(s3_ld_wb_meta.uop.exceptionVec, LduCfg)
 
   // TODO: check this --hx

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -221,6 +221,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     val prf           = Bool()
     val prf_rd        = Bool()
     val prf_wr        = Bool()
+    val prf_i         = Bool()
     val sched_idx     = UInt(log2Up(LoadQueueReplaySize+1).W)
     val hlv           = Bool()
     val hlvx          = Bool()
@@ -371,7 +372,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.canAcceptHighConfPrefetch := s0_high_conf_prf_ready && io.dcache.req.ready
 
   // query DTLB
-  io.tlb.req.valid                   := s0_valid && !s0_hw_prf_select // if is hardware prefetch, don't send valid to tlb, but need no_translate
+  io.tlb.req.valid                   := s0_valid && !s0_hw_prf_select && !s0_sel_src.prf_i  // if is hardware prefetch, don't send valid to tlb, but need no_translate
   io.tlb.req.bits.cmd                := Mux(s0_sel_src.prf,
                                          Mux(s0_sel_src.prf_wr, TlbCmd.write, TlbCmd.read),
                                          TlbCmd.read
@@ -390,7 +391,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.debug.isFirstIssue := s0_sel_src.isFirstIssue
 
   // query DCache
-  io.dcache.req.valid             := s0_valid
+  io.dcache.req.valid             := s0_valid && !s0_sel_src.prf_i
   io.dcache.req.bits.cmd          := Mux(s0_sel_src.prf_rd,
                                       MemoryOpConstants.M_PFR,
                                       Mux(s0_sel_src.prf_wr, MemoryOpConstants.M_PFW, MemoryOpConstants.M_XRD)
@@ -428,6 +429,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     out.prf           := LSUOpType.isPrefetch(src.uop.fuOpType) && !src.isvec
     out.prf_rd        := src.uop.fuOpType === LSUOpType.prefetch_r
     out.prf_wr        := src.uop.fuOpType === LSUOpType.prefetch_w
+    out.prf_i         := false.B
     out.sched_idx     := src.schedIndex
     out.isvec         := src.isvec
     out.is128bit      := src.is128bit
@@ -461,6 +463,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     out.prf           := false.B
     out.prf_rd        := false.B
     out.prf_wr        := false.B
+    out.prf_i         := false.B
     out.sched_idx     := 0.U
     out.hlv           := LSUOpType.isHlv(src.uop.fuOpType)
     out.hlvx          := LSUOpType.isHlvx(src.uop.fuOpType)
@@ -483,6 +486,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     out.prf           := LSUOpType.isPrefetch(src.uop.fuOpType) && !src.isvec
     out.prf_rd        := src.uop.fuOpType === LSUOpType.prefetch_r
     out.prf_wr        := src.uop.fuOpType === LSUOpType.prefetch_w
+    out.prf_i         := false.B
     out.sched_idx     := src.schedIndex
     out.isvec         := src.isvec
     out.is128bit      := src.is128bit
@@ -516,6 +520,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     out.prf           := true.B
     out.prf_rd        := !src.is_store
     out.prf_wr        := src.is_store
+    out.prf_i         := false.B
     out.sched_idx     := 0.U
     out
   }
@@ -537,6 +542,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     out.prf           := false.B
     out.prf_rd        := false.B
     out.prf_wr        := false.B
+    out.prf_i         := false.B
     out.sched_idx     := 0.U
     // Vector load interface
     out.isvec               := true.B
@@ -577,6 +583,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     out.prf           := LSUOpType.isPrefetch(src.uop.fuOpType)
     out.prf_rd        := src.uop.fuOpType === LSUOpType.prefetch_r
     out.prf_wr        := src.uop.fuOpType === LSUOpType.prefetch_w
+    out.prf_i         := src.uop.fuOpType === LSUOpType.prefetch_i
     out.sched_idx     := 0.U
     out.hlv           := LSUOpType.isHlv(src.uop.fuOpType)
     out.hlvx          := LSUOpType.isHlvx(src.uop.fuOpType)
@@ -604,6 +611,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     out.prf                := false.B
     out.prf_rd             := false.B
     out.prf_wr             := false.B
+    out.prf_i              := false.B
     out.sched_idx          := 0.U
     out.hlv                := LSUOpType.isHlv(out.uop.fuOpType)
     out.hlvx               := LSUOpType.isHlvx(out.uop.fuOpType)
@@ -745,7 +753,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     io.ldin.bits.uop,
   )
   val s0_wakeup_uop = ParallelPriorityMux(s0_wakeup_selector, s0_wakeup_format)
-  io.wakeup.valid := !s0_sel_src.isvec && s0_fire && (s0_super_ld_rep_valid || s0_ld_fast_rep_valid || s0_ld_rep_valid || s0_int_iss_valid && !s0_vec_iss_valid && !s0_high_conf_prf_valid) || s0_mmio_fire
+  io.wakeup.valid := !s0_sel_src.isvec && s0_fire && (s0_super_ld_rep_valid || s0_ld_fast_rep_valid || s0_ld_rep_valid || (s0_int_iss_valid && !s0_sel_src.prf) && !s0_vec_iss_valid && !s0_high_conf_prf_valid) || s0_mmio_fire
   io.wakeup.bits := s0_wakeup_uop
 
   XSDebug(io.dcache.req.fire,
@@ -1181,7 +1189,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     !s1_kill &&
     !io.tlb.resp.bits.miss &&
     !io.lsq.forward.dataInvalidFast
-  io.fast_uop.valid := GatedValidRegNext(s1_fast_uop_valid) && (s2_valid && !s2_out.rep_info.need_rep && !s2_mmio) && !s2_isvec
+  io.fast_uop.valid := GatedValidRegNext(s1_fast_uop_valid) && (s2_valid && !s2_out.rep_info.need_rep && !s2_mmio && !(s2_prf && !s2_hw_prf)) && !s2_isvec
   io.fast_uop.bits := RegEnable(s1_out.uop, s1_fast_uop_valid)
 
   //
@@ -1431,7 +1439,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s3_outexception = ExceptionNO.selectByFu(s3_out.bits.uop.exceptionVec, LduCfg).asUInt.orR && s3_vecActive
   io.ldout.bits        := s3_ld_wb_meta
   io.ldout.bits.data   := Mux(s3_valid, s3_ld_data_frm_cache, s3_ld_data_frm_uncache)
-  io.ldout.valid       := (s3_out.valid && !s3_vecout.isvec || (s3_mmio.valid && !s3_valid))
+  io.ldout.valid       := (s3_out.valid && !s3_vecout.isvec || (s3_mmio.valid && !s3_valid) || (s3_in.isPrefetch && !s3_in.isHWPrefetch && s3_valid))
   io.ldout.bits.uop.exceptionVec := ExceptionNO.selectByFu(s3_ld_wb_meta.uop.exceptionVec, LduCfg)
 
   // TODO: check this --hx

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -148,6 +148,9 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     val canAcceptLowConfPrefetch  = Output(Bool())
     val canAcceptHighConfPrefetch = Output(Bool())
 
+    // IfetchPrefetch
+    val IfetchPrefetch = ValidIO(new SoftIfetchPrefetchBundle)
+
     // load to load fast path
     val l2l_fwd_in    = Input(new LoadToLoadIO)
     val l2l_fwd_out   = Output(new LoadToLoadIO)
@@ -755,6 +758,10 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s0_wakeup_uop = ParallelPriorityMux(s0_wakeup_selector, s0_wakeup_format)
   io.wakeup.valid := !s0_sel_src.isvec && s0_fire && (s0_super_ld_rep_valid || s0_ld_fast_rep_valid || s0_ld_rep_valid || (s0_int_iss_valid && !s0_sel_src.prf) && !s0_vec_iss_valid && !s0_high_conf_prf_valid) || s0_mmio_fire
   io.wakeup.bits := s0_wakeup_uop
+
+  // prefetch.i(Zicbop)
+  io.IfetchPrefetch.valid := s0_int_iss_valid && s0_sel_src.prf_i
+  io.IfetchPrefetch.bits.vaddr := s0_out.vaddr
 
   XSDebug(io.dcache.req.fire,
     p"[DCACHE LOAD REQ] pc ${Hexadecimal(s0_sel_src.uop.pc)}, vaddr ${Hexadecimal(s0_dcache_vaddr)}\n"


### PR DESCRIPTION
1. Support RVA23 SoftPrefetch instructions, include prefetch.i , prefetch.w and prefetch.r.
2. In DecodeUnit, add decode of SoftPrefetch.
3. prefetch.i , prefetch.w and prefetch.r will be dispatch into load-pipe, and then prefetch.w and prefetch.r execute like a load.
4. preftch.i just calculate address in loadUnit, then transfer address to Frontend.(TODO)
5. All SoftPrefetch instructions return “ldout” signals to Backend in stage3 wether hit or miss.
