### PR TITLE
fix(L2TLB): Fix exception generation logic 

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -1156,8 +1156,9 @@ class PtwMergeResp(implicit p: Parameters) extends PtwBundle {
   val entry = Vec(tlbcontiguous, new PtwMergeEntry(tagLen = sectorvpnLen, hasPerm = true, hasLevel = true))
   val pteidx = Vec(tlbcontiguous, Bool())
   val not_super = Bool()
+  val not_merge = Bool()
 
-  def apply(pf: Bool, af: Bool, level: UInt, pte: PteBundle, vpn: UInt, asid: UInt, vmid:UInt, addr_low : UInt, not_super : Boolean = true) = {
+  def apply(pf: Bool, af: Bool, level: UInt, pte: PteBundle, vpn: UInt, asid: UInt, vmid:UInt, addr_low : UInt, not_super : Boolean = true, not_merge: Boolean = false) = {
     assert(tlbcontiguous == 8, "Only support tlbcontiguous = 8!")
     val resp_pte = pte
     val ptw_resp = Wire(new PtwMergeEntry(tagLen = sectorvpnLen, hasPerm = true, hasLevel = true))
@@ -1175,7 +1176,7 @@ class PtwMergeResp(implicit p: Parameters) extends PtwBundle {
     ptw_resp.vmid.map(_ := vmid)
     this.pteidx := UIntToOH(addr_low).asBools
     this.not_super := not_super.B
-
+    this.not_merge := not_merge.B
 
     for (i <- 0 until tlbcontiguous) {
       this.entry(i) := ptw_resp

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -696,7 +696,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
         l3GoodToRefill := !memPte(2).isAf()
       }
       is (onlyStage2) {
-        l3GoodToRefill := !memPte(2).isGpf(refill.level_dup(2), mPBMTE)
+        l3GoodToRefill := !memPte(2).isAf() && !memPte(2).isGpf(refill.level_dup(2), mPBMTE)
       }
       is (noS2xlate) {
         l3GoodToRefill := !memPte(2).isAf()
@@ -748,7 +748,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
       l2GoodToRefill := !memPte(2).isAf()
     }
     is (onlyStage2) {
-      l2GoodToRefill := !memPte(2).isGpf(refill.level_dup(2), mPBMTE)
+      l2GoodToRefill := !memPte(2).isAf() && !memPte(2).isGpf(refill.level_dup(2), mPBMTE)
     }
     is (noS2xlate) {
       l2GoodToRefill := !memPte(2).isAf()

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -653,6 +653,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   }
   io.resp.bits.stage1.pteidx := UIntToOH(idx).asBools
   io.resp.bits.stage1.not_super := Mux(resp_res.l0.hit, true.B, false.B)
+  io.resp.bits.stage1.not_merge := false.B
   io.resp.valid := stageResp.valid
   XSError(stageResp.valid && resp_res.l0.hit && resp_res.sp.hit, "normal page and super page both hit")
   XSError(stageResp.valid && io.resp.bits.hit && bypassed(0), "page cache, bypassed but hit")

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -898,7 +898,15 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
 
   io.req.ready := idle
   val resp = Wire(new HptwResp())
-  resp.apply(pageFault && !accessFault && !ppn_af, accessFault || ppn_af, Mux(accessFault, af_level, level), pte, vpn, hgatp.vmid)
+  // accessFault > pageFault > ppn_af
+  resp.apply(
+    gpf = pageFault && !accessFault,
+    gaf = accessFault || (ppn_af && !pageFault),
+    level = Mux(accessFault, af_level, level),
+    pte = pte, 
+    vpn = vpn, 
+    vmid = hgatp.vmid
+  )
   io.resp.valid := resp_valid
   io.resp.bits.id := id
   io.resp.bits.resp := resp

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -140,7 +140,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   val stage1 = RegEnable(io.req.bits.stage1, io.req.fire)
   val hptw_resp_stage2 = Reg(Bool())
 
-  val ppn_af = Mux(enableS2xlate, Mux(onlyS1xlate, pte.isAf() && !pte.isStage1Gpf(io.csr.vsatp.mode), false.B), pte.isAf()) // In two-stage address translation, stage 1 ppn is a vpn for host, so don't need to check ppn_high
+  val ppn_af = Mux(enableS2xlate, Mux(onlyS1xlate, pte.isAf(), false.B), pte.isAf()) // In two-stage address translation, stage 1 ppn is a vpn for host, so don't need to check ppn_high
   val find_pte = pte.isLeaf() || ppn_af || pageFault
   val to_find_pte = level === 1.U && find_pte === false.B
   val source = RegEnable(io.req.bits.req_info.source, io.req.fire)
@@ -174,7 +174,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     ))),
     0.U(offLen.W))
   ))
-  val gvpn_gpf = Mux(enableS2xlate && io.csr.hgatp.mode === Sv39x4, gpaddr(gpaddr.getWidth - 1, GPAddrBitsSv39x4) =/= 0.U, Mux(enableS2xlate && io.csr.hgatp.mode === Sv48x4, gpaddr(gpaddr.getWidth - 1, GPAddrBitsSv48x4) =/= 0.U, false.B))
+  val gvpn_gpf = Mux(s2xlate && io.csr.hgatp.mode === Sv39x4, gpaddr(gpaddr.getWidth - 1, GPAddrBitsSv39x4) =/= 0.U, Mux(s2xlate && io.csr.hgatp.mode === Sv48x4, gpaddr(gpaddr.getWidth - 1, GPAddrBitsSv48x4) =/= 0.U, false.B))
   val guestFault = hptw_pageFault || hptw_accessFault || gvpn_gpf
   val hpaddr = Cat(hptw_resp.genPPNS2(get_pn(gpaddr)), get_off(gpaddr))
   val fake_h_resp = 0.U.asTypeOf(new HptwResp)
