### PR TITLE
ci(perf): optimize the schedule

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -25,18 +25,8 @@ jobs:
     timeout-minutes: 2880
     name: Performance Regression - Checkpoints
     steps:
-      - name: Determine if this is the biweekly run
-        id: determine_run
-        run: |
-          if [ $(( $(date +'%V') % 2 )) -eq 1 ]; then
-            echo "run_biweekly=true" >> $GITHUB_OUTPUT
-          else
-            echo "run_biweekly=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Set test commit
         id: set_test_commit
-        if: steps.determine_run.outputs.run_biweekly == 'true'
         run: |
           if [ "${{ github.event.inputs.test_commit }}" = "" ]; then
             echo "Using latest commit."
@@ -44,6 +34,17 @@ jobs:
           else
             echo "Using specified commit: ${{ github.event.inputs.test_commit }}"
             echo "commit_sha=${{ github.event.inputs.test_commit }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Determine if this is the biweekly run
+        id: determine_run
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_biweekly=true" >> $GITHUB_OUTPUT
+          elif [ $(( $(date +'%V') % 2 )) -eq 1 ]; then
+            echo "run_biweekly=true" >> $GITHUB_OUTPUT
+          else
+            echo "run_biweekly=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code at specific commit

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "run_biweekly=true" >> $GITHUB_OUTPUT
-          elif [ $(( $(date +'%V') % 2 )) -eq 1 ]; then
+          elif [ $(( $(date +'%V') % 2 )) -eq 0 ]; then
             echo "run_biweekly=true" >> $GITHUB_OUTPUT
           else
             echo "run_biweekly=false" >> $GITHUB_OUTPUT
@@ -66,18 +66,23 @@ jobs:
           echo "SPEC_DIR=/nfs/home/ci-runner/master-perf-report/cr${DATE}-${SHORT_SHA}" >> $GITHUB_ENV
           echo "CKPT_HOME=/nfs/home/share/checkpoints_profiles/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/checkpoint-0-0-0" >> $GITHUB_ENV
           echo "CKPT_JSON_PATH=/nfs/home/share/checkpoints_profiles/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/checkpoint-0-0-0/cluster-0-0.json" >> $GITHUB_ENV
-
+    
       - name: Test
         if: steps.determine_run.outputs.run_biweekly == 'true'
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
-          mkdir -p $NOOP_HOME/build
-          echo "hello world" > $NOOP_HOME/build/test.log
+          if [ -e "$SPEC_DIR/emu" ]; then
+            echo "no need build"
+          else
+            python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+            mkdir -p $NOOP_HOME/build
+            echo "need build"
+          fi
 
       # - name: Clean Up
       #   if: steps.determine_run.outputs.run_biweekly == 'true'
       #   run: |
       #     python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+
       # - name: Build EMU with DRAMsim3
       #   if: steps.determine_run.outputs.run_biweekly == 'true'
       #   run: |
@@ -93,6 +98,7 @@ jobs:
       #       mkdir -p $SPEC_DIR
       #       cp $NOOP_HOME/build/emu $SPEC_DIR/emu
       #     fi
+
       # - name: Run SPEC CPU2006 checkpoints
       #   if: steps.determine_run.outputs.run_biweekly == 'true'
       #   run: |
@@ -101,6 +107,7 @@ jobs:
       #       --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR --resume \
       #       -L "node033 node034 node036 node037 node038 node039 node040 node041 node042"
       #     find $NOOP_HOME/build/ -maxdepth 1 -name "*.vcd" -exec mv {} $SPEC_DIR \;
+
       # - name: Report SPEC CPU2006 score
       #   if: steps.determine_run.outputs.run_biweekly == 'true'
       #   run: |
@@ -114,6 +121,7 @@ jobs:
       #     mkdir $GITHUB_WORKSPACE/result
       #     cp $SPEC_DIR/err_ckps.json $GITHUB_WORKSPACE/result/err_ckps.json
       #     cp $SPEC_DIR/score.txt $GITHUB_WORKSPACE/result/score.txt
+
       # - name: Upload result
       #   if: steps.determine_run.outputs.run_biweekly == 'true'
       #   uses: actions/upload-artifact@v4

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -12,9 +12,9 @@ on:
         description: 'Commit SHA to run the workflow on'
         required: false
         default: ''
-  #only for test
-  push:
-    branches: [ ci-perf-yml ]
+  #only for test push
+  # push:
+  #   branches: [ ci-perf-yml ]
 
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
     continue-on-error: false
     #At most 2 days to finish
     timeout-minutes: 2880
