### PR TITLE
fix(VLSU): fix bug in flush of pipeline connect & skid buffer

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -1439,7 +1439,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vsSplit(i).io.toMergeBuffer <> vsMergeBuffer(i).io.fromSplit.head
     NewPipelineConnect(
       vsSplit(i).io.out, storeUnits(i).io.vecstin, storeUnits(i).io.vecstin.fire,
-      vsSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect),
+      Mux(vsSplit(i).io.out.fire, vsSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect), storeUnits(i).io.vecstin.bits.uop.robIdx.needFlush(io.redirect)),
       Option("VsSplitConnectStu")
     )
     vsSplit(i).io.vstd.get := DontCare // Todo: Discuss how to pass vector store data
@@ -1453,7 +1453,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vlSplit(i).io.toMergeBuffer <> vlMergeBuffer.io.fromSplit(i)
     NewPipelineConnect(
       vlSplit(i).io.out, loadUnits(i).io.vecldin, loadUnits(i).io.vecldin.fire,
-      vlSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect),
+      Mux(vlSplit(i).io.out.fire, vlSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect), loadUnits(i).io.vecldin.bits.uop.robIdx.needFlush(io.redirect)),
       Option("VlSplitConnectLdu")
     )
 

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -484,7 +484,11 @@ class VLSplitImp(implicit p: Parameters) extends VLSUModule{
   io.toMergeBuffer <> splitPipeline.io.toMergeBuffer
 
   // skid buffer
-  skidBuffer(splitPipeline.io.out, splitBuffer.io.in, splitBuffer.io.in.bits.uop.robIdx.needFlush(io.redirect), "VLSplitSkidBuffer")
+  skidBuffer(splitPipeline.io.out, splitBuffer.io.in,
+    Mux(splitPipeline.io.out.fire,
+      splitPipeline.io.out.bits.uop.robIdx.needFlush(io.redirect),
+      splitBuffer.io.in.bits.uop.robIdx.needFlush(io.redirect)),
+    "VSSplitSkidBuffer")
 
   // Split Buffer
   splitBuffer.io.redirect <> io.redirect
@@ -501,7 +505,11 @@ class VSSplitImp(implicit p: Parameters) extends VLSUModule{
   io.toMergeBuffer <> splitPipeline.io.toMergeBuffer
 
   // skid buffer
-  skidBuffer(splitPipeline.io.out, splitBuffer.io.in, splitBuffer.io.in.bits.uop.robIdx.needFlush(io.redirect),"VSSplitSkidBuffer")
+  skidBuffer(splitPipeline.io.out, splitBuffer.io.in,
+    Mux(splitPipeline.io.out.fire,
+      splitPipeline.io.out.bits.uop.robIdx.needFlush(io.redirect),
+      splitBuffer.io.in.bits.uop.robIdx.needFlush(io.redirect)),
+    "VSSplitSkidBuffer")
 
   // Split Buffer
   splitBuffer.io.redirect <> io.redirect


### PR DESCRIPTION
In the previous design, the judgment of `flush` of pipeline connect and skid buffer is `io.in.bits.uop.robidx.needFlush(redirect)`, which will causes the request stored in the buffer that should not be flushed to be flushed. 

The function of `flush`: 
1. When `in.fire`, `flush` means to cancel request that will be buffer stored.
2. When `!in.fire`, `flush` means to cancel the request which stored in the buffer can't be send to the next stage, new request can't enter the buffer. 

This patch fixs the meaning of `flush` above.
