### PR TITLE
Memblock: optimize timing

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -576,7 +576,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   dtlb.map(_.sfence := sfence)
   dtlb.map(_.csr := tlbcsr)
   dtlb.map(_.flushPipe.map(a => a := false.B)) // non-block doesn't need
-  dtlb.map(_.redirect := io.redirect)
+  dtlb.map(_.redirect := redirect)
   if (refillBothTlb) {
     require(ldtlbParams.outReplace == sttlbParams.outReplace)
     require(ldtlbParams.outReplace == hytlbParams.outReplace)

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -1618,7 +1618,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   vSegmentUnit.io.dtlb.resp.valid <> dtlb_reqs.take(LduCnt).head.resp.valid
   vSegmentUnit.io.pmpResp <> pmp_check.head.resp
   vSegmentUnit.io.flush_sbuffer.empty := stIsEmpty
-  vSegmentUnit.io.redirect <> io.redirect
+  vSegmentUnit.io.redirect <> redirect
   vSegmentUnit.io.rdcache.resp.bits := dcache.io.lsu.load(0).resp.bits
   vSegmentUnit.io.rdcache.resp.valid := dcache.io.lsu.load(0).resp.valid
   vSegmentUnit.io.rdcache.s2_bank_conflict := dcache.io.lsu.load(0).s2_bank_conflict

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -1161,11 +1161,17 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   }
 
   // mmio store writeback will use store writeback port 0
-  lsq.io.mmioStout.ready := false.B
-  when (lsq.io.mmioStout.valid && !storeUnits(0).io.stout.valid) {
+  val mmioStout = WireInit(0.U.asTypeOf(lsq.io.mmioStout))
+  NewPipelineConnect(
+    lsq.io.mmioStout, mmioStout, mmioStout.fire,
+    false.B,
+    Option("mmioStOutConnect")
+  )
+  mmioStout.ready := false.B
+  when (mmioStout.valid && !storeUnits(0).io.stout.valid) {
     stOut(0).valid := true.B
-    stOut(0).bits  := lsq.io.mmioStout.bits
-    lsq.io.mmioStout.ready := true.B
+    stOut(0).bits  := mmioStout.bits
+    mmioStout.ready := true.B
   }
   // vec mmio writeback
   lsq.io.vecmmioStout.ready := false.B

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -1360,9 +1360,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     vsSplit(i).io.toMergeBuffer <> vsMergeBuffer(i).io.fromSplit.head
     NewPipelineConnect(
       vsSplit(i).io.out, storeUnits(i).io.vecstin, storeUnits(i).io.vecstin.fire,
-      Mux(vsSplit(i).io.out.fire,
-          vsSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect),
-          storeUnits(i).io.vecstin.bits.uop.robIdx.needFlush(io.redirect)),
+      vsSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect),
       Option("VsSplitConnectStu")
     )
     vsSplit(i).io.vstd.get := DontCare // Todo: Discuss how to pass vector store data
@@ -1376,9 +1374,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     vlSplit(i).io.toMergeBuffer <> vlMergeBuffer.io.fromSplit(i)
     NewPipelineConnect(
       vlSplit(i).io.out, loadUnits(i).io.vecldin, loadUnits(i).io.vecldin.fire,
-      Mux(vlSplit(i).io.out.fire,
-          vlSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect),
-          loadUnits(i).io.vecldin.bits.uop.robIdx.needFlush(io.redirect)),
+      vlSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect),
       Option("VlSplitConnectLdu")
     )
 

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -781,7 +781,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
       val vsegmentDtlbReqValid = vSegmentUnit.io.dtlb.req.valid // segment tlb resquest need to delay 1 cycle
       dtlb_reqs.take(LduCnt)(i).req.valid := loadUnits(i).io.tlb.req.valid || RegNext(vsegmentDtlbReqValid)
       vSegmentUnit.io.dtlb.req.ready      := dtlb_reqs.take(LduCnt)(i).req.ready
