### PR TITLE
fix(PTW, RVH): the pte of G-stage which support VS-stage is load rather than original access type

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -279,16 +279,18 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     pte_valid := false.B
     check_g_perm_fail := false.B
     req_s2xlate := io.req.bits.req_info.s2xlate
-    when(io.req.bits.req_info.s2xlate =/= noS2xlate && io.req.bits.req_info.s2xlate =/= onlyStage1){
+    when(io.req.bits.req_info.s2xlate === onlyStage2){
       val onlys2_gpaddr = Cat(io.req.bits.req_info.vpn, 0.U(offLen.W)) // is 50 bits, don't need to check high bits when sv48x4 is enabled
       val check_gpa_high_fail = Mux(io.req.bits.req_info.s2xlate === onlyStage2 && io.csr.hgatp.mode === Sv39x4, onlys2_gpaddr(onlys2_gpaddr.getWidth - 1, GPAddrBitsSv39x4) =/= 0.U, false.B)
-      when(io.req.bits.req_info.s2xlate === onlyStage2 && check_gpa_high_fail){
+      last_s2xlate := false.B
+      when(check_gpa_high_fail){
         mem_addr_update := true.B
-        last_s2xlate := false.B
       }.otherwise{
-        last_s2xlate := true.B
         s_last_hptw_req := false.B
       }
+    }.elsewhen(io.req.bits.req_info.s2xlate === allStage){
+      last_s2xlate := true.B
+      s_hptw_req := false.B
     }.otherwise {
       last_s2xlate := false.B
       s_pmp_check := false.B

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -320,7 +320,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   }
 
   when (io.hptw.resp.fire && w_last_hptw_resp === false.B && stage1Hit){
-    w_hptw_resp := true.B
+    w_last_hptw_resp := true.B
     hptw_resp_stage2 := true.B
     hptw_resp := io.hptw.resp.bits.h_resp
   }


### PR DESCRIPTION
In riscv-privileged, it is load or store in G-stage which support VS-stage, such as to get the non-leaf pte of VS-stage

> For G-stage address translation, all memory accesses (including those made to access data structures for VS-stage address
translation) are considered to be user-level accesses, as though executed in U-mode. Access type permissions—readable, writable, or executable—are checked during G-stage translation the same as for VS-stage translation. For a memory access made to support VS-stage address translation (such as to read/write a VS-level page table), permissions and the need to set A and/or D bits at the G-stage level are checked as though for an implicit load or store, not for the original access type. However, any exception is always reported for the original access type (instruction, load, or store/AMO).