### PR TITLE
fix(csr): fix trap inst update when CSRR insts raise trap and remove useless io

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
@@ -347,6 +347,4 @@ trait HypervisorBundle { self: CSRModule[_] =>
 
 trait HasHypervisorEnvBundle { self: CSRModule[_] =>
   val menvcfg = IO(Input(new MEnvCfg))
-  val privState = IO(Input(new PrivState))
-  val accessStimecmp = IO(Input(Bool()))
 }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -595,8 +595,6 @@ class NewCSR(implicit val p: Parameters) extends Module
     mod match {
       case m: HasHypervisorEnvBundle =>
         m.menvcfg := menvcfg.regOut
-        m.privState := privState
-        m.accessStimecmp := (ren || wen) && (addr === CSRs.stimecmp.U || addr === CSRs.vstimecmp.U)
       case _ =>
     }
     mod match {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/TrapInstMod.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/TrapInstMod.scala
@@ -62,7 +62,14 @@ class TrapInstMod(implicit p: Parameters) extends Module with HasCircularQueuePt
     valid := false.B
   }.elsewhen(newCSRInstValid) {
     valid := true.B
-    trapInstInfo := newCSRInst
+    when (!valid) {
+      trapInstInfo := newCSRInst
+    }.elsewhen(valid &&
+      (newCSRInst.ftqPtr === trapInstInfo.ftqPtr && newCSRInst.ftqOffset < trapInstInfo.ftqOffset ||
+      newCSRInst.ftqPtr < trapInstInfo.ftqPtr)
+    ) {
+      trapInstInfo := newCSRInst
+    }
   }.elsewhen(newTrapInstInfo.valid && !valid) {
     valid := true.B
     trapInstInfo := newTrapInstInfo.bits


### PR DESCRIPTION
This PR fix trap inst update.
Because of CSRR inst is out of order insts, trap inst should select the oldest trap inst when CSRR inst raise trap.