### PR TITLE
Fix multiple ftq entries in single rob entry

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -161,6 +161,7 @@ class CtrlFlow(implicit p: Parameters) extends XSBundle {
   val ssid = UInt(SSIDWidth.W)
   val ftqPtr = new FtqPtr
   val ftqOffset = UInt(log2Up(PredictWidth).W)
+  val isLastInFtqEntry = Bool()
 }
 
 

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -40,17 +40,18 @@ object Bundles {
   }
   // frontend -> backend
   class StaticInst(implicit p: Parameters) extends XSBundle {
-    val instr           = UInt(32.W)
-    val pc              = UInt(VAddrBits.W)
-    val foldpc          = UInt(MemPredPCWidth.W)
-    val exceptionVec    = ExceptionVec()
-    val isFetchMalAddr  = Bool()
-    val trigger         = TriggerAction()
-    val preDecodeInfo   = new PreDecodeInfo
-    val pred_taken      = Bool()
-    val crossPageIPFFix = Bool()
-    val ftqPtr          = new FtqPtr
-    val ftqOffset       = UInt(log2Up(PredictWidth).W)
+    val instr            = UInt(32.W)
+    val pc               = UInt(VAddrBits.W)
+    val foldpc           = UInt(MemPredPCWidth.W)
+    val exceptionVec     = ExceptionVec()
+    val isFetchMalAddr   = Bool()
+    val trigger          = TriggerAction()
+    val preDecodeInfo    = new PreDecodeInfo
+    val pred_taken       = Bool()
+    val crossPageIPFFix  = Bool()
+    val ftqPtr           = new FtqPtr
+    val ftqOffset        = UInt(log2Up(PredictWidth).W)
+    val isLastInFtqEntry = Bool()
 
     def connectCtrlFlow(source: CtrlFlow): Unit = {
       this.instr            := source.instr
@@ -64,6 +65,7 @@ object Bundles {
       this.crossPageIPFFix  := source.crossPageIPFFix
       this.ftqPtr           := source.ftqPtr
       this.ftqOffset        := source.ftqOffset
+      this.isLastInFtqEntry := source.isLastInFtqEntry
     }
   }
 

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -1153,6 +1153,9 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
     (isCboInval && io.fromCSR.special.cboI2F) -> LSUOpType.cbo_flush,
   ))
 
+  // Don't compress in the same Rob entry when crossing Ftq entry boundary
+  io.deq.decodedInst.canRobCompress := decodedInst.canRobCompress && !io.enq.ctrlFlow.isLastInFtqEntry
+
   //-------------------------------------------------------------
   // Debug Info
 //  XSDebug("in:  instr=%x pc=%x excepVec=%b crossPageIPFFix=%d\n",

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -215,7 +215,6 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     robBanksRaddrNextLine := robBanksRaddrThisLine
   )
   val robDeqGroup = Reg(Vec(bankNum, new RobCommitEntryBundle))
-  val rawInfo = VecInit((0 until CommitWidth).map(i => robDeqGroup(deqPtrVec(i).value(bankAddrWidth-1, 0)))).toSeq
   val commitInfo = VecInit((0 until CommitWidth).map(i => robDeqGroup(deqPtrVec(i).value(bankAddrWidth-1,0)))).toSeq
   val walkInfo = VecInit((0 until CommitWidth).map(i => robDeqGroup(walkPtrVec(i).value(bankAddrWidth-1, 0)))).toSeq
   for (i <- 0 until CommitWidth) {
@@ -225,15 +224,6 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     }
   }
   
-  // In each robentry, the ftqIdx and ftqOffset belong to the first instruction that was compressed, 
-  // that is Necessary when exceptions happen.
-  // Update the ftqIdx and ftqOffset to correctly notify the frontend which instructions have been committed.
-  for (i <- 0 until CommitWidth) {
-    val lastOffset = (rawInfo(i).traceBlockInPipe.iretire - (1.U << rawInfo(i).traceBlockInPipe.ilastsize.asUInt)) +& rawInfo(i).ftqOffset
-    commitInfo(i).ftqIdx := rawInfo(i).ftqIdx + lastOffset.head(1)
-    commitInfo(i).ftqOffset := lastOffset.tail(1)
-  }
-
   // data for debug
   // Warn: debug_* prefix should not exist in generated verilog.
   val debug_microOp = DebugMem(RobSize, new DynInst)

