### PR TITLE
feat(VceExceptionGen): Cancel the exception of the Zvfhmin extension instruction and support Zvfhmin extension.

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/VecExceptionGen.scala
+++ b/src/main/scala/xiangshan/backend/decode/VecExceptionGen.scala
@@ -181,9 +181,11 @@ class VecExceptionGen(implicit p: Parameters) extends XSModule{
   private val doubleFpInst = Seq(
     VFWCVT_F_X_V, VFWCVT_F_XU_V, VFNCVT_RTZ_X_F_W, VFNCVT_RTZ_XU_F_W, VFNCVT_X_F_W, VFNCVT_XU_F_W
   ).map(_ === inst.ALL).reduce(_ || _)
+  //Zvfhmin Inst
+  private val ZvfhminInst = Seq(VFWCVT_F_F_V, VFNCVT_F_F_W).map(_ === inst.ALL).reduce(_ || _)
   // funct3 of OPFVV is 001, funct3 of OPFVF is 101
   private val isFp = (inst.FUNCT3 === BitPat("b?01")) && (inst.OPCODE7Bit === OPCODE7Bit.VECTOR_ARITH)
-  private val fpEewIllegal = isFp && ((!doubleFpInst && (SEW === 1.U)) || SEW === 0.U)
+  private val fpEewIllegal = isFp && (((!doubleFpInst || !ZvfhminInst) && (SEW === 1.U)) || SEW === 0.U)
 
   private val intExtEewIllegal = intExt2 && SEW === 0.U ||
                                  intExt4 && SEW <= 1.U ||


### PR DESCRIPTION
feat(VceExceptionGen): Cancel the exception of the Zvfhmin extension instruction and support Zvfhmin extension.

* The Zvfhmin extension refers to the case where sew==1, where the exceptions for VFWCVT_F_F_V and VFNCVT_F_F_W instructions are removed.