### PR TITLE
refactor(Pmem): use `Seq` for physical memory ranges

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -41,8 +41,7 @@ case class SoCParameters
 (
   EnableILA: Boolean = false,
   PAddrBits: Int = 48,
-  PmemLowBounds: Seq[BigInt] = Seq(0x80000000L),
-  PmemHighBounds: Seq[BigInt] = Seq(0x80000000000L),
+  PmemRanges: Seq[(BigInt, BigInt)] = Seq((0x80000000L, 0x80000000000L)),
   extIntrs: Int = 64,
   L3NBanks: Int = 4,
   L3CacheParamsOpt: Option[HCCacheParameters] = Some(HCCacheParameters(

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -41,8 +41,8 @@ case class SoCParameters
 (
   EnableILA: Boolean = false,
   PAddrBits: Int = 48,
-  PmemLowBound: Long = 0x80000000L,
-  PmemHighBound: Long = 0x80000000000L,
+  PmemLowBounds: Seq[BigInt] = Seq(0x80000000L),
+  PmemHighBounds: Seq[BigInt] = Seq(0x80000000000L),
   extIntrs: Int = 64,
   L3NBanks: Int = 4,
   L3CacheParamsOpt: Option[HCCacheParameters] = Some(HCCacheParameters(

--- a/src/main/scala/xiangshan/PMParameters.scala
+++ b/src/main/scala/xiangshan/PMParameters.scala
@@ -43,9 +43,9 @@ trait HasPMParameters {
   implicit val p: Parameters
 
   def PMPAddrBits = p(SoCParamsKey).PAddrBits
-  def PMPPmemLowBounds = p(SoCParamsKey).PmemLowBounds
-  def PMPPmemHighBounds = p(SoCParamsKey).PmemHighBounds
-  def PMPPmemRanges = PMPPmemLowBounds zip PMPPmemHighBounds
+  def PMPPmemRanges = p(SoCParamsKey).PmemRanges
+  def PMPPmemLowBounds = PMPPmemRanges.unzip._1
+  def PMPPmemHighBounds = PMPPmemRanges.unzip._2
   def PMXLEN = p(XLen)
   def pmParams = p(PMParameKey)
   def NumPMP = pmParams.NumPMP

--- a/src/main/scala/xiangshan/PMParameters.scala
+++ b/src/main/scala/xiangshan/PMParameters.scala
@@ -42,14 +42,15 @@ case class PMParameters
 trait HasPMParameters {
   implicit val p: Parameters
 
-  val PMPAddrBits = p(SoCParamsKey).PAddrBits
-  val PMPPmemLowBound = p(SoCParamsKey).PmemLowBound
-  val PMPPmemHighBound = p(SoCParamsKey).PmemHighBound
-  val PMXLEN = p(XLen)
-  val pmParams = p(PMParameKey)
-  val NumPMP = pmParams.NumPMP
-  val NumPMA = pmParams.NumPMA
+  def PMPAddrBits = p(SoCParamsKey).PAddrBits
+  def PMPPmemLowBounds = p(SoCParamsKey).PmemLowBounds
+  def PMPPmemHighBounds = p(SoCParamsKey).PmemHighBounds
+  def PMPPmemRanges = PMPPmemLowBounds zip PMPPmemHighBounds
+  def PMXLEN = p(XLen)
+  def pmParams = p(PMParameKey)
+  def NumPMP = pmParams.NumPMP
+  def NumPMA = pmParams.NumPMA
 
-  val PlatformGrain = pmParams.PlatformGrain
-  val mmpma = pmParams.mmpma
+  def PlatformGrain = pmParams.PlatformGrain
+  def mmpma = pmParams.mmpma
 }

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -562,8 +562,9 @@ trait HasXSParameter {
   implicit val p: Parameters
 
   def PAddrBits = p(SoCParamsKey).PAddrBits // PAddrBits is Phyical Memory addr bits
-  def PmemLowBound = p(SoCParamsKey).PmemLowBound
-  def PmemHighBound = p(SoCParamsKey).PmemHighBound
+  def PmemLowBounds = p(SoCParamsKey).PmemLowBounds
+  def PmemHighBounds = p(SoCParamsKey).PmemHighBounds
+  def PmemRanges = PmemLowBounds zip PmemHighBounds
   final val PageOffsetWidth = 12
   def NodeIDWidth = p(SoCParamsKey).NodeIDWidthList(p(CHIIssue)) // NodeID width among NoC
 

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -563,6 +563,8 @@ trait HasXSParameter {
 
   def PAddrBits = p(SoCParamsKey).PAddrBits // PAddrBits is Phyical Memory addr bits
   def PmemRanges = p(SoCParamsKey).PmemRanges
+  def PmemLowBounds = PmemRanges.unzip._1
+  def PmemHighBounds = PmemRanges.unzip._2
   final val PageOffsetWidth = 12
   def NodeIDWidth = p(SoCParamsKey).NodeIDWidthList(p(CHIIssue)) // NodeID width among NoC
 

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -562,9 +562,7 @@ trait HasXSParameter {
   implicit val p: Parameters
 
   def PAddrBits = p(SoCParamsKey).PAddrBits // PAddrBits is Phyical Memory addr bits
-  def PmemLowBounds = p(SoCParamsKey).PmemLowBounds
-  def PmemHighBounds = p(SoCParamsKey).PmemHighBounds
-  def PmemRanges = PmemLowBounds zip PmemHighBounds
+  def PmemRanges = p(SoCParamsKey).PmemRanges
   final val PageOffsetWidth = 12
   def NodeIDWidth = p(SoCParamsKey).NodeIDWidthList(p(CHIIssue)) // NodeID width among NoC
 

--- a/src/main/scala/xiangshan/backend/fu/PMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMA.scala
@@ -157,8 +157,8 @@ trait PMAMethod extends PMAConst {
     }
 
     addPMA(0x0L, range = 0x1000000000000L, a = 3)
-    addPMA(PMPPmemHighBound, c = true, atomic = true, a = 1, x = true, w = true, r = true)
-    addPMA(PMPPmemLowBound, a = 1, w = true, r = true)
+    addPMA(PMPPmemHighBounds(0), c = true, atomic = true, a = 1, x = true, w = true, r = true)
+    addPMA(PMPPmemLowBounds(0), a = 1, w = true, r = true)
     addPMA(0x3A000000L, a = 1)
     addPMA(0x39002000L, a = 1, w = true, r = true)
     addPMA(0x39000000L, a = 1)

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1592,14 +1592,15 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   //----------------------------------------
   // assertions
   // dcache should only deal with DRAM addresses
+  import freechips.rocketchip.util._
   when (bus.a.fire) {
-    assert(bus.a.bits.address >= PmemLowBound.U && bus.a.bits.address < PmemHighBound.U)
+    PmemRanges.foreach(range => assert(bus.a.bits.address.inRange(range._1.U, range._2.U)))
   }
   when (bus.b.fire) {
-    assert(bus.b.bits.address >= PmemLowBound.U && bus.b.bits.address < PmemHighBound.U)
+    PmemRanges.foreach(range => assert(bus.b.bits.address.inRange(range._1.U, range._2.U)))
   }
   when (bus.c.fire) {
-    assert(bus.c.bits.address >= PmemLowBound.U && bus.c.bits.address < PmemHighBound.U)
+    PmemRanges.foreach(range => assert(bus.c.bits.address.inRange(range._1.U, range._2.U)))
   }
 
   //----------------------------------------

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchInterface.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchInterface.scala
@@ -94,7 +94,7 @@ class L1PrefetchFuzzer(implicit p: Parameters) extends DCacheModule{
   val rand_vaddr = DelayN(io.vaddr, 2)
   val rand_paddr = DelayN(io.paddr, 2)
 
-  io.req.bits.paddr := PmemLowBound.U + rand_offset
+  io.req.bits.paddr := PmemLowBounds.min.U + rand_offset
   io.req.bits.alias := io.req.bits.paddr(13,12)
   io.req.bits.confidence := LFSR64(seed=Some(789L))(4,0) === 0.U
   io.req.bits.is_store := LFSR64(seed=Some(890L))(4,0) === 0.U

--- a/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
@@ -1096,7 +1096,7 @@ class SMSTrainFilter()(implicit p: Parameters) extends XSModule with HasSMSModul
 }
 
 class SMSPrefetcher()(implicit p: Parameters) extends BasePrefecher with HasSMSModuleHelper with HasL1PrefetchSourceParameter {
-
+  import freechips.rocketchip.util._
 
   val io_agt_en = IO(Input(Bool()))
   val io_stride_en = IO(Input(Bool()))
@@ -1202,7 +1202,7 @@ class SMSPrefetcher()(implicit p: Parameters) extends BasePrefecher with HasSMSM
   pf_filter.io.gen_req.valid := pht_gen_valid || agt_gen_valid || stride_gen_valid
   pf_filter.io.gen_req.bits := pf_gen_req
   io.tlb_req <> pf_filter.io.tlb_req
-  val is_valid_address = pf_filter.io.l2_pf_addr.bits >= PmemLowBound.U && pf_filter.io.l2_pf_addr.bits < PmemHighBound.U
+  val is_valid_address = PmemRanges.map(range => pf_filter.io.l2_pf_addr.bits.inRange(range._1.U, range._2.U)).reduce(_ && _)
 
   io.l2_req.valid := pf_filter.io.l2_pf_addr.valid && io.enable && is_valid_address
   io.l2_req.bits.addr := pf_filter.io.l2_pf_addr.bits


### PR DESCRIPTION
This is beneficial if we have several sparse memory ranges.