-    name: Performance Regression - Checkpoints
+    name: Checkpoints
     steps:
       - name: Set test commit
         id: set_test_commit
@@ -41,7 +41,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "run_biweekly=true" >> $GITHUB_OUTPUT
-          elif [ $(( $(date +'%V') % 2 )) -eq 0 ]; then
+          elif [ $(( $(date +'%V') % 2 )) -eq 1 ]; then
             echo "run_biweekly=true" >> $GITHUB_OUTPUT
           else
             echo "run_biweekly=false" >> $GITHUB_OUTPUT
@@ -66,65 +66,54 @@ jobs:
           echo "SPEC_DIR=/nfs/home/ci-runner/master-perf-report/cr${DATE}-${SHORT_SHA}" >> $GITHUB_ENV
           echo "CKPT_HOME=/nfs/home/share/checkpoints_profiles/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/checkpoint-0-0-0" >> $GITHUB_ENV
           echo "CKPT_JSON_PATH=/nfs/home/share/checkpoints_profiles/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/checkpoint-0-0-0/cluster-0-0.json" >> $GITHUB_ENV
-    
-      - name: Test
+
+      - name: Clean Up
+        if: steps.determine_run.outputs.run_biweekly == 'true'
+        run: |
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+
+      - name: Build EMU with DRAMsim3
         if: steps.determine_run.outputs.run_biweekly == 'true'
         run: |
           if [ -e "$SPEC_DIR/emu" ]; then
-            echo "no need build"
-          else
-            python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
             mkdir -p $NOOP_HOME/build
-            echo "need build"
+            cp $SPEC_DIR/emu $NOOP_HOME/build/emu
+          else
+            python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build          \
+              --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3              \
+              --with-dramsim3 --threads 16                                  \
+              --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin \
+              --llvm-profdata llvm-profdata
+            mkdir -p $SPEC_DIR
+            cp $NOOP_HOME/build/emu $SPEC_DIR/emu
           fi
 
-      # - name: Clean Up
-      #   if: steps.determine_run.outputs.run_biweekly == 'true'
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+      - name: Run SPEC CPU2006 checkpoints
+        if: steps.determine_run.outputs.run_biweekly == 'true'
+        run: |
+          cd $PERF_HOME
+          python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
+            --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR --resume \
+            -L "node033 node034 node036 node037 node038 node039 node040 node041 node042"
+          find $NOOP_HOME/build/ -maxdepth 1 -name "*.vcd" -exec mv {} $SPEC_DIR \;
 
-      # - name: Build EMU with DRAMsim3
-      #   if: steps.determine_run.outputs.run_biweekly == 'true'
-      #   run: |
-      #     if [ -e "$SPEC_DIR/emu" ]; then
-      #       mkdir -p $NOOP_HOME/build
-      #       cp $SPEC_DIR/emu $NOOP_HOME/build/emu
-      #     else
-      #       python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build          \
-      #         --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3              \
-      #         --with-dramsim3 --threads 16                                  \
-      #         --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin \
-      #         --llvm-profdata llvm-profdata
-      #       mkdir -p $SPEC_DIR
-      #       cp $NOOP_HOME/build/emu $SPEC_DIR/emu
-      #     fi
+      - name: Report SPEC CPU2006 score
+        if: steps.determine_run.outputs.run_biweekly == 'true'
+        run: |
+          cd $PERF_HOME
+          python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
+            --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR \
+            --check --dump-json-path $SPEC_DIR/err_ckps.json
+          python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
+            --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR --report \
+            > $SPEC_DIR/score.txt
+          mkdir $GITHUB_WORKSPACE/result
+          cp $SPEC_DIR/err_ckps.json $GITHUB_WORKSPACE/result/err_ckps.json
+          cp $SPEC_DIR/score.txt $GITHUB_WORKSPACE/result/score.txt
 
