### PR TITLE
fix(tlb): overwrite resp information when high address exception happens

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -368,6 +368,9 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       resp(idx).bits.excp(nDups).af.instr := false.B
 
       resp(idx).bits.excp(nDups).vaNeedExt := false.B
+      // overwrite miss & gpaddr when exception related to high address truncation happens
+      resp(idx).bits.miss := false.B
+      resp(idx).bits.gpaddr(nDups) := RegNext(req(idx).bits.fullva)
     } .otherwise {
       // isForVSnonLeafPTE is used only when gpf happens and it caused by a G-stage translation which supports VS-stage translation
       // it will be sent to CSR in order to modify the m/htinst.


### PR DESCRIPTION
In our design, when tlb returns miss, the exception returned by TLB is considered invalid. However, for the case where an exception related to high address truncation happens (preaf | prepf | pregpf), the returned exception message should be considered valid by tlb.miss = false.B

Also, in this condition, gpaddr should be vaddr.