### PR TITLE
fix(vnclip): use uimm instead of imm for vnclip_wi instructions

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/VecDecoder.scala
+++ b/src/main/scala/xiangshan/backend/decode/VecDecoder.scala
@@ -355,7 +355,7 @@ object VecDecoder extends DecodeConstants {
     VSSRA_VI      -> OPIVI(FuType.vialuF, VialuFixType.vssra_vv, T, F, F, selImm = SelImm.IMM_OPIVIU),
 
     VNCLIPU_WI    -> OPIVI(FuType.vialuF, VialuFixType.vnclipu_wv, T, F, T, selImm = SelImm.IMM_OPIVIU, uopSplitType = UopSplitType.VEC_WXV),
-    VNCLIP_WI     -> OPIVI(FuType.vialuF, VialuFixType.vnclip_wv, T, F, T, uopSplitType = UopSplitType.VEC_WXV),
+    VNCLIP_WI     -> OPIVI(FuType.vialuF, VialuFixType.vnclip_wv, T, F, T, selImm = SelImm.IMM_OPIVIU, uopSplitType = UopSplitType.VEC_WXV),
 
     VMV1R_V       -> OPIVI(FuType.vppu, VpermType.vmv1r, T, F, F, uopSplitType = UopSplitType.VEC_MVNR, src1 = SrcType.no), // vmv1r.v vd, vs2
     VMV2R_V       -> OPIVI(FuType.vppu, VpermType.vmv2r, T, F, F, uopSplitType = UopSplitType.VEC_MVNR, src1 = SrcType.no), // vmv2r.v vd, vs2


### PR DESCRIPTION
<img width="505" alt="image" src="https://github.com/user-attachments/assets/277ec8e6-5236-4bc6-874c-8a83b29b6171">

Although the vs2 used by the vnclip instruction is signed, the immediate number is unsigned