-      # - name: Run SPEC CPU2006 checkpoints
-      #   if: steps.determine_run.outputs.run_biweekly == 'true'
-      #   run: |
-      #     cd $PERF_HOME
-      #     python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
-      #       --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR --resume \
-      #       -L "node033 node034 node036 node037 node038 node039 node040 node041 node042"
-      #     find $NOOP_HOME/build/ -maxdepth 1 -name "*.vcd" -exec mv {} $SPEC_DIR \;
-
-      # - name: Report SPEC CPU2006 score
-      #   if: steps.determine_run.outputs.run_biweekly == 'true'
-      #   run: |
-      #     cd $PERF_HOME
-      #     python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
-      #       --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR \
-      #       --check --dump-json-path $SPEC_DIR/err_ckps.json
-      #     python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
-      #       --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR --report \
-      #       > $SPEC_DIR/score.txt
-      #     mkdir $GITHUB_WORKSPACE/result
-      #     cp $SPEC_DIR/err_ckps.json $GITHUB_WORKSPACE/result/err_ckps.json
-      #     cp $SPEC_DIR/score.txt $GITHUB_WORKSPACE/result/score.txt
-
-      # - name: Upload result
-      #   if: steps.determine_run.outputs.run_biweekly == 'true'
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: result
-      #     path: result
+      - name: Upload result
+        if: steps.determine_run.outputs.run_biweekly == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: result
+          path: result

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -28,7 +28,11 @@ jobs:
       - name: Determine if this is the biweekly run
         id: determine_run
         run: |
-          [ $(( $(date +'%U') % 2 )) -eq 0 ] && echo "run_biweekly::true" >> $GITHUB_OUTPUT || echo "run_biweekly::false" >> $GITHUB_OUTPUT
+          if [ $(( $(date +'%V') % 2 )) -eq 1 ]; then
+            echo "run_biweekly=true" >> $GITHUB_OUTPUT
+          else
+            echo "run_biweekly=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set test commit
         id: set_test_commit
@@ -36,10 +40,10 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.test_commit }}" = "" ]; then
             echo "Using latest commit."
-            echo "commit_sha::${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "commit_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
           else
             echo "Using specified commit: ${{ github.event.inputs.test_commit }}"
-            echo "commit_sha::${{ github.event.inputs.test_commit }}" >> $GITHUB_OUTPUT
+            echo "commit_sha=${{ github.event.inputs.test_commit }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code at specific commit

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -2,11 +2,20 @@ name: Performance Regression
 on:
   schedule:
     #run at 15:30 UTC (23:30 UTC+8) on Friday
-    # - cron: '30 15 * * 5'
+    - cron: '30 15 * * 5'
     #run at 15:30 UTC (23:30 UTC+8) Every two weeks
-    - cron: '30 15 13,27 * *'
+    # - cron: '30 15 13,27 * *'
   #run it manually when the workflow is in the default branch
   workflow_dispatch:
+    inputs:
+      test_commit:
+        description: 'Commit SHA to run the workflow on'
+        required: false
+        default: ''
+  #only for test
+  push:
+    branches: [ ci-perf-yml ]
+
 
 jobs:
   run:
@@ -16,10 +25,32 @@ jobs:
     timeout-minutes: 2880
     name: Performance Regression - Checkpoints
     steps:
-      - uses: actions/checkout@v2
+      - name: Determine if this is the biweekly run
+        id: determine_run
+        run: |
+          [ $(( $(date +'%V') % 2 )) -eq 0 ] && echo "::set-output name=run_biweekly::true" || echo "::set-output name=run_biweekly::false"
+
+      - name: Set test commit
+        id: set_test_commit
+        if: steps.determine_run.outputs.run_biweekly == 'true'
+        run: |
+          if [ "${{ github.event.inputs.test_commit }}" = "" ]; then
+            echo "Using latest commit."
+            echo "::set-output name=commit_sha::${{ github.sha }}"
+          else
+            echo "Using specified commit: ${{ github.event.inputs.test_commit }}"
+            echo "::set-output name=commit_sha::${{ github.event.inputs.test_commit }}"
+          fi
+
+      - name: Checkout code at specific commit
+        if: steps.determine_run.outputs.run_biweekly == 'true'
+        uses: actions/checkout@v2
         with:
+          ref: ${{ steps.set_test_commit.outputs.commit_sha }}
           submodules: 'recursive'
+
       - name: Set env
+        if: steps.determine_run.outputs.run_biweekly == 'true'
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
           DATE=$(git show -s --format=%cd --date=format:%y%m%d HEAD)  
@@ -30,17 +61,25 @@ jobs:
           echo "SPEC_DIR=/nfs/home/ci-runner/master-perf-report/cr${DATE}-${SHORT_SHA}" >> $GITHUB_ENV
           echo "CKPT_HOME=/nfs/home/share/checkpoints_profiles/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/checkpoint-0-0-0" >> $GITHUB_ENV
           echo "CKPT_JSON_PATH=/nfs/home/share/checkpoints_profiles/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/checkpoint-0-0-0/cluster-0-0.json" >> $GITHUB_ENV
