### PR TITLE
fix(RVC): C.MV should expand to MV instead of ADDI

### DIFF
--- a/src/main/scala/xiangshan/frontend/PreDecode.scala
+++ b/src/main/scala/xiangshan/frontend/PreDecode.scala
@@ -288,7 +288,7 @@ class RVCExpander(implicit p: Parameters) extends XSModule {
     val ill = Output(Bool())
   })
 
-  val decoder = new RVCDecoder(io.in, XLEN, fLen, useAddiForMv = true)
+  val decoder = new RVCDecoder(io.in, XLEN, fLen, useAddiForMv = false)
 
   if (HasCExtension) {
     io.out := decoder.decode


### PR DESCRIPTION
According to the RISC-V unprivileged specification，C.MV expands to a different instruction than the canonical MV pseudo instruction,  which instead uses ADDI. Implementations that handle MV specially, e.g. using register-renaming hardware, may find it more convenient to expand C.MV to MV instead of ADD, at slight additional hardware cost.
So, in the case where XiangShan has the move elimination feature, C.MV should be expanded to MV, which incurs less overhead than executing the ADDI instruction.