### PR TITLE
feat(frontend): add ClockGate at frontend SRAMTemplate

### DIFF
--- a/src/main/scala/xiangshan/frontend/FTB.scala
+++ b/src/main/scala/xiangshan/frontend/FTB.scala
@@ -497,7 +497,8 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
       way = numWays,
       shouldReset = true,
       holdRead = false,
-      singlePort = true
+      singlePort = true,
+      withClockGate = true
     ))
     val ftb_r_entries = ftb.io.r.resp.data.map(_.entry)
 

--- a/src/main/scala/xiangshan/frontend/ITTAGE.scala
+++ b/src/main/scala/xiangshan/frontend/ITTAGE.scala
@@ -201,7 +201,8 @@ class ITTageTable(
     shouldReset = true,
     holdRead = true,
     singlePort = true,
-    useBitmask = true
+    useBitmask = true,
+    withClockGate = true
   ))
 
   table.io.r.req.valid       := io.req.fire

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -68,7 +68,7 @@ class FtqNRSRAM[T <: Data](gen: T, numRead: Int)(implicit p: Parameters) extends
   })
 
   for (i <- 0 until numRead) {
-    val sram = Module(new SRAMTemplate(gen, FtqSize))
+    val sram = Module(new SRAMTemplate(gen, FtqSize, withClockGate=true))
     sram.io.r.req.valid       := io.ren(i)
     sram.io.r.req.bits.setIdx := io.raddr(i)
     io.rdata(i)               := sram.io.r.resp.data(0)

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -68,7 +68,7 @@ class FtqNRSRAM[T <: Data](gen: T, numRead: Int)(implicit p: Parameters) extends
   })
 
   for (i <- 0 until numRead) {
-    val sram = Module(new SRAMTemplate(gen, FtqSize, withClockGate=true))
+    val sram = Module(new SRAMTemplate(gen, FtqSize, withClockGate = true))
     sram.io.r.req.valid       := io.ren(i)
     sram.io.r.req.bits.setIdx := io.raddr(i)
     io.rdata(i)               := sram.io.r.resp.data(0)

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -68,7 +68,8 @@ class SCTable(val nRows: Int, val ctrBits: Int, val histLen: Int)(implicit p: Pa
     shouldReset = true,
     holdRead = true,
     singlePort = false,
-    bypassWrite = true
+    bypassWrite = true,
+    withClockGate = true
   ))
 
   // def getIdx(hist: UInt, pc: UInt) = {

--- a/src/main/scala/xiangshan/frontend/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/Tage.scala
@@ -150,7 +150,8 @@ class TageBTable(implicit p: Parameters) extends XSModule with TBTParams {
       way = numBr,
       shouldReset = false,
       holdRead = true,
-      bypassWrite = true
+      bypassWrite = true,
+      withClockGate = true
     )
   )
 
@@ -333,7 +334,8 @@ class TageTable(
     shouldReset = true,
     extraReset = true,
     holdRead = true,
-    singlePort = true
+    singlePort = true,
+    withClockGate = true
   ))
   us.extra_reset.get := io.update.reset_u.reduce(_ || _) && io.update.mask.reduce(_ || _)
 
@@ -345,7 +347,8 @@ class TageTable(
       way = numBr,
       shouldReset = true,
       holdRead = true,
-      singlePort = true
+      singlePort = true,
+      withClockGate = true
     ))
   )
 

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -755,7 +755,7 @@ class SRAMTemplateWithFixedWidth[T <: Data](
       holdRead = holdRead,
       singlePort = singlePort,
       bypassWrite = bypassWrite,
-      withClockGate = withClockGate,
+      withClockGate = withClockGate
     ))
     // read req
     sramBank.io.r.req.valid       := io.r.req.valid

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -246,7 +246,8 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray {
       way = nWays,
       shouldReset = true,
       holdRead = true,
-      singlePort = true
+      singlePort = true,
+      withClockGate = true
     ))
 
     // meta connection
@@ -385,7 +386,8 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray {
         width = ICacheDataSRAMWidth,
         shouldReset = true,
         holdRead = true,
-        singlePort = true
+        singlePort = true,
+        withClockGate = true
       ))
 
       // read
@@ -690,7 +692,8 @@ class ICachePartWayArray[T <: Data](gen: T, pWay: Int)(implicit p: Parameters) e
       way = pWay,
       shouldReset = true,
       holdRead = true,
-      singlePort = true
+      singlePort = true,
+      withClockGate = true
     ))
 
     sramBank.io.r.req.valid := io.read.req(bank).valid
@@ -716,14 +719,15 @@ class ICachePartWayArray[T <: Data](gen: T, pWay: Int)(implicit p: Parameters) e
 // Automatically partition the SRAM based on the width of the data and the desired width.
 // final SRAM width = width * way
 class SRAMTemplateWithFixedWidth[T <: Data](
-    gen:         T,
-    set:         Int,
-    width:       Int,
-    way:         Int = 1,
-    shouldReset: Boolean = false,
-    holdRead:    Boolean = false,
-    singlePort:  Boolean = false,
-    bypassWrite: Boolean = false
+    gen:           T,
+    set:           Int,
+    width:         Int,
+    way:           Int = 1,
+    shouldReset:   Boolean = false,
+    holdRead:      Boolean = false,
+    singlePort:    Boolean = false,
+    bypassWrite:   Boolean = false,
+    withClockGate: Boolean = false
 ) extends Module {
 
   val dataBits  = gen.getWidth
@@ -750,7 +754,8 @@ class SRAMTemplateWithFixedWidth[T <: Data](
       shouldReset = shouldReset,
       holdRead = holdRead,
       singlePort = singlePort,
-      bypassWrite = bypassWrite
+      bypassWrite = bypassWrite,
+      withClockGate = withClockGate,
     ))
     // read req
     sramBank.io.r.req.valid       := io.r.req.valid


### PR DESCRIPTION
* Add param `withClockGate` at SRAMTemplate
* when SRAM is single-port, use maskedClock for both array\.read\(\) and array\.write\(\) to ensure single-port SRAM access.
* when SRAM is multi-port, the read and write ports of the multi-port SRAM are gated using different clocks.