### PR TITLE
Trigger: refactor trigger information in pipeline.

### DIFF
--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -43,7 +43,7 @@ object Bundles {
     val pc              = UInt(VAddrBits.W)
     val foldpc          = UInt(MemPredPCWidth.W)
     val exceptionVec    = ExceptionVec()
-    val trigger         = new TriggerCf
+    val trigger         = TriggerAction()
     val preDecodeInfo   = new PreDecodeInfo
     val pred_taken      = Bool()
     val crossPageIPFFix = Bool()
@@ -72,7 +72,7 @@ object Bundles {
     val pc              = UInt(VAddrBits.W)
     val foldpc          = UInt(MemPredPCWidth.W)
     val exceptionVec    = ExceptionVec()
-    val trigger         = new TriggerCf
+    val trigger         = TriggerAction()
     val preDecodeInfo   = new PreDecodeInfo
     val pred_taken      = Bool()
     val crossPageIPFFix = Bool()
@@ -148,7 +148,7 @@ object Bundles {
     val foldpc          = UInt(MemPredPCWidth.W)
     val exceptionVec    = ExceptionVec()
     val hasException    = Bool()
-    val trigger         = new TriggerCf
+    val trigger         = TriggerAction()
     val preDecodeInfo   = new PreDecodeInfo
     val pred_taken      = Bool()
     val crossPageIPFFix = Bool()
@@ -690,7 +690,7 @@ object Bundles {
     val lqIdx        = if (params.hasLoadFu)    Some(new LqPtr())             else None
     val sqIdx        = if (params.hasStoreAddrFu || params.hasStdFu)
                                                 Some(new SqPtr())             else None
-    val trigger      = if (params.trigger)      Some(new TriggerCf)           else None
+    val trigger      = if (params.trigger)      Some(TriggerAction())           else None
     // uop info
     val predecodeInfo = if(params.hasPredecode) Some(new PreDecodeInfo) else None
     // vldu used only
@@ -835,7 +835,7 @@ object Bundles {
     val isInterrupt = Bool()
     val isHls = Bool()
     val vls = Bool()
-    val trigger  = new TriggerCf
+    val trigger = TriggerAction()
   }
 
   object UopIdx {

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -140,7 +140,7 @@ class CtrlBlockImp(
   val delayedNotFlushedWriteBackNeedFlush = Wire(Vec(params.allExuParams.filter(_.needExceptionGen).length, Bool()))
   delayedNotFlushedWriteBackNeedFlush := delayedNotFlushedWriteBack.filter(_.bits.params.needExceptionGen).map{ x =>
     x.bits.exceptionVec.get.asUInt.orR || x.bits.flushPipe.getOrElse(false.B) || x.bits.replay.getOrElse(false.B) ||
-      (if (x.bits.trigger.nonEmpty) x.bits.trigger.get.getBackendCanFire else false.B)
+      (if (x.bits.trigger.nonEmpty) TriggerAction.isDmode(x.bits.trigger.get) else false.B)
   }
 
   val wbDataNoStd = io.fromWB.wbData.filter(!_.bits.params.hasStdFu)

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -24,7 +24,7 @@ import freechips.rocketchip.rocket.Instructions._
 import freechips.rocketchip.util.uintToBitPat
 import utility._
 import utils._
-import xiangshan.ExceptionNO.{illegalInstr, virtualInstr}
+import xiangshan.ExceptionNO.{breakPoint, illegalInstr, virtualInstr}
 import xiangshan._
 import xiangshan.backend.fu.FuType
 import xiangshan.backend.Bundles.{DecodedInst, DynInst, StaticInst}
@@ -808,6 +808,9 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
 
   decodedInst.exceptionVec(illegalInstr) := exceptionII
   decodedInst.exceptionVec(virtualInstr) := exceptionVI
+
+  //update exceptionVec: from frontend trigger's breakpoint exception. To reduce 1 bit of overhead in ibuffer entry.
+  decodedInst.exceptionVec(breakPoint) := TriggerAction.isExp(ctrl_flow.trigger)
 
   decodedInst.imm := LookupTree(decodedInst.selImm, ImmUnion.immSelMap.map(
     x => {

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -243,7 +243,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents {
       updatedUop(i).singleStep := false.B
     }
     when (io.fromRename(i).fire) {
-      XSDebug(updatedUop(i).trigger.getFrontendCanFire, s"Debug Mode: inst ${i} has frontend trigger exception\n")
+      XSDebug(TriggerAction.isDmode(updatedUop(i).trigger) || updatedUop(i).exceptionVec(breakPoint), s"Debug Mode: inst ${i} has frontend trigger exception\n")
       XSDebug(updatedUop(i).singleStep, s"Debug Mode: inst ${i} has single step exception\n")
     }
     if (env.EnableDifftest) {
@@ -375,9 +375,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents {
     io.toLsDq.req(i).bits   := updatedUop(i)
 
     //delete trigger message from frontend
-    io.toDq.map(dq => {
-      dq.req(i).bits.trigger.clear()
-    })
+    io.toDq.map(dq => { dq.req(i).bits.trigger := TriggerAction.None })
 
     XSDebug(io.toIntDq0.req(i).valid, p"pc 0x${Hexadecimal(io.toIntDq0.req(i).bits.pc)} int index $i\n")
     XSDebug(io.toIntDq1.req(i).valid, p"pc 0x${Hexadecimal(io.toIntDq1.req(i).bits.pc)} int index $i\n")

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -117,7 +117,7 @@ class VtypeStruct(implicit p: Parameters) extends XSBundle {
   val vsew = UInt(3.W)
   val vlmul = UInt(3.W)
 }
-
+/*
 class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   with HasCSRConst
   with PMPMethod
@@ -1633,7 +1633,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
     difftest.vlenb := vlenb
   }
 }
-
+*/
 class PFEvent(implicit p: Parameters) extends XSModule with HasCSRConst  {
   val io = IO(new Bundle {
     val distribute_csr = Flipped(new DistributedCSRIO())

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryDEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryDEvent.scala
@@ -1,10 +1,10 @@
 package xiangshan.backend.fu.NewCSR.CSREvents
 
 import chisel3._
-import chisel3.util.{MuxCase, _}
+import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.{SignExt, ZeroExt}
-import xiangshan.{ExceptionNO, HasXSParameter, TriggerCf}
+import xiangshan.{ExceptionNO, HasXSParameter, TriggerAction}
 import xiangshan.ExceptionNO._
 import xiangshan.backend.fu.NewCSR
 import xiangshan.backend.fu.NewCSR.CSRBundles.{CauseBundle, OneFieldBundle, PrivState}
@@ -32,7 +32,7 @@ class TrapEntryDEventInput(implicit override val p: Parameters) extends TrapEntr
   val hasTrap                 = Input(Bool())
   val debugMode               = Input(Bool())
   val hasDebugIntr            = Input(Bool())
-  val hasTriggerFire          = Input(Bool())
+  val triggerEnterDebugMode   = Input(Bool())
   val hasDebugEbreakException = Input(Bool())
   val hasSingleStep           = Input(Bool())
   val breakPoint              = Input(Bool())
@@ -52,14 +52,14 @@ class TrapEntryDEventModule(implicit val p: Parameters) extends Module with CSRE
   private val debugMode               = in.debugMode
   private val hasDebugIntr            = in.hasDebugIntr
   private val breakPoint              = in.breakPoint
-  private val hasTriggerFire          = in.hasTriggerFire
+  private val triggerEnterDebugMode   = in.triggerEnterDebugMode
   private val hasDebugEbreakException = in.hasDebugEbreakException
   private val hasSingleStep           = in.hasSingleStep
 
   private val hasExceptionInDmode = debugMode && hasTrap
   val causeIntr = DcsrCause.Haltreq.asUInt
   val causeExp = MuxCase(0.U, Seq(
-    hasTriggerFire          -> DcsrCause.Trigger.asUInt,
+    triggerEnterDebugMode   -> DcsrCause.Trigger.asUInt,
     hasDebugEbreakException -> DcsrCause.Ebreak.asUInt,
     hasSingleStep           -> DcsrCause.Step.asUInt
   ))

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/Debug.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/Debug.scala
@@ -3,7 +3,6 @@ package xiangshan.backend.fu.NewCSR
 import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
-
 import xiangshan.backend.fu.NewCSR.CSRBundles.PrivState
 import xiangshan.backend.fu.util.CSRConst
 import xiangshan.backend.fu.util.SdtrigExt
@@ -18,7 +17,7 @@ class Debug(implicit val p: Parameters) extends Module with HasXSParameter {
   private val intrVec         = trapInfo.bits.intrVec
   private val trapVec         = trapInfo.bits.trapVec
   private val singleStep      = trapInfo.bits.singleStep
-  private val triggerCf       = io.in.trapInfo.bits.triggerCf
+  private val trigger         = io.in.trapInfo.bits.trigger
 
   private val privState = io.in.privState
   private val debugMode = io.in.debugMode
@@ -58,32 +57,19 @@ class Debug(implicit val p: Parameters) extends Module with HasXSParameter {
   val hasDebugEbreakException = hasBreakPoint && ebreakEnterDebugMode
 
   // debug_exception_trigger
-  val triggerFrontendHitVec = triggerCf.frontendHit
-  val triggerMemHitVec = triggerCf.backendHit
-  val triggerHitVec = triggerFrontendHitVec.asUInt | triggerMemHitVec.asUInt // Todo: update mcontrol.hit
-  val triggerFrontendCanFireVec = triggerCf.frontendCanFire.asUInt
-  val triggerMemCanFireVec = triggerCf.backendCanFire.asUInt
-  val triggerCanFireVec = triggerFrontendCanFireVec | triggerMemCanFireVec
-
   val mcontrolWireVec = tdata1Vec.map{ mod => {
     val mcontrolWire = Wire(new Mcontrol)
     mcontrolWire := mod.DATA.asUInt
     mcontrolWire
   }}
 
-  // More than one triggers can hit at the same time, but only fire one
-  // We select the first hit trigger to fire
-  val triggerCanRaiseBpExp = Mux(privState.isModeM && !debugMode, tcontrol.MTE.asBool, true.B)
-  val triggerFireOH = PriorityEncoderOH(triggerCanFireVec)
-  val triggerFireAction = PriorityMux(triggerFireOH, tdata1Vec.map(_.getTriggerAction)).asUInt
-  val hasTriggerFire = hasExp && triggerCf.canFire
-  val hasDebugTriggerException = hasTriggerFire && (triggerFireAction === TrigAction.DebugMode.asUInt)
-  val triggerCanFire = hasTriggerFire && (triggerFireAction === TrigAction.BreakpointExp.asUInt) && triggerCanRaiseBpExp // todo: Should trigger be fire in dmode?
+  val triggerCanRaiseBpExp = Mux(privState.isModeM, tcontrol.MTE.asBool, true.B)
+  val triggerEnterDebugMode = hasExp && TriggerAction.isDmode(trigger)
 
   // debug_exception_single
   val hasSingleStep = hasExp && singleStep
 
-  val hasDebugException = hasDebugEbreakException || hasDebugTriggerException || hasSingleStep
+  val hasDebugException = hasDebugEbreakException || triggerEnterDebugMode || hasSingleStep
   val hasDebugTrap = hasDebugException || hasDebugIntr
 
   val tselect1H = UIntToOH(tselect.asUInt, TriggerNum).asBools
@@ -122,25 +108,27 @@ class Debug(implicit val p: Parameters) extends Module with HasXSParameter {
     case (tEnable, mod) => tEnable && mod.isMemAccTrigger
   }
   
-  io.out.frontendTrigger.tUpdate.valid       := RegNext(RegNext(frontendTriggerUpdate))
-  io.out.frontendTrigger.tUpdate.bits.addr   := tselect.asUInt
+  io.out.frontendTrigger.tUpdate.valid        := RegNext(RegNext(frontendTriggerUpdate))
+  io.out.frontendTrigger.tUpdate.bits.addr    := tselect.asUInt
   io.out.frontendTrigger.tUpdate.bits.tdata.GenTdataDistribute(tdata1Selected, tdata2Selected)
-  io.out.frontendTrigger.tEnableVec          := fetchTriggerEnableVec
+  io.out.frontendTrigger.tEnableVec           := fetchTriggerEnableVec
+  io.out.frontendTrigger.triggerCanRaiseBpExp := triggerCanRaiseBpExp
+  io.out.frontendTrigger.debugMode            := debugMode
 
   io.out.memTrigger.tUpdate.valid            := RegNext(RegNext(memTriggerUpdate))
   io.out.memTrigger.tUpdate.bits.addr        := tselect.asUInt
   io.out.memTrigger.tUpdate.bits.tdata.GenTdataDistribute(tdata1Selected, tdata2Selected)
   io.out.memTrigger.tEnableVec               := memAccTriggerEnableVec
   io.out.memTrigger.triggerCanRaiseBpExp     := triggerCanRaiseBpExp
+  io.out.memTrigger.debugMode                := debugMode
 
   io.out.triggerFrontendChange  := frontendTriggerUpdate
   io.out.newTriggerChainIsLegal := newTriggerChainIsLegal
 
   io.out.hasDebugTrap            := hasDebugTrap
   io.out.hasDebugIntr            := hasDebugIntr
-  io.out.triggerCanFire          := triggerCanFire
   io.out.hasSingleStep           := hasSingleStep
-  io.out.hasTriggerFire          := hasTriggerFire
+  io.out.triggerEnterDebugMode   := triggerEnterDebugMode
   io.out.hasDebugEbreakException := hasDebugEbreakException
   io.out.breakPoint              := breakPoint
 }
@@ -152,7 +140,7 @@ class DebugIO(implicit val p: Parameters) extends Bundle with HasXSParameter {
       val intrVec = UInt(64.W)
       val isInterrupt = Bool()
       val singleStep = Bool()
-      val triggerCf = new TriggerCf
+      val trigger = TriggerAction()
     })
 
     val privState = new PrivState
@@ -180,8 +168,7 @@ class DebugIO(implicit val p: Parameters) extends Bundle with HasXSParameter {
     val hasDebugTrap = Bool()
     val hasDebugIntr = Bool()
     val hasSingleStep = Bool()
-    val hasTriggerFire = Bool()
-    val triggerCanFire = Bool()
+    val triggerEnterDebugMode = Bool()
     val hasDebugEbreakException = Bool()
     val breakPoint = Bool()
   })
@@ -190,9 +177,10 @@ class DebugIO(implicit val p: Parameters) extends Bundle with HasXSParameter {
 class CsrTriggerBundle(implicit val p: Parameters) extends Bundle with HasXSParameter {
   val tdataVec = Vec(TriggerNum, new MatchTriggerIO)
   val tEnableVec = Vec(TriggerNum, Bool())
+  val debugMode = Bool()
   val triggerCanRaiseBpExp = Bool()
 }
-class StoreTrigger(implicit val p: Parameters)extends Module with HasXSParameter with SdtrigExt {
+class StoreTrigger(implicit val p: Parameters) extends Module with HasXSParameter with SdtrigExt {
   val io = IO(new Bundle(){
     val fromCsrTrigger = Input(new CsrTriggerBundle)
 
@@ -201,14 +189,13 @@ class StoreTrigger(implicit val p: Parameters)extends Module with HasXSParameter
     })
 
     val toStore = Output(new Bundle{
-      val triggerHitVec = Vec(TriggerNum,  Bool())
-      val triggerCanFireVec = Vec(TriggerNum, Bool())
-      val breakPointExp = Bool()
+      val triggerAction = TriggerAction()
     })
   })
   val tdataVec      = io.fromCsrTrigger.tdataVec
   val tEnableVec    = io.fromCsrTrigger.tEnableVec
   val triggerCanRaiseBpExp = io.fromCsrTrigger.triggerCanRaiseBpExp
+  val debugMode = io.fromCsrTrigger.debugMode
   val vaddr = io.fromStore.vaddr
 
   val triggerTimingVec = VecInit(tdataVec.map(_.timing))
@@ -217,8 +204,9 @@ class StoreTrigger(implicit val p: Parameters)extends Module with HasXSParameter
   val triggerHitVec = WireInit(VecInit(Seq.fill(TriggerNum)(false.B)))
   val triggerCanFireVec = WireInit(VecInit(Seq.fill(TriggerNum)(false.B)))
 
+  // Trigger can't hit/fire in debug mode.
   for (i <- 0 until TriggerNum) {
-    triggerHitVec(i) := !tdataVec(i).select && TriggerCmp(
+    triggerHitVec(i) := !tdataVec(i).select && !debugMode && TriggerCmp(
       vaddr,
       tdataVec(i).tdata2,
       tdataVec(i).matchType,
@@ -227,12 +215,9 @@ class StoreTrigger(implicit val p: Parameters)extends Module with HasXSParameter
   }
   TriggerCheckCanFire(TriggerNum, triggerCanFireVec, triggerHitVec, triggerTimingVec, triggerChainVec)
 
-  val triggerFireOH = PriorityEncoderOH(triggerCanFireVec)
-  val triggerFireAction = PriorityMux(triggerFireOH, tdataVec.map(_.action)).asUInt
-  val breakPointExp = ((triggerFireAction === TrigAction.BreakpointExp.asUInt) && triggerCanRaiseBpExp ||
-    (triggerFireAction === TrigAction.DebugMode.asUInt)) && triggerCanFireVec.asUInt.orR
+  val actionVec = VecInit(tdataVec.map(_.action))
+  val triggerAction = Wire(TriggerAction())
+  TriggerUtil.triggerActionGen(triggerAction, triggerCanFireVec, actionVec, triggerCanRaiseBpExp)
 
-  io.toStore.triggerHitVec     := triggerHitVec
-  io.toStore.triggerCanFireVec := triggerCanFireVec
-  io.toStore.breakPointExp     := breakPointExp
+  io.toStore.triggerAction := triggerAction
 }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -111,7 +111,7 @@ class NewCSR(implicit val p: Parameters) extends Module
         val instr = UInt(32.W)
         val trapVec = UInt(64.W)
         val singleStep = Bool()
-        val triggerCf = new TriggerCf
+        val trigger = TriggerAction()
         val crossPageIPFFix = Bool()
         val isInterrupt = Bool()
         val isHls = Bool()
@@ -203,7 +203,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   val trapPCGPA = io.fromRob.trap.bits.pcGPA
   val trapIsInterrupt = io.fromRob.trap.bits.isInterrupt
   val trapIsCrossPageIPF = io.fromRob.trap.bits.crossPageIPFFix
-  val triggerCf = io.fromRob.trap.bits.triggerCf
+  val trigger = io.fromRob.trap.bits.trigger
   val singleStep = io.fromRob.trap.bits.singleStep
   val trapIsHls = io.fromRob.trap.bits.isHls
 
@@ -312,7 +312,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   trapHandleMod.io.in.vstvec := vstvec.regOut
 
   val entryPrivState = trapHandleMod.io.out.entryPrivState
-  val entryDebugMode = Wire(Bool())
+  val entryDebugMode = WireInit(false.B)
 
   // PMP
   val pmpEntryMod = Module(new PMPEntryHandleModule)
@@ -858,7 +858,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   debugMod.io.in.trapInfo.bits.trapVec     := trapVec.asUInt
   debugMod.io.in.trapInfo.bits.intrVec     := intrVec
   debugMod.io.in.trapInfo.bits.isInterrupt := trapIsInterrupt
-  debugMod.io.in.trapInfo.bits.triggerCf   := triggerCf
+  debugMod.io.in.trapInfo.bits.trigger     := trigger
   debugMod.io.in.trapInfo.bits.singleStep  := singleStep
   debugMod.io.in.privState                 := privState
   debugMod.io.in.debugMode                 := debugMode
@@ -879,12 +879,11 @@ class NewCSR(implicit val p: Parameters) extends Module
   trapEntryDEvent.in.debugMode                := debugMode
   trapEntryDEvent.in.hasTrap                  := hasTrap
   trapEntryDEvent.in.hasSingleStep            := debugMod.io.out.hasSingleStep
-  trapEntryDEvent.in.hasTriggerFire           := debugMod.io.out.hasTriggerFire
+  trapEntryDEvent.in.triggerEnterDebugMode    := debugMod.io.out.triggerEnterDebugMode
   trapEntryDEvent.in.hasDebugEbreakException  := debugMod.io.out.hasDebugEbreakException
   trapEntryDEvent.in.breakPoint               := debugMod.io.out.breakPoint
 
   trapHandleMod.io.in.trapInfo.bits.singleStep  := debugMod.io.out.hasSingleStep
-  trapHandleMod.io.in.trapInfo.bits.triggerFire := debugMod.io.out.triggerCanFire
 
   intrMod.io.in.debugMode := debugMode
   intrMod.io.in.debugIntr := debugIntr

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/TrapHandleModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/TrapHandleModule.scala
@@ -98,7 +98,7 @@ class TrapHandleModule extends Module {
   // Todo: support more interrupt and exception
   private val exceptionRegular = OHToUInt(highestPrioEX)
   private val interruptNO = OHToUInt(highestPrioIR)
-  private val exceptionNO = Mux(trapInfo.bits.singleStep || trapInfo.bits.triggerFire, ExceptionNO.breakPoint.U, exceptionRegular)
+  private val exceptionNO = Mux(trapInfo.bits.singleStep, ExceptionNO.breakPoint.U, exceptionRegular)
 
   private val causeNO = Mux(hasIR, interruptNO, exceptionNO)
 
@@ -154,7 +154,6 @@ class TrapHandleIO extends Bundle {
       val intrVec = UInt(64.W)
       val isInterrupt = Bool()
       val singleStep = Bool()
-      val triggerFire = Bool()
     })
     val privState = new PrivState
     val mideleg = new MidelegBundle

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -96,7 +96,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   csrMod.io.fromRob.trap.bits.singleStep := csrIn.exception.bits.singleStep
   csrMod.io.fromRob.trap.bits.crossPageIPFFix := csrIn.exception.bits.crossPageIPFFix
   csrMod.io.fromRob.trap.bits.isInterrupt := csrIn.exception.bits.isInterrupt
-  csrMod.io.fromRob.trap.bits.triggerCf := csrIn.exception.bits.trigger
+  csrMod.io.fromRob.trap.bits.trigger := csrIn.exception.bits.trigger
   csrMod.io.fromRob.trap.bits.isHls := csrIn.exception.bits.isHls
 
   csrMod.io.fromRob.commit.fflags := setFflags

--- a/src/main/scala/xiangshan/backend/rename/CompressUnit.scala
+++ b/src/main/scala/xiangshan/backend/rename/CompressUnit.scala
@@ -19,7 +19,7 @@ class CompressUnit(implicit p: Parameters) extends XSModule{
     }
   })
 
-  val noExc = io.in.map(!_.bits.exceptionVec.asUInt.orR)
+  val noExc = io.in.map(in => !in.bits.exceptionVec.asUInt.orR && !TriggerAction.isDmode(in.bits.trigger))
   val uopCanCompress = io.in.map(_.bits.canRobCompress)
   val canCompress = io.in.zip(noExc).zip(uopCanCompress).map { case ((in, noExc), canComp) =>
     in.valid && !CommitType.isFused(in.bits.commitType) && in.bits.lastUop && noExc && canComp

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -306,7 +306,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
 
     uops(i).robIdx := robIdxHead + PopCount(io.in.zip(needRobFlags).take(i).map{ case(in, needRobFlag) => in.valid && in.bits.lastUop && needRobFlag})
     uops(i).instrSize := instrSizesVec(i)
-    val hasExceptionExceptFlushPipe = Cat(selectFrontend(uops(i).exceptionVec) :+ uops(i).exceptionVec(illegalInstr) :+ uops(i).exceptionVec(virtualInstr)).orR || uops(i).trigger.getFrontendCanFire
+    val hasExceptionExceptFlushPipe = Cat(selectFrontend(uops(i).exceptionVec) :+ uops(i).exceptionVec(illegalInstr) :+ uops(i).exceptionVec(virtualInstr)).orR || TriggerAction.isDmode(uops(i).trigger)
     when(isMove(i) || hasExceptionExceptFlushPipe) {
       uops(i).numUops := 0.U
       uops(i).numWB := 0.U
@@ -495,7 +495,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   val allowSnpt = if (EnableRenameSnapshot) notInSameSnpt && !lastCycleCreateSnpt && io.in.head.bits.firstUop else false.B
   io.out.zip(io.in).foreach{ case (out, in) => out.bits.snapshot := allowSnpt && (!in.bits.preDecodeInfo.notCFI || FuType.isJump(in.bits.fuType)) && in.fire }
   io.out.map{ x =>
-    x.bits.hasException := Cat(selectFrontend(x.bits.exceptionVec) :+ x.bits.exceptionVec(illegalInstr) :+ x.bits.exceptionVec(virtualInstr)).orR || x.bits.trigger.getFrontendCanFire
+    x.bits.hasException := Cat(selectFrontend(x.bits.exceptionVec) :+ x.bits.exceptionVec(illegalInstr) :+ x.bits.exceptionVec(virtualInstr)).orR || TriggerAction.isDmode(x.bits.trigger)
   }
   if(backendParams.debugEn){
     dontTouch(robIdxHeadNext)

--- a/src/main/scala/xiangshan/backend/rob/ExceptionGen.scala
+++ b/src/main/scala/xiangshan/backend/rob/ExceptionGen.scala
@@ -125,7 +125,7 @@ class ExceptionGen(params: BackendParams)(implicit p: Parameters) extends XSModu
         current.flushPipe := s1_out_bits.flushPipe || current.flushPipe
         current.replayInst := s1_out_bits.replayInst || current.replayInst
         current.singleStep := s1_out_bits.singleStep || current.singleStep
-        current.trigger := (s1_out_bits.trigger.asUInt | current.trigger.asUInt).asTypeOf(new TriggerCf)
+        current.trigger := (s1_out_bits.trigger | current.trigger)
       }
     }
   }.elsewhen (s1_out_valid && !s1_flush) {

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -278,14 +278,14 @@ class RobExceptionInfo(implicit p: Parameters) extends XSBundle {
   val replayInst = Bool() // redirect to that inst itself
   val singleStep = Bool() // TODO add frontend hit beneath
   val crossPageIPFFix = Bool()
-  val trigger = new TriggerCf
+  val trigger = TriggerAction()
   val vstartEn = Bool()
   val vstart = UInt(XLEN.W)
 
-  def has_exception = hasException || flushPipe || singleStep || replayInst || trigger.canFire
-  def not_commit = hasException || singleStep || replayInst || trigger.canFire
+  def has_exception = hasException || flushPipe || singleStep || replayInst || TriggerAction.isDmode(trigger)
+  def not_commit = hasException || singleStep || replayInst || TriggerAction.isDmode(trigger)
   // only exceptions are allowed to writeback when enqueue
-  def can_writeback = hasException || singleStep || trigger.canFire
+  def can_writeback = hasException || singleStep || TriggerAction.isDmode(trigger)
 }
 
 class RobFlushInfo(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -234,7 +234,7 @@ class FetchToIBuffer(implicit p: Parameters) extends XSBundle {
   val ftqOffset    = Vec(PredictWidth, ValidUndirectioned(UInt(log2Ceil(PredictWidth).W)))
   val exceptionType = Vec(PredictWidth, UInt(ExceptionType.width.W))
   val crossPageIPFFix = Vec(PredictWidth, Bool())
-  val triggered    = Vec(PredictWidth, new TriggerCf)
+  val triggered    = Vec(PredictWidth, TriggerAction())
   val topdown_info = new FrontendTopDownBundle
 }
 

--- a/src/main/scala/xiangshan/frontend/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/IBuffer.scala
@@ -65,7 +65,7 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
   val ftqOffset = UInt(log2Ceil(PredictWidth).W)
   val exceptionType = UInt(ExceptionType.width.W)
   val crossPageIPFFix = Bool()
-  val triggered = new TriggerCf
+  val triggered = TriggerAction()
 
   def fromFetch(fetch: FetchToIBuffer, i: Int): IBufEntry = {
     inst   := fetch.instrs(i)

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -699,6 +699,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   storeTrigger.io.fromCsrTrigger.tdataVec             := io.fromCsrTrigger.tdataVec
   storeTrigger.io.fromCsrTrigger.tEnableVec           := io.fromCsrTrigger.tEnableVec
   storeTrigger.io.fromCsrTrigger.triggerCanRaiseBpExp := io.fromCsrTrigger.triggerCanRaiseBpExp
+  storeTrigger.io.fromCsrTrigger.debugMode            := io.fromCsrTrigger.debugMode
   storeTrigger.io.fromStore.vaddr                     := s1_in.vaddr
 
   when (s1_ld_flow) {
@@ -716,9 +717,8 @@ class HybridUnit(implicit p: Parameters) extends XSModule
     s1_out.uop.exceptionVec(storePageFault)        := io.tlb.resp.bits.excp(0).pf.st
     s1_out.uop.exceptionVec(storeGuestPageFault)   := io.tlb.resp.bits.excp(0).gpf.st
     s1_out.uop.exceptionVec(storeAccessFault)      := io.tlb.resp.bits.excp(0).af.st
-    s1_out.uop.trigger.backendHit                  := storeTrigger.io.toStore.triggerHitVec
-    s1_out.uop.trigger.backendCanFire              := storeTrigger.io.toStore.triggerCanFireVec
-    s1_out.uop.exceptionVec(breakPoint)            := storeTrigger.io.toStore.breakPointExp
+    s1_out.uop.trigger                             := storeTrigger.io.toStore.triggerAction
+    s1_out.uop.exceptionVec(breakPoint)            := TriggerAction.isExp(storeTrigger.io.toStore.triggerAction)
   }
 
   // pointer chasing

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -308,12 +308,12 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   storeTrigger.io.fromCsrTrigger.tdataVec             := io.fromCsrTrigger.tdataVec
   storeTrigger.io.fromCsrTrigger.tEnableVec           := io.fromCsrTrigger.tEnableVec
   storeTrigger.io.fromCsrTrigger.triggerCanRaiseBpExp := io.fromCsrTrigger.triggerCanRaiseBpExp
+  storeTrigger.io.fromCsrTrigger.debugMode            := io.fromCsrTrigger.debugMode
   storeTrigger.io.fromStore.vaddr                     := s1_in.vaddr
 
   s1_out.uop.flushPipe                := false.B
-  s1_out.uop.trigger.backendHit       := storeTrigger.io.toStore.triggerHitVec
-  s1_out.uop.trigger.backendCanFire   := storeTrigger.io.toStore.triggerCanFireVec
-  s1_out.uop.exceptionVec(breakPoint) := storeTrigger.io.toStore.breakPointExp
+  s1_out.uop.trigger                  := storeTrigger.io.toStore.triggerAction
+  s1_out.uop.exceptionVec(breakPoint) := TriggerAction.isExp(storeTrigger.io.toStore.triggerAction)
 
   // scalar store and scalar load nuke check, and also other purposes
   io.lsq.valid     := s1_valid && !s1_in.isHWPrefetch && !s1_frm_mabuf

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -862,7 +862,8 @@ package object xiangshan {
       illegalInstr,
       instrPageFault,
       instrGuestPageFault,
-      virtualInstr
+      virtualInstr,
+      breakPoint
     )
     def partialSelect(vec: Vec[Bool], select: Seq[Int]): Vec[Bool] = {
       val new_vec = Wire(ExceptionVec())


### PR DESCRIPTION
 * use `triggerAction` to replace `triggerHitVec` & `TriggerCanfireVec`, that is useful for trace in the future.
 * use triggerAction = 15.U to express that action is None.
 * put breakpoint exception generated by trigger into ExceptionVec[BP] derectly.
 * update exceptionVec in `decode` for bp exception from frontend trigger.
 * trigger don't genetate exception in debugMode.
 * trigger don't generate exception when tcontrol.mte is false in Mmode.