-      - name: Clean up
-        run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+
       - name: Build EMU with DRAMsim3
+        if: steps.determine_run.outputs.run_biweekly == 'true'
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build          \
-            --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3              \
-            --with-dramsim3 --threads 16                                  \
-            --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin \
-            --llvm-profdata llvm-profdata
+          if [ -e "$SPEC_DIR/emu" ]; then
+            mkdir -p $NOOP_HOME/build
+            cp $SPEC_DIR/emu $NOOP_HOME/build/emu
+          else
+            python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+            python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build          \
+              --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3              \
+              --with-dramsim3 --threads 16                                  \
+              --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin \
+              --llvm-profdata llvm-profdata
+            mkdir -p $SPEC_DIR
+            cp $NOOP_HOME/build/emu $SPEC_DIR/emu
+          fi
       - name: Run SPEC CPU2006 checkpoints
+        if: steps.determine_run.outputs.run_biweekly == 'true'
         run: |
           cd $PERF_HOME
           python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
@@ -48,6 +87,7 @@ jobs:
             -L "node033 node034 node036 node037 node038 node039 node040 node041 node042"
           find $NOOP_HOME/build/ -maxdepth 1 -name "*.vcd" -exec mv {} $SPEC_DIR \;
       - name: Report SPEC CPU2006 score
+        if: steps.determine_run.outputs.run_biweekly == 'true'
         run: |
           cd $PERF_HOME
           python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
@@ -60,6 +100,7 @@ jobs:
           cp $SPEC_DIR/err_ckps.json $GITHUB_WORKSPACE/result/err_ckps.json
           cp $SPEC_DIR/score.txt $GITHUB_WORKSPACE/result/score.txt
       - name: Upload result
+        if: steps.determine_run.outputs.run_biweekly == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: result

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -62,46 +62,53 @@ jobs:
           echo "CKPT_HOME=/nfs/home/share/checkpoints_profiles/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/checkpoint-0-0-0" >> $GITHUB_ENV
           echo "CKPT_JSON_PATH=/nfs/home/share/checkpoints_profiles/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/checkpoint-0-0-0/cluster-0-0.json" >> $GITHUB_ENV
 
-      - name: Build EMU with DRAMsim3
+      - name: Test
         if: steps.determine_run.outputs.run_biweekly == 'true'
         run: |
-          if [ -e "$SPEC_DIR/emu" ]; then
-            mkdir -p $NOOP_HOME/build
-            cp $SPEC_DIR/emu $NOOP_HOME/build/emu
-          else
-            python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
-            python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build          \
-              --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3              \
-              --with-dramsim3 --threads 16                                  \
-              --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin \
-              --llvm-profdata llvm-profdata
-            mkdir -p $SPEC_DIR
-            cp $NOOP_HOME/build/emu $SPEC_DIR/emu
-          fi
-      - name: Run SPEC CPU2006 checkpoints
-        if: steps.determine_run.outputs.run_biweekly == 'true'
-        run: |
-          cd $PERF_HOME
-          python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
-            --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR --resume \
-            -L "node033 node034 node036 node037 node038 node039 node040 node041 node042"
-          find $NOOP_HOME/build/ -maxdepth 1 -name "*.vcd" -exec mv {} $SPEC_DIR \;
-      - name: Report SPEC CPU2006 score
-        if: steps.determine_run.outputs.run_biweekly == 'true'
-        run: |
-          cd $PERF_HOME
-          python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
-            --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR \
-            --check --dump-json-path $SPEC_DIR/err_ckps.json
-          python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
-            --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR --report \
-            > $SPEC_DIR/score.txt
-          mkdir $GITHUB_WORKSPACE/result
-          cp $SPEC_DIR/err_ckps.json $GITHUB_WORKSPACE/result/err_ckps.json
-          cp $SPEC_DIR/score.txt $GITHUB_WORKSPACE/result/score.txt
-      - name: Upload result
-        if: steps.determine_run.outputs.run_biweekly == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: result
-          path: result
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+          mkdir -p $NOOP_HOME/build
+          echo "hello world" > $NOOP_HOME/build/test.log
+
+      # - name: Build EMU with DRAMsim3
+      #   if: steps.determine_run.outputs.run_biweekly == 'true'
+      #   run: |
+      #     if [ -e "$SPEC_DIR/emu" ]; then
+      #       mkdir -p $NOOP_HOME/build
+      #       cp $SPEC_DIR/emu $NOOP_HOME/build/emu
+      #     else
+      #       python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+      #       python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build          \
+      #         --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3              \
+      #         --with-dramsim3 --threads 16                                  \
+      #         --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin \
+      #         --llvm-profdata llvm-profdata
+      #       mkdir -p $SPEC_DIR
+      #       cp $NOOP_HOME/build/emu $SPEC_DIR/emu
+      #     fi
+      # - name: Run SPEC CPU2006 checkpoints
+      #   if: steps.determine_run.outputs.run_biweekly == 'true'
+      #   run: |
+      #     cd $PERF_HOME
+      #     python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
+      #       --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR --resume \
+      #       -L "node033 node034 node036 node037 node038 node039 node040 node041 node042"
+      #     find $NOOP_HOME/build/ -maxdepth 1 -name "*.vcd" -exec mv {} $SPEC_DIR \;
+      # - name: Report SPEC CPU2006 score
+      #   if: steps.determine_run.outputs.run_biweekly == 'true'
+      #   run: |
+      #     cd $PERF_HOME
+      #     python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
+      #       --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR \
+      #       --check --dump-json-path $SPEC_DIR/err_ckps.json
+      #     python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
+      #       --xs $NOOP_HOME --threads 16 --dir $SPEC_DIR --report \
+      #       > $SPEC_DIR/score.txt
+      #     mkdir $GITHUB_WORKSPACE/result
+      #     cp $SPEC_DIR/err_ckps.json $GITHUB_WORKSPACE/result/err_ckps.json
+      #     cp $SPEC_DIR/score.txt $GITHUB_WORKSPACE/result/score.txt
+      # - name: Upload result
+      #   if: steps.determine_run.outputs.run_biweekly == 'true'
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: result
+      #     path: result

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Determine if this is the biweekly run
         id: determine_run
         run: |