@@ -195,7 +195,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
 
   io.req.ready := idle
   val ptw_resp = Wire(new PtwMergeResp)
-  ptw_resp.apply(Mux(pte_valid, pageFault && !accessFault && !ppn_af, false.B), accessFault || ppn_af, Mux(accessFault, af_level, Mux(guestFault, gpf_level, level)), Mux(pte_valid, pte, fake_pte), vpn, satp.asid, hgatp.vmid, vpn(sectortlbwidth - 1, 0), not_super = false)
+  ptw_resp.apply(Mux(pte_valid, pageFault && !accessFault, false.B), accessFault || (ppn_af && !(pte_valid && (pageFault || guestFault))), Mux(accessFault, af_level, Mux(guestFault, gpf_level, level)), Mux(pte_valid, pte, fake_pte), vpn, satp.asid, hgatp.vmid, vpn(sectortlbwidth - 1, 0), not_super = false, not_merge = false)
 
   val normal_resp = idle === false.B && mem_addr_update && !last_s2xlate && (guestFault || (w_mem_resp && find_pte) || (s_pmp_check && accessFault) || onlyS2xlate )
   val stageHit_resp = idle === false.B && hptw_resp_stage2
@@ -658,9 +658,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
                 , state_last_hptw_req, state_mem_out)
         mem_resp_hit(i) := true.B
         entries(i).ppn := ptes(index).getPPN() // for last stage 2 translation
-        // when onlystage1, gpf has higher priority
-        entries(i).af := Mux(entries(i).req_info.s2xlate === allStage, false.B, Mux(entries(i).req_info.s2xlate === onlyStage1, ptes(index).isAf() && !ptes(index).isStage1Gpf(io.csr.vsatp.mode), ptes(index).isAf()))
-        entries(i).hptw_resp.gpf := Mux(entries(i).req_info.s2xlate === allStage || entries(i).req_info.s2xlate === onlyStage1, ptes(index).isStage1Gpf(io.csr.vsatp.mode), false.B)
+        entries(i).hptw_resp.gpf := Mux(entries(i).req_info.s2xlate === allStage, ptes(index).isStage1Gpf(io.csr.vsatp.mode), false.B)
       }
     }
   }


### PR DESCRIPTION
* fix(L2TLB): Fix exception generation logic

We may currently generate three types of exceptions, pf, gpf, and af. There must be only one type of exception that should occur in each resp returned by L2 TLB, which is the type of exception that occurs for the first time during the PTW process. Among them
pf & gpf: the two cases correspond to stage1 and stage2 respectively. **In our previous design, the error is that onlyStage1 is also considered to need gpf checking, but in fact, onlyStage1 shouldn't report gpf.**
af: there are two kinds of access faults, the first one is the access fault obtained by querying pmp before PTW accesses the memory, and the second one is the access fault obtained by the PPN high level of page table is not 0 after PTW accesses the memory. we call these two kinds of access faults as pmp_af and ppn_af respectively.

For allStage case: pf, gpf, af can happen. pf precedes gpf (if pf is reported in the first stage, it should be returned directly without checking gpf in the second stage). For af, if it's pmp_af, this af will be reported before actually accessing memory, and will have a higher priority than pf or gpf (actually, if pmp_af occurs, no memory will be accessed, and there will not be a pf or gpf at the same time). In case of ppn_af, this af should actually be checked in pmp before being reported before using this physical address for fetch or access. However, since our physical address will be truncated directly on return, we need to check the af in advance, and this af will have the lowest priority and will be lower than pf | gpf. (i.e., pf and gpf will not occur at the same time, pf > gpf. The two kinds of pf and pmp_af will not occur at the same time, but may occur at the same time as ppn_af, pmp_af > {pf or gpf} > ppn_af).

For onlyStage1: only pf or af will appear, same as above.
For onlyStage2: only gpf or af will appear, same as above.
For noS2xlate: only pf or af will appear, same as above.

* fix(L2TLB): prevent L1 PTEs with PPN AF to be refilled into PageTableCache

L0 and L1 of PageTableCache caches 8 PTEs at once. When any of 8 PTEs have a PPN with non-zero high bits, all 8 PTEs should not be refilled into PageTableCache. Also, GPF refill filter is moved to vs generator.

* fix(L2TLB): block L2/L3 PTEs with PPN AF to be refilled

For onlyStage2, any PTE with non-zero high bits should not be refilled into PageTableCache.

* fix(HPTW): incorrect priority of different kinds of AF and PF

In HTPW, there is 3 kinds of AF/PF:
- accessFault: PMP check failed when accessing THIS level PTE
- pageFault: this level PTE is not valid, such as v =0.
- ppn_af: the high bits of the PPN in this level PTE is not zero, which means accessing NEXT level PTE will raise accessFault.

The priority of the above three is accessFault > pageFault > ppn_af. This patch ensured this.
