### PR TITLE
fix(misalign): fix misaligned HLV and HLVX

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
@@ -479,6 +479,11 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
 
   io.splitLoadReq.valid := req_valid && (bufferState === s_req)
   io.splitLoadReq.bits  := splitLoadReqs(curPtr)
+  // Restore the information of H extension load
+  // bit encoding: | hlv 1 | hlvx 1 | is unsigned(1bit) | size(2bit) |
+  val reqIsHlv  = LSUOpType.isHlv(req.uop.fuOpType)
+  val reqIsHlvx = LSUOpType.isHlvx(req.uop.fuOpType)
+  io.splitLoadReq.bits.uop.fuOpType := Cat(reqIsHlv, reqIsHlvx, 0.U(1.W), splitLoadReqs(curPtr).uop.fuOpType(1, 0))
 
   when (io.splitLoadResp.valid) {
     splitLoadResp(curPtr) := io.splitLoadResp.bits

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -443,6 +443,10 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
 
   io.splitStoreReq.valid := req_valid && (bufferState === s_req)
   io.splitStoreReq.bits  := splitStoreReqs(curPtr)
+  // Restore the information of H extension store
+  // bit encoding: | hsv 1 | store 00 | size(2bit) |
+  val reqIsHsv  = LSUOpType.isHsv(req.uop.fuOpType)
+  io.splitStoreReq.bits.uop.fuOpType := Cat(reqIsHsv, 0.U(2.W), splitStoreReqs(curPtr).uop.fuOpType(1, 0))
 
   when (io.splitStoreResp.valid) {
     splitStoreResp(curPtr) := io.splitStoreResp.bits


### PR DESCRIPTION
In the previous design, the H extension information was lost in the `fuOpType` of the misalignBuffer split instruction, causing the split instruction to not perform two-stage address translation and cause errors.

This PR fixes the information about H extension in `fuOpType` in misalignBuffer.