### PR TITLE
fix(L1PF): fix good_prefetch Counting logic

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -991,8 +991,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     val extra_flag_prefetch = Mux1H(extra_flag_way_en, prefetchArray.io.resp.last)
     val extra_flag_access = Mux1H(extra_flag_way_en, accessArray.io.resp.last)
 
-    prefetcherMonitor.io.validity.good_prefetch := extra_flag_valid && isFromL1Prefetch(extra_flag_prefetch) && extra_flag_access
-    prefetcherMonitor.io.validity.bad_prefetch := extra_flag_valid && isFromL1Prefetch(extra_flag_prefetch) && !extra_flag_access
+    prefetcherMonitor.io.validity.good_prefetch := extra_flag_valid && isPrefetchRelated(extra_flag_prefetch) && extra_flag_access
+    prefetcherMonitor.io.validity.bad_prefetch := extra_flag_valid && isPrefetchRelated(extra_flag_prefetch) && !extra_flag_access
   }
 
   // write extra meta

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -430,8 +430,8 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
 
   XSPerfAccumulate("dcache_read_bank_conflict", io.bank_conflict_slow && s2_valid)
-  XSPerfAccumulate("dcache_read_from_prefetched_line", s2_valid && isFromL1Prefetch(s2_hit_prefetch) && !resp.bits.miss)
-  XSPerfAccumulate("dcache_first_read_from_prefetched_line", s2_valid && isFromL1Prefetch(s2_hit_prefetch) && !resp.bits.miss && !s2_hit_access)
+  XSPerfAccumulate("dcache_read_from_prefetched_line", s2_valid && isPrefetchRelated(s2_hit_prefetch) && !resp.bits.miss)
+  XSPerfAccumulate("dcache_first_read_from_prefetched_line", s2_valid && isPrefetchRelated(s2_hit_prefetch) && !resp.bits.miss && !s2_hit_access)
 
   // if ldu0 and ldu1 hit the same, count for 1
   val total_prefetch = s2_valid && (s2_req.instrtype === DCACHE_PREFETCH_SOURCE.U)
@@ -527,7 +527,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.prefetch_flag_write.valid := s3_clear_pf_flag_en && !io.counter_filter_query.resp
   io.prefetch_flag_write.bits.idx := get_idx(s3_vaddr)
   io.prefetch_flag_write.bits.way_en := s3_tag_match_way
-  io.prefetch_flag_write.bits.source := L1_HW_PREFETCH_NULL
+  io.prefetch_flag_write.bits.source := L1_HW_PREFETCH_CLEAR
 
   io.counter_filter_query.req.valid := s3_clear_pf_flag_en
   io.counter_filter_query.req.bits.idx := get_idx(s3_vaddr)

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchInterface.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchInterface.scala
@@ -31,13 +31,19 @@ trait HasL1PrefetchSourceParameter {
   // l1 prefetch source related
   def L1PfSourceBits = 3
   def L1_HW_PREFETCH_NULL = 0.U
-  def L1_HW_PREFETCH_STRIDE = 1.U
-  def L1_HW_PREFETCH_STREAM = 2.U
-  def L1_HW_PREFETCH_STORE  = 3.U
+  def L1_HW_PREFETCH_CLEAR = 1.U // used to be a prefetch, clear by demand request
+  def L1_HW_PREFETCH_STRIDE = 2.U
+  def L1_HW_PREFETCH_STREAM = 3.U
+  def L1_HW_PREFETCH_STORE  = 4.U
+  
+  // ------------------------------------------------------------------------------------------------------------------------
+  // timeline: L1_HW_PREFETCH_NULL  --(pf by stream)--> L1_HW_PREFETCH_STREAM --(pf hit by load)--> L1_HW_PREFETCH_CLEAR
+  // ------------------------------------------------------------------------------------------------------------------------
 
-  def isFromL1Prefetch(value: UInt) = value =/= L1_HW_PREFETCH_NULL
-  def isFromStride(value: UInt)     = value === L1_HW_PREFETCH_STRIDE
-  def isFromStream(value: UInt)     = value === L1_HW_PREFETCH_STREAM
+  def isPrefetchRelated(value: UInt) = value >= L1_HW_PREFETCH_CLEAR
+  def isFromL1Prefetch(value: UInt)  = value >  L1_HW_PREFETCH_CLEAR
+  def isFromStride(value: UInt)      = value === L1_HW_PREFETCH_STRIDE
+  def isFromStream(value: UInt)      = value === L1_HW_PREFETCH_STREAM
 }
 
 class L1PrefetchSource(implicit p: Parameters) extends XSBundle with HasL1PrefetchSourceParameter {

--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherMonitor.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherMonitor.scala
@@ -77,7 +77,7 @@ class PrefetcherMonitor()(implicit p: Parameters) extends XSModule with HasPrefe
   val back_off_cnt = RegInit(0.U((log2Up(BACK_OFF_INTERVAL) + 1).W))
   val low_conf_cnt = RegInit(0.U((log2Up(LOW_CONF_INTERVAL) + 1).W))
 
-  val timely_reset = total_prefetch_cnt === TIMELY_CHECK_INTERVAL.U
+  val timely_reset = (total_prefetch_cnt === TIMELY_CHECK_INTERVAL.U) || (late_hit_prefetch_cnt >= TIMELY_CHECK_INTERVAL.U)
   val validity_reset = (good_prefetch_cnt + bad_prefetch_cnt) === VALIDITY_CHECK_INTERVAL.U
   val back_off_reset = back_off_cnt === BACK_OFF_INTERVAL.U
   val conf_reset = low_conf_cnt === LOW_CONF_INTERVAL.U


### PR DESCRIPTION
Previous design:
    When a demand load hits a Cache block fetched by the prefetcher, the `PrefetchSource` of this block will be cleared,
    causing it to be mistakenly believed that it was not fetched by the prefetcher initially when it is subsequently replaced from the cache, resulting in not increasing the `good_prefetch` counter

Fix:
    Now add a new cache block status(L1_HW_PREFETCH_CLEAR): indicating that this block was originally fetched by the prefetcher

