### PR TITLE
fix(loadUnit): rollback should be used for flush

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1413,7 +1413,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   s3_out.bits.uop.fpWen       := s3_in.uop.fpWen
   s3_out.bits.uop.exceptionVec(loadAccessFault) := (s3_dly_ld_err || s3_in.uop.exceptionVec(loadAccessFault)) && s3_vecActive
   s3_out.bits.uop.flushPipe   := false.B
-  s3_out.bits.uop.replayInst  := s3_rep_frm_fetch || s3_flushPipe
+  s3_out.bits.uop.replayInst  := false.B
   s3_out.bits.data            := s3_in.data
   s3_out.bits.isFromLoadUnit  := true.B
   s3_out.bits.debug.isMMIO    := s3_in.mmio


### PR DESCRIPTION
According to the backend instructions, currently, we have a total of three signals that can notify the backend to generate a flush pipe:

`flushPipe`, `replayInst`, and `rollback`

Among these, `flushPipe` and `replayInst` will be combined into the same flush signal in the backend, and the flush will be generated only when the command reaches the Rob dequeue pointer.
The `rollback` signal will flush as soon as it is sent, so flushing the pipe via the `rollback` signal is faster.
Currently in MemBlock, store/load MisalignBuffer will flush via `flushPipe`, RAR violations and mismatch of virtual and physics addresses in the forward will flush via both `flushPipe` and `rollback`, and RAW and uncached nack will flush via `rollback`.
When `flushPipe` and `rollback` are triggered at the same time, `flushPipe` is triggered when the rob dequeue pointer is selected, rather than `rollback` being triggered immediately.

**This commit removes the `flushPipe` signal in the RAR violation and the mismatch of virtual and physics addresses in the forward, and only triggers flush through `rollback`.**

Any subsequent flushes that may occur should give priority to whether they can be triggered immediately via the `rollback` signal, and `flushPipe`/`replayInst` should only be used if a non-speculative flush is required.
The `flushPipe` generated by store/load MisalignBuffer is temporarily retained, considering that store/load MisalignBuffer is actually being refactored.