### PR TITLE
LDU: fix prefetch.i the transfer condition of address from MemBlock to Frontend

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -260,7 +260,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     val mem_to_ooo = new mem_to_ooo
     val fetch_to_mem = new fetch_to_mem
 
-    val IfetchPrefetch = Vec(LduCnt, ValidIO(new SoftIfetchPrefetchBundle))
+    val ifetchPrefetch = Vec(LduCnt, ValidIO(new SoftIfetchPrefetchBundle))
     
     // misc
     val error = ValidIO(new L1CacheErrorInfo)
@@ -725,7 +725,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     loadUnits(i).io.fast_rep_in <> loadUnits(i).io.fast_rep_out
     
     // SoftPrefetch to frontend (prefetch.i)
-    loadUnits(i).io.IfetchPrefetch <> io.IfetchPrefetch(i)
+    loadUnits(i).io.ifetchPrefetch <> io.ifetchPrefetch(i)
 
     // dcache access
     loadUnits(i).io.dcache <> dcache.io.lsu.load(i)

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -760,7 +760,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.wakeup.bits := s0_wakeup_uop
 
   // prefetch.i(Zicbop)
-  io.ifetchPrefetch.valid := s0_int_iss_valid && s0_sel_src.prf_i
+  io.ifetchPrefetch.valid := s0_fire && s0_int_iss_select && s0_sel_src.prf_i
   io.ifetchPrefetch.bits.vaddr := s0_out.vaddr
 
   XSDebug(io.dcache.req.fire,

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -148,8 +148,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     val canAcceptLowConfPrefetch  = Output(Bool())
     val canAcceptHighConfPrefetch = Output(Bool())
 
-    // IfetchPrefetch
-    val IfetchPrefetch = ValidIO(new SoftIfetchPrefetchBundle)
+    // ifetchPrefetch
+    val ifetchPrefetch = ValidIO(new SoftIfetchPrefetchBundle)
 
     // load to load fast path
     val l2l_fwd_in    = Input(new LoadToLoadIO)
@@ -760,8 +760,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.wakeup.bits := s0_wakeup_uop
 
   // prefetch.i(Zicbop)
-  io.IfetchPrefetch.valid := s0_int_iss_valid && s0_sel_src.prf_i
-  io.IfetchPrefetch.bits.vaddr := s0_out.vaddr
+  io.ifetchPrefetch.valid := s0_int_iss_valid && s0_sel_src.prf_i
+  io.ifetchPrefetch.bits.vaddr := s0_out.vaddr
 
   XSDebug(io.dcache.req.fire,
     p"[DCACHE LOAD REQ] pc ${Hexadecimal(s0_sel_src.uop.pc)}, vaddr ${Hexadecimal(s0_dcache_vaddr)}\n"


### PR DESCRIPTION
when so_fire = 1 and s0_int_iss_select =1,  the vaddr of prefetch.i can be passed to Frontend.