### PR TITLE
feat(Zicbom,Zicboz): add permission check and convert CBO.INVAL to CBO.FLUSH when CBIE=0b01

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRBundles.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRBundles.scala
@@ -43,17 +43,17 @@ object CSRBundles {
   class XtinstBundle extends FieldInitBundle
 
   abstract class EnvCfg extends CSRBundle {
-    // Set all fields as RO in base class
-    val STCE  = RO(    63).withReset(0.U) // Sstc Enable
-    val PBMTE = RO(    62).withReset(0.U) // Svpbmt Enable
-    val ADUE  = RO(    61).withReset(0.U) // Svadu extension Enable
-    val PMM   = RO(33, 32).withReset(0.U) // Smnpm extension
-    val CBZE  = RO(     7).withReset(0.U) // Zicboz extension
-    val CBCFE = RO(     6).withReset(0.U) // Zicbom extension
-    val CBIE  = RO( 5,  4).withReset(0.U) // Zicbom extension
-    val SSE   = RO(     3).withReset(0.U) // Zicfiss extension Enable in S mode
-    val LPE   = RO(     2).withReset(0.U) // Zicfilp extension
-    val FIOM  = RO(     0).withReset(0.U) // Fence of I/O implies Memory
+    // Set all fields not supported as RO in base class
+    val STCE  =      RO(    63)           .withReset(0.U) // Sstc Enable
+    val PBMTE =      RO(    62)           .withReset(0.U) // Svpbmt Enable
+    val ADUE  =      RO(    61)           .withReset(0.U) // Svadu extension Enable
+    val PMM   =      RO(33, 32)           .withReset(0.U) // Smnpm extension
+    val CBZE  =      RW(     7)           .withReset(1.U) // Zicboz extension
+    val CBCFE =      RW(     6)           .withReset(1.U) // Zicbom extension
+    val CBIE  = EnvCBIE( 5,  4, wNoEffect).withReset(EnvCBIE.Inval) // Zicbom extension
+    val SSE   =      RO(     3)           .withReset(0.U) // Zicfiss extension Enable in S mode
+    val LPE   =      RO(     2)           .withReset(0.U) // Zicfilp extension
+    val FIOM  =      RO(     0)           .withReset(0.U) // Fence of I/O implies Memory
   }
 
   class PrivState extends Bundle { self =>

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRDefines.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRDefines.scala
@@ -182,6 +182,8 @@ object CSRDefines {
     val Off   = Value("b00".U)
     val Flush = Value("b01".U)
     val Inval = Value("b11".U)
+
+    override def isLegal(enumeration: CSREnumType): Bool = enumeration.isOneOf(Off, Flush, Inval)
   }
 
   object ReflectHelper {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRDefines.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRDefines.scala
@@ -178,6 +178,12 @@ object CSRDefines {
     override def isLegal(enumeration: CSREnumType): Bool = enumeration.isOneOf(Bare, Sv39x4, Sv48x4)
   }
 
+  object EnvCBIE extends CSREnum with WARLApply {
+    val Off   = Value("b00".U)
+    val Flush = Value("b01".U)
+    val Inval = Value("b11".U)
+  }
+
   object ReflectHelper {
     val mirror: ru.Mirror = ru.runtimeMirror(getClass.getClassLoader)
 

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -409,7 +409,26 @@ class CSRToDecode(implicit p: Parameters) extends XSBundle {
      * raise EX_II when frm.data > 4
      */
     val frm = Bool()
+
+    /**
+     * illegal CBO.ZERO
+     * raise [[EX_II]] when !isModeM && !MEnvCfg.CBZE || isModeHU && !SEnvCfg.CBZE
+     */
+    val cboZ = Bool()
+
+    /**
+     * illegal CBO.CLEAN/FLUSH
+     * raise [[EX_II]] when !isModeM && !MEnvCfg.CBCFE || isModeHU && !SEnvCfg.CBCFE
+     */
+    val cboCF = Bool()
+
+    /**
+     * illegal CBO.INVAL
+     * raise [[EX_II]] when !isModeM && MEnvCfg.CBIE = EnvCBIE.Off || isModeHU && SEnvCfg.CBIE = EnvCBIE.Off
+     */
+    val cboI = Bool()
   }
+
   val virtualInst = new Bundle {
     /**
      * illegal sfence.vma, svinval.vma
@@ -440,5 +459,37 @@ class CSRToDecode(implicit p: Parameters) extends XSBundle {
      * raise EX_VI when isModeVU && mstatus.TW=0 || isModeVS && mstatus.TW=0 && hstatus.VTW=1
      */
     val wfi = Bool()
+
+    /**
+     * illegal CBO.ZERO
+     * raise [[EX_VI]] when MEnvCfg.CBZE && (isModeVS && !HEnvCfg.CBZE || isModeVU && (!HEnvCfg.CBZE || !SEnvCfg.CBZE))
+     */
+    val cboZ = Bool()
+
+    /**
+     * illegal CBO.CLEAN/FLUSH
+     * raise [[EX_VI]] when MEnvCfg.CBZE && (isModeVS && !HEnvCfg.CBCFE || isModeVU && (!HEnvCfg.CBCFE || !SEnvCfg.CBCFE))
+     */
+    val cboCF = Bool()
+
+    /**
+     * illegal CBO.INVAL <br/>
+     * raise [[EX_VI]] when MEnvCfg.CBIE =/= EnvCBIE.Off && ( <br/>
+     *   isModeVS && HEnvCfg.CBIE === EnvCBIE.Off || <br/>
+     *   isModeVU && (HEnvCfg.CBIE === EnvCBIE.Off || SEnvCfg.CBIE === EnvCBIE.Off) <br/>
+     * ) <br/>
+     */
+    val cboI = Bool()
+  }
+
+  val special = new Bundle {
+    /**
+     * execute CBO.INVAL and perform flush operation when <br/>
+     * isModeHS && MEnvCfg.CBIE === EnvCBIE.Flush || <br/>
+     * isModeHU && (MEnvCfg.CBIE === EnvCBIE.Flush || SEnvCfg.CBIE === EnvCBIE.Flush) <br/>
+     * isModeVS && (MEnvCfg.CBIE === EnvCBIE.Flush || HEnvCfg.CBIE === EnvCBIE.Flush) <br/>
+     * isModeVU && (MEnvCfg.CBIE === EnvCBIE.Flush || HEnvCfg.CBIE === EnvCBIE.Flush || SEnvCfg.CBIE === EnvCBIE.Flush) <br/>
+     */
+    val cboI2F = Bool()
   }
 }


### PR DESCRIPTION
* CSR
  * When reset, xenvcfg.CBZE = 1, xenvcfg.CBCFE = 1, xenvcfg.CBIE = 0b11, while x in {m, s, h}.
  * Support xenvcfg.CBIE = Flush(0b01)
* Decode
  * Use the illegalInst and virtualInst conditions from CSR to assert EX_II or EX_VI.
  * Convert CBO.INVAL to CBO.FLUSH when envcfg.CBIE === EnvCBIE.Flush.