### PR TITLE
fix(exception): Add guest page fault logic of misalign and vlsu

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadExceptionBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadExceptionBuffer.scala
@@ -103,7 +103,7 @@ class LqExceptionBuffer(implicit p: Parameters) extends XSModule with HasCircula
     req := reqSel._2(0)
   }
 
-  io.exceptionAddr.vaddr := req.vaddr
+  io.exceptionAddr.vaddr  := req.vaddr
   io.exceptionAddr.vstart := req.uop.vpu.vstart
   io.exceptionAddr.vl     := req.uop.vpu.vl
   io.exceptionAddr.gpaddr := req.gpaddr

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -264,6 +264,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     exceptionBuffer.io.req(LoadPipelineWidth + i).valid                 := io.vecFeedback(i).valid && io.vecFeedback(i).bits.feedback(VecFeedbacks.FLUSH) // have exception
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits                  := DontCare
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits.vaddr            := io.vecFeedback(i).bits.vaddr
+    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.gpaddr           := io.vecFeedback(i).bits.gpaddr
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.uopIdx       := io.vecFeedback(i).bits.uopidx
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.robIdx       := io.vecFeedback(i).bits.robidx
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.vpu.vstart   := io.vecFeedback(i).bits.vstart

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -94,6 +94,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
     val overwriteExpBuf = Output(new XSBundle {
       val valid = Bool()
       val vaddr = UInt(VAddrBits.W)
+      val gpaddr = UInt(GPAddrBits.W)
     })
     val sqControl       = new StoreMaBufToSqControlIO
   })
@@ -591,9 +592,11 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   // if exception happens in the higher page address part, overwrite the storeExceptionBuffer vaddr
   val overwriteExpBuf = GatedValidRegNext(req_valid && cross16BytesBoundary && globalException && (curPtr === 1.U))
   val overwriteAddr = GatedRegNext(splitStoreResp(curPtr).vaddr)
+  val overwriteGpaddr = GatedRegNext(splitStoreResp(curPtr).gpaddr)
 
   io.overwriteExpBuf.valid := overwriteExpBuf
   io.overwriteExpBuf.vaddr := overwriteAddr
+  io.overwriteExpBuf.gpaddr := overwriteGpaddr
 
   XSPerfAccumulate("alloc",                  RegNext(!req_valid) && req_valid)
   XSPerfAccumulate("flush",                  flush)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -229,6 +229,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     exceptionBuffer.io.storeAddrIn(StorePipelineWidth * 2 + i).valid               := io.vecFeedback(i).valid && io.vecFeedback(i).bits.feedback(VecFeedbacks.FLUSH) // have exception
     exceptionBuffer.io.storeAddrIn(StorePipelineWidth * 2 + i).bits                := DontCare
     exceptionBuffer.io.storeAddrIn(StorePipelineWidth * 2 + i).bits.vaddr          := io.vecFeedback(i).bits.vaddr
+    exceptionBuffer.io.storeAddrIn(StorePipelineWidth * 2 + i).bits.gpaddr         := io.vecFeedback(i).bits.gpaddr
     exceptionBuffer.io.storeAddrIn(StorePipelineWidth * 2 + i).bits.uop.uopIdx     := io.vecFeedback(i).bits.uopidx
     exceptionBuffer.io.storeAddrIn(StorePipelineWidth * 2 + i).bits.uop.robIdx     := io.vecFeedback(i).bits.robidx
     exceptionBuffer.io.storeAddrIn(StorePipelineWidth * 2 + i).bits.uop.vpu.vstart := io.vecFeedback(i).bits.vstart

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1553,6 +1553,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.vecldout.bits.flushState := DontCare
   io.vecldout.bits.exceptionVec := ExceptionNO.selectByFu(s3_out.bits.uop.exceptionVec, VlduCfg)
   io.vecldout.bits.vaddr := s3_in.vaddr
+  io.vecldout.bits.gpaddr := s3_in.gpaddr
   io.vecldout.bits.mmio := DontCare
 
   io.vecldout.valid := s3_out.valid && !s3_out.bits.uop.robIdx.needFlush(io.redirect) && s3_vecout.isvec ||

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -485,6 +485,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
       sx_in(i).mbIndex     := s3_in.mbIndex
       sx_in(i).mask        := s3_in.mask
       sx_in(i).vaddr       := s3_in.vaddr
