### PR TITLE
fix(lsq): uncache req can be assigned only in idle state

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -267,10 +267,15 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   storeQueue.io.uncache.req.ready := false.B
   loadQueue.io.uncache.resp.valid := false.B
   storeQueue.io.uncache.resp.valid := false.B
-  when(loadQueue.io.uncache.req.valid){
-    io.uncache.req <> loadQueue.io.uncache.req
+  when(pendingstate === s_idle){
+    when(loadQueue.io.uncache.req.valid){
+      io.uncache.req <> loadQueue.io.uncache.req
+    }.otherwise{
+      io.uncache.req <> storeQueue.io.uncache.req
+    }
   }.otherwise{
-    io.uncache.req <> storeQueue.io.uncache.req
+    io.uncache.req.valid := false.B
+    io.uncache.req.bits := DontCare
   }
   when (io.uncacheOutstanding) {
     io.uncache.resp <> loadQueue.io.uncache.resp


### PR DESCRIPTION
**Bug Description:**

When an uncache store (st) is immediately followed by an uncache load (ld), due to the `AddPipelineReg` in MemBlock when the LSQ transfers data with the Uncache, even though Uncache is handling the store request, `MemBlock.uncacheReq.ready` is still true. Under the original assignment conditions, the ld request(ld req) from LQ will be received by `MemBlock.uncacheReq` in the `s_store` state. So when `MemBlock.uncacheReq` is received by Uncache, the LSQ state has already transitioned from `s_store` to `s_idle`, without switching to `s_load`. As a result, the load response (ld resp) from Uncache can never be received by the LSQ. The process is briefly described as follows: 

1. SQ: st req
2. Uncache: st req received
3. LQ: ld req in `s_store` state
4. Uncache: st resp
5. SQ: st resp received; Uncache: ld req received
6. LSQ: state to `s_idle`
7. Uncache: ld resp
8. **ERROR**: LSQ can not receive ld resp in `s_idle` state

**Fix**：In LSQ, uncache req can be assigned only in idle state.
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/1d2d417d-06d6-43bf-a876-5cc53d0ff9ed">
