### PR TITLE
ldu: fix potential bug when exec unaligned hlv or hlvx

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -462,8 +462,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     out.isvec         := false.B
     out.is128bit      := src.is128bit
     out.vecActive     := true.B
-    out.hlv           := false.B
-    out.hlvx          := false.B
+    out.hlv           := LSUOpType.isHlv(src.uop.fuOpType)
+    out.hlvx          := LSUOpType.isHlvx(src.uop.fuOpType)
     out
   }
 


### PR DESCRIPTION
Potential Bug Description:
* If an unaligned `hlv` or `hlvx` is executed, the unaligned exception will be caught and processed by the hardware. When loadMisalignBuffer sends a split request to ldu, the `hlv` and `hlvx` identifiers need to be given, otherwise tlb cannot recognize it.