### PR TITLE
ICache: fix metaArray ECC check

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -80,14 +80,19 @@ trait HasICacheParameters extends HasL1CacheParameters with HasInstrMMIOConst wi
   def ICacheDataSRAMWidth   = cacheParams.ICacheDataSRAMWidth
   def partWayNum            = cacheParams.partWayNum
 
+  def ICacheMetaBits        = tagBits  // FIXME: unportable: maybe use somemethod to get width
+  def ICacheMetaCodeBits    = 1  // FIXME: unportable: maybe use cacheParams.tagCode.somemethod to get width
+  def ICacheMetaEntryBits   = ICacheMetaBits + ICacheMetaCodeBits
+
   def ICacheDataBits        = blockBits / ICacheDataBanks
-  def ICacheCodeBits        = math.ceil(ICacheDataBits / DataCodeUnit).toInt
-  def ICacheEntryBits       = ICacheDataBits + ICacheCodeBits
+  def ICacheDataCodeSegs    = math.ceil(ICacheDataBits / DataCodeUnit).toInt  // split data to segments for ECC checking
+  def ICacheDataCodeBits    = ICacheDataCodeSegs * 1  // FIXME: unportable: maybe use cacheParams.dataCode.somemethod to get width
+  def ICacheDataEntryBits   = ICacheDataBits + ICacheDataCodeBits
   def ICacheBankVisitNum    = 32 * 8 / ICacheDataBits + 1
   def highestIdxBit         = log2Ceil(nSets) - 1
 
   require((ICacheDataBanks >= 2) && isPow2(ICacheDataBanks))
-  require(ICacheDataSRAMWidth >= ICacheEntryBits)
+  require(ICacheDataSRAMWidth >= ICacheDataEntryBits)
   require(isPow2(ICacheSets), s"nSets($ICacheSets) must be pow2")
   require(isPow2(ICacheWays), s"nWays($ICacheWays) must be pow2")
 
@@ -128,10 +133,17 @@ trait HasICacheParameters extends HasL1CacheParameters with HasInstrMMIOConst wi
     return RegInit(VecInit(Seq.fill(size)(0.U.asTypeOf(entry.cloneType))))
   }
 
-  def encode(data: UInt): UInt = {
-    val datas = data.asTypeOf(Vec(ICacheCodeBits, UInt((ICacheDataBits / ICacheCodeBits).W)))
-    val codes = VecInit(datas.map(cacheParams.dataCode.encode(_) >> (ICacheDataBits / ICacheCodeBits)))
-    codes.asTypeOf(UInt(ICacheCodeBits.W))
+  def encodeMetaECC(meta: UInt): UInt = {
+    require(meta.getWidth == ICacheMetaBits)
+    val code = cacheParams.tagCode.encode(meta) >> ICacheMetaBits
+    code.asTypeOf(UInt(ICacheMetaCodeBits.W))
+  }
+
+  def encodeDataECC(data: UInt): UInt = {
+    require(data.getWidth == ICacheDataBits)
+    val datas = data.asTypeOf(Vec(ICacheDataCodeSegs, UInt((ICacheDataBits / ICacheDataCodeSegs).W)))
+    val codes = VecInit(datas.map(cacheParams.dataCode.encode(_) >> (ICacheDataBits / ICacheDataCodeSegs)))
+    codes.asTypeOf(UInt(ICacheDataCodeBits.W))
   }
 
   def getBankSel(blkOffset: UInt, valid: Bool = true.B): Vec[UInt] = {
@@ -149,7 +161,7 @@ trait HasICacheParameters extends HasL1CacheParameters with HasInstrMMIOConst wi
   }
 
   def getBlkAddr(addr: UInt) = addr >> blockOffBits
-  def getPhyTagFromBlk(addr: UInt) = addr >> (pgUntagBits - blockOffBits)
+  def getPhyTagFromBlk(addr: UInt): UInt = addr >> (pgUntagBits - blockOffBits)
   def getIdxFromBlk(addr: UInt) = addr(idxBits - 1, 0)
   def get_paddr_from_ptag(vaddr: UInt, ptag: UInt) = Cat(ptag, vaddr(pgUntagBits - 1, 0))
 }
