### PR TITLE
StoreUnit: DONT report af to exceptionBuffer when store is killed

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -397,7 +397,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
 
   // mmio and exception
   io.lsq_replenish := s2_out
-  io.lsq_replenish.af := s2_out.af && !s2_kill
+  io.lsq_replenish.af := s2_out.af && s2_valid && !s2_kill
 
   // prefetch related
   io.lsq_replenish.miss := io.dcache.resp.fire && io.dcache.resp.bits.miss // miss info


### PR DESCRIPTION
When a store is killed at s1 in StoreUnit because of MMIO check or pipeline flush, the store should not be reported to exception buffer no matter whether there is af exception at s2 or not.