### PR TITLE
timing(ICache): add WayLookupEnableBypass switch

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -44,6 +44,7 @@ case class ICacheParameters(
     nFetchMshr: Int = 4,
     nPrefetchMshr: Int = 10,
     nWayLookupSize: Int = 32,
+    WayLookupEnableBypass: Boolean = false,
     DataCodeUnit: Int = 64,
     ICacheDataBanks: Int = 8,
     ICacheDataSRAMWidth: Int = 66,
@@ -75,6 +76,7 @@ trait HasICacheParameters extends HasL1CacheParameters with HasInstrMMIOConst wi
   def nFetchMshr            = cacheParams.nFetchMshr
   def nPrefetchMshr         = cacheParams.nPrefetchMshr
   def nWayLookupSize        = cacheParams.nWayLookupSize
+  def WayLookupEnableBypass = cacheParams.WayLookupEnableBypass
   def DataCodeUnit          = cacheParams.DataCodeUnit
   def ICacheDataBanks       = cacheParams.ICacheDataBanks
   def ICacheDataSRAMWidth   = cacheParams.ICacheDataSRAMWidth

--- a/src/main/scala/xiangshan/frontend/icache/WayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/WayLookup.scala
@@ -141,8 +141,9 @@ class WayLookup(implicit p: Parameters) extends ICacheModule {
     * read
     ******************************************************************************
     */
-  io.read.valid := !empty || io.write.valid
-  when (empty && io.write.valid) {  // bypass
+  private val bypass = if (WayLookupEnableBypass) { empty && io.write.valid } else { false.B }
+  io.read.valid := !empty || bypass
+  when (bypass) {
     io.read.bits := io.write.bits
   }.otherwise {
     io.read.bits.entry := entries(readPtr.value)


### PR DESCRIPTION
- enable bypass: better performance due to reduced redirect latency
- disable bypass: better timing due to no critical path of metaArray -> dataArray

Disable WayLookup bypass by default.

Performance drop is expected, maybe we can compensate this by implementing dynamic fetch pipe, and this PR will be rebased when it's done.
