### PR TITLE
CSR: fix custom IRQ injection mechanism

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -305,6 +305,8 @@ class NewCSR(implicit val p: Parameters) extends Module
   trapHandleMod.io.in.medeleg := medeleg.regOut
   trapHandleMod.io.in.hideleg := hideleg.regOut
   trapHandleMod.io.in.hedeleg := hedeleg.regOut
+  trapHandleMod.io.in.mvien := mvien.regOut
+  trapHandleMod.io.in.hvien := hvien.regOut
   trapHandleMod.io.in.mtvec := mtvec.regOut
   trapHandleMod.io.in.stvec := stvec.regOut
   trapHandleMod.io.in.vstvec := vstvec.regOut

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/TrapHandleModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/TrapHandleModule.scala
@@ -17,6 +17,8 @@ class TrapHandleModule extends Module {
   private val hideleg = io.in.hideleg.asUInt
   private val medeleg = io.in.medeleg.asUInt
   private val hedeleg = io.in.hedeleg.asUInt
+  private val mvien = io.in.mvien.asUInt
+  private val hvien = io.in.hvien.asUInt
 
   private val hasTrap = trapInfo.valid
   private val hasIR = hasTrap && trapInfo.bits.isInterrupt
@@ -70,9 +72,9 @@ class TrapHandleModule extends Module {
   private val highestPrioIR = highestPrioIRVec.asUInt
   private val highestPrioEX = highestPrioEXVec.asUInt
 
-  private val mIRVec  = highestPrioIR
-  private val hsIRVec = highestPrioIR & mideleg
-  private val vsIRVec = highestPrioIR & mideleg & hideleg
+  private val mIRVec  = dontTouch(WireInit(highestPrioIR))
+  private val hsIRVec = (mIRVec  & mideleg) | (mIRVec  & mvien & ~mideleg)
+  private val vsIRVec = (hsIRVec & hideleg) | (hsIRVec & hvien & ~hideleg)
 
   private val mEXVec  = highestPrioEX
   private val hsEXVec = highestPrioEX & medeleg
@@ -159,6 +161,8 @@ class TrapHandleIO extends Bundle {
     val medeleg = new MedelegBundle
     val hideleg = new HidelegBundle
     val hedeleg = new HedelegBundle
+    val mvien = new MvienBundle
+    val hvien = new HvienBundle
     // trap vector
     val mtvec = Input(new XtvecBundle)
     val stvec = Input(new XtvecBundle)


### PR DESCRIPTION
* The injected interrupts for HS mode can set some bits in mIRVec and hsIRVec.
* `mIRVec` holds the highest priority interrupt numbered from 1 to 63. Only interrupt 1-13 can trap in M mode. And interrupt 14-63 must trap in HS mode or VS mode, since bits in mideleg(63,14) are read-only 0.
* `hsIRVec` holds the mip parts(by mIRVec & mideleg) and mvip parts(by mIRVec & ~mideleg & mvien) interrupts.
* `vsIRVec` holds the sip|hip parts(by hsIRVec & hideleg) and hvip parts(by hsIRVec & ~hideleg & hvien) interrupts.