### PR TITLE
fix(ICache): use PriorityMux instead of Mux1H for io.error

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -629,7 +629,11 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   // Parity error port
   val errors       = mainPipe.io.errors
   val errors_valid = errors.map(e => e.valid).reduce(_ | _)
-  io.error.bits <> RegEnable(Mux1H(errors.map(e => e.valid -> e.bits)), 0.U.asTypeOf(errors(0).bits), errors_valid)
+  io.error.bits <> RegEnable(
+    PriorityMux(errors.map(e => e.valid -> e.bits)),
+    0.U.asTypeOf(errors(0).bits),
+    errors_valid
+  )
   io.error.valid := RegNext(errors_valid, false.B)
 
   XSPerfAccumulate(


### PR DESCRIPTION
mainPipe.io.errors is not ensured to be at-most-one-hot, ECC errors may occur on both cachelines at the same time.

Note: DCache may have similar problems, as this code is actually copy-and-pasted from DCache 3 years ago.
https://github.com/OpenXiangShan/XiangShan/blob/0303f76a84fd705d32f6f0434c63c55e2ff02186/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala#L991-L997
