### PR TITLE
PTW, RVH: init the A、D、PPN of fake pte to avoid wrong pf and wrong gpaddr in L1TLB

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -189,7 +189,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   fake_pte.perm.a := true.B
   fake_pte.perm.d := true.B
   fake_pte.ppn := ppn(ppnLen - 1, 0)
-  fake_pte.ppn_high := ppn(pteResLen - ppnLen -1, ppnLen)
+  fake_pte.ppn_high := ppn(pteResLen - 1, ppnLen)
 
   io.req.ready := idle
   val ptw_resp = Wire(new PtwMergeResp)

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -189,7 +189,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   fake_pte.perm.a := true.B
   fake_pte.perm.d := true.B
   fake_pte.ppn := ppn(ppnLen - 1, 0)
-  fake_pte.ppn_high := ppn(pteResLen - 1, ppnLen)
+  fake_pte.ppn_high := ppn(ptePPNLen - 1, ppnLen)
 
   io.req.ready := idle
   val ptw_resp = Wire(new PtwMergeResp)

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -186,6 +186,10 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   fake_pte.perm.r := true.B
   fake_pte.perm.w := true.B
   fake_pte.perm.x := true.B
+  fake_pte.perm.a := true.B
+  fake_pte.perm.d := true.B
+  fake_pte.ppn := get_pn(gpaddr)(ppnLen - 1, 0)
+  fake_pte.ppn_high := get_pn(gpaddr)(pteResLen - ppnLen -1, ppnLen)
 
   io.req.ready := idle
   val ptw_resp = Wire(new PtwMergeResp)

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -188,8 +188,8 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   fake_pte.perm.x := true.B
   fake_pte.perm.a := true.B
   fake_pte.perm.d := true.B
-  fake_pte.ppn := get_pn(gpaddr)(ppnLen - 1, 0)
-  fake_pte.ppn_high := get_pn(gpaddr)(pteResLen - ppnLen -1, ppnLen)
+  fake_pte.ppn := ppn(ppnLen - 1, 0)
+  fake_pte.ppn_high := ppn(pteResLen - ppnLen -1, ppnLen)
 
   io.req.ready := idle
   val ptw_resp = Wire(new PtwMergeResp)


### PR DESCRIPTION
1. init a、d、ppn of fake pte
2. modify the logic of isPf and isAf