### PR TITLE
fix(VMergeBuffer): `uopFinish` should not be set when redirect

### DIFF
--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -314,7 +314,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
 
   //uopwriteback(deq)
   for (i <- 0 until uopSize){
-    when(allocated(i) && entries(i).allReady()){
+    when(allocated(i) && entries(i).allReady() && !needCancel(i)){
       uopFinish(i) := true.B
     }
   }


### PR DESCRIPTION
If `uopFinish` is set when redirecting, it may cause incorrect dequeuing and enqueuing conflicts, which may cause `allocated` to be unable to be set correctly.