### PR TITLE
area(DCache): reduce 8 way to 4 way

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -408,7 +408,7 @@ class FuzzConfig(dummy: Int = 0) extends Config(
 class DefaultConfig(n: Int = 1) extends Config(
   new WithNKBL3(16 * 1024, inclusive = false, banks = 4, ways = 16)
     ++ new WithNKBL2(2 * 512, inclusive = true, banks = 4)
-    ++ new WithNKBL1D(64, ways = 8)
+    ++ new WithNKBL1D(64, ways = 4)
     ++ new BaseConfig(n)
 )
 
@@ -422,7 +422,7 @@ class KunminghuV2Config(n: Int = 1) extends Config(
       case SoCParamsKey => up(SoCParamsKey).copy(L3CacheParamsOpt = None) // There will be no L3
     })
     ++ new WithNKBL2(2 * 512, inclusive = true, banks = 4, tp = false)
-    ++ new WithNKBL1D(64, ways = 8)
+    ++ new WithNKBL1D(64, ways = 4)
     ++ new DefaultConfig(n)
 )
 
@@ -435,7 +435,7 @@ class XSNoCTopConfig(n: Int = 1) extends Config(
 class FpgaDefaultConfig(n: Int = 1) extends Config(
   (new WithNKBL3(3 * 1024, inclusive = false, banks = 1, ways = 6)
     ++ new WithNKBL2(2 * 512, inclusive = true, banks = 4)
-    ++ new WithNKBL1D(64, ways = 8)
+    ++ new WithNKBL1D(64, ways = 4)
     ++ new BaseConfig(n)).alter((site, here, up) => {
     case DebugOptionsKey => up(DebugOptionsKey).copy(
       AlwaysBasicDiff = false,

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -55,8 +55,8 @@ case class ICacheParameters(
     blockBytes: Int = 64
 ) extends L1CacheParameters {
 
-  val setBytes = nSets * blockBytes
-  val aliasBitsOpt = if(setBytes > pageSize) Some(log2Ceil(setBytes / pageSize)) else None
+  val setBytes     = nSets * blockBytes
+  val aliasBitsOpt = if (setBytes > pageSize) Some(log2Ceil(setBytes / pageSize)) else None
   val reqFields: Seq[BundleFieldBase] = Seq(
     PrefetchField(),
     ReqSourceField()

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -56,8 +56,7 @@ case class ICacheParameters(
 ) extends L1CacheParameters {
 
   val setBytes = nSets * blockBytes
-  val aliasBitsOpt =
-    DCacheParameters().aliasBitsOpt // if(setBytes > pageSize) Some(log2Ceil(setBytes / pageSize)) else None
+  val aliasBitsOpt = if(setBytes > pageSize) Some(log2Ceil(setBytes / pageSize)) else None
   val reqFields: Seq[BundleFieldBase] = Seq(
     PrefetchField(),
     ReqSourceField()


### PR DESCRIPTION
| gcc12, 0.8 coverage              | master-8way |        | master-4way |        | speedup  |
|----------------------------------|-------------|--------|-------------|--------|----------|
| ********* SPECINT 2006 ********* | 3GHz        | /GHz   | 3GHz        | /GHz   |          |
| 400.perlbench                    | 37.155      | 12.385 | 37.053      | 12.351 | -0.27%   |
| 401.bzip2                        | 26.535      | 8.845  | 26.503      | 8.834  | -0.12%   |
| 403.gcc                          | 47.012      | 15.671 | 46.925      | 15.642 | -0.19%   |
| 429.mcf                          | 59.51       | 19.837 | 59.43       | 19.81  | -0.13%   |
| 445.gobmk                        | 30.241      | 10.08  | 30.208      | 10.069 | -0.11%   |
| 456.hmmer                        | 40.753      | 13.584 | 40.702      | 13.567 | -0.13%   |
| 458.sjeng                        | 30.5        | 10.167 | 30.416      | 10.139 | -0.28%   |
| 462.libquantum                   | 125.755     | 41.918 | 125.505     | 41.835 | -0.20%   |
| 464.h264ref                      | 58.356      | 19.452 | 58.281      | 19.427 | -0.13%   |
| 471.omnetpp                      | 39.032      | 13.011 | 39.117      | 13.039 | 0.22%    |
| 473.astar                        | 30.797      | 10.266 | 30.818      | 10.273 | 0.07%    |
| 483.xalancbmk                    | 75.264      | 25.088 | 74.797      | 24.932 | -0.62%   |
| SPECint2006@3GHz                 | 44.994      |        | 44.923      |        | -0.16%   |
| SPECint2006/GHz                  | 14.998      |        | 14.974      |        | -0.16%   |
|                                  |             |        |             |        |          |
| ********* SPECFP  2006 ********* |             |        |             |        |          |
| 410.bwaves                       | 74.762      | 24.921 | 64.536      | 21.512 | -13.68%  |
| 416.gamess                       | 43.281      | 14.427 | 43.268      | 14.423 | -0.03%   |
| 433.milc                         | 44.617      | 14.872 | 44.356      | 14.785 | -0.58%   |
| 434.zeusmp                       | 56.385      | 18.795 | 56.012      | 18.671 | -0.66%   |
| 435.gromacs                      | 36.504      | 12.168 | 36.482      | 12.161 | -0.06%   |
| 436.cactusADM                    | 48.636      | 16.212 | 47.842      | 15.947 | -1.63%   |
| 437.leslie3d                     | 44.766      | 14.922 | 44.894      | 14.965 | 0.29%    |
| 444.namd                         | 34.881      | 11.627 | 34.826      | 11.609 | -0.16%   |
| 447.dealII                       | 69.124      | 23.041 | 71.079      | 23.693 | 2.83%    |
| 450.soplex                       | 56.027      | 18.676 | 56.014      | 18.671 | -0.02%   |
| 453.povray                       | 55.99       | 18.663 | 55.041      | 18.347 | -1.69%   |
| 454.Calculix                     | 18.458      | 6.153  | 18.452      | 6.151  | -0.03%   |
| 459.GemsFDTD                     | 36.784      | 12.261 | 36.377      | 12.126 | -1.11%   |
| 465.tonto                        | 37.946      | 12.649 | 37.967      | 12.656 | 0.06%    |
| 470.lbm                          | 102.217     | 34.072 | 102.6       | 34.2   | 0.37%    |
| 481.wrf                          | 41.303      | 13.768 | 41.092      | 13.697 | -0.51%   |
| 482.sphinx3                      | 52.474      | 17.491 | 52.426      | 17.475 | -0.09%   |
| SPECfp2006@3GHz                  | 47.13       |        | 46.638      |        | -1.04%   |
| SPECfp2006/GHz                   | 15.71       |        | 15.546      |        | -1.04%   |
