### PR TITLE
fix(csr): not skip read/write menvcfg/henvcfg

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -777,8 +777,6 @@ class NewCSR(implicit val p: Parameters) extends Module
     (addr === CSRs.mip.U) || (addr === CSRs.sip.U) || (addr === CSRs.vsip.U) ||
     (addr === CSRs.hip.U) || (addr === CSRs.mvip.U) || (addr === CSRs.hvip.U) ||
     Cat(aiaSkipCSRs.map(_.addr.U === addr)).orR ||
-    (addr === CSRs.menvcfg.U) ||
-    (addr === CSRs.henvcfg.U) ||
     (addr === CSRs.stimecmp.U)
   )
 


### PR DESCRIPTION
Previously, menvcfg and henvcfg were added to "PerfCnt" to skip read/write them, because its implementation is different between XiangShan and NEMU. This patch removes this workaround as both XiangShan and NEMU support menvcfg and henvcfg. This could solve the pbmte diff problem.