### PR TITLE
refactor(LDU, HYU): optimized for low coupling

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -201,94 +201,39 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   // priority: high to low
   val s0_ld_flow             = FuType.isLoad(s0_uop.fuType) || FuType.isVLoad(s0_uop.fuType)
   val s0_rep_stall           = io.lsin.valid && isAfter(io.ldu_io.replay.bits.uop.robIdx, io.lsin.bits.uop.robIdx)
-  val s0_super_ld_rep_valid  = io.ldu_io.replay.valid && io.ldu_io.replay.bits.forward_tlDchannel
-  val s0_ld_fast_rep_valid   = io.ldu_io.fast_rep_in.valid
-  val s0_ld_rep_valid        = io.ldu_io.replay.valid && !io.ldu_io.replay.bits.forward_tlDchannel && !s0_rep_stall
-  val s0_high_conf_prf_valid = io.ldu_io.prefetch_req.valid && io.ldu_io.prefetch_req.bits.confidence > 0.U
-  val s0_int_iss_valid       = io.lsin.valid // int flow first issue or software prefetch
-  val s0_vec_iss_valid       = io.vec_stu_io.in.valid
-  val s0_l2l_fwd_valid       = io.ldu_io.l2l_fwd_in.valid && io.ldu_io.ld_fast_match
-  val s0_low_conf_prf_valid  = io.ldu_io.prefetch_req.valid && io.ldu_io.prefetch_req.bits.confidence === 0.U
-  dontTouch(s0_super_ld_rep_valid)
-  dontTouch(s0_ld_fast_rep_valid)
-  dontTouch(s0_ld_rep_valid)
-  dontTouch(s0_high_conf_prf_valid)
-  dontTouch(s0_int_iss_valid)
-  dontTouch(s0_vec_iss_valid)
-  dontTouch(s0_l2l_fwd_valid)
-  dontTouch(s0_low_conf_prf_valid)
-
+  private val SRC_NUM = 8
+  private val Seq(
+    super_rep_idx, fast_rep_idx, lsq_rep_idx, high_pf_idx, 
+    int_iss_idx, vec_iss_idx, l2l_fwd_idx, low_pf_idx
+  ) = (0 until SRC_NUM).toSeq
+  // load flow source valid
+  val s0_src_valid_vec = WireInit(VecInit(Seq(
+    io.ldu_io.replay.valid && io.ldu_io.replay.bits.forward_tlDchannel,
+    io.ldu_io.fast_rep_in.valid,
+    io.ldu_io.replay.valid && !io.ldu_io.replay.bits.forward_tlDchannel && !s0_rep_stall,
+    io.ldu_io.prefetch_req.valid && io.ldu_io.prefetch_req.bits.confidence > 0.U,
+    io.lsin.valid, // int flow first issue or software prefetch
+    io.vec_stu_io.in.valid,
+    io.ldu_io.l2l_fwd_in.valid && io.ldu_io.ld_fast_match,
+    io.ldu_io.prefetch_req.valid && io.ldu_io.prefetch_req.bits.confidence === 0.U,
+  )))
   // load flow source ready
-  val s0_super_ld_rep_ready  = WireInit(true.B)
-  val s0_ld_fast_rep_ready   = !s0_super_ld_rep_valid
-  val s0_ld_rep_ready        = !s0_super_ld_rep_valid &&
-                               !s0_ld_fast_rep_valid
-  val s0_high_conf_prf_ready = !s0_super_ld_rep_valid &&
-                               !s0_ld_fast_rep_valid &&
-                               !s0_ld_rep_valid
-
-  val s0_int_iss_ready       = !s0_super_ld_rep_valid &&
-                               !s0_ld_fast_rep_valid &&
-                               !s0_ld_rep_valid &&
-                               !s0_high_conf_prf_valid
-
-  val s0_vec_iss_ready       = !s0_super_ld_rep_valid &&
-                               !s0_ld_fast_rep_valid &&
-                               !s0_ld_rep_valid &&
-                               !s0_high_conf_prf_valid &&
-                               !s0_int_iss_valid
-
-  val s0_l2l_fwd_ready       = !s0_super_ld_rep_valid &&
-                               !s0_ld_fast_rep_valid &&
-                               !s0_ld_rep_valid &&
-                               !s0_high_conf_prf_valid &&
-                               !s0_int_iss_valid &&
-                               !s0_vec_iss_valid
-
-  val s0_low_conf_prf_ready  = !s0_super_ld_rep_valid &&
-                               !s0_ld_fast_rep_valid &&
-                               !s0_ld_rep_valid &&
-                               !s0_high_conf_prf_valid &&
-                               !s0_int_iss_valid &&
-                               !s0_vec_iss_valid &&
-                               !s0_l2l_fwd_valid
-  dontTouch(s0_super_ld_rep_ready)
-  dontTouch(s0_ld_fast_rep_ready)
-  dontTouch(s0_ld_rep_ready)
-  dontTouch(s0_high_conf_prf_ready)
-  dontTouch(s0_int_iss_ready)
-  dontTouch(s0_vec_iss_ready)
-  dontTouch(s0_l2l_fwd_ready)
-  dontTouch(s0_low_conf_prf_ready)
-
+  val s0_src_ready_vec = Wire(Vec(SRC_NUM, Bool()))
+  s0_src_ready_vec(0) := true.B
+  for(i <- 1 until SRC_NUM){
+    s0_src_ready_vec(i) := !s0_src_valid_vec.take(i).reduce(_ || _)
+  }
   // load flow source select (OH)
