### PR TITLE
fix(LoadMisalignBuffer): all exception from misalignbuffer should ove…

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -640,12 +640,15 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   )
 
   // only first issue of int / vec load intructions need to check full vaddr
-  s0_tlb_fullva := Mux(s0_src_select_vec(vec_iss_idx),
-    io.vecldin.bits.vaddr,
-    Mux(
-      s0_src_select_vec(int_iss_idx),
-      io.ldin.bits.src(0) + SignExt(io.ldin.bits.uop.imm(11, 0), XLEN),
-      s0_dcache_vaddr
+  s0_tlb_fullva := Mux(s0_src_valid_vec(mab_idx),
+    io.misalign_ldin.bits.fullva,
+    Mux(s0_src_select_vec(vec_iss_idx),
+      io.vecldin.bits.vaddr,
+      Mux(
+        s0_src_select_vec(int_iss_idx),
+        io.ldin.bits.src(0) + SignExt(io.ldin.bits.uop.imm(11, 0), XLEN),
+        s0_dcache_vaddr
+      )
     )
   )
 


### PR DESCRIPTION
…rwrite

In our previous design, we would only overwrite from misalignbuffer for cross-page requests; misalign requests that don't cross pages would still be written back from exceptionbuffer. However, exception messages such as gpaddr, which require a TLB hit to return, need to be written back from the misalignbuffer instead.

This commit writes back all exceptions of misalign requests from the misalignbuffer.