### PR TITLE
fix(L1TLB): fix the wrong refill of gpaddr when ptw resp is onlyS2

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -181,7 +181,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       resp_gpa_refill := false.B
       need_gpa_robidx := req_out(i).debug.robIdx
     }.elsewhen (ptw.resp.fire && need_gpa && need_gpa_vpn === ptw.resp.bits.getVpn(need_gpa_vpn)) {
-      resp_gpa_gvpn := ptw.resp.bits.s1.genPPN(need_gpa_vpn)
+      resp_gpa_gvpn := Mux(ptw.resp.bits.s2xlate === onlyStage2, ptw.resp.bits.s2.entry.tag, ptw.resp.bits.s1.genPPN(need_gpa_vpn))
       resp_s1_level := ptw.resp.bits.s1.entry.level.get
       resp_s1_isLeaf := ptw.resp.bits.s1.isLeaf()
       resp_s1_isFakePte := ptw.resp.bits.s1.isFakePte()


### PR DESCRIPTION
When ptw resp is onlyS2, the gvpn of gpaddr is from the tag of stage2 pte in ptw resp.