### PR TITLE
style(AtomicsUnit): remove unnecessary logics

### DIFF
--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -917,6 +917,7 @@ object Bundles {
     val flowNum      = OptionWrapper(isVector, NumLsElem())
 
     def src_rs1 = src(0)
+    def src_rs2 = src(1)
     def src_stride = src(1)
     def src_vs3 = src(2)
     def src_mask = if (isVector) src(3) else 0.U


### PR DESCRIPTION
Atomics memory operations only work on word, double word and quad word in the future. Therefore any code concerning byte and half word is redundant and only contributes to worse timing and area.