### PR TITLE
fix(LoadQueueReplay): fix blocking logic

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -302,8 +302,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     // dequeue
     //  FIXME: store*Ptr is not accurate
     dataNotBlockVec(i) := isAfter(io.stDataReadySqPtr, blockSqIdx(i)) || stDataReadyVec(blockSqIdx(i).value) || io.sqEmpty // for better timing
-    addrNotBlockVec(i) := Mux(strict(i), isAfter(io.stAddrReadySqPtr, blockSqIdx(i)), stAddrReadyVec(blockSqIdx(i).value)) || io.sqEmpty // for better timing
-
+    addrNotBlockVec(i) := isAfter(io.stAddrReadySqPtr, blockSqIdx(i)) || !strict(i) && stAddrReadyVec(blockSqIdx(i).value) || io.sqEmpty // for better timing
     // store address execute
     storeAddrInSameCycleVec(i) := VecInit((0 until StorePipelineWidth).map(w => {
       io.storeAddrIn(w).valid &&


### PR DESCRIPTION
Because the vector unit-stride instruction may not set all addr and data entries in storequeue to valid, it may cause retransmissions to fail from the replayqueue, resulting in a stuck.