### PR TITLE
refactor(frontend): prune the least significant bit of PC

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -95,6 +95,7 @@ class PredictorAnswer(implicit p: Parameters) extends XSBundle {
 
 class CfiUpdateInfo(implicit p: Parameters) extends XSBundle with HasBPUParameter {
   // from backend
+  //TODO: This should be PrunedAddr. It remains UInt now because modifications are needed in backend.
   val pc = UInt(VAddrBits.W)
   // frontend -> backend -> frontend
   val pd = new PreDecodeInfo
@@ -134,7 +135,7 @@ class CfiUpdateInfo(implicit p: Parameters) extends XSBundle with HasBPUParamete
     this.TOSW := entry.TOSW
     this.TOSR := entry.TOSR
     this.NOS := entry.NOS
-    this.topAddr := entry.topAddr
+    this.topAddr := entry.topAddr.toUInt
     this
   }
 

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -250,7 +250,8 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
 
   // top-down info
   memBlock.io.debugTopDown.robHeadVaddr := backend.io.debugTopDown.fromRob.robHeadVaddr
-  frontend.io.debugTopDown.robHeadVaddr := backend.io.debugTopDown.fromRob.robHeadVaddr
+  frontend.io.debugTopDown.robHeadVaddr.bits := backend.io.debugTopDown.fromRob.robHeadVaddr.bits
+  frontend.io.debugTopDown.robHeadVaddr.valid := backend.io.debugTopDown.fromRob.robHeadVaddr.valid
   io.debugTopDown.robHeadPaddr := backend.io.debugTopDown.fromRob.robHeadPaddr
   io.debugTopDown.robTrueCommit := backend.io.debugRolling.robTrueCommit
   backend.io.debugTopDown.fromCore.l2MissMatch := io.debugTopDown.l2MissMatch

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -107,7 +107,7 @@ class CtrlBlockImp(
 
   pcMem.io.ren.get(pcMemRdIndexes("robFlush").head) := s0_robFlushRedirect.valid
   pcMem.io.raddr(pcMemRdIndexes("robFlush").head) := s0_robFlushRedirect.bits.ftqIdx.value
-  private val s1_robFlushPc = pcMem.io.rdata(pcMemRdIndexes("robFlush").head).startAddr + (RegEnable(s0_robFlushRedirect.bits.ftqOffset, s0_robFlushRedirect.valid) << instOffsetBits)
+  private val s1_robFlushPc = pcMem.io.rdata(pcMemRdIndexes("robFlush").head).startAddr.toUInt + (RegEnable(s0_robFlushRedirect.bits.ftqOffset, s0_robFlushRedirect.valid) << instOffsetBits)
   private val s3_redirectGen = redirectGen.io.stage2Redirect
   private val s1_s3_redirect = Mux(s1_robFlushRedirect.valid, s1_robFlushRedirect, s3_redirectGen)
   private val s2_s4_pendingRedirectValid = RegInit(false.B)
@@ -219,7 +219,7 @@ class CtrlBlockImp(
   pcMem.io.raddr(pcMemRdIndexes("redirect").head) := memViolation.bits.ftqIdx.value
   pcMem.io.ren.get(pcMemRdIndexes("memPred").head) := memViolation.valid
   pcMem.io.raddr(pcMemRdIndexes("memPred").head) := memViolation.bits.stFtqIdx.value
-  redirectGen.io.memPredPcRead.data := pcMem.io.rdata(pcMemRdIndexes("memPred").head).startAddr + (RegEnable(memViolation.bits.stFtqOffset, memViolation.valid) << instOffsetBits)
+  redirectGen.io.memPredPcRead.data := pcMem.io.rdata(pcMemRdIndexes("memPred").head).startAddr.toUInt + (RegEnable(memViolation.bits.stFtqOffset, memViolation.valid) << instOffsetBits)
 
   for ((pcMemIdx, i) <- pcMemRdIndexes("bjuPc").zipWithIndex) {
     val ren = io.toDataPath.pcToDataPathIO.fromDataPathValid(i)
@@ -227,7 +227,7 @@ class CtrlBlockImp(
     val roffset = io.toDataPath.pcToDataPathIO.fromDataPathFtqOffset(i)
     pcMem.io.ren.get(pcMemIdx) := ren
     pcMem.io.raddr(pcMemIdx) := raddr
-    io.toDataPath.pcToDataPathIO.toDataPathPC(i) := pcMem.io.rdata(pcMemIdx).startAddr
+    io.toDataPath.pcToDataPathIO.toDataPathPC(i) := pcMem.io.rdata(pcMemIdx).startAddr.toUInt
   }
 
   val newestEn = RegNext(io.frontend.fromFtq.newest_entry_en)
@@ -241,7 +241,7 @@ class CtrlBlockImp(
     pcMem.io.ren.get(pcMemIdx) := ren
     pcMem.io.raddr(pcMemIdx) := raddr
     val needNewest = RegNext(baseAddr === newestPtr.value)
-    io.toDataPath.pcToDataPathIO.toDataPathTargetPC(i) := Mux(needNewest, newestTargetNext, pcMem.io.rdata(pcMemIdx).startAddr)
+    io.toDataPath.pcToDataPathIO.toDataPathTargetPC(i) := Mux(needNewest, newestTargetNext, pcMem.io.rdata(pcMemIdx).startAddr.toUInt)
   }
 
   val baseIdx = params.BrhCnt
@@ -252,21 +252,21 @@ class CtrlBlockImp(
     val roffset = io.toDataPath.pcToDataPathIO.fromDataPathFtqOffset(baseIdx+i)
     pcMem.io.ren.get(pcMemIdx) := ren
     pcMem.io.raddr(pcMemIdx) := raddr
-    io.toDataPath.pcToDataPathIO.toDataPathPC(baseIdx+i) := pcMem.io.rdata(pcMemIdx).startAddr
+    io.toDataPath.pcToDataPathIO.toDataPathPC(baseIdx+i) := pcMem.io.rdata(pcMemIdx).startAddr.toUInt
   }
 
   for ((pcMemIdx, i) <- pcMemRdIndexes("hybrid").zipWithIndex) {
     // load read pcMem (s0) -> get rdata (s1) -> reg next in Memblock (s2) -> reg next in Memblock (s3) -> consumed by pf (s3)
     pcMem.io.ren.get(pcMemIdx) := io.memHyPcRead(i).valid
     pcMem.io.raddr(pcMemIdx) := io.memHyPcRead(i).ptr.value
-    io.memHyPcRead(i).data := pcMem.io.rdata(pcMemIdx).startAddr + (RegEnable(io.memHyPcRead(i).offset, io.memHyPcRead(i).valid) << instOffsetBits)
+    io.memHyPcRead(i).data := pcMem.io.rdata(pcMemIdx).startAddr.toUInt + (RegEnable(io.memHyPcRead(i).offset, io.memHyPcRead(i).valid) << instOffsetBits)
   }
 
   if (EnableStorePrefetchSMS) {
     for ((pcMemIdx, i) <- pcMemRdIndexes("store").zipWithIndex) {
       pcMem.io.ren.get(pcMemIdx) := io.memStPcRead(i).valid
       pcMem.io.raddr(pcMemIdx) := io.memStPcRead(i).ptr.value
-      io.memStPcRead(i).data := pcMem.io.rdata(pcMemIdx).startAddr + (RegEnable(io.memStPcRead(i).offset, io.memStPcRead(i).valid) << instOffsetBits)
+      io.memStPcRead(i).data := pcMem.io.rdata(pcMemIdx).startAddr.toUInt + (RegEnable(io.memStPcRead(i).offset, io.memStPcRead(i).valid) << instOffsetBits)
     }
   } else {
     io.memStPcRead.foreach(_.data := 0.U)
@@ -285,7 +285,7 @@ class CtrlBlockImp(
     val traceValid = trace.toPcMem.blocks(i).valid
     pcMem.io.ren.get(pcMemIdx) := traceValid
     pcMem.io.raddr(pcMemIdx) := trace.toPcMem.blocks(i).bits.ftqIdx.get.value
-    tracePcStart(i) := pcMem.io.rdata(pcMemIdx).startAddr
+    tracePcStart(i) := pcMem.io.rdata(pcMemIdx).startAddr.toUInt
   }
 
   // Trap/Xret only occur in block(0).
@@ -319,7 +319,7 @@ class CtrlBlockImp(
   redirectGen.io.loadReplay <> loadReplay
   val loadRedirectOffset = Mux(memViolation.bits.flushItself(), 0.U, Mux(memViolation.bits.isRVC, 2.U, 4.U))
   val loadRedirectPcFtqOffset = RegEnable((memViolation.bits.ftqOffset << instOffsetBits).asUInt +& loadRedirectOffset, memViolation.valid)
-  val loadRedirectPcRead = pcMem.io.rdata(pcMemRdIndexes("redirect").head).startAddr + loadRedirectPcFtqOffset
+  val loadRedirectPcRead = pcMem.io.rdata(pcMemRdIndexes("redirect").head).startAddr.toUInt + loadRedirectPcFtqOffset
 
   redirectGen.io.loadReplay.bits.cfiUpdate.pc := loadRedirectPcRead
   val load_target = loadRedirectPcRead

--- a/src/main/scala/xiangshan/cache/L1Cache.scala
+++ b/src/main/scala/xiangshan/cache/L1Cache.scala
@@ -22,6 +22,7 @@ import org.chipsalliance.cde.config.Parameters
 import chisel3._
 import chisel3.util._
 import xiangshan.{HasXSParameter, XSBundle, XSModule}
+import xiangshan.frontend.PrunedAddr
 
 // this file contains common building blocks that can be shared by ICache and DCache
 // this is the common parameter base for L1 ICache and L1 DCache
@@ -79,9 +80,11 @@ trait HasL1CacheParameters extends HasXSParameter
   def refillWords = refillBytes / wordBytes
 
   def get_phy_tag(paddr: UInt) = (paddr >> pgUntagBits).asUInt
+  def get_phy_tag(paddr: PrunedAddr): UInt = (paddr >> pgUntagBits).asUInt
   def get_vir_tag(vaddr: UInt) = (vaddr >> untagBits).asUInt
   def get_tag(addr: UInt) = get_phy_tag(addr)
   def get_idx(addr: UInt) = addr(untagBits-1, blockOffBits)
+  def get_idx(addr: PrunedAddr) = addr(untagBits-1, blockOffBits)
   def get_untag(addr: UInt) = addr(pgUntagBits-1, 0)
   def get_block(addr: UInt) = addr >> blockOffBits
   def get_block_addr(addr: UInt) = (addr >> blockOffBits) << blockOffBits

--- a/src/main/scala/xiangshan/frontend/FTB.scala
+++ b/src/main/scala/xiangshan/frontend/FTB.scala
@@ -58,10 +58,10 @@ class FtbSlot(val offsetLen: Int, val subOffsetLen: Option[Int] = None)(implicit
   val lower   = UInt(offsetLen.W)
   val tarStat = UInt(TAR_STAT_SZ.W)
 
-  def setLowerStatByTarget(pc: UInt, target: UInt, isShare: Boolean) = {
+  def setLowerStatByTarget(pc: PrunedAddr, target: PrunedAddr, isShare: Boolean): Unit = {
     def getTargetStatByHigher(pc_higher: UInt, target_higher: UInt) =
       Mux(target_higher > pc_higher, TAR_OVF, Mux(target_higher < pc_higher, TAR_UDF, TAR_FIT))
-    def getLowerByTarget(target: UInt, offsetLen: Int) = target(offsetLen, 1)
+    def getLowerByTarget(target: PrunedAddr, offsetLen: Int) = target(offsetLen, 1)
     val offLen        = if (isShare) this.subOffsetLen.get else this.offsetLen
     val pc_higher     = pc(VAddrBits - 1, offLen + 1)
     val target_higher = target(VAddrBits - 1, offLen + 1)
@@ -72,8 +72,13 @@ class FtbSlot(val offsetLen: Int, val subOffsetLen: Option[Int] = None)(implicit
     this.sharing := isShare.B
   }
 
-  def getTarget(pc: UInt, last_stage: Option[Tuple2[UInt, Bool]] = None) = {
-    def getTarget(offLen: Int)(pc: UInt, lower: UInt, stat: UInt, last_stage: Option[Tuple2[UInt, Bool]] = None) = {
+  def getTarget(pc: PrunedAddr, last_stage: Option[(UInt, Bool)] = None): PrunedAddr = {
+    def getTarget(offLen: Int)(
+        pc:         PrunedAddr,
+        lower:      UInt,
+        stat:       UInt,
+        last_stage: Option[(UInt, Bool)] = None
+    ): PrunedAddr = {
       val h                = pc(VAddrBits - 1, offLen + 1)
       val higher           = Wire(UInt((VAddrBits - offLen - 1).W))
       val higher_plus_one  = Wire(UInt((VAddrBits - offLen - 1).W))
@@ -93,28 +98,28 @@ class FtbSlot(val offsetLen: Int, val subOffsetLen: Option[Int] = None)(implicit
         higher_plus_one  := h + 1.U
         higher_minus_one := h - 1.U
       }
-      val target =
-        Cat(
-          Mux1H(Seq(
-            (stat === TAR_OVF, higher_plus_one),
-            (stat === TAR_UDF, higher_minus_one),
-            (stat === TAR_FIT, higher)
-          )),
-          lower(offLen - 1, 0),
-          0.U(1.W)
-        )
-      require(target.getWidth == VAddrBits)
+      val target = PrunedAddrInit(Cat(
+        Mux1H(Seq(
+          (stat === TAR_OVF, higher_plus_one),
+          (stat === TAR_UDF, higher_minus_one),
+          (stat === TAR_FIT, higher)
+        )),
+        lower(offLen - 1, 0),
+        0.U(1.W)
+      ))
+      require(target.length == VAddrBits)
       require(offLen != 0)
       target
     }
-    if (subOffsetLen.isDefined)
+    if (subOffsetLen.isDefined) {
       Mux(
         sharing,
         getTarget(subOffsetLen.get)(pc, lower, tarStat, last_stage),
         getTarget(offsetLen)(pc, lower, tarStat, last_stage)
       )
-    else
+    } else {
       getTarget(offsetLen)(pc, lower, tarStat, last_stage)
+    }
   }
   def fromAnotherSlot(that: FtbSlot) = {
     require(
@@ -203,14 +208,14 @@ class FTBEntry(implicit p: Parameters) extends FTBEntry_part with FTBParams with
   }
   def allSlotsForBr =
     (0 until numBr).map(getSlotForBr(_))
-  def setByBrTarget(brIdx: Int, pc: UInt, target: UInt) = {
+  def setByBrTarget(brIdx: Int, pc: PrunedAddr, target: PrunedAddr): Unit = {
     val slot = getSlotForBr(brIdx)
     slot.setLowerStatByTarget(pc, target, brIdx == numBr - 1)
   }
-  def setByJmpTarget(pc: UInt, target: UInt) =
-    this.tailSlot.setLowerStatByTarget(pc, target, false)
+  def setByJmpTarget(pc: PrunedAddr, target: PrunedAddr): Unit =
+    this.tailSlot.setLowerStatByTarget(pc, target, isShare = false)
 
-  def getTargetVec(pc: UInt, last_stage: Option[Tuple2[UInt, Bool]] = None) = {
+  def getTargetVec(pc: PrunedAddr, last_stage: Option[Tuple2[PrunedAddr, Bool]] = None): Vec[PrunedAddr] = {
     /*
     Previous design: Use the getTarget function of FTBSlot to calculate three sets of targets separately;
     During this process, nine sets of registers will be generated to register the values of the higher plus one minus one
@@ -263,7 +268,7 @@ class FTBEntry(implicit p: Parameters) extends FTBEntry_part with FTBParams with
       higher_minus_one_tail := h_tail - 1.U
     }
     val br_slots_targets = VecInit(brSlots.map(s =>
-      Cat(
+      PrunedAddrInit(Cat(
         Mux1H(Seq(
           (s.tarStat === TAR_OVF, higher_plus_one_br),
           (s.tarStat === TAR_UDF, higher_minus_one_br),
@@ -271,9 +276,9 @@ class FTBEntry(implicit p: Parameters) extends FTBEntry_part with FTBParams with
         )),
         s.lower(s.offsetLen - 1, 0),
         0.U(1.W)
-      )
+      ))
     ))
-    val tail_target = Wire(UInt(VAddrBits.W))
+    val tail_target = Wire(PrunedAddr(VAddrBits))
     if (tailSlot.subOffsetLen.isDefined) {
       tail_target := Mux(
         tailSlot.sharing,
@@ -308,14 +313,14 @@ class FTBEntry(implicit p: Parameters) extends FTBEntry_part with FTBParams with
       )
     }
 
-    br_slots_targets.map(t => require(t.getWidth == VAddrBits))
-    require(tail_target.getWidth == VAddrBits)
+    br_slots_targets.map(t => require(t.length == VAddrBits))
+    require(tail_target.length == VAddrBits)
     val targets = VecInit(br_slots_targets :+ tail_target)
     targets
   }
 
   def getOffsetVec = VecInit(brSlots.map(_.offset) :+ tailSlot.offset)
-  def getFallThrough(pc: UInt, last_stage_entry: Option[Tuple2[FTBEntry, Bool]] = None) =
+  def getFallThrough(pc: PrunedAddr, last_stage_entry: Option[Tuple2[FTBEntry, Bool]] = None): PrunedAddr =
     if (last_stage_entry.isDefined) {
       var stashed_carry = RegEnable(last_stage_entry.get._1.carry, last_stage_entry.get._2)
       getFallThroughAddr(pc, stashed_carry, pftAddr)
@@ -440,7 +445,7 @@ object FTBMeta {
 }
 
 // class UpdateQueueEntry(implicit p: Parameters) extends XSBundle with FTBParams {
-//   val pc = UInt(VAddrBits.W)
+//   val pc = PrunedAddr(VAddrBits)
 //   val ftb_entry = new FTBEntry
 //   val hit = Bool()
 //   val hit_way = UInt(log2Ceil(numWays).W)
@@ -459,8 +464,9 @@ object FTBMeta {
 
 class FTBTableAddr(val idxBits: Int, val banks: Int, val skewedBits: Int)(implicit p: Parameters) extends XSBundle {
   val addr = new TableAddr(idxBits, banks)
-  def getIdx(x: UInt) = addr.getIdx(x) ^ Cat(addr.getTag(x), addr.getIdx(x))(idxBits + skewedBits - 1, skewedBits)
-  def getTag(x: UInt) = addr.getTag(x)
+  def getIdx(x: PrunedAddr): UInt =
+    addr.getIdx(x) ^ Cat(addr.getTag(x), addr.getIdx(x))(idxBits + skewedBits - 1, skewedBits)
+  def getTag(x: PrunedAddr): UInt = addr.getTag(x)
 }
 
 class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUUtils
@@ -476,18 +482,18 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
       // when ftb hit, read_hits.valid is true, and read_hits.bits is OH of hit way
       // when ftb not hit, read_hits.valid is false, and read_hits is OH of allocWay
       // val read_hits = Valid(Vec(numWays, Bool()))
-      val req_pc    = Flipped(DecoupledIO(UInt(VAddrBits.W)))
+      val req_pc    = Flipped(DecoupledIO(PrunedAddr(VAddrBits)))
       val read_resp = Output(new FTBEntry)
       val read_hits = Valid(UInt(log2Ceil(numWays).W))
 
       val read_multi_entry = Output(new FTBEntry)
       val read_multi_hits  = Valid(UInt(log2Ceil(numWays).W))
 
-      val u_req_pc      = Flipped(DecoupledIO(UInt(VAddrBits.W)))
+      val u_req_pc      = Flipped(DecoupledIO(PrunedAddr(VAddrBits)))
       val update_hits   = Valid(UInt(log2Ceil(numWays).W))
       val update_access = Input(Bool())
 
-      val update_pc          = Input(UInt(VAddrBits.W))
+      val update_pc          = Input(PrunedAddr(VAddrBits))
       val update_write_data  = Flipped(Valid(new FTBEntryWithTag))
       val update_write_way   = Input(UInt(log2Ceil(numWays).W))
       val update_write_alloc = Input(Bool())
@@ -695,7 +701,7 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
     RegEnable(Mux(s2_multi_hit_enable, s2_multi_hit_entry, e), f)
   }
   val real_s2_ftb_entry         = Mux(s2_multi_hit_enable, s2_multi_hit_entry, s2_ftb_entry_dup(0))
-  val real_s2_pc                = s2_pc_dup(0).getAddr()
+  val real_s2_pc                = s2_pc_dup(0)
   val real_s2_startLower        = Cat(0.U(1.W), real_s2_pc(instOffsetBits + log2Ceil(PredictWidth) - 1, instOffsetBits))
   val real_s2_endLowerwithCarry = Cat(real_s2_ftb_entry.carry, real_s2_ftb_entry.pftAddr)
   val real_s2_fallThroughErr =
@@ -789,7 +795,7 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
   ) {
     full_pred.fromFtbEntry(
       s2_ftb_entry,
-      s2_pc.getAddr(),
+      s2_pc,
       // Previous stage meta for better timing
       Some(s1_pc, s1_fire),
       Some(s1_read_resp, s1_fire)
@@ -802,7 +808,7 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
     full_pred & s3_ftb_entry & s3_pc & s2_pc & s2_fire <-
       io.out.s3.full_pred zip s3_ftb_entry_dup zip s3_pc_dup zip s2_pc_dup zip io.s2_fire
   )
-    full_pred.fromFtbEntry(s3_ftb_entry, s3_pc.getAddr(), Some((s2_pc.getAddr(), s2_fire)))
+    full_pred.fromFtbEntry(s3_ftb_entry, s3_pc, Some((s2_pc, s2_fire)))
 
   // Overwrite the fallThroughErr value
   io.out.s3.full_pred.zipWithIndex.map { case (fp, i) => fp.fallThroughErr := real_s3_fallThroughErr_dup(i) }
@@ -829,7 +835,7 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
       out_fp.br_taken_mask(i) := in_fp.br_taken_mask(i) || s3_hit && s3_ftb_entry.strong_bias(i)
   }
 
-  val s3_pc_diff       = s3_pc_dup(0).getAddr()
+  val s3_pc_diff       = s3_pc_dup(0)
   val s3_pc_startLower = Cat(0.U(1.W), s3_pc_diff(instOffsetBits + log2Ceil(PredictWidth) - 1, instOffsetBits))
   val s3_ftb_entry_endLowerwithCarry = Cat(s3_ftb_entry_dup(0).carry, s3_ftb_entry_dup(0).pftAddr)
   val fallThroughErr =
@@ -882,14 +888,19 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
     assert(write_pc + (FetchWidth * 4).U >= ftb_write_fallThrough, s"FTB write_entry fallThrough address error!")
   }
 
-  XSDebug("req_v=%b, req_pc=%x, ready=%b (resp at next cycle)\n", io.s0_fire(0), s0_pc_dup(0), ftbBank.io.req_pc.ready)
+  XSDebug(
+    "req_v=%b, req_pc=%x, ready=%b (resp at next cycle)\n",
+    io.s0_fire(0),
+    s0_pc_dup(0).toUInt,
+    ftbBank.io.req_pc.ready
+  )
   XSDebug("s2_hit=%b, hit_way=%b\n", s2_hit_dup(0), writeWay.asUInt)
   XSDebug(
     "s2_br_taken_mask=%b, s2_real_taken_mask=%b\n",
     io.in.bits.resp_in(0).s2.full_pred(0).br_taken_mask.asUInt,
     io.out.s2.full_pred(0).real_slot_taken_mask().asUInt
   )
-  XSDebug("s2_target=%x\n", io.out.s2.getTarget(0))
+  XSDebug("s2_target=%x\n", io.out.s2.getTarget(0).toUInt)
 
   s2_ftb_entry_dup(0).display(true.B)
 

--- a/src/main/scala/xiangshan/frontend/FauFTB.scala
+++ b/src/main/scala/xiangshan/frontend/FauFTB.scala
@@ -35,7 +35,7 @@ trait FauFTBParams extends HasXSParameter with HasBPUConst {
   def BR_OFFSET_LEN  = 12
   def JMP_OFFSET_LEN = 20
 
-  def getTag(pc: UInt) = pc(tagSize + instOffsetBits - 1, instOffsetBits)
+  def getTag(pc: PrunedAddr): UInt = pc(tagSize + instOffsetBits - 1, instOffsetBits)
 }
 
 class FauFTBEntry(implicit p: Parameters) extends FTBEntry()(p) {}

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -76,7 +76,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
     with HasPerfEvents {
   val io = IO(new Bundle() {
     val hartId       = Input(UInt(hartIdLen.W))
-    val reset_vector = Input(UInt(PAddrBits.W))
+    val reset_vector = Input(PrunedAddr(PAddrBits))
     val fencei       = Input(Bool())
     val ptw          = new TlbPtwIO()
     val backend      = new FrontendToCtrlIO
@@ -94,7 +94,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
     }
     val resetInFrontend = Output(Bool())
     val debugTopDown = new Bundle {
-      val robHeadVaddr = Flipped(Valid(UInt(VAddrBits.W)))
+      val robHeadVaddr = Flipped(Valid(PrunedAddr(VAddrBits)))
     }
     val dft       = if (hasMbist) Some(Input(new SramBroadcastBundle)) else None
     val dft_reset = if (hasMbist) Some(Input(new DFTResetSignals)) else None
@@ -209,13 +209,13 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
   }
 
   val checkTargetPtr = Wire(Vec(DecodeWidth, new FtqPtr))
-  val checkTarget    = Wire(Vec(DecodeWidth, UInt(VAddrBits.W)))
+  val checkTarget    = Wire(Vec(DecodeWidth, PrunedAddr(VAddrBits)))
 
   for (i <- 0 until DecodeWidth) {
     checkTargetPtr(i) := ibuffer.io.out(i).bits.ftqPtr
     checkTarget(i) := Mux(
       ftq.io.toBackend.newest_entry_ptr.value === checkTargetPtr(i).value,
-      ftq.io.toBackend.newest_entry_target,
+      PrunedAddrInit(ftq.io.toBackend.newest_entry_target),
       checkPcMem((checkTargetPtr(i) + 1.U).value).startAddr
     )
   }
@@ -305,7 +305,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
   }
 
   def checkNotTakenPC = {
-    val prevNotTakenPC    = Reg(UInt(VAddrBits.W))
+    val prevNotTakenPC    = Reg(PrunedAddr(VAddrBits))
     val prevIsRVC         = Reg(Bool())
     val prevNotTakenValid = RegInit(0.B)
 
@@ -338,7 +338,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
     }
     XSError(
       prevNotTakenValid && ibuffer.io.out(0).fire &&
-        prevNotTakenPC + Mux(prevIsRVC, 2.U, 4.U) =/= ibuffer.io.out(0).bits.pc,
+        prevNotTakenPC + Mux(prevIsRVC, 2.U, 4.U) =/= PrunedAddrInit(ibuffer.io.out(0).bits.pc),
       "not-taken br should have same pc\n"
     )
     when(needFlush) {
@@ -349,7 +349,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
   def checkTakenPC = {
     val prevTakenFtqPtr = Reg(new FtqPtr)
     val prevTakenValid  = RegInit(0.B)
-    val prevTakenTarget = Wire(UInt(VAddrBits.W))
+    val prevTakenTarget = Wire(PrunedAddr(VAddrBits))
     prevTakenTarget := checkPcMem((prevTakenFtqPtr + 1.U).value).startAddr
 
     for (i <- 0 until DecodeWidth - 1) {
@@ -362,7 +362,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
       XSError(
         ibuffer.io.out(i).fire && !ibuffer.io.out(i).bits.pd.notCFI && ibuffer.io.out(i).bits.pred_taken &&
           ibuffer.io.out(i + 1).fire &&
-          checkTarget(i) =/= ibuffer.io.out(i + 1).bits.pc,
+          checkTarget(i) =/= PrunedAddrInit(ibuffer.io.out(i + 1).bits.pc),
         "taken instr should follow target pc\n"
       )
     }
@@ -377,7 +377,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
     }
     XSError(
       prevTakenValid && ibuffer.io.out(0).fire &&
-        prevTakenTarget =/= ibuffer.io.out(0).bits.pc,
+        prevTakenTarget =/= PrunedAddrInit(ibuffer.io.out(0).bits.pc),
       "taken instr should follow target pc\n"
     )
     when(needFlush) {
@@ -418,7 +418,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
 
   icache.io.hartId := io.hartId
 
-  itlbRepeater1.io.debugTopDown.robHeadVaddr := io.debugTopDown.robHeadVaddr
+  itlbRepeater1.io.debugTopDown.robHeadVaddr := io.debugTopDown.robHeadVaddr.map(_.toUInt)
 
   io.frontendInfo.ibufFull := RegNext(ibuffer.io.full)
   io.resetInFrontend       := reset.asBool

--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -33,9 +33,9 @@ class FrontendTopDownBundle(implicit p: Parameters) extends XSBundle {
 class FetchRequestBundle(implicit p: Parameters) extends XSBundle with HasICacheParameters {
 
   // fast path: Timing critical
-  val startAddr     = UInt(VAddrBits.W)
-  val nextlineStart = UInt(VAddrBits.W)
-  val nextStartAddr = UInt(VAddrBits.W)
+  val startAddr     = PrunedAddr(VAddrBits)
+  val nextlineStart = PrunedAddr(VAddrBits)
+  val nextStartAddr = PrunedAddr(VAddrBits)
   // slow path
   val ftqIdx    = new FtqPtr
   val ftqOffset = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
@@ -60,14 +60,14 @@ class FetchRequestBundle(implicit p: Parameters) extends XSBundle with HasICache
     this
   }
   override def toPrintable: Printable =
-    p"[start] ${Hexadecimal(startAddr)} [next] ${Hexadecimal(nextlineStart)}" +
-      p"[tgt] ${Hexadecimal(nextStartAddr)} [ftqIdx] $ftqIdx [jmp] v:${ftqOffset.valid}" +
+    p"[start] ${Hexadecimal(startAddr.toUInt)} [next] ${Hexadecimal(nextlineStart.toUInt)}" +
+      p"[tgt] ${Hexadecimal(nextStartAddr.toUInt)} [ftqIdx] $ftqIdx [jmp] v:${ftqOffset.valid}" +
       p" offset: ${ftqOffset.bits}\n"
 }
 
 class FtqICacheInfo(implicit p: Parameters) extends XSBundle with HasICacheParameters {
-  val startAddr      = UInt(VAddrBits.W)
-  val nextlineStart  = UInt(VAddrBits.W)
+  val startAddr      = PrunedAddr(VAddrBits)
+  val nextlineStart  = PrunedAddr(VAddrBits)
   val ftqIdx         = new FtqPtr
   def crossCacheline = startAddr(blockOffBits - 1) === 1.U
   def fromFtqPcBundle(b: Ftq_RF_Components) = {
@@ -91,14 +91,14 @@ class FtqToICacheRequestBundle(implicit p: Parameters) extends XSBundle with Has
 }
 
 class PredecodeWritebackBundle(implicit p: Parameters) extends XSBundle {
-  val pc         = Vec(PredictWidth, UInt(VAddrBits.W))
+  val pc         = Vec(PredictWidth, PrunedAddr(VAddrBits))
   val pd         = Vec(PredictWidth, new PreDecodeInfo) // TODO: redefine Predecode
   val ftqIdx     = new FtqPtr
   val ftqOffset  = UInt(log2Ceil(PredictWidth).W)
   val misOffset  = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
   val cfiOffset  = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
-  val target     = UInt(VAddrBits.W)
-  val jalTarget  = UInt(VAddrBits.W)
+  val target     = PrunedAddr(VAddrBits)
+  val jalTarget  = PrunedAddr(VAddrBits)
   val instrRange = Vec(PredictWidth, Bool())
 }
 
@@ -249,7 +249,7 @@ class FetchToIBuffer(implicit p: Parameters) extends XSBundle {
   val triggered        = Vec(PredictWidth, TriggerAction())
   val isLastInFtqEntry = Vec(PredictWidth, Bool())
 
-  val pc           = Vec(PredictWidth, UInt(VAddrBits.W))
+  val pc           = Vec(PredictWidth, PrunedAddr(VAddrBits))
   val ftqPtr       = new FtqPtr
   val topdown_info = new FrontendTopDownBundle
 }
@@ -500,20 +500,20 @@ class AllFoldedHistories(val gen: Seq[Tuple2[Int, Int]])(implicit p: Parameters)
 class TableAddr(val idxBits: Int, val banks: Int)(implicit p: Parameters) extends XSBundle {
   def tagBits = VAddrBits - idxBits - instOffsetBits
 
-  val tag    = UInt(tagBits.W)
-  val idx    = UInt(idxBits.W)
-  val offset = UInt(instOffsetBits.W)
+  val tag = UInt(tagBits.W)
+  val idx = UInt(idxBits.W)
+//  val offset = UInt(instOffsetBits.W)
 
-  def fromUInt(x:   UInt) = x.asTypeOf(UInt(VAddrBits.W)).asTypeOf(this)
-  def getTag(x:     UInt) = fromUInt(x).tag
-  def getIdx(x:     UInt) = fromUInt(x).idx
-  def getBank(x:    UInt) = if (banks > 1) getIdx(x)(log2Up(banks) - 1, 0) else 0.U
-  def getBankIdx(x: UInt) = if (banks > 1) getIdx(x)(idxBits - 1, log2Up(banks)) else getIdx(x)
+  def fromUInt(x:   PrunedAddr): TableAddr = x.asTypeOf(PrunedAddr(VAddrBits)).asTypeOf(this)
+  def getTag(x:     PrunedAddr): UInt      = fromUInt(x).tag
+  def getIdx(x:     PrunedAddr): UInt      = fromUInt(x).idx
+  def getBank(x:    PrunedAddr): UInt      = if (banks > 1) getIdx(x)(log2Up(banks) - 1, 0) else 0.U
+  def getBankIdx(x: PrunedAddr): UInt      = if (banks > 1) getIdx(x)(idxBits - 1, log2Up(banks)) else getIdx(x)
 }
 
 trait BasicPrediction extends HasXSParameter {
   def cfiIndex: ValidUndirectioned[UInt]
-  def target(pc: UInt): UInt
+  def target(pc: PrunedAddr): PrunedAddr
   def lastBrPosOH:    Vec[Bool]
   def brTaken:        Bool
   def shouldShiftVec: Vec[Bool]
@@ -539,10 +539,10 @@ class FullBranchPrediction(val isNotS3: Boolean)(implicit p: Parameters) extends
 
   val slot_valids = Vec(totalSlot, Bool())
 
-  val targets         = Vec(totalSlot, UInt(VAddrBits.W))
-  val jalr_target     = UInt(VAddrBits.W) // special path for indirect predictors
+  val targets         = Vec(totalSlot, PrunedAddr(VAddrBits))
+  val jalr_target     = PrunedAddr(VAddrBits) // special path for indirect predictors
   val offsets         = Vec(totalSlot, UInt(log2Ceil(PredictWidth).W))
-  val fallThroughAddr = UInt(VAddrBits.W)
+  val fallThroughAddr = PrunedAddr(VAddrBits)
   val fallThroughErr  = Bool()
   val multiHit        = Bool()
 
@@ -602,7 +602,7 @@ class FullBranchPrediction(val isNotS3: Boolean)(implicit p: Parameters) extends
 
   def brTaken = (br_valids zip br_taken_mask).map { case (a, b) => a && b && hit }.reduce(_ || _)
 
-  def target(pc: UInt): UInt =
+  def target(pc: PrunedAddr): PrunedAddr =
     if (isNotS3) {
       selectByTaken(taken_mask_on_slot, hit, allTarget(pc))
     } else {
@@ -614,7 +614,7 @@ class FullBranchPrediction(val isNotS3: Boolean)(implicit p: Parameters) extends
   //
   // This exposes internal targets for timing optimization,
   // since usually targets are generated quicker than taken
-  def allTarget(pc: UInt): Vec[UInt] =
+  def allTarget(pc: PrunedAddr): Vec[PrunedAddr] =
     VecInit(targets :+ fallThroughAddr :+ (pc + (FetchWidth * 4).U))
 
   def fallThruError: Bool = hit && fallThroughErr
@@ -641,8 +641,8 @@ class FullBranchPrediction(val isNotS3: Boolean)(implicit p: Parameters) extends
 
   def fromFtbEntry(
       entry:            FTBEntry,
-      pc:               UInt,
-      last_stage_pc:    Option[Tuple2[UInt, Bool]] = None,
+      pc:               PrunedAddr,
+      last_stage_pc:    Option[Tuple2[PrunedAddr, Bool]] = None,
       last_stage_entry: Option[Tuple2[FTBEntry, Bool]] = None
   ) = {
     slot_valids          := entry.brSlots.map(_.valid) :+ entry.tailSlot.valid
@@ -675,21 +675,21 @@ class SpeculativeInfo(implicit p: Parameters) extends XSBundle
   val TOSW    = new RASPtr
   val TOSR    = new RASPtr
   val NOS     = new RASPtr
-  val topAddr = UInt(VAddrBits.W)
+  val topAddr = PrunedAddr(VAddrBits)
 }
 
 //
 class BranchPredictionBundle(val isNotS3: Boolean)(implicit p: Parameters) extends XSBundle
     with HasBPUConst with BPUUtils {
-  val pc          = Vec(numDup, UInt(VAddrBits.W))
+  val pc          = Vec(numDup, PrunedAddr(VAddrBits))
   val valid       = Vec(numDup, Bool())
   val hasRedirect = Vec(numDup, Bool())
   val ftq_idx     = new FtqPtr
   val full_pred   = Vec(numDup, new FullBranchPrediction(isNotS3))
 
-  def target(pc:     UInt)      = VecInit(full_pred.map(_.target(pc)))
-  def targets(pc:    Vec[UInt]) = VecInit(pc.zipWithIndex.map { case (pc, idx) => full_pred(idx).target(pc) })
-  def allTargets(pc: Vec[UInt]) = VecInit(pc.zipWithIndex.map { case (pc, idx) => full_pred(idx).allTarget(pc) })
+  def target(pc:     PrunedAddr)      = VecInit(full_pred.map(_.target(pc)))
+  def targets(pc:    Vec[PrunedAddr]) = VecInit(pc.zipWithIndex.map { case (pc, idx) => full_pred(idx).target(pc) })
+  def allTargets(pc: Vec[PrunedAddr]) = VecInit(pc.zipWithIndex.map { case (pc, idx) => full_pred(idx).allTarget(pc) })
   def cfiIndex       = VecInit(full_pred.map(_.cfiIndex))
   def lastBrPosOH    = VecInit(full_pred.map(_.lastBrPosOH))
   def brTaken        = VecInit(full_pred.map(_.brTaken))
@@ -703,7 +703,7 @@ class BranchPredictionBundle(val isNotS3: Boolean)(implicit p: Parameters) exten
   def getAllTargets = allTargets(pc)
 
   def display(cond: Bool): Unit = {
-    XSDebug(cond, p"[pc] ${Hexadecimal(pc(0))}\n")
+    XSDebug(cond, p"[pc] ${Hexadecimal(pc(0).toUInt)}\n")
     full_pred(0).display(cond)
   }
 }
@@ -744,7 +744,7 @@ class BranchPredictionResp(implicit p: Parameters) extends XSBundle with HasBPUC
 class BpuToFtqBundle(implicit p: Parameters) extends BranchPredictionResp {}
 
 class BranchPredictionUpdate(implicit p: Parameters) extends XSBundle with HasBPUConst {
-  val pc        = UInt(VAddrBits.W)
+  val pc        = PrunedAddr(VAddrBits)
   val spec_info = new SpeculativeInfo
   val ftb_entry = new FTBEntry()
 
@@ -758,7 +758,7 @@ class BranchPredictionUpdate(implicit p: Parameters) extends XSBundle with HasBP
   val new_br_insert_pos = Vec(numBr, Bool())
   val old_entry         = Bool()
   val meta              = UInt(MaxMetaLength.W)
-  val full_target       = UInt(VAddrBits.W)
+  val full_target       = PrunedAddr(VAddrBits)
   val from_stage        = UInt(2.W)
   val ghist             = UInt(HistoryLength.W)
 

--- a/src/main/scala/xiangshan/frontend/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/IBuffer.scala
@@ -50,7 +50,7 @@ class IBufferIO(implicit p: Parameters) extends XSBundle {
 
 class IBufEntry(implicit p: Parameters) extends XSBundle {
   val inst             = UInt(32.W)
-  val pc               = UInt(VAddrBits.W)
+  val pc               = PrunedAddr(VAddrBits)
   val foldpc           = UInt(MemPredPCWidth.W)
   val pd               = new PreDecodeInfo
   val pred_taken       = Bool()
@@ -83,7 +83,7 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
   def toCtrlFlow: CtrlFlow = {
     val cf = Wire(new CtrlFlow)
     cf.instr                             := inst
-    cf.pc                                := pc
+    cf.pc                                := pc.toUInt
     cf.foldpc                            := foldpc
     cf.exceptionVec                      := 0.U.asTypeOf(ExceptionVec())
     cf.exceptionVec(instrPageFault)      := IBufferExceptionType.isPF(this.exceptionType)
@@ -444,7 +444,7 @@ class IBuffer(implicit p: Parameters) extends XSModule with HasCircularQueuePtrH
   XSDebug(io.in.fire, "Enque:\n")
   XSDebug(io.in.fire, p"MASK=${Binary(io.in.bits.valid)}\n")
   for (i <- 0 until PredictWidth) {
-    XSDebug(io.in.fire, p"PC=${Hexadecimal(io.in.bits.pc(i))} ${Hexadecimal(io.in.bits.instrs(i))}\n")
+    XSDebug(io.in.fire, p"PC=${Hexadecimal(io.in.bits.pc(i).toUInt)} ${Hexadecimal(io.in.bits.instrs(i))}\n")
   }
 
   for (i <- 0 until DecodeWidth) {

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -38,7 +38,7 @@ trait HasIFUConst extends HasXSParameter {
     Cat(addr(highest - 1, log2Ceil(bytes)), 0.U(log2Ceil(bytes).W))
   def fetchQueueSize = 2
 
-  def getBasicBlockIdx(pc: UInt, start: UInt): UInt = {
+  def getBasicBlockIdx(pc: PrunedAddr, start: PrunedAddr): UInt = {
     val byteOffset = pc - start
     (byteOffset - instBytes.U)(log2Ceil(PredictWidth), instOffsetBits)
   }
@@ -87,36 +87,36 @@ class NewIFUIO(implicit p: Parameters) extends XSBundle {
 // the middle of an RVI inst
 class LastHalfInfo(implicit p: Parameters) extends XSBundle {
   val valid    = Bool()
-  val middlePC = UInt(VAddrBits.W)
-  def matchThisBlock(startAddr: UInt) = valid && middlePC === startAddr
+  val middlePC = PrunedAddr(VAddrBits)
+  def matchThisBlock(startAddr: PrunedAddr): Bool = valid && middlePC === startAddr
 }
 
 class IfuToPreDecode(implicit p: Parameters) extends XSBundle {
   val data            = if (HasCExtension) Vec(PredictWidth + 1, UInt(16.W)) else Vec(PredictWidth, UInt(32.W))
   val frontendTrigger = new FrontendTdataDistributeIO
-  val pc              = Vec(PredictWidth, UInt(VAddrBits.W))
+  val pc              = Vec(PredictWidth, PrunedAddr(VAddrBits))
 }
 
 class IfuToPredChecker(implicit p: Parameters) extends XSBundle {
   val ftqOffset  = Valid(UInt(log2Ceil(PredictWidth).W))
   val jumpOffset = Vec(PredictWidth, UInt(XLEN.W))
-  val target     = UInt(VAddrBits.W)
+  val target     = PrunedAddr(VAddrBits)
   val instrRange = Vec(PredictWidth, Bool())
   val instrValid = Vec(PredictWidth, Bool())
   val pds        = Vec(PredictWidth, new PreDecodeInfo)
-  val pc         = Vec(PredictWidth, UInt(VAddrBits.W))
+  val pc         = Vec(PredictWidth, PrunedAddr(VAddrBits))
   val fire_in    = Bool()
 }
 
-class FetchToIBufferDB extends Bundle {
-  val start_addr   = UInt(39.W)
+class FetchToIBufferDB(implicit p: Parameters) extends XSBundle {
+  val start_addr   = PrunedAddr(VAddrBits)
   val instr_count  = UInt(32.W)
   val exception    = Bool()
   val is_cache_hit = Bool()
 }
 
-class IfuWbToFtqDB extends Bundle {
-  val start_addr        = UInt(39.W)
+class IfuWbToFtqDB(implicit p: Parameters) extends XSBundle {
+  val start_addr        = PrunedAddr(VAddrBits)
   val is_miss_pred      = Bool()
   val miss_pred_offset  = UInt(32.W)
   val checkJalFault     = Bool()
@@ -145,13 +145,13 @@ class NewIFU(implicit p: Parameters) extends XSModule
   def numOfStage = 3
   // equal lower_result overflow bit
   def PcCutPoint = (VAddrBits / 4) - 1
-  def CatPC(low: UInt, high: UInt, high1: UInt): UInt =
-    Mux(
+  def CatPC(low: UInt, high: UInt, high1: UInt): PrunedAddr =
+    PrunedAddrInit(Mux(
       low(PcCutPoint),
       Cat(high1, low(PcCutPoint - 1, 0)),
       Cat(high, low(PcCutPoint - 1, 0))
-    )
-  def CatPC(lowVec: Vec[UInt], high: UInt, high1: UInt): Vec[UInt] = VecInit(lowVec.map(CatPC(_, high, high1)))
+    ))
+  def CatPC(lowVec: Vec[UInt], high: UInt, high1: UInt): Vec[PrunedAddr] = VecInit(lowVec.map(CatPC(_, high, high1)))
   require(numOfStage > 1, "BPU numOfStage must be greater than 1")
   val topdown_stages = RegInit(VecInit(Seq.fill(numOfStage)(0.U.asTypeOf(new FrontendTopDownBundle))))
   // bubble events in IFU, only happen in stage 1
@@ -241,7 +241,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f0_valid      = fromFtq.req.valid
   val f0_ftq_req    = fromFtq.req.bits
   val f0_doubleLine = fromFtq.req.bits.crossCacheline
-  val f0_vSetIdx    = VecInit(get_idx(f0_ftq_req.startAddr), get_idx(f0_ftq_req.nextlineStart))
+  val f0_vSetIdx    = VecInit(get_idx(f0_ftq_req.startAddr.toUInt), get_idx(f0_ftq_req.nextlineStart.toUInt))
   val f0_fire       = fromFtq.req.fire
 
   val f0_flush, f1_flush, f2_flush, f3_flush = WireInit(false.B)
@@ -425,10 +425,10 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f2_cut_ptr      = RegEnable(f1_cut_ptr, f1_fire)
   val f2_resend_vaddr = RegEnable(f1_ftq_req.startAddr + 2.U, f1_fire)
 
-  def isNextLine(pc: UInt, startAddr: UInt) =
+  def isNextLine(pc: PrunedAddr, startAddr: PrunedAddr): Bool =
     startAddr(blockOffBits) ^ pc(blockOffBits)
 
-  def isLastInLine(pc: UInt) =
+  def isLastInLine(pc: PrunedAddr): Bool =
     pc(blockOffBits - 1, 0) === "b111110".U
 
   val f2_foldpc = VecInit(f2_pc.map(i => XORFold(i(VAddrBits - 1, 1), MemPredPCWidth)))
@@ -598,7 +598,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
     * Half snpc(i) is larger than pc(i) by 4. Using pc to calculate half snpc may be a good choice.
     ***********************************************************************
     */
-  val f3_half_snpc = Wire(Vec(PredictWidth, UInt(VAddrBits.W)))
+  val f3_half_snpc = Wire(Vec(PredictWidth, PrunedAddr(VAddrBits)))
   for (i <- 0 until PredictWidth) {
     if (i == (PredictWidth - 2)) {
       f3_half_snpc(i) := CatPC(f3_pc_last_lower_result_plus2, f3_pc_high, f3_pc_high_plus1)
@@ -618,8 +618,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f3_resend_vaddr      = RegEnable(f2_resend_vaddr, f2_fire)
 
   // Expand 1 bit to prevent overflow when assert
-  val f3_ftq_req_startAddr     = Cat(0.U(1.W), f3_ftq_req.startAddr)
-  val f3_ftq_req_nextStartAddr = Cat(0.U(1.W), f3_ftq_req.nextStartAddr)
+  val f3_ftq_req_startAddr     = PrunedAddrInit(Cat(0.U(1.W), f3_ftq_req.startAddr.toUInt))
+  val f3_ftq_req_nextStartAddr = PrunedAddrInit(Cat(0.U(1.W), f3_ftq_req.nextStartAddr.toUInt))
   // brType, isCall and isRet generation is delayed to f3 stage
   val f3Predecoder = Module(new F3Predecoder)
 
@@ -646,7 +646,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val mmio_exception   = RegInit(0.U(ExceptionType.width.W))
   val mmio_is_RVC      = RegInit(false.B)
   val mmio_has_resend  = RegInit(false.B)
-  val mmio_resend_addr = RegInit(0.U(PAddrBits.W))
+  val mmio_resend_addr = RegInit(PrunedAddrInit(0.U(PAddrBits.W)))
   // NOTE: we dont use GPAddrBits here, refer to ICacheMainPipe.scala L43-48 and PR#3795
   val mmio_resend_gpaddr            = RegInit(0.U(PAddrBitsMax.W))
   val mmio_resend_isForVSnonLeafPTE = RegInit(false.B)
@@ -842,8 +842,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
   // send itlb request in m_sendTLB state
   io.iTLBInter.req.valid                   := (mmio_state === m_sendTLB) && f3_req_is_mmio
   io.iTLBInter.req.bits.size               := 3.U
-  io.iTLBInter.req.bits.vaddr              := f3_resend_vaddr
-  io.iTLBInter.req.bits.debug.pc           := f3_resend_vaddr
+  io.iTLBInter.req.bits.vaddr              := f3_resend_vaddr.toUInt
+  io.iTLBInter.req.bits.debug.pc           := f3_resend_vaddr.toUInt
   io.iTLBInter.req.bits.cmd                := TlbCmd.exec
   io.iTLBInter.req.bits.isPrefetch         := false.B
   io.iTLBInter.req.bits.kill               := false.B // IFU use itlb for mmio, doesn't need sync, set it to false
@@ -862,7 +862,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   io.iTLBInter.resp.ready := (mmio_state === m_tlbResp) && f3_req_is_mmio
 
   io.pmp.req.valid     := (mmio_state === m_sendPMP) && f3_req_is_mmio
-  io.pmp.req.bits.addr := mmio_resend_addr
+  io.pmp.req.bits.addr := mmio_resend_addr.toUInt
   io.pmp.req.bits.size := 3.U
   io.pmp.req.bits.cmd  := TlbCmd.exec
 
@@ -1139,8 +1139,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
   XSDebug(
     checkRetFault,
     "startAddr:%x  nextstartAddr:%x  taken:%d    takenIdx:%d\n",
-    wb_ftq_req.startAddr,
-    wb_ftq_req.nextStartAddr,
+    wb_ftq_req.startAddr.toUInt,
+    wb_ftq_req.nextStartAddr.toUInt,
     wb_ftq_req.ftqOffset.valid,
     wb_ftq_req.ftqOffset.bits
   )

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -816,7 +816,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
       mmio_exception                := ExceptionType.none
       mmio_is_RVC                   := false.B
       mmio_has_resend               := false.B
-      mmio_resend_addr              := 0.U
+      mmio_resend_addr              := PrunedAddrInit(0.U(PAddrBits.W))
       mmio_resend_gpaddr            := 0.U
       mmio_resend_isForVSnonLeafPTE := false.B
     }
@@ -829,7 +829,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
     mmio_exception                := ExceptionType.none
     mmio_is_RVC                   := false.B
     mmio_has_resend               := false.B
-    mmio_resend_addr              := 0.U
+    mmio_resend_addr              := PrunedAddrInit(0.U(PAddrBits.W))
     mmio_resend_gpaddr            := 0.U
     mmio_resend_isForVSnonLeafPTE := false.B
     f3_mmio_data.map(_ := 0.U)

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -39,7 +39,7 @@ trait HasIFUConst extends HasXSParameter {
   def fetchQueueSize = 2
 
   def getBasicBlockIdx(pc: PrunedAddr, start: PrunedAddr): UInt = {
-    val byteOffset = pc - start
+    val byteOffset = (pc - start).toUInt
     (byteOffset - instBytes.U)(log2Ceil(PredictWidth), instOffsetBits)
   }
 }
@@ -99,7 +99,7 @@ class IfuToPreDecode(implicit p: Parameters) extends XSBundle {
 
 class IfuToPredChecker(implicit p: Parameters) extends XSBundle {
   val ftqOffset  = Valid(UInt(log2Ceil(PredictWidth).W))
-  val jumpOffset = Vec(PredictWidth, UInt(XLEN.W))
+  val jumpOffset = Vec(PredictWidth, PrunedAddr(VAddrBits))
   val target     = PrunedAddr(VAddrBits)
   val instrRange = Vec(PredictWidth, Bool())
   val instrValid = Vec(PredictWidth, Bool())

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -648,7 +648,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val mmio_has_resend  = RegInit(false.B)
   val mmio_resend_addr = RegInit(PrunedAddrInit(0.U(PAddrBits.W)))
   // NOTE: we dont use GPAddrBits here, refer to ICacheMainPipe.scala L43-48 and PR#3795
-  val mmio_resend_gpaddr            = RegInit(0.U(PAddrBitsMax.W))
+  val mmio_resend_gpaddr            = RegInit(PrunedAddrInit(0.U(PAddrBitsMax.W)))
   val mmio_resend_isForVSnonLeafPTE = RegInit(false.B)
 
   // last instuction finish
@@ -817,7 +817,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
       mmio_is_RVC                   := false.B
       mmio_has_resend               := false.B
       mmio_resend_addr              := PrunedAddrInit(0.U(PAddrBits.W))
-      mmio_resend_gpaddr            := 0.U
+      mmio_resend_gpaddr            := PrunedAddrInit(0.U(PAddrBitsMax.W))
       mmio_resend_isForVSnonLeafPTE := false.B
     }
   }
@@ -830,7 +830,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
     mmio_is_RVC                   := false.B
     mmio_has_resend               := false.B
     mmio_resend_addr              := PrunedAddrInit(0.U(PAddrBits.W))
-    mmio_resend_gpaddr            := 0.U
+    mmio_resend_gpaddr            := PrunedAddrInit(0.U(PAddrBitsMax.W))
     mmio_resend_isForVSnonLeafPTE := false.B
     f3_mmio_data.map(_ := 0.U)
   }
@@ -961,7 +961,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
     f3_exception.map(_ === ExceptionType.gpf).reduce(_ || _)
   )
   io.toBackend.gpaddrMem_waddr        := f3_ftq_req.ftqIdx.value
-  io.toBackend.gpaddrMem_wdata.gpaddr := Mux(f3_req_is_mmio, mmio_resend_gpaddr, f3_gpaddr)
+  io.toBackend.gpaddrMem_wdata.gpaddr := Mux(f3_req_is_mmio, mmio_resend_gpaddr.toUInt, f3_gpaddr.toUInt)
   io.toBackend.gpaddrMem_wdata.isForVSnonLeafPTE := Mux(
     f3_req_is_mmio,
     mmio_resend_isForVSnonLeafPTE,

--- a/src/main/scala/xiangshan/frontend/ITTAGE.scala
+++ b/src/main/scala/xiangshan/frontend/ITTAGE.scala
@@ -53,8 +53,8 @@ trait ITTageParams extends HasXSParameter with HasBPUParameter {
     ctr < (1 << (ctrBits - 1)).U
   val UAONA_bits = 4
 
-  def targetGetRegion(target: UInt): UInt = target(VAddrBits - 1, TargetOffsetBits)
-  def targetGetOffset(target: UInt): UInt = target(TargetOffsetBits - 1, 0)
+  def targetGetRegion(target: PrunedAddr): UInt = target(VAddrBits - 1, TargetOffsetBits)
+  def targetGetOffset(target: PrunedAddr): UInt = target(TargetOffsetBits - 1, 0)
 
   lazy val TotalBits: Int = ITTageTableInfos.map {
     case (s, h, t) => {
@@ -70,12 +70,12 @@ abstract class ITTageModule(implicit p: Parameters)
     extends XSModule with ITTageParams with BPUUtils {}
 
 class ITTageReq(implicit p: Parameters) extends ITTageBundle {
-  val pc          = UInt(VAddrBits.W)
+  val pc          = PrunedAddr(VAddrBits)
   val folded_hist = new AllFoldedHistories(foldedGHistInfos)
 }
 
 class ITTageOffset(implicit p: Parameters) extends ITTageBundle {
-  val offset      = UInt(TargetOffsetBits.W)
+  val offset      = PrunedAddr(TargetOffsetBits)
   val pointer     = UInt(log2Ceil(RegionNums).W)
   val usePCRegion = Bool()
 }
@@ -87,7 +87,7 @@ class ITTageResp(implicit p: Parameters) extends ITTageBundle {
 }
 
 class ITTageUpdate(implicit p: Parameters) extends ITTageBundle {
-  val pc    = UInt(VAddrBits.W)
+  val pc    = PrunedAddr(VAddrBits)
   val ghist = UInt(HistoryLength.W)
   // update tag and ctr
   val valid   = Bool()
@@ -111,13 +111,13 @@ class ITTageMeta(implicit p: Parameters) extends XSBundle with ITTageParams {
   val providerCtr       = UInt(ITTageCtrBits.W)
   val altProviderCtr    = UInt(ITTageCtrBits.W)
   val allocate          = ValidUndirectioned(UInt(log2Ceil(ITTageNTables).W))
-  val providerTarget    = UInt(VAddrBits.W)
-  val altProviderTarget = UInt(VAddrBits.W)
+  val providerTarget    = PrunedAddr(VAddrBits)
+  val altProviderTarget = PrunedAddr(VAddrBits)
   val pred_cycle        = if (!env.FPGAPlatform) Some(UInt(64.W)) else None
 
   override def toPrintable =
-    p"pvdr(v:${provider.valid} num:${provider.bits} ctr:$providerCtr u:$providerU tar:${Hexadecimal(providerTarget)}), " +
-      p"altpvdr(v:${altProvider.valid} num:${altProvider.bits}, ctr:$altProviderCtr, tar:${Hexadecimal(altProviderTarget)})"
+    p"pvdr(v:${provider.valid} num:${provider.bits} ctr:$providerCtr u:$providerU tar:${Hexadecimal(providerTarget.toUInt)}), " +
+      p"altpvdr(v:${altProvider.valid} num:${altProvider.bits}, ctr:$altProviderCtr, tar:${Hexadecimal(altProviderTarget.toUInt)})"
 }
 
 class FakeITTageTable()(implicit p: Parameters) extends ITTageModule {
@@ -250,13 +250,15 @@ class ITTageTable(
     val ctr           = UInt(ITTageCtrBits.W)
     val target_offset = new ITTageOffset()
     val useful        = Bool() // Due to the bitMask the useful bit needs to be at the lowest bit
+    val paddingBit    = UInt(1.W)
   }
 
+  // The least significant bit of offset is pruned
   val ittageEntrySz = 1 + tagLen + ITTageCtrBits + ITTageUsBits + TargetOffsetBits + log2Ceil(RegionNums) + 1
   require(ittageEntrySz == (new ITTageEntry).getWidth)
 
   // pc is start address of basic block, most 2 branch inst in block
-  def getUnhashedIdx(pc: UInt): UInt = (pc >> instOffsetBits).asUInt
+  def getUnhashedIdx(pc: PrunedAddr): UInt = (pc >> instOffsetBits).asUInt
 
   val s0_valid        = io.req.valid
   val s0_pc           = io.req.bits.pc
@@ -362,6 +364,7 @@ class ITTageTable(
     io.update.target_offset,
     io.update.old_target_offset
   )
+  update_wdata.paddingBit := DontCare
 
   XSPerfAccumulate("ittage_table_updates", io.update.valid)
   XSPerfAccumulate("ittage_table_hits", io.resp.valid)
@@ -374,24 +377,24 @@ class ITTageTable(
     val tag = s0_tag
     XSDebug(
       io.req.fire,
-      p"ITTageTableReq: pc=0x${Hexadecimal(io.req.bits.pc)}, " +
+      p"ITTageTableReq: pc=0x${Hexadecimal(io.req.bits.pc.toUInt)}, " +
         p"idx=$idx, tag=$tag\n"
     )
     XSDebug(
       RegNext(io.req.fire) && s1_req_rhit,
       p"ITTageTableResp: idx=$s1_idx, hit:${s1_req_rhit}, " +
-        p"ctr:${io.resp.bits.ctr}, u:${io.resp.bits.u}, tar:${Hexadecimal(io.resp.bits.target_offset.offset)}\n"
+        p"ctr:${io.resp.bits.ctr}, u:${io.resp.bits.u}, tar:${Hexadecimal(io.resp.bits.target_offset.offset.toUInt)}\n"
     )
     XSDebug(
       io.update.valid,
-      p"update ITTAGE Table: pc:${Hexadecimal(u.pc)}}, " +
+      p"update ITTAGE Table: pc:${Hexadecimal(u.pc.toUInt)}}, " +
         p"correct:${u.correct}, alloc:${u.alloc}, oldCtr:${u.oldCtr}, " +
-        p"target:${Hexadecimal(u.target_offset.offset)}, old_target:${Hexadecimal(u.old_target_offset.offset)}\n"
+        p"target:${Hexadecimal(u.target_offset.offset.toUInt)}, old_target:${Hexadecimal(u.old_target_offset.offset.toUInt)}\n"
     )
     XSDebug(
       io.update.valid,
       p"update ITTAGE Table: writing tag:${update_tag}, " +
-        p"ctr: ${update_wdata.ctr}, target:${Hexadecimal(update_wdata.target_offset.offset)}" +
+        p"ctr: ${update_wdata.ctr}, target:${Hexadecimal(update_wdata.target_offset.offset.toUInt)}" +
         p" in idx $update_idx\n"
     )
     XSDebug(RegNext(io.req.fire) && !s1_req_rhit, "TageTableResp: no hits!\n")
@@ -442,9 +445,9 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
   val debug_pc_s2 = RegEnable(debug_pc_s1, io.s1_fire(3))
   val debug_pc_s3 = RegEnable(debug_pc_s2, io.s2_fire(3))
 
-  val s2_tageTarget        = Wire(UInt(VAddrBits.W))
-  val s2_providerTarget    = Wire(UInt(VAddrBits.W))
-  val s2_altProviderTarget = Wire(UInt(VAddrBits.W))
+  val s2_tageTarget        = Wire(PrunedAddr(VAddrBits))
+  val s2_providerTarget    = Wire(PrunedAddr(VAddrBits))
+  val s2_altProviderTarget = Wire(PrunedAddr(VAddrBits))
   val s2_provided          = Wire(Bool())
   val s2_provider          = Wire(UInt(log2Ceil(ITTageNTables).W))
   val s2_altProvided       = Wire(Bool())
@@ -575,22 +578,22 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
     req_pointer := region_r_target_offset(i).pointer
   }
   // When the entry corresponding to the pointer is valid and does not use PCRegion, use rTable region.
-  val region_targets = Wire(Vec(ITTageNTables, UInt(VAddrBits.W)))
+  val region_targets = Wire(Vec(ITTageNTables, PrunedAddr(VAddrBits)))
   for (i <- 0 until ITTageNTables) {
-    region_targets(i) := Mux(
+    region_targets(i) := PrunedAddrInit(Mux(
       rTable.io.resp_hit(i) && !region_r_target_offset(i).usePCRegion,
-      Cat(rTable.io.resp_region(i), region_r_target_offset(i).offset),
-      Cat(targetGetRegion(s2_pc_dup(0).getAddr()), region_r_target_offset(i).offset)
-    )
+      Cat(rTable.io.resp_region(i), region_r_target_offset(i).offset.toUInt),
+      Cat(targetGetRegion(s2_pc_dup(0)), region_r_target_offset(i).offset.toUInt)
+    ))
   }
 
-  val providerCatTarget = providerInfo.maskTarget.zipWithIndex.map {
-    case (mask, i) => mask & region_targets(i)
-  }.reduce(_ | _)
+  val providerCatTarget = PrunedAddrInit(providerInfo.maskTarget.zipWithIndex.map {
+    case (mask, i) => mask & region_targets(i).toUInt
+  }.reduce(_ | _))
 
-  val altproviderCatTarget = altProviderInfo.maskTarget.zipWithIndex.map {
-    case (mask, i) => mask & region_targets(i)
-  }.reduce(_ | _)
+  val altproviderCatTarget = PrunedAddrInit(altProviderInfo.maskTarget.zipWithIndex.map {
+    case (mask, i) => mask & region_targets(i).toUInt
+  }.reduce(_ | _))
 
   s2_tageTarget := Mux1H(Seq(
     (provided && !(providerNull && altProvided), providerCatTarget),
@@ -810,9 +813,14 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
 
   if (debug) {
     val s2_resps_regs = RegEnable(s2_resps, io.s2_fire(3))
-    XSDebug("req: v=%d, pc=0x%x\n", io.s0_fire(3), s0_pc_dup(3))
-    XSDebug("s1_fire:%d, resp: pc=%x\n", io.s1_fire(3), debug_pc_s1)
-    XSDebug("s2_fireOnLastCycle: resp: pc=%x, target=%x, hit=%b\n", debug_pc_s2, io.out.s2.getTarget(3), s2_provided)
+    XSDebug("req: v=%d, pc=0x%x\n", io.s0_fire(3), s0_pc_dup(3).toUInt)
+    XSDebug("s1_fire:%d, resp: pc=%x\n", io.s1_fire(3), debug_pc_s1.toUInt)
+    XSDebug(
+      "s2_fireOnLastCycle: resp: pc=%x, target=%x, hit=%b\n",
+      debug_pc_s2.toUInt,
+      io.out.s2.getTarget(3).toUInt,
+      s2_provided
+    )
     for (i <- 0 until ITTageNTables) {
       XSDebug(
         "TageTable(%d): valids:%b, resp_ctrs:%b, resp_us:%b, target:%x\n",
@@ -820,11 +828,11 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
         VecInit(s2_resps_regs(i).valid).asUInt,
         s2_resps_regs(i).bits.ctr,
         s2_resps_regs(i).bits.u,
-        s2_resps_regs(i).bits.target_offset.offset
+        s2_resps_regs(i).bits.target_offset.offset.toUInt
       )
     }
   }
-  XSDebug(updateValid, p"pc: ${Hexadecimal(update_pc)}, target: ${Hexadecimal(update.full_target)}\n")
+  XSDebug(updateValid, p"pc: ${Hexadecimal(update_pc.toUInt)}, target: ${Hexadecimal(update.full_target.toUInt)}\n")
   XSDebug(updateValid, updateMeta.toPrintable + p"\n")
   XSDebug(updateValid, p"correct(${!updateMisPred})\n")
 

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -1675,7 +1675,8 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val ftb_modified_entry_br_full              = ftb_modified_entry && ftbEntryGen.is_br_full
   val ftb_modified_entry_strong_bias          = ftb_modified_entry && ftbEntryGen.is_strong_bias_modified
 
-  def getFtbEntryLen(pc: PrunedAddr, entry: FTBEntry): UInt = (entry.getFallThrough(pc) - pc) >> instOffsetBits
+  def getFtbEntryLen(pc: PrunedAddr, entry: FTBEntry): UInt =
+    ((entry.getFallThrough(pc) - pc).toUInt >> instOffsetBits).asUInt
   val gen_ftb_entry_len = getFtbEntryLen(update.pc, ftbEntryGen.new_entry)
   XSPerfHistogram("ftb_init_entry_len", gen_ftb_entry_len, ftb_new_entry, 0, PredictWidth + 1, 1)
   XSPerfHistogram("ftb_modified_entry_len", gen_ftb_entry_len, ftb_modified_entry, 0, PredictWidth + 1, 1)

--- a/src/main/scala/xiangshan/frontend/PreDecode.scala
+++ b/src/main/scala/xiangshan/frontend/PreDecode.scala
@@ -40,17 +40,17 @@ trait HasPdConst extends HasXSParameter with HasICacheParameters with HasIFUCons
     val isRet  = brType === BrType.jalr && isLink(rs) && !isCall
     List(brType, isCall, isRet)
   }
-  def jal_offset(inst: UInt, rvc: Bool): UInt = {
+  def jal_offset(inst: UInt, rvc: Bool): PrunedAddr = {
     val rvc_offset = Cat(inst(12), inst(8), inst(10, 9), inst(6), inst(7), inst(2), inst(11), inst(5, 3), 0.U(1.W))
     val rvi_offset = Cat(inst(31), inst(19, 12), inst(20), inst(30, 21), 0.U(1.W))
     val max_width  = rvi_offset.getWidth
-    SignExt(Mux(rvc, SignExt(rvc_offset, max_width), SignExt(rvi_offset, max_width)), XLEN)
+    PrunedAddrInit(SignExt(Mux(rvc, SignExt(rvc_offset, max_width), SignExt(rvi_offset, max_width)), VAddrBits))
   }
-  def br_offset(inst: UInt, rvc: Bool): UInt = {
+  def br_offset(inst: UInt, rvc: Bool): PrunedAddr = {
     val rvc_offset = Cat(inst(12), inst(6, 5), inst(2), inst(11, 10), inst(4, 3), 0.U(1.W))
     val rvi_offset = Cat(inst(31), inst(7), inst(30, 25), inst(11, 8), 0.U(1.W))
     val max_width  = rvi_offset.getWidth
-    SignExt(Mux(rvc, SignExt(rvc_offset, max_width), SignExt(rvi_offset, max_width)), XLEN)
+    PrunedAddrInit(SignExt(Mux(rvc, SignExt(rvc_offset, max_width), SignExt(rvi_offset, max_width)), VAddrBits))
   }
 
   def NOP = "h4501".U(16.W)
@@ -87,7 +87,7 @@ class PreDecodeResp(implicit p: Parameters) extends XSBundle with HasPdConst {
   val hasHalfValid = Vec(PredictWidth, Bool())
   // val expInstr = Vec(PredictWidth, UInt(32.W))
   val instr      = Vec(PredictWidth, UInt(32.W))
-  val jumpOffset = Vec(PredictWidth, UInt(XLEN.W))
+  val jumpOffset = Vec(PredictWidth, PrunedAddr(VAddrBits))
 //  val hasLastHalf = Bool()
   val triggered = Vec(PredictWidth, TriggerAction())
 }

--- a/src/main/scala/xiangshan/frontend/PreDecode.scala
+++ b/src/main/scala/xiangshan/frontend/PreDecode.scala
@@ -333,8 +333,8 @@ class PredCheckerResp(implicit p: Parameters) extends XSBundle with HasPdConst {
   }
   // to Ftq write back port (stage 2)
   val stage2Out = new Bundle {
-    val fixedTarget   = Vec(PredictWidth, UInt(VAddrBits.W))
-    val jalTarget     = Vec(PredictWidth, UInt(VAddrBits.W))
+    val fixedTarget   = Vec(PredictWidth, PrunedAddr(VAddrBits))
+    val jalTarget     = Vec(PredictWidth, PrunedAddr(VAddrBits))
     val fixedMissPred = Vec(PredictWidth, Bool())
     val faultType     = Vec(PredictWidth, new CheckInfo)
   }
@@ -395,7 +395,7 @@ class PredChecker(implicit p: Parameters) extends XSModule with HasPdConst {
   })
 
   val jumpTargets = VecInit(pds.zipWithIndex.map { case (pd, i) =>
-    (pc(i) + jumpOffset(i)).asTypeOf(UInt(VAddrBits.W))
+    (pc(i) + jumpOffset(i)).asTypeOf(PrunedAddr(VAddrBits))
   })
   val seqTargets = VecInit((0 until PredictWidth).map(i => pc(i) + Mux(pds(i).isRVC || !instrValid(i), 2.U, 4.U)))
 
@@ -452,7 +452,7 @@ class FrontendTrigger(implicit p: Parameters) extends XSModule with SdtrigExt {
     val triggered       = Output(Vec(PredictWidth, TriggerAction()))
 
     val pds = Input(Vec(PredictWidth, new PreDecodeInfo))
-    val pc  = Input(Vec(PredictWidth, UInt(VAddrBits.W)))
+    val pc  = Input(Vec(PredictWidth, PrunedAddr(VAddrBits)))
     val data = if (HasCExtension) Input(Vec(PredictWidth + 1, UInt(16.W)))
     else Input(Vec(PredictWidth, UInt(32.W)))
   })
@@ -479,7 +479,13 @@ class FrontendTrigger(implicit p: Parameters) extends XSModule with SdtrigExt {
   val triggerCanRaiseBpExp = io.frontendTrigger.triggerCanRaiseBpExp
   // val triggerHitVec = Wire(Vec(PredictWidth, Vec(TriggerNum, Bool())))
   val triggerHitVec = (0 until TriggerNum).map(j =>
-    TriggerCmpConsecutive(io.pc, tdataVec(j).tdata2, tdataVec(j).matchType, triggerEnableVec(j)).map(hit =>
+    TriggerCmpConsecutive(
+      // FIXME: TriggerCmpConsecutive is defined in backend. This should be written once backend uses PrunedAddr.
+      VecInit(io.pc.map(_.toUInt)),
+      tdataVec(j).tdata2,
+      tdataVec(j).matchType,
+      triggerEnableVec(j)
+    ).map(hit =>
       hit && !tdataVec(j).select && !debugMode
     )
   ).transpose

--- a/src/main/scala/xiangshan/frontend/PrunedAddr.scala
+++ b/src/main/scala/xiangshan/frontend/PrunedAddr.scala
@@ -1,0 +1,72 @@
+/***************************************************************************************
+ * Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+ * Copyright (c) 2020-2021 Peng Cheng Laboratory
+ *
+ * XiangShan is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package xiangshan.frontend
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+import xiangshan.XSBundle
+
+class PrunedAddr(val length: Int)(implicit p: Parameters) extends XSBundle {
+  val addr: UInt = UInt((length - instOffsetBits).W)
+
+  def toUInt: UInt = Cat(addr, 0.U(instOffsetBits.W))
+
+  def apply(x: Int): Bool = toUInt(x)
+
+  def apply(x: Int, y: Int): UInt = toUInt(x, y)
+
+  def :=(UIntAddr: UInt): Unit = {
+    assert(length == UIntAddr.getWidth)
+    addr := UIntAddr(length - 1, instOffsetBits)
+  }
+
+  def +(offset: UInt): PrunedAddr = PrunedAddrInit(toUInt + offset)
+
+  def -(offset: UInt): PrunedAddr = PrunedAddrInit(toUInt - offset)
+
+  def -(that: PrunedAddr): UInt = toUInt - that.toUInt
+
+  def >>(offset: Int): UInt = (toUInt >> offset).asUInt
+
+  def ===(that: PrunedAddr): Bool = {
+    assert(length == that.length)
+    addr === that.addr
+  }
+
+  def =/=(that: PrunedAddr): Bool = { // scalastyle:ignore method.name
+    assert(length == that.length)
+    addr =/= that.addr
+  }
+
+  def >=(that: PrunedAddr): Bool = {
+    assert(length == that.length)
+    addr >= that.addr
+  }
+}
+
+object PrunedAddr {
+  def apply(length: Int)(implicit p: Parameters): PrunedAddr = new PrunedAddr(length)
+}
+
+object PrunedAddrInit {
+  def apply(fullAddr: UInt)(implicit p: Parameters): PrunedAddr = {
+    val address = Wire(new PrunedAddr(fullAddr.getWidth))
+    address := fullAddr
+    address
+  }
+}

--- a/src/main/scala/xiangshan/frontend/PrunedAddr.scala
+++ b/src/main/scala/xiangshan/frontend/PrunedAddr.scala
@@ -1,18 +1,19 @@
 /***************************************************************************************
- * Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
- * Copyright (c) 2020-2021 Peng Cheng Laboratory
- *
- * XiangShan is licensed under Mulan PSL v2.
- * You can use this software according to the terms and conditions of the Mulan PSL v2.
- * You may obtain a copy of Mulan PSL v2 at:
- *          http://license.coscl.org.cn/MulanPSL2
- *
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
- * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
- * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
- *
- * See the Mulan PSL v2 for more details.
- ***************************************************************************************/
+* Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2021 Peng Cheng Laboratory
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
 
 package xiangshan.frontend
 

--- a/src/main/scala/xiangshan/frontend/PrunedAddr.scala
+++ b/src/main/scala/xiangshan/frontend/PrunedAddr.scala
@@ -35,11 +35,12 @@ class PrunedAddr(val length: Int)(implicit p: Parameters) extends XSBundle {
     addr := UIntAddr(length - 1, instOffsetBits)
   }
 
+  // This method should only be used when offset is an immediate value
   def +(offset: UInt): PrunedAddr = PrunedAddrInit(toUInt + offset)
 
-  def -(offset: UInt): PrunedAddr = PrunedAddrInit(toUInt - offset)
+  def +(that: PrunedAddr): PrunedAddr = PrunedAddrInit(toUInt + that.toUInt)
 
-  def -(that: PrunedAddr): UInt = toUInt - that.toUInt
+  def -(that: PrunedAddr): PrunedAddr = PrunedAddrInit(toUInt - that.toUInt)
 
   def >>(offset: Int): UInt = (toUInt >> offset).asUInt
 

--- a/src/main/scala/xiangshan/frontend/RAS.scala
+++ b/src/main/scala/xiangshan/frontend/RAS.scala
@@ -27,7 +27,7 @@ import scala.{Tuple2 => &}
 
 
 class RASEntry()(implicit p: Parameters) extends XSBundle {
-    val retAddr = UInt(VAddrBits.W)
+    val retAddr = PrunedAddr(VAddrBits)
     val ctr = UInt(8.W) // layer of nested call functions
 }
 
@@ -45,14 +45,14 @@ class RAS(implicit p: Parameters) extends BasePredictor {
     val io = IO(new Bundle {
       val push_valid = Input(Bool())
       val pop_valid = Input(Bool())
-      val spec_new_addr = Input(UInt(VAddrBits.W))
+      val spec_new_addr = Input(PrunedAddr(VAddrBits))
 
       val recover_sp = Input(UInt(log2Up(rasSize).W))
       val recover_top = Input(new RASEntry)
       val recover_valid = Input(Bool())
       val recover_push = Input(Bool())
       val recover_pop = Input(Bool())
-      val recover_new_addr = Input(UInt(VAddrBits.W))
+      val recover_new_addr = Input(PrunedAddr(VAddrBits))
 
       val sp = Output(UInt(log2Up(rasSize).W))
       val top = Output(new RASEntry)

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -55,7 +55,7 @@ class SCResp(val ctrBits: Int = 6)(implicit p: Parameters) extends SCBundle {
 }
 
 class SCUpdate(val ctrBits: Int = 6)(implicit p: Parameters) extends SCBundle {
-  val pc        = UInt(VAddrBits.W)
+  val pc        = PrunedAddr(VAddrBits)
   val ghist     = UInt(HistoryLength.W)
   val mask      = Vec(numBr, Bool())
   val oldCtrs   = Vec(numBr, SInt(ctrBits.W))
@@ -94,7 +94,7 @@ class SCTable(val nRows: Int, val ctrBits: Int, val histLen: Int)(implicit p: Pa
 
   def getFoldedHistoryInfo = Set(idxFhInfo).filter(_._1 > 0)
 
-  def getIdx(pc: UInt, allFh: AllFoldedHistories) =
+  def getIdx(pc: PrunedAddr, allFh: AllFoldedHistories) =
     if (histLen > 0) {
       val idx_fh = allFh.getHistWithInfo(idxFhInfo).folded_hist
       // require(idx_fh.getWidth == log2Ceil(nRows))
@@ -215,7 +215,7 @@ class SCTable(val nRows: Int, val ctrBits: Int, val histLen: Int)(implicit p: Pa
   val u = io.update
   XSDebug(
     io.req.valid,
-    p"scTableReq: pc=0x${Hexadecimal(io.req.bits.pc)}, " +
+    p"scTableReq: pc=0x${Hexadecimal(io.req.bits.pc.toUInt)}, " +
       p"s0_idx=${s0_idx}\n"
   )
   XSDebug(
@@ -225,7 +225,7 @@ class SCTable(val nRows: Int, val ctrBits: Int, val histLen: Int)(implicit p: Pa
   )
   XSDebug(
     io.update.mask.reduce(_ || _),
-    p"update Table: pc:${Hexadecimal(u.pc)}, " +
+    p"update Table: pc:${Hexadecimal(u.pc.toUInt)}, " +
       p"tageTakens:${u.tagePreds}, taken:${u.takens}, oldCtr:${u.oldCtrs}\n"
   )
 }
@@ -349,8 +349,9 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
       scMeta.scPreds(w) := RegEnable(s2_scPreds(s2_chooseBit), io.s2_fire(3))
       scMeta.ctrs(w)    := RegEnable(s2_scCtrs, io.s2_fire(3))
 
-      val pred     = s2_scPreds(s2_chooseBit)
-      val debug_pc = Cat(debug_pc_s2, w.U, 0.U(instOffsetBits.W))
+      val pred = s2_scPreds(s2_chooseBit)
+      // FIXME: This looks strange. Maybe we don't need this anymore.
+      val debug_pc = Cat(debug_pc_s2.toUInt, w.U, 0.U(instOffsetBits.W))
       when(s2_provideds(w)) {
         s2_sc_used(w) := true.B
         s2_unconf(w)  := !s2_sumAboveThresholds(s2_chooseBit)

--- a/src/main/scala/xiangshan/frontend/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/Tage.scala
@@ -48,7 +48,7 @@ trait TageParams extends HasBPUConst with HasXSParameter {
 
   val USE_ALT_ON_NA_WIDTH = 4
   val NUM_USE_ALT_ON_NA   = 128
-  def use_alt_idx(pc: UInt) = (pc >> instOffsetBits)(log2Ceil(NUM_USE_ALT_ON_NA) - 1, 0)
+  def use_alt_idx(pc: PrunedAddr) = (pc >> instOffsetBits)(log2Ceil(NUM_USE_ALT_ON_NA) - 1, 0)
 
   val TotalBits = TageTableInfos.map {
     case (s, h, t) => {
@@ -87,7 +87,7 @@ abstract class TageModule(implicit p: Parameters)
     extends XSModule with TageParams with BPUUtils {}
 
 class TageReq(implicit p: Parameters) extends TageBundle {
-  val pc          = UInt(VAddrBits.W)
+  val pc          = PrunedAddr(VAddrBits)
   val ghist       = UInt(HistoryLength.W)
   val folded_hist = new AllFoldedHistories(foldedGHistInfos)
 }
@@ -102,7 +102,7 @@ class TageResp(implicit p: Parameters) extends TageResp_meta {
 }
 
 class TageUpdate(implicit p: Parameters) extends TageBundle {
-  val pc    = UInt(VAddrBits.W)
+  val pc    = PrunedAddr(VAddrBits)
   val ghist = UInt(HistoryLength.W)
   // update tag and ctr
   val mask    = Vec(numBr, Bool())
@@ -141,10 +141,10 @@ trait TBTParams extends HasXSParameter with TageParams {
 
 class TageBTable(implicit p: Parameters) extends XSModule with TBTParams {
   val io = IO(new Bundle {
-    val req           = Flipped(DecoupledIO(UInt(VAddrBits.W))) // s0_pc
+    val req           = Flipped(DecoupledIO(PrunedAddr(VAddrBits))) // s0_pc
     val s1_cnt        = Output(Vec(numBr, UInt(2.W)))
     val update_mask   = Input(Vec(TageBanks, Bool()))
-    val update_pc     = Input(UInt(VAddrBits.W))
+    val update_pc     = Input(PrunedAddr(VAddrBits))
     val update_cnt    = Input(Vec(numBr, UInt(2.W)))
     val update_takens = Input(Vec(TageBanks, Bool()))
     // val update  = Input(new TageUpdate)
@@ -315,7 +315,7 @@ class TageTable(
   }
   // pc is start address of basic block, most 2 branch inst in block
   // def getUnhashedIdx(pc: UInt) = pc >> (instOffsetBits+log2Ceil(TageBanks))
-  def getUnhashedIdx(pc: UInt): UInt = pc >> instOffsetBits
+  def getUnhashedIdx(pc: PrunedAddr): UInt = pc >> instOffsetBits
 
   // val s1_pc = io.req.bits.pc
   val req_unhashed_idx = getUnhashedIdx(io.req.bits.pc)
@@ -569,7 +569,7 @@ class TageTable(
   val ub = PriorityEncoder(u.uMask)
   XSDebug(
     io.req.fire,
-    p"tableReq: pc=0x${Hexadecimal(io.req.bits.pc)}, " +
+    p"tableReq: pc=0x${Hexadecimal(io.req.bits.pc.toUInt)}, " +
       p"idx=$s0_idx, tag=$s0_tag\n"
   )
   for (i <- 0 until numBr) {
@@ -580,7 +580,7 @@ class TageTable(
     )
     XSDebug(
       io.update.mask(i),
-      p"update Table_br_$i: pc:${Hexadecimal(u.pc)}}, " +
+      p"update Table_br_$i: pc:${Hexadecimal(u.pc.toUInt)}}, " +
         p"taken:${u.takens(i)}, alloc:${u.alloc(i)}, oldCtrs:${u.oldCtrs(i)}\n"
     )
     val bank = OHToUInt(update_req_bank_1h.asUInt, nBanks)
@@ -1023,7 +1023,7 @@ class Tage(implicit p: Parameters) extends BaseTage {
       updateValids(b),
       "update(%d): pc=%x, cycle=%d, taken:%b, misPred:%d, bimctr:%d, pvdr(%d):%d, altDiff:%d, pvdrU:%d, pvdrCtr:%d, alloc:%b\n",
       b.U,
-      update_pc,
+      update_pc.toUInt,
       0.U,
       update.br_taken_mask(b),
       update.mispred_mask(b),
@@ -1037,12 +1037,12 @@ class Tage(implicit p: Parameters) extends BaseTage {
     )
   }
   val s2_resps = RegEnable(s1_resps, io.s1_fire(1))
-  XSDebug("req: v=%d, pc=0x%x\n", io.s0_fire(1), s0_pc_dup(1))
-  XSDebug("s1_fire:%d, resp: pc=%x\n", io.s1_fire(1), debug_pc_s1)
+  XSDebug("req: v=%d, pc=0x%x\n", io.s0_fire(1), s0_pc_dup(1).toUInt)
+  XSDebug("s1_fire:%d, resp: pc=%x\n", io.s1_fire(1), debug_pc_s1.toUInt)
   XSDebug(
     "s2_fireOnLastCycle: resp: pc=%x, target=%x, hits=%b, takens=%b\n",
-    debug_pc_s2,
-    io.out.s2.getTarget(1),
+    debug_pc_s2.toUInt,
+    io.out.s2.getTarget(1).toUInt,
     s2_provideds.asUInt,
     s2_tageTakens_dup(0).asUInt
   )

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -172,11 +172,11 @@ trait HasICacheParameters extends HasL1CacheParameters with HasInstrMMIOConst wi
     lineSel
   }
 
-  def getBlkAddr(addr:        UInt): UInt = (addr >> blockOffBits).asUInt
+  def getBlkAddr(addr:        PrunedAddr): UInt = (addr >> blockOffBits).asUInt
   def getPhyTagFromBlk(addr:  UInt): UInt = (addr >> (pgUntagBits - blockOffBits)).asUInt
   def getIdxFromBlk(addr:     UInt): UInt = addr(idxBits - 1, 0)
-  def getPaddrFromPtag(vaddr: UInt, ptag: UInt): UInt = Cat(ptag, vaddr(pgUntagBits - 1, 0))
-  def getPaddrFromPtag(vaddrVec: Vec[UInt], ptagVec: Vec[UInt]): Vec[UInt] =
+  def getPaddrFromPtag(vaddr: PrunedAddr, ptag: UInt): PrunedAddr = PrunedAddrInit(Cat(ptag, vaddr(pgUntagBits - 1, 0)))
+  def getPaddrFromPtag(vaddrVec: Vec[PrunedAddr], ptagVec: Vec[UInt]): Vec[PrunedAddr] =
     VecInit((vaddrVec zip ptagVec).map { case (vaddr, ptag) => getPaddrFromPtag(vaddr, ptag) })
 }
 

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -45,8 +45,8 @@ class ICacheMainPipeResp(implicit p: Parameters) extends ICacheBundle {
    * PAddrBitsMax(=56bit currently) is required for the frontend datapath due to the itlb ppn length limitation
    * (cases 56<x<=64 are handled by the backend datapath)
    */
-  val gpaddr:            UInt = UInt(PAddrBitsMax.W)
-  val isForVSnonLeafPTE: Bool = Bool()
+  val gpaddr:            PrunedAddr = PrunedAddr(PAddrBitsMax)
+  val isForVSnonLeafPTE: Bool       = Bool()
 }
 
 class ICacheMainPipeBundle(implicit p: Parameters) extends ICacheBundle {

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -28,16 +28,17 @@ import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.cache.mmu._
 import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.FtqToICacheRequestBundle
+import xiangshan.frontend.PrunedAddr
 
 class ICacheMainPipeResp(implicit p: Parameters) extends ICacheBundle {
-  val doubleline:       Bool      = Bool()
-  val vaddr:            Vec[UInt] = Vec(PortNumber, UInt(VAddrBits.W))
-  val data:             UInt      = UInt(blockBits.W)
-  val paddr:            Vec[UInt] = Vec(PortNumber, UInt(PAddrBits.W))
-  val exception:        Vec[UInt] = Vec(PortNumber, UInt(ExceptionType.width.W))
-  val pmp_mmio:         Vec[Bool] = Vec(PortNumber, Bool())
-  val itlb_pbmt:        Vec[UInt] = Vec(PortNumber, UInt(Pbmt.width.W))
-  val backendException: Bool      = Bool()
+  val doubleline:       Bool            = Bool()
+  val vaddr:            Vec[PrunedAddr] = Vec(PortNumber, PrunedAddr(VAddrBits))
+  val data:             UInt            = UInt(blockBits.W)
+  val paddr:            Vec[PrunedAddr] = Vec(PortNumber, PrunedAddr(PAddrBits))
+  val exception:        Vec[UInt]       = Vec(PortNumber, UInt(ExceptionType.width.W))
+  val pmp_mmio:         Vec[Bool]       = Vec(PortNumber, Bool())
+  val itlb_pbmt:        Vec[UInt]       = Vec(PortNumber, UInt(Pbmt.width.W))
+  val backendException: Bool            = Bool()
   /* NOTE: GPAddrBits(=50bit) is not enough for gpaddr here, refer to PR#3795
    * Sv48*4 only allows 50bit gpaddr, when software violates this requirement
    * it needs to fill the mtval2 register with the full XLEN(=64bit) gpaddr,
@@ -199,7 +200,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule with HasICache
     assert(
       (0 until PortNumber).map(i => s0_req_vSetIdx(i) === fromWayLookup.bits.vSetIdx(i)).reduce(_ && _),
       "vSetIdx from ftq and wayLookup mismatch! vaddr=0x%x ftq: vSet0=0x%x vSet1=0x%x wayLookup: vSet0=0x%x vSet1=0x%x",
-      s0_req_vaddr(0),
+      s0_req_vaddr(0).toUInt,
       s0_req_vSetIdx(0),
       s0_req_vSetIdx(1),
       fromWayLookup.bits.vSetIdx(0),
@@ -287,7 +288,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule with HasICache
   toPMP.zipWithIndex.foreach { case (p, i) =>
     // if itlb has exception, paddr can be invalid, therefore pmp check can be skipped do not do this now for timing
     p.valid     := s1_valid // && !ExceptionType.hasException(s1_itlb_exception(i))
-    p.bits.addr := s1_req_paddr(i)
+    p.bits.addr := s1_req_paddr(i).toUInt
     p.bits.size := 3.U
     p.bits.cmd  := TlbCmd.exec
   }
@@ -393,7 +394,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule with HasICache
   (0 until PortNumber).foreach { i =>
     io.errors(i).valid              := (s2_meta_corrupt(i) || s2_data_corrupt(i)) && RegNext(s1_fire)
     io.errors(i).bits.report_to_beu := (s2_meta_corrupt(i) || s2_data_corrupt(i)) && RegNext(s1_fire)
-    io.errors(i).bits.paddr         := s2_req_paddr(i)
+    io.errors(i).bits.paddr         := s2_req_paddr(i).toUInt
     io.errors(i).bits.source        := DontCare
     io.errors(i).bits.source.tag    := s2_meta_corrupt(i)
     io.errors(i).bits.source.data   := s2_data_corrupt(i)
@@ -563,7 +564,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule with HasICache
     when(RegNext(s2_fire && s2_l2_corrupt(i))) {
       io.errors(i).valid              := true.B
       io.errors(i).bits.report_to_beu := false.B // l2 should have report that to bus error unit, no need to do it again
-      io.errors(i).bits.paddr         := RegNext(s2_req_paddr(i))
+      io.errors(i).bits.paddr         := RegNext(s2_req_paddr(i).toUInt)
       io.errors(i).bits.source.tag    := false.B
       io.errors(i).bits.source.data   := false.B
       io.errors(i).bits.source.l2     := true.B

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -29,12 +29,12 @@ abstract class IPrefetchBundle(implicit p: Parameters) extends ICacheBundle
 abstract class IPrefetchModule(implicit p: Parameters) extends ICacheModule
 
 class IPrefetchReq(implicit p: Parameters) extends IPrefetchBundle {
-  val startAddr:        UInt   = UInt(VAddrBits.W)
-  val nextlineStart:    UInt   = UInt(VAddrBits.W)
-  val ftqIdx:           FtqPtr = new FtqPtr
-  val isSoftPrefetch:   Bool   = Bool()
-  val backendException: UInt   = UInt(ExceptionType.width.W)
-  def crossCacheline:   Bool   = startAddr(blockOffBits - 1) === 1.U
+  val startAddr:        PrunedAddr = PrunedAddr(VAddrBits)
+  val nextlineStart:    PrunedAddr = PrunedAddr(VAddrBits)
+  val ftqIdx:           FtqPtr     = new FtqPtr
+  val isSoftPrefetch:   Bool       = Bool()
+  val backendException: UInt       = UInt(ExceptionType.width.W)
+  def crossCacheline:   Bool       = startAddr(blockOffBits - 1) === 1.U
 
   def fromFtqICacheInfo(info: FtqICacheInfo): IPrefetchReq = {
     this.startAddr      := info.startAddr
@@ -174,8 +174,8 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule with HasICac
     toITLB(i).valid             := s1_need_itlb(i) || (s0_valid && (if (i == 0) true.B else s0_doubleline))
     toITLB(i).bits              := DontCare
     toITLB(i).bits.size         := 3.U
-    toITLB(i).bits.vaddr        := Mux(s1_need_itlb(i), s1_req_vaddr(i), s0_req_vaddr(i))
-    toITLB(i).bits.debug.pc     := Mux(s1_need_itlb(i), s1_req_vaddr(i), s0_req_vaddr(i))
+    toITLB(i).bits.vaddr        := Mux(s1_need_itlb(i), s1_req_vaddr(i).toUInt, s0_req_vaddr(i).toUInt)
+    toITLB(i).bits.debug.pc     := Mux(s1_need_itlb(i), s1_req_vaddr(i).toUInt, s0_req_vaddr(i).toUInt)
     toITLB(i).bits.cmd          := TlbCmd.exec
     toITLB(i).bits.no_translate := false.B
   }
@@ -187,9 +187,9 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule with HasICac
     * Receive resp from ITLB
     ******************************************************************************
     */
-  private val s1_req_paddr_wire = VecInit(fromITLB.map(_.bits.paddr(0)))
+  private val s1_req_paddr_wire = VecInit(fromITLB.map(tlbRequest => PrunedAddrInit(tlbRequest.bits.paddr(0))))
   private val s1_req_paddr_reg = VecInit((0 until PortNumber).map { i =>
-    RegEnable(s1_req_paddr_wire(i), 0.U(PAddrBits.W), tlb_valid_pulse(i))
+    RegEnable(s1_req_paddr_wire(i), PrunedAddrInit(0.U(PAddrBits.W)), tlb_valid_pulse(i))
   })
   private val s1_req_paddr = VecInit((0 until PortNumber).map { i =>
     Mux(tlb_valid_pulse(i), s1_req_paddr_wire(i), s1_req_paddr_reg(i))
@@ -265,7 +265,7 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule with HasICac
   private val s1_meta_ptags  = fromMeta.tags
   private val s1_meta_valids = fromMeta.entryValid
 
-  private def getWaymask(paddrs: Vec[UInt]): Vec[UInt] = {
+  private def getWaymask(paddrs: Vec[PrunedAddr]): Vec[UInt] = {
     val ptags = paddrs.map(get_phy_tag)
     val tag_eq_vec =
       VecInit((0 until PortNumber).map(p => VecInit((0 until nWays).map(w => s1_meta_ptags(p)(w) === ptags(p)))))
@@ -371,11 +371,11 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule with HasICac
       PopCount(s1_waymasks_vec(0)) > 1.U,
       s1_req_ptags(0),
       get_idx(s1_req_vaddr(0)),
-      s1_req_vaddr(0),
+      s1_req_vaddr(0).toUInt,
       PopCount(s1_waymasks_vec(1)) > 1.U && s1_doubleline,
       s1_req_ptags(1),
       get_idx(s1_req_vaddr(1)),
-      s1_req_vaddr(1)
+      s1_req_vaddr(1).toUInt
     )
   }
 
@@ -387,7 +387,7 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule with HasICac
   toPMP.zipWithIndex.foreach { case (p, i) =>
     // if itlb has exception, paddr can be invalid, therefore pmp check can be skipped
     p.valid     := s1_valid // !ExceptionType.hasException(s1_itlb_exception(i))
-    p.bits.addr := s1_req_paddr(i)
+    p.bits.addr := s1_req_paddr(i).toUInt
     p.bits.size := 3.U
     p.bits.cmd  := TlbCmd.exec
   }

--- a/src/main/scala/xiangshan/frontend/icache/InstrUncache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/InstrUncache.scala
@@ -34,7 +34,7 @@ import utils._
 import xiangshan.frontend._
 
 class InsUncacheReq(implicit p: Parameters) extends ICacheBundle {
-  val addr: UInt = UInt(PAddrBits.W)
+  val addr: PrunedAddr = PrunedAddr(PAddrBits)
 }
 
 class InsUncacheResp(implicit p: Parameters) extends ICacheBundle {
@@ -118,7 +118,7 @@ class InstrMMIOEntry(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheModu
     }
   }
 
-  private def getDataFromBus(pc: UInt): UInt = {
+  private def getDataFromBus(pc: PrunedAddr): UInt = {
     val respData = Wire(UInt(maxInstrLen.W))
     respData := Mux(
       pc(2, 1) === "b00".U,

--- a/src/main/scala/xiangshan/frontend/icache/WayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/WayLookup.scala
@@ -23,6 +23,7 @@ import org.chipsalliance.cde.config.Parameters
 import utility._
 import xiangshan.cache.mmu.Pbmt
 import xiangshan.frontend.ExceptionType
+import xiangshan.frontend.PrunedAddr
 
 /* WayLookupEntry is for internal storage, while WayLookupInfo is for interface
  * Notes:
@@ -41,8 +42,8 @@ class WayLookupEntry(implicit p: Parameters) extends ICacheBundle {
 
 class WayLookupGPFEntry(implicit p: Parameters) extends ICacheBundle {
   // NOTE: we don't use GPAddrBits here, refer to ICacheMainPipe.scala L43-48 and PR#3795
-  val gpaddr:            UInt = UInt(PAddrBitsMax.W)
-  val isForVSnonLeafPTE: Bool = Bool()
+  val gpaddr:            PrunedAddr = PrunedAddr(PAddrBitsMax)
+  val isForVSnonLeafPTE: Bool       = Bool()
 }
 
 class WayLookupInfo(implicit p: Parameters) extends ICacheBundle {
@@ -50,14 +51,14 @@ class WayLookupInfo(implicit p: Parameters) extends ICacheBundle {
   val gpf   = new WayLookupGPFEntry
 
   // for compatibility
-  def vSetIdx:           Vec[UInt] = entry.vSetIdx
-  def waymask:           Vec[UInt] = entry.waymask
-  def ptag:              Vec[UInt] = entry.ptag
-  def itlb_exception:    Vec[UInt] = entry.itlb_exception
-  def itlb_pbmt:         Vec[UInt] = entry.itlb_pbmt
-  def meta_codes:        Vec[UInt] = entry.meta_codes
-  def gpaddr:            UInt      = gpf.gpaddr
-  def isForVSnonLeafPTE: Bool      = gpf.isForVSnonLeafPTE
+  def vSetIdx:           Vec[UInt]  = entry.vSetIdx
+  def waymask:           Vec[UInt]  = entry.waymask
+  def ptag:              Vec[UInt]  = entry.ptag
+  def itlb_exception:    Vec[UInt]  = entry.itlb_exception
+  def itlb_pbmt:         Vec[UInt]  = entry.itlb_pbmt
+  def meta_codes:        Vec[UInt]  = entry.meta_codes
+  def gpaddr:            PrunedAddr = gpf.gpaddr
+  def isForVSnonLeafPTE: Bool       = gpf.isForVSnonLeafPTE
 }
 
 class WayLookupInterface(implicit p: Parameters) extends ICacheBundle {

--- a/src/main/scala/xiangshan/frontend/newRAS.scala
+++ b/src/main/scala/xiangshan/frontend/newRAS.scala
@@ -36,7 +36,7 @@ import xiangshan._
 import xiangshan.frontend._
 
 class RASEntry()(implicit p: Parameters) extends XSBundle {
-  val retAddr = UInt(VAddrBits.W)
+  val retAddr = PrunedAddr(VAddrBits)
   val ctr     = UInt(RasCtrSize.W) // layer of nested call functions
   def =/=(that: RASEntry) = this.retAddr =/= that.retAddr || this.ctr =/= that.ctr
 }
@@ -97,7 +97,7 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
   override val meta_size = WireInit(0.U.asTypeOf(new RASMeta)).getWidth
 
   object RASEntry {
-    def apply(retAddr: UInt, ctr: UInt): RASEntry = {
+    def apply(retAddr: PrunedAddr, ctr: UInt): RASEntry = {
       val e = Wire(new RASEntry)
       e.retAddr := retAddr
       e.ctr     := ctr
@@ -109,7 +109,7 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
     val io = IO(new Bundle {
       val spec_push_valid = Input(Bool())
       val spec_pop_valid  = Input(Bool())
-      val spec_push_addr  = Input(UInt(VAddrBits.W))
+      val spec_push_addr  = Input(PrunedAddr(VAddrBits))
       // for write bypass between s2 and s3
 
       val s2_fire        = Input(Bool())
@@ -118,13 +118,13 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
       val s3_meta        = Input(new RASInternalMeta)
       val s3_missed_pop  = Input(Bool())
       val s3_missed_push = Input(Bool())
-      val s3_pushAddr    = Input(UInt(VAddrBits.W))
-      val spec_pop_addr  = Output(UInt(VAddrBits.W))
+      val s3_pushAddr    = Input(PrunedAddr(VAddrBits))
+      val spec_pop_addr  = Output(PrunedAddr(VAddrBits))
 
       val commit_valid      = Input(Bool())
       val commit_push_valid = Input(Bool())
       val commit_pop_valid  = Input(Bool())
-      val commit_push_addr  = Input(UInt(VAddrBits.W))
+      val commit_push_addr  = Input(PrunedAddr(VAddrBits))
       val commit_meta_TOSW  = Input(new RASPtr)
       // for debug purpose only
       val commit_meta_ssp = Input(UInt(log2Up(RasSize).W))
@@ -137,7 +137,7 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
       val redirect_meta_TOSW = Input(new RASPtr)
       val redirect_meta_TOSR = Input(new RASPtr)
       val redirect_meta_NOS  = Input(new RASPtr)
-      val redirect_callAddr  = Input(UInt(VAddrBits.W))
+      val redirect_callAddr  = Input(PrunedAddr(VAddrBits))
 
       val ssp  = Output(UInt(log2Up(RasSize).W))
       val sctr = Output(UInt(RasCtrSize.W))
@@ -152,8 +152,8 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
       val debug = new RASDebug
     })
 
-    val commit_stack = RegInit(VecInit(Seq.fill(RasSize)(RASEntry(0.U, 0.U))))
-    val spec_queue   = RegInit(VecInit(Seq.fill(rasSpecSize)(RASEntry(0.U, 0.U))))
+    val commit_stack = RegInit(VecInit(Seq.fill(RasSize)(RASEntry(PrunedAddrInit(0.U(VAddrBits.W)), 0.U))))
+    val spec_queue   = RegInit(VecInit(Seq.fill(rasSpecSize)(RASEntry(PrunedAddrInit(0.U(VAddrBits.W)), 0.U))))
     val spec_nos     = RegInit(VecInit(Seq.fill(rasSpecSize)(RASPtr(false.B, 0.U))))
 
     val nsp = RegInit(0.U(log2Up(rasSize).W))
@@ -430,7 +430,7 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
     }
 
     def specPush(
-        retAddr:     UInt,
+        retAddr:     PrunedAddr,
         currentSsp:  UInt,
         currentSctr: UInt,
         currentTOSR: RASPtr,
@@ -756,14 +756,14 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
 
   val spec_debug = stack.debug
   XSDebug(io.s2_fire(2), "----------------RAS----------------\n")
-  XSDebug(io.s2_fire(2), " TopRegister: 0x%x\n", stack.spec_pop_addr)
+  XSDebug(io.s2_fire(2), " TopRegister: 0x%x\n", stack.spec_pop_addr.toUInt)
   XSDebug(io.s2_fire(2), "  index       addr           ctr           nos (spec part)\n")
   for (i <- 0 until RasSpecSize) {
     XSDebug(
       io.s2_fire(2),
       "  (%d)   0x%x      %d       %d",
       i.U,
-      spec_debug.spec_queue(i).retAddr,
+      spec_debug.spec_queue(i).retAddr.toUInt,
       spec_debug.spec_queue(i).ctr,
       spec_debug.spec_nos(i).value
     )
@@ -778,7 +778,7 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
       io.s2_fire(2),
       "  (%d)   0x%x      %d",
       i.U,
-      spec_debug.commit_stack(i).retAddr,
+      spec_debug.commit_stack(i).retAddr.toUInt,
       spec_debug.commit_stack(i).ctr
     )
     XSDebug(io.s2_fire(2) && i.U === stack.ssp, "   <----ssp")

--- a/src/test/scala/xiangshan/frontend/FrontendTrigger.scala
+++ b/src/test/scala/xiangshan/frontend/FrontendTrigger.scala
@@ -7,10 +7,11 @@ import org.scalatest.matchers.must.Matchers
 import top.DefaultConfig
 import utility.{LogUtilsOptions, LogUtilsOptionsKey}
 import xiangshan.{DebugOptionsKey, XSCoreParameters, XSCoreParamsKey}
+import xiangshan.frontend.PrunedAddrInit
 
 
 class FrontendTriggerTest extends AnyFlatSpec with ChiselScalatestTester with Matchers {
-  val defaultConfig = (new DefaultConfig).alterPartial {
+  implicit val defaultConfig: org.chipsalliance.cde.config.Parameters = (new DefaultConfig).alterPartial {
     case XSCoreParamsKey => XSCoreParameters()
   }.alter((site, here, up) => {
     case LogUtilsOptionsKey => LogUtilsOptions(
@@ -24,7 +25,7 @@ class FrontendTriggerTest extends AnyFlatSpec with ChiselScalatestTester with Ma
 
   behavior of "FrontendTrigger"
   it should "run" in {
-    test(new FrontendTrigger()(defaultConfig)).withAnnotations(Seq(VerilatorBackendAnnotation)) {
+    test(new FrontendTrigger()).withAnnotations(Seq(VerilatorBackendAnnotation)) {
       m: FrontendTrigger =>
         m.io.frontendTrigger.debugMode.poke(false.B)
         m.io.frontendTrigger.tEnableVec.map(_.poke(false.B))
@@ -35,7 +36,7 @@ class FrontendTriggerTest extends AnyFlatSpec with ChiselScalatestTester with Ma
         m.io.frontendTrigger.tUpdate.bits.tdata.matchType.poke(3.U)
         m.io.frontendTrigger.tUpdate.bits.tdata.tdata2.poke("h1234_567f".U)
         m.io.pc.zipWithIndex.map { case (pc, i) =>
-          pc.poke((0x1234_5676 + 2 * i).U)
+          pc.poke(PrunedAddrInit((0x1234_5676 + 2 * i).U))
         }
         for (_ <- 0 until 4) { m.clock.step() }
         m.io.triggered.zipWithIndex.map { case (action, i) =>


### PR DESCRIPTION
According to RISC-V specification, the least significant 1 or 2 bits (depending on whether the C extension is enabled or not) are hardwired to zero. Therefore, these bits can be pruned to save area.

This PR prunes almost all the addresses in the frontend, except those related to the backend. The backend should also use `PrunedAddr` instead of plain `UInt`. Some of these places have been labeled with FIXME or TODO in the code.

Apart from this, there are several other things that need attention:
 * Line 351 of SC.scala appears to have a historical that needs to be fixed.
 * `>>` of `PrunedAddr` should be removed to avoid confusion. This is mostly used to calculate tags, which can be rewritten as selecting corresponding bits.
* Implicit conversion of Scala has been attempted. However, the types of `:=` are not decided until runtime, making `UInt` inevitable. Considering potential confusion, this approach was abandoned. There might be a better way of doing this, especially after backend modifications are merged.