-  val s0_super_ld_rep_select = s0_super_ld_rep_valid && s0_super_ld_rep_ready
-  val s0_ld_fast_rep_select  = s0_ld_fast_rep_valid && s0_ld_fast_rep_ready
-  val s0_ld_rep_select       = s0_ld_rep_valid && s0_ld_rep_ready
-  val s0_hw_prf_select       = s0_high_conf_prf_ready && s0_high_conf_prf_valid ||
-                               s0_low_conf_prf_ready && s0_low_conf_prf_valid
-  val s0_int_iss_select      = s0_int_iss_ready && s0_int_iss_valid
-  val s0_vec_iss_select      = s0_vec_iss_ready && s0_vec_iss_valid
-  val s0_l2l_fwd_select      = s0_l2l_fwd_ready && s0_l2l_fwd_valid
-  dontTouch(s0_super_ld_rep_select)
-  dontTouch(s0_ld_fast_rep_select)
-  dontTouch(s0_ld_rep_select)
-  dontTouch(s0_hw_prf_select)
-  dontTouch(s0_int_iss_select)
-  dontTouch(s0_vec_iss_select)
-  dontTouch(s0_l2l_fwd_select)
+  val s0_src_select_vec = WireInit(VecInit((0 until SRC_NUM).map{i => s0_src_valid_vec(i) && s0_src_ready_vec(i)}))
+  val s0_hw_prf_select = s0_src_select_vec(high_pf_idx) || s0_src_select_vec(low_pf_idx)
+  dontTouch(s0_src_valid_vec)
+  dontTouch(s0_src_ready_vec)
+  dontTouch(s0_src_select_vec)
 
-  s0_valid := (s0_super_ld_rep_valid ||
-               s0_ld_fast_rep_valid ||
-               s0_ld_rep_valid ||
-               s0_high_conf_prf_valid ||
-               s0_int_iss_valid ||
-               s0_vec_iss_valid ||
-               s0_l2l_fwd_valid ||
-               s0_low_conf_prf_valid) && !s0_kill
+  s0_valid := s0_src_valid_vec.reduce(_ || _) && !s0_kill
 
   // which is S0's out is ready and dcache is ready
-  val s0_try_ptr_chasing      = s0_l2l_fwd_select
+  val s0_try_ptr_chasing      = s0_src_select_vec(l2l_fwd_idx)
   val s0_do_try_ptr_chasing   = s0_try_ptr_chasing && s0_can_go && io.ldu_io.dcache.req.ready
   val s0_ptr_chasing_vaddr    = io.ldu_io.l2l_fwd_in.data(5, 0) +& io.ldu_io.ld_fast_imm(5, 0)
   val s0_ptr_chasing_canceled = WireInit(false.B)
@@ -300,8 +245,8 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   val s0_prf_wr = Wire(Bool())
   val s0_hw_prf = s0_hw_prf_select
 