-          [ $(( $(date +'%V') % 2 )) -eq 0 ] && echo "::set-output name=run_biweekly::true" || echo "::set-output name=run_biweekly::false"
+          [ $(( $(date +'%V') % 2 )) -eq 0 ] && echo "run_biweekly::true" >> $GITHUB_OUTPUT || echo "run_biweekly::false" >> $GITHUB_OUTPUT
 
       - name: Set test commit
         id: set_test_commit
@@ -36,10 +36,10 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.test_commit }}" = "" ]; then
             echo "Using latest commit."
-            echo "::set-output name=commit_sha::${{ github.sha }}"
+            echo "commit_sha::${{ github.sha }}" >> $GITHUB_OUTPUT
           else
             echo "Using specified commit: ${{ github.event.inputs.test_commit }}"
-            echo "::set-output name=commit_sha::${{ github.event.inputs.test_commit }}"
+            echo "commit_sha::${{ github.event.inputs.test_commit }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code at specific commit
@@ -69,6 +69,10 @@ jobs:
           mkdir -p $NOOP_HOME/build
           echo "hello world" > $NOOP_HOME/build/test.log
 
+      # - name: Clean Up
+      #   if: steps.determine_run.outputs.run_biweekly == 'true'
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       # - name: Build EMU with DRAMsim3
       #   if: steps.determine_run.outputs.run_biweekly == 'true'
       #   run: |
@@ -76,7 +80,6 @@ jobs:
       #       mkdir -p $NOOP_HOME/build
       #       cp $SPEC_DIR/emu $NOOP_HOME/build/emu
       #     else
-      #       python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
       #       python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build          \
       #         --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3              \
       #         --with-dramsim3 --threads 16                                  \

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Determine if this is the biweekly run
         id: determine_run
         run: |
-          [ $(( $(date +'%V') % 2 )) -eq 0 ] && echo "run_biweekly::true" >> $GITHUB_OUTPUT || echo "run_biweekly::false" >> $GITHUB_OUTPUT
+          [ $(( $(date +'%U') % 2 )) -eq 0 ] && echo "run_biweekly::true" >> $GITHUB_OUTPUT || echo "run_biweekly::false" >> $GITHUB_OUTPUT
 
       - name: Set test commit
         id: set_test_commit


### PR DESCRIPTION
1. Use a conditional step after the schedule to ensure strict biweekly execution.
2. Allow specifying a commit SHA for manual runs.
3. Retain each test's emu; if an emu exists, skip the build. This approach both preserves the emu for reproducibility and saves build time.