--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -249,15 +249,17 @@ class FetchToIBuffer(implicit p: Parameters) extends XSBundle {
   val valid     = UInt(PredictWidth.W)
   val enqEnable = UInt(PredictWidth.W)
   val pd        = Vec(PredictWidth, new PreDecodeInfo)
-  val pc        = Vec(PredictWidth, UInt(VAddrBits.W))
   val foldpc    = Vec(PredictWidth, UInt(MemPredPCWidth.W))
-  val ftqPtr       = new FtqPtr
   val ftqOffset    = Vec(PredictWidth, ValidUndirectioned(UInt(log2Ceil(PredictWidth).W)))
   val exceptionFromBackend = Vec(PredictWidth, Bool())
   val exceptionType = Vec(PredictWidth, UInt(ExceptionType.width.W))
   val crossPageIPFFix = Vec(PredictWidth, Bool())
   val illegalInstr = Vec(PredictWidth, Bool())
   val triggered    = Vec(PredictWidth, TriggerAction())
+  val isLastInFtqEntry = Vec(PredictWidth, Bool())
+
+  val pc        = Vec(PredictWidth, UInt(VAddrBits.W))
+  val ftqPtr       = new FtqPtr
   val topdown_info = new FrontendTopDownBundle
 }
 

--- a/src/main/scala/xiangshan/frontend/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/IBuffer.scala
@@ -66,6 +66,7 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
   val exceptionType = IBufferExceptionType()
   val exceptionFromBackend = Bool()
   val triggered = TriggerAction()
+  val isLastInFtqEntry = Bool()
 
   def fromFetch(fetch: FetchToIBuffer, i: Int): IBufEntry = {
     inst   := fetch.instrs(i)
@@ -82,6 +83,7 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
     )
     exceptionFromBackend := fetch.exceptionFromBackend(i)
     triggered := fetch.triggered(i)
+    isLastInFtqEntry := fetch.isLastInFtqEntry(i)
     this
   }
 
@@ -107,6 +109,7 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
     cf.ssid := DontCare
     cf.ftqPtr := ftqPtr
     cf.ftqOffset := ftqOffset
+    cf.isLastInFtqEntry := isLastInFtqEntry
     cf
   }
 

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -827,6 +827,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   io.toIbuffer.bits.pd          := f3_pd
   io.toIbuffer.bits.ftqPtr      := f3_ftq_req.ftqIdx
   io.toIbuffer.bits.pc          := f3_pc
+  io.toIbuffer.bits.isLastInFtqEntry := Reverse(PriorityEncoderOH(Reverse(io.toIbuffer.bits.enqEnable))).asBools
   io.toIbuffer.bits.ftqOffset.zipWithIndex.map{case(a, i) => a.bits := i.U; a.valid := checkerOutStage1.fixedTaken(i) && !f3_req_is_mmio}
   io.toIbuffer.bits.foldpc      := f3_foldpc
   io.toIbuffer.bits.exceptionType := ExceptionType.merge(f3_exception_vec, f3_crossPage_exception_vec)

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -827,6 +827,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   io.toIbuffer.bits.pd          := f3_pd
   io.toIbuffer.bits.ftqPtr      := f3_ftq_req.ftqIdx
   io.toIbuffer.bits.pc          := f3_pc
+  // Find last using PriorityMux
   io.toIbuffer.bits.isLastInFtqEntry := Reverse(PriorityEncoderOH(Reverse(io.toIbuffer.bits.enqEnable))).asBools
   io.toIbuffer.bits.ftqOffset.zipWithIndex.map{case(a, i) => a.bits := i.U; a.valid := checkerOutStage1.fixedTaken(i) && !f3_req_is_mmio}
   io.toIbuffer.bits.foldpc      := f3_foldpc


### PR DESCRIPTION
Multiple Ftq entries in one Rob entry have caused numerous issues related to MMIO instruction fetching. This PR tries to disallow RobCompress when crossing a Ftq entry boundary. Also, fix buggy code related.