### PR TITLE
fix(DCache): remove block_decoupled by refill_req

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1357,10 +1357,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   // mainPipe
   // when a req enters main pipe, if it is set-conflict with replace pipe or refill pipe,
   // block the req in main pipe
-  // block_decoupled(probeQueue.io.pipe_req, mainPipe.io.probe_req, missQueue.io.refill_pipe_req.valid)
-  block_decoupled(probeQueue.io.pipe_req, mainPipe.io.probe_req, refill_req)
-  // block_decoupled(io.lsu.store.req, mainPipe.io.store_req, refillPipe.io.req.valid)
-  block_decoupled(io.lsu.store.req, mainPipe.io.store_req, refill_req)
+  probeQueue.io.pipe_req <> mainPipe.io.probe_req
+  io.lsu.store.req <> mainPipe.io.store_req
 
   io.lsu.store.replay_resp.valid := RegNext(mainPipe.io.store_replay_resp.valid)
   io.lsu.store.replay_resp.bits := RegEnable(mainPipe.io.store_replay_resp.bits, mainPipe.io.store_replay_resp.valid)


### PR DESCRIPTION
In previous design, when a miss_req is waiting for a probe and replay in mshr continually, refill_req will block store_req ans probe_req which will cause dead lock. 
Remove useless block now to fix this problem.