### PR TITLE
fix(CSR): add a finite state machine in NewCSR

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -851,7 +851,7 @@ class NewCSR(implicit val p: Parameters) extends Module
 
   /** the state machine of newCSR module */
   private val state = RegInit(s_idle)
-  /** the mext state of newCSR */
+  /** the next state of newCSR */
   private val stateNext = WireInit(state)
   state := stateNext
 

--- a/src/main/scala/xiangshan/backend/fu/SRT16Divider.scala
+++ b/src/main/scala/xiangshan/backend/fu/SRT16Divider.scala
@@ -100,7 +100,7 @@ class SRT16DividerDataModule(len: Int) extends Module {
     state := state
   }
 
-  io.in_ready := state(s_idle)
+  // io.in_ready := state(s_idle)
   aInverter := -Mux(state(s_idle), a, quotIterReg) // 64, 0
   dInverter := -Mux(state(s_idle), d, quotM1IterReg) // 64, 0
 

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -36,6 +36,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   val flushPipe = Wire(Bool())
   val flush = io.flush.valid
 
+  /** Alias of input signals */
   val (valid, src1, imm, func) = (
     io.in.valid,
     io.in.bits.data.src(0),
@@ -254,11 +255,15 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   tlb.mPBMTE := csrMod.io.tlb.mPBMTE
   tlb.hPBMTE := csrMod.io.tlb.hPBMTE
 
-  io.in.ready := true.B // Todo: Async read imsic may block CSR
+  /** Since some CSR read instructions are allowed to be pipelined, ready/valid signals should be modified */
+  io.in.ready := csrMod.io.in.ready // Todo: Async read imsic may block CSR
   io.out.valid := csrModOutValid
   io.out.bits.ctrl.exceptionVec.get := exceptionVec
   io.out.bits.ctrl.flushPipe.get := flushPipe
   io.out.bits.res.data := csrMod.io.out.bits.rData
+
+  /** initialize NewCSR's io_out_ready from wrapper's io */
+  csrMod.io.out.ready := io.out.ready
 
   io.out.bits.res.redirect.get.valid := isXRet
   val redirect = io.out.bits.res.redirect.get.bits


### PR DESCRIPTION
CSR instructions used to be executed without pipelining, so a state machine is not needed inside the CSR module. After adding an optimization that allows certain CSRR instructions to be pipelined, a state machine is required, since the arbiter to integer register files must allow a write request before a CSRR instructions is successfully executed.