### PR TITLE
fix(Parameters): change incorrect VecDqDeqWidth to FpDqDeqWidth

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -425,7 +425,7 @@ case class XSCoreParameters
       numDeqOutside = 0,
       schdType = schdType,
       rfDataWidth = fpPreg.dataCfg.dataWidth,
-      numUopIn = dpParams.VecDqDeqWidth,
+      numUopIn = dpParams.FpDqDeqWidth,
     )
   }
 


### PR DESCRIPTION
FpDqDeqWidth in fpSchdParams is incorrectly written as VecDqDeqWidth