### PR TITLE
fix(decode): not eliminate old vd when vstart is not zero

### DIFF
--- a/src/main/scala/xiangshan/backend/issue/Dispatch2Iq.scala
+++ b/src/main/scala/xiangshan/backend/issue/Dispatch2Iq.scala
@@ -232,12 +232,11 @@ abstract class Dispatch2IqImp(override val wrapper: Dispatch2Iq)(implicit p: Par
       val vlIsNonZero = !vlSrcIsZeroVec.get(i)
       val ignoreTail = vlIsVlmax && (vm =/= 0.U || vma) && !isWritePartVd
       val ignoreWhole = (vm =/= 0.U || vma) && vta
-      val isFof = VlduType.isFof(io.in(i).bits.fuOpType)
       for (j <- 0 until numRegSrcVf) {
         val ignoreOldVd = Wire(Bool())
         if (j == numRegSrcVf - 1) {
           // check whether can ignore the old vd dependency
-          ignoreOldVd := SrcState.isReady(vlSrcStateVec.get(i)) && !isFof && vlIsNonZero && !isDependOldVd && (ignoreTail || ignoreWhole)
+          ignoreOldVd := SrcState.isReady(vlSrcStateVec.get(i)) && vlIsNonZero && !isDependOldVd && (ignoreTail || ignoreWhole)
         } else {
           // check whether can ignore the src
           ignoreOldVd := false.B

--- a/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
+++ b/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
@@ -321,7 +321,7 @@ object EntryBundles extends HasCircularQueuePtrHelper {
           * 2. when vl = 0, we cannot set the srctype to imm because the vd keep the old value
           * 3. when vl = vlmax, we can set srctype to imm when vta is not set
           */
-        ignoreOldVd := !VlduType.isFof(entryReg.payload.fuOpType) && srcIsVec && vlIsNonZero && !isDependOldVd && (ignoreTail || ignoreWhole)
+        ignoreOldVd := srcIsVec && vlIsNonZero && !isDependOldVd && (ignoreTail || ignoreWhole)
       } else {
         ignoreOldVd := false.B
       }


### PR DESCRIPTION
* when vstart is not zero, it need to combine the old data in the range of 0 to vstart, so we need old vd in this case
* different instructions may have same fuoptype, so we need to check both futype and fuoptype to distinguish the instructions