### PR TITLE
fix(CSR,interrupt): use rdata instead of regOut to produce interrupt

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRModule.scala
@@ -42,7 +42,7 @@ class CSRModule[T <: CSRBundle](
 
   reconnectReg()
 
-  protected val rdataFields = Wire(bundle)
+  val rdataFields = IO(Output(bundle))
   rdataFields :|= regOut
 
   rdata := rdataFields.asUInt

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -300,7 +300,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   intrMod.io.in.mstatusMIE := mstatus.regOut.MIE.asBool
   intrMod.io.in.sstatusSIE := mstatus.regOut.SIE.asBool
   intrMod.io.in.vsstatusSIE := vsstatus.regOut.SIE.asBool
-  intrMod.io.in.mip := mip.regOut
+  intrMod.io.in.mip := mip.rdataFields
   intrMod.io.in.mie := mie.regOut
   intrMod.io.in.mideleg := mideleg.regOut
   intrMod.io.in.sip := sip.regOut


### PR DESCRIPTION
* Make rdataFields as Output for InterruptFilter usage.
* This commit fix the problem that SEIP cannot be raised.