### PR TITLE
refactor(MemBlock):  turn on `dontTouch` only when debugging

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -645,7 +645,9 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   val tlbreplay = WireInit(VecInit(Seq.fill(LdExuCnt)(false.B)))
   val tlbreplay_reg = GatedValidRegNext(tlbreplay)
   val dtlb_ld0_tlbreplay_reg = GatedValidRegNext(dtlb_ld(0).tlbreplay)
-  dontTouch(tlbreplay)
+
+  if (backendParams.debugEn){ dontTouch(tlbreplay) }
+
   for (i <- 0 until LdExuCnt) {
     tlbreplay(i) := dtlb_ld(0).ptw.req(i).valid && ptw_resp_next.vector(0) && ptw_resp_v &&
       ptw_resp_next.data.hit(dtlb_ld(0).ptw.req(i).bits.vpn, tlbcsr.satp.asid, tlbcsr.vsatp.asid, tlbcsr.hgatp.vmid, allType = true, ignoreAsid = true)

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -135,8 +135,8 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   storeQueue.io.hartId := io.hartId
   storeQueue.io.uncacheOutstanding := io.uncacheOutstanding
 
+  if (backendParams.debugEn){ dontTouch(loadQueue.io.tlbReplayDelayCycleCtrl) }
 
-  dontTouch(loadQueue.io.tlbReplayDelayCycleCtrl)
   // Todo: imm
   val tlbReplayDelayCycleCtrl = WireInit(VecInit(Seq(14.U(ReSelectLen.W), 0.U(ReSelectLen.W), 125.U(ReSelectLen.W), 0.U(ReSelectLen.W))))
   loadQueue.io.tlbReplayDelayCycleCtrl := tlbReplayDelayCycleCtrl

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -939,7 +939,9 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
   val commitVec = WireInit(VecInit(Seq.fill(CommitWidth)(false.B)))
   val needCancel = Wire(Vec(StoreQueueSize, Bool())) // Will be assigned later
-  dontTouch(commitVec)
+
+  if (backendParams.debugEn){ dontTouch(commitVec) }
+
   // TODO: Deal with vector store mmio
   for (i <- 0 until CommitWidth) {
     // don't mark misalign store as committed

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -226,9 +226,12 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   // load flow source select (OH)
   val s0_src_select_vec = WireInit(VecInit((0 until SRC_NUM).map{i => s0_src_valid_vec(i) && s0_src_ready_vec(i)}))
   val s0_hw_prf_select = s0_src_select_vec(high_pf_idx) || s0_src_select_vec(low_pf_idx)
-  dontTouch(s0_src_valid_vec)
-  dontTouch(s0_src_ready_vec)
-  dontTouch(s0_src_select_vec)
+
+  if (backendParams.debugEn){
+    dontTouch(s0_src_valid_vec)
+    dontTouch(s0_src_ready_vec)
+    dontTouch(s0_src_select_vec)
+  }
 
   s0_valid := s0_src_valid_vec.reduce(_ || _) && !s0_kill
 

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -300,9 +300,12 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   // load flow source select (OH)
   val s0_src_select_vec = WireInit(VecInit((0 until SRC_NUM).map{i => s0_src_valid_vec(i) && s0_src_ready_vec(i)}))
   val s0_hw_prf_select = s0_src_select_vec(high_pf_idx) || s0_src_select_vec(low_pf_idx)
-  dontTouch(s0_src_valid_vec)
-  dontTouch(s0_src_ready_vec)
-  dontTouch(s0_src_select_vec)
+
+  if (backendParams.debugEn){
+    dontTouch(s0_src_valid_vec)
+    dontTouch(s0_src_ready_vec)
+    dontTouch(s0_src_select_vec)
+  }
 
   val s0_tlb_no_query = s0_hw_prf_select || s0_src_select_vec(fast_rep_idx) || s0_src_select_vec(mmio_idx) || s0_sel_src.prf_i
   s0_valid := (

--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -187,8 +187,11 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
       io.fromPipeline(j).bits.mBIndex === io.fromPipeline(i).bits.mBIndex &&
       io.fromPipeline(j).valid)).orR
   }
-  dontTouch(mergePortMatrix)
-  dontTouch(mergedByPrevPortVec)
+
+  if (backendParams.debugEn){
+    dontTouch(mergePortMatrix)
+    dontTouch(mergedByPrevPortVec)
+  }
 
   // for exception, select exception, when multi port writeback exception, we need select oldest one
   def selectOldest[T <: VecPipelineFeedbackIO](valid: Seq[Bool], bits: Seq[T], sel: Seq[UInt]): (Seq[Bool], Seq[T], Seq[UInt]) = {

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -610,11 +610,13 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
      (splitPtr + splitPtrOffset)
     )
 
-  dontTouch(issueUopFlowNumLog2)
-  dontTouch(issueEmul)
-  dontTouch(splitPtrNext)
-  dontTouch(stridePtr)
-  dontTouch(segmentActive)
+  if (backendParams.debugEn){
+    dontTouch(issueUopFlowNumLog2)
+    dontTouch(issueEmul)
+    dontTouch(splitPtrNext)
+    dontTouch(stridePtr)
+    dontTouch(segmentActive)
+  }
 
   // update splitPtr
   when(state === s_latch_and_merge_data || (state === s_send_data && (fieldActiveWirteFinish || !segmentActive))){

--- a/src/main/scala/xiangshan/mem/vector/VecCommon.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecCommon.scala
@@ -172,8 +172,12 @@ trait HasVLSUParameters extends HasXSParameter with VLSUConstants {
       val muxLength = data.length
       val selDataMatrix = Wire(Vec(muxLength, Vec(2, UInt((VLEN * 2).W)))) // 3 * 2 * 256
       val selMaskMatrix = Wire(Vec(muxLength, Vec(2, UInt((VLENB * 2).W)))) // 3 * 2 * 16
-      dontTouch(selDataMatrix)
-      dontTouch(selMaskMatrix)
+
+      if (backendParams.debugEn){
+        dontTouch(selDataMatrix)
+        dontTouch(selMaskMatrix)
+      }
+
       for(i <- 0 until muxLength){
         if(i == 0){
           selDataMatrix(i)(0) := Cat(0.U(VLEN.W), data(i))


### PR DESCRIPTION
This will result in the delivery of clean generated code and may remove some of the pseudo-paths.