### PR TITLE
refactor(LoadPipe): remove the redundant logic of the `mq_nack`

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -429,8 +429,8 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   resp.bits.data := s2_resp_data
   io.lsu.s2_first_hit := s2_req.isFirstIssue && s2_hit
   // load pipe need replay when there is a bank conflict or wpu predict fail
-  resp.bits.replay := (resp.bits.miss && (!s2_miss_req_fire || s2_nack || io.mq_enq_cancel)) || io.bank_conflict_slow || s2_wpu_pred_fail
-  resp.bits.replayCarry.valid := (resp.bits.miss && (!s2_miss_req_fire || s2_nack || io.mq_enq_cancel)) || io.bank_conflict_slow || s2_wpu_pred_fail
+  resp.bits.replay := (resp.bits.miss && (s2_nack || io.mq_enq_cancel)) || io.bank_conflict_slow || s2_wpu_pred_fail
+  resp.bits.replayCarry.valid := (resp.bits.miss && (s2_nack || io.mq_enq_cancel)) || io.bank_conflict_slow || s2_wpu_pred_fail
   resp.bits.replayCarry.real_way_en := s2_real_way_en
   resp.bits.meta_prefetch := s2_hit_prefetch
   resp.bits.meta_access := s2_hit_access
@@ -490,7 +490,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.lsu.s1_disable_fast_wakeup := io.disable_ld_fast_wakeup
   io.lsu.s2_bank_conflict := io.bank_conflict_slow
   io.lsu.s2_wpu_pred_fail := s2_wpu_pred_fail_and_real_hit
-  io.lsu.s2_mq_nack       := (resp.bits.miss && (!s2_miss_req_fire || s2_nack_no_mshr || io.mq_enq_cancel || io.wbq_block_miss_req))
+  io.lsu.s2_mq_nack       := (resp.bits.miss && (s2_nack_no_mshr || io.mq_enq_cancel || io.wbq_block_miss_req))
   assert(RegNext(s1_ready && s2_ready), "load pipeline should never be blocked")
 
   // --------------------------------------------------------------------------------


### PR DESCRIPTION
Remove the redundant logic of the miss queue nack based on the issues raised in the issues(https://github.com/OpenXiangShan/XiangShan/issues/3916).

When a tlb miss and a dcache miss occur at the same time and the miss queue nack, it will cause the `LoadUnit` to generate both replay signals `C_TM` and `C_DR`. We will give priority to `C_TM`, which is why we need to send a kill signal to dcache when a tlb miss occurs.

Although there was no problem before, as the issue(https://github.com/OpenXiangShan/XiangShan/issues/3916) says, this will cause ambiguity, and the miss queue nack message is already included in `s2_nack_no_mshr`, so the choice is to remove the `s2_miss_req_fire` signal from the generation logic of the `s2_mq_nack` signal.