### PR TITLE
feat(Ss/Smdbltrp) : Support RISC-V Ss/Smdbltrp Extension

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -299,7 +299,7 @@ object FuConfig {
     piped = false,
     writeIntRf = true,
     latency = UncertainLatency(),
-    exceptionOut = Seq(illegalInstr, virtualInstr, breakPoint, ecallU, ecallS, ecallVS, ecallM),
+    exceptionOut = Seq(illegalInstr, virtualInstr, doubleTrap, breakPoint, ecallU, ecallS, ecallVS, ecallM),
     flushPipe = true,
   )
 

--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -299,7 +299,7 @@ object FuConfig {
     piped = false,
     writeIntRf = true,
     latency = UncertainLatency(),
-    exceptionOut = Seq(illegalInstr, virtualInstr, doubleTrap, breakPoint, ecallU, ecallS, ecallVS, ecallM),
+    exceptionOut = Seq(illegalInstr, virtualInstr, breakPoint, ecallU, ecallS, ecallVS, ecallM),
     flushPipe = true,
   )
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRBundles.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRBundles.scala
@@ -47,7 +47,7 @@ object CSRBundles {
     val STCE  =      RO(    63)           .withReset(0.U) // Sstc Enable
     val PBMTE =      RO(    62)           .withReset(0.U) // Svpbmt Enable
     val ADUE  =      RO(    61)           .withReset(0.U) // Svadu extension Enable
-    val DTE   =      RO(    59)           .withReset(0.U) // Ssdbltrp extension Enabel
+    val DTE   =      RO(    59)           .withReset(0.U) // Ssdbltrp extension Enable
     val PMM   =      RO(33, 32)           .withReset(0.U) // Smnpm extension
     val CBZE  =      RW(     7)           .withReset(1.U) // Zicboz extension
     val CBCFE =      RW(     6)           .withReset(1.U) // Zicbom extension

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRBundles.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRBundles.scala
@@ -47,6 +47,7 @@ object CSRBundles {
     val STCE  =      RO(    63)           .withReset(0.U) // Sstc Enable
     val PBMTE =      RO(    62)           .withReset(0.U) // Svpbmt Enable
     val ADUE  =      RO(    61)           .withReset(0.U) // Svadu extension Enable
+    val DTE   =      RO(    59)           .withReset(0.U) // Ssdbltrp extension Enabel
     val PMM   =      RO(33, 32)           .withReset(0.U) // Smnpm extension
     val CBZE  =      RW(     7)           .withReset(1.U) // Zicboz extension
     val CBCFE =      RW(     6)           .withReset(1.U) // Zicbom extension

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/CSREvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/CSREvent.scala
@@ -125,6 +125,7 @@ class TrapEntryEventInput(implicit val p: Parameters) extends Bundle with HasXSP
   val isFetchMalAddr = Input(Bool())
   val isFetchBkpt = Input(Bool())
   val trapIsForVSnonLeafPTE = Input(Bool())
+  val hasDTExcp = Input(Bool())
 
   // always current privilege
   val iMode = Input(new PrivState())
@@ -136,6 +137,9 @@ class TrapEntryEventInput(implicit val p: Parameters) extends Bundle with HasXSP
   val hstatus = Input(new HstatusBundle)
   val sstatus = Input(new SstatusBundle)
   val vsstatus = Input(new SstatusBundle)
+  // envcfg
+  val menvcfg = Input(new MEnvCfg)
+  val henvcfg = Input(new HEnvCfg)
 
   val pcFromXtvec = Input(UInt(XLEN.W))
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/MNretEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/MNretEvent.scala
@@ -56,6 +56,7 @@ class MNretEventModule(implicit p: Parameters) extends Module with CSREventBase 
   outPrivState.V    := Mux(in.mnstatus.MNPP === PrivMode.M, VirtMode.Off.asUInt, in.mnstatus.MNPV.asUInt)
 
   val mnretToM  = outPrivState.isModeM
+  val mnretToS  = outPrivState.isModeHS
   val mnretToVU = outPrivState.isModeVU
 
   out := DontCare
@@ -71,7 +72,7 @@ class MNretEventModule(implicit p: Parameters) extends Module with CSREventBase 
   out.mstatus.bits.MPRV       := Mux(in.mnstatus.MNPP =/= PrivMode.M, 0.U, in.mstatus.MPRV.asUInt)
   // clear MDT when mnret to below M
   out.mstatus.bits.MDT        := Mux(mnretToM, in.mstatus.MDT.asBool, 0.U)
-  out.mstatus.bits.SDT        := Mux(mnretToM, in.mstatus.SDT.asBool, 0.U) // ?? return to S clear SDT?
+  out.mstatus.bits.SDT        := Mux(mnretToM || mnretToS, in.mstatus.SDT.asBool, 0.U)
   out.vsstatus.bits.SDT       := Mux(mnretToVU, 0.U, in.vsstatus.SDT.asBool)
   out.targetPc.bits.pc        := in.mnepc.asUInt
   out.targetPc.bits.raiseIPF  := instrAddrTransType.checkPageFault(in.mnepc.asUInt)

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryHSEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryHSEvent.scala
@@ -15,7 +15,7 @@ import xiangshan.AddrTransType
 class TrapEntryHSEventOutput extends Bundle with EventUpdatePrivStateOutput with EventOutputBase  {
 
   // Todo: use sstatus instead of mstatus
-  val mstatus = ValidIO((new MstatusBundle ).addInEvent(_.SPP, _.SPIE, _.SIE))
+  val mstatus = ValidIO((new MstatusBundle ).addInEvent(_.SPP, _.SPIE, _.SIE, _.SDT))
   val hstatus = ValidIO((new HstatusBundle ).addInEvent(_.SPV, _.SPVP, _.GVA))
   val sepc    = ValidIO((new Epc           ).addInEvent(_.epc))
   val scause  = ValidIO((new CauseBundle   ).addInEvent(_.Interrupt, _.ExceptionCode))

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryHSEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryHSEvent.scala
@@ -124,6 +124,7 @@ class TrapEntryHSEventModule(implicit val p: Parameters) extends Module with CSR
   out.mstatus.bits.SPP          := current.privState.PRVM.asUInt(0, 0) // SPP is not PrivMode enum type, so asUInt and shrink the width
   out.mstatus.bits.SPIE         := current.sstatus.SIE
   out.mstatus.bits.SIE          := 0.U
+  out.mstatus.bits.SDT          := in.menvcfg.DTE.asBool // when DTE open set SDT to 1, else SDT is readonly 0
   // hstatus
   out.hstatus.bits.SPV          := current.privState.V
     // SPVP is not PrivMode enum type, so asUInt and shrink the width

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala
@@ -13,7 +13,7 @@ import xiangshan.AddrTransType
 
 class TrapEntryMEventOutput extends Bundle with EventUpdatePrivStateOutput with EventOutputBase  {
 
-  val mstatus   = ValidIO((new MstatusBundle ).addInEvent(_.MPV, _.MPP, _.GVA, _.MPIE, _.MIE))
+  val mstatus   = ValidIO((new MstatusBundle ).addInEvent(_.MPV, _.MPP, _.GVA, _.MPIE, _.MIE, _.MDT))
   val mepc      = ValidIO((new Epc           ).addInEvent(_.epc))
   val mcause    = ValidIO((new CauseBundle   ).addInEvent(_.Interrupt, _.ExceptionCode))
   val mtval     = ValidIO((new OneFieldBundle).addInEvent(_.ALL))

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala
@@ -32,6 +32,7 @@ class TrapEntryMEventModule(implicit val p: Parameters) extends Module with CSRE
   private val satp  = current.satp
   private val vsatp = current.vsatp
   private val hgatp = current.hgatp
+  private val isDTExcp = current.hasDTExcp
 
   private val highPrioTrapNO = in.causeNO.ExceptionCode.asUInt
   private val isException = !in.causeNO.Interrupt.asBool
@@ -96,6 +97,8 @@ class TrapEntryMEventModule(implicit val p: Parameters) extends Module with CSRE
     (isLSGuestExcp                                         ) -> trapMemGPA,
   ))
 
+  private val precause = Cat(isInterrupt, highPrioTrapNO)
+
   out := DontCare
 
   out.privState.valid := valid
@@ -113,11 +116,12 @@ class TrapEntryMEventModule(implicit val p: Parameters) extends Module with CSRE
   out.mstatus.bits.GVA          := tvalFillGVA
   out.mstatus.bits.MPIE         := current.mstatus.MIE
   out.mstatus.bits.MIE          := 0.U
+  out.mstatus.bits.MDT          := 1.U
   out.mepc.bits.epc             := Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1))
   out.mcause.bits.Interrupt     := isInterrupt
