### PR TITLE
power(MemBlock): add  ClockGate for DCache SRAM

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1114,7 +1114,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     // refillPipe.io.access_flag_write
   )
   access_flag_write_ports.zip(accessArray.io.write).foreach { case (p, w) => w <> p }
-
+  
   //----------------------------------------
   // tag array
   if(StorePrefetchL1Enabled) {

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -187,6 +187,7 @@ class DataSRAMBank(index: Int)(implicit p: Parameters) extends DCacheModule {
     )
     data_bank(w).io.r.req.valid := io.r.en
     data_bank(w).io.r.req.bits.apply(setIdx = io.r.addr)
+    data_bank(w).clock := ClockGate(false.B, io.r.en | (io.w.en & io.w.way_en(w)), clock)
   }
   XSPerfAccumulate("part_data_read_counter", PopCount(Cat(data_bank.map(_.io.r.req.valid))))
 

--- a/src/main/scala/xiangshan/cache/dcache/meta/TagArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/meta/TagArray.scala
@@ -19,7 +19,7 @@ package xiangshan.cache
 import org.chipsalliance.cde.config.Parameters
 import chisel3._
 import chisel3.util._
-import utility.{SRAMTemplate, XSPerfAccumulate}
+import utility.{SRAMTemplate, XSPerfAccumulate, ClockGate}
 import xiangshan.cache.CacheInstrucion._
 
 class TagReadReq(implicit p: Parameters) extends DCacheBundle {
@@ -102,6 +102,7 @@ class TagArray(implicit p: Parameters) extends AbstractTagArray {
 
   tag_array.io.r.req.valid := ren
   tag_array.io.r.req.bits.apply(setIdx = io.read.bits.idx)
+  tag_array.clock := ClockGate(false.B, ren | wen, clock)
   io.resp := tag_array.io.r.resp.data
   XSPerfAccumulate("part_tag_read_counter", tag_array.io.r.req.valid)
 
@@ -111,6 +112,7 @@ class TagArray(implicit p: Parameters) extends AbstractTagArray {
       ecc.io.r.req.valid := ecc_ren
       ecc.io.r.req.bits.apply(setIdx = io.ecc_read.bits.idx)
       io.ecc_resp := ecc.io.r.resp.data
+      ecc.clock := ClockGate(false.B, ecc_ren | ecc_wen, clock)
     case None =>
       io.ecc_resp := 0.U.asTypeOf(io.ecc_resp)
   }

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -437,6 +437,10 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     (hit, hitWayData.ppns(genPtwL1SectorIdx(check_vpn)), hitWayData.pbmts(genPtwL1SectorIdx(check_vpn)), hitWayData.prefetch, eccError)
   }
 
+  val l0_masked_clock = ClockGate(false.B, stageReq.fire | (!flush_dup(0) && refill.levelOH.l0), clock)
+  val l1_masked_clock = ClockGate(false.B, stageReq.fire | (!flush_dup(1) && refill.levelOH.l1), clock)
+  l0.clock := l0_masked_clock
+  l1.clock := l1_masked_clock
   // l0
   val ptwl0replace = ReplacementPolicy.fromString(l2tlbParams.l0Replacer,l2tlbParams.l0nWays,l2tlbParams.l0nSets)
   val (l0Hit, l0HitData, l0Pre, l0eccError) = {

--- a/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
@@ -726,7 +726,7 @@ class PatternHistoryTable()(implicit p: Parameters) extends XSModule with HasSMS
   pht_ram.io.w(
     s3_ram_en, s3_ram_wdata, s3_ram_waddr, s3_way_mask
   )
-
+  pht_ram.clock := ClockGate(false.B, s1_valid | s3_ram_en, clock)
   when(s3_valid && s3_hit){
     assert(!Cat(s3_hit_vec).andR, "sms_pht: multi-hit!")
   }


### PR DESCRIPTION
By using ClockGate for DCache SRAM, memory Power has 64% reduction, MemBlock total power has 23.38% reduction.