-  io.canAcceptLowConfPrefetch  := s0_low_conf_prf_ready && io.ldu_io.dcache.req.ready
-  io.canAcceptHighConfPrefetch := s0_high_conf_prf_ready && io.ldu_io.dcache.req.ready
+  io.canAcceptLowConfPrefetch  := s0_src_ready_vec(low_pf_idx) && io.ldu_io.dcache.req.ready
+  io.canAcceptHighConfPrefetch := s0_src_ready_vec(high_pf_idx) && io.ldu_io.dcache.req.ready
 
   if (StorePrefetchL1Enabled) {
     s0_dcache_ready := Mux(s0_ld_flow, io.ldu_io.dcache.req.ready, io.stu_io.dcache.req.ready)
@@ -340,7 +285,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   io.ldu_io.dcache.req.bits.replayCarry  := s0_rep_carry
   io.ldu_io.dcache.req.bits.id           := DontCare // TODO: update cache meta
   io.ldu_io.dcache.pf_source             := Mux(s0_hw_prf_select, io.ldu_io.prefetch_req.bits.pf_source.value, L1_HW_PREFETCH_NULL)
-  io.ldu_io.dcache.is128Req              := is128Bit(io.vec_stu_io.in.bits.alignedType) && io.vec_stu_io.in.valid && s0_vec_iss_select
+  io.ldu_io.dcache.is128Req              := is128Bit(io.vec_stu_io.in.bits.alignedType) && io.vec_stu_io.in.valid && s0_src_select_vec(vec_iss_idx)
 
   // for store
   io.stu_io.dcache.req.valid             := s0_valid && s0_dcache_ready && !s0_ld_flow && !s0_prf
@@ -487,12 +432,12 @@ class HybridUnit(implicit p: Parameters) extends XSModule
 
   // set default
   s0_uop := DontCare
-  when (s0_super_ld_rep_select)      { fromNormalReplaySource(io.ldu_io.replay.bits)     }
-  .elsewhen (s0_ld_fast_rep_select)  { fromFastReplaySource(io.ldu_io.fast_rep_in.bits)  }
-  .elsewhen (s0_ld_rep_select)       { fromNormalReplaySource(io.ldu_io.replay.bits)     }
-  .elsewhen (s0_hw_prf_select)       { fromPrefetchSource(io.ldu_io.prefetch_req.bits)   }
-  .elsewhen (s0_int_iss_select)      { fromIntIssueSource(io.lsin.bits)                  }
-  .elsewhen (s0_vec_iss_select)      { fromVecIssueSource(io.vec_stu_io.in.bits)         }
+  when (s0_src_select_vec(super_rep_idx)) { fromNormalReplaySource(io.ldu_io.replay.bits)     }
+  .elsewhen (s0_src_select_vec(fast_rep_idx)) { fromFastReplaySource(io.ldu_io.fast_rep_in.bits)  }
+  .elsewhen (s0_src_select_vec(lsq_rep_idx)) { fromNormalReplaySource(io.ldu_io.replay.bits)     }
+  .elsewhen (s0_hw_prf_select) { fromPrefetchSource(io.ldu_io.prefetch_req.bits)   }
+  .elsewhen (s0_src_select_vec(int_iss_idx)) { fromIntIssueSource(io.lsin.bits)                  }
+  .elsewhen (s0_src_select_vec(vec_iss_idx)) { fromVecIssueSource(io.vec_stu_io.in.bits)         }
   .otherwise {
     if (EnableLoadToLoadForward) {
       fromLoadToLoadSource(io.ldu_io.l2l_fwd_in)
@@ -529,7 +474,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   // s0_out.sflowPtr      := s0_flowPtr
   s0_out.uop.exceptionVec(loadAddrMisaligned)  := !s0_addr_aligned && s0_ld_flow
   s0_out.uop.exceptionVec(storeAddrMisaligned) := !s0_addr_aligned && !s0_ld_flow
-  s0_out.forward_tlDchannel := s0_super_ld_rep_select
+  s0_out.forward_tlDchannel := s0_src_select_vec(super_rep_idx)
   when(io.tlb.req.valid && s0_isFirstIssue) {
     s0_out.uop.debugInfo.tlbFirstReqTime := GTimer()
   }.otherwise{
@@ -538,12 +483,12 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   s0_out.schedIndex     := s0_sched_idx
 
   // load fast replay
-  io.ldu_io.fast_rep_in.ready := (s0_can_go && io.ldu_io.dcache.req.ready && s0_ld_fast_rep_ready)
+  io.ldu_io.fast_rep_in.ready := (s0_can_go && io.ldu_io.dcache.req.ready && s0_src_ready_vec(fast_rep_idx))
 
   // load flow source ready
   // cache missed load has highest priority
   // always accept cache missed load flow from load replay queue
-  io.ldu_io.replay.ready := (s0_can_go && io.ldu_io.dcache.req.ready && (s0_ld_rep_ready && !s0_rep_stall || s0_super_ld_rep_select))
+  io.ldu_io.replay.ready := (s0_can_go && io.ldu_io.dcache.req.ready && (s0_src_ready_vec(lsq_rep_idx) && !s0_rep_stall || s0_src_select_vec(super_rep_idx)))
 
   // accept load flow from rs when:
   // 1) there is no lsq-replayed load
@@ -551,8 +496,8 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   // 3) there is no high confidence prefetch request
   io.lsin.ready := (s0_can_go &&
                     Mux(FuType.isLoad(io.lsin.bits.uop.fuType), io.ldu_io.dcache.req.ready,
-                    (if (StorePrefetchL1Enabled) io.stu_io.dcache.req.ready else true.B)) && s0_int_iss_ready)
-  io.vec_stu_io.in.ready := s0_can_go && io.ldu_io.dcache.req.ready && s0_vec_iss_ready
+                    (if (StorePrefetchL1Enabled) io.stu_io.dcache.req.ready else true.B)) && s0_src_ready_vec(int_iss_idx))
+  io.vec_stu_io.in.ready := s0_can_go && io.ldu_io.dcache.req.ready && s0_src_ready_vec(vec_iss_idx)
 
 
   // for hw prefetch load flow feedback, to be added later
@@ -560,7 +505,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
 
   // dcache replacement extra info
   // TODO: should prefetch load update replacement?
-  io.ldu_io.dcache.replacementUpdated := Mux(s0_ld_rep_select || s0_super_ld_rep_select, io.ldu_io.replay.bits.replacementUpdated, false.B)
+  io.ldu_io.dcache.replacementUpdated := Mux(s0_src_select_vec(lsq_rep_idx) || s0_src_select_vec(super_rep_idx), io.ldu_io.replay.bits.replacementUpdated, false.B)
 
   io.stu_io.prefetch_req.ready := s1_ready && io.stu_io.dcache.req.ready && !io.lsin.valid
 
@@ -765,7 +710,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
       s1_in.uop.debugInfo.tlbRespTime     := GTimer()
     }
     when (!s1_cancel_ptr_chasing) {
-      s0_ptr_chasing_canceled := s1_try_ptr_chasing && !io.ldu_io.replay.fire && !io.ldu_io.fast_rep_in.fire && !(s0_high_conf_prf_valid && io.canAcceptHighConfPrefetch)
+      s0_ptr_chasing_canceled := s1_try_ptr_chasing && !io.ldu_io.replay.fire && !io.ldu_io.fast_rep_in.fire && !(s0_src_valid_vec(high_pf_idx) && io.canAcceptHighConfPrefetch)
       when (s1_try_ptr_chasing) {
         io.lsin.ready := true.B
       }
@@ -788,7 +733,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   io.ldu_io.forward_mshr.mshrid := s1_out.mshrid
   io.ldu_io.forward_mshr.paddr  := s1_out.paddr
 
-  io.ldu_io.wakeup.valid := s0_fire && s0_ld_flow && (s0_super_ld_rep_select || s0_ld_fast_rep_select || s0_ld_rep_select || s0_int_iss_select)
+  io.ldu_io.wakeup.valid := s0_fire && s0_ld_flow && (s0_src_select_vec(super_rep_idx) || s0_src_select_vec(fast_rep_idx) || s0_src_select_vec(lsq_rep_idx) || s0_src_select_vec(int_iss_idx))
   io.ldu_io.wakeup.bits := s0_uop
 
   io.stu_io.dcache.s1_kill := s1_tlb_miss || s1_exception || s1_mmio || s1_in.uop.robIdx.needFlush(io.redirect)
@@ -1421,7 +1366,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("s0_addr_spec_failed_once",     s0_fire && s0_vaddr(VAddrBits-1, 12) =/= io.lsin.bits.src(0)(VAddrBits-1, 12) && s0_isFirstIssue)
   XSPerfAccumulate("s0_forward_tl_d_channel",      s0_out.forward_tlDchannel)
   XSPerfAccumulate("s0_hardware_prefetch_fire",    s0_fire && s0_hw_prf_select)
-  XSPerfAccumulate("s0_software_prefetch_fire",    s0_fire && s0_prf && s0_int_iss_select)
+  XSPerfAccumulate("s0_software_prefetch_fire",    s0_fire && s0_prf && s0_src_select_vec(int_iss_idx))
   XSPerfAccumulate("s0_hardware_prefetch_blocked", io.ldu_io.prefetch_req.valid && !s0_hw_prf_select)
   XSPerfAccumulate("s0_hardware_prefetch_total",   io.ldu_io.prefetch_req.valid)
 


### PR DESCRIPTION
The old version involved manually handling multiple load sources and processing signals like `valid`, `ready`, and `select` one by one. Each time a new source was added, multiple lines of dependent code had to be written. In the new version, `Vec` are used for unified handling, so adding a new source only requires adding the corresponding `idx` and the necessary dependent code.