### PR TITLE
XSCore,Backend,MemBlock: let Top-to-Backend bundles bypass MemBlock

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -112,11 +112,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   frontend.io.csrCtrl <> backend.io.frontendCsrCtrl
   frontend.io.fencei <> backend.io.fenceio.fencei
 
-  backend.io.fromTop.hartId := memBlock.io.inner_hartId
-  backend.io.fromTop.msiInfo := io.msiInfo
-  backend.io.fromTop.clintTime := io.clintTime
-
-  backend.io.fromTop.externalInterrupt := memBlock.io.externalInterrupt
+  backend.io.fromTop := memBlock.io.mem_to_ooo.topToBackendBypass
 
   require(backend.io.mem.stIn.length == memBlock.io.mem_to_ooo.stIn.length)
   backend.io.mem.stIn.zip(memBlock.io.mem_to_ooo.stIn).foreach { case (sink, source) =>
@@ -127,7 +123,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
     sink.bits.storeSetHit := source.bits.uop.storeSetHit
     // The other signals have not been used
   }
-  backend.io.mem.memoryViolation <> memBlock.io.mem_to_ooo.memoryViolation
+  backend.io.mem.memoryViolation := memBlock.io.mem_to_ooo.memoryViolation
   backend.io.mem.lsqEnqIO <> memBlock.io.ooo_to_mem.enqLsq
   backend.io.mem.sqDeq := memBlock.io.mem_to_ooo.sqDeq
   backend.io.mem.lqDeq := memBlock.io.mem_to_ooo.lqDeq
@@ -137,13 +133,13 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   backend.io.mem.sqCancelCnt := memBlock.io.mem_to_ooo.sqCancelCnt
   backend.io.mem.otherFastWakeup := memBlock.io.mem_to_ooo.otherFastWakeup
   backend.io.mem.stIssuePtr := memBlock.io.mem_to_ooo.stIssuePtr
-  backend.io.mem.ldaIqFeedback <> memBlock.io.mem_to_ooo.ldaIqFeedback
-  backend.io.mem.staIqFeedback <> memBlock.io.mem_to_ooo.staIqFeedback
-  backend.io.mem.hyuIqFeedback <> memBlock.io.mem_to_ooo.hyuIqFeedback
-  backend.io.mem.vstuIqFeedback <> memBlock.io.mem_to_ooo.vstuIqFeedback
-  backend.io.mem.vlduIqFeedback <> memBlock.io.mem_to_ooo.vlduIqFeedback
-  backend.io.mem.ldCancel <> memBlock.io.mem_to_ooo.ldCancel
-  backend.io.mem.wakeup <> memBlock.io.mem_to_ooo.wakeup
+  backend.io.mem.ldaIqFeedback := memBlock.io.mem_to_ooo.ldaIqFeedback
+  backend.io.mem.staIqFeedback := memBlock.io.mem_to_ooo.staIqFeedback
+  backend.io.mem.hyuIqFeedback := memBlock.io.mem_to_ooo.hyuIqFeedback
+  backend.io.mem.vstuIqFeedback := memBlock.io.mem_to_ooo.vstuIqFeedback
+  backend.io.mem.vlduIqFeedback := memBlock.io.mem_to_ooo.vlduIqFeedback
+  backend.io.mem.ldCancel := memBlock.io.mem_to_ooo.ldCancel
+  backend.io.mem.wakeup := memBlock.io.mem_to_ooo.wakeup
   backend.io.mem.writebackLda <> memBlock.io.mem_to_ooo.writebackLda
   backend.io.mem.writebackSta <> memBlock.io.mem_to_ooo.writebackSta
   backend.io.mem.writebackHyuLda <> memBlock.io.mem_to_ooo.writebackHyuLda
@@ -154,7 +150,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   backend.io.mem.robLsqIO.uop := memBlock.io.mem_to_ooo.lsqio.uop
 
   // memblock error exception writeback, 1 cycle after normal writeback