-  out.mcause.bits.ExceptionCode := highPrioTrapNO
+  out.mcause.bits.ExceptionCode := Mux(isDTExcp, ExceptionNO.EX_DT.U, highPrioTrapNO)
   out.mtval.bits.ALL            := Mux(isFetchMalAddr, in.fetchMalTval, tval)
-  out.mtval2.bits.ALL           := tval2 >> 2
+  out.mtval2.bits.ALL           := Mux(isDTExcp, precause, tval2 >> 2)
   out.mtinst.bits.ALL           := Mux(isFetchGuestExcp && in.trapIsForVSnonLeafPTE || isLSGuestExcp && in.memExceptionIsForVSnonLeafPTE, 0x3000.U, 0.U)
   out.targetPc.bits.pc          := in.pcFromXtvec
   out.targetPc.bits.raiseIPF    := false.B

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryVSEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryVSEvent.scala
@@ -14,7 +14,7 @@ import xiangshan.AddrTransType
 
 class TrapEntryVSEventOutput extends Bundle with EventUpdatePrivStateOutput with EventOutputBase  {
 
-  val vsstatus = ValidIO((new SstatusBundle ).addInEvent(_.SPP, _.SPIE, _.SIE))
+  val vsstatus = ValidIO((new SstatusBundle ).addInEvent(_.SPP, _.SPIE, _.SIE, _.SDT))
   val vsepc    = ValidIO((new Epc           ).addInEvent(_.epc))
   val vscause  = ValidIO((new CauseBundle   ).addInEvent(_.Interrupt, _.ExceptionCode))
   val vstval   = ValidIO((new OneFieldBundle).addInEvent(_.ALL))

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryVSEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryVSEvent.scala
@@ -122,6 +122,7 @@ class TrapEntryVSEventModule(implicit val p: Parameters) extends Module with CSR
   out.vsstatus.bits.SPP          := current.privState.PRVM.asUInt(0, 0) // SPP is not PrivMode enum type, so asUInt and shrink the width
   out.vsstatus.bits.SPIE         := current.vsstatus.SIE
   out.vsstatus.bits.SIE          := 0.U
+  out.vsstatus.bits.SDT          := in.henvcfg.DTE.asBool // when DTE open set SDT to 1, else SDT is readonly 0
   // SPVP is not PrivMode enum type, so asUInt and shrink the width
   out.vsepc.bits.epc             := Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1))
   out.vscause.bits.Interrupt     := isInterrupt

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
@@ -62,14 +62,16 @@ trait HypervisorLevel { self: NewCSR =>
     .setAddr(CSRs.hvictl)
 
   val henvcfg = Module(new CSRModule("Henvcfg", new HEnvCfg) with HasHypervisorEnvBundle {
-    when (!menvcfg.STCE.asBool) {
+    when(!menvcfg.STCE.asBool) {
       regOut.STCE := 0.U
     }
-    when (!menvcfg.PBMTE) {
+    when(!menvcfg.PBMTE) {
       regOut.PBMTE := 0.U
     }
-  })
-    .setAddr(CSRs.henvcfg)
+    when(!menvcfg.DTE.asBool) {
+      regOut.DTE := 0.U
+    }
+  }).setAddr(CSRs.henvcfg)
 
   val htval = Module(new CSRModule("Htval", new XtvalBundle) with TrapEntryHSEventSinkBundle)
     .setAddr(CSRs.htval)
@@ -340,6 +342,9 @@ class HEnvCfg extends EnvCfg {
     this.STCE.setRW().withReset(1.U)
   }
   this.PBMTE.setRW().withReset(0.U)
+  if (CSRConfig.EXT_SSTC) {
+    this.DTE.setRW().withReset(1.U)
+  }
 }
 
 trait HypervisorBundle { self: CSRModule[_] =>

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
@@ -62,13 +62,13 @@ trait HypervisorLevel { self: NewCSR =>
     .setAddr(CSRs.hvictl)
 
   val henvcfg = Module(new CSRModule("Henvcfg", new HEnvCfg) with HasHypervisorEnvBundle {
-    when(!menvcfg.STCE.asBool) {
+    when(!menvcfg.STCE) {
       regOut.STCE := 0.U
     }
     when(!menvcfg.PBMTE) {
       regOut.PBMTE := 0.U
     }
-    when(!menvcfg.DTE.asBool) {
+    when(!menvcfg.DTE) {
       regOut.DTE := 0.U
     }
   }).setAddr(CSRs.henvcfg)
@@ -342,8 +342,10 @@ class HEnvCfg extends EnvCfg {
     this.STCE.setRW().withReset(1.U)
   }
   this.PBMTE.setRW().withReset(0.U)
-  if (CSRConfig.EXT_SSTC) {
-    this.DTE.setRW().withReset(1.U)
+  if (CSRConfig.EXT_DBLTRP) {
+    // software write envcfg to open ssdbltrp if need
+    // set 0 to pass ci
+    this.DTE.setRW().withReset(0.U)
   }
 }
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/InterruptFilter.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/InterruptFilter.scala
@@ -319,6 +319,7 @@ class InterruptFilter extends Module {
   dontTouch(mIRVec)
   dontTouch(hsIRVec)
   dontTouch(vsIRVec)
+  dontTouch(nmiReg)
 }
 
 class InterruptFilterIO extends Bundle {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/InterruptFilter.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/InterruptFilter.scala
@@ -319,7 +319,6 @@ class InterruptFilter extends Module {
   dontTouch(mIRVec)
   dontTouch(hsIRVec)
   dontTouch(vsIRVec)
-  dontTouch(nmiReg)
 }
 
 class InterruptFilterIO extends Bundle {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
@@ -452,12 +452,14 @@ class MstatusBundle extends CSRBundle {
   val TVM  = CSRRWField     (20).withReset(0.U)
   val TW   = CSRRWField     (21).withReset(0.U)
   val TSR  = CSRRWField     (22).withReset(0.U)
+  val SDT  = CSRRWField     (24).withReset(1.U)
   val UXL  = XLENField      (33, 32).withReset(XLENField.XLEN64)
   val SXL  = XLENField      (35, 34).withReset(XLENField.XLEN64)
   val SBE  = CSRROField     (36).withReset(0.U)
   val MBE  = CSRROField     (37).withReset(0.U)
   val GVA  = CSRRWField     (38).withReset(0.U)
   val MPV  = VirtMode       (39).withReset(0.U)
+  val MDT  = CSRRWField     (42).withReset(1.U)
   val SD   = CSRROField     (63,
     (_, _) => FS === ContextStatus.Dirty || VS === ContextStatus.Dirty
   )
@@ -471,6 +473,7 @@ class MstatusModule(implicit override val p: Parameters) extends CSRModule("MSta
   with MNretEventSinkBundle
   with SretEventSinkBundle
   with HasRobCommitBundle
+  with HasMachineEnvBundle
 {
   val mstatus = IO(Output(bundle))
   val sstatus = IO(Output(new SstatusBundle))
@@ -496,7 +499,22 @@ class MstatusModule(implicit override val p: Parameters) extends CSRModule("MSta
     assert(reg.VS =/= ContextStatus.Off, "The [m|s]status.VS should not be Off when set dirty, please check decode")
     reg.VS := ContextStatus.Dirty
   }
+  // when MDT is explicitly written by 1, clear MIE
+  // only when reg.MDT is zero or wdata.MDT is zero , MIE can be explicitly written by 1
+  when (w.wdataFields.MDT.asBool) {
+    reg.MIE := false.B
+  }.elsewhen(!reg.MDT.asBool || !w.wdataFields.MDT.asBool) {
+    reg.MIE := w.wdataFields.MIE.asBool
+  }
+  // when DTE is zero, SDT field is read-only zero
+  reg.SDT := Mux(this.menvcfg.DTE.asBool, w.wdataFields.SDT.asBool, 0.U)
 
+  // SDT and SIE is the same as MDT and MIE
+  when (w.wdataFields.SDT.asBool) {
+    reg.SIE := false.B
+  }.elsewhen(!reg.SDT.asBool || !w.wdataFields.SDT.asBool) {
+    reg.SIE := w.wdataFields.SIE.asBool
+  }
   // read connection
   mstatus :|= reg
   sstatus := mstatus
@@ -628,6 +646,9 @@ class MEnvCfg extends EnvCfg {
     this.STCE.setRW().withReset(1.U)
   }
   this.PBMTE.setRW().withReset(0.U)
+  if (CSRConfig.EXT_DBLTRP) {
+    this.DTE.setRW().withReset(1.U)
+  }
 }
 
 object MarchidField extends CSREnum with ROApply {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/SupervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/SupervisorLevel.scala
@@ -210,6 +210,7 @@ class SstatusBundle extends CSRBundle {
   val XS   = ContextStatusRO(16, 15).withReset(0.U)
   val SUM  = CSRWARLField   (18, wNoFilter).withReset(0.U)
   val MXR  = CSRWARLField   (19, wNoFilter).withReset(0.U)
+  val SDT  = CSRWARLField   (24, wNoFilter).withReset(1.U)
   val UXL  = XLENField      (33, 32).withReset(XLENField.XLEN64)
   val SD   = CSRROField     (63, (_, _) => FS === ContextStatus.Dirty || VS === ContextStatus.Dirty)
 }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/SupervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/SupervisorLevel.scala
@@ -210,7 +210,7 @@ class SstatusBundle extends CSRBundle {
   val XS   = ContextStatusRO(16, 15).withReset(0.U)
   val SUM  = CSRWARLField   (18, wNoFilter).withReset(0.U)
   val MXR  = CSRWARLField   (19, wNoFilter).withReset(0.U)
-  val SDT  = CSRWARLField   (24, wNoFilter).withReset(1.U)
+  val SDT  = CSRWARLField   (24, wNoFilter).withReset(0.U)
   val UXL  = XLENField      (33, 32).withReset(XLENField.XLEN64)
   val SD   = CSRROField     (63, (_, _) => FS === ContextStatus.Dirty || VS === ContextStatus.Dirty)
 }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/TrapHandleModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/TrapHandleModule.scala
@@ -13,6 +13,9 @@ class TrapHandleModule extends Module {
 
   private val trapInfo = io.in.trapInfo
   private val privState = io.in.privState
+  private val mstatus  = io.in.mstatus
+  private val vsstatus = io.in.vsstatus
+  private val mnstatus = io.in.mnstatus
   private val mideleg = io.in.mideleg.asUInt
   private val hideleg = io.in.hideleg.asUInt
   private val medeleg = io.in.medeleg.asUInt
@@ -110,6 +113,7 @@ class TrapHandleModule extends Module {
 
   private val handleTrapUnderHS = !privState.isModeM && hsHasTrap
   private val handleTrapUnderVS = privState.isVirtual && vsHasTrap
+  private val handleTrapUnderM = !handleTrapUnderVS && !handleTrapUnderHS
 
   // Todo: support more interrupt and exception
   private val exceptionRegular = OHToUInt(highestPrioEX)
@@ -118,20 +122,33 @@ class TrapHandleModule extends Module {
 
   private val causeNO = Mux(hasIR, interruptNO, exceptionNO)
 
+  // sm/ssdbltrp
+  private val m_EX_DT  = handleTrapUnderM  && mstatus.MDT.asBool  && hasTrap
+  private val s_EX_DT  = handleTrapUnderHS && mstatus.SDT.asBool  && hasTrap
+  private val vs_EX_DT = handleTrapUnderVS && vsstatus.SDT.asBool && hasTrap
+
+  private val dbltrpToMN = m_EX_DT && mnstatus.NMIE.asBool // NMI not allow double trap
+  private val hasDTExcp  = m_EX_DT || s_EX_DT || vs_EX_DT
+
+  private val trapToHS = handleTrapUnderHS && !s_EX_DT && !vs_EX_DT
+  private val traptoVS = handleTrapUnderVS && !vs_EX_DT
+
   private val xtvec = MuxCase(io.in.mtvec, Seq(
-    handleTrapUnderVS -> io.in.vstvec,
-    handleTrapUnderHS -> io.in.stvec
+    traptoVS -> io.in.vstvec,
+    trapToHS -> io.in.stvec
   ))
   private val pcFromXtvec = Cat(xtvec.addr.asUInt + Mux(xtvec.mode === XtvecMode.Vectored && hasIR, interruptNO(5, 0), 0.U), 0.U(2.W))
 
   io.out.entryPrivState := MuxCase(default = PrivState.ModeM, mapping = Seq(
-    handleTrapUnderVS -> PrivState.ModeVS,
-    handleTrapUnderHS -> PrivState.ModeHS,
+    traptoVS -> PrivState.ModeVS,
+    trapToHS -> PrivState.ModeHS,
   ))
 
   io.out.causeNO.Interrupt := hasIR
   io.out.causeNO.ExceptionCode := causeNO
   io.out.pcFromXtvec := pcFromXtvec
+  io.out.hasDTExcp := hasDTExcp
+  io.out.dbltrpToMN := dbltrpToMN
 
   def filterIRQs(group: Seq[Int], originIRQ: UInt): Seq[Bool] = {
     group.map(irqNum => originIRQ(irqNum))
@@ -173,6 +190,9 @@ class TrapHandleIO extends Bundle {
       val singleStep = Bool()
     })
     val privState = new PrivState
+    val mstatus = new MstatusBundle
+    val vsstatus = new SstatusBundle
+    val mnstatus = new MnstatusBundle
     val mideleg = new MidelegBundle
     val medeleg = new MedelegBundle
     val hideleg = new HidelegBundle
@@ -190,6 +210,8 @@ class TrapHandleIO extends Bundle {
   val out = new Bundle {
     val entryPrivState = new PrivState
     val causeNO = new CauseBundle
+    val dbltrpToMN = Bool()
+    val hasDTExcp = Bool()
     val pcFromXtvec = UInt()
   }
 }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/VirtualSupervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/VirtualSupervisorLevel.scala
@@ -7,7 +7,7 @@ import freechips.rocketchip.rocket.CSRs
 import utility.{SignExt, ZeroExt}
 import xiangshan.backend.fu.NewCSR.CSRBundles._
 import xiangshan.backend.fu.NewCSR.CSRDefines.{VirtMode, CSRROField => RO, CSRRWField => RW, CSRWARLField => WARL, CSRWLRLField => WLRL, _}
-import xiangshan.backend.fu.NewCSR.CSREvents.{SretEventSinkBundle, TrapEntryVSEventSinkBundle}
+import xiangshan.backend.fu.NewCSR.CSREvents.{SretEventSinkBundle, MretEventSinkBundle, MNretEventSinkBundle, TrapEntryVSEventSinkBundle}
 import xiangshan.backend.fu.NewCSR.CSREnumTypeImplicitCast._
 import xiangshan.backend.fu.NewCSR.CSRBundleImplicitCast._
 import xiangshan.backend.fu.NewCSR.CSRConfig.PPNLength
@@ -20,8 +20,11 @@ trait VirtualSupervisorLevel { self: NewCSR with SupervisorLevel with Hypervisor
   val vsstatus = Module(
     new CSRModule("VSstatus", new SstatusBundle)
       with SretEventSinkBundle
+      with MretEventSinkBundle
+      with MNretEventSinkBundle
       with TrapEntryVSEventSinkBundle
       with HasRobCommitBundle
+      with HasVirtualSupervisorEnvBundle
     {
       when ((robCommit.fsDirty || writeFCSR) && isVirtMode) {
         assert(reg.FS =/= ContextStatus.Off, "The vsstatus.FS should not be Off when set dirty, please check decode")
@@ -32,6 +35,15 @@ trait VirtualSupervisorLevel { self: NewCSR with SupervisorLevel with Hypervisor
         assert(reg.VS =/= ContextStatus.Off, "The vsstatus.VS should not be Off when set dirty, please check decode")
         reg.VS := ContextStatus.Dirty
       }
+      // when menvcfg or henvcfg.DTE close,  vsstatus.SDT is read-only
+      reg.SDT := Mux(this.menvcfg.DTE.asBool && this.henvcfg.DTE.asBool, w.wdataFields.SDT.asBool, 0.U)
+      // SDT and SIE is the same as mstatus
+      when (w.wdataFields.SDT.asBool) {
+        reg.SIE := false.B
+      }.elsewhen(!reg.SDT.asBool || !w.wdataFields.SDT.asBool) {
+        reg.SIE := w.wdataFields.SIE.asBool
+      }
+
     }
   )
     .setAddr(CSRs.vsstatus)
@@ -295,4 +307,9 @@ class VSipToHip extends Bundle {
 trait VirtualSupervisorBundle { self: CSRModule[_] =>
   val v = IO(Input(Bool()))
   val hgatp = IO(Input(new HgatpBundle))
+}
+
+trait HasVirtualSupervisorEnvBundle { self: CSRModule[_] =>
+  val menvcfg = IO(Input(new MEnvCfg))
+  val henvcfg = IO(Input(new HEnvCfg))
 }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/VirtualSupervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/VirtualSupervisorLevel.scala
@@ -36,12 +36,14 @@ trait VirtualSupervisorLevel { self: NewCSR with SupervisorLevel with Hypervisor
         reg.VS := ContextStatus.Dirty
       }
       // when menvcfg or henvcfg.DTE close,  vsstatus.SDT is read-only
-      reg.SDT := Mux(this.menvcfg.DTE.asBool && this.henvcfg.DTE.asBool, w.wdataFields.SDT.asBool, 0.U)
+      val writeSDT = Wire(Bool())
+      writeSDT := Mux(this.menvcfg.DTE && this.henvcfg.DTE, w.wdataFields.SDT.asBool, 0.U)
+      when (!(this.menvcfg.DTE && this.henvcfg.DTE)) {
+        regOut.SDT := false.B
+      }
       // SDT and SIE is the same as mstatus
-      when (w.wdataFields.SDT.asBool) {
+      when (writeSDT && w.wen ) {
         reg.SIE := false.B
-      }.elsewhen(!reg.SDT.asBool || !w.wdataFields.SDT.asBool) {
-        reg.SIE := w.wdataFields.SIE.asBool
       }
 
     }

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -817,6 +817,7 @@ package object xiangshan {
     def loadPageFault       = 13
     // def singleStep          = 14
     def storePageFault      = 15
+    def doubleTrap          = 16
     def instrGuestPageFault = 20
     def loadGuestPageFault  = 21
     def virtualInstr        = 22
@@ -838,6 +839,7 @@ package object xiangshan {
     def EX_IPF    = instrPageFault
     def EX_LPF    = loadPageFault
     def EX_SPF    = storePageFault
+    def EX_DT     = doubleTrap
     def EX_IGPF   = instrGuestPageFault
     def EX_LGPF   = loadGuestPageFault
     def EX_VI     = virtualInstr
@@ -860,6 +862,7 @@ package object xiangshan {
     def getStoreFault = Seq(EX_SAM, EX_SAF, EX_SPF)
 
     def priorities = Seq(
+      doubleTrap,
       breakPoint, // TODO: different BP has different priority
       instrPageFault,
       instrGuestPageFault,


### PR DESCRIPTION
* NEMU commit: 066cb1f1c61feb21153399c26ca393dfb3a560d7
* NEMU configs:
  * riscv64-xs-ref_defconfig
  * riscv64-dual-xs-ref_defconfig

Including:
  * fix(format): adjust code format and add one config (OpenXiangShan/NEMU#603)
  * fix(vfredusum): set xstatus.fs and xstatus.vs dirty (OpenXiangShan/NEMU#605)
  * fix(vf): do not set dirtyFs for some instructions (OpenXiangShan/NEMU#606)
  * feat(trigger): add trigger support for rva.
  * configs(xs): open Sm/sdbltrp extension and add MDT_INIT config (OpenXiangShan/NEMU#604)

---

* spike commit: c0b18d3913d8ceac83743a053a7dbd2fb8716c83
* spike config: CPU=XIANGSHAN

Including:
* fix(rva, trigger): For rva instr, raise BP from trigger prior to misaligned.
* fix(Makefile): Increase maxdepth for finding .h files.
* fix(tdata1): CPU_XIANGSHAN do not implement hit bit in tdata1.
* fix(icount): place the read before the return of the detect_icount_match.