### PR TITLE
perf(L1PF): Stream only pf at miss/pfHit

### DIFF
--- a/src/main/scala/xiangshan/mem/MemCommon.scala
+++ b/src/main/scala/xiangshan/mem/MemCommon.scala
@@ -216,10 +216,11 @@ class LdPrefetchTrainBundle(implicit p: Parameters) extends LsPipelineBundle {
 
   def asPrefetchReqBundle(): PrefetchReqBundle = {
     val res = Wire(new PrefetchReqBundle)
-    res.vaddr := this.vaddr
-    res.paddr := this.paddr
-    res.pc    := this.uop.pc
-    res.miss  := this.miss
+    res.vaddr       := this.vaddr
+    res.paddr       := this.paddr
+    res.pc          := this.uop.pc
+    res.miss        := this.miss
+    res.pfHitStream := isFromStream(this.meta_prefetch)
 
     res
   }

--- a/src/main/scala/xiangshan/mem/prefetch/BasePrefecher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/BasePrefecher.scala
@@ -41,10 +41,11 @@ class PrefetcherIO()(implicit p: Parameters) extends XSBundle {
 }
 
 class PrefetchReqBundle()(implicit p: Parameters) extends XSBundle {
-  val vaddr = UInt(VAddrBits.W)
-  val paddr = UInt(PAddrBits.W)
-  val pc    = UInt(VAddrBits.W)
-  val miss  = Bool()
+  val vaddr       = UInt(VAddrBits.W)
+  val paddr       = UInt(PAddrBits.W)
+  val pc          = UInt(VAddrBits.W)
+  val miss        = Bool()
+  val pfHitStream = Bool()
 }
 
 trait PrefetcherParams


### PR DESCRIPTION
Perf Bug Description:
<img src="https://github.com/user-attachments/assets/3d1a7105-088b-467a-9c93-833f534bb4e6" width="300"/>
Stream Prefetcher is **trained and triggered in all memory access traces**. If the program(As shown above) repeatedly accesses an 8K space in a loop, the first loop can be prefetched normally, but in the subsequent loop the data has been fetched back to Dcache already. In theory, there is no need to prefetch again, since the Stream Prefetcher is triggered in all memory access traces, which will cause subsequent prefetching requests to be triggered and preempt the pipeline which may cause performance loss.

FIX:
Let the Stream prefetcher only trigger prefetching when **miss and Prefetch hit** (training still uses all memory access traces).