### PR TITLE
fix(LoadQueue): software prefetch should always be ready to deq

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
@@ -247,17 +247,19 @@ class VirtualLoadQueue(implicit p: Parameters) extends XSModule
 
       when (!need_rep) {
       // update control flag
-        addrvalid(loadWbIndex) := hasExceptions || !io.ldin(i).bits.tlbMiss
+        addrvalid(loadWbIndex) := hasExceptions || !io.ldin(i).bits.tlbMiss || io.ldin(i).bits.isSWPrefetch
         datavalid(loadWbIndex) :=
           (if (EnableFastForward) {
               hasExceptions ||
               io.ldin(i).bits.mmio ||
              !io.ldin(i).bits.miss && // dcache miss
-             !io.ldin(i).bits.dcacheRequireReplay // do not writeback if that inst will be resend from rs
+             !io.ldin(i).bits.dcacheRequireReplay || // do not writeback if that inst will be resend from rs
+              io.ldin(i).bits.isSWPrefetch
            } else {
               hasExceptions ||
               io.ldin(i).bits.mmio ||
-             !io.ldin(i).bits.miss
+             !io.ldin(i).bits.miss ||
+              io.ldin(i).bits.isSWPrefetch
            })
 
         //


### PR DESCRIPTION
A software prefetch instruction is similar to a normal load instruction in that it allocates loadqueue entries, and we need to write them back to the backend through loadunit. Unlike normal load instructions, software prefetch instructions will not be replayed, and will be written directly back to the backend. At the same time in loadqueue, as long as this instruction is at the head of the queue, it can deq.

In the past design, although the software prefetch instruction will not enter load replay queue, it still needs to wait for both addrvalid and datavalid to be ready before it can deq from loadqueue, which in fact will cause the entry to never deq from loadqueue, resulting in a deadlock. This commit fixes this bug: addrvalid and datavalid will always be considered true for software prefetch instructions.