### PR TITLE
fix(intr): support non-mmio load-store instructions to trigger interrupts

### DIFF
--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -148,6 +148,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   backend.io.mem.writebackHyuSta <> memBlock.io.mem_to_ooo.writebackHyuSta
   backend.io.mem.writebackStd <> memBlock.io.mem_to_ooo.writebackStd
   backend.io.mem.writebackVldu <> memBlock.io.mem_to_ooo.writebackVldu
+  backend.io.mem.robLsqIO.update := memBlock.io.mem_to_ooo.lsqio.update
   backend.io.mem.robLsqIO.mmio := memBlock.io.mem_to_ooo.lsqio.mmio
   backend.io.mem.robLsqIO.uop := memBlock.io.mem_to_ooo.lsqio.uop
 
@@ -215,6 +216,7 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   memBlock.io.ooo_to_mem.lsqio.commit           := backend.io.mem.robLsqIO.commit
   memBlock.io.ooo_to_mem.lsqio.pendingPtr       := backend.io.mem.robLsqIO.pendingPtr
   memBlock.io.ooo_to_mem.lsqio.pendingPtrNext   := backend.io.mem.robLsqIO.pendingPtrNext
+  memBlock.io.ooo_to_mem.lsqio.pendingIntr      := backend.io.mem.robLsqIO.pendingIntr
   memBlock.io.ooo_to_mem.isStoreException       := backend.io.mem.isStoreException
   memBlock.io.ooo_to_mem.isVlsException         := backend.io.mem.isVlsException
 

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -96,6 +96,7 @@ class ooo_to_mem(implicit p: Parameters) extends MemBlockBundle {
     val commit = Input(Bool())
     val pendingPtr = Input(new RobPtr)
     val pendingPtrNext = Input(new RobPtr)
+    val pendingIntr = Input(Bool())
   }
 
   val isStoreException = Input(Bool())
@@ -142,6 +143,7 @@ class mem_to_ooo(implicit p: Parameters) extends MemBlockBundle {
     val vl = Output(UInt((log2Up(VLEN) + 1).W))
     val gpaddr = Output(UInt(XLEN.W))
     val isForVSnonLeafPTE = Output(Bool())
+    val update = Output(Vec(LoadPipelineWidth, Bool()))
     val mmio = Output(Vec(LoadPipelineWidth, Bool()))
     val uop = Output(Vec(LoadPipelineWidth, new DynInst))
     val lqCanAccept = Output(Bool())
@@ -1081,6 +1083,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   loadMisalignBuffer.io.rob.commit              := io.ooo_to_mem.lsqio.commit
   loadMisalignBuffer.io.rob.pendingPtr          := io.ooo_to_mem.lsqio.pendingPtr
   loadMisalignBuffer.io.rob.pendingPtrNext      := io.ooo_to_mem.lsqio.pendingPtrNext
+  loadMisalignBuffer.io.rob.pendingIntr         := io.ooo_to_mem.lsqio.pendingIntr
 
   lsq.io.flushFrmMaBuf                          := loadMisalignBuffer.io.flushLdExpBuff
 
@@ -1094,6 +1097,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   storeMisalignBuffer.io.rob.commit             := io.ooo_to_mem.lsqio.commit
   storeMisalignBuffer.io.rob.pendingPtr         := io.ooo_to_mem.lsqio.pendingPtr
   storeMisalignBuffer.io.rob.pendingPtrNext     := io.ooo_to_mem.lsqio.pendingPtrNext
+  storeMisalignBuffer.io.rob.pendingIntr        := io.ooo_to_mem.lsqio.pendingIntr
 
   lsq.io.maControl                              <> storeMisalignBuffer.io.sqControl
 
@@ -1272,6 +1276,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   lsq.io.uncacheOutstanding := io.ooo_to_mem.csrCtrl.uncache_write_outstanding_enable
 
   // Lsq
+  io.mem_to_ooo.lsqio.update     := lsq.io.rob.update
   io.mem_to_ooo.lsqio.mmio       := lsq.io.rob.mmio
   io.mem_to_ooo.lsqio.uop        := lsq.io.rob.uop
   lsq.io.rob.lcommit             := io.ooo_to_mem.lsqio.lcommit
@@ -1283,6 +1288,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   lsq.io.rob.commit              := io.ooo_to_mem.lsqio.commit
   lsq.io.rob.pendingPtr          := io.ooo_to_mem.lsqio.pendingPtr
   lsq.io.rob.pendingPtrNext      := io.ooo_to_mem.lsqio.pendingPtrNext
+  lsq.io.rob.pendingIntr         := io.ooo_to_mem.lsqio.pendingIntr
 
   //  lsq.io.rob            <> io.lsqio.rob
   lsq.io.enq            <> io.ooo_to_mem.enqLsq

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -239,7 +239,9 @@ class RobLsqIO(implicit p: Parameters) extends XSBundle {
   val commit = Output(Bool())
   val pendingPtr = Output(new RobPtr)
   val pendingPtrNext = Output(new RobPtr)
+  val pendingIntr = Output(Bool())
 
+  val update = Input(Vec(LoadPipelineWidth, Bool()))
   val mmio = Input(Vec(LoadPipelineWidth, Bool()))
   // Todo: what's this?
   val uop = Input(Vec(LoadPipelineWidth, new DynInst))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
@@ -130,6 +130,7 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
     val flushLdExpBuff  = Output(Bool())
   })
 
+  io.rob.update := 0.U.asTypeOf(Vec(LoadPipelineWidth, Bool()))
   io.rob.mmio := 0.U.asTypeOf(Vec(LoadPipelineWidth, Bool()))
   io.rob.uop  := 0.U.asTypeOf(Vec(LoadPipelineWidth, new DynInst))
 
@@ -569,7 +570,7 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
   io.writeBack.bits.debug.paddr := req.paddr
   io.writeBack.bits.debug.vaddr := req.vaddr
 
-  val flush = req_valid && req.uop.robIdx.needFlush(io.redirect)
+  val flush = req_valid && req.uop.robIdx.needFlush(io.redirect) || io.rob.pendingIntr
 
   when (flush && (bufferState =/= s_idle)) {
     bufferState := s_idle

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -102,6 +102,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
     val sqControl       = new StoreMaBufToSqControlIO
   })
 
+  io.rob.update := 0.U.asTypeOf(Vec(LoadPipelineWidth, Bool()))
   io.rob.mmio := 0.U.asTypeOf(Vec(LoadPipelineWidth, Bool()))
   io.rob.uop  := 0.U.asTypeOf(Vec(LoadPipelineWidth, new DynInst))
 
@@ -584,7 +585,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
 
   io.sqControl.control.removeSq := req_valid && (bufferState === s_wait) && !(globalMMIO || globalException) && (io.rob.scommit =/= 0.U)
 
-  val flush = req_valid && req.uop.robIdx.needFlush(io.redirect)
+  val flush = req_valid && req.uop.robIdx.needFlush(io.redirect) || io.rob.pendingIntr
 
   when (flush && (bufferState =/= s_idle)) {
     bufferState := s_idle


### PR DESCRIPTION
* This PR does not merge.

* For now, we allow non-load-store, non-fence, non-csr instructions to trigger interrupts.
* For MMIO instructions, they should not trigger interrupts since they may be sent to lower level before it writes back.
* In order to support non-mmio load-store instructions to trigger interrupt, we allow load-store instruction trigger interrupt, while mmio-load-store instructions will flush pipe.