### PR TITLE
fix(IMSIC): add TLBuffer for tilelink IO

### DIFF
--- a/src/main/scala/device/imsic_axi_top.scala
+++ b/src/main/scala/device/imsic_axi_top.scala
@@ -127,6 +127,7 @@ class imsic_bus_top(
         TLToAXI4() :=
         TLWidthWidget(4) :=
         TLFIFOFixer() :=
+        TLBuffer() :=
         tlnode
     }
 


### PR DESCRIPTION
It is better for Top IO to be register out. Add TLBuffer for TileLink version of IMSIC.