+      sx_in(i).gpaddr      := s3_in.gpaddr
       sx_ready(i) := !s3_valid(i) || sx_in(i).output.uop.robIdx.needFlush(io.redirect) || (if (TotalDelayCycles == 0) io.stout.ready else sx_ready(i+1))
     } else {
       val cur_kill   = sx_in(i).output.uop.robIdx.needFlush(io.redirect)
@@ -522,6 +523,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.vecstout.bits.alignedType := sx_last_in.alignedType
   io.vecstout.bits.mask        := sx_last_in.mask
   io.vecstout.bits.vaddr       := sx_last_in.vaddr
+  io.vecstout.bits.gpaddr      := sx_last_in.gpaddr
   // io.vecstout.bits.reg_offset.map(_ := DontCare)
   // io.vecstout.bits.elemIdx.map(_ := sx_last_in.elemIdx)
   // io.vecstout.bits.elemIdxInsideVd.map(_ := DontCare)

--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -44,6 +44,7 @@ class MBufferBundle(implicit p: Parameters) extends VLSUBundle{
   val vstart           = UInt(elemIdxBits.W)
   val vl               = UInt(elemIdxBits.W)
   val vaddr            = UInt(VAddrBits.W)
+  val gpaddr           = UInt(GPAddrBits.W)
   val fof              = Bool()
   val vlmax            = UInt(elemIdxBits.W)
 
@@ -102,6 +103,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     sink.feedback(VecFeedbacks.LAST)        := true.B
     sink.vstart                             := source.vstart // TODO: if lsq need vl for fof?
     sink.vaddr                              := source.vaddr
+    sink.gpaddr                             := source.gpaddr
     sink.vl                                 := source.vl
     sink.exceptionVec                       := ExceptionNO.selectByFu(source.exceptionVec, fuCfg)
     sink
@@ -241,6 +243,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
         entries(wbMbIndex(i)).vstart       := selElemInfield
         entries(wbMbIndex(i)).exceptionVec := ExceptionNO.selectByFu(selExceptionVec, fuCfg)
         entries(wbMbIndex(i)).vaddr        := vaddr
+        entries(wbMbIndex(i)).gpaddr       := selPort(0).gpaddr
       }.otherwise{
         entries(wbMbIndex(i)).vl           := selElemInfield
       }

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -110,6 +110,7 @@ class VecPipelineFeedbackIO(isVStore: Boolean=false) (implicit p: Parameters) ex
   //val atomic               = Bool()
   val exceptionVec         = ExceptionVec()
   val vaddr                = UInt(VAddrBits.W)
+  val gpaddr               = UInt(GPAddrBits.W)
   //val vec                  = new OnlyVecExuOutput
    // feedback
   val vecFeedback          = Bool()
@@ -191,6 +192,7 @@ class FeedbackToLsqIO(implicit p: Parameters) extends VLSUBundle{
   val robidx = new RobPtr
   val uopidx = UopIdx()
   val vaddr = UInt(VAddrBits.W)
+  val gpaddr = UInt(GPAddrBits.W)
   val feedback = Vec(VecFeedbacks.allFeedbacks, Bool())
     // for exception
   val vstart           = UInt(elemIdxBits.W)

--- a/src/main/scala/xiangshan/mem/vector/VecCommon.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecCommon.scala
@@ -290,6 +290,7 @@ class VecMemExuOutput(isVector: Boolean = false)(implicit p: Parameters) extends
   val mbIndex     = UInt(vsmBindexBits.W)
   val mask        = UInt(VLENB.W)
   val vaddr       = UInt(VAddrBits.W)
+  val gpaddr      = UInt(GPAddrBits.W)
 }
 
 object MulNum {


### PR DESCRIPTION
In our previous design, we did not consider the handling of gpf of unaligned & vector load and stores. This commit adds a fix to correctly return the guest paddr when gpf happens in the above instructions.