-      dtlb_reqs.take(LduCnt)(i).req.bits  := Mux1H(Seq(
+      dtlb_reqs.take(LduCnt)(i).req.bits  := ParallelPriorityMux(Seq(
         RegNext(vsegmentDtlbReqValid)     -> RegEnable(vSegmentUnit.io.dtlb.req.bits, vsegmentDtlbReqValid),
         loadUnits(i).io.tlb.req.valid     -> loadUnits(i).io.tlb.req.bits
       ))

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -131,11 +131,9 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   // check pmp use paddr (for timing optization, use pmp_addr here)
   // check permisson
   (0 until Width).foreach{i =>
-    when (RegNext(req(i).bits.no_translate)) {
-      pmp_check(req(i).bits.pmp_addr, req_out(i).size, req_out(i).cmd, i)
-    } .otherwise {
-      pmp_check(pmp_addr(i), req_out(i).size, req_out(i).cmd, i)
-    }
+    val noTranslateReg = RegNext(req(i).bits.no_translate)
+    val addr = Mux(noTranslateReg, req(i).bits.pmp_addr, pmp_addr(i))
+    pmp_check(addr, req_out(i).size, req_out(i).cmd, noTranslateReg, i)
     for (d <- 0 until nRespDups) {
       perm_check(perm(i)(d), req_out(i).cmd, i, d, g_perm(i)(d), req_out(i).hlvx, req_out_s2xlate(i))
     }
@@ -215,8 +213,8 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     (hit, miss, pmp_paddr, perm, g_perm)
   }
 
-  def pmp_check(addr: UInt, size: UInt, cmd: UInt, idx: Int): Unit = {
-    pmp(idx).valid := resp(idx).valid
+  def pmp_check(addr: UInt, size: UInt, cmd: UInt, noTranslate: Bool, idx: Int): Unit = {
+    pmp(idx).valid := resp(idx).valid || noTranslate
     pmp(idx).bits.addr := addr
     pmp(idx).bits.size := size
     pmp(idx).bits.cmd := cmd
@@ -356,7 +354,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
         resp(idx).bits.gpaddr(d) := s1_paddr
         perm_check(stage1, req_out(idx).cmd, idx, d, stage2, req_out(idx).hlvx, s2xlate)
       }
-      pmp_check(resp(idx).bits.paddr(0), req_out(idx).size, req_out(idx).cmd, idx)
+      pmp_check(resp(idx).bits.paddr(0), req_out(idx).size, req_out(idx).cmd, false.B, idx)
 
       // NOTE: the unfiltered req would be handled by Repeater
     }

--- a/src/main/scala/xiangshan/mem/MemCommon.scala
+++ b/src/main/scala/xiangshan/mem/MemCommon.scala
@@ -147,6 +147,8 @@ class LsPipelineBundle(implicit p: Parameters) extends XSBundle
   val ldCancel = ValidUndirectioned(UInt(log2Ceil(LoadPipelineWidth).W))
   // loadQueueReplay index.
   val schedIndex = UInt(log2Up(LoadQueueReplaySize).W)
+  // hardware prefetch and fast replay no need to query tlb
+  val tlbNoQuery = Bool()
 }
 
 class LdPrefetchTrainBundle(implicit p: Parameters) extends LsPipelineBundle {
@@ -174,6 +176,7 @@ class LdPrefetchTrainBundle(implicit p: Parameters) extends LsPipelineBundle {
     if (latch) hasROBEntry := RegEnable(input.hasROBEntry, enable) else hasROBEntry := input.hasROBEntry
     if (latch) dcacheRequireReplay := RegEnable(input.dcacheRequireReplay, enable) else dcacheRequireReplay := input.dcacheRequireReplay
     if (latch) schedIndex := RegEnable(input.schedIndex, enable) else schedIndex := input.schedIndex
+    if (latch) tlbNoQuery := RegEnable(input.tlbNoQuery, enable) else tlbNoQuery := input.tlbNoQuery
     if (latch) isvec               := RegEnable(input.isvec, enable)               else isvec               := input.isvec
     if (latch) isLastElem          := RegEnable(input.isLastElem, enable)          else isLastElem          := input.isLastElem
     if (latch) is128bit            := RegEnable(input.is128bit, enable)            else is128bit            := input.is128bit

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -859,9 +859,10 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   when (!s1_dly_err) {
     // current ori test will cause the case of ldest == 0, below will be modifeid in the future.
     // af & pf exception were modified
-    s1_out.uop.exceptionVec(loadPageFault)   := io.tlb.resp.bits.excp(0).pf.ld && s1_vecActive && !s1_tlb_miss
-    s1_out.uop.exceptionVec(loadGuestPageFault)   := io.tlb.resp.bits.excp(0).gpf.ld && !s1_tlb_miss
-    s1_out.uop.exceptionVec(loadAccessFault) := io.tlb.resp.bits.excp(0).af.ld && s1_vecActive && !s1_tlb_miss
+    // if is tlbNoQuery request, don't trigger exception from tlb resp
+    s1_out.uop.exceptionVec(loadPageFault)   := io.tlb.resp.bits.excp(0).pf.ld && s1_vecActive && !s1_tlb_miss && !s1_in.tlbNoQuery
+    s1_out.uop.exceptionVec(loadGuestPageFault)   := io.tlb.resp.bits.excp(0).gpf.ld && !s1_tlb_miss && !s1_in.tlbNoQuery
+    s1_out.uop.exceptionVec(loadAccessFault) := io.tlb.resp.bits.excp(0).af.ld && s1_vecActive && !s1_tlb_miss && !s1_in.tlbNoQuery
   } .otherwise {
     s1_out.uop.exceptionVec(loadPageFault)      := false.B
     s1_out.uop.exceptionVec(loadGuestPageFault) := false.B

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -352,6 +352,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   dontTouch(s0_int_iss_select)
   dontTouch(s0_l2l_fwd_select)
 
+  val s0_tlb_no_query        = s0_ld_fast_rep_select || s0_hw_prf_select
   s0_valid := (s0_super_ld_rep_valid ||
                s0_ld_fast_rep_valid ||
                s0_ld_rep_valid ||
@@ -375,7 +376,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.canAcceptHighConfPrefetch := s0_high_conf_prf_ready && io.dcache.req.ready
 
   // query DTLB
-  io.tlb.req.valid                   := s0_valid && !s0_hw_prf_select && !s0_sel_src.prf_i  // if is hardware prefetch, don't send valid to tlb, but need no_translate
+  io.tlb.req.valid                   := s0_valid && !s0_tlb_no_query && !s0_sel_src.prf_i // if is hardware prefetch or fast replay, don't send valid to tlb, but need no_translate
   io.tlb.req.bits.cmd                := Mux(s0_sel_src.prf,
                                          Mux(s0_sel_src.prf_wr, TlbCmd.write, TlbCmd.read),
                                          TlbCmd.read
@@ -389,7 +390,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.memidx.is_st       := false.B
   io.tlb.req.bits.memidx.idx         := s0_sel_src.uop.lqIdx.value
   io.tlb.req.bits.debug.robIdx       := s0_sel_src.uop.robIdx
-  io.tlb.req.bits.no_translate       := s0_hw_prf_select  // hw b.reqetch addr does not need to be translated, need this signal for pmp check
+  io.tlb.req.bits.no_translate       := s0_tlb_no_query  // hardware prefetch and fast replay does not need to be translated, need this signal for pmp check
   io.tlb.req.bits.debug.pc           := s0_sel_src.uop.pc
   io.tlb.req.bits.debug.isFirstIssue := s0_sel_src.isFirstIssue
 
@@ -646,24 +647,11 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   )
   s0_sel_src := ParallelPriorityMux(s0_src_selector, s0_src_format)
 
-  val s0_addr_selector = Seq(
-    s0_super_ld_rep_valid,
-    s0_ld_fast_rep_valid,
-    s0_ld_rep_valid,
-    s0_vec_iss_valid,
-    s0_int_iss_valid,
-    (if (EnableLoadToLoadForward) s0_l2l_fwd_valid else false.B),
-  )
-  val s0_addr_format = Seq(
-    io.replay.bits.vaddr,
-    io.fast_rep_in.bits.vaddr,
-    io.replay.bits.vaddr,
-    io.vecldin.bits.vaddr,
-    io.ldin.bits.src(0) + SignExt(io.ldin.bits.uop.imm(11, 0), VAddrBits),
-    (if (EnableLoadToLoadForward) Cat(io.l2l_fwd_in.data(XLEN-1, 6), s0_ptr_chasing_vaddr(5,0)) else 0.U(VAddrBits.W)),
-  )
-  s0_tlb_vaddr := ParallelPriorityMux(s0_addr_selector, s0_addr_format)
-  s0_dcache_vaddr := Mux(s0_hw_prf_select, io.prefetch_req.bits.getVaddr(), s0_tlb_vaddr)
+  // fast replay and hardware prefetch don't need to query tlb
+  val int_issue_vaddr = io.ldin.bits.src(0) + SignExt(io.ldin.bits.uop.imm(11, 0), VAddrBits)
+  val int_vec_vaddr = Mux(s0_vec_iss_valid, io.vecldin.bits.vaddr, int_issue_vaddr)
+  s0_tlb_vaddr := Mux((s0_super_ld_rep_valid || s0_ld_rep_valid), io.replay.bits.vaddr, int_vec_vaddr)
+  s0_dcache_vaddr := Mux(s0_ld_fast_rep_select, io.fast_rep_in.bits.vaddr, Mux(s0_hw_prf_select, io.prefetch_req.bits.getVaddr(), s0_tlb_vaddr))
 
   // address align check
   val s0_addr_aligned = LookupTree(Mux(s0_sel_src.isvec, s0_sel_src.alignedType(1,0), s0_sel_src.uop.fuOpType(1, 0)), List(
@@ -691,7 +679,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   s0_out.isvec           := s0_sel_src.isvec
   s0_out.is128bit        := s0_sel_src.is128bit
   s0_out.uop_unit_stride_fof := s0_sel_src.uop_unit_stride_fof
-  s0_out.paddr         := io.prefetch_req.bits.paddr // only for prefetch
+  s0_out.paddr         := Mux(s0_ld_fast_rep_valid, io.fast_rep_in.bits.paddr, io.prefetch_req.bits.paddr) // only for prefetch and fast_rep
+  s0_out.tlbNoQuery    := s0_tlb_no_query
   // s0_out.rob_idx_valid   := s0_rob_idx_valid
   // s0_out.inner_idx       := s0_inner_idx
   // s0_out.rob_idx         := s0_rob_idx
@@ -809,9 +798,9 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   s1_vaddr_hi         := s1_in.vaddr(VAddrBits - 1, 6)
   s1_vaddr_lo         := s1_in.vaddr(5, 0)
   s1_vaddr            := Cat(s1_vaddr_hi, s1_vaddr_lo)
-  s1_paddr_dup_lsu    := Mux(s1_hw_prf, s1_in.paddr, io.tlb.resp.bits.paddr(0))
-  s1_paddr_dup_dcache := Mux(s1_hw_prf, s1_in.paddr, io.tlb.resp.bits.paddr(1))
-  s1_gpaddr_dup_lsu   := Mux(s1_hw_prf, s1_in.paddr, io.tlb.resp.bits.gpaddr(0))
+  s1_paddr_dup_lsu    := Mux(s1_in.tlbNoQuery, s1_in.paddr, io.tlb.resp.bits.paddr(0))
+  s1_paddr_dup_dcache := Mux(s1_in.tlbNoQuery, s1_in.paddr, io.tlb.resp.bits.paddr(1))
+  s1_gpaddr_dup_lsu   := Mux(s1_in.isFastReplay, s1_in.paddr, io.tlb.resp.bits.gpaddr(0))
 
   when (s1_tlb_memidx.is_ld && io.tlb.resp.valid && !s1_tlb_miss && s1_tlb_memidx.idx === s1_in.uop.lqIdx.value) {
     // printf("load idx = %d\n", s1_tlb_memidx.idx)

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -584,7 +584,7 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
   }
 
   //update deqPtr
-  when(io.uopwriteback.fire){
+  when((state === s_finish) && !isEmpty(enqPtr, deqPtr)){
     deqPtr := deqPtr + 1.U
   }
 
@@ -600,31 +600,44 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
   when(stateNext === s_idle){
     instMicroOpValid := false.B
   }
-  io.uopwriteback.valid               := (state === s_finish) && !isEmpty(enqPtr, deqPtr)
-  io.uopwriteback.bits.uop            := uopq(deqPtr.value).uop
-  io.uopwriteback.bits.uop.vpu        := instMicroOp.uop.vpu
-  io.uopwriteback.bits.uop.exceptionVec := instMicroOp.uop.exceptionVec
-  io.uopwriteback.bits.mask.get       := instMicroOp.mask
-  io.uopwriteback.bits.data           := data(deqPtr.value)
-  io.uopwriteback.bits.vdIdx.get      := vdIdxInField
-  io.uopwriteback.bits.uop.vpu.vl     := instMicroOp.vl
-  io.uopwriteback.bits.uop.vpu.vstart := instMicroOp.vstart
-  io.uopwriteback.bits.uop.vpu.vmask  := maskUsed
-  io.uopwriteback.bits.uop.vpu.vuopIdx  := uopq(deqPtr.value).uop.vpu.vuopIdx
-  io.uopwriteback.bits.debug          := DontCare
-  io.uopwriteback.bits.vdIdxInField.get := vdIdxInField
-  io.uopwriteback.bits.uop.robIdx     := instMicroOp.uop.robIdx
-  io.uopwriteback.bits.uop.fuOpType   := instMicroOp.uop.fuOpType
+  // writeback to backend
+  val writebackOut                     = WireInit(io.uopwriteback.bits)
+  val writebackValid                   = (state === s_finish) && !isEmpty(enqPtr, deqPtr)
+  writebackOut.uop                    := uopq(deqPtr.value).uop
+  writebackOut.uop.vpu                := instMicroOp.uop.vpu
+  writebackOut.uop.exceptionVec       := instMicroOp.uop.exceptionVec
+  writebackOut.mask.get               := instMicroOp.mask
+  writebackOut.data                   := data(deqPtr.value)
+  writebackOut.vdIdx.get              := vdIdxInField
+  writebackOut.uop.vpu.vl             := instMicroOp.vl
+  writebackOut.uop.vpu.vstart         := instMicroOp.vstart
+  writebackOut.uop.vpu.vmask          := maskUsed
+  writebackOut.uop.vpu.vuopIdx        := uopq(deqPtr.value).uop.vpu.vuopIdx
+  writebackOut.debug                  := DontCare
+  writebackOut.vdIdxInField.get       := vdIdxInField
+  writebackOut.uop.robIdx             := instMicroOp.uop.robIdx
+  writebackOut.uop.fuOpType           := instMicroOp.uop.fuOpType
+
+  io.uopwriteback.valid               := RegNext(writebackValid)
+  io.uopwriteback.bits                := RegEnable(writebackOut, writebackValid)
+
+  dontTouch(writebackValid)
 
   //to RS
-  io.feedback.valid                   := state === s_finish && !isEmpty(enqPtr, deqPtr)
-  io.feedback.bits.hit                := true.B
-  io.feedback.bits.robIdx             := instMicroOp.uop.robIdx
-  io.feedback.bits.sourceType         := DontCare
-  io.feedback.bits.flushState         := DontCare
-  io.feedback.bits.dataInvalidSqIdx   := DontCare
-  io.feedback.bits.sqIdx              := uopq(deqPtr.value).uop.sqIdx
-  io.feedback.bits.lqIdx              := uopq(deqPtr.value).uop.lqIdx
+  val feedbackOut                      = WireInit(0.U.asTypeOf(io.feedback.bits))
+  val feedbackValid                    = state === s_finish && !isEmpty(enqPtr, deqPtr)
+  feedbackOut.hit                     := true.B
+  feedbackOut.robIdx                  := instMicroOp.uop.robIdx
+  feedbackOut.sourceType              := DontCare
+  feedbackOut.flushState              := DontCare
+  feedbackOut.dataInvalidSqIdx        := DontCare
+  feedbackOut.sqIdx                   := uopq(deqPtr.value).uop.sqIdx
+  feedbackOut.lqIdx                   := uopq(deqPtr.value).uop.lqIdx
+
+  io.feedback.valid                   := RegNext(feedbackValid)
+  io.feedback.bits                    := RegEnable(feedbackOut, feedbackValid)
+
+  dontTouch(feedbackValid)
 
   // exception
   io.exceptionInfo                    := DontCare

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -473,8 +473,10 @@ class VLSplitImp(implicit p: Parameters) extends VLSUModule{
   splitPipeline.io.redirect <> io.redirect
   io.toMergeBuffer <> splitPipeline.io.toMergeBuffer
 
+  // skid buffer
+  skidBuffer(splitPipeline.io.out, splitBuffer.io.in, splitBuffer.io.in.bits.uop.robIdx.needFlush(io.redirect), "VLSplitSkidBuffer")
+
   // Split Buffer
-  splitBuffer.io.in <> splitPipeline.io.out
   splitBuffer.io.redirect <> io.redirect
   io.out <> splitBuffer.io.out
 }
@@ -488,8 +490,10 @@ class VSSplitImp(implicit p: Parameters) extends VLSUModule{
   splitPipeline.io.redirect <> io.redirect
   io.toMergeBuffer <> splitPipeline.io.toMergeBuffer
 
+  // skid buffer
+  skidBuffer(splitPipeline.io.out, splitBuffer.io.in, splitBuffer.io.in.bits.uop.robIdx.needFlush(io.redirect),"VSSplitSkidBuffer")
+
   // Split Buffer
-  splitBuffer.io.in <> splitPipeline.io.out
   splitBuffer.io.redirect <> io.redirect
   io.out <> splitBuffer.io.out
   io.vstd.get <> splitBuffer.io.vstd.get


### PR DESCRIPTION
* refactor address generation of stage 0 in LoadUnit.
* fix bug of pmp checker when not query tlb.
* prefetch and fast_rep don't need to query TLB.
* store mmio delay 1 cycle to writeback. 
* optimize ldCancel generation.
* remove forward data from D channel in loadUnit s3 due to its minimal impact on performance.