### PR TITLE
fix(ghist): fix ghist maintaining

### DIFF
--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -603,7 +603,7 @@ class FullBranchPrediction(implicit p: Parameters) extends XSBundle with HasBPUC
   // the vec indicating if ghr should shift on each branch
   def shouldShiftVec =
     VecInit(br_valids.zipWithIndex.map{ case (v, i) =>
-      v && !real_br_taken_mask().take(i).reduceOption(_||_).getOrElse(false.B)})
+      v && hit && !real_br_taken_mask().take(i).reduceOption(_||_).getOrElse(false.B)})
 
   def lastBrPosOH =
     VecInit((!hit || !br_valids.reduce(_||_)) +: // not hit or no brs in entry


### PR DESCRIPTION
shouldShiftVec should be all zero when not hit


Related issue:

<img width="1243" alt="Screenshot 2024-09-23 at 21 25 07" src="https://github.com/user-attachments/assets/28b94bb8-a9bb-43d9-927c-31c269adb60f">
