### PR TITLE
fix(CSR,RVC): c.fp instrs should be illegal when fs is off

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -614,6 +614,8 @@ class CustomCSRCtrlIO(implicit p: Parameters) extends XSBundle {
   val mem_trigger = new MemTdataDistributeIO()
   // Virtualization Mode
   val virtMode = Output(Bool())
+  // xstatus.fs field is off
+  val fsIsOff = Output(Bool())
 }
 
 class DistributedCSRIO(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -353,6 +353,8 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
       custom.mem_trigger      := csrMod.io.status.memTrigger
       // virtual mode
       custom.virtMode := csrMod.io.status.privState.V.asBool
+      // xstatus.fs field is off
+      custom.fsIsOff := csrMod.io.toDecode.illegalInst.fsIsOff
   }
 
   csrOut.instrAddrTransType := csrMod.io.status.instrAddrTransType

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -105,11 +105,14 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
   // trigger
   ifu.io.frontendTrigger := csrCtrl.frontend_trigger
 
+  // RVCDecoder fsIsOff
+  ifu.io.csr_fsIsOff := csrCtrl.fsIsOff
+
   // bpu ctrl
   bpu.io.ctrl         := csrCtrl.bp_ctrl
   bpu.io.reset_vector := io.reset_vector
 
-// pmp
+  // pmp
   val PortNumber = ICacheParameters().PortNumber
   val pmp        = Module(new PMP())
   val pmp_check  = VecInit(Seq.fill(coreParams.ipmpPortNum)(Module(new PMPChecker(3, sameCycle = true)).io))
@@ -151,8 +154,8 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
   ftq.io.fromBpu <> bpu.io.bpu_to_ftq
 
   ftq.io.mmioCommitRead <> ifu.io.mmioCommitRead
-  // IFU-ICache
 
+  // IFU-ICache
   icache.io.fetch.req <> ftq.io.toICache.req
   ftq.io.toICache.req.ready := ifu.io.ftqInter.fromFtq.req.ready && icache.io.fetch.req.ready
 

--- a/src/main/scala/xiangshan/frontend/PreDecode.scala
+++ b/src/main/scala/xiangshan/frontend/PreDecode.scala
@@ -281,12 +281,13 @@ class F3Predecoder(implicit p: Parameters) extends XSModule with HasPdConst {
 
 class RVCExpander(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle {
-    val in  = Input(UInt(32.W))
-    val out = Output(new ExpandedInstruction)
-    val ill = Output(Bool())
+    val in      = Input(UInt(32.W))
+    val fsIsOff = Input(Bool())
+    val out     = Output(new ExpandedInstruction)
+    val ill     = Output(Bool())
   })
 
-  val decoder = new RVCDecoder(io.in, XLEN, fLen, useAddiForMv = true)
+  val decoder = new RVCDecoder(io.in, io.fsIsOff, XLEN, fLen, useAddiForMv = true)
 
   if (HasCExtension) {
     io.out := decoder.decode


### PR DESCRIPTION
* fix RVC floating-point inst raise EX_II in predecode when xstatus.fs is off

Fix #3864

Update: https://github.com/OpenXiangShan/rocket-chip/pull/20 is merged and this PR is rebased, ready to review.