### PR TITLE
timing(IPrefetch): add 1 cycle to s2_finish

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -517,7 +517,9 @@ class IPrefetchPipe(implicit p: Parameters) extends  IPrefetchModule
 
   s2_flush := io.flush
 
-  val s2_finish  = (0 until PortNumber).map(i => has_send(i) || !s2_miss(i) || toMSHRArbiter.io.in(i).fire).reduce(_&&_)
+  // toMSHRArbiter.io.in(i).fire is not used here for timing consideration
+  // val s2_finish  = (0 until PortNumber).map(i => has_send(i) || !s2_miss(i) || toMSHRArbiter.io.in(i).fire).reduce(_&&_)
+  val s2_finish  = (0 until PortNumber).map(i => has_send(i) || !s2_miss(i)).reduce(_&&_)
   s2_ready      := s2_finish || !s2_valid
   s2_fire       := s2_valid && s2_finish && !s2_flush
 


### PR DESCRIPTION
Cut critical path prefetchPipe s2 -> toMSHRArbiter.valid(i) -> toMSHR.paddr -> missUnit hit -> missUnit.req.ready -> prefetchPipe toMSHRArbiter.ready ***-> s2_finish ->*** s2_ready -> s1_ready -> toFtq.ready
 for timing.

This can be thought of as adding 1 cycle to the prefetchPipe s2_finish, but only a minor performance change is expected, since the timing of issuing the first miss request is unchanged, and the additional waiting delay for subsequent miss requests can be hidden by the l2 cache access delay.