### PR TITLE
fix(LoadUnit): forward resp is only valid when req valid

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1089,10 +1089,10 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   val s2_full_fwd      = Wire(Bool())
   val s2_mem_amb       = s2_in.uop.storeSetHit &&
-                         io.lsq.forward.addrInvalid
+                         io.lsq.forward.addrInvalid && RegNext(io.lsq.forward.valid)
 
   val s2_tlb_miss      = s2_in.tlbMiss
-  val s2_fwd_fail      = io.lsq.forward.dataInvalid
+  val s2_fwd_fail      = io.lsq.forward.dataInvalid && RegNext(io.lsq.forward.valid)
   val s2_dcache_miss   = io.dcache.resp.bits.miss &&
                          !s2_fwd_frm_d_chan_or_mshr &&
                          !s2_full_fwd


### PR DESCRIPTION
In load_s1 stage, a forward request is sent to storequeue to check whether there is any data forward, and also whether a violation occurs when mdp turns on.

In storequeue forward check, both vaddr and paddr need to be checked, so it needs TLB hit (!miss), and when TLB misses, the forward.valid is false. When forward.valid is false, the forward checking information returned by storequeue in load_s2 stage (for example, addrInvalid, dataInvalid, etc.) is uncertain. Only when forward.valid signal of load_s1 is true, can we judge the load replay condition based on the forward information returned from storequeue in load_s2.

Therefore, we add the RegNext(io.lsq.forward.valid) condition to the generation of s2_mem_amb and s2_fwd_fail signals, which are only meaningful when RegNext(io.lsq.forward.valid) is true.