### PR TITLE
FTQ: backend redirect indicates that instructions before the flushed …

### DIFF
--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -1266,7 +1266,9 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
     (isAfter(robCommPtr, commPtr) ||
       validInstructions.reduce(_ || _) && lastInstructionStatus =/= c_toCommit)
 
-  when (io.fromBackend.rob_commits.map(_.valid).reduce(_ | _)) {
+  when (io.fromBackend.redirect.valid) {
+    robCommPtr_write := io.fromBackend.redirect.bits.ftqIdx
+  } .elsewhen (io.fromBackend.rob_commits.map(_.valid).reduce(_ | _)) {
     robCommPtr_write := ParallelPriorityMux(io.fromBackend.rob_commits.map(_.valid).reverse, io.fromBackend.rob_commits.map(_.bits.ftqIdx).reverse)
   } .elsewhen (isAfter(commPtr, robCommPtr)) {
     robCommPtr_write := commPtr

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -1256,16 +1256,15 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val bpu_ftb_update_stall = RegInit(0.U(2.W)) // 2-cycle stall, so we need 3 states
   may_have_stall_from_bpu := bpu_ftb_update_stall =/= 0.U
 
-  val validInstructions = commitStateQueueReg(commPtr.value).map(s => s === c_toCommit || s === c_committed)
+  val validInstructions = commitStateQueueReg(commPtr.value).map(s => s =/= c_empty)
   val lastInstructionStatus = PriorityMux(validInstructions.reverse.zip(commitStateQueueReg(commPtr.value).reverse))
   val firstInstructionFlushed = commitStateQueueReg(commPtr.value)(0) === c_flushed
   canCommit := commPtr =/= ifuWbPtr && !may_have_stall_from_bpu &&
     (isAfter(robCommPtr, commPtr) ||
-      validInstructions.reduce(_ || _) && lastInstructionStatus === c_committed)
+      validInstructions.reduce(_ || _) && lastInstructionStatus =/= c_toCommit && !firstInstructionFlushed)
   val canMoveCommPtr = commPtr =/= ifuWbPtr && !may_have_stall_from_bpu &&
     (isAfter(robCommPtr, commPtr) ||
-      validInstructions.reduce(_ || _) && lastInstructionStatus === c_committed ||
-      firstInstructionFlushed)
+      validInstructions.reduce(_ || _) && lastInstructionStatus =/= c_toCommit)
 
   when (io.fromBackend.rob_commits.map(_.valid).reduce(_ | _)) {
     robCommPtr_write := ParallelPriorityMux(io.fromBackend.rob_commits.map(_.valid).reverse, io.fromBackend.rob_commits.map(_.bits.ftqIdx).reverse)
@@ -1282,7 +1281,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
     */
   val mmioReadPtr = io.mmioCommitRead.mmioFtqPtr
   val mmioLastCommit = isAfter(commPtr, mmioReadPtr) ||
-    commPtr === mmioReadPtr && validInstructions.reduce(_ || _) && lastInstructionStatus === c_committed
+    commPtr === mmioReadPtr && validInstructions.reduce(_ || _) && lastInstructionStatus =/= c_toCommit
   io.mmioCommitRead.mmioLastCommit := RegNext(mmioLastCommit)
 
   // commit reads


### PR DESCRIPTION
…instructions have been committed