@@ -178,18 +190,29 @@ object ICacheMetadata {
 
 class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray
 {
-  def onReset = ICacheMetadata(0.U)
-  val metaBits = onReset.getWidth
-  val metaEntryBits = cacheParams.tagCode.width(metaBits)
+  class ICacheMetaEntry(implicit p: Parameters) extends ICacheBundle {
+    val meta: ICacheMetadata = new ICacheMetadata
+    val code: UInt           = UInt(ICacheMetaCodeBits.W)
+  }
 
-  val io=IO{new Bundle{
+  private object ICacheMetaEntry {
+    def apply(meta: ICacheMetadata)(implicit p: Parameters): ICacheMetaEntry = {
+      val entry = Wire(new ICacheMetaEntry)
+      entry.meta := meta
+      entry.code := encodeMetaECC(meta.asUInt)
+      entry
+    }
+  }
+
+  // sanity check
+  require(ICacheMetaEntryBits == (new ICacheMetaEntry).getWidth)
+
+  val io = IO(new Bundle {
     val write    = Flipped(DecoupledIO(new ICacheMetaWriteBundle))
     val read     = Flipped(DecoupledIO(new ICacheReadBundle))
     val readResp = Output(new ICacheMetaRespBundle)
     val fencei   = Input(Bool())
-  }}
-
-  io.read.ready := !io.write.valid
+  })
 
   val port_0_read_0 = io.read.valid  && !io.read.bits.vSetIdx(0)(0)
   val port_0_read_1 = io.read.valid  &&  io.read.bits.vSetIdx(0)(0)
@@ -208,11 +231,13 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray
   val write_bank_0 = io.write.valid && !io.write.bits.bankIdx
   val write_bank_1 = io.write.valid &&  io.write.bits.bankIdx
 
-  val write_meta_bits = Wire(UInt(metaEntryBits.W))
+  val write_meta_bits = ICacheMetaEntry(meta = ICacheMetadata(
+    tag = io.write.bits.phyTag
+  ))
 
   val tagArrays = (0 until 2) map { bank =>
     val tagArray = Module(new SRAMTemplate(
-      UInt(metaEntryBits.W),
+      new ICacheMetaEntry(),
       set=nSets/2,
       way=nWays,
       shouldReset = true,
@@ -249,32 +274,6 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray
 
   io.read.ready := !io.write.valid && !io.fencei && tagArrays.map(_.io.r.req.ready).reduce(_&&_)
 
-  //Parity Decode
-  val read_fire_delay1 = RegNext(io.read.fire, init = false.B)
-  val read_fire_delay2 = RegNext(read_fire_delay1, init = false.B)
-  val read_metas = Wire(Vec(2,Vec(nWays,new ICacheMetadata())))
-  for((tagArray,i) <- tagArrays.zipWithIndex){
-    val read_meta_bits = tagArray.io.r.resp.asTypeOf(Vec(nWays,UInt(metaEntryBits.W)))
-    val read_meta_decoded = read_meta_bits.map{ way_bits => cacheParams.tagCode.decode(way_bits)}
-    val read_meta_wrong = read_meta_decoded.map{ way_bits_decoded => way_bits_decoded.error}
-    val read_meta_corrected = VecInit(read_meta_decoded.map{ way_bits_decoded => way_bits_decoded.corrected})
-    read_metas(i) := read_meta_corrected.asTypeOf(Vec(nWays,new ICacheMetadata()))
-    (0 until nWays).foreach{ w => io.readResp.errors(i)(w) := RegEnable(read_meta_wrong(w), 0.U.asTypeOf(read_meta_wrong(w)), read_fire_delay1) && read_fire_delay2}
-  }
-
-  // TEST: force ECC to fail by setting errors to true.B
-  if (ICacheForceMetaECCError) {
-    (0 until PortNumber).foreach( p =>
-      (0 until nWays).foreach( w =>
-        io.readResp.errors(p)(w) := true.B
-      )
-    )
-  }
-
-  //Parity Encode
-  val write = io.write.bits
-  write_meta_bits := cacheParams.tagCode.encode(ICacheMetadata(tag = write.phyTag).asUInt)
-
   // valid write
   val way_num = OHToUInt(io.write.bits.waymask)
   when (io.write.valid) {
@@ -283,19 +282,34 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray
 
   XSPerfAccumulate("meta_refill_num", io.write.valid)
 
-  io.readResp.metaData <> DontCare
+  io.readResp.metas <> DontCare
+  io.readResp.codes <> DontCare
+  val readMetaEntries = tagArrays.map{ port =>
+    port.io.r.resp.asTypeOf(Vec(nWays, new ICacheMetaEntry()))
+  }
+  val readMetas = readMetaEntries.map(_.map(_.meta))
+  val readCodes = readMetaEntries.map(_.map(_.code))
+
+  // TEST: force ECC to fail by setting readCodes to 0
+  if (ICacheForceMetaECCError) {
+    readCodes.foreach(_.foreach(_ := 0.U))
+  }
+
   when(port_0_read_0_reg){
-    io.readResp.metaData(0) := read_metas(0)
+    io.readResp.metas(0) := readMetas(0)
+    io.readResp.codes(0) := readCodes(0)
   }.elsewhen(port_0_read_1_reg){
-    io.readResp.metaData(0) := read_metas(1)
+    io.readResp.metas(0) := readMetas(1)
+    io.readResp.codes(0) := readCodes(1)
   }
 
   when(port_1_read_0_reg){
-    io.readResp.metaData(1) := read_metas(0)
+    io.readResp.metas(1) := readMetas(0)
+    io.readResp.codes(1) := readCodes(0)
   }.elsewhen(port_1_read_1_reg){
-    io.readResp.metaData(1) := read_metas(1)
+    io.readResp.metas(1) := readMetas(1)
+    io.readResp.codes(1) := readCodes(1)
   }
-
 
   io.write.ready := true.B // TODO : has bug ? should be !io.cacheOp.req.valid
 
@@ -307,21 +321,18 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray
   }
 }
 
-// Vec(2,Vec(nWays, Bool()))
-
 class ICacheDataArray(implicit p: Parameters) extends ICacheArray
 {
   class ICacheDataEntry(implicit p: Parameters) extends ICacheBundle {
     val data = UInt(ICacheDataBits.W)
-    val code = UInt(ICacheCodeBits.W)
+    val code = UInt(ICacheDataCodeBits.W)
   }
 
   object ICacheDataEntry {
     def apply(data: UInt)(implicit p: Parameters) = {
-      require(data.getWidth == ICacheDataBits)
       val entry = Wire(new ICacheDataEntry)
       entry.data := data
-      entry.code := encode(data)
+      entry.code := encodeDataECC(data)
       entry
     }
   }
@@ -355,7 +366,7 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray
   val dataArrays = (0 until nWays).map{ way =>
     (0 until ICacheDataBanks).map { bank =>
       val sramBank = Module(new SRAMTemplateWithFixedWidth(
-        UInt(ICacheEntryBits.W),
+        UInt(ICacheDataEntryBits.W),
         set=nSets,
         width=ICacheDataSRAMWidth,
         shouldReset = true,

--- a/src/main/scala/xiangshan/frontend/icache/ICacheBundle.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheBundle.scala
@@ -33,16 +33,6 @@ class ICacheReadBundle(implicit p: Parameters) extends ICacheBundle
   val isDoubleLine  = Bool()
 }
 
-
-class ICacheMetaRespBundle(implicit p: Parameters) extends ICacheBundle
-{
-  val metaData   = Vec(2, Vec(nWays, new ICacheMetadata))
-  val errors     = Vec(2, Vec(nWays ,Bool() ))
-  val entryValid = Vec(2, Vec(nWays, Bool()))
-
-  def tags = VecInit(metaData.map(port => VecInit(port.map( way=> way.tag ))))
-}
-
 class ICacheMetaWriteBundle(implicit p: Parameters) extends ICacheBundle
 {
   val virIdx  = UInt(idxBits.W)
@@ -75,10 +65,20 @@ class ICacheDataWriteBundle(implicit p: Parameters) extends ICacheBundle
 
 }
 
+class ICacheMetaRespBundle(implicit p: Parameters) extends ICacheBundle
+{
+  val metas      = Vec(PortNumber, Vec(nWays, new ICacheMetadata))
+  val codes      = Vec(PortNumber, Vec(nWays, UInt(ICacheMetaCodeBits.W)))
+  val entryValid = Vec(PortNumber, Vec(nWays, Bool()))
+
+  // for compatibility
+  def tags = VecInit(metas.map(port => VecInit(port.map( way => way.tag ))))
+}
+
 class ICacheDataRespBundle(implicit p: Parameters) extends ICacheBundle
 {
   val datas   = Vec(ICacheDataBanks, UInt(ICacheDataBits.W))
-  val codes   = Vec(ICacheDataBanks, UInt(ICacheCodeBits.W))
+  val codes   = Vec(ICacheDataBanks, UInt(ICacheDataCodeBits.W))
 }
 
 class ICacheMetaReadBundle(implicit p: Parameters) extends ICacheBundle

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -235,8 +235,6 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
 
   val s1_meta_ptags   = fromMeta.tags
   val s1_meta_valids  = fromMeta.entryValid
-  // If error is found in either way, the tag_eq_vec is unreliable, so we do not use waymask, but directly .orR
-  val s1_meta_corrupt = VecInit(fromMeta.errors.map(_.asUInt.orR))
 
   def get_waymask(paddrs: Vec[UInt]): Vec[UInt] = {
     val ptags         = paddrs.map(get_phy_tag)
@@ -280,6 +278,23 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
     s1_waymasks(i) := update_waymask(old_waymask, s1_req_vSetIdx(i), s1_req_ptags(i))
   }
 
+  // select ecc code
+  /* NOTE:
+   * When ECC check fails, s1_waymasks may be corrupted, so this selected meta_codes may be wrong.
+   * However, we can guarantee that the request sent to the l2 cache and the response to the IFU are both correct,
+   * considering the probability of bit flipping abnormally is very small, consider there's up to 1 bit being wrong:
+   * 1. miss -> fake hit: The wrong bit in s1_waymasks was set to true.B, thus selects the wrong meta_codes,
+   *                      but we can detect this by checking whether `encodeMetaECC(req_ptags) === meta_codes`.
+   * 2. hit -> fake multi-hit: In normal situation, multi-hit never happens, so multi-hit indicates ECC failure,
+   *                           we can detect this by checking whether `PopCount(waymasks) <= 1.U`,
+   *                           and meta_codes is not important in this situation.
+   * 3. hit -> fake miss: We can't detect this, but we can (pre)fetch the correct data from L2 cache, so it's not a problem.
+   * 4. hit -> hit / miss -> miss: ECC failure happens in a irrelevant way, so we don't care about it this time.
+   */
+  val s1_meta_codes = VecInit((0 until PortNumber).map { port =>
+    Mux1H(s1_waymasks(port), fromMeta.codes(port))
+  })
+
   /**
     ******************************************************************************
     * send enqueu req to WayLookup
@@ -292,12 +307,12 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   toWayLookup.bits.waymask      := s1_waymasks
   toWayLookup.bits.ptag         := s1_req_ptags
   toWayLookup.bits.gpaddr       := s1_req_gpaddr
+  toWayLookup.bits.meta_codes   := s1_meta_codes
   (0 until PortNumber).foreach { i =>
     val excpValid = (if (i == 0) true.B else s1_doubleline)  // exception in first line is always valid, in second line is valid iff is doubleline request
     // Send s1_itlb_exception to WayLookup (instead of s1_exception_out) for better timing. Will check pmp again in mainPipe
     toWayLookup.bits.itlb_exception(i) := Mux(excpValid, s1_itlb_exception(i), ExceptionType.none)
     toWayLookup.bits.itlb_pbmt(i)      := Mux(excpValid, s1_itlb_pbmt(i), Pbmt.pma)
-    toWayLookup.bits.meta_corrupt(i)   := excpValid && s1_meta_corrupt(i)
   }
 
   val s1_waymasks_vec = s1_waymasks.map(_.asTypeOf(Vec(nWays, Bool())))
@@ -323,14 +338,11 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   val s1_pmp_exception = VecInit(fromPMP.map(ExceptionType.fromPMPResp))
   val s1_pmp_mmio      = VecInit(fromPMP.map(_.mmio))
 
-  // also raise af when meta array corrupt is detected, to cancel prefetch
-  val s1_meta_exception = VecInit(s1_meta_corrupt.map(ExceptionType.fromECC(io.csr_parity_enable, _)))
-
-  // merge s1 itlb/pmp/meta exceptions, itlb has the highest priority, pmp next, meta lowest
+  // merge s1 itlb/pmp exceptions, itlb has the highest priority, pmp next
+  // for timing consideration, meta_corrupt is not merged, and it will NOT cancel prefetch
   val s1_exception_out = ExceptionType.merge(
     s1_itlb_exception,
-    s1_pmp_exception,
-    s1_meta_exception
+    s1_pmp_exception
   )
 
   // merge pmp mmio and itlb pbmt
@@ -411,12 +423,29 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
   val s2_isSoftPrefetch = RegEnable(s1_isSoftPrefetch, 0.U.asTypeOf(s1_isSoftPrefetch), s1_real_fire)
   val s2_doubleline   = RegEnable(s1_doubleline,    0.U.asTypeOf(s1_doubleline),    s1_real_fire)
   val s2_req_paddr    = RegEnable(s1_req_paddr,     0.U.asTypeOf(s1_req_paddr),     s1_real_fire)
-  val s2_exception    = RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_real_fire)  // includes itlb/pmp/meta exception
+  val s2_exception    = RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_real_fire)  // includes itlb/pmp exception
+//  val s2_exception_in = RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_real_fire)  // disabled for timing consideration
   val s2_mmio         = RegEnable(s1_mmio,          0.U.asTypeOf(s1_mmio),          s1_real_fire)
   val s2_waymasks     = RegEnable(s1_waymasks,      0.U.asTypeOf(s1_waymasks),      s1_real_fire)
+//  val s2_meta_codes   = RegEnable(s1_meta_codes,    0.U.asTypeOf(s1_meta_codes),    s1_real_fire)  // disabled for timing consideration
 
   val s2_req_vSetIdx  = s2_req_vaddr.map(get_idx)
   val s2_req_ptags    = s2_req_paddr.map(get_phy_tag)
+
+  // disabled for timing consideration
+//  // do metaArray ECC check
+//  val s2_meta_corrupt = VecInit((s2_req_ptags zip s2_meta_codes zip s2_waymasks).map{ case ((meta, code), waymask) =>
+//    val hit_num = PopCount(waymask)
+//    // NOTE: if not hit, encodeMetaECC(meta) =/= code can also be true, but we don't care about it
+//    (encodeMetaECC(meta) =/= code && hit_num === 1.U) ||  // hit one way, but parity code does not match, ECC failure
+//      hit_num > 1.U                                       // hit multi way, must be a ECC failure
+//  })
+//
+//  // generate exception
+//  val s2_meta_exception = VecInit(s2_meta_corrupt.map(ExceptionType.fromECC(io.csr_parity_enable, _)))
+//
+//  // merge meta exception and itlb/pmp exception
+//  val s2_exception = ExceptionType.merge(s2_exception_in, s2_meta_exception)
 
   /**
     ******************************************************************************


### PR DESCRIPTION
Currently, metaArray ECC check is valid 2 cycles after request:
https://github.com/OpenXiangShan/XiangShan/blob/49162c9ab67070931573c1d4a372e2c858a72716/src/main/scala/xiangshan/frontend/icache/ICache.scala#L262

However, prefetchPipe s1 handshakes with both WayLookup and prefetchPipe s2 assuming that all signals of the metaArray.io.readResp are valid 1 cycle after the request, resulting in the error.

Simply removing this RegEnable may lead to problems with long timing paths (metaArray (sram) -> ECC check (xor reduction) -> prefetchPipe s1 (wire) -> wayLookup (bypass, wire) -> mainPipe s0 (wire) -> mainPipe s1 (reg)), so no.

This PR may result in case-specific errors not being checked out, which in turn results in additional fetch requests being sent to the L2 cache, but does not causes corrupted data being sent to the backend. See discussion in notes:
https://github.com/OpenXiangShan/XiangShan/blob/8b87b8dcbfd5945c5bd7815eb5e569fec252ddc6/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala#L279-L293

There are 2 more potential solutions described in an internal yuque document, however, due to the complexity of implementation, area overhead and other considerations, the current solution is considered to be optimal.