### PR TITLE
fix(cmo): Support Difftest with cbo.inval instruction

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -1083,6 +1083,12 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
       io.sbufferVecDifftestInfo(i).bits := difftestBuffer.get.io.deq(i).bits
     }
+
+    // commit cbo.inval to difftest
+    val cmoInvalEvent = DifftestModule(new DiffCMOInvalEvent)
+    cmoInvalEvent.coreid := io.hartId
+    cmoInvalEvent.valid  := io.mmioStout.fire && deqCanDoCbo && LSUOpType.isCboInval(uop(deqPtr).fuOpType)
+    cmoInvalEvent.addr   := cboMmioAddr
   }
 
   (1 until EnsbufferWidth).foreach(i => when(io.sbuffer(i).fire) { assert(io.sbuffer(i - 1).fire) })

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -584,6 +584,9 @@ package object xiangshan {
     def cbo_inval = "b1110".U
 
     def isCbo(op: UInt): Bool = op(3, 2) === "b11".U && (op(6, 4) === "b000".U)
+    def isCboClean(op: UInt): Bool = isCbo(op) && (op(3, 0) === cbo_clean)
+    def isCboFlush(op: UInt): Bool = isCbo(op) && (op(3, 0) === cbo_flush)
+    def isCboInval(op: UInt): Bool = isCbo(op) && (op(3, 0) === cbo_inval)
 
     // atomics
     // bit(1, 0) are size


### PR DESCRIPTION
When the DUT executes a cbo.inval, a set in Difftest is used to record its cacheline address.
Later, if there is a data mismatch between DUT and GoldenMem in the address space operated by the cbo.inval instruction, the Pmem of REF and GoldenMem will be directly updated using the data of DUT.