### PR TITLE
fix(SQ, SimMMIO, L2): fix bugs in mtval when non-data error is raised

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -797,7 +797,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
         uncacheState := s_wb
 
         when (io.uncache.resp.bits.nderr) {
-          uop(deqPtr).exceptionVec(storeAccessFault) := true.B
+          uncacheUop.exceptionVec(storeAccessFault) := true.B
         }
       }
     }


### PR DESCRIPTION
When a SoC level non-data error such as an attempt to access a location that does not exist is generated, SimMMIO should be capable of returning `DECERR` on the r/b channel of AXI4. The TLToAXI4 Bridge will transfer the `DECERR` and drive `denied` field in TileLink high. Receiving the `denied` signal, StoreQueue will raise store access fault and update mtval CSR with the exception virtual address.