### PR TITLE
DCache: Remove wbq conflict check to LoadPipe/MainPipe to fix timing

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -118,6 +118,9 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     val miss_req = DecoupledIO(new MissReq)
     val miss_resp = Input(new MissResp) // miss resp is used to support plru update
     val refill_req = Flipped(DecoupledIO(new MainPipeReq))
+    // send miss request to wbq
+    val wbq_conflict_check = Valid(UInt())
+    val wbq_block_miss_req = Input(Bool())
     // store buffer
     val store_req = Flipped(DecoupledIO(new DCacheLineReq))
     val store_replay_resp = ValidIO(new DCacheLineResp)
@@ -442,7 +445,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     s2_valid_dup_for_status.foreach(_ := false.B)
   }
   s2_ready := !s2_valid_dup(3) || s2_can_go
-  val replay = !io.miss_req.ready
+  val replay = !io.miss_req.ready || io.wbq_block_miss_req
 
   val data_resp = Wire(io.data_resp.cloneType)
   data_resp := Mux(GatedValidRegNext(s1_fire), io.data_resp, RegEnable(data_resp, s2_valid))
@@ -1447,6 +1450,9 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   miss_req.cancel := false.B
   miss_req.pc := DontCare
   miss_req.full_overwrite := s2_req.isStore && s2_req.store_mask.andR
+
+  io.wbq_conflict_check.valid := s2_valid_dup(4) && s2_can_go_to_mq_dup(0)
+  io.wbq_conflict_check.bits := s2_req.addr
 
   io.store_replay_resp.valid := s2_valid_dup(5) && s2_can_go_to_mq_dup(1) && replay && s2_req.isStore
   io.store_replay_resp.bits.data := DontCare

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
@@ -315,8 +315,9 @@ class WritebackQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
     //val probe_ttob_check_req = Flipped(ValidIO(new ProbeToBCheckReq))
     //val probe_ttob_check_resp = ValidIO(new ProbeToBCheckResp)
 
-    val miss_req = Flipped(Valid(UInt()))
-    val block_miss_req = Output(Bool()) 
+    // 5 miss_req to check: 3*LoadPipe + 1*MainPipe + 1*missReqArb_out
+    val miss_req_conflict_check = Vec(LoadPipelineWidth + 2, Flipped(Valid(UInt())))
+    val block_miss_req = Vec(LoadPipelineWidth + 2, Output(Bool()))
   })
 
   require(cfg.nReleaseEntries > cfg.nMissEntries)
@@ -373,8 +374,12 @@ class WritebackQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
 
   io.mem_grant.ready := true.B
   block_conflict := VecInit(entries.map(e => e.io.block_addr.valid && e.io.block_addr.bits === io.req.bits.addr)).asUInt.orR
-  val miss_req_conflict = VecInit(entries.map(e => e.io.block_addr.valid && e.io.block_addr.bits === io.miss_req.bits)).asUInt.orR
-  io.block_miss_req := io.miss_req.valid && miss_req_conflict
+  val miss_req_conflict = io.miss_req_conflict_check.map{ r =>
+    VecInit(entries.map(e => e.io.block_addr.valid && e.io.block_addr.bits === r.bits)).asUInt.orR
+  }
+  io.block_miss_req.zipWithIndex.foreach{ case(blk, i) =>
+    blk := io.miss_req_conflict_check(i).valid && miss_req_conflict(i)
+  }
 
   TLArbiter.robin(edge, io.mem_release, entries.map(_.io.mem_release):_*)
 
@@ -389,13 +394,13 @@ class WritebackQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
     io.mem_grant.bits.dump
   }
 
-  when (io.miss_req.valid) {
-    XSDebug("miss_req: addr: %x\n", io.miss_req.bits)
-  }
+  // when (io.miss_req.valid) {
+  //   XSDebug("miss_req: addr: %x\n", io.miss_req.bits)
+  // }
 
-  when (io.block_miss_req) {
-    XSDebug("block_miss_req\n")
-  }
+  // when (io.block_miss_req) {
+  //   XSDebug("block_miss_req\n")
+  // }
 
   // performance counters
   XSPerfAccumulate("wb_req", io.req.fire)


### PR DESCRIPTION
Fix timing of DCache missqueue enq:

- Remove wbq_block from path missReqArb - wbq - mshr_handled - LoadPipe.handled
- Move wbq block_miss_req_check to LoadPipe/MainPipe separately when issue miss_req