### PR TITLE
fix(VecExcp): use `isEnqExcp` to distinguish pc and mem trigger

### DIFF
--- a/src/main/scala/xiangshan/backend/rob/ExceptionGen.scala
+++ b/src/main/scala/xiangshan/backend/rob/ExceptionGen.scala
@@ -146,12 +146,15 @@ class ExceptionGen(params: BackendParams)(implicit p: Parameters) extends XSModu
         current.vlmul     := Mux(isVecUpdate, s1_out_bits.vlmul,      current.vlmul)
       }
     }
+    current.isEnqExcp := false.B
   }.elsewhen (s1_out_valid && !s1_flush) {
     currentValid := true.B
     current := s1_out_bits
+    current.isEnqExcp := false.B
   }.elsewhen (enq_s1_valid && !(io.redirect.valid || io.flush)) {
     currentValid := true.B
     current := enq_s1_bits
+    current.isEnqExcp := true.B
   }
 
   io.out.valid   := s1_out_valid || enq_s1_valid && enq_s1_bits.can_writeback

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -283,6 +283,9 @@ class RobExceptionInfo(implicit p: Parameters) extends XSBundle {
   val ftqOffset = UInt(log2Up(PredictWidth).W)
   // set 1 if there is 1 exists in exceptionVec
   val hasException = Bool()
+  // This signal is valid iff currentValid is true
+  // 0: is execute exception, 1: is fetch exception
+  val isEnqExcp = Bool()
   val exceptionVec = ExceptionVec()
   val isFetchMalAddr = Bool()
   val flushPipe = Bool()


### PR DESCRIPTION
Futher fix after #3722 