### PR TITLE
refactor(ICache): refactor code style & eliminate IDE warnings

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -36,7 +36,6 @@ import huancun.AliasField
 import huancun.PrefetchField
 import org.chipsalliance.cde.config.Parameters
 import utility._
-import utils._
 import xiangshan._
 import xiangshan.cache._
 import xiangshan.cache.mmu.TlbRequestIO
@@ -63,8 +62,8 @@ case class ICacheParameters(
     blockBytes: Int = 64
 ) extends L1CacheParameters {
 
-  val setBytes     = nSets * blockBytes
-  val aliasBitsOpt = if (setBytes > pageSize) Some(log2Ceil(setBytes / pageSize)) else None
+  val setBytes:     Int         = nSets * blockBytes
+  val aliasBitsOpt: Option[Int] = Option.when(setBytes > pageSize)(log2Ceil(setBytes / pageSize))
   val reqFields: Seq[BundleFieldBase] = Seq(
     PrefetchField(),
     ReqSourceField()
@@ -76,37 +75,36 @@ case class ICacheParameters(
 }
 
 trait HasICacheParameters extends HasL1CacheParameters with HasInstrMMIOConst with HasIFUConst {
-  val cacheParams = icacheParameters
+  val cacheParams: ICacheParameters = icacheParameters
 
-  def ICacheSets          = cacheParams.nSets
-  def ICacheWays          = cacheParams.nWays
-  def PortNumber          = cacheParams.PortNumber
-  def nFetchMshr          = cacheParams.nFetchMshr
-  def nPrefetchMshr       = cacheParams.nPrefetchMshr
-  def nWayLookupSize      = cacheParams.nWayLookupSize
-  def DataCodeUnit        = cacheParams.DataCodeUnit
-  def ICacheDataBanks     = cacheParams.ICacheDataBanks
-  def ICacheDataSRAMWidth = cacheParams.ICacheDataSRAMWidth
-  def partWayNum          = cacheParams.partWayNum
+  def ICacheSets:          Int = cacheParams.nSets
+  def ICacheWays:          Int = cacheParams.nWays
+  def PortNumber:          Int = cacheParams.PortNumber
+  def nFetchMshr:          Int = cacheParams.nFetchMshr
+  def nPrefetchMshr:       Int = cacheParams.nPrefetchMshr
+  def nWayLookupSize:      Int = cacheParams.nWayLookupSize
+  def DataCodeUnit:        Int = cacheParams.DataCodeUnit
+  def ICacheDataBanks:     Int = cacheParams.ICacheDataBanks
+  def ICacheDataSRAMWidth: Int = cacheParams.ICacheDataSRAMWidth
+  def partWayNum:          Int = cacheParams.partWayNum
 
-  def ICacheMetaBits      = tagBits // FIXME: unportable: maybe use somemethod to get width
-  def ICacheMetaCodeBits  = 1       // FIXME: unportable: maybe use cacheParams.tagCode.somemethod to get width
-  def ICacheMetaEntryBits = ICacheMetaBits + ICacheMetaCodeBits
+  def ICacheMetaBits:      Int = tagBits // FIXME: unportable: maybe use somemethod to get width
+  def ICacheMetaCodeBits:  Int = 1       // FIXME: unportable: maybe use cacheParams.tagCode.somemethod to get width
+  def ICacheMetaEntryBits: Int = ICacheMetaBits + ICacheMetaCodeBits
 
-  def ICacheDataBits     = blockBits / ICacheDataBanks
-  def ICacheDataCodeSegs = math.ceil(ICacheDataBits / DataCodeUnit).toInt // split data to segments for ECC checking
-  def ICacheDataCodeBits =
+  def ICacheDataBits: Int = blockBits / ICacheDataBanks
+  def ICacheDataCodeSegs: Int =
+    math.ceil(ICacheDataBits / DataCodeUnit).toInt // split data to segments for ECC checking
+  def ICacheDataCodeBits: Int =
     ICacheDataCodeSegs * 1 // FIXME: unportable: maybe use cacheParams.dataCode.somemethod to get width
-  def ICacheDataEntryBits = ICacheDataBits + ICacheDataCodeBits
-  def ICacheBankVisitNum  = 32 * 8 / ICacheDataBits + 1
-  def highestIdxBit       = log2Ceil(nSets) - 1
+  def ICacheDataEntryBits: Int = ICacheDataBits + ICacheDataCodeBits
+  def ICacheBankVisitNum:  Int = 32 * 8 / ICacheDataBits + 1
+  def highestIdxBit:       Int = log2Ceil(nSets) - 1
 
   require((ICacheDataBanks >= 2) && isPow2(ICacheDataBanks))
   require(ICacheDataSRAMWidth >= ICacheDataEntryBits)
   require(isPow2(ICacheSets), s"nSets($ICacheSets) must be pow2")
   require(isPow2(ICacheWays), s"nWays($ICacheWays) must be pow2")
-
-  def getBits(num: Int) = log2Ceil(num).W
 
   def generatePipeControl(lastFire: Bool, thisFire: Bool, thisFlush: Bool, lastFlush: Bool): Bool = {
     val valid = RegInit(false.B)
@@ -138,7 +136,7 @@ trait HasICacheParameters extends HasL1CacheParameters with HasInstrMMIOConst wi
   }
 
   def InitQueue[T <: Data](entry: T, size: Int): Vec[T] =
-    return RegInit(VecInit(Seq.fill(size)(0.U.asTypeOf(entry.cloneType))))
+    RegInit(VecInit(Seq.fill(size)(0.U.asTypeOf(entry.cloneType))))
 
   def encodeMetaECC(meta: UInt): UInt = {
     require(meta.getWidth == ICacheMetaBits)
@@ -154,8 +152,8 @@ trait HasICacheParameters extends HasL1CacheParameters with HasInstrMMIOConst wi
   }
 
   def getBankSel(blkOffset: UInt, valid: Bool = true.B): Vec[UInt] = {
-    val bankIdxLow  = Cat(0.U(1.W), blkOffset) >> log2Ceil(blockBytes / ICacheDataBanks)
-    val bankIdxHigh = (Cat(0.U(1.W), blkOffset) + 32.U) >> log2Ceil(blockBytes / ICacheDataBanks)
+    val bankIdxLow  = (Cat(0.U(1.W), blkOffset) >> log2Ceil(blockBytes / ICacheDataBanks)).asUInt
+    val bankIdxHigh = ((Cat(0.U(1.W), blkOffset) + 32.U) >> log2Ceil(blockBytes / ICacheDataBanks)).asUInt
     val bankSel     = VecInit((0 until ICacheDataBanks * 2).map(i => (i.U >= bankIdxLow) && (i.U <= bankIdxHigh)))
     assert(
       !valid || PopCount(bankSel) === ICacheBankVisitNum.U,
@@ -166,16 +164,18 @@ trait HasICacheParameters extends HasL1CacheParameters with HasInstrMMIOConst wi
     bankSel.asTypeOf(UInt((ICacheDataBanks * 2).W)).asTypeOf(Vec(2, UInt(ICacheDataBanks.W)))
   }
 
-  def getLineSel(blkOffset: UInt)(implicit p: Parameters): Vec[Bool] = {
-    val bankIdxLow = blkOffset >> log2Ceil(blockBytes / ICacheDataBanks)
+  def getLineSel(blkOffset: UInt): Vec[Bool] = {
+    val bankIdxLow = (blkOffset >> log2Ceil(blockBytes / ICacheDataBanks)).asUInt
     val lineSel    = VecInit((0 until ICacheDataBanks).map(i => i.U < bankIdxLow))
     lineSel
   }
 
-  def getBlkAddr(addr:           UInt) = addr >> blockOffBits
-  def getPhyTagFromBlk(addr:     UInt): UInt = addr >> (pgUntagBits - blockOffBits)
-  def getIdxFromBlk(addr:        UInt) = addr(idxBits - 1, 0)
-  def get_paddr_from_ptag(vaddr: UInt, ptag: UInt) = Cat(ptag, vaddr(pgUntagBits - 1, 0))
+  def getBlkAddr(addr:        UInt): UInt = (addr >> blockOffBits).asUInt
+  def getPhyTagFromBlk(addr:  UInt): UInt = (addr >> (pgUntagBits - blockOffBits)).asUInt
+  def getIdxFromBlk(addr:     UInt): UInt = addr(idxBits - 1, 0)
+  def getPaddrFromPtag(vaddr: UInt, ptag: UInt): UInt = Cat(ptag, vaddr(pgUntagBits - 1, 0))
+  def getPaddrFromPtag(vaddrVec: Vec[UInt], ptagVec: Vec[UInt]): Vec[UInt] =
+    VecInit((vaddrVec zip ptagVec).map { case (vaddr, ptag) => getPaddrFromPtag(vaddr, ptag) })
 }
 
 abstract class ICacheBundle(implicit p: Parameters) extends XSBundle
@@ -188,18 +188,26 @@ abstract class ICacheArray(implicit p: Parameters) extends XSModule
     with HasICacheParameters
 
 class ICacheMetadata(implicit p: Parameters) extends ICacheBundle {
-  val tag = UInt(tagBits.W)
+  val tag: UInt = UInt(tagBits.W)
 }
 
 object ICacheMetadata {
-  def apply(tag: Bits)(implicit p: Parameters) = {
+  def apply(tag: Bits)(implicit p: Parameters): ICacheMetadata = {
     val meta = Wire(new ICacheMetadata)
     meta.tag := tag
     meta
   }
 }
 
-class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray {
+class ICacheMetaArrayIO(implicit p: Parameters) extends ICacheBundle {
+  val write:    DecoupledIO[ICacheMetaWriteBundle] = Flipped(DecoupledIO(new ICacheMetaWriteBundle))
+  val read:     DecoupledIO[ICacheReadBundle]      = Flipped(DecoupledIO(new ICacheReadBundle))
+  val readResp: ICacheMetaRespBundle               = Output(new ICacheMetaRespBundle)
+  val flush:    Vec[Valid[ICacheMetaFlushBundle]]  = Vec(PortNumber, Flipped(ValidIO(new ICacheMetaFlushBundle)))
+  val flushAll: Bool                               = Input(Bool())
+}
+
+class ICacheMetaArray(implicit p: Parameters) extends ICacheArray {
   class ICacheMetaEntry(implicit p: Parameters) extends ICacheBundle {
     val meta: ICacheMetadata = new ICacheMetadata
     val code: UInt           = UInt(ICacheMetaCodeBits.W)
@@ -217,41 +225,34 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray {
   // sanity check
   require(ICacheMetaEntryBits == (new ICacheMetaEntry).getWidth)
 
-  val io = IO(new Bundle {
-    val write    = Flipped(DecoupledIO(new ICacheMetaWriteBundle))
-    val read     = Flipped(DecoupledIO(new ICacheReadBundle))
-    val readResp = Output(new ICacheMetaRespBundle)
-    val flush    = Vec(PortNumber, Flipped(ValidIO(new ICacheMetaFlushBundle)))
-    val flushAll = Input(Bool())
-  })
+  val io: ICacheMetaArrayIO = IO(new ICacheMetaArrayIO)
 
-  val port_0_read_0 = io.read.valid && !io.read.bits.vSetIdx(0)(0)
-  val port_0_read_1 = io.read.valid && io.read.bits.vSetIdx(0)(0)
-  val port_1_read_1 = io.read.valid && io.read.bits.vSetIdx(1)(0) && io.read.bits.isDoubleLine
-  val port_1_read_0 = io.read.valid && !io.read.bits.vSetIdx(1)(0) && io.read.bits.isDoubleLine
+  private val port_0_read_0 = io.read.valid && !io.read.bits.vSetIdx(0)(0)
+  private val port_0_read_1 = io.read.valid && io.read.bits.vSetIdx(0)(0)
+  private val port_1_read_1 = io.read.valid && io.read.bits.vSetIdx(1)(0) && io.read.bits.isDoubleLine
+  private val port_1_read_0 = io.read.valid && !io.read.bits.vSetIdx(1)(0) && io.read.bits.isDoubleLine
 
-  val port_0_read_0_reg = RegEnable(port_0_read_0, 0.U.asTypeOf(port_0_read_0), io.read.fire)
-  val port_0_read_1_reg = RegEnable(port_0_read_1, 0.U.asTypeOf(port_0_read_1), io.read.fire)
-  val port_1_read_1_reg = RegEnable(port_1_read_1, 0.U.asTypeOf(port_1_read_1), io.read.fire)
-  val port_1_read_0_reg = RegEnable(port_1_read_0, 0.U.asTypeOf(port_1_read_0), io.read.fire)
+  private val port_0_read_0_reg = RegEnable(port_0_read_0, 0.U.asTypeOf(port_0_read_0), io.read.fire)
+  private val port_0_read_1_reg = RegEnable(port_0_read_1, 0.U.asTypeOf(port_0_read_1), io.read.fire)
+  private val port_1_read_1_reg = RegEnable(port_1_read_1, 0.U.asTypeOf(port_1_read_1), io.read.fire)
+  private val port_1_read_0_reg = RegEnable(port_1_read_0, 0.U.asTypeOf(port_1_read_0), io.read.fire)
 
-  val bank_0_idx = Mux(port_0_read_0, io.read.bits.vSetIdx(0), io.read.bits.vSetIdx(1))
-  val bank_1_idx = Mux(port_0_read_1, io.read.bits.vSetIdx(0), io.read.bits.vSetIdx(1))
-  val bank_idx   = Seq(bank_0_idx, bank_1_idx)
+  private val bank_0_idx = Mux(port_0_read_0, io.read.bits.vSetIdx(0), io.read.bits.vSetIdx(1))
+  private val bank_1_idx = Mux(port_0_read_1, io.read.bits.vSetIdx(0), io.read.bits.vSetIdx(1))
 
-  val write_bank_0 = io.write.valid && !io.write.bits.bankIdx
-  val write_bank_1 = io.write.valid && io.write.bits.bankIdx
+  private val write_bank_0 = io.write.valid && !io.write.bits.bankIdx
+  private val write_bank_1 = io.write.valid && io.write.bits.bankIdx
 
-  val write_meta_bits = ICacheMetaEntry(meta =
+  private val write_meta_bits = ICacheMetaEntry(meta =
     ICacheMetadata(
       tag = io.write.bits.phyTag
     )
   )
 
-  val tagArrays = (0 until 2) map { bank =>
+  private val tagArrays = (0 until PortNumber) map { bank =>
     val tagArray = Module(new SRAMTemplate(
       new ICacheMetaEntry(),
-      set = nSets / 2,
+      set = nSets / PortNumber,
       way = nWays,
       shouldReset = true,
       holdRead = true,
@@ -283,9 +284,9 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray {
     tagArray
   }
 
-  val read_set_idx_next = RegEnable(io.read.bits.vSetIdx, 0.U.asTypeOf(io.read.bits.vSetIdx), io.read.fire)
-  val valid_array       = RegInit(VecInit(Seq.fill(nWays)(0.U(nSets.W))))
-  val valid_metas       = Wire(Vec(PortNumber, Vec(nWays, Bool())))
+  private val read_set_idx_next = RegEnable(io.read.bits.vSetIdx, 0.U.asTypeOf(io.read.bits.vSetIdx), io.read.fire)
+  private val valid_array       = RegInit(VecInit(Seq.fill(nWays)(0.U(nSets.W))))
+  private val valid_metas       = Wire(Vec(PortNumber, Vec(nWays, Bool())))
   // valid read
   (0 until PortNumber).foreach(i =>
     (0 until nWays).foreach(way =>
@@ -298,7 +299,7 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray {
     tagArrays.map(_.io.r.req.ready).reduce(_ && _)
 
   // valid write
-  val way_num = OHToUInt(io.write.bits.waymask)
+  private val way_num = OHToUInt(io.write.bits.waymask)
   when(io.write.valid) {
     valid_array(way_num) := valid_array(way_num).bitSet(io.write.bits.virIdx, true.B)
   }
@@ -307,9 +308,9 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray {
 
   io.readResp.metas <> DontCare
   io.readResp.codes <> DontCare
-  val readMetaEntries = tagArrays.map(port => port.io.r.resp.asTypeOf(Vec(nWays, new ICacheMetaEntry())))
-  val readMetas       = readMetaEntries.map(_.map(_.meta))
-  val readCodes       = readMetaEntries.map(_.map(_.code))
+  private val readMetaEntries = tagArrays.map(port => port.io.r.resp.asTypeOf(Vec(nWays, new ICacheMetaEntry())))
+  private val readMetas       = readMetaEntries.map(_.map(_.meta))
+  private val readCodes       = readMetaEntries.map(_.map(_.code))
 
   // TEST: force ECC to fail by setting readCodes to 0
   if (ICacheForceMetaECCError) {
@@ -361,14 +362,20 @@ class ICacheMetaArray()(implicit p: Parameters) extends ICacheArray {
   XSPerfAccumulate("flush_all", io.flushAll)
 }
 
+class ICacheDataArrayIO(implicit p: Parameters) extends ICacheBundle {
+  val write:    DecoupledIO[ICacheDataWriteBundle] = Flipped(DecoupledIO(new ICacheDataWriteBundle))
+  val read:     Vec[DecoupledIO[ICacheReadBundle]] = Flipped(Vec(partWayNum, DecoupledIO(new ICacheReadBundle)))
+  val readResp: ICacheDataRespBundle               = Output(new ICacheDataRespBundle)
+}
+
 class ICacheDataArray(implicit p: Parameters) extends ICacheArray {
   class ICacheDataEntry(implicit p: Parameters) extends ICacheBundle {
-    val data = UInt(ICacheDataBits.W)
-    val code = UInt(ICacheDataCodeBits.W)
+    val data: UInt = UInt(ICacheDataBits.W)
+    val code: UInt = UInt(ICacheDataCodeBits.W)
   }
 
-  object ICacheDataEntry {
-    def apply(data: UInt)(implicit p: Parameters) = {
+  private object ICacheDataEntry {
+    def apply(data: UInt)(implicit p: Parameters): ICacheDataEntry = {
       val entry = Wire(new ICacheDataEntry)
       entry.data := data
       entry.code := encodeDataECC(data)
@@ -376,27 +383,21 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray {
     }
   }
 
-  val io = IO {
-    new Bundle {
-      val write = Flipped(DecoupledIO(new ICacheDataWriteBundle))
-      // TODO: fix hard code
-      val read     = Flipped(Vec(4, DecoupledIO(new ICacheReadBundle)))
-      val readResp = Output(new ICacheDataRespBundle)
-    }
-  }
+  val io: ICacheDataArrayIO = IO(new ICacheDataArrayIO)
 
   /**
     ******************************************************************************
     * data array
     ******************************************************************************
     */
-  val writeDatas   = io.write.bits.data.asTypeOf(Vec(ICacheDataBanks, UInt(ICacheDataBits.W)))
-  val writeEntries = writeDatas.map(ICacheDataEntry(_).asUInt)
+  private val writeDatas   = io.write.bits.data.asTypeOf(Vec(ICacheDataBanks, UInt(ICacheDataBits.W)))
+  private val writeEntries = writeDatas.map(ICacheDataEntry(_).asUInt)
 
-  val bankSel  = getBankSel(io.read(0).bits.blkOffset, io.read(0).valid)
-  val lineSel  = getLineSel(io.read(0).bits.blkOffset)
-  val waymasks = io.read(0).bits.wayMask
-  val masks    = Wire(Vec(nWays, Vec(ICacheDataBanks, Bool())))
+  // io.read() are copies to control fan-out, we can simply use .head here
+  private val bankSel  = getBankSel(io.read.head.bits.blkOffset, io.read.head.valid)
+  private val lineSel  = getLineSel(io.read.head.bits.blkOffset)
+  private val waymasks = io.read.head.bits.waymask
+  private val masks    = Wire(Vec(nWays, Vec(ICacheDataBanks, Bool())))
   (0 until nWays).foreach { way =>
     (0 until ICacheDataBanks).foreach { bank =>
       masks(way)(bank) := Mux(
@@ -407,7 +408,7 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray {
     }
   }
 
-  val dataArrays = (0 until nWays).map { way =>
+  private val dataArrays = (0 until nWays).map { way =>
     (0 until ICacheDataBanks).map { bank =>
       val sramBank = Module(new SRAMTemplateWithFixedWidth(
         UInt(ICacheDataEntryBits.W),
@@ -441,13 +442,13 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray {
     * read logic
     ******************************************************************************
     */
-  val masksReg = RegEnable(masks, 0.U.asTypeOf(masks), io.read(0).valid)
-  val readDataWithCode = (0 until ICacheDataBanks).map(bank =>
+  private val masksReg = RegEnable(masks, 0.U.asTypeOf(masks), io.read(0).valid)
+  private val readDataWithCode = (0 until ICacheDataBanks).map { bank =>
     Mux1H(VecInit(masksReg.map(_(bank))).asTypeOf(UInt(nWays.W)), dataArrays.map(_(bank).io.r.resp.asUInt))
-  )
-  val readEntries = readDataWithCode.map(_.asTypeOf(new ICacheDataEntry()))
-  val readDatas   = VecInit(readEntries.map(_.data))
-  val readCodes   = VecInit(readEntries.map(_.code))
+  }
+  private val readEntries = readDataWithCode.map(_.asTypeOf(new ICacheDataEntry()))
+  private val readDatas   = VecInit(readEntries.map(_.data))
+  private val readCodes   = VecInit(readEntries.map(_.code))
 
   // TEST: force ECC to fail by setting readCodes to 0
   if (ICacheForceDataECCError) {
@@ -465,17 +466,20 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray {
   io.read.foreach(_.ready := !io.write.valid)
 }
 
-class ICacheReplacer(implicit p: Parameters) extends ICacheModule {
-  val io = IO(new Bundle {
-    val touch  = Vec(PortNumber, Flipped(ValidIO(new ReplacerTouch)))
-    val victim = Flipped(new ReplacerVictim)
-  })
+class ICacheReplacerIO(implicit p: Parameters) extends ICacheBundle {
+  val touch:  Vec[Valid[ReplacerTouch]] = Vec(PortNumber, Flipped(ValidIO(new ReplacerTouch)))
+  val victim: ReplacerVictim            = Flipped(new ReplacerVictim)
+}
 
-  val replacers = Seq.fill(PortNumber)(ReplacementPolicy.fromString(cacheParams.replacer, nWays, nSets / PortNumber))
+class ICacheReplacer(implicit p: Parameters) extends ICacheModule {
+  val io: ICacheReplacerIO = IO(new ICacheReplacerIO)
+
+  private val replacers =
+    Seq.fill(PortNumber)(ReplacementPolicy.fromString(cacheParams.replacer, nWays, nSets / PortNumber))
 
   // touch
-  val touch_sets = Seq.fill(PortNumber)(Wire(Vec(2, UInt(log2Ceil(nSets / 2).W))))
-  val touch_ways = Seq.fill(PortNumber)(Wire(Vec(2, Valid(UInt(log2Ceil(nWays).W)))))
+  private val touch_sets = Seq.fill(PortNumber)(Wire(Vec(PortNumber, UInt(log2Ceil(nSets / PortNumber).W))))
+  private val touch_ways = Seq.fill(PortNumber)(Wire(Vec(PortNumber, Valid(UInt(wayBits.W)))))
   (0 until PortNumber).foreach { i =>
     touch_sets(i)(0) := Mux(
       io.touch(i).bits.vSetIdx(0),
@@ -494,40 +498,50 @@ class ICacheReplacer(implicit p: Parameters) extends ICacheModule {
   )
 
   // touch the victim in next cycle
-  val victim_vSetIdx_reg =
+  private val victim_vSetIdx_reg =
     RegEnable(io.victim.vSetIdx.bits, 0.U.asTypeOf(io.victim.vSetIdx.bits), io.victim.vSetIdx.valid)
-  val victim_way_reg = RegEnable(io.victim.way, 0.U.asTypeOf(io.victim.way), io.victim.vSetIdx.valid)
+  private val victim_way_reg = RegEnable(io.victim.way, 0.U.asTypeOf(io.victim.way), io.victim.vSetIdx.valid)
   (0 until PortNumber).foreach { i =>
     touch_sets(i)(1)       := victim_vSetIdx_reg(highestIdxBit, 1)
     touch_ways(i)(1).bits  := victim_way_reg
     touch_ways(i)(1).valid := RegNext(io.victim.vSetIdx.valid) && (victim_vSetIdx_reg(0) === i.U)
   }
 
-  ((replacers zip touch_sets) zip touch_ways).map { case ((r, s), w) => r.access(s, w) }
+  ((replacers zip touch_sets) zip touch_ways).foreach { case ((r, s), w) => r.access(s, w) }
 }
 
 class ICacheIO(implicit p: Parameters) extends ICacheBundle {
-  val hartId       = Input(UInt(hartIdLen.W))
-  val ftqPrefetch  = Flipped(new FtqToPrefetchIO)
-  val softPrefetch = Vec(backendParams.LduCnt, Flipped(Valid(new SoftIfetchPrefetchBundle)))
-  val stop         = Input(Bool())
-  val fetch        = new ICacheMainPipeBundle
-  val toIFU        = Output(Bool())
-  val pmp          = Vec(2 * PortNumber, new ICachePMPBundle)
-  val itlb         = Vec(PortNumber, new TlbRequestIO)
-  val perfInfo     = Output(new ICachePerfInfo)
-  val error        = ValidIO(new L1CacheErrorInfo)
-  /* CSR control signal */
-  val csr_pf_enable     = Input(Bool())
-  val csr_parity_enable = Input(Bool())
-  val fencei            = Input(Bool())
-  val flush             = Input(Bool())
+  val hartId: UInt = Input(UInt(hartIdLen.W))
+  // FTQ
+  val fetch:       ICacheMainPipeBundle = new ICacheMainPipeBundle
+  val ftqPrefetch: FtqToPrefetchIO      = Flipped(new FtqToPrefetchIO)
+  // memblock
+  val softPrefetch: Vec[Valid[SoftIfetchPrefetchBundle]] =
+    Vec(backendParams.LduCnt, Flipped(Valid(new SoftIfetchPrefetchBundle)))
+  // IFU
+  val stop:  Bool = Input(Bool())
+  val toIFU: Bool = Output(Bool())
+  // PMP: mainPipe & prefetchPipe need PortNumber each
+  val pmp: Vec[ICachePMPBundle] = Vec(2 * PortNumber, new ICachePMPBundle)
+  // iTLB
+  val itlb: Vec[TlbRequestIO] = Vec(PortNumber, new TlbRequestIO)
+  // backend/BEU
+  val error: Valid[L1CacheErrorInfo] = ValidIO(new L1CacheErrorInfo)
+  // backend/CSR
+  val csr_pf_enable:     Bool = Input(Bool())
+  val csr_parity_enable: Bool = Input(Bool())
+  // flush
+  val fencei: Bool = Input(Bool())
+  val flush:  Bool = Input(Bool())
+
+  // perf
+  val perfInfo: ICachePerfInfo = Output(new ICachePerfInfo)
 }
 
 class ICache()(implicit p: Parameters) extends LazyModule with HasICacheParameters {
   override def shouldBeInlined: Boolean = false
 
-  val clientParameters = TLMasterPortParameters.v1(
+  val clientParameters: TLMasterPortParameters = TLMasterPortParameters.v1(
     Seq(TLMasterParameters.v1(
       name = "icache",
       sourceId = IdRange(0, cacheParams.nFetchMshr + cacheParams.nPrefetchMshr + 1)
@@ -536,13 +550,13 @@ class ICache()(implicit p: Parameters) extends LazyModule with HasICacheParamete
     echoFields = cacheParams.echoFields
   )
 
-  val clientNode = TLClientNode(Seq(clientParameters))
+  val clientNode: TLClientNode = TLClientNode(Seq(clientParameters))
 
-  lazy val module = new ICacheImp(this)
+  lazy val module: ICacheImp = new ICacheImp(this)
 }
 
 class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParameters with HasPerfEvents {
-  val io = IO(new ICacheIO)
+  val io: ICacheIO = IO(new ICacheIO)
 
   println("ICache:")
   println("  TagECC: " + cacheParams.tagECC)
@@ -559,13 +573,13 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
 
   val (bus, edge) = outer.clientNode.out.head
 
-  val metaArray  = Module(new ICacheMetaArray)
-  val dataArray  = Module(new ICacheDataArray)
-  val mainPipe   = Module(new ICacheMainPipe)
-  val missUnit   = Module(new ICacheMissUnit(edge))
-  val replacer   = Module(new ICacheReplacer)
-  val prefetcher = Module(new IPrefetchPipe)
-  val wayLookup  = Module(new WayLookup)
+  private val metaArray  = Module(new ICacheMetaArray)
+  private val dataArray  = Module(new ICacheDataArray)
+  private val mainPipe   = Module(new ICacheMainPipe)
+  private val missUnit   = Module(new ICacheMissUnit(edge))
+  private val replacer   = Module(new ICacheReplacer)
+  private val prefetcher = Module(new IPrefetchPipe)
+  private val wayLookup  = Module(new WayLookup)
 
   dataArray.io.write <> missUnit.io.data_write
   dataArray.io.read <> mainPipe.io.dataArray.toIData
@@ -659,8 +673,8 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   bus.a <> missUnit.io.mem_acquire
 
   // Parity error port
-  val errors       = mainPipe.io.errors
-  val errors_valid = errors.map(e => e.valid).reduce(_ | _)
+  private val errors       = mainPipe.io.errors
+  private val errors_valid = errors.map(e => e.valid).reduce(_ | _)
   io.error.bits <> RegEnable(
     PriorityMux(errors.map(e => e.valid -> e.bits)),
     0.U.asTypeOf(errors(0).bits),
@@ -675,75 +689,80 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   XSPerfAccumulate("softPrefetch_drop_multi_req", PopCount(io.softPrefetch.map(_.valid)) > 1.U)
   XSPerfAccumulate("softPrefetch_block_ftq", softPrefetchValid && io.ftqPrefetch.req.valid)
 
-  val perfEvents = Seq(
+  val perfEvents: Seq[(String, Bool)] = Seq(
     ("icache_miss_cnt  ", false.B),
     ("icache_miss_penalty", BoolStopWatch(start = false.B, stop = false.B || false.B, startHighPriority = true))
   )
   generatePerfEvent()
 }
 
-class ICachePartWayReadBundle[T <: Data](gen: T, pWay: Int)(implicit p: Parameters)
-    extends ICacheBundle {
-  val req = Flipped(Vec(
-    PortNumber,
-    Decoupled(new Bundle {
-      val ridx = UInt((log2Ceil(nSets) - 1).W)
-    })
-  ))
-  val resp = Output(new Bundle {
-    val rdata = Vec(PortNumber, Vec(pWay, gen))
-  })
-}
+//class ICachePartWayReadBundle[T <: Data](gen: T, pWay: Int)(implicit p: Parameters)
+//    extends ICacheBundle {
+//  val req = Flipped(Vec(
+//    PortNumber,
+//    Decoupled(new Bundle {
+//      val ridx = UInt((log2Ceil(nSets) - 1).W)
+//    })
+//  ))
+//  val resp = Output(new Bundle {
+//    val rdata = Vec(PortNumber, Vec(pWay, gen))
+//  })
+//}
 
-class ICacheWriteBundle[T <: Data](gen: T, pWay: Int)(implicit p: Parameters)
-    extends ICacheBundle {
-  val wdata    = gen
-  val widx     = UInt((log2Ceil(nSets) - 1).W)
-  val wbankidx = Bool()
-  val wmask    = Vec(pWay, Bool())
-}
+//class ICacheWriteBundle[T <: Data](gen: T, pWay: Int)(implicit p: Parameters)
+//    extends ICacheBundle {
+//  val wdata    = gen
+//  val widx     = UInt((log2Ceil(nSets) - 1).W)
+//  val wbankidx = Bool()
+//  val wmask    = Vec(pWay, Bool())
+//}
 
-class ICachePartWayArray[T <: Data](gen: T, pWay: Int)(implicit p: Parameters) extends ICacheArray {
+//class ICachePartWayArray[T <: Data](gen: T, pWay: Int)(implicit p: Parameters) extends ICacheArray {
+//
+//  // including part way data
+//  val io = IO {
+//    new Bundle {
+//      val read  = new ICachePartWayReadBundle(gen, pWay)
+//      val write = Flipped(ValidIO(new ICacheWriteBundle(gen, pWay)))
+//    }
+//  }
+//
+//  io.read.req.map(_.ready := !io.write.valid)
+//
+//  val srams = (0 until PortNumber) map { bank =>
+//    val sramBank = Module(new SRAMTemplate(
+//      gen,
+//      set = nSets / 2,
+//      way = pWay,
+//      shouldReset = true,
+//      holdRead = true,
+//      singlePort = true,
+//      withClockGate = true
+//    ))
+//
+//    sramBank.io.r.req.valid := io.read.req(bank).valid
+//    sramBank.io.r.req.bits.apply(setIdx = io.read.req(bank).bits.ridx)
+//
+//    if (bank == 0) sramBank.io.w.req.valid := io.write.valid && !io.write.bits.wbankidx
+//    else sramBank.io.w.req.valid           := io.write.valid && io.write.bits.wbankidx
+//    sramBank.io.w.req.bits.apply(
+//      data = io.write.bits.wdata,
+//      setIdx = io.write.bits.widx,
+//      waymask = io.write.bits.wmask.asUInt
+//    )
+//
+//    sramBank
+//  }
+//
+//  io.read.req.map(_.ready := !io.write.valid && srams.map(_.io.r.req.ready).reduce(_ && _))
+//
+//  io.read.resp.rdata := VecInit(srams.map(bank => bank.io.r.resp.asTypeOf(Vec(pWay, gen))))
+//
+//}
 
-  // including part way data
-  val io = IO {
-    new Bundle {
-      val read  = new ICachePartWayReadBundle(gen, pWay)
-      val write = Flipped(ValidIO(new ICacheWriteBundle(gen, pWay)))
-    }
-  }
-
-  io.read.req.map(_.ready := !io.write.valid)
-
-  val srams = (0 until PortNumber) map { bank =>
-    val sramBank = Module(new SRAMTemplate(
-      gen,
-      set = nSets / 2,
-      way = pWay,
-      shouldReset = true,
-      holdRead = true,
-      singlePort = true,
-      withClockGate = true
-    ))
-
-    sramBank.io.r.req.valid := io.read.req(bank).valid
-    sramBank.io.r.req.bits.apply(setIdx = io.read.req(bank).bits.ridx)
-
-    if (bank == 0) sramBank.io.w.req.valid := io.write.valid && !io.write.bits.wbankidx
-    else sramBank.io.w.req.valid           := io.write.valid && io.write.bits.wbankidx
-    sramBank.io.w.req.bits.apply(
-      data = io.write.bits.wdata,
-      setIdx = io.write.bits.widx,
-      waymask = io.write.bits.wmask.asUInt
-    )
-
-    sramBank
-  }
-
-  io.read.req.map(_.ready := !io.write.valid && srams.map(_.io.r.req.ready).reduce(_ && _))
-
-  io.read.resp.rdata := VecInit(srams.map(bank => bank.io.r.resp.asTypeOf(Vec(pWay, gen))))
-
+class SRAMTemplateWithFixedWidthIO[T <: Data](gen: T, set: Int, way: Int) extends Bundle {
+  val r: SRAMReadBus[T]  = Flipped(new SRAMReadBus(gen, set, way))
+  val w: SRAMWriteBus[T] = Flipped(new SRAMWriteBus(gen, set, way))
 }
 
 // Automatically partition the SRAM based on the width of the data and the desired width.
@@ -760,23 +779,20 @@ class SRAMTemplateWithFixedWidth[T <: Data](
     withClockGate: Boolean = false
 ) extends Module {
 
-  val dataBits  = gen.getWidth
-  val bankNum   = math.ceil(dataBits.toDouble / width.toDouble).toInt
-  val totalBits = bankNum * width
+  private val dataBits  = gen.getWidth
+  private val bankNum   = math.ceil(dataBits.toDouble / width.toDouble).toInt
+  private val totalBits = bankNum * width
 
-  val io = IO(new Bundle {
-    val r = Flipped(new SRAMReadBus(gen, set, way))
-    val w = Flipped(new SRAMWriteBus(gen, set, way))
-  })
+  val io: SRAMTemplateWithFixedWidthIO[T] = IO(new SRAMTemplateWithFixedWidthIO(gen, set, way))
 
-  val wordType = UInt(width.W)
-  val writeDatas = (0 until bankNum).map(bank =>
-    VecInit((0 until way).map(i =>
+  private val wordType = UInt(width.W)
+  private val writeDatas = (0 until bankNum).map { bank =>
+    VecInit((0 until way).map { i =>
       io.w.req.bits.data(i).asTypeOf(UInt(totalBits.W)).asTypeOf(Vec(bankNum, wordType))(bank)
-    ))
-  )
+    })
+  }
 
-  val srams = (0 until bankNum) map { bank =>
+  private val srams = (0 until bankNum) map { bank =>
     val sramBank = Module(new SRAMTemplate(
       wordType,
       set = set,
@@ -795,7 +811,7 @@ class SRAMTemplateWithFixedWidth[T <: Data](
     sramBank.io.w.req.valid       := io.w.req.valid
     sramBank.io.w.req.bits.setIdx := io.w.req.bits.setIdx
     sramBank.io.w.req.bits.data   := writeDatas(bank)
-    sramBank.io.w.req.bits.waymask.map(_ := io.w.req.bits.waymask.get)
+    sramBank.io.w.req.bits.waymask.foreach(_ := io.w.req.bits.waymask.get)
 
     sramBank
   }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheBundle.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheBundle.scala
@@ -19,25 +19,20 @@ package xiangshan.frontend.icache
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.tilelink.ClientMetadata
-import freechips.rocketchip.tilelink.TLPermissions
 import org.chipsalliance.cde.config.Parameters
-import utility._
-import utils._
-import xiangshan._
 
 class ICacheReadBundle(implicit p: Parameters) extends ICacheBundle {
-  val vSetIdx      = Vec(2, UInt(log2Ceil(nSets).W))
-  val wayMask      = Vec(2, Vec(nWays, Bool()))
-  val blkOffset    = UInt(log2Ceil(blockBytes).W)
-  val isDoubleLine = Bool()
+  val vSetIdx:      Vec[UInt]      = Vec(2, UInt(idxBits.W))
+  val waymask:      Vec[Vec[Bool]] = Vec(2, Vec(nWays, Bool()))
+  val blkOffset:    UInt           = UInt(log2Ceil(blockBytes).W)
+  val isDoubleLine: Bool           = Bool()
 }
 
 class ICacheMetaWriteBundle(implicit p: Parameters) extends ICacheBundle {
-  val virIdx  = UInt(idxBits.W)
-  val phyTag  = UInt(tagBits.W)
-  val waymask = UInt(nWays.W)
-  val bankIdx = Bool()
+  val virIdx:  UInt = UInt(idxBits.W)
+  val phyTag:  UInt = UInt(tagBits.W)
+  val waymask: UInt = UInt(nWays.W)
+  val bankIdx: Bool = Bool()
 
   def generate(tag: UInt, idx: UInt, waymask: UInt, bankIdx: Bool): Unit = {
     this.virIdx  := idx
@@ -48,15 +43,15 @@ class ICacheMetaWriteBundle(implicit p: Parameters) extends ICacheBundle {
 }
 
 class ICacheMetaFlushBundle(implicit p: Parameters) extends ICacheBundle {
-  val virIdx  = UInt(idxBits.W)
-  val waymask = UInt(nWays.W)
+  val virIdx:  UInt = UInt(idxBits.W)
+  val waymask: UInt = UInt(nWays.W)
 }
 
 class ICacheDataWriteBundle(implicit p: Parameters) extends ICacheBundle {
-  val virIdx  = UInt(idxBits.W)
-  val data    = UInt(blockBits.W)
-  val waymask = UInt(nWays.W)
-  val bankIdx = Bool()
+  val virIdx:  UInt = UInt(idxBits.W)
+  val data:    UInt = UInt(blockBits.W)
+  val waymask: UInt = UInt(nWays.W)
+  val bankIdx: Bool = Bool()
 
   def generate(data: UInt, idx: UInt, waymask: UInt, bankIdx: Bool): Unit = {
     this.virIdx  := idx
@@ -67,25 +62,25 @@ class ICacheDataWriteBundle(implicit p: Parameters) extends ICacheBundle {
 }
 
 class ICacheMetaRespBundle(implicit p: Parameters) extends ICacheBundle {
-  val metas      = Vec(PortNumber, Vec(nWays, new ICacheMetadata))
-  val codes      = Vec(PortNumber, Vec(nWays, UInt(ICacheMetaCodeBits.W)))
-  val entryValid = Vec(PortNumber, Vec(nWays, Bool()))
+  val metas:      Vec[Vec[ICacheMetadata]] = Vec(PortNumber, Vec(nWays, new ICacheMetadata))
+  val codes:      Vec[Vec[UInt]]           = Vec(PortNumber, Vec(nWays, UInt(ICacheMetaCodeBits.W)))
+  val entryValid: Vec[Vec[Bool]]           = Vec(PortNumber, Vec(nWays, Bool()))
 
   // for compatibility
-  def tags = VecInit(metas.map(port => VecInit(port.map(way => way.tag))))
+  def tags: Vec[Vec[UInt]] = VecInit(metas.map(port => VecInit(port.map(way => way.tag))))
 }
 
 class ICacheDataRespBundle(implicit p: Parameters) extends ICacheBundle {
-  val datas = Vec(ICacheDataBanks, UInt(ICacheDataBits.W))
-  val codes = Vec(ICacheDataBanks, UInt(ICacheDataCodeBits.W))
+  val datas: Vec[UInt] = Vec(ICacheDataBanks, UInt(ICacheDataBits.W))
+  val codes: Vec[UInt] = Vec(ICacheDataBanks, UInt(ICacheDataCodeBits.W))
 }
 
 class ReplacerTouch(implicit p: Parameters) extends ICacheBundle {
-  val vSetIdx = UInt(log2Ceil(nSets).W)
-  val way     = UInt(log2Ceil(nWays).W)
+  val vSetIdx: UInt = UInt(idxBits.W)
+  val way:     UInt = UInt(wayBits.W)
 }
 
 class ReplacerVictim(implicit p: Parameters) extends ICacheBundle {
-  val vSetIdx = ValidIO(UInt(log2Ceil(nSets).W))
-  val way     = Input(UInt(log2Ceil(nWays).W))
+  val vSetIdx: Valid[UInt] = ValidIO(UInt(idxBits.W))
+  val way:     UInt        = Input(UInt(wayBits.W))
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -19,134 +19,134 @@ package xiangshan.frontend.icache
 import chisel3._
 import chisel3.util._
 import difftest._
-import freechips.rocketchip.tilelink.ClientStates
 import org.chipsalliance.cde.config.Parameters
 import utility._
-import utils._
 import xiangshan._
 import xiangshan.backend.fu.PMPReqBundle
 import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.cache.mmu._
 import xiangshan.frontend.ExceptionType
-import xiangshan.frontend.FtqICacheInfo
 import xiangshan.frontend.FtqToICacheRequestBundle
 
-class ICacheMainPipeReq(implicit p: Parameters) extends ICacheBundle {
-  val vaddr   = UInt(VAddrBits.W)
-  def vSetIdx = get_idx(vaddr)
-}
-
 class ICacheMainPipeResp(implicit p: Parameters) extends ICacheBundle {
-  val doubleline       = Bool()
-  val vaddr            = Vec(PortNumber, UInt(VAddrBits.W))
-  val data             = UInt(blockBits.W)
-  val paddr            = Vec(PortNumber, UInt(PAddrBits.W))
-  val exception        = Vec(PortNumber, UInt(ExceptionType.width.W))
-  val pmp_mmio         = Vec(PortNumber, Bool())
-  val itlb_pbmt        = Vec(PortNumber, UInt(Pbmt.width.W))
-  val backendException = Bool()
+  val doubleline:       Bool      = Bool()
+  val vaddr:            Vec[UInt] = Vec(PortNumber, UInt(VAddrBits.W))
+  val data:             UInt      = UInt(blockBits.W)
+  val paddr:            Vec[UInt] = Vec(PortNumber, UInt(PAddrBits.W))
+  val exception:        Vec[UInt] = Vec(PortNumber, UInt(ExceptionType.width.W))
+  val pmp_mmio:         Vec[Bool] = Vec(PortNumber, Bool())
+  val itlb_pbmt:        Vec[UInt] = Vec(PortNumber, UInt(Pbmt.width.W))
+  val backendException: Bool      = Bool()
   /* NOTE: GPAddrBits(=50bit) is not enough for gpaddr here, refer to PR#3795
    * Sv48*4 only allows 50bit gpaddr, when software violates this requirement
    * it needs to fill the mtval2 register with the full XLEN(=64bit) gpaddr,
    * PAddrBitsMax(=56bit currently) is required for the frontend datapath due to the itlb ppn length limitation
    * (cases 56<x<=64 are handled by the backend datapath)
    */
-  val gpaddr            = UInt(PAddrBitsMax.W)
-  val isForVSnonLeafPTE = Bool()
+  val gpaddr:            UInt = UInt(PAddrBitsMax.W)
+  val isForVSnonLeafPTE: Bool = Bool()
 }
 
 class ICacheMainPipeBundle(implicit p: Parameters) extends ICacheBundle {
-  val req               = Flipped(Decoupled(new FtqToICacheRequestBundle))
-  val resp              = ValidIO(new ICacheMainPipeResp)
-  val topdownIcacheMiss = Output(Bool())
-  val topdownItlbMiss   = Output(Bool())
+  val req:               DecoupledIO[FtqToICacheRequestBundle] = Flipped(DecoupledIO(new FtqToICacheRequestBundle))
+  val resp:              Valid[ICacheMainPipeResp]             = ValidIO(new ICacheMainPipeResp)
+  val topdownIcacheMiss: Bool                                  = Output(Bool())
+  val topdownItlbMiss:   Bool                                  = Output(Bool())
 }
 
 class ICacheMetaReqBundle(implicit p: Parameters) extends ICacheBundle {
-  val toIMeta   = DecoupledIO(new ICacheReadBundle)
-  val fromIMeta = Input(new ICacheMetaRespBundle)
+  val toIMeta:   DecoupledIO[ICacheReadBundle] = DecoupledIO(new ICacheReadBundle)
+  val fromIMeta: ICacheMetaRespBundle          = Input(new ICacheMetaRespBundle)
 }
 
 class ICacheDataReqBundle(implicit p: Parameters) extends ICacheBundle {
-  val toIData   = Vec(partWayNum, DecoupledIO(new ICacheReadBundle))
-  val fromIData = Input(new ICacheDataRespBundle)
+  val toIData:   Vec[DecoupledIO[ICacheReadBundle]] = Vec(partWayNum, DecoupledIO(new ICacheReadBundle))
+  val fromIData: ICacheDataRespBundle               = Input(new ICacheDataRespBundle)
 }
 
 class ICacheMSHRBundle(implicit p: Parameters) extends ICacheBundle {
-  val req  = Decoupled(new ICacheMissReq)
-  val resp = Flipped(ValidIO(new ICacheMissResp))
+  val req:  DecoupledIO[ICacheMissReq] = DecoupledIO(new ICacheMissReq)
+  val resp: Valid[ICacheMissResp]      = Flipped(ValidIO(new ICacheMissResp))
 }
 
 class ICachePMPBundle(implicit p: Parameters) extends ICacheBundle {
-  val req  = Valid(new PMPReqBundle())
-  val resp = Input(new PMPRespBundle())
+  val req:  Valid[PMPReqBundle] = ValidIO(new PMPReqBundle())
+  val resp: PMPRespBundle       = Input(new PMPRespBundle())
 }
 
 class ICachePerfInfo(implicit p: Parameters) extends ICacheBundle {
-  val only_0_hit      = Bool()
-  val only_0_miss     = Bool()
-  val hit_0_hit_1     = Bool()
-  val hit_0_miss_1    = Bool()
-  val miss_0_hit_1    = Bool()
-  val miss_0_miss_1   = Bool()
-  val hit_0_except_1  = Bool()
-  val miss_0_except_1 = Bool()
-  val except_0        = Bool()
-  val bank_hit        = Vec(2, Bool())
-  val hit             = Bool()
+  val only_0_hit:      Bool      = Bool()
+  val only_0_miss:     Bool      = Bool()
+  val hit_0_hit_1:     Bool      = Bool()
+  val hit_0_miss_1:    Bool      = Bool()
+  val miss_0_hit_1:    Bool      = Bool()
+  val miss_0_miss_1:   Bool      = Bool()
+  val hit_0_except_1:  Bool      = Bool()
+  val miss_0_except_1: Bool      = Bool()
+  val except_0:        Bool      = Bool()
+  val bank_hit:        Vec[Bool] = Vec(PortNumber, Bool())
+  val hit:             Bool      = Bool()
 }
 
 class ICacheMainPipeInterface(implicit p: Parameters) extends ICacheBundle {
-  val hartId = Input(UInt(hartIdLen.W))
+  val hartId: UInt = Input(UInt(hartIdLen.W))
 
   /*** internal interface ***/
-  val dataArray      = new ICacheDataReqBundle
-  val metaArrayFlush = Vec(PortNumber, ValidIO(new ICacheMetaFlushBundle))
-
-  /** prefetch io */
-  val touch         = Vec(PortNumber, ValidIO(new ReplacerTouch))
-  val wayLookupRead = Flipped(DecoupledIO(new WayLookupInfo))
-
-  val mshr   = new ICacheMSHRBundle
-  val errors = Output(Vec(PortNumber, ValidIO(new L1CacheErrorInfo)))
+  val dataArray:      ICacheDataReqBundle               = new ICacheDataReqBundle
+  val metaArrayFlush: Vec[Valid[ICacheMetaFlushBundle]] = Vec(PortNumber, ValidIO(new ICacheMetaFlushBundle))
+  val touch:          Vec[Valid[ReplacerTouch]]         = Vec(PortNumber, ValidIO(new ReplacerTouch))
+  val wayLookupRead:  DecoupledIO[WayLookupInfo]        = Flipped(DecoupledIO(new WayLookupInfo))
+  val mshr:           ICacheMSHRBundle                  = new ICacheMSHRBundle
 
   /*** outside interface ***/
-  // val fetch       = Vec(PortNumber, new ICacheMainPipeBundle)
-  /* when ftq.valid is high in T + 1 cycle
-   * the ftq component must be valid in T cycle
-   */
-  val fetch     = new ICacheMainPipeBundle
-  val pmp       = Vec(PortNumber, new ICachePMPBundle)
-  val respStall = Input(Bool())
+  // FTQ
+  val fetch: ICacheMainPipeBundle = new ICacheMainPipeBundle
+  val flush: Bool                 = Input(Bool())
+  // PMP
+  val pmp: Vec[ICachePMPBundle] = Vec(PortNumber, new ICachePMPBundle)
+  // IFU
+  val respStall: Bool = Input(Bool())
+  // backend/BEU
+  val errors: Vec[Valid[L1CacheErrorInfo]] = Output(Vec(PortNumber, ValidIO(new L1CacheErrorInfo)))
+  // backend/CSR
+  val csr_parity_enable: Bool = Input(Bool())
 
-  val csr_parity_enable = Input(Bool())
-  val flush             = Input(Bool())
-
-  val perfInfo = Output(new ICachePerfInfo)
+  /*** PERF ***/
+  val perfInfo: ICachePerfInfo = Output(new ICachePerfInfo)
 }
 
-class ICacheDB(implicit p: Parameters) extends ICacheBundle {
-  val blk_vaddr = UInt((VAddrBits - blockOffBits).W)
-  val blk_paddr = UInt((PAddrBits - blockOffBits).W)
-  val hit       = Bool()
-}
+//class ICacheDB(implicit p: Parameters) extends ICacheBundle {
+//  val blk_vaddr: UInt = UInt((VAddrBits - blockOffBits).W)
+//  val blk_paddr: UInt = UInt((PAddrBits - blockOffBits).W)
+//  val hit:       Bool = Bool()
+//}
 
 class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
-  val io = IO(new ICacheMainPipeInterface)
+  val io: ICacheMainPipeInterface = IO(new ICacheMainPipeInterface)
 
   /** Input/Output port */
-  val (fromFtq, toIFU)   = (io.fetch.req, io.fetch.resp)
-  val (toData, fromData) = (io.dataArray.toIData, io.dataArray.fromIData)
-  val toMetaFlush        = io.metaArrayFlush
-  val (toMSHR, fromMSHR) = (io.mshr.req, io.mshr.resp)
-  val (toPMP, fromPMP)   = (io.pmp.map(_.req), io.pmp.map(_.resp))
-  val fromWayLookup      = io.wayLookupRead
-  val csr_parity_enable  = if (ICacheForceMetaECCError || ICacheForceDataECCError) true.B else io.csr_parity_enable
+  private val (fromFtq, toIFU)   = (io.fetch.req, io.fetch.resp)
+  private val (toData, fromData) = (io.dataArray.toIData, io.dataArray.fromIData)
+  private val toMetaFlush        = io.metaArrayFlush
+  private val (toMSHR, fromMSHR) = (io.mshr.req, io.mshr.resp)
+  private val (toPMP, fromPMP)   = (io.pmp.map(_.req), io.pmp.map(_.resp))
+  private val fromWayLookup      = io.wayLookupRead
+  private val csr_parity_enable =
+    if (ICacheForceMetaECCError || ICacheForceDataECCError) true.B else io.csr_parity_enable
 
   // Statistics on the frequency distribution of FTQ fire interval
-  val cntFtqFireInterval = RegInit(0.U(32.W))
+  private val cntFtqFireInterval      = RegInit(0.U(32.W))
+  private val cntFtqFireIntervalStart = 1
+  private val cntFtqFireIntervalEnd   = 300
   cntFtqFireInterval := Mux(fromFtq.fire, 1.U, cntFtqFireInterval + 1.U)
-  XSPerfHistogram("ftq2icache_fire", cntFtqFireInterval, fromFtq.fire, 1, 300, 1, right_strict = true)
+  XSPerfHistogram(
+    "ftq2icache_fire",
+    cntFtqFireInterval,
+    fromFtq.fire,
+    cntFtqFireIntervalStart,
+    cntFtqFireIntervalEnd,
+    right_strict = true
+  )
 
   /** pipeline control signal */
   val s1_ready, s2_ready           = Wire(Bool())
@@ -164,20 +164,21 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
   /** s0 control */
   // 0,1,2,3 -> dataArray(data); 4 -> mainPipe
   // Ftq RegNext Register
-  val fromFtqReq       = fromFtq.bits.pcMemRead
-  val s0_valid         = fromFtq.valid
-  val s0_req_valid_all = (0 until partWayNum + 1).map(i => fromFtq.bits.readValid(i))
-  val s0_req_vaddr_all =
+  private val fromFtqReq       = fromFtq.bits.pcMemRead
+  private val s0_valid         = fromFtq.valid
+  private val s0_req_valid_all = (0 until partWayNum + 1).map(i => fromFtq.bits.readValid(i))
+  private val s0_req_vaddr_all =
     (0 until partWayNum + 1).map(i => VecInit(Seq(fromFtqReq(i).startAddr, fromFtqReq(i).nextlineStart)))
-  val s0_req_vSetIdx_all = (0 until partWayNum + 1).map(i => VecInit(s0_req_vaddr_all(i).map(get_idx)))
-  val s0_req_offset_all  = (0 until partWayNum + 1).map(i => s0_req_vaddr_all(i)(0)(log2Ceil(blockBytes) - 1, 0))
-  val s0_doubleline_all  = (0 until partWayNum + 1).map(i => fromFtq.bits.readValid(i) && fromFtqReq(i).crossCacheline)
+  private val s0_req_vSetIdx_all = (0 until partWayNum + 1).map(i => VecInit(s0_req_vaddr_all(i).map(get_idx)))
+  private val s0_req_offset_all = (0 until partWayNum + 1).map(i => s0_req_vaddr_all(i)(0)(log2Ceil(blockBytes) - 1, 0))
+  private val s0_doubleline_all =
+    (0 until partWayNum + 1).map(i => fromFtq.bits.readValid(i) && fromFtqReq(i).crossCacheline)
 
-  val s0_req_vaddr   = s0_req_vaddr_all.last
-  val s0_req_vSetIdx = s0_req_vSetIdx_all.last
-  val s0_doubleline  = s0_doubleline_all.last
+  private val s0_req_vaddr   = s0_req_vaddr_all.last
+  private val s0_req_vSetIdx = s0_req_vSetIdx_all.last
+  private val s0_doubleline  = s0_doubleline_all.last
 
-  val s0_backendException = fromFtq.bits.backendException
+  private val s0_backendException = fromFtq.bits.backendException
 
   /**
     ******************************************************************************
@@ -185,19 +186,19 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     ******************************************************************************
     */
   fromWayLookup.ready := s0_fire
-  val s0_waymasks              = VecInit(fromWayLookup.bits.waymask.map(_.asTypeOf(Vec(nWays, Bool()))))
-  val s0_req_ptags             = fromWayLookup.bits.ptag
-  val s0_req_gpaddr            = fromWayLookup.bits.gpaddr
-  val s0_req_isForVSnonLeafPTE = fromWayLookup.bits.isForVSnonLeafPTE
-  val s0_itlb_exception        = fromWayLookup.bits.itlb_exception
-  val s0_itlb_pbmt             = fromWayLookup.bits.itlb_pbmt
-  val s0_meta_codes            = fromWayLookup.bits.meta_codes
-  val s0_hits                  = VecInit(fromWayLookup.bits.waymask.map(_.orR))
+  private val s0_waymasks              = VecInit(fromWayLookup.bits.waymask.map(_.asTypeOf(Vec(nWays, Bool()))))
+  private val s0_req_ptags             = fromWayLookup.bits.ptag
+  private val s0_req_gpaddr            = fromWayLookup.bits.gpaddr
+  private val s0_req_isForVSnonLeafPTE = fromWayLookup.bits.isForVSnonLeafPTE
+  private val s0_itlb_exception        = fromWayLookup.bits.itlb_exception
+  private val s0_itlb_pbmt             = fromWayLookup.bits.itlb_pbmt
+  private val s0_meta_codes            = fromWayLookup.bits.meta_codes
+  private val s0_hits                  = VecInit(fromWayLookup.bits.waymask.map(_.orR))
 
   when(s0_fire) {
     assert(
       (0 until PortNumber).map(i => s0_req_vSetIdx(i) === fromWayLookup.bits.vSetIdx(i)).reduce(_ && _),
-      "vSetIdxs from ftq and wayLookup are different! vaddr0=0x%x ftq: vidx0=0x%x vidx1=0x%x wayLookup: vidx0=0x%x vidx1=0x%x",
+      "vSetIdx from ftq and wayLookup mismatch! vaddr=0x%x ftq: vSet0=0x%x vSet1=0x%x wayLookup: vSet0=0x%x vSet1=0x%x",
       s0_req_vaddr(0),
       s0_req_vSetIdx(0),
       s0_req_vSetIdx(1),
@@ -211,15 +212,15 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     * data SRAM request
     ******************************************************************************
     */
-  for (i <- 0 until partWayNum) {
+  (0 until partWayNum).foreach { i =>
     toData(i).valid             := s0_req_valid_all(i)
     toData(i).bits.isDoubleLine := s0_doubleline_all(i)
     toData(i).bits.vSetIdx      := s0_req_vSetIdx_all(i)
     toData(i).bits.blkOffset    := s0_req_offset_all(i)
-    toData(i).bits.wayMask      := s0_waymasks
+    toData(i).bits.waymask      := s0_waymasks
   }
 
-  val s0_can_go = toData.last.ready && fromWayLookup.valid && s1_ready
+  private val s0_can_go = toData.last.ready && fromWayLookup.valid && s1_ready
   s0_flush := io.flush
   s0_fire  := s0_valid && s0_can_go && !s0_flush
 
@@ -233,30 +234,33 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     * - monitor missUint response port
     ******************************************************************************
     */
-  val s1_valid = generatePipeControl(lastFire = s0_fire, thisFire = s1_fire, thisFlush = s1_flush, lastFlush = false.B)
+  private val s1_valid =
+    generatePipeControl(lastFire = s0_fire, thisFire = s1_fire, thisFlush = s1_flush, lastFlush = false.B)
 
-  val s1_req_vaddr             = RegEnable(s0_req_vaddr, 0.U.asTypeOf(s0_req_vaddr), s0_fire)
-  val s1_req_ptags             = RegEnable(s0_req_ptags, 0.U.asTypeOf(s0_req_ptags), s0_fire)
-  val s1_req_gpaddr            = RegEnable(s0_req_gpaddr, 0.U.asTypeOf(s0_req_gpaddr), s0_fire)
-  val s1_req_isForVSnonLeafPTE = RegEnable(s0_req_isForVSnonLeafPTE, 0.U.asTypeOf(s0_req_isForVSnonLeafPTE), s0_fire)
-  val s1_doubleline            = RegEnable(s0_doubleline, 0.U.asTypeOf(s0_doubleline), s0_fire)
-  val s1_SRAMhits              = RegEnable(s0_hits, 0.U.asTypeOf(s0_hits), s0_fire)
-  val s1_itlb_exception        = RegEnable(s0_itlb_exception, 0.U.asTypeOf(s0_itlb_exception), s0_fire)
-  val s1_backendException      = RegEnable(s0_backendException, false.B, s0_fire)
-  val s1_itlb_pbmt             = RegEnable(s0_itlb_pbmt, 0.U.asTypeOf(s0_itlb_pbmt), s0_fire)
-  val s1_waymasks              = RegEnable(s0_waymasks, 0.U.asTypeOf(s0_waymasks), s0_fire)
-  val s1_meta_codes            = RegEnable(s0_meta_codes, 0.U.asTypeOf(s0_meta_codes), s0_fire)
+  private val s1_req_vaddr  = RegEnable(s0_req_vaddr, 0.U.asTypeOf(s0_req_vaddr), s0_fire)
+  private val s1_req_ptags  = RegEnable(s0_req_ptags, 0.U.asTypeOf(s0_req_ptags), s0_fire)
+  private val s1_req_gpaddr = RegEnable(s0_req_gpaddr, 0.U.asTypeOf(s0_req_gpaddr), s0_fire)
+  private val s1_req_isForVSnonLeafPTE =
+    RegEnable(s0_req_isForVSnonLeafPTE, 0.U.asTypeOf(s0_req_isForVSnonLeafPTE), s0_fire)
+  private val s1_doubleline       = RegEnable(s0_doubleline, 0.U.asTypeOf(s0_doubleline), s0_fire)
+  private val s1_SRAMhits         = RegEnable(s0_hits, 0.U.asTypeOf(s0_hits), s0_fire)
+  private val s1_itlb_exception   = RegEnable(s0_itlb_exception, 0.U.asTypeOf(s0_itlb_exception), s0_fire)
+  private val s1_backendException = RegEnable(s0_backendException, false.B, s0_fire)
+  private val s1_itlb_pbmt        = RegEnable(s0_itlb_pbmt, 0.U.asTypeOf(s0_itlb_pbmt), s0_fire)
+  private val s1_waymasks         = RegEnable(s0_waymasks, 0.U.asTypeOf(s0_waymasks), s0_fire)
+  private val s1_meta_codes       = RegEnable(s0_meta_codes, 0.U.asTypeOf(s0_meta_codes), s0_fire)
 
-  val s1_req_vSetIdx = s1_req_vaddr.map(get_idx)
-  val s1_req_paddr   = s1_req_vaddr.zip(s1_req_ptags).map { case (vaddr, ptag) => get_paddr_from_ptag(vaddr, ptag) }
-  val s1_req_offset  = s1_req_vaddr(0)(log2Ceil(blockBytes) - 1, 0)
+  private val s1_req_vSetIdx = s1_req_vaddr.map(get_idx)
+  private val s1_req_paddr   = getPaddrFromPtag(s1_req_vaddr, s1_req_ptags)
+  private val s1_req_offset  = s1_req_vaddr(0)(log2Ceil(blockBytes) - 1, 0)
 
   // do metaArray ECC check
-  val s1_meta_corrupt = VecInit((s1_req_ptags zip s1_meta_codes zip s1_waymasks).map { case ((meta, code), waymask) =>
-    val hit_num = PopCount(waymask)
-    // NOTE: if not hit, encodeMetaECC(meta) =/= code can also be true, but we don't care about it
-    (encodeMetaECC(meta) =/= code && hit_num === 1.U) || // hit one way, but parity code does not match, ECC failure
-    hit_num > 1.U                                        // hit multi way, must be a ECC failure
+  private val s1_meta_corrupt = VecInit((s1_req_ptags zip s1_meta_codes zip s1_waymasks).map {
+    case ((meta, code), waymask) =>
+      val hit_num = PopCount(waymask)
+      // NOTE: if not hit, encodeMetaECC(meta) =/= code can also be true, but we don't care about it
+      (encodeMetaECC(meta) =/= code && hit_num === 1.U) || // hit one way, but parity code does not match, ECC failure
+      hit_num > 1.U                                        // hit multi-way, must be an ECC failure
   })
   // force clear meta_corrupt when parity check is disabled
   when(!csr_parity_enable) {
@@ -281,17 +285,17 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     ******************************************************************************
     */
   toPMP.zipWithIndex.foreach { case (p, i) =>
-    // if itlb has exception, paddr can be invalid, therefore pmp check can be skipped
+    // if itlb has exception, paddr can be invalid, therefore pmp check can be skipped do not do this now for timing
     p.valid     := s1_valid // && !ExceptionType.hasException(s1_itlb_exception(i))
     p.bits.addr := s1_req_paddr(i)
-    p.bits.size := 3.U      // TODO
+    p.bits.size := 3.U
     p.bits.cmd  := TlbCmd.exec
   }
-  val s1_pmp_exception = VecInit(fromPMP.map(ExceptionType.fromPMPResp))
-  val s1_pmp_mmio      = VecInit(fromPMP.map(_.mmio))
+  private val s1_pmp_exception = VecInit(fromPMP.map(ExceptionType.fromPMPResp))
+  private val s1_pmp_mmio      = VecInit(fromPMP.map(_.mmio))
 
   // merge s1 itlb/pmp exceptions, itlb has the highest priority, pmp next
-  val s1_exception_out = ExceptionType.merge(
+  private val s1_exception_out = ExceptionType.merge(
     s1_itlb_exception,
     s1_pmp_exception
   )
@@ -301,30 +305,30 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     * select data from MSHR, SRAM
     ******************************************************************************
     */
-  val s1_MSHR_match = VecInit((0 until PortNumber).map(i =>
+  private val s1_MSHR_match = VecInit((0 until PortNumber).map { i =>
     (s1_req_vSetIdx(i) === fromMSHR.bits.vSetIdx) &&
-      (s1_req_ptags(i) === getPhyTagFromBlk(fromMSHR.bits.blkPaddr)) &&
-      fromMSHR.valid && !fromMSHR.bits.corrupt
-  ))
-  val s1_MSHR_hits  = Seq(s1_valid && s1_MSHR_match(0), s1_valid && (s1_MSHR_match(1) && s1_doubleline))
-  val s1_MSHR_datas = fromMSHR.bits.data.asTypeOf(Vec(ICacheDataBanks, UInt((blockBits / ICacheDataBanks).W)))
+    (s1_req_ptags(i) === getPhyTagFromBlk(fromMSHR.bits.blkPaddr)) &&
+    fromMSHR.valid && !fromMSHR.bits.corrupt
+  })
+  private val s1_MSHR_hits  = Seq(s1_valid && s1_MSHR_match(0), s1_valid && (s1_MSHR_match(1) && s1_doubleline))
+  private val s1_MSHR_datas = fromMSHR.bits.data.asTypeOf(Vec(ICacheDataBanks, UInt((blockBits / ICacheDataBanks).W)))
 
-  val s1_hits = (0 until PortNumber).map(i =>
+  private val s1_hits = (0 until PortNumber).map { i =>
     ValidHoldBypass(s1_MSHR_hits(i) || (RegNext(s0_fire) && s1_SRAMhits(i)), s1_fire || s1_flush)
-  )
+  }
 
-  val s1_bankIdxLow = s1_req_offset >> log2Ceil(blockBytes / ICacheDataBanks)
-  val s1_bankMSHRHit = VecInit((0 until ICacheDataBanks).map(i =>
+  private val s1_bankIdxLow = (s1_req_offset >> log2Ceil(blockBytes / ICacheDataBanks)).asUInt
+  private val s1_bankMSHRHit = VecInit((0 until ICacheDataBanks).map { i =>
     (i.U >= s1_bankIdxLow) && s1_MSHR_hits(0) ||
-      (i.U < s1_bankIdxLow) && s1_MSHR_hits(1)
-  ))
-  val s1_datas = VecInit((0 until ICacheDataBanks).map(i =>
+    (i.U < s1_bankIdxLow) && s1_MSHR_hits(1)
+  })
+  private val s1_datas = VecInit((0 until ICacheDataBanks).map { i =>
     DataHoldBypass(Mux(s1_bankMSHRHit(i), s1_MSHR_datas(i), fromData.datas(i)), s1_bankMSHRHit(i) || RegNext(s0_fire))
-  ))
-  val s1_data_is_from_MSHR = VecInit((0 until ICacheDataBanks).map(i =>
+  })
+  private val s1_data_is_from_MSHR = VecInit((0 until ICacheDataBanks).map { i =>
     DataHoldBypass(s1_bankMSHRHit(i), s1_bankMSHRHit(i) || RegNext(s0_fire))
-  ))
-  val s1_codes = DataHoldBypass(fromData.codes, RegNext(s0_fire))
+  })
+  private val s1_codes = DataHoldBypass(fromData.codes, RegNext(s0_fire))
 
   s1_flush := io.flush
   s1_ready := s2_ready || !s1_valid
@@ -339,28 +343,30 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     ******************************************************************************
     */
 
-  val s2_valid = generatePipeControl(lastFire = s1_fire, thisFire = s2_fire, thisFlush = s2_flush, lastFlush = false.B)
+  private val s2_valid =
+    generatePipeControl(lastFire = s1_fire, thisFire = s2_fire, thisFlush = s2_flush, lastFlush = false.B)
 
-  val s2_req_vaddr             = RegEnable(s1_req_vaddr, 0.U.asTypeOf(s1_req_vaddr), s1_fire)
-  val s2_req_ptags             = RegEnable(s1_req_ptags, 0.U.asTypeOf(s1_req_ptags), s1_fire)
-  val s2_req_gpaddr            = RegEnable(s1_req_gpaddr, 0.U.asTypeOf(s1_req_gpaddr), s1_fire)
-  val s2_req_isForVSnonLeafPTE = RegEnable(s1_req_isForVSnonLeafPTE, 0.U.asTypeOf(s1_req_isForVSnonLeafPTE), s1_fire)
-  val s2_doubleline            = RegEnable(s1_doubleline, 0.U.asTypeOf(s1_doubleline), s1_fire)
-  val s2_exception             = RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_fire)
-  val s2_backendException      = RegEnable(s1_backendException, false.B, s1_fire)
-  val s2_pmp_mmio              = RegEnable(s1_pmp_mmio, 0.U.asTypeOf(s1_pmp_mmio), s1_fire)
-  val s2_itlb_pbmt             = RegEnable(s1_itlb_pbmt, 0.U.asTypeOf(s1_itlb_pbmt), s1_fire)
-  val s2_waymasks              = RegEnable(s1_waymasks, 0.U.asTypeOf(s1_waymasks), s1_fire)
+  private val s2_req_vaddr  = RegEnable(s1_req_vaddr, 0.U.asTypeOf(s1_req_vaddr), s1_fire)
+  private val s2_req_ptags  = RegEnable(s1_req_ptags, 0.U.asTypeOf(s1_req_ptags), s1_fire)
+  private val s2_req_gpaddr = RegEnable(s1_req_gpaddr, 0.U.asTypeOf(s1_req_gpaddr), s1_fire)
+  private val s2_req_isForVSnonLeafPTE =
+    RegEnable(s1_req_isForVSnonLeafPTE, 0.U.asTypeOf(s1_req_isForVSnonLeafPTE), s1_fire)
+  private val s2_doubleline       = RegEnable(s1_doubleline, 0.U.asTypeOf(s1_doubleline), s1_fire)
+  private val s2_exception        = RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_fire)
+  private val s2_backendException = RegEnable(s1_backendException, false.B, s1_fire)
+  private val s2_pmp_mmio         = RegEnable(s1_pmp_mmio, 0.U.asTypeOf(s1_pmp_mmio), s1_fire)
+  private val s2_itlb_pbmt        = RegEnable(s1_itlb_pbmt, 0.U.asTypeOf(s1_itlb_pbmt), s1_fire)
+  private val s2_waymasks         = RegEnable(s1_waymasks, 0.U.asTypeOf(s1_waymasks), s1_fire)
 
-  val s2_req_vSetIdx = s2_req_vaddr.map(get_idx)
-  val s2_req_offset  = s2_req_vaddr(0)(log2Ceil(blockBytes) - 1, 0)
-  val s2_req_paddr   = s2_req_vaddr.zip(s2_req_ptags).map { case (vaddr, ptag) => get_paddr_from_ptag(vaddr, ptag) }
+  private val s2_req_vSetIdx = s2_req_vaddr.map(get_idx)
+  private val s2_req_offset  = s2_req_vaddr(0)(log2Ceil(blockBytes) - 1, 0)
+  private val s2_req_paddr   = getPaddrFromPtag(s2_req_vaddr, s2_req_ptags)
 
-  val s2_SRAMhits          = RegEnable(s1_SRAMhits, 0.U.asTypeOf(s1_SRAMhits), s1_fire)
-  val s2_codes             = RegEnable(s1_codes, 0.U.asTypeOf(s1_codes), s1_fire)
-  val s2_hits              = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
-  val s2_datas             = RegInit(VecInit(Seq.fill(ICacheDataBanks)(0.U((blockBits / ICacheDataBanks).W))))
-  val s2_data_is_from_MSHR = RegInit(VecInit(Seq.fill(ICacheDataBanks)(false.B)))
+  private val s2_SRAMhits          = RegEnable(s1_SRAMhits, 0.U.asTypeOf(s1_SRAMhits), s1_fire)
+  private val s2_codes             = RegEnable(s1_codes, 0.U.asTypeOf(s1_codes), s1_fire)
+  private val s2_hits              = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
+  private val s2_datas             = RegInit(VecInit(Seq.fill(ICacheDataBanks)(0.U((blockBits / ICacheDataBanks).W))))
+  private val s2_data_is_from_MSHR = RegInit(VecInit(Seq.fill(ICacheDataBanks)(false.B)))
 
   /**
     ******************************************************************************
@@ -368,23 +374,23 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     ******************************************************************************
     */
   // check data error
-  val s2_bankSel      = getBankSel(s2_req_offset, s2_valid)
-  val s2_bank_corrupt = (0 until ICacheDataBanks).map(i => encodeDataECC(s2_datas(i)) =/= s2_codes(i))
+  private val s2_bankSel      = getBankSel(s2_req_offset, s2_valid)
+  private val s2_bank_corrupt = (0 until ICacheDataBanks).map(i => encodeDataECC(s2_datas(i)) =/= s2_codes(i))
   // if data is from MSHR, we don't need to check ECC
-  val s2_data_corrupt = VecInit((0 until PortNumber).map(port =>
-    (0 until ICacheDataBanks).map(bank =>
+  private val s2_data_corrupt = VecInit((0 until PortNumber).map { port =>
+    (0 until ICacheDataBanks).map { bank =>
       s2_bank_corrupt(bank) && s2_bankSel(port)(bank).asBool && !s2_data_is_from_MSHR(bank)
-    ).reduce(_ || _) && s2_SRAMhits(port)
-  ))
+    }.reduce(_ || _) && s2_SRAMhits(port)
+  })
   // force clear data_corrupt when parity check is disabled
   when(!csr_parity_enable) {
     s2_data_corrupt := VecInit(Seq.fill(PortNumber)(false.B))
   }
   // meta error is checked in s1 stage
-  val s2_meta_corrupt = RegEnable(s1_meta_corrupt, 0.U.asTypeOf(s1_meta_corrupt), s1_fire)
+  private val s2_meta_corrupt = RegEnable(s1_meta_corrupt, 0.U.asTypeOf(s1_meta_corrupt), s1_fire)
   // send errors to top
   // TODO: support RERI spec standard interface
-  (0 until PortNumber).map { i =>
+  (0 until PortNumber).foreach { i =>
     io.errors(i).valid              := (s2_meta_corrupt(i) || s2_data_corrupt(i)) && RegNext(s1_fire)
     io.errors(i).bits.report_to_beu := (s2_meta_corrupt(i) || s2_data_corrupt(i)) && RegNext(s1_fire)
     io.errors(i).bits.paddr         := s2_req_paddr(i)
@@ -419,18 +425,18 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     * monitor missUint response port
     ******************************************************************************
     */
-  val s2_MSHR_match = VecInit((0 until PortNumber).map(i =>
+  private val s2_MSHR_match = VecInit((0 until PortNumber).map { i =>
     (s2_req_vSetIdx(i) === fromMSHR.bits.vSetIdx) &&
-      (s2_req_ptags(i) === getPhyTagFromBlk(fromMSHR.bits.blkPaddr)) &&
-      fromMSHR.valid // we don't care about whether it's corrupt here
-  ))
-  val s2_MSHR_hits  = Seq(s2_valid && s2_MSHR_match(0), s2_valid && s2_MSHR_match(1) && s2_doubleline)
-  val s2_MSHR_datas = fromMSHR.bits.data.asTypeOf(Vec(ICacheDataBanks, UInt((blockBits / ICacheDataBanks).W)))
+    (s2_req_ptags(i) === getPhyTagFromBlk(fromMSHR.bits.blkPaddr)) &&
+    fromMSHR.valid // we don't care about whether it's corrupt here
+  })
+  private val s2_MSHR_hits  = Seq(s2_valid && s2_MSHR_match(0), s2_valid && s2_MSHR_match(1) && s2_doubleline)
+  private val s2_MSHR_datas = fromMSHR.bits.data.asTypeOf(Vec(ICacheDataBanks, UInt((blockBits / ICacheDataBanks).W)))
 
-  val s2_bankIdxLow = s2_req_offset >> log2Ceil(blockBytes / ICacheDataBanks)
-  val s2_bankMSHRHit = VecInit((0 until ICacheDataBanks).map(i =>
+  private val s2_bankIdxLow = (s2_req_offset >> log2Ceil(blockBytes / ICacheDataBanks)).asUInt
+  private val s2_bankMSHRHit = VecInit((0 until ICacheDataBanks).map { i =>
     ((i.U >= s2_bankIdxLow) && s2_MSHR_hits(0)) || ((i.U < s2_bankIdxLow) && s2_MSHR_hits(1))
-  ))
+  })
 
   (0 until ICacheDataBanks).foreach { i =>
     when(s1_fire) {
@@ -454,7 +460,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     }
   }
 
-  val s2_l2_corrupt = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
+  private val s2_l2_corrupt = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
   (0 until PortNumber).foreach { i =>
     when(s1_fire) {
       s2_l2_corrupt(i) := false.B
@@ -470,12 +476,12 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     */
 
   // merge pmp mmio and itlb pbmt
-  val s2_mmio = VecInit((s2_pmp_mmio zip s2_itlb_pbmt).map { case (mmio, pbmt) =>
+  private val s2_mmio = VecInit((s2_pmp_mmio zip s2_itlb_pbmt).map { case (mmio, pbmt) =>
     mmio || Pbmt.isUncache(pbmt)
   })
 
   // try re-fetch data from L2 cache if ECC error is detected, unless it's from MSHR
-  val s2_corrupt_refetch = (s2_meta_corrupt zip s2_data_corrupt).map {
+  private val s2_corrupt_refetch = (s2_meta_corrupt zip s2_data_corrupt).map {
     case (meta, data) => meta || data
   }
 
@@ -483,17 +489,17 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
    * mmio should not be fetched, it will be fetched by IFU mmio fsm
    * also, if previous has exception, latter port should also not be fetched
    */
-  val s2_should_fetch = VecInit((0 until PortNumber).map { i =>
+  private val s2_should_fetch = VecInit((0 until PortNumber).map { i =>
     (!s2_hits(i) || s2_corrupt_refetch(i)) &&
     (if (i == 0) true.B else s2_doubleline) &&
     !ExceptionType.hasException(s2_exception.take(i + 1)) &&
     s2_mmio.take(i + 1).map(!_).reduce(_ && _)
   })
 
-  val toMSHRArbiter = Module(new Arbiter(new ICacheMissReq, PortNumber))
+  private val toMSHRArbiter = Module(new Arbiter(new ICacheMissReq, PortNumber))
 
   // To avoid sending duplicate requests.
-  val s2_has_send = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
+  private val s2_has_send = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
   (0 until PortNumber).foreach { i =>
     when(s1_fire) {
       s2_has_send(i) := false.B
@@ -502,7 +508,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     }
   }
 
-  (0 until PortNumber).map { i =>
+  (0 until PortNumber).foreach { i =>
     toMSHRArbiter.io.in(i).valid         := s2_valid && s2_should_fetch(i) && !s2_has_send(i) && !s2_flush
     toMSHRArbiter.io.in(i).bits.blkPaddr := getBlkAddr(s2_req_paddr(i))
     toMSHRArbiter.io.in(i).bits.vSetIdx  := s2_req_vSetIdx(i)
@@ -511,14 +517,14 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
 
   XSPerfAccumulate("to_missUnit_stall", toMSHR.valid && !toMSHR.ready)
 
-  val s2_fetch_finish = !s2_should_fetch.reduce(_ || _)
+  private val s2_fetch_finish = !s2_should_fetch.reduce(_ || _)
 
   // also raise af if l2 corrupt is detected
-  val s2_l2_exception = VecInit(s2_l2_corrupt.map(ExceptionType.fromECC(true.B, _)))
+  private val s2_l2_exception = VecInit(s2_l2_corrupt.map(ExceptionType.fromECC(true.B, _)))
   // NOTE: do NOT raise af if meta/data corrupt is detected, they are automatically recovered by re-fetching from L2
 
   // merge s2 exceptions, itlb has the highest priority, then l2
-  val s2_exception_out = ExceptionType.merge(
+  private val s2_exception_out = ExceptionType.merge(
     s2_exception, // includes itlb/pmp exception
     s2_l2_exception
   )
@@ -553,7 +559,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
     * report Tilelink corrupt error
     ******************************************************************************
     */
-  (0 until PortNumber).map { i =>
+  (0 until PortNumber).foreach { i =>
     when(RegNext(s2_fire && s2_l2_corrupt(i))) {
       io.errors(i).valid              := true.B
       io.errors(i).bits.report_to_beu := false.B // l2 should have report that to bus error unit, no need to do it again
@@ -575,8 +581,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
   io.perfInfo.hit_0_miss_1    := s2_hits(0) && !s2_hits(1) && s2_doubleline
   io.perfInfo.miss_0_hit_1    := !s2_hits(0) && s2_hits(1) && s2_doubleline
   io.perfInfo.miss_0_miss_1   := !s2_hits(0) && !s2_hits(1) && s2_doubleline
-  io.perfInfo.hit_0_except_1  := s2_hits(0) && (ExceptionType.hasException(s2_exception(1))) && s2_doubleline
-  io.perfInfo.miss_0_except_1 := !s2_hits(0) && (ExceptionType.hasException(s2_exception(1))) && s2_doubleline
+  io.perfInfo.hit_0_except_1  := s2_hits(0) && ExceptionType.hasException(s2_exception(1)) && s2_doubleline
+  io.perfInfo.miss_0_except_1 := !s2_hits(0) && ExceptionType.hasException(s2_exception(1)) && s2_doubleline
   io.perfInfo.bank_hit(0)     := s2_hits(0)
   io.perfInfo.bank_hit(1)     := s2_hits(1) && s2_doubleline
   io.perfInfo.except_0        := ExceptionType.hasException(s2_exception(0))
@@ -592,11 +598,13 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
   // class ICacheTouchDB(implicit p: Parameters) extends ICacheBundle{
   //   val blkPaddr  = UInt((PAddrBits - blockOffBits).W)
   //   val vSetIdx   = UInt(idxBits.W)
-  //   val waymask   = UInt(log2Ceil(nWays).W)
+  //   val waymask   = UInt(wayBits.W)
   // }
 
-  // val isWriteICacheTouchTable = WireInit(Constantin.createRecord("isWriteICacheTouchTable" + p(XSCoreParamsKey).HartId.toString))
-  // val ICacheTouchTable = ChiselDB.createTable("ICacheTouchTable" + p(XSCoreParamsKey).HartId.toString, new ICacheTouchDB)
+  // private val isWriteICacheTouchTable =
+  //   WireInit(Constantin.createRecord("isWriteICacheTouchTable" + p(XSCoreParamsKey).HartId.toString))
+  // private val ICacheTouchTable =
+  //   ChiselDB.createTable("ICacheTouchTable" + p(XSCoreParamsKey).HartId.toString, new ICacheTouchDB)
 
   // val ICacheTouchDumpData = Wire(Vec(PortNumber, new ICacheTouchDB))
   // (0 until PortNumber).foreach{ i =>
@@ -623,8 +631,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
       toIFU.bits.pmp_mmio(i) ||
       Pbmt.isUncache(toIFU.bits.itlb_pbmt(i))
     }
-    val blkPaddrAll = s2_req_paddr.map(addr => addr(PAddrBits - 1, blockOffBits) << blockOffBits)
-    (0 until ICacheDataBanks).map { i =>
+    val blkPaddrAll = s2_req_paddr.map(addr => (addr(PAddrBits - 1, blockOffBits) << blockOffBits).asUInt)
+    (0 until ICacheDataBanks).foreach { i =>
       val diffMainPipeOut = DifftestModule(new DiffRefillEvent, dontCare = true)
       diffMainPipeOut.coreid := io.hartId
       diffMainPipeOut.index  := (3 + i).U
@@ -635,8 +643,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule {
       diffMainPipeOut.valid := s2_fire && bankSel(i).asBool && Mux(lineSel(i), !discards(1), !discards(0))
       diffMainPipeOut.addr := Mux(
         lineSel(i),
-        blkPaddrAll(1) + (i.U << (log2Ceil(blockBytes / ICacheDataBanks))),
-        blkPaddrAll(0) + (i.U << (log2Ceil(blockBytes / ICacheDataBanks)))
+        blkPaddrAll(1) + (i.U << log2Ceil(blockBytes / ICacheDataBanks)).asUInt,
+        blkPaddrAll(0) + (i.U << log2Ceil(blockBytes / ICacheDataBanks)).asUInt
       )
 
       diffMainPipeOut.data  := s2_datas(i).asTypeOf(diffMainPipeOut.data)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
@@ -19,36 +19,26 @@ package xiangshan.frontend.icache
 import chisel3._
 import chisel3.util._
 import difftest._
-import freechips.rocketchip.diplomacy.IdRange
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.tilelink.ClientStates._
-import freechips.rocketchip.tilelink.TLPermissions._
 import org.chipsalliance.cde.config.Parameters
 import utility._
-import utils._
 import xiangshan._
-import xiangshan.cache._
 
-abstract class ICacheMissUnitModule(implicit p: Parameters) extends XSModule
-    with HasICacheParameters
+class DeMultiplexerIO[T <: Data](gen: T, n: Int) extends Bundle {
+  val in:     DecoupledIO[T]      = Flipped(DecoupledIO(gen))
+  val out:    Vec[DecoupledIO[T]] = Vec(n, DecoupledIO(gen))
+  val chosen: UInt                = Output(UInt(log2Ceil(n).W))
+}
 
-abstract class ICacheMissUnitBundle(implicit p: Parameters) extends XSBundle
-    with HasICacheParameters
-
-class Demultiplexer[T <: Data](val gen: T, val n: Int) extends Module {
-
-  /** Hardware module that is used to sequence 1 producers into n consumer.
-    * Priority is given to lower producer.
-    */
+/** Hardware module that is used to sequence 1 producer into n consumer.
+ * Priority is given to lower producer.
+ */
+class DeMultiplexer[T <: Data](val gen: T, val n: Int) extends Module {
   require(n >= 2)
-  val io = IO(new Bundle {
-    val in     = Flipped(DecoupledIO(gen))
-    val out    = Vec(n, DecoupledIO(gen))
-    val chosen = Output(UInt(log2Ceil(n).W))
-  })
+  val io: DeMultiplexerIO[T] = IO(new DeMultiplexerIO(gen, n))
 
-  val grant = false.B +: (1 until n).map(i => (0 until i).map(io.out(_).ready).reduce(_ || _))
-  for (i <- 0 until n) {
+  private val grant = false.B +: (1 until n).map(i => (0 until i).map(io.out(_).ready).reduce(_ || _))
+  (0 until n).foreach { i =>
     io.out(i).bits  := io.in.bits
     io.out(i).valid := !grant(i) && io.in.valid
   }
@@ -57,17 +47,19 @@ class Demultiplexer[T <: Data](val gen: T, val n: Int) extends Module {
   io.chosen   := PriorityEncoder(VecInit(io.out.map(_.ready)))
 }
 
+class MuxBundleIO[T <: Data](gen: T, n: Int) extends Bundle {
+  val sel: UInt                = Input(UInt(log2Ceil(n).W))
+  val in:  Vec[DecoupledIO[T]] = Flipped(Vec(n, DecoupledIO(gen)))
+  val out: DecoupledIO[T]      = DecoupledIO(gen)
+}
+
 class MuxBundle[T <: Data](val gen: T, val n: Int) extends Module {
   require(n >= 2)
-  val io = IO(new Bundle {
-    val sel = Input(UInt(log2Ceil(n).W))
-    val in  = Flipped(Vec(n, DecoupledIO(gen)))
-    val out = DecoupledIO(gen)
-  })
+  val io: MuxBundleIO[T] = IO(new MuxBundleIO[T](gen, n))
 
   io.in <> DontCare
   io.out <> DontCare
-  for (i <- 0 until n) {
+  (0 until n).foreach { i =>
     when(io.sel === i.U) {
       io.out <> io.in(i)
     }
@@ -76,62 +68,64 @@ class MuxBundle[T <: Data](val gen: T, val n: Int) extends Module {
 }
 
 class ICacheMissReq(implicit p: Parameters) extends ICacheBundle {
-  val blkPaddr = UInt((PAddrBits - blockOffBits).W)
-  val vSetIdx  = UInt(idxBits.W)
+  val blkPaddr: UInt = UInt((PAddrBits - blockOffBits).W)
+  val vSetIdx:  UInt = UInt(idxBits.W)
 }
 
 class ICacheMissResp(implicit p: Parameters) extends ICacheBundle {
-  val blkPaddr = UInt((PAddrBits - blockOffBits).W)
-  val vSetIdx  = UInt(idxBits.W)
-  val waymask  = UInt(nWays.W)
-  val data     = UInt(blockBits.W)
-  val corrupt  = Bool()
+  val blkPaddr: UInt = UInt((PAddrBits - blockOffBits).W)
+  val vSetIdx:  UInt = UInt(idxBits.W)
+  val waymask:  UInt = UInt(nWays.W)
+  val data:     UInt = UInt(blockBits.W)
+  val corrupt:  Bool = Bool()
 }
 
 class LookUpMSHR(implicit p: Parameters) extends ICacheBundle {
-  val info = ValidIO(new ICacheMissReq)
-  val hit  = Input(Bool())
+  val info: Valid[ICacheMissReq] = ValidIO(new ICacheMissReq)
+  val hit:  Bool                 = Input(Bool())
 }
 
 class MSHRResp(implicit p: Parameters) extends ICacheBundle {
-  val blkPaddr = UInt((PAddrBits - blockOffBits).W)
-  val vSetIdx  = UInt(idxBits.W)
-  val waymask  = UInt(log2Ceil(nWays).W)
+  val blkPaddr: UInt = UInt((PAddrBits - blockOffBits).W)
+  val vSetIdx:  UInt = UInt(idxBits.W)
+  val way:      UInt = UInt(wayBits.W)
 }
 
 class MSHRAcquire(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheBundle {
-  val acquire = new TLBundleA(edge.bundle)
-  val vSetIdx = UInt(idxBits.W)
+  val acquire: TLBundleA = new TLBundleA(edge.bundle)
+  val vSetIdx: UInt      = UInt(idxBits.W)
 }
 
-class ICacheMSHR(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Parameters) extends ICacheMissUnitModule {
-  val io = IO(new Bundle {
-    val fencei    = Input(Bool())
-    val flush     = Input(Bool())
-    val invalid   = Input(Bool())
-    val req       = Flipped(DecoupledIO(new ICacheMissReq))
-    val acquire   = DecoupledIO(new MSHRAcquire(edge))
-    val lookUps   = Flipped(Vec(2, new LookUpMSHR))
-    val resp      = ValidIO(new MSHRResp)
-    val victimWay = Input(UInt(log2Ceil(nWays).W))
-  })
+class ICacheMSHRIO(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheBundle {
+  val fencei:    Bool                       = Input(Bool())
+  val flush:     Bool                       = Input(Bool())
+  val invalid:   Bool                       = Input(Bool())
+  val req:       DecoupledIO[ICacheMissReq] = Flipped(DecoupledIO(new ICacheMissReq))
+  val acquire:   DecoupledIO[MSHRAcquire]   = DecoupledIO(new MSHRAcquire(edge))
+  val lookUps:   Vec[LookUpMSHR]            = Flipped(Vec(2, new LookUpMSHR))
+  val resp:      Valid[MSHRResp]            = ValidIO(new MSHRResp)
+  val victimWay: UInt                       = Input(UInt(wayBits.W))
+}
 
-  val valid = RegInit(Bool(), false.B)
-  // this MSHR doesn't respones to fetch and sram
-  val flush  = RegInit(Bool(), false.B)
-  val fencei = RegInit(Bool(), false.B)
+class ICacheMSHR(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Parameters) extends ICacheModule {
+  val io: ICacheMSHRIO = IO(new ICacheMSHRIO(edge))
+
+  private val valid = RegInit(Bool(), false.B)
+  // this MSHR doesn't respond to fetch and sram
+  private val flush  = RegInit(Bool(), false.B)
+  private val fencei = RegInit(Bool(), false.B)
   // this MSHR has been issued
-  val issue = RegInit(Bool(), false.B)
+  private val issue = RegInit(Bool(), false.B)
 
-  val blkPaddr = RegInit(UInt((PAddrBits - blockOffBits).W), 0.U)
-  val vSetIdx  = RegInit(UInt(idxBits.W), 0.U)
-  val waymask  = RegInit(UInt(log2Ceil(nWays).W), 0.U)
+  private val blkPaddr = RegInit(UInt((PAddrBits - blockOffBits).W), 0.U)
+  private val vSetIdx  = RegInit(UInt(idxBits.W), 0.U)
+  private val way      = RegInit(UInt(wayBits.W), 0.U)
 
   // look up and return result at the same cycle
-  val hits = io.lookUps.map(lookup =>
+  private val hits = io.lookUps.map { lookup =>
     valid && !fencei && !flush && (lookup.info.bits.vSetIdx === vSetIdx) &&
-      (lookup.info.bits.blkPaddr === blkPaddr)
-  )
+    (lookup.info.bits.blkPaddr === blkPaddr)
+  }
   // Decoupling valid and bits
   (0 until 2).foreach(i => io.lookUps(i).hit := hits(i))
 
@@ -162,7 +156,7 @@ class ICacheMSHR(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Paramet
 
   // send request to L2
   io.acquire.valid := valid && !issue && !io.flush && !io.fencei
-  val getBlock = edge.Get(
+  private val getBlock = edge.Get(
     fromSource = ID.U,
     toAddress = Cat(blkPaddr, 0.U(blockOffBits.W)),
     lgSize = log2Up(cacheParams.blockBytes).U
@@ -173,8 +167,8 @@ class ICacheMSHR(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Paramet
 
   // get victim way when acquire fire
   when(io.acquire.fire) {
-    issue   := true.B
-    waymask := io.victimWay
+    issue := true.B
+    way   := io.victimWay
   }
 
   // invalid request when grant finish
@@ -186,32 +180,32 @@ class ICacheMSHR(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Paramet
   io.resp.valid         := valid && (!flush && !fencei)
   io.resp.bits.blkPaddr := blkPaddr
   io.resp.bits.vSetIdx  := vSetIdx
-  io.resp.bits.waymask  := waymask
+  io.resp.bits.way      := way
 }
 
-class ICacheMissBundle(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheBundle {
+class ICacheMissUnitIO(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheBundle {
   // difftest
-  val hartId = Input(Bool())
+  val hartId: Bool = Input(Bool())
   // control
-  val fencei = Input(Bool())
-  val flush  = Input(Bool())
+  val fencei: Bool = Input(Bool())
+  val flush:  Bool = Input(Bool())
   // fetch
-  val fetch_req  = Flipped(DecoupledIO(new ICacheMissReq))
-  val fetch_resp = ValidIO(new ICacheMissResp)
+  val fetch_req:  DecoupledIO[ICacheMissReq] = Flipped(DecoupledIO(new ICacheMissReq))
+  val fetch_resp: Valid[ICacheMissResp]      = ValidIO(new ICacheMissResp)
   // prefetch
-  val prefetch_req = Flipped(DecoupledIO(new ICacheMissReq))
+  val prefetch_req: DecoupledIO[ICacheMissReq] = Flipped(DecoupledIO(new ICacheMissReq))
   // SRAM Write Req
-  val meta_write = DecoupledIO(new ICacheMetaWriteBundle)
-  val data_write = DecoupledIO(new ICacheDataWriteBundle)
+  val meta_write: DecoupledIO[ICacheMetaWriteBundle] = DecoupledIO(new ICacheMetaWriteBundle)
+  val data_write: DecoupledIO[ICacheDataWriteBundle] = DecoupledIO(new ICacheDataWriteBundle)
   // get victim from replacer
-  val victim = new ReplacerVictim
+  val victim: ReplacerVictim = new ReplacerVictim
   // Tilelink
-  val mem_acquire = DecoupledIO(new TLBundleA(edge.bundle))
-  val mem_grant   = Flipped(DecoupledIO(new TLBundleD(edge.bundle)))
+  val mem_acquire: DecoupledIO[TLBundleA] = DecoupledIO(new TLBundleA(edge.bundle))
+  val mem_grant:   DecoupledIO[TLBundleD] = Flipped(DecoupledIO(new TLBundleD(edge.bundle)))
 }
 
-class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMissUnitModule {
-  val io = IO(new ICacheMissBundle(edge))
+class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheModule {
+  val io: ICacheMissUnitIO = IO(new ICacheMissUnitIO(edge))
 
   /**
     ******************************************************************************
@@ -226,7 +220,7 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
     *                                                           |
     *                                -----------------          |
     *                                | prefetch MSHR |          |
-    *                 ---------      -----------------     ----------- 
+    *                 ---------      -----------------     -----------
     * ---fetch reg--->| Demux |----> | prefetch MSHR |---->| Arbiter |
     *                 ---------      -----------------     -----------
     *                                |    .......    |
@@ -234,13 +228,14 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
     ******************************************************************************
     */
 
-  val fetchDemux    = Module(new Demultiplexer(new ICacheMissReq, nFetchMshr))
-  val prefetchDemux = Module(new Demultiplexer(new ICacheMissReq, nPrefetchMshr))
-  val prefetchArb   = Module(new MuxBundle(new MSHRAcquire(edge), nPrefetchMshr))
-  val acquireArb    = Module(new Arbiter(new MSHRAcquire(edge), nFetchMshr + 1))
+  private val fetchDemux    = Module(new DeMultiplexer(new ICacheMissReq, nFetchMshr))
+  private val prefetchDemux = Module(new DeMultiplexer(new ICacheMissReq, nPrefetchMshr))
+  private val prefetchArb   = Module(new MuxBundle(new MSHRAcquire(edge), nPrefetchMshr))
+  private val acquireArb    = Module(new Arbiter(new MSHRAcquire(edge), nFetchMshr + 1))
 
   // To avoid duplicate request reception.
-  val fetchHit, prefetchHit = Wire(Bool())
+  private val fetchHit    = Wire(Bool())
+  private val prefetchHit = Wire(Bool())
   fetchDemux.io.in <> io.fetch_req
   fetchDemux.io.in.valid := io.fetch_req.valid && !fetchHit
   io.fetch_req.ready     := fetchDemux.io.in.ready || fetchHit
@@ -254,7 +249,7 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
   io.mem_acquire.bits     := acquireArb.io.out.bits.acquire
   acquireArb.io.out.ready := io.mem_acquire.ready
 
-  val fetchMSHRs = (0 until nFetchMshr).map { i =>
+  private val fetchMSHRs = (0 until nFetchMshr).map { i =>
     val mshr = Module(new ICacheMSHR(edge, true, i))
     mshr.io.flush  := false.B
     mshr.io.fencei := io.fencei
@@ -268,7 +263,7 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
     mshr
   }
 
-  val prefetchMSHRs = (0 until nPrefetchMshr).map { i =>
+  private val prefetchMSHRs = (0 until nPrefetchMshr).map { i =>
     val mshr = Module(new ICacheMSHR(edge, false, nFetchMshr + i))
     mshr.io.flush  := io.flush
     mshr.io.fencei := io.fencei
@@ -288,8 +283,8 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
     * - look up all mshr
     ******************************************************************************
     */
-  val allMSHRs = fetchMSHRs ++ prefetchMSHRs
-  val prefetchHitFetchReq = (io.prefetch_req.bits.blkPaddr === io.fetch_req.bits.blkPaddr) &&
+  private val allMSHRs = fetchMSHRs ++ prefetchMSHRs
+  private val prefetchHitFetchReq = (io.prefetch_req.bits.blkPaddr === io.fetch_req.bits.blkPaddr) &&
     (io.prefetch_req.bits.vSetIdx === io.fetch_req.bits.vSetIdx) &&
     io.fetch_req.valid
   fetchHit    := allMSHRs.map(mshr => mshr.io.lookUps(0).hit).reduce(_ || _)
@@ -299,14 +294,14 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
     ******************************************************************************
     * prefetchMSHRs priority
     * - The requests that enter the prefetchMSHRs earlier have a higher priority in issuing.
-    * - The order of enqueuing is recorded in FIFO when requset enters MSHRs.
+    * - The order of enqueuing is recorded in FIFO when request enters MSHRs.
     * - The requests are dispatched in the order they are recorded in FIFO.
     ******************************************************************************
     */
   // When the FIFO is full, enqueue and dequeue operations do not occur at the same cycle.
   // So the depth of the FIFO is set to match the number of MSHRs.
   // val priorityFIFO = Module(new Queue(UInt(log2Ceil(nPrefetchMshr).W), nPrefetchMshr, hasFlush=true))
-  val priorityFIFO = Module(new FIFOReg(UInt(log2Ceil(nPrefetchMshr).W), nPrefetchMshr, hasFlush = true))
+  private val priorityFIFO = Module(new FIFOReg(UInt(log2Ceil(nPrefetchMshr).W), nPrefetchMshr, hasFlush = true))
   priorityFIFO.io.flush.get := io.flush || io.fencei
   priorityFIFO.io.enq.valid := prefetchDemux.io.in.fire
   priorityFIFO.io.enq.bits  := prefetchDemux.io.chosen
@@ -327,27 +322,27 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
     ******************************************************************************
     */
   // cacheline register
-  val readBeatCnt = RegInit(UInt(log2Up(refillCycles).W), 0.U)
-  val respDataReg = RegInit(VecInit(Seq.fill(refillCycles)(0.U(beatBits.W))))
+  private val readBeatCnt = RegInit(UInt(log2Up(refillCycles).W), 0.U)
+  private val respDataReg = RegInit(VecInit(Seq.fill(refillCycles)(0.U(beatBits.W))))
 
-  val wait_last = readBeatCnt === (refillCycles - 1).U
+  private val wait_last = readBeatCnt === (refillCycles - 1).U
   when(io.mem_grant.fire && edge.hasData(io.mem_grant.bits)) {
     respDataReg(readBeatCnt) := io.mem_grant.bits.data
     readBeatCnt              := Mux(wait_last, 0.U, readBeatCnt + 1.U)
   }
 
-  // last transition finsh or corrupt
-  val last_fire = io.mem_grant.fire && edge.hasData(io.mem_grant.bits) && wait_last
+  // last transition finish or corrupt
+  private val last_fire = io.mem_grant.fire && edge.hasData(io.mem_grant.bits) && wait_last
 
-  val (_, _, refill_done, _) = edge.addr_inc(io.mem_grant)
+  private val (_, _, refill_done, _) = edge.addr_inc(io.mem_grant)
   assert(!(refill_done ^ last_fire), "refill not done!")
   io.mem_grant.ready := true.B
 
-  val last_fire_r = RegNext(last_fire)
-  val id_r        = RegNext(io.mem_grant.bits.source)
+  private val last_fire_r = RegNext(last_fire)
+  private val id_r        = RegNext(io.mem_grant.bits.source)
 
   // if any beat is corrupt, the whole response (to mainPipe/metaArray/dataArray) is corrupt
-  val corrupt_r = RegInit(false.B)
+  private val corrupt_r = RegInit(false.B)
   when(io.mem_grant.fire && edge.hasData(io.mem_grant.bits) && io.mem_grant.bits.corrupt) {
     corrupt_r := true.B
   }.elsewhen(io.fetch_resp.fire) {
@@ -367,19 +362,19 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
     ******************************************************************************
     */
   // get request information from MSHRs
-  val allMSHRs_resp = VecInit(allMSHRs.map(mshr => mshr.io.resp))
-  val mshr_resp     = allMSHRs_resp(id_r)
+  private val allMSHRs_resp = VecInit(allMSHRs.map(mshr => mshr.io.resp))
+  private val mshr_resp     = allMSHRs_resp(id_r)
 
   // get waymask from replacer when acquire fire
   io.victim.vSetIdx.valid := acquireArb.io.out.fire
   io.victim.vSetIdx.bits  := acquireArb.io.out.bits.vSetIdx
-  val waymask = UIntToOH(mshr_resp.bits.waymask)
+  private val waymask = UIntToOH(mshr_resp.bits.way)
   // NOTE: when flush/fencei, missUnit will still send response to mainPipe/prefetchPipe
   //       this is intentional to fix timing (io.flush -> mainPipe/prefetchPipe s2_miss -> s2_ready -> ftq ready)
   //       unnecessary response will be dropped by mainPipe/prefetchPipe/wayLookup since their sx_valid is set to false
-  val fetch_resp_valid = mshr_resp.valid && last_fire_r
+  private val fetch_resp_valid = mshr_resp.valid && last_fire_r
   // NOTE: but we should not write meta/dataArray when flush/fencei
-  val write_sram_valid = fetch_resp_valid && !corrupt_r && !io.flush && !io.fencei
+  private val write_sram_valid = fetch_resp_valid && !corrupt_r && !io.flush && !io.fencei
 
   // write SRAM
   io.meta_write.bits.generate(
@@ -420,17 +415,18 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheMiss
     * ChiselDB: record ICache SRAM write log
     ******************************************************************************
     */
-  class ICacheSRAMDB(implicit p: Parameters) extends ICacheBundle {
-    val blkPaddr = UInt((PAddrBits - blockOffBits).W)
-    val vSetIdx  = UInt(idxBits.W)
-    val waymask  = UInt(log2Ceil(nWays).W)
+  private class ICacheSRAMDB(implicit p: Parameters) extends ICacheBundle {
+    val blkPaddr: UInt = UInt((PAddrBits - blockOffBits).W)
+    val vSetIdx:  UInt = UInt(idxBits.W)
+    val waymask:  UInt = UInt(wayBits.W)
   }
 
-  val isWriteICacheSRAMTable =
+  private val isWriteICacheSRAMTable =
     WireInit(Constantin.createRecord("isWriteICacheSRAMTable" + p(XSCoreParamsKey).HartId.toString))
-  val ICacheSRAMTable = ChiselDB.createTable("ICacheSRAMTable" + p(XSCoreParamsKey).HartId.toString, new ICacheSRAMDB)
+  private val ICacheSRAMTable =
+    ChiselDB.createTable("ICacheSRAMTable" + p(XSCoreParamsKey).HartId.toString, new ICacheSRAMDB)
 
-  val ICacheSRAMDBDumpData = Wire(new ICacheSRAMDB)
+  private val ICacheSRAMDBDumpData = Wire(new ICacheSRAMDB)
   ICacheSRAMDBDumpData.blkPaddr := mshr_resp.bits.blkPaddr
   ICacheSRAMDBDumpData.vSetIdx  := mshr_resp.bits.vSetIdx
   ICacheSRAMDBDumpData.waymask  := OHToUInt(waymask)

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -18,16 +18,9 @@ package xiangshan.frontend.icache
 
 import chisel3._
 import chisel3.util._
-import difftest._
-import freechips.rocketchip.tilelink._
-import huancun.PreferCacheKey
 import org.chipsalliance.cde.config.Parameters
 import utility._
-import utils._
 import xiangshan.SoftIfetchPrefetchBundle
-import xiangshan.XSCoreParamsKey
-import xiangshan.backend.fu.PMPReqBundle
-import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.cache.mmu._
 import xiangshan.frontend._
 
@@ -61,34 +54,33 @@ class IPrefetchReq(implicit p: Parameters) extends IPrefetchBundle {
 
 class IPrefetchIO(implicit p: Parameters) extends IPrefetchBundle {
   // control
-  val csr_pf_enable     = Input(Bool())
-  val csr_parity_enable = Input(Bool())
-  val flush             = Input(Bool())
+  val csr_pf_enable:     Bool = Input(Bool())
+  val csr_parity_enable: Bool = Input(Bool())
+  val flush:             Bool = Input(Bool())
 
-  val req            = Flipped(Decoupled(new IPrefetchReq))
-  val flushFromBpu   = Flipped(new BpuFlushInfo)
-  val itlb           = Vec(PortNumber, new TlbRequestIO)
-  val pmp            = Vec(PortNumber, new ICachePMPBundle)
-  val metaRead       = new ICacheMetaReqBundle
-  val MSHRReq        = DecoupledIO(new ICacheMissReq)
-  val MSHRResp       = Flipped(ValidIO(new ICacheMissResp))
-  val wayLookupWrite = DecoupledIO(new WayLookupInfo)
+  val req:            DecoupledIO[IPrefetchReq]  = Flipped(Decoupled(new IPrefetchReq))
+  val flushFromBpu:   BpuFlushInfo               = Flipped(new BpuFlushInfo)
+  val itlb:           Vec[TlbRequestIO]          = Vec(PortNumber, new TlbRequestIO)
+  val pmp:            Vec[ICachePMPBundle]       = Vec(PortNumber, new ICachePMPBundle)
+  val metaRead:       ICacheMetaReqBundle        = new ICacheMetaReqBundle
+  val MSHRReq:        DecoupledIO[ICacheMissReq] = DecoupledIO(new ICacheMissReq)
+  val MSHRResp:       Valid[ICacheMissResp]      = Flipped(ValidIO(new ICacheMissResp))
+  val wayLookupWrite: DecoupledIO[WayLookupInfo] = DecoupledIO(new WayLookupInfo)
 }
 
 class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
   val io: IPrefetchIO = IO(new IPrefetchIO)
 
-  val (toITLB, fromITLB) = (io.itlb.map(_.req), io.itlb.map(_.resp))
-  val (toPMP, fromPMP)   = (io.pmp.map(_.req), io.pmp.map(_.resp))
-  val (toMeta, fromMeta) = (io.metaRead.toIMeta, io.metaRead.fromIMeta)
-  val (toMSHR, fromMSHR) = (io.MSHRReq, io.MSHRResp)
-  val toWayLookup        = io.wayLookupWrite
+  private val (toITLB, fromITLB) = (io.itlb.map(_.req), io.itlb.map(_.resp))
+  private val (toPMP, fromPMP)   = (io.pmp.map(_.req), io.pmp.map(_.resp))
+  private val (toMeta, fromMeta) = (io.metaRead.toIMeta, io.metaRead.fromIMeta)
+  private val (toMSHR, fromMSHR) = (io.MSHRReq, io.MSHRResp)
+  private val toWayLookup        = io.wayLookupWrite
 
-  val s0_fire, s1_fire, s2_fire            = WireInit(false.B)
-  val s0_discard, s2_discard               = WireInit(false.B)
-  val s0_ready, s1_ready, s2_ready         = WireInit(false.B)
-  val s0_flush, s1_flush, s2_flush         = WireInit(false.B)
-  val from_bpu_s0_flush, from_bpu_s1_flush = WireInit(false.B)
+  private val s0_fire, s1_fire, s2_fire            = WireInit(false.B)
+  private val s1_ready, s2_ready                   = WireInit(false.B)
+  private val s0_flush, s1_flush, s2_flush         = WireInit(false.B)
+  private val from_bpu_s0_flush, from_bpu_s1_flush = WireInit(false.B)
 
   /**
     ******************************************************************************
@@ -98,25 +90,25 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     * - 3. send req to Meta SRAM
     ******************************************************************************
     */
-  val s0_valid = io.req.valid
+  private val s0_valid = io.req.valid
 
   /**
     ******************************************************************************
     * receive ftq req
     ******************************************************************************
     */
-  val s0_req_vaddr        = VecInit(Seq(io.req.bits.startAddr, io.req.bits.nextlineStart))
-  val s0_req_ftqIdx       = io.req.bits.ftqIdx
-  val s0_isSoftPrefetch   = io.req.bits.isSoftPrefetch
-  val s0_doubleline       = io.req.bits.crossCacheline
-  val s0_req_vSetIdx      = s0_req_vaddr.map(get_idx)
-  val s0_backendException = VecInit(Seq.fill(PortNumber)(io.req.bits.backendException))
+  private val s0_req_vaddr        = VecInit(Seq(io.req.bits.startAddr, io.req.bits.nextlineStart))
+  private val s0_req_ftqIdx       = io.req.bits.ftqIdx
+  private val s0_isSoftPrefetch   = io.req.bits.isSoftPrefetch
+  private val s0_doubleline       = io.req.bits.crossCacheline
+  private val s0_req_vSetIdx      = s0_req_vaddr.map(get_idx)
+  private val s0_backendException = VecInit(Seq.fill(PortNumber)(io.req.bits.backendException))
 
   from_bpu_s0_flush := !s0_isSoftPrefetch && (io.flushFromBpu.shouldFlushByStage2(s0_req_ftqIdx) ||
     io.flushFromBpu.shouldFlushByStage3(s0_req_ftqIdx))
   s0_flush := io.flush || from_bpu_s0_flush || s1_flush
 
-  val s0_can_go = s1_ready && toITLB(0).ready && toITLB(1).ready && toMeta.ready
+  private val s0_can_go = s1_ready && toITLB(0).ready && toITLB(1).ready && toMeta.ready
   io.req.ready := s0_can_go
 
   s0_fire := s0_valid && s0_can_go && !s0_flush
@@ -127,22 +119,24 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     * - 1. Receive resp from ITLB
     * - 2. Receive resp from IMeta and check
     * - 3. Monitor the requests from missUnit to write to SRAM.
-    * - 4. Wirte wayLookup
+    * - 4. Write wayLookup
     ******************************************************************************
     */
-  val s1_valid = generatePipeControl(lastFire = s0_fire, thisFire = s1_fire, thisFlush = s1_flush, lastFlush = false.B)
+  private val s1_valid =
+    generatePipeControl(lastFire = s0_fire, thisFire = s1_fire, thisFlush = s1_flush, lastFlush = false.B)
 
-  val s1_req_vaddr        = RegEnable(s0_req_vaddr, 0.U.asTypeOf(s0_req_vaddr), s0_fire)
-  val s1_isSoftPrefetch   = RegEnable(s0_isSoftPrefetch, 0.U.asTypeOf(s0_isSoftPrefetch), s0_fire)
-  val s1_doubleline       = RegEnable(s0_doubleline, 0.U.asTypeOf(s0_doubleline), s0_fire)
-  val s1_req_ftqIdx       = RegEnable(s0_req_ftqIdx, 0.U.asTypeOf(s0_req_ftqIdx), s0_fire)
-  val s1_req_vSetIdx      = VecInit(s1_req_vaddr.map(get_idx))
-  val s1_backendException = RegEnable(s0_backendException, 0.U.asTypeOf(s0_backendException), s0_fire)
+  private val s1_req_vaddr        = RegEnable(s0_req_vaddr, 0.U.asTypeOf(s0_req_vaddr), s0_fire)
+  private val s1_isSoftPrefetch   = RegEnable(s0_isSoftPrefetch, 0.U.asTypeOf(s0_isSoftPrefetch), s0_fire)
+  private val s1_doubleline       = RegEnable(s0_doubleline, 0.U.asTypeOf(s0_doubleline), s0_fire)
+  private val s1_req_ftqIdx       = RegEnable(s0_req_ftqIdx, 0.U.asTypeOf(s0_req_ftqIdx), s0_fire)
+  private val s1_req_vSetIdx      = VecInit(s1_req_vaddr.map(get_idx))
+  private val s1_backendException = RegEnable(s0_backendException, 0.U.asTypeOf(s0_backendException), s0_fire)
 
-  val m_idle :: m_itlbResend :: m_metaResend :: m_enqWay :: m_enterS2 :: Nil = Enum(5)
-  val state                                                                  = RegInit(m_idle)
-  val next_state                                                             = WireDefault(state)
-  val s0_fire_r                                                              = RegNext(s0_fire)
+  private val m_idle :: m_itlbResend :: m_metaResend :: m_enqWay :: m_enterS2 :: Nil = Enum(5)
+
+  private val state      = RegInit(m_idle)
+  private val next_state = WireDefault(state)
+  private val s0_fire_r  = RegNext(s0_fire)
   dontTouch(state)
   dontTouch(next_state)
   state := next_state
@@ -152,7 +146,7 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     * resend itlb req if miss
     ******************************************************************************
     */
-  val s1_wait_itlb = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
+  private val s1_wait_itlb = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
   (0 until PortNumber).foreach { i =>
     when(s1_flush) {
       s1_wait_itlb(i) := false.B
@@ -162,19 +156,19 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
       s1_wait_itlb(i) := false.B
     }
   }
-  val s1_need_itlb = VecInit(Seq(
+  private val s1_need_itlb = VecInit(Seq(
     (RegNext(s0_fire) || s1_wait_itlb(0)) && fromITLB(0).bits.miss,
     (RegNext(s0_fire) || s1_wait_itlb(1)) && fromITLB(1).bits.miss && s1_doubleline
   ))
-  val tlb_valid_pulse = VecInit(Seq(
+  private val tlb_valid_pulse = VecInit(Seq(
     (RegNext(s0_fire) || s1_wait_itlb(0)) && !fromITLB(0).bits.miss,
     (RegNext(s0_fire) || s1_wait_itlb(1)) && !fromITLB(1).bits.miss && s1_doubleline
   ))
-  val tlb_valid_latch =
+  private val tlb_valid_latch =
     VecInit((0 until PortNumber).map(i => ValidHoldBypass(tlb_valid_pulse(i), s1_fire, flush = s1_flush)))
-  val itlb_finish = tlb_valid_latch(0) && (!s1_doubleline || tlb_valid_latch(1))
+  private val itlb_finish = tlb_valid_latch(0) && (!s1_doubleline || tlb_valid_latch(1))
 
-  for (i <- 0 until PortNumber) {
+  (0 until PortNumber).foreach { i =>
     toITLB(i).valid             := s1_need_itlb(i) || (s0_valid && (if (i == 0) true.B else s0_doubleline))
     toITLB(i).bits              := DontCare
     toITLB(i).bits.size         := 3.U
@@ -191,43 +185,43 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     * Receive resp from ITLB
     ******************************************************************************
     */
-  val s1_req_paddr_wire = VecInit(fromITLB.map(_.bits.paddr(0)))
-  val s1_req_paddr_reg = VecInit((0 until PortNumber).map(i =>
+  private val s1_req_paddr_wire = VecInit(fromITLB.map(_.bits.paddr(0)))
+  private val s1_req_paddr_reg = VecInit((0 until PortNumber).map { i =>
     RegEnable(s1_req_paddr_wire(i), 0.U(PAddrBits.W), tlb_valid_pulse(i))
-  ))
-  val s1_req_paddr = VecInit((0 until PortNumber).map(i =>
+  })
+  private val s1_req_paddr = VecInit((0 until PortNumber).map { i =>
     Mux(tlb_valid_pulse(i), s1_req_paddr_wire(i), s1_req_paddr_reg(i))
-  ))
-  val s1_req_gpaddr_tmp = VecInit((0 until PortNumber).map(i =>
+  })
+  private val s1_req_gpaddr_tmp = VecInit((0 until PortNumber).map { i =>
     ResultHoldBypass(
       valid = tlb_valid_pulse(i),
       // NOTE: we dont use GPAddrBits or XLEN here, refer to ICacheMainPipe.scala L43-48 and PR#3795
       init = 0.U(PAddrBitsMax.W),
       data = fromITLB(i).bits.gpaddr(0)
     )
-  ))
-  val s1_req_isForVSnonLeafPTE_tmp = VecInit((0 until PortNumber).map(i =>
+  })
+  private val s1_req_isForVSnonLeafPTE_tmp = VecInit((0 until PortNumber).map { i =>
     ResultHoldBypass(
       valid = tlb_valid_pulse(i),
       init = 0.U.asTypeOf(fromITLB(i).bits.isForVSnonLeafPTE),
       data = fromITLB(i).bits.isForVSnonLeafPTE
     )
-  ))
-  val s1_itlb_exception = VecInit((0 until PortNumber).map(i =>
+  })
+  private val s1_itlb_exception = VecInit((0 until PortNumber).map { i =>
     ResultHoldBypass(
       valid = tlb_valid_pulse(i),
       init = 0.U(ExceptionType.width.W),
       data = ExceptionType.fromTlbResp(fromITLB(i).bits)
     )
-  ))
-  val s1_itlb_pbmt = VecInit((0 until PortNumber).map(i =>
+  })
+  private val s1_itlb_pbmt = VecInit((0 until PortNumber).map { i =>
     ResultHoldBypass(
       valid = tlb_valid_pulse(i),
       init = 0.U.asTypeOf(fromITLB(i).bits.pbmt(0)),
       data = fromITLB(i).bits.pbmt(0)
     )
-  ))
-  val s1_itlb_exception_gpf = VecInit(s1_itlb_exception.map(_ === ExceptionType.gpf))
+  })
+  private val s1_itlb_exception_gpf = VecInit(s1_itlb_exception.map(_ === ExceptionType.gpf))
 
   /* Select gpaddr with the first gpf
    * Note: the backend wants the base guest physical address of a fetch block
@@ -235,12 +229,12 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
    *       see GPAMem: https://github.com/OpenXiangShan/XiangShan/blob/344cf5d55568dd40cd658a9ee66047a505eeb504/src/main/scala/xiangshan/backend/GPAMem.scala#L33-L34
    *       see also: https://github.com/OpenXiangShan/XiangShan/blob/344cf5d55568dd40cd658a9ee66047a505eeb504/src/main/scala/xiangshan/frontend/IFU.scala#L374-L375
    */
-  val s1_req_gpaddr = PriorityMuxDefault(
+  private val s1_req_gpaddr = PriorityMuxDefault(
     s1_itlb_exception_gpf zip (0 until PortNumber).map(i => s1_req_gpaddr_tmp(i) - (i << blockOffBits).U),
     0.U.asTypeOf(s1_req_gpaddr_tmp(0))
   )
 
-  val s1_req_isForVSnonLeafPTE = PriorityMuxDefault(
+  private val s1_req_isForVSnonLeafPTE = PriorityMuxDefault(
     s1_itlb_exception_gpf zip s1_req_isForVSnonLeafPTE_tmp,
     0.U.asTypeOf(s1_req_isForVSnonLeafPTE_tmp(0))
   )
@@ -250,12 +244,12 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     * resend metaArray read req when itlb miss finish
     ******************************************************************************
     */
-  val s1_need_meta = ((state === m_itlbResend) && itlb_finish) || (state === m_metaResend)
+  private val s1_need_meta = ((state === m_itlbResend) && itlb_finish) || (state === m_metaResend)
   toMeta.valid             := s1_need_meta || s0_valid
   toMeta.bits              := DontCare
   toMeta.bits.isDoubleLine := Mux(s1_need_meta, s1_doubleline, s0_doubleline)
 
-  for (i <- 0 until PortNumber) {
+  (0 until PortNumber).foreach { i =>
     toMeta.bits.vSetIdx(i) := Mux(s1_need_meta, s1_req_vSetIdx(i), s0_req_vSetIdx(i))
   }
 
@@ -264,24 +258,24 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     * Receive resp from IMeta and check
     ******************************************************************************
     */
-  val s1_req_ptags = VecInit(s1_req_paddr.map(get_phy_tag))
+  private val s1_req_ptags = VecInit(s1_req_paddr.map(get_phy_tag))
 
-  val s1_meta_ptags  = fromMeta.tags
-  val s1_meta_valids = fromMeta.entryValid
+  private val s1_meta_ptags  = fromMeta.tags
+  private val s1_meta_valids = fromMeta.entryValid
 
-  def get_waymask(paddrs: Vec[UInt]): Vec[UInt] = {
+  private def getWaymask(paddrs: Vec[UInt]): Vec[UInt] = {
     val ptags = paddrs.map(get_phy_tag)
     val tag_eq_vec =
       VecInit((0 until PortNumber).map(p => VecInit((0 until nWays).map(w => s1_meta_ptags(p)(w) === ptags(p)))))
-    val tag_match_vec = VecInit((0 until PortNumber).map(k =>
+    val tag_match_vec = VecInit((0 until PortNumber).map { k =>
       VecInit(tag_eq_vec(k).zipWithIndex.map { case (way_tag_eq, w) => way_tag_eq && s1_meta_valids(k)(w) })
-    ))
+    })
     val waymasks = VecInit(tag_match_vec.map(_.asUInt))
     waymasks
   }
 
-  val s1_SRAM_waymasks = VecInit((0 until PortNumber).map { port =>
-    Mux(tlb_valid_pulse(port), get_waymask(s1_req_paddr_wire)(port), get_waymask(s1_req_paddr_reg)(port))
+  private val s1_SRAM_waymasks = VecInit((0 until PortNumber).map { port =>
+    Mux(tlb_valid_pulse(port), getWaymask(s1_req_paddr_wire)(port), getWaymask(s1_req_paddr_reg)(port))
   })
 
   // select ecc code
@@ -295,9 +289,9 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
    *                           we can detect this by checking whether `PopCount(waymasks) <= 1.U`,
    *                           and meta_codes is not important in this situation.
    * 3. hit -> fake miss: We can't detect this, but we can (pre)fetch the correct data from L2 cache, so it's not a problem.
-   * 4. hit -> hit / miss -> miss: ECC failure happens in a irrelevant way, so we don't care about it this time.
+   * 4. hit -> hit / miss -> miss: ECC failure happens in an irrelevant way, so we don't care about it this time.
    */
-  val s1_SRAM_meta_codes = VecInit((0 until PortNumber).map { port =>
+  private val s1_SRAM_meta_codes = VecInit((0 until PortNumber).map { port =>
     Mux1H(s1_SRAM_waymasks(port), fromMeta.codes(port))
   })
 
@@ -306,7 +300,7 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     * update waymasks and meta_codes according to MSHR update data
     ******************************************************************************
     */
-  def update_meta_info(mask: UInt, vSetIdx: UInt, ptag: UInt, code: UInt): Tuple2[UInt, UInt] = {
+  private def updateMetaInfo(mask: UInt, vSetIdx: UInt, ptag: UInt, code: UInt): (UInt, UInt) = {
     require(mask.getWidth == nWays)
     val new_mask  = WireInit(mask)
     val new_code  = WireInit(code)
@@ -322,31 +316,31 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
         new_code := encodeMetaECC(ptag)
       }.elsewhen(way_same) {
         new_mask := 0.U
-        // we dont care about new_code, since it's not used for a missed request
+        // we don't care about new_code, since it's not used for a missed request
       }
     }
     (new_mask, new_code)
   }
 
-  val s1_SRAM_valid   = s0_fire_r || RegNext(s1_need_meta && toMeta.ready)
-  val s1_MSHR_valid   = fromMSHR.valid && !fromMSHR.bits.corrupt
-  val s1_waymasks     = WireInit(VecInit(Seq.fill(PortNumber)(0.U(nWays.W))))
-  val s1_waymasks_r   = RegEnable(s1_waymasks, 0.U.asTypeOf(s1_waymasks), s1_SRAM_valid || s1_MSHR_valid)
-  val s1_meta_codes   = WireInit(VecInit(Seq.fill(PortNumber)(0.U(ICacheMetaCodeBits.W))))
-  val s1_meta_codes_r = RegEnable(s1_meta_codes, 0.U.asTypeOf(s1_meta_codes), s1_SRAM_valid || s1_MSHR_valid)
+  private val s1_SRAM_valid   = s0_fire_r || RegNext(s1_need_meta && toMeta.ready)
+  private val s1_MSHR_valid   = fromMSHR.valid && !fromMSHR.bits.corrupt
+  private val s1_waymasks     = WireInit(VecInit(Seq.fill(PortNumber)(0.U(nWays.W))))
+  private val s1_waymasks_r   = RegEnable(s1_waymasks, 0.U.asTypeOf(s1_waymasks), s1_SRAM_valid || s1_MSHR_valid)
+  private val s1_meta_codes   = WireInit(VecInit(Seq.fill(PortNumber)(0.U(ICacheMetaCodeBits.W))))
+  private val s1_meta_codes_r = RegEnable(s1_meta_codes, 0.U.asTypeOf(s1_meta_codes), s1_SRAM_valid || s1_MSHR_valid)
 
   // update waymasks and meta_codes
   (0 until PortNumber).foreach { i =>
     val old_waymask    = Mux(s1_SRAM_valid, s1_SRAM_waymasks(i), s1_waymasks_r(i))
     val old_meta_codes = Mux(s1_SRAM_valid, s1_SRAM_meta_codes(i), s1_meta_codes_r(i))
-    val new_info       = update_meta_info(old_waymask, s1_req_vSetIdx(i), s1_req_ptags(i), old_meta_codes)
+    val new_info       = updateMetaInfo(old_waymask, s1_req_vSetIdx(i), s1_req_ptags(i), old_meta_codes)
     s1_waymasks(i)   := new_info._1
     s1_meta_codes(i) := new_info._2
   }
 
   /**
     ******************************************************************************
-    * send enqueu req to WayLookup
+    * send enqueue req to WayLookup
     ******** **********************************************************************
     */
   // Disallow enqueuing wayLookup when SRAM write occurs.
@@ -359,18 +353,19 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
   toWayLookup.bits.isForVSnonLeafPTE := s1_req_isForVSnonLeafPTE
   toWayLookup.bits.meta_codes        := s1_meta_codes
   (0 until PortNumber).foreach { i =>
-    val excpValid = if (i == 0) true.B
-    else s1_doubleline // exception in first line is always valid, in second line is valid iff is doubleline request
-    // Send s1_itlb_exception to WayLookup (instead of s1_exception_out) for better timing. Will check pmp again in mainPipe
+    // exception in first line is always valid, in second line is valid iff is doubleline request
+    val excpValid = if (i == 0) true.B else s1_doubleline
+    // Send s1_itlb_exception to WayLookup (instead of s1_exception_out) for better timing.
+    // Will check pmp again in mainPipe
     toWayLookup.bits.itlb_exception(i) := Mux(excpValid, s1_itlb_exception(i), ExceptionType.none)
     toWayLookup.bits.itlb_pbmt(i)      := Mux(excpValid, s1_itlb_pbmt(i), Pbmt.pma)
   }
 
-  val s1_waymasks_vec = s1_waymasks.map(_.asTypeOf(Vec(nWays, Bool())))
+  private val s1_waymasks_vec = s1_waymasks.map(_.asTypeOf(Vec(nWays, Bool())))
   when(toWayLookup.fire) {
     assert(
       PopCount(s1_waymasks_vec(0)) <= 1.U && (PopCount(s1_waymasks_vec(1)) <= 1.U || !s1_doubleline),
-      "Multiple hit in main pipe, port0:is=%d,ptag=0x%x,vidx=0x%x,vaddr=0x%x port1:is=%d,ptag=0x%x,vidx=0x%x,vaddr=0x%x ",
+      "Multi-hit:\nport0: count=%d ptag=0x%x vSet=0x%x vaddr=0x%x\nport1: count=%d ptag=0x%x vSet=0x%x vaddr=0x%x",
       PopCount(s1_waymasks_vec(0)) > 1.U,
       s1_req_ptags(0),
       get_idx(s1_req_vaddr(0)),
@@ -391,22 +386,22 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     // if itlb has exception, paddr can be invalid, therefore pmp check can be skipped
     p.valid     := s1_valid // !ExceptionType.hasException(s1_itlb_exception(i))
     p.bits.addr := s1_req_paddr(i)
-    p.bits.size := 3.U      // TODO
+    p.bits.size := 3.U
     p.bits.cmd  := TlbCmd.exec
   }
-  val s1_pmp_exception = VecInit(fromPMP.map(ExceptionType.fromPMPResp))
-  val s1_pmp_mmio      = VecInit(fromPMP.map(_.mmio))
+  private val s1_pmp_exception = VecInit(fromPMP.map(ExceptionType.fromPMPResp))
+  private val s1_pmp_mmio      = VecInit(fromPMP.map(_.mmio))
 
   // merge s1 itlb/pmp exceptions, itlb has the highest priority, pmp next
   // for timing consideration, meta_corrupt is not merged, and it will NOT cancel prefetch
-  val s1_exception_out = ExceptionType.merge(
+  private val s1_exception_out = ExceptionType.merge(
     s1_backendException,
     s1_itlb_exception,
     s1_pmp_exception
   )
 
   // merge pmp mmio and itlb pbmt
-  val s1_mmio = VecInit((s1_pmp_mmio zip s1_itlb_pbmt).map { case (mmio, pbmt) =>
+  private val s1_mmio = VecInit((s1_pmp_mmio zip s1_itlb_pbmt).map { case (mmio, pbmt) =>
     mmio || Pbmt.isUncache(pbmt)
   })
 
@@ -468,7 +463,7 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
 
   s1_ready := next_state === m_idle
   s1_fire  := (next_state === m_idle) && s1_valid && !s1_flush // used to clear s1_valid & itlb_valid_latch
-  val s1_real_fire = s1_fire && io.csr_pf_enable // real "s1 fire" that s1 enters s2
+  private val s1_real_fire = s1_fire && io.csr_pf_enable // real "s1 fire" that s1 enters s2
 
   /**
     ******************************************************************************
@@ -477,22 +472,25 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     * - 2. send req to missUnit
     ******************************************************************************
     */
-  val s2_valid =
+  private val s2_valid =
     generatePipeControl(lastFire = s1_real_fire, thisFire = s2_fire, thisFlush = s2_flush, lastFlush = false.B)
 
-  val s2_req_vaddr      = RegEnable(s1_req_vaddr, 0.U.asTypeOf(s1_req_vaddr), s1_real_fire)
-  val s2_isSoftPrefetch = RegEnable(s1_isSoftPrefetch, 0.U.asTypeOf(s1_isSoftPrefetch), s1_real_fire)
-  val s2_doubleline     = RegEnable(s1_doubleline, 0.U.asTypeOf(s1_doubleline), s1_real_fire)
-  val s2_req_paddr      = RegEnable(s1_req_paddr, 0.U.asTypeOf(s1_req_paddr), s1_real_fire)
-  val s2_exception =
+  private val s2_req_vaddr      = RegEnable(s1_req_vaddr, 0.U.asTypeOf(s1_req_vaddr), s1_real_fire)
+  private val s2_isSoftPrefetch = RegEnable(s1_isSoftPrefetch, 0.U.asTypeOf(s1_isSoftPrefetch), s1_real_fire)
+  private val s2_doubleline     = RegEnable(s1_doubleline, 0.U.asTypeOf(s1_doubleline), s1_real_fire)
+  private val s2_req_paddr      = RegEnable(s1_req_paddr, 0.U.asTypeOf(s1_req_paddr), s1_real_fire)
+  private val s2_exception =
     RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_real_fire) // includes itlb/pmp exception
-//  val s2_exception_in = RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_real_fire)  // disabled for timing consideration
-  val s2_mmio     = RegEnable(s1_mmio, 0.U.asTypeOf(s1_mmio), s1_real_fire)
-  val s2_waymasks = RegEnable(s1_waymasks, 0.U.asTypeOf(s1_waymasks), s1_real_fire)
-//  val s2_meta_codes   = RegEnable(s1_meta_codes,    0.U.asTypeOf(s1_meta_codes),    s1_real_fire)  // disabled for timing consideration
+  // disabled for timing consideration
+// private val s2_exception_in =
+//   RegEnable(s1_exception_out, 0.U.asTypeOf(s1_exception_out), s1_real_fire)
+  private val s2_mmio     = RegEnable(s1_mmio, 0.U.asTypeOf(s1_mmio), s1_real_fire)
+  private val s2_waymasks = RegEnable(s1_waymasks, 0.U.asTypeOf(s1_waymasks), s1_real_fire)
+  // disabled for timing consideration
+// private val s2_meta_codes   = RegEnable(s1_meta_codes, 0.U.asTypeOf(s1_meta_codes), s1_real_fire)
 
-  val s2_req_vSetIdx = s2_req_vaddr.map(get_idx)
-  val s2_req_ptags   = s2_req_paddr.map(get_phy_tag)
+  private val s2_req_vSetIdx = s2_req_vaddr.map(get_idx)
+  private val s2_req_ptags   = s2_req_paddr.map(get_phy_tag)
 
   // disabled for timing consideration
 //  // do metaArray ECC check
@@ -500,7 +498,7 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
 //    val hit_num = PopCount(waymask)
 //    // NOTE: if not hit, encodeMetaECC(meta) =/= code can also be true, but we don't care about it
 //    (encodeMetaECC(meta) =/= code && hit_num === 1.U) ||  // hit one way, but parity code does not match, ECC failure
-//      hit_num > 1.U                                       // hit multi way, must be a ECC failure
+//      hit_num > 1.U                                       // hit multi-way, must be an ECC failure
 //  })
 //
 //  // generate exception
@@ -519,21 +517,21 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
    * This is the opposite of how mainPipe handles fromMSHR.bits.corrupt,
    *   in which we should set s2_MSHR_hits to true.B, and send error to ifu.
    */
-  val s2_MSHR_match = VecInit((0 until PortNumber).map(i =>
+  private val s2_MSHR_match = VecInit((0 until PortNumber).map { i =>
     (s2_req_vSetIdx(i) === fromMSHR.bits.vSetIdx) &&
-      (s2_req_ptags(i) === getPhyTagFromBlk(fromMSHR.bits.blkPaddr)) &&
-      s2_valid && fromMSHR.valid && !fromMSHR.bits.corrupt
-  ))
-  val s2_MSHR_hits = (0 until PortNumber).map(i => ValidHoldBypass(s2_MSHR_match(i), s2_fire || s2_flush))
+    (s2_req_ptags(i) === getPhyTagFromBlk(fromMSHR.bits.blkPaddr)) &&
+    s2_valid && fromMSHR.valid && !fromMSHR.bits.corrupt
+  })
+  private val s2_MSHR_hits = (0 until PortNumber).map(i => ValidHoldBypass(s2_MSHR_match(i), s2_fire || s2_flush))
 
-  val s2_SRAM_hits = s2_waymasks.map(_.orR)
-  val s2_hits      = VecInit((0 until PortNumber).map(i => s2_MSHR_hits(i) || s2_SRAM_hits(i)))
+  private val s2_SRAM_hits = s2_waymasks.map(_.orR)
+  private val s2_hits      = VecInit((0 until PortNumber).map(i => s2_MSHR_hits(i) || s2_SRAM_hits(i)))
 
   /* s2_exception includes itlb pf/gpf/af, pmp af and meta corruption (af), neither of which should be prefetched
    * mmio should not be prefetched
    * also, if previous has exception, latter port should also not be prefetched
    */
-  val s2_miss = VecInit((0 until PortNumber).map { i =>
+  private val s2_miss = VecInit((0 until PortNumber).map { i =>
     !s2_hits(i) && (if (i == 0) true.B else s2_doubleline) &&
     !ExceptionType.hasException(s2_exception.take(i + 1)) &&
     s2_mmio.take(i + 1).map(!_).reduce(_ && _)
@@ -544,10 +542,10 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     * send req to missUnit
     ******************************************************************************
     */
-  val toMSHRArbiter = Module(new Arbiter(new ICacheMissReq, PortNumber))
+  private val toMSHRArbiter = Module(new Arbiter(new ICacheMissReq, PortNumber))
 
   // To avoid sending duplicate requests.
-  val has_send = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
+  private val has_send = RegInit(VecInit(Seq.fill(PortNumber)(false.B)))
   (0 until PortNumber).foreach { i =>
     when(s1_real_fire) {
       has_send(i) := false.B
@@ -556,7 +554,7 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
     }
   }
 
-  (0 until PortNumber).map { i =>
+  (0 until PortNumber).foreach { i =>
     toMSHRArbiter.io.in(i).valid         := s2_valid && s2_miss(i) && !has_send(i)
     toMSHRArbiter.io.in(i).bits.blkPaddr := getBlkAddr(s2_req_paddr(i))
     toMSHRArbiter.io.in(i).bits.vSetIdx  := s2_req_vSetIdx(i)
@@ -567,8 +565,9 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
   s2_flush := io.flush
 
   // toMSHRArbiter.io.in(i).fire is not used here for timing consideration
-  // val s2_finish  = (0 until PortNumber).map(i => has_send(i) || !s2_miss(i) || toMSHRArbiter.io.in(i).fire).reduce(_&&_)
-  val s2_finish = (0 until PortNumber).map(i => has_send(i) || !s2_miss(i)).reduce(_ && _)
+// private val s2_finish =
+//   (0 until PortNumber).map(i => has_send(i) || !s2_miss(i) || toMSHRArbiter.io.in(i).fire).reduce(_ && _)
+  private val s2_finish = (0 until PortNumber).map(i => has_send(i) || !s2_miss(i)).reduce(_ && _)
   s2_ready := s2_finish || !s2_valid
   s2_fire  := s2_valid && s2_finish && !s2_flush
 
@@ -589,15 +588,15 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule {
   /**
     * Count the number of requests that are filtered for various reasons.
     * The number of prefetch discard in Performance Accumulator may be
-    * a littel larger the number of really discarded. Because there can
+    * a little larger the number of really discarded. Because there can
     * be multiple reasons for a canceled request at the same time.
     */
   // discard prefetch request by flush
   // XSPerfAccumulate("fdip_prefetch_discard_by_tlb_except",  p1_discard && p1_tlb_except)
   // // discard prefetch request by hit icache SRAM
   // XSPerfAccumulate("fdip_prefetch_discard_by_hit_cache",   p2_discard && p1_meta_hit)
-  // // discard prefetch request by hit wirte SRAM
-  // XSPerfAccumulate("fdip_prefetch_discard_by_p1_monoitor", p1_discard && p1_monitor_hit)
+  // // discard prefetch request by hit write SRAM
+  // XSPerfAccumulate("fdip_prefetch_discard_by_p1_monitor",  p1_discard && p1_monitor_hit)
   // // discard prefetch request by pmp except or mmio
   // XSPerfAccumulate("fdip_prefetch_discard_by_pmp",         p2_discard && p2_pmp_except)
   // // discard prefetch request by hit mainPipe info

--- a/src/main/scala/xiangshan/frontend/icache/InstrUncache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/InstrUncache.scala
@@ -21,7 +21,6 @@ import chisel3.util._
 import freechips.rocketchip.diplomacy.IdRange
 import freechips.rocketchip.diplomacy.LazyModule
 import freechips.rocketchip.diplomacy.LazyModuleImp
-import freechips.rocketchip.diplomacy.TransferSizes
 import freechips.rocketchip.tilelink.TLArbiter
 import freechips.rocketchip.tilelink.TLBundleA
 import freechips.rocketchip.tilelink.TLBundleD
@@ -30,40 +29,39 @@ import freechips.rocketchip.tilelink.TLEdgeOut
 import freechips.rocketchip.tilelink.TLMasterParameters
 import freechips.rocketchip.tilelink.TLMasterPortParameters
 import org.chipsalliance.cde.config.Parameters
-import utility._
 import utils._
-import xiangshan._
 import xiangshan.frontend._
 
 class InsUncacheReq(implicit p: Parameters) extends ICacheBundle {
-  val addr = UInt(PAddrBits.W)
+  val addr: UInt = UInt(PAddrBits.W)
 }
 
 class InsUncacheResp(implicit p: Parameters) extends ICacheBundle {
-  val data = UInt(maxInstrLen.W)
+  val data: UInt = UInt(maxInstrLen.W)
+}
+
+class InstrMMIOEntryIO(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheBundle {
+  val id: UInt = Input(UInt(log2Up(cacheParams.nMMIOs).W))
+  // client requests
+  val req:  DecoupledIO[InsUncacheReq]  = Flipped(DecoupledIO(new InsUncacheReq))
+  val resp: DecoupledIO[InsUncacheResp] = DecoupledIO(new InsUncacheResp)
+
+  val mmio_acquire: DecoupledIO[TLBundleA] = DecoupledIO(new TLBundleA(edge.bundle))
+  val mmio_grant:   DecoupledIO[TLBundleD] = Flipped(DecoupledIO(new TLBundleD(edge.bundle)))
+
+  val flush: Bool = Input(Bool())
 }
 
 // One miss entry deals with one mmio request
-class InstrMMIOEntry(edge: TLEdgeOut)(implicit p: Parameters) extends XSModule with HasICacheParameters
-    with HasIFUConst {
-  val io = IO(new Bundle {
-    val id = Input(UInt(log2Up(cacheParams.nMMIOs).W))
-    // client requests
-    val req  = Flipped(DecoupledIO(new InsUncacheReq))
-    val resp = DecoupledIO(new InsUncacheResp)
+class InstrMMIOEntry(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheModule with HasIFUConst {
+  val io: InstrMMIOEntryIO = IO(new InstrMMIOEntryIO(edge))
 
-    val mmio_acquire = DecoupledIO(new TLBundleA(edge.bundle))
-    val mmio_grant   = Flipped(DecoupledIO(new TLBundleD(edge.bundle)))
+  private val s_invalid :: s_refill_req :: s_refill_resp :: s_send_resp :: Nil = Enum(4)
 
-    val flush = Input(Bool())
-  })
+  private val state = RegInit(s_invalid)
 
-  val s_invalid :: s_refill_req :: s_refill_resp :: s_send_resp :: Nil = Enum(4)
-
-  val state = RegInit(s_invalid)
-
-  val req         = Reg(new InsUncacheReq)
-  val respDataReg = Reg(UInt(mmioBusWidth.W))
+  private val req         = Reg(new InsUncacheReq)
+  private val respDataReg = Reg(UInt(mmioBusWidth.W))
 
   // assign default values to output signals
   io.req.ready  := false.B
@@ -75,7 +73,7 @@ class InstrMMIOEntry(edge: TLEdgeOut)(implicit p: Parameters) extends XSModule w
 
   io.mmio_grant.ready := false.B
 
-  val needFlush = RegInit(false.B)
+  private val needFlush = RegInit(false.B)
 
   when(io.flush && (state =/= s_invalid) && (state =/= s_send_resp))(needFlush := true.B)
     .elsewhen((state === s_send_resp) && needFlush)(needFlush := false.B)
@@ -116,7 +114,7 @@ class InstrMMIOEntry(edge: TLEdgeOut)(implicit p: Parameters) extends XSModule w
     }
   }
 
-  def getDataFromBus(pc: UInt) = {
+  private def getDataFromBus(pc: UInt): UInt = {
     val respData = Wire(UInt(maxInstrLen.W))
     respData := Mux(
       pc(2, 1) === "b00".U,
@@ -133,7 +131,7 @@ class InstrMMIOEntry(edge: TLEdgeOut)(implicit p: Parameters) extends XSModule w
   when(state === s_send_resp) {
     io.resp.valid     := !needFlush
     io.resp.bits.data := getDataFromBus(req.addr)
-    // meta data should go with the response
+    // metadata should go with the response
     when(io.resp.fire || needFlush) {
       state := s_invalid
     }
@@ -141,43 +139,42 @@ class InstrMMIOEntry(edge: TLEdgeOut)(implicit p: Parameters) extends XSModule w
 }
 
 class InstrUncacheIO(implicit p: Parameters) extends ICacheBundle {
-  val req   = Flipped(DecoupledIO(new InsUncacheReq))
-  val resp  = DecoupledIO(new InsUncacheResp)
-  val flush = Input(Bool())
+  val req:   DecoupledIO[InsUncacheReq]  = Flipped(DecoupledIO(new InsUncacheReq))
+  val resp:  DecoupledIO[InsUncacheResp] = DecoupledIO(new InsUncacheResp)
+  val flush: Bool                        = Input(Bool())
 }
 
 class InstrUncache()(implicit p: Parameters) extends LazyModule with HasICacheParameters {
   override def shouldBeInlined: Boolean = false
 
-  val clientParameters = TLMasterPortParameters.v1(
+  val clientParameters: TLMasterPortParameters = TLMasterPortParameters.v1(
     clients = Seq(TLMasterParameters.v1(
       "InstrUncache",
       sourceId = IdRange(0, cacheParams.nMMIOs)
     ))
   )
-  val clientNode = TLClientNode(Seq(clientParameters))
+  val clientNode: TLClientNode = TLClientNode(Seq(clientParameters))
 
-  lazy val module = new InstrUncacheImp(this)
-
+  lazy val module: InstrUncacheImp = new InstrUncacheImp(this)
 }
 
 class InstrUncacheImp(outer: InstrUncache)
     extends LazyModuleImp(outer)
     with HasICacheParameters
     with HasTLDump {
-  val io = IO(new InstrUncacheIO)
+  val io: InstrUncacheIO = IO(new InstrUncacheIO)
 
-  val (bus, edge) = outer.clientNode.out.head
+  private val (bus, edge) = outer.clientNode.out.head
 
-  val resp_arb = Module(new Arbiter(new InsUncacheResp, cacheParams.nMMIOs))
+  private val resp_arb = Module(new Arbiter(new InsUncacheResp, cacheParams.nMMIOs))
 
-  val req          = io.req
-  val resp         = io.resp
-  val mmio_acquire = bus.a
-  val mmio_grant   = bus.d
+  private val req          = io.req
+  private val resp         = io.resp
+  private val mmio_acquire = bus.a
+  private val mmio_grant   = bus.d
 
-  val entry_alloc_idx = Wire(UInt())
-  val req_ready       = WireInit(false.B)
+  private val entry_alloc_idx = Wire(UInt())
+  private val req_ready       = WireInit(false.B)
 
   // assign default values to output signals
   bus.b.ready := false.B
@@ -187,7 +184,7 @@ class InstrUncacheImp(outer: InstrUncache)
   bus.e.valid := false.B
   bus.e.bits  := DontCare
 
-  val entries = (0 until cacheParams.nMMIOs) map { i =>
+  private val entries = (0 until cacheParams.nMMIOs).map { i =>
     val entry = Module(new InstrMMIOEntry(edge))
 
     entry.io.id    := i.U(log2Up(cacheParams.nMMIOs).W)
@@ -216,5 +213,4 @@ class InstrUncacheImp(outer: InstrUncache)
   req.ready := req_ready
   resp <> resp_arb.io.out
   TLArbiter.lowestFromSeq(edge, mmio_acquire, entries.map(_.io.mmio_acquire))
-
 }


### PR DESCRIPTION
- add type annotation to public members
- add private qualifier to other members
- add `asUInt` to shift results (Bits)
- fix typo
- remove unused imports
- rename `ICacheMSHR.waymask` to `way` since it is not a mask
- use `idxBits` for `log2Up(nSets)`
- use `wayBits` for `log2Up(nWays)`
- use `foreach` instead of `map` when return value is not needed
- use `{}` instead of `()` for multi-line `foreach` and `map`

The generated verilog is checked and is identical with the original (except `waymask` -> `way` & order changes).