### PR TITLE
ICache: raise af if meta/data array ECC fail

### DIFF
--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -141,8 +141,8 @@ object ExceptionType {
   }
 
   // raise af if meta/data array ecc check failed or l2 cache respond with tilelink corrupt
-  def fromECC(corrupt: Bool): UInt = {
-    Mux(corrupt, af, none)
+  def fromECC(enable: Bool, corrupt: Bool): UInt = {
+    Mux(enable && corrupt, af, none)
   }
 
   /**Generates exception mux tree

--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -141,6 +141,19 @@ object ExceptionType {
   }
 
   // raise af if meta/data array ecc check failed or l2 cache respond with tilelink corrupt
+  /* FIXME: RISC-V Machine ISA v1.13 (draft) introduced a "hardware error" exception, described as:
+   * > A Hardware Error exception is a synchronous exception triggered when corrupted or
+   * > uncorrectable data is accessed explicitly or implicitly by an instruction. In this context,
+   * > "data" encompasses all types of information used within a RISC-V hart. Upon a hardware
+   * > error exception, the xepc register is set to the address of the instruction that attempted to
+   * > access corrupted data, while the xtval register is set either to 0 or to the virtual address
+   * > of an instruction fetch, load, or store that attempted to access corrupted data. The priority
+   * > of Hardware Error exception is implementation-defined, but any given occurrence is
+   * > generally expected to be recognized at the point in the overall priority order at which the
+   * > hardware error is discovered.
+   * Maybe it's better to raise hardware error instead of access fault when ECC check failed.
+   * But it's draft and XiangShan backend does not implement this exception code yet, so we still raise af here.
+   */
   def fromECC(enable: Bool, corrupt: Bool): UInt = {
     Mux(enable && corrupt, af, none)
   }

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -516,6 +516,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
 
   prefetcher.io.flush             := io.flush
   prefetcher.io.csr_pf_enable     := io.csr_pf_enable
+  prefetcher.io.csr_parity_enable := io.csr_parity_enable
   prefetcher.io.ftqReq            <> io.prefetch
   prefetcher.io.MSHRResp          := missUnit.io.fetch_resp
 

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -252,7 +252,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   val s1_mmio          = VecInit(fromPMP.map(_.mmio))
 
   // also raise af when meta array corrupt is detected, to cancel fetch
-  val s1_meta_exception = VecInit(s1_meta_corrupt.map(ExceptionType.fromECC))
+  val s1_meta_exception = VecInit(s1_meta_corrupt.map(ExceptionType.fromECC(io.csr_parity_enable, _)))
 
   // merge s1 itlb/pmp/meta exceptions, itlb has the highest priority, pmp next, meta lowest
   val s1_exception_out = ExceptionType.merge(
@@ -423,7 +423,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   val s2_fetch_finish = !s2_miss.reduce(_||_)
   val s2_exception_out = ExceptionType.merge(
     s2_exception,
-    VecInit(s2_l2_corrupt.map(ExceptionType.fromECC))
+    VecInit(s2_l2_corrupt.map(ExceptionType.fromECC(true.B, _)))
     // FIXME: maybe we should also raise af if meta/data error is detected
 //     VecInit((s2_meta_corrupt zip s2_data_corrupt zip s2_l2_corrupt).map{ case ((m, d), l2) => ExceptionType.fromECC(m || d || l2)}
   )

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -35,6 +35,7 @@ abstract class IPrefetchModule(implicit p: Parameters) extends ICacheModule
 class IPrefetchIO(implicit p: Parameters) extends IPrefetchBundle {
   // control
   val csr_pf_enable     = Input(Bool())
+  val csr_parity_enable = Input(Bool())
   val flush             = Input(Bool())
 
   val ftqReq            = Flipped(new FtqToPrefetchIO)
@@ -295,7 +296,7 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   val s1_mmio          = VecInit(fromPMP.map(_.mmio))
 
   // also raise af when meta array corrupt is detected, to cancel prefetch
-  val s1_meta_exception = VecInit(s1_meta_corrupt.map(ExceptionType.fromECC))
+  val s1_meta_exception = VecInit(s1_meta_corrupt.map(ExceptionType.fromECC(io.csr_parity_enable, _)))
 
   // merge s1 itlb/pmp/meta exceptions, itlb has the highest priority, pmp next, meta lowest
   val s1_exception_out = ExceptionType.merge(


### PR DESCRIPTION
In current design, meta/data array corruption does not raise any exception (whether or not `io.csr_parity_enable === true.B`), which may pose two problems:
1. When meta corrupt, `ptag` comparison result may be invalid, and thus cache hit may be treated as a cache miss, thereby sending (pre)fetch request to L2 cache incorrectly;
2. When meta/data/l2 corrupt, instruction data sent to the backend may be invalid. Although the errors are sent to beu, which sends an interrupt via plic, the timing of the interrupt is not as controllable as an exception. It is therefore reasonable to mark invalid data as access fault to keep it from execution.

This PR:
1. Raise af if meta/data array ECC fail (when `io.csr_parity_enable === true.B`), the priority of this af is lower than iTLB & PMP exceptions
2. Cancle (pre)fetching if meta array ECC fail (by merging `meta_corrupt` exceptions to `s2_exception`)

Note:
RISC-V Machine ISA v1.13 (draft) introduced a "hardware error" exception, described as:
> A Hardware Error exception is a synchronous exception triggered when corrupted or uncorrectable data is accessed explicitly or implicitly by an instruction. In this context, "data" encompasses all types of information used within a RISC-V hart. Upon a hardware error exception, the xepc register is set to the address of the instruction that attempted to access corrupted data, while the xtval register is set either to 0 or to the virtual address of an instruction fetch, load, or store that attempted to access corrupted data. The priority of Hardware Error exception is implementation-defined, but any given occurrence is generally expected to be recognized at the point in the overall priority order at which the hardware error is discovered.

Maybe it's better to raise hardware error instead of access fault when ECC check failed. But it's draft and XiangShan backend does not implement this exception code yet, so we still raise af here. This may need to be modified in the future.