### PR TITLE
Backend: accelerate csrr for read only CSRs by pipelining

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -1064,9 +1064,6 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
     isCsrrVlenb -> ALUOpType.add,
   ))
 
-  // io.deq.decodedInst.blockBackward := MuxCase(decodedInst.blockBackward, Seq(
-  //   isRoCsrr -> false.B,
-  // ))
   //-------------------------------------------------------------
   // Debug Info
 //  XSDebug("in:  instr=%x pc=%x excepVec=%b crossPageIPFFix=%d\n",

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -989,15 +989,15 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
   io.deq.uopInfo.numOfWB := uopInfoGen.io.out.uopInfo.numOfWB
   io.deq.uopInfo.lmul := uopInfoGen.io.out.uopInfo.lmul
 
-  val isCSR = inst.OPCODE5Bit === OPCODE5Bit.SYSTEM && inst.FUNCT3(1, 0) =/= 0.U
-  val isCSRR = isCSR && inst.FUNCT3 === BitPat("b?1?") && inst.RS1 === 0.U
-  val isCSRW = isCSR && inst.FUNCT3 === BitPat("b?10") && inst.RD  === 0.U
-  dontTouch(isCSRR)
-  dontTouch(isCSRW)
+  val isCsr = inst.OPCODE5Bit === OPCODE5Bit.SYSTEM && inst.FUNCT3(1, 0) =/= 0.U
+  val isCsrr = isCsr && inst.FUNCT3 === BitPat("b?1?") && inst.RS1 === 0.U
+  val isCsrw = isCsr && inst.FUNCT3 === BitPat("b?01") && inst.RD  === 0.U
+  dontTouch(isCsrr)
+  dontTouch(isCsrw)
 
   // for csrr vl instruction, convert to vsetvl
-  val isCsrrVlenb = isCSRR && inst.CSRIDX === CSRs.vlenb.U
-  val isCsrrVl    = isCSRR && inst.CSRIDX === CSRs.vl.U
+  val isCsrrVlenb = isCsrr && inst.CSRIDX === CSRs.vlenb.U
+  val isCsrrVl    = isCsrr && inst.CSRIDX === CSRs.vl.U
 
   // decode for SoftPrefetch instructions (prefetch.w / prefetch.r / prefetch.i)
   val isSoftPrefetch = inst.OPCODE === BitPat("b0010011") && inst.FUNCT3 === BitPat("b110") && inst.RD === 0.U
@@ -1064,9 +1064,9 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
     isCsrrVlenb -> ALUOpType.add,
   ))
 
-  io.deq.decodedInst.blockBackward := MuxCase(decodedInst.blockBackward, Seq(
-    isCSRR -> false.B,
-  ))
+  // io.deq.decodedInst.blockBackward := MuxCase(decodedInst.blockBackward, Seq(
+  //   isRoCsrr -> false.B,
+  // ))
   //-------------------------------------------------------------
   // Debug Info
 //  XSDebug("in:  instr=%x pc=%x excepVec=%b crossPageIPFFix=%d\n",

--- a/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
+++ b/src/main/scala/xiangshan/backend/fu/util/CSRConst.scala
@@ -267,6 +267,56 @@ trait HasCSRConst {
   val Dscratch0     = 0x7B2
   val Dscratch1     = 0x7B3
 
+  /**
+   * "Read only" CSRs that can be fully pipelined when read in CSRR instruction.
+   * Only read by csr instructions.
+   */
+  val roCsrrAddr = List(
+    Frm,
+    Vxrm,
+    Stvec,
+    Scounteren,
+    Senvcfg,
+    Sscratch,
+    Sepc,
+    Scause,
+    Stval,
+    Satp,
+    Vstvec,
+    Vsscratch,
+    Vsepc,
+    Vscause,
+    Vstval,
+    Vsatp,
+    Medeleg,
+    Mideleg,
+    Mtvec,
+    Mcounteren,
+    Menvcfg,
+    Mcountinhibit,
+    Mscratch,
+    Mepc,
+    Mcause,
+    Mtval,
+    Mtinst,
+    Mtval2,
+    Sbpctl,     // customized csr: sbpctl      S-mode Branch Prediction ConTroL
+    Spfctl,     // customized csr: spfctl      S-mode PreFetch ConTroL
+    Slvpredctl, // customized csr: slvpredctl  S-mode Load Violation PREDict ConTroL
+    Smblockctl, // customized csr: smblockctl  S-mode Memory BlockConTroL
+    Srnctl,     // customized csr: srnctl      S-mode ?
+    Hedeleg,
+    Hideleg,
+    Hcounteren,
+    Htval,
+    Hgatp,
+    Mvendorid,
+    Marchid,
+    Mimpid,
+    Mhartid,
+    Mconfigptr
+  )
+
   def privEcall  = 0x000.U
   def privEbreak = 0x001.U
   def privMret   = 0x302.U

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -282,8 +282,14 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     isRoCsrr(i) := isCsrr(i) && LookupTreeDefault(
       inst(i).CSRIDX, false.B, CSRConst.roCsrrAddr.map(_.U -> true.B))
 
+    /*
+     * For read-only CSRs, CSRR instructions do not need to wait forward instructions to finish.
+     * For all CSRs, CSRR instructions do not need to block backward instructions for issuing.
+     * Signal "isCsrr" contains not only alias instruction CSRR, but also other csr instructions which
+     *   do not require write to any CSR.
+     */
     uops(i).waitForward := io.in(i).bits.waitForward && !isRoCsrr(i)
-    uops(i).blockBackward := io.in(i).bits.blockBackward && !isRoCsrr(i)
+    uops(i).blockBackward := io.in(i).bits.blockBackward && !isCsrr(i)
 
     // update cf according to ssit result
     uops(i).storeSetHit := io.ssit(i).valid


### PR DESCRIPTION
Add a table of "read only" CSRs, which can only be modified by CSR instructions (or almost). Modify this table to simplify circuits.