-  backend.io.mem.s3_delayed_load_error <> memBlock.io.mem_to_ooo.s3_delayed_load_error
+  backend.io.mem.s3_delayed_load_error := memBlock.io.mem_to_ooo.s3_delayed_load_error
 
   backend.io.mem.exceptionAddr.vaddr  := memBlock.io.mem_to_ooo.lsqio.vaddr
   backend.io.mem.exceptionAddr.gpaddr := memBlock.io.mem_to_ooo.lsqio.gpaddr
@@ -174,17 +170,19 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   backend.io.perf.ctrlInfo := DontCare
 
   // top -> memBlock
+  memBlock.io.fromTopToBackend.clintTime := io.clintTime
+  memBlock.io.fromTopToBackend.msiInfo := io.msiInfo
   memBlock.io.hartId := io.hartId
   memBlock.io.outer_reset_vector := io.reset_vector
   // frontend -> memBlock
   memBlock.io.inner_beu_errors_icache <> frontend.io.error.bits.toL1BusErrorUnitInfo(frontend.io.error.valid)
   memBlock.io.inner_l2_pf_enable := backend.io.csrCustomCtrl.l2_pf_enable
-  memBlock.io.inner_cpu_halt := backend.io.toTop.cpuHalted
+  memBlock.io.ooo_to_mem.backendToTopBypass := backend.io.toTop
   memBlock.io.ooo_to_mem.issueLda <> backend.io.mem.issueLda
   memBlock.io.ooo_to_mem.issueSta <> backend.io.mem.issueSta
   memBlock.io.ooo_to_mem.issueStd <> backend.io.mem.issueStd
   memBlock.io.ooo_to_mem.issueHya <> backend.io.mem.issueHylda
-  backend.io.mem.issueHysta.map(_.ready := false.B) // this fake port should not be used
+  backend.io.mem.issueHysta.foreach(_.ready := false.B) // this fake port should not be used
   memBlock.io.ooo_to_mem.issueVldu <> backend.io.mem.issueVldu
 
   // By default, instructions do not have exceptions when they enter the function units.
@@ -199,9 +197,9 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
 
   memBlock.io.ooo_to_mem.sfence <> backend.io.mem.sfence
 
-  memBlock.io.redirect <> backend.io.mem.redirect
-  memBlock.io.ooo_to_mem.csrCtrl <> backend.io.mem.csrCtrl
-  memBlock.io.ooo_to_mem.tlbCsr <> backend.io.mem.tlbCsr
+  memBlock.io.redirect := backend.io.mem.redirect
+  memBlock.io.ooo_to_mem.csrCtrl := backend.io.mem.csrCtrl
+  memBlock.io.ooo_to_mem.tlbCsr := backend.io.mem.tlbCsr
   memBlock.io.ooo_to_mem.lsqio.lcommit        := backend.io.mem.robLsqIO.lcommit
   memBlock.io.ooo_to_mem.lsqio.scommit        := backend.io.mem.robLsqIO.scommit
   memBlock.io.ooo_to_mem.lsqio.pendingld      := backend.io.mem.robLsqIO.pendingld

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -751,7 +751,7 @@ class BackendMemIO(implicit p: Parameters, params: BackendParams) extends XSBund
   val hyuIqFeedback = Vec(params.HyuCnt, Flipped(new MemRSFeedbackIO))
   val vstuIqFeedback = Flipped(Vec(params.VstuCnt, new MemRSFeedbackIO(isVector = true)))
   val vlduIqFeedback = Flipped(Vec(params.VlduCnt, new MemRSFeedbackIO(isVector = true)))
-  val ldCancel = Vec(params.LdExuCnt, Flipped(new LoadCancelIO))
+  val ldCancel = Vec(params.LdExuCnt, Input(new LoadCancelIO))
   val wakeup = Vec(params.LdExuCnt, Flipped(Valid(new DynInst)))
   val loadPcRead = Vec(params.LduCnt, Output(UInt(VAddrBits.W)))
   val storePcRead = Vec(params.StaCnt, Output(UInt(VAddrBits.W)))
