### PR TITLE
refactor(IFU,ICache): refactor interface

### DIFF
--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -79,7 +79,7 @@ class FtqICacheInfo(implicit p: Parameters) extends XSBundle with HasICacheParam
 
 class IFUICacheIO(implicit p: Parameters) extends XSBundle with HasICacheParameters {
   val icacheReady       = Output(Bool())
-  val resp              = Vec(PortNumber, ValidIO(new ICacheMainPipeResp))
+  val resp              = ValidIO(new ICacheMainPipeResp)
   val topdownIcacheMiss = Output(Bool())
   val topdownItlbMiss   = Output(Bool())
 }

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -368,7 +368,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f2_icache_all_resp_wire =
     fromICache.valid &&
       fromICache.bits.vaddr(0) === f2_ftq_req.startAddr &&
-      fromICache.bits.doubleline && (fromICache.bits.vaddr(1) === f2_ftq_req.nextlineStart || !f2_doubleLine)
+      (fromICache.bits.doubleline && fromICache.bits.vaddr(1) === f2_ftq_req.nextlineStart || !f2_doubleLine)
   val f2_icache_all_resp_reg = RegInit(false.B)
 
   icacheRespAllValid := f2_icache_all_resp_reg || f2_icache_all_resp_wire


### PR DESCRIPTION
Move Vec(2) inside `ICacheMainPipeResp` to eliminate unused ports. No functional changes.