### PR TITLE
feat(IFU,Svpbmt): allow speculative fetch in pbmt.NC (idempotent) spaces

### DIFF
--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -791,14 +791,15 @@ class NewIFU(implicit p: Parameters) extends XSModule
 
     is(m_waitResendResp) {
       when(fromUncache.fire) {
-        // in idempotent spaces, we can skip waiting for commit (i.e. can do speculative fetch)
-        mmio_state      := Mux(f3_itlb_pbmt === Pbmt.nc, m_commited, m_waitCommit)
+        mmio_state      := m_waitCommit
         f3_mmio_data(1) := fromUncache.bits.data(15, 0)
       }
     }
 
     is(m_waitCommit) {
-      mmio_state := Mux(mmio_commit, m_commited, m_waitCommit)
+      // in idempotent spaces, we can skip waiting for commit (i.e. can do speculative fetch)
+      // but we do not skip m_waitCommit state, as other signals (e.g. f3_mmio_can_go relies on this)
+      mmio_state := Mux(mmio_commit || f3_itlb_pbmt === Pbmt.nc, m_commited, m_waitCommit)
     }
 
     // normal mmio instruction

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -716,7 +716,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
   switch(mmio_state) {
     is(m_idle) {
       when(f3_req_is_mmio) {
-        mmio_state := m_waitLastCmt
+        // in idempotent spaces, we can send request directly (i.e. can do speculative fetch)
+        mmio_state := Mux(f3_itlb_pbmt === Pbmt.nc, m_sendReq, m_waitLastCmt)
       }
     }
 
@@ -790,7 +791,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
 
     is(m_waitResendResp) {
       when(fromUncache.fire) {
-        mmio_state      := m_waitCommit
+        // in idempotent spaces, we can skip waiting for commit (i.e. can do speculative fetch)
+        mmio_state      := Mux(f3_itlb_pbmt === Pbmt.nc, m_commited, m_waitCommit)
         f3_mmio_data(1) := fromUncache.bits.data(15, 0)
       }
     }


### PR DESCRIPTION
Skip `m_waitLastCmt` & `m_waitCommit` state if `f3_itlb_pbmt === Pbmt.nc`, as these memory spaces are idempotent and in which we can do speculative inst fetch.