@@ -825,17 +825,21 @@ class BackendMemIO(implicit p: Parameters, params: BackendParams) extends XSBund
   }
 }
 
-class BackendIO(implicit p: Parameters, params: BackendParams) extends XSBundle with HasSoCParameter {
-  val fromTop = new Bundle {
-    val hartId = Input(UInt(hartIdLen.W))
-    val externalInterrupt = Input(new ExternalInterruptIO)
-    val msiInfo = Input(ValidIO(new MsiInfoBundle))
-    val clintTime = Input(ValidIO(UInt(64.W)))
-  }
+class TopToBackendBundle(implicit p: Parameters) extends XSBundle {
+  val hartId            = Output(UInt(hartIdLen.W))
+  val externalInterrupt = Output(new ExternalInterruptIO)
+  val msiInfo           = Output(ValidIO(new MsiInfoBundle))
+  val clintTime         = Output(ValidIO(UInt(64.W)))
+}
 
-  val toTop = new Bundle {
-    val cpuHalted = Output(Bool())
-  }
+class BackendToTopBundle extends Bundle {
+  val cpuHalted = Output(Bool())
+}
+
+class BackendIO(implicit p: Parameters, params: BackendParams) extends XSBundle with HasSoCParameter {
+  val fromTop = Flipped(new TopToBackendBundle)
+
+  val toTop = new BackendToTopBundle
 
   val fenceio = new FenceIO
   // Todo: merge these bundles into BackendFrontendIO

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -25,6 +25,7 @@ import freechips.rocketchip.interrupts.{IntSinkNode, IntSinkPortSimple}
 import freechips.rocketchip.tile.HasFPUParameters
 import freechips.rocketchip.tilelink._
 import coupledL2.PrefetchRecv
+import device.MsiInfoBundle
 import utils._
 import utility._
 import xiangshan._
@@ -72,6 +73,8 @@ class Std(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
 }
 
 class ooo_to_mem(implicit p: Parameters) extends MemBlockBundle {
+  val backendToTopBypass = Flipped(new BackendToTopBundle)
+
   val loadFastMatch = Vec(LdExuCnt, Input(UInt(LdExuCnt.W)))
   val loadFastFuOpType = Vec(LdExuCnt, Input(FuOpType()))
   val loadFastImm = Vec(LdExuCnt, Input(UInt(12.W)))
@@ -108,6 +111,8 @@ class ooo_to_mem(implicit p: Parameters) extends MemBlockBundle {
 }
 
 class mem_to_ooo(implicit p: Parameters) extends MemBlockBundle {
+  val topToBackendBypass = new TopToBackendBundle
+
   val otherFastWakeup = Vec(LdExuCnt, ValidIO(new DynInst))
   val lqCancelCnt = Output(UInt(log2Up(VirtualLoadQueueSize + 1).W))
   val sqCancelCnt = Output(UInt(log2Up(StoreQueueSize + 1).W))
@@ -261,7 +266,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     val fetch_to_mem = new fetch_to_mem
 
     val IfetchPrefetch = Vec(LduCnt, ValidIO(new SoftIfetchPrefetchBundle))
-    
+
     // misc
     val error = ValidIO(new L1CacheErrorInfo)
     val memInfo = new Bundle {
@@ -282,11 +287,13 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
     val debugRolling = Flipped(new RobDebugRollingIO)
 
     // All the signals from/to frontend/backend to/from bus will go through MemBlock
-    val externalInterrupt = Flipped(new ExternalInterruptIO)
+    val fromTopToBackend = Input(new Bundle {
+      val msiInfo   = ValidIO(new MsiInfoBundle)
+      val clintTime = ValidIO(UInt(64.W))
+    })
     val inner_hartId = Output(UInt(hartIdLen.W))
     val inner_reset_vector = Output(UInt(PAddrBits.W))
     val outer_reset_vector = Input(UInt(PAddrBits.W))
-    val inner_cpu_halt = Input(Bool())
     val outer_cpu_halt = Output(Bool())
     val inner_beu_errors_icache = Input(new L1BusErrorUnitInfo)
     val outer_beu_errors_icache = Output(new L1BusErrorUnitInfo)
@@ -299,11 +306,9 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   // reset signals of frontend & backend are generated in memblock
   val reset_backend = IO(Output(Reset()))
 
-  dontTouch(io.externalInterrupt)
   dontTouch(io.inner_hartId)
   dontTouch(io.inner_reset_vector)
   dontTouch(io.outer_reset_vector)
-  dontTouch(io.inner_cpu_halt)
   dontTouch(io.outer_cpu_halt)
   dontTouch(io.inner_beu_errors_icache)
   dontTouch(io.outer_beu_errors_icache)
@@ -723,7 +728,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
 
     // fast replay
     loadUnits(i).io.fast_rep_in <> loadUnits(i).io.fast_rep_out
-    
+
     // SoftPrefetch to frontend (prefetch.i)
     loadUnits(i).io.IfetchPrefetch <> io.IfetchPrefetch(i)
 
@@ -1595,18 +1600,24 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
   XSError(atomicsException && atomicsUnit.io.in.valid, "new instruction before exception triggers\n")
   io.mem_to_ooo.lsqio.gpaddr := RegNext(Mux(atomicsException, atomicsExceptionGPAddress, lsq.io.exceptionAddr.gpaddr))
 
+  io.mem_to_ooo.topToBackendBypass match { case x =>
+    x.hartId            := io.hartId
+    x.externalInterrupt.msip  := outer.clint_int_sink.in.head._1(0)
+    x.externalInterrupt.mtip  := outer.clint_int_sink.in.head._1(1)
+    x.externalInterrupt.meip  := outer.plic_int_sink.in.head._1(0)
+    x.externalInterrupt.seip  := outer.plic_int_sink.in.last._1(0)
+    x.externalInterrupt.debug := outer.debug_int_sink.in.head._1(0)
+    x.msiInfo           := DelayNWithValid(io.fromTopToBackend.msiInfo, 1)
+    x.clintTime         := DelayNWithValid(io.fromTopToBackend.clintTime, 1)
+  }
+
   io.memInfo.sqFull := RegNext(lsq.io.sqFull)
   io.memInfo.lqFull := RegNext(lsq.io.lqFull)
   io.memInfo.dcacheMSHRFull := RegNext(dcache.io.mshrFull)
 
-  io.externalInterrupt.msip := outer.clint_int_sink.in.head._1(0)
-  io.externalInterrupt.mtip := outer.clint_int_sink.in.head._1(1)
-  io.externalInterrupt.meip := outer.plic_int_sink.in.head._1(0)
-  io.externalInterrupt.seip := outer.plic_int_sink.in.last._1(0)
-  io.externalInterrupt.debug := outer.debug_int_sink.in.head._1(0)
   io.inner_hartId := io.hartId
   io.inner_reset_vector := RegNext(io.outer_reset_vector)
-  io.outer_cpu_halt := io.inner_cpu_halt
+  io.outer_cpu_halt := io.ooo_to_mem.backendToTopBypass.cpuHalted
   io.outer_beu_errors_icache := RegNext(io.inner_beu_errors_icache)
   io.outer_l2_pf_enable := io.inner_l2_pf_enable
   // io.inner_hc_perfEvents <> io.outer_hc_perfEvents


### PR DESCRIPTION
* All Top-to-Backend bundles are in class TopToBackendBundle.
  * Including hartId, externalInterrupt, msiInfo, clintTime
* All Backend-to-Top bundles are in class BackendToTopBundle.
  * Only cpuHalted included
* Use := instead of <> for non-Bidirectional bundles in XSCore.