### PR TITLE
fix(topdownCounter): obtain ROB head from deqPtr instead of from "head"

### DIFF
--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1140,7 +1140,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   }
   io.csr.perfinfo.retiredInstr := retireCounter
   io.robFull := !allowEnqueue
-  io.headNotReady := commit_vDeqGroup.head && !commit_wDeqGroup.head
+  io.headNotReady := commit_vDeqGroup(deqPtr.value(bankNumWidth-1, 0)) && !commit_wDeqGroup(deqPtr.value(bankNumWidth-1, 0))
 
   /**
    * debug info


### PR DESCRIPTION
The "head" of commit_vDeqGroup and commit_wDeqGroup might be invalid after the instruction at index[0] committed.
So the "head" is not real rob head, which skews the meaning of headNotReady and skews topdown counters.