### PR TITLE
fix(csr): fix width of instruction commit

### DIFF
--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -232,7 +232,7 @@ class RobCSRIO(implicit p: Parameters) extends XSBundle {
   val dirty_fs   = Output(Bool())
   val dirty_vs   = Output(Bool())
   val perfinfo   = new Bundle {
-    val retiredInstr = Output(UInt(3.W))
+    val retiredInstr = Output(UInt(7.W))
   }
 }
 


### PR DESCRIPTION
Due to the rob compression mechanism, the number of instructions committed per cycle may be greater than 7.
And the source signal `retiredInstr` sent by rob to the csr module has a bit width of 3, while the sink signal `instNum` has a bit width of 7, causing the low bits to be truncated when any cycle the number of commit instructions is greater than 7, making the minstret update inaccurate.