### PR TITLE
fix(Parameters): remove require of PaddrBits to speed up compile

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -606,7 +606,6 @@ trait HasXSParameter {
         coreParams.VAddrBitsSv39
     }
   } // VAddrBits is Virtual Memory addr bits
-  require(PAddrBits == 48 || !EnableSv48) // Paddr bits should be 48 when Sv48 enable
 
   def VAddrMaxBits = {
     if(EnableSv48) {


### PR DESCRIPTION
In fact, our compilation speed has dropped by 75% since Sv48 was merged into the master. The reason is that this require **(`require(PAddrBits == 48 || !EnableSv48)`)**  takes over 70% of the entire compile time. 

This commit fixes it.