### PR TITLE
fix(MMIO): use fine-grained on-chip MMIO ranges

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -367,7 +367,7 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
     }
   }
 
-  val clint = LazyModule(new CLINT(CLINTParams(0x38000000L), 8))
+  val clint = LazyModule(new CLINT(CLINTParams(soc.CLINTRange.base), 8))
   if (enableCHI) { clint.node := device_xbar.get }
   else { clint.node := peripheralXbar.get }
 
@@ -380,7 +380,7 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
     lazy val module = new IntSourceNodeToModuleImp(this)
   }
 
-  val plic = LazyModule(new TLPLIC(PLICParams(0x3c000000L), 8))
+  val plic = LazyModule(new TLPLIC(PLICParams(soc.PLICRange.base), 8))
   val plicSource = LazyModule(new IntSourceNodeToModule(NrExtIntr))
 
   plic.intnode := plicSource.sourceNode
@@ -388,7 +388,7 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
   else { plic.node := peripheralXbar.get }
 
   val pll_node = TLRegisterNode(
-    address = Seq(AddressSet(0x3a000000L, 0xfff)),
+    address = Seq(soc.PLLRange),
     device = new SimpleDevice("pll_ctrl", Seq()),
     beatBytes = 8,
     concurrency = 1

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -21,6 +21,7 @@ import chisel3._
 import chisel3.util._
 import device.{DebugModule, TLPMA, TLPMAIO}
 import freechips.rocketchip.amba.axi4._
+import freechips.rocketchip.devices.debug.DebugModuleKey
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy.{AddressSet, IdRange, InModuleBody, LazyModule, LazyModuleImp, MemoryDevice, RegionType, SimpleDevice, TransferSizes}
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
@@ -34,6 +35,7 @@ import xiangshan.backend.fu.PMAConst
 import xiangshan.{DebugOptionsKey, XSTileKey}
 import coupledL2.EnableCHI
 import coupledL2.tl2chi.CHIIssue
+import xiangshan.PMParameKey
 
 case object SoCParamsKey extends Field[SoCParameters]
 
@@ -42,6 +44,11 @@ case class SoCParameters
   EnableILA: Boolean = false,
   PAddrBits: Int = 48,
   PmemRanges: Seq[(BigInt, BigInt)] = Seq((0x80000000L, 0x80000000000L)),
+  CLINTRange: AddressSet = AddressSet(0x38000000L, CLINTConsts.size - 1),
+  BEURange: AddressSet = AddressSet(0x38010000L, 0xfff),
+  PLICRange: AddressSet = AddressSet(0x3c000000L, PLICConsts.size(PLICConsts.maxMaxHarts) - 1),
+  PLLRange: AddressSet = AddressSet(0x3a000000L, 0xfff),
+  UARTLiteForDTS: Boolean = true, // should be false in SimMMIO
   extIntrs: Int = 64,
   L3NBanks: Int = 4,
   L3CacheParamsOpt: Option[HCCacheParameters] = Some(HCCacheParameters(
@@ -68,6 +75,7 @@ case class SoCParameters
   val L3BlockSize = 64
   // on chip network configurations
   val L3OuterBusWidth = 256
+  val UARTLiteRange = AddressSet(0x40600000, if (UARTLiteForDTS) 0x3f else 0xf)
 }
 
 trait HasSoCParameter {
@@ -101,10 +109,39 @@ trait HasSoCParameter {
   val EnableClintAsyncBridge = soc.EnableClintAsyncBridge
 }
 
+trait HasPeripheralRanges {
+  implicit val p: Parameters
+
+  private def soc = p(SoCParamsKey)
+  private def dm = p(DebugModuleKey)
+  private def pmParams = p(PMParameKey)
+
+  private def mmpma = pmParams.mmpma
+
+  def onChipPeripheralRanges: Map[String, AddressSet] = Map(
+    "CLINT" -> soc.CLINTRange,
+    "BEU"   -> soc.BEURange,
+    "PLIC"  -> soc.PLICRange,
+    "PLL"   -> soc.PLLRange,
+    "UART"  -> soc.UARTLiteRange,
+    "DEBUG" -> dm.get.address,
+    "MMPMA" -> AddressSet(mmpma.address, mmpma.mask)
+  ) ++ (
+    if (soc.L3CacheParamsOpt.map(_.ctrl.isDefined).getOrElse(false))
+      Map("L3CTL" -> AddressSet(soc.L3CacheParamsOpt.get.ctrl.get.address, 0xffff))
+    else
+      Map()
+  )
+
+  def peripheralRange = onChipPeripheralRanges.values.foldLeft(Seq(AddressSet(0x0, 0x7fffffffL))) { (acc, x) =>
+    acc.flatMap(_.subtract(x))
+  }
+}
+
 class ILABundle extends Bundle {}
 
 
-abstract class BaseSoC()(implicit p: Parameters) extends LazyModule with HasSoCParameter {
+abstract class BaseSoC()(implicit p: Parameters) extends LazyModule with HasSoCParameter with HasPeripheralRanges {
   val bankedNode = Option.when(!enableCHI)(BankBinder(L3NBanks, L3BlockSize))
   val peripheralXbar = Option.when(!enableCHI)(TLXbar())
   val l3_xbar = Option.when(!enableCHI)(TLXbar())
@@ -220,20 +257,14 @@ trait HaveAXI4MemPort {
 }
 
 trait HaveAXI4PeripheralPort { this: BaseSoC =>
-  // on-chip devices: 0x3800_0000 - 0x3fff_ffff 0x0000_0000 - 0x0000_0fff
-  val onChipPeripheralRange = AddressSet(0x38000000L, 0x07ffffffL)
-  val uartRange = AddressSet(0x40600000, 0x3f)
   val uartDevice = new SimpleDevice("serial", Seq("xilinx,uartlite"))
   val uartParams = AXI4SlaveParameters(
-    address = Seq(uartRange),
+    address = Seq(soc.UARTLiteRange),
     regionType = RegionType.UNCACHED,
     supportsRead = TransferSizes(1, 32),
     supportsWrite = TransferSizes(1, 32),
     resources = uartDevice.reg
   )
-  val peripheralRange = AddressSet(
-    0x0, 0x7fffffff
-  ).subtract(onChipPeripheralRange).flatMap(x => x.subtract(uartRange))
   val peripheralNode = AXI4SlaveNode(Seq(AXI4SlavePortParameters(
     Seq(AXI4SlaveParameters(
       address = peripheralRange,

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -75,7 +75,8 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
   val mmio_port = TLIdentityNode() // to L3
   val memory_port = if (enableCHI && enableL2) None else Some(TLIdentityNode())
   val beu = LazyModule(new BusErrorUnit(
-    new XSL1BusErrors(), BusErrorUnitParams(0x38010000)
+    new XSL1BusErrors(),
+    BusErrorUnitParams(soc.BEURange.base, soc.BEURange.mask.toInt + 1)
   ))
 
   val i_mmio_port = TLTempNode()

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -28,6 +28,7 @@ import freechips.rocketchip.diplomacy.{DisableMonitors, LazyModule}
 import freechips.rocketchip.util.HeterogeneousBag
 import utility.{ChiselDB, Constantin, FileRegisters, GTimer}
 import xiangshan.DebugOptionsKey
+import system.SoCParamsKey
 
 class SimTop(implicit p: Parameters) extends Module {
   val debugOpts = p(DebugOptionsKey)
@@ -42,7 +43,9 @@ class SimTop(implicit p: Parameters) extends Module {
     l_soc.module.dma.get <> WireDefault(0.U.asTypeOf(l_soc.module.dma.get))
   }
 
-  val l_simMMIO = LazyModule(new SimMMIO(l_soc.misc.peripheralNode.in.head._2))
+  val l_simMMIO = LazyModule(new SimMMIO(l_soc.misc.peripheralNode.in.head._2)(p.alter((site, here, up) => {
+    case SoCParamsKey => up(SoCParamsKey).copy(UARTLiteForDTS = false)
+  })))
   val simMMIO = Module(l_simMMIO.module)
   l_simMMIO.io_axi4.elements.head._2 <> soc.peripheral.viewAs[AXI4Bundle]
 


### PR DESCRIPTION
Previously, on-chip devices use a continuous memory range, which contains many memory holes not actually used. If we access these holes, the core will hang. This commit use fine-grained on-chip MMIO ranges so that memory accessing of these holes will be routed out of core and handled by other mechanisms.