### PR TITLE
chore(gitignore): ignore log file like *.err and *.log

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -4,6 +4,7 @@ core:
   - "!.github/filters.yaml"
   - "!.github/workflows/nightly.yml"
   - "!.github/workflows/perf.yml"
+  - "!.gitignore"
   - "!**/*.md"
   - "!LICENSE"
   - "!images/**"

--- a/.gitignore
+++ b/.gitignore
@@ -363,5 +363,8 @@ stack.info*
 
 !ready-to-run/*
 
+# Log files
 simulator_err.txt
 simulator_out.txt
+*.log
+*.err


### PR DESCRIPTION
In our development pratices, it's common to name stdout and stderr output log as *.log and *.err, respectively, based on informal observation within our team. 

This patch adds *.log and *.err to the .gitignore file to ensure they are ignored by Git. Notably, *.log is already ignored due to existing rules, and there is no source files in the projects with a *.err extension. As such, this patch is safe.

This patch also adds .gitignore into .github/filters.yaml to sikp ci. It seems no need to run CI again when .gitignore is modified.