### PR TITLE
chore(dts): remove very vague print

### DIFF
--- a/src/main/scala/xiangshan/XSDts.scala
+++ b/src/main/scala/xiangshan/XSDts.scala
@@ -104,7 +104,6 @@ trait HasXSDts {
       memBlock.inner.nmi_int_sink.edges.in.flatMap(_.source.sources)
       ).flatMap {
       s =>
-        println(s.resources.map(_.key), s.range)
         (s.range.start until s.range.`end`).map(_ => s.resources)
     }
     val int_ids = Seq(


### PR DESCRIPTION
This line makes the following print, which is not human-readable.
<img width="282" alt="Screenshot 2024-10-28 at 22 05 08" src="https://github.com/user-attachments/assets/0b5b26b2-b6cd-48c4-b5dc-add04927828f">
