### PR TITLE
Config: Add FpgaDefaultConfig for FPGAs Bitstream generation

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -414,3 +414,20 @@ class XSNoCTopConfig(n: Int = 1) extends Config(
     case SoCParamsKey => up(SoCParamsKey).copy(UseXSNoCTop = true)
   })
 )
+
+class FpgaDefaultConfig(n: Int = 1) extends Config(
+  (new WithNKBL3(3 * 1024, inclusive = false, banks = 1, ways = 6)
+    ++ new WithNKBL2(2 * 512, inclusive = true, banks = 4)
+    ++ new WithNKBL1D(64, ways = 8)
+    ++ new BaseConfig(n)).alter((site, here, up) => {
+    case DebugOptionsKey => up(DebugOptionsKey).copy(
+      AlwaysBasicDiff = false,
+      AlwaysBasicDB = false
+    )
+    case SoCParamsKey => up(SoCParamsKey).copy(
+      L3CacheParamsOpt = Some(up(SoCParamsKey).L3CacheParamsOpt.get.copy(
+        sramClkDivBy2 = false,
+      )),
+    )
+  })
+)


### PR DESCRIPTION
Add a new Class FpgaDefaultConfig for FPGAs Bitstream generation. The L3 Cache clock was turned off, and the L3 Cache size was reduced form 16M to 3M. Set DebugOptions AlwaysBasicDiff and AlwaysBasicDB to false.