### PR TITLE
fix(HPM): Fix PTW perfevent print error, organize the code format of some perfevents .

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -600,11 +600,10 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   ptw.io.csr.tlb <> tlbcsr
   ptw.io.csr.distribute_csr <> csrCtrl.distribute_csr
 
-  val perfEventsPTW = Wire(Vec(19, new PerfEvent))
-  if (!coreParams.softPTW) {
-    perfEventsPTW := ptw.getPerf
+  val perfEventsPTW = if (!coreParams.softPTW) {
+    ptw.getPerfEvents
   } else {
-    perfEventsPTW := DontCare
+    Seq()
   }
 
   // dtlb
@@ -1930,13 +1929,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   pfevent.io.distribute_csr := csrCtrl.distribute_csr
   val csrevents = pfevent.io.hpmevent.slice(16,24)
 
-  val memBlockPerfEvents = Seq(
-    ("ldDeqCount", ldDeqCount),
-    ("stDeqCount", stDeqCount),
-  )
-
   val perfFromUnits = (loadUnits ++ Seq(sbuffer, lsq, dcache)).flatMap(_.getPerfEvents)
-  val perfFromPTW    = perfEventsPTW.map(x => ("perfEventsPTW", x.value))
+  val perfFromPTW = perfEventsPTW.map(x => ("PTW_" + x._1, x._2))
   val perfBlock     = Seq(("ldDeqCount", ldDeqCount),
                           ("stDeqCount", stDeqCount))
   // let index = 0 be no event

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -253,7 +253,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   val inValidNotReady = io.in.map(in => GatedValidRegNext(in.valid && !in.ready))
   val perfEvents = Seq(
     ("decoder_fused_instr", PopCount(fusionValid)       ),
-    ("decoder_waitInstr",   PopCount(inValidNotReady)            ),
+    ("decoder_waitInstr",   PopCount(inValidNotReady)   ),
     ("decoder_stall_cycle", hasValid && !io.out(0).ready),
     ("decoder_utilization", PopCount(io.in.map(_.valid))),
   )

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -520,15 +520,15 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents {
   XSPerfHistogram("slots_valid_rough", PopCount(io.enqRob.req.map(_.valid)), true.B, 0, RenameWidth+1, 1)
 
   val perfEvents = Seq(
-    ("dispatch_in",                 PopCount(io.fromRename.map(_.valid & io.fromRename(0).ready))                  ),
-    ("dispatch_empty",              !hasValidInstr                                                                 ),
-    ("dispatch_utili",              PopCount(io.fromRename.map(_.valid))                                           ),
-    ("dispatch_waitinstr",          PopCount(io.fromRename.map(!_.valid && canAccept))                 ),
-    ("dispatch_stall_cycle_lsq",    false.B                                                                        ),
-    ("dispatch_stall_cycle_rob",    stall_rob                                                                      ),
-    ("dispatch_stall_cycle_int_dq", stall_int_dq                                                                   ),
-    ("dispatch_stall_cycle_fp_dq",  stall_fp_dq                                                                    ),
-    ("dispatch_stall_cycle_ls_dq",  stall_ls_dq                                                                    )
+    ("dispatch_in",                 PopCount(io.fromRename.map(_.valid & io.fromRename(0).ready))),
+    ("dispatch_empty",              !hasValidInstr                                               ),
+    ("dispatch_utili",              PopCount(io.fromRename.map(_.valid))                         ),
+    ("dispatch_waitinstr",          PopCount(io.fromRename.map(!_.valid && canAccept))           ),
+    ("dispatch_stall_cycle_lsq",    false.B                                                      ),
+    ("dispatch_stall_cycle_rob",    stall_rob                                                    ),
+    ("dispatch_stall_cycle_int_dq", stall_int_dq                                                 ),
+    ("dispatch_stall_cycle_fp_dq",  stall_fp_dq                                                  ),
+    ("dispatch_stall_cycle_ls_dq",  stall_ls_dq                                                  )
   )
   generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/backend/rename/BusyTable.scala
+++ b/src/main/scala/xiangshan/backend/rename/BusyTable.scala
@@ -177,10 +177,10 @@ class BusyTable(numReadPorts: Int, numWritePorts: Int, numPhyPregs: Int, pregWB:
   XSPerfAccumulate("busy_count", PopCount(table))
 
   val perfEvents = Seq(
-    ("bt_std_freelist_1_4_valid", busyCount < (numPhyPregs / 4).U                                      ),
+    ("bt_std_freelist_1_4_valid", busyCount < (numPhyPregs / 4).U                                        ),
     ("bt_std_freelist_2_4_valid", busyCount > (numPhyPregs / 4).U && busyCount <= (numPhyPregs / 2).U    ),
     ("bt_std_freelist_3_4_valid", busyCount > (numPhyPregs / 2).U && busyCount <= (numPhyPregs * 3 / 4).U),
-    ("bt_std_freelist_4_4_valid", busyCount > (numPhyPregs * 3 / 4).U                                  )
+    ("bt_std_freelist_4_4_valid", busyCount > (numPhyPregs * 3 / 4).U                                    )
   )
   generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -730,8 +730,8 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   XSPerfAccumulate("fused_lui_load_instr_count", PopCount(is_fused_lui_load))
 
   val renamePerf = Seq(
-    ("rename_in                  ", PopCount(io.in.map(_.valid & io.in(0).ready ))                                                               ),
-    ("rename_waitinstr           ", PopCount((0 until RenameWidth).map(i => io.in(i).valid && !io.in(i).ready))                                  ),
+    ("rename_in                  ", PopCount(io.in.map(_.valid & io.in(0).ready ))),
+    ("rename_waitinstr           ", PopCount((0 until RenameWidth).map(i => io.in(i).valid && !io.in(i).ready))),
     ("rename_stall               ", inHeadStall),
     ("rename_stall_cycle_walk    ", inHeadValid &&  io.rabCommits.isWalk),
     ("rename_stall_cycle_dispatch", inHeadValid && !io.rabCommits.isWalk && !dispatchCanAcc),

--- a/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
+++ b/src/main/scala/xiangshan/backend/rename/freelist/StdFreeList.scala
@@ -114,10 +114,10 @@ class StdFreeList(freeListSize: Int, numLogicRegs: Int, regType: RegType, realNu
 
   val freeRegCntReg = RegNext(freeRegCnt)
   val perfEvents = Seq(
-    ("std_freelist_1_4_valid", freeRegCntReg <  (freeListSize / 4).U                                    ),
+    ("std_freelist_1_4_valid", freeRegCntReg <  (freeListSize / 4).U                                            ),
     ("std_freelist_2_4_valid", freeRegCntReg >= (freeListSize / 4).U && freeRegCntReg < (freeListSize / 2).U    ),
     ("std_freelist_3_4_valid", freeRegCntReg >= (freeListSize / 2).U && freeRegCntReg < (freeListSize * 3 / 4).U),
-    ("std_freelist_4_4_valid", freeRegCntReg >= (freeListSize * 3 / 4).U                                )
+    ("std_freelist_4_4_valid", freeRegCntReg >= (freeListSize * 3 / 4).U                                        )
   )
 
   QueuePerf(size = freeListSize, utilization = freeRegCntReg, full = freeRegCntReg === 0.U)

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -1239,8 +1239,8 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     ("l0_hit           ", l0Hit                           ),
     ("sp_hit           ", spHit                           ),
     ("pte_hit          ", l0Hit || spHit                  ),
-    ("rwHarzad         ",  io.req.valid && !io.req.ready  ),
-    ("out_blocked      ",  io.resp.valid && !io.resp.ready),
+    ("rwHarzad         ", io.req.valid && !io.req.ready   ),
+    ("out_blocked      ", io.resp.valid && !io.resp.ready ),
   )
   generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -456,12 +456,12 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
 
   val perfEvents = Seq(
     ("fsm_count         ", io.req.fire                                     ),
-    ("fsm_busy          ", !idle                                             ),
-    ("fsm_idle          ", idle                                              ),
-    ("resp_blocked      ", io.resp.valid && !io.resp.ready                   ),
+    ("fsm_busy          ", !idle                                           ),
+    ("fsm_idle          ", idle                                            ),
+    ("resp_blocked      ", io.resp.valid && !io.resp.ready                 ),
     ("mem_count         ", mem.req.fire                                    ),
     ("mem_cycle         ", BoolStopWatch(mem.req.fire, mem.resp.fire, true)),
-    ("mem_blocked       ", mem.req.valid && !mem.req.ready                   ),
+    ("mem_blocked       ", mem.req.valid && !mem.req.ready                 ),
   )
   generatePerfEvent()
 }


### PR DESCRIPTION
`getperfevent` retrieves both the `name` and `value` fields, whereas `getperf` only retrieves the `value` port. The original implementation caused all perf event information for PTW to be printed as `perfEventsPTW`, making them indistinguishable.