### PR TITLE
fix(exception): check high address bits of lsu

### DIFF
--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -787,8 +787,8 @@ class BackendMemIO(implicit p: Parameters, params: BackendParams) extends XSBund
   val stIn = Input(Vec(params.StaExuCnt, ValidIO(new DynInst())))
   val memoryViolation = Flipped(ValidIO(new Redirect))
   val exceptionAddr = Input(new Bundle {
-    val vaddr = UInt(VAddrBits.W)
-    val gpaddr = UInt(GPAddrBits.W)
+    val vaddr = UInt(XLEN.W)
+    val gpaddr = UInt(XLEN.W)
   })
   val sqDeq = Input(UInt(log2Ceil(EnsbufferWidth + 1).W))
   val lqDeq = Input(UInt(log2Up(CommitWidth + 1).W))

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -855,7 +855,7 @@ object Bundles {
     val commitType = CommitType()
     val exceptionVec = ExceptionVec()
     val isFetchMalAddr = Bool()
-    val gpaddr = UInt(GPAddrBits.W)
+    val gpaddr = UInt(XLEN.W)
     val singleStep = Bool()
     val crossPageIPFFix = Bool()
     val isInterrupt = Bool()

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -133,10 +133,10 @@ class mem_to_ooo(implicit p: Parameters) extends MemBlockBundle {
   val lsTopdownInfo = Vec(LdExuCnt, Output(new LsTopdownInfo))
 
   val lsqio = new Bundle {
-    val vaddr = Output(UInt(VAddrBits.W))
+    val vaddr = Output(UInt(XLEN.W))
     val vstart = Output(UInt((log2Up(VLEN) + 1).W))
     val vl = Output(UInt((log2Up(VLEN) + 1).W))
-    val gpaddr = Output(UInt(GPAddrBits.W))
+    val gpaddr = Output(UInt(XLEN.W))
     val mmio = Output(Vec(LoadPipelineWidth, Bool()))
     val uop = Output(Vec(LoadPipelineWidth, new DynInst))
     val lqCanAccept = Output(Bool())

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -99,8 +99,8 @@ class CSRFileIO(implicit p: Parameters) extends XSBundle {
   val interrupt = Output(Bool())
   val wfi_event = Output(Bool())
   // from LSQ
-  val memExceptionVAddr = Input(UInt(VAddrBits.W))
-  val memExceptionGPAddr = Input(UInt(GPAddrBits.W))
+  val memExceptionVAddr = Input(UInt(XLEN.W))
+  val memExceptionGPAddr = Input(UInt(XLEN.W))
   // from outside cpu,externalInterrupt
   val externalInterrupt = Input(new ExternalInterruptIO)
   // TLB

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/CSREvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/CSREvent.scala
@@ -134,8 +134,8 @@ class TrapEntryEventInput(implicit val p: Parameters) extends Bundle with HasXSP
   val vsatp = Input(new SatpBundle)
   val hgatp = Input(new HgatpBundle)
   // from mem
-  val memExceptionVAddr = Input(UInt(VAddrBits.W))
-  val memExceptionGPAddr = Input(UInt(GPAddrBits.W))
+  val memExceptionVAddr = Input(UInt(XLEN.W))
+  val memExceptionGPAddr = Input(UInt(XLEN.W))
   val virtualInterruptIsHvictlInject = Input(Bool())
   val hvictlIID = Input(UInt(HIIDWidth.W))
 }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryHSEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryHSEvent.scala
@@ -62,15 +62,9 @@ class TrapEntryHSEventModule(implicit val p: Parameters) extends Module with CSR
 
   private val trapPCGPA = SignExt(in.trapPcGPA, XLEN)
 
-  private val trapMemVA = genTrapVA(
-    dMode,
-    satp,
-    vsatp,
-    hgatp,
-    in.memExceptionVAddr,
-  )
+  private val trapMemVA = in.memExceptionVAddr
 
-  private val trapMemGPA = SignExt(in.memExceptionGPAddr, XLEN)
+  private val trapMemGPA = in.memExceptionGPAddr
 
   private val trapInst = Mux(in.trapInst.valid, in.trapInst.bits, 0.U)
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala
@@ -60,15 +60,9 @@ class TrapEntryMEventModule(implicit val p: Parameters) extends Module with CSRE
 
   private val trapPCGPA = SignExt(in.trapPcGPA, XLEN)
 
-  private val trapMemVA = genTrapVA(
-    dMode,
-    satp,
-    vsatp,
-    hgatp,
-    in.memExceptionVAddr,
-  )
+  private val trapMemVA = in.memExceptionVAddr
 
-  private val trapMemGPA = SignExt(in.memExceptionGPAddr, XLEN)
+  private val trapMemGPA = in.memExceptionGPAddr
 
   private val trapInst = Mux(in.trapInst.valid, in.trapInst.bits, 0.U)
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryVSEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryVSEvent.scala
@@ -72,14 +72,9 @@ class TrapEntryVSEventModule(implicit val p: Parameters) extends Module with CSR
     in.trapPc,
   )
 
-  private val trapMemVA = genTrapVA(
-    dMode,
-    satp,
-    vsatp,
-    hgatp,
-    in.memExceptionVAddr,
-  )
-  private val trapMemGPA = SignExt(in.memExceptionGPAddr, XLEN)
+  private val trapMemVA = in.memExceptionVAddr
+
+  private val trapMemGPA = in.memExceptionGPAddr
 
   private val trapInst = Mux(in.trapInst.valid, in.trapInst.bits, 0.U)
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -108,8 +108,8 @@ class NewCSR(implicit val p: Parameters) extends Module
     }))
     val trapInst = Input(ValidIO(UInt(InstWidth.W)))
     val fromMem = Input(new Bundle {
-      val excpVA  = UInt(VaddrMaxWidth.W)
-      val excpGPA = UInt(VaddrMaxWidth.W) // Todo: use guest physical address width
+      val excpVA  = UInt(XLEN.W)
+      val excpGPA = UInt(XLEN.W) // Todo: use guest physical address width
     })
     val fromRob = Input(new Bundle {
       val trap = ValidIO(new Bundle {

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -510,6 +510,8 @@ class MemBlockidxBundle(implicit p: Parameters) extends TlbBundle {
 
 class TlbReq(implicit p: Parameters) extends TlbBundle {
   val vaddr = Output(UInt(VAddrBits.W))
+  val fullva = Output(UInt(XLEN.W))
+  val checkfullva = Output(Bool())
   val cmd = Output(TlbCmd())
   val hyperinst = Output(Bool())
   val hlvx = Output(Bool())
@@ -539,7 +541,7 @@ class TlbExceptionBundle(implicit p: Parameters) extends TlbBundle {
 
 class TlbResp(nDups: Int = 1)(implicit p: Parameters) extends TlbBundle {
   val paddr = Vec(nDups, Output(UInt(PAddrBits.W)))
-  val gpaddr = Vec(nDups, Output(UInt(GPAddrBits.W)))
+  val gpaddr = Vec(nDups, Output(UInt(XLEN.W)))
   val pbmt = Vec(nDups, Output(UInt(ptePbmtLen.W)))
   val miss = Output(Bool())
   val fastMiss = Output(Bool())

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -738,6 +738,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
   io.iTLBInter.req.bits.cmd                := TlbCmd.exec
   io.iTLBInter.req.bits.kill               := false.B // IFU use itlb for mmio, doesn't need sync, set it to false
   io.iTLBInter.req.bits.no_translate       := false.B
+  io.iTLBInter.req.bits.fullva             := 0.U
+  io.iTLBInter.req.bits.checkfullva        := false.B
   io.iTLBInter.req.bits.hyperinst          := DontCare
   io.iTLBInter.req.bits.hlvx               := DontCare
   io.iTLBInter.req.bits.memidx             := DontCare

--- a/src/main/scala/xiangshan/mem/MemCommon.scala
+++ b/src/main/scala/xiangshan/mem/MemCommon.scala
@@ -81,8 +81,9 @@ class LsPipelineBundle(implicit p: Parameters) extends XSBundle
   with HasVLSUParameters {
   val uop = new DynInst
   val vaddr = UInt(VAddrBits.W)
+  val fullva = UInt(XLEN.W)
   val paddr = UInt(PAddrBits.W)
-  val gpaddr = UInt(GPAddrBits.W)
+  val gpaddr = UInt(XLEN.W)
   // val func = UInt(6.W)
   val mask = UInt((VLEN/8).W)
   val data = UInt((VLEN+1).W)
@@ -160,6 +161,7 @@ class LdPrefetchTrainBundle(implicit p: Parameters) extends LsPipelineBundle {
 
   def fromLsPipelineBundle(input: LsPipelineBundle, latch: Boolean = false, enable: Bool = true.B) = {
     if (latch) vaddr := RegEnable(input.vaddr, enable) else vaddr := input.vaddr
+    if (latch) fullva := RegEnable(input.fullva, enable) else fullva := input.fullva
     if (latch) paddr := RegEnable(input.paddr, enable) else paddr := input.paddr
     if (latch) gpaddr := RegEnable(input.gpaddr, enable) else gpaddr := input.gpaddr
     if (latch) mask := RegEnable(input.mask, enable) else mask := input.mask
@@ -238,6 +240,7 @@ class LqWriteBundle(implicit p: Parameters) extends LsPipelineBundle {
 
   def fromLsPipelineBundle(input: LsPipelineBundle, latch: Boolean = false, enable: Bool = true.B) = {
     if(latch) vaddr := RegEnable(input.vaddr, enable) else vaddr := input.vaddr
+    if(latch) fullva := RegEnable(input.fullva, enable) else fullva := input.fullva
     if(latch) paddr := RegEnable(input.paddr, enable) else paddr := input.paddr
     if(latch) gpaddr := RegEnable(input.gpaddr, enable) else gpaddr := input.gpaddr
     if(latch) mask := RegEnable(input.mask, enable) else mask := input.mask

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -34,10 +34,10 @@ import xiangshan.backend.fu.FuType
 
 class ExceptionAddrIO(implicit p: Parameters) extends XSBundle {
   val isStore = Input(Bool())
-  val vaddr = Output(UInt(VAddrBits.W))
+  val vaddr = Output(UInt(XLEN.W))
   val vstart = Output(UInt((log2Up(VLEN) + 1).W))
   val vl = Output(UInt((log2Up(VLEN) + 1).W))
-  val gpaddr = Output(UInt(GPAddrBits.W))
+  val gpaddr = Output(UInt(XLEN.W))
 }
 
 class FwdEntry extends Bundle {

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadExceptionBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadExceptionBuffer.scala
@@ -103,7 +103,7 @@ class LqExceptionBuffer(implicit p: Parameters) extends XSModule with HasCircula
     req := reqSel._2(0)
   }
 
-  io.exceptionAddr.vaddr  := req.vaddr
+  io.exceptionAddr.vaddr  := req.fullva
   io.exceptionAddr.vstart := req.uop.vpu.vstart
   io.exceptionAddr.vl     := req.uop.vpu.vl
   io.exceptionAddr.gpaddr := req.gpaddr

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
@@ -118,8 +118,8 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
     val writeBack       = Decoupled(new MemExuOutput)
     val overwriteExpBuf = Output(new XSBundle {
       val valid  = Bool()
-      val vaddr  = UInt(VAddrBits.W)
-      val gpaddr = UInt(GPAddrBits.W)
+      val vaddr  = UInt(XLEN.W)
+      val gpaddr = UInt(XLEN.W)
     })
     val flushLdExpBuff  = Output(Bool())
   })

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -144,7 +144,7 @@ class StoreExceptionBuffer(implicit p: Parameters) extends XSModule with HasCirc
     req := reqSel._2(0)
   }
 
-  io.exceptionAddr.vaddr  := req.vaddr
+  io.exceptionAddr.vaddr  := req.fullva
   io.exceptionAddr.gpaddr := req.gpaddr
   io.exceptionAddr.vstart := req.uop.vpu.vstart
   io.exceptionAddr.vl     := req.uop.vpu.vl

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -47,8 +47,8 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
     val feedbackSlow  = ValidIO(new RSFeedback)
     val redirect      = Flipped(ValidIO(new Redirect))
     val exceptionAddr = ValidIO(new Bundle {
-      val vaddr = UInt(VAddrBits.W)
-      val gpaddr = UInt(GPAddrBits.W)
+      val vaddr = UInt(XLEN.W)
+      val gpaddr = UInt(XLEN.W)
     })
     val csrCtrl       = Flipped(new CustomCSRCtrlIO)
   })
@@ -141,6 +141,8 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
     // keep firing until tlb hit
     io.dtlb.req.valid       := true.B
     io.dtlb.req.bits.vaddr  := in.src(0)
+    io.dtlb.req.bits.fullva := in.src(0)
+    io.dtlb.req.bits.checkfullva := true.B
     io.dtlb.resp.ready      := true.B
     io.dtlb.req.bits.cmd    := Mux(isLr, TlbCmd.atom_read, TlbCmd.atom_write)
     io.dtlb.req.bits.debug.pc := in.uop.pc

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -604,6 +604,8 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
     tlb_req_arb.io.in(i).bits.size := 3.U
     tlb_req_arb.io.in(i).bits.kill := false.B
     tlb_req_arb.io.in(i).bits.no_translate := false.B
+    tlb_req_arb.io.in(i).bits.fullva := 0.U
+    tlb_req_arb.io.in(i).bits.checkfullva := false.B
     tlb_req_arb.io.in(i).bits.memidx := DontCare
     tlb_req_arb.io.in(i).bits.debug := DontCare
     tlb_req_arb.io.in(i).bits.hlvx := DontCare

--- a/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
@@ -888,6 +888,8 @@ class PrefetchFilter()(implicit p: Parameters) extends XSModule with HasSMSModul
     tlb_req_arb.io.in(i).bits.size := 3.U
     tlb_req_arb.io.in(i).bits.kill := false.B
     tlb_req_arb.io.in(i).bits.no_translate := false.B
+    tlb_req_arb.io.in(i).bits.fullva := 0.U
+    tlb_req_arb.io.in(i).bits.checkfullva := false.B
     tlb_req_arb.io.in(i).bits.memidx := DontCare
     tlb_req_arb.io.in(i).bits.debug := DontCare
     tlb_req_arb.io.in(i).bits.hlvx := DontCare

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -36,7 +36,7 @@ class VLSBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBun
   // val fof            = Bool() // fof is only used for vector loads
   val excp_eew_index      = UInt(elemIdxBits.W)
   // val exceptionVec   = ExceptionVec() // uop has exceptionVec
-  val baseAddr            = UInt(VAddrBits.W)
+  val baseAddr            = UInt(XLEN.W)
   val stride              = UInt(VLEN.W)
   // val flow_counter = UInt(flowIdxBits.W)
 
@@ -109,8 +109,8 @@ class VecPipelineFeedbackIO(isVStore: Boolean=false) (implicit p: Parameters) ex
   val mmio                 = Bool()
   //val atomic               = Bool()
   val exceptionVec         = ExceptionVec()
-  val vaddr                = UInt(VAddrBits.W)
-  val gpaddr               = UInt(GPAddrBits.W)
+  val vaddr                = UInt(XLEN.W)
+  val gpaddr               = UInt(XLEN.W)
   //val vec                  = new OnlyVecExuOutput
    // feedback
   val vecFeedback          = Bool()
@@ -126,7 +126,7 @@ class VecPipelineFeedbackIO(isVStore: Boolean=false) (implicit p: Parameters) ex
 }
 
 class VecPipeBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle {
-  val vaddr               = UInt(VAddrBits.W)
+  val vaddr               = UInt(XLEN.W)
   val mask                = UInt(VLENB.W)
   val isvec               = Bool()
   val uop_unit_stride_fof = Bool()
@@ -191,7 +191,7 @@ class FeedbackToSplitIO(implicit p: Parameters) extends VLSUBundle{
 class FeedbackToLsqIO(implicit p: Parameters) extends VLSUBundle{
   val robidx = new RobPtr
   val uopidx = UopIdx()
-  val vaddr = UInt(VAddrBits.W)
+  val vaddr = UInt(XLEN.W)
   val gpaddr = UInt(GPAddrBits.W)
   val feedback = Vec(VecFeedbacks.allFeedbacks, Bool())
     // for exception

--- a/src/main/scala/xiangshan/mem/vector/VecCommon.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecCommon.scala
@@ -289,7 +289,7 @@ class VecMemExuOutput(isVector: Boolean = false)(implicit p: Parameters) extends
   val alignedType = UInt(alignTypeBits.W)
   val mbIndex     = UInt(vsmBindexBits.W)
   val mask        = UInt(VLENB.W)
-  val vaddr       = UInt(VAddrBits.W)
+  val vaddr       = UInt(XLEN.W)
   val gpaddr      = UInt(GPAddrBits.W)
 }
 


### PR DESCRIPTION
In previous implementation, we simply truncated the higher bits of jump target or load & store address, which made it impossible to raise exceptions in such cases.

Commit https://github.com/OpenXiangShan/XiangShan/commit/c1b28b66879239a5b3a44741376f3b002e8ac834 has already fixed high address bits checking of jump target. This commit fixes lsu part, checking full address in tlb and passing full address directly to csr.