### PR TITLE
area(csr): fix intr NO bits and remove reg for waddr/wdata

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/Debug.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/Debug.scala
@@ -14,7 +14,7 @@ class Debug(implicit val p: Parameters) extends Module with HasXSParameter {
   private val trapInfo        = io.in.trapInfo
   private val hasTrap         = trapInfo.valid
   private val trapIsInterrupt = trapInfo.bits.isInterrupt
-  private val intrVec         = trapInfo.bits.intrVec
+  private val isDebugIntr     = trapInfo.bits.isDebugIntr
   private val trapVec         = trapInfo.bits.trapVec
   private val singleStep      = trapInfo.bits.singleStep
   private val trigger         = io.in.trapInfo.bits.trigger
@@ -42,7 +42,7 @@ class Debug(implicit val p: Parameters) extends Module with HasXSParameter {
    */
   // debug_intr
   val hasIntr = hasTrap && trapIsInterrupt
-  val hasDebugIntr = hasIntr && intrVec(CSRConst.IRQ_DEBUG)
+  val hasDebugIntr = hasIntr && isDebugIntr
 
   // debug_exception_ebreak
   val hasExp = hasTrap && !trapIsInterrupt
@@ -144,7 +144,7 @@ class DebugIO(implicit val p: Parameters) extends Bundle with HasXSParameter {
   val in = Input(new Bundle {
     val trapInfo = ValidIO(new Bundle {
       val trapVec = UInt(64.W)
-      val intrVec = UInt(64.W)
+      val isDebugIntr = Bool()
       val isInterrupt = Bool()
       val singleStep = Bool()
       val trigger = TriggerAction()

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -382,10 +382,11 @@ class NewCSR(implicit val p: Parameters) extends Module
   intrMod.io.in.dcsr      := dcsr.regOut
 
   when(intrMod.io.out.nmi && intrMod.io.out.interruptVec.valid) {
-    nmip.NMI_31 := nmip.NMI_31 & !intrMod.io.out.interruptVec.bits(NonMaskableIRNO.NMI_31).asBool
-    nmip.NMI_43 := nmip.NMI_43 & !intrMod.io.out.interruptVec.bits(NonMaskableIRNO.NMI_43).asBool
+    nmip.NMI_31 := nmip.NMI_31 & !UIntToOH(intrMod.io.out.interruptVec.bits, 64)(NonMaskableIRNO.NMI_31)
+    nmip.NMI_43 := nmip.NMI_43 & !UIntToOH(intrMod.io.out.interruptVec.bits, 64)(NonMaskableIRNO.NMI_43)
   }
   val intrVec = RegEnable(intrMod.io.out.interruptVec.bits, 0.U, intrMod.io.out.interruptVec.valid)
+  val debug = RegEnable(intrMod.io.out.debug, false.B, intrMod.io.out.interruptVec.valid)
   val nmi = RegEnable(intrMod.io.out.nmi, false.B, intrMod.io.out.interruptVec.valid)
   val virtualInterruptIsHvictlInject = RegEnable(intrMod.io.out.virtualInterruptIsHvictlInject, false.B, intrMod.io.out.interruptVec.valid)
   val irToHS = RegEnable(intrMod.io.out.irToHS, false.B, intrMod.io.out.interruptVec.valid)
@@ -1073,7 +1074,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   val debugMod = Module(new Debug)
   debugMod.io.in.trapInfo.valid            := hasTrap
   debugMod.io.in.trapInfo.bits.trapVec     := trapVec.asUInt
-  debugMod.io.in.trapInfo.bits.intrVec     := intrVec
+  debugMod.io.in.trapInfo.bits.isDebugIntr := debug
   debugMod.io.in.trapInfo.bits.isInterrupt := trapIsInterrupt
   debugMod.io.in.trapInfo.bits.trigger     := trigger
   debugMod.io.in.trapInfo.bits.singleStep  := singleStep

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -81,7 +81,6 @@ class NewCSRInput(implicit p: Parameters) extends Bundle {
   val ren = Bool()
   val op = UInt(2.W)
   val addr = UInt(12.W)
-  val waddrReg = UInt(12.W)
   val src = UInt(64.W)
   val wdata = UInt(64.W)
   val mnret = Input(Bool())
@@ -243,12 +242,10 @@ class NewCSR(implicit val p: Parameters) extends Module
   /* Alias of input signals */
   val wen   = io.in.bits.wen && valid
   val addr  = io.in.bits.addr
+  val wdata = io.in.bits.wdata
 
   val ren   = io.in.bits.ren && valid
   val raddr = io.in.bits.addr
-
-  val waddrReg = io.in.bits.waddrReg
-  val wdataReg = io.in.bits.wdata
 
   val hasTrap = io.fromRob.trap.valid
   val trapVec = io.fromRob.trap.bits.trapVec
@@ -306,7 +303,6 @@ class NewCSR(implicit val p: Parameters) extends Module
   val legalDret  = permitMod.io.out.hasLegalDret
 
   private val wenLegalReg = GatedValidRegNext(wenLegal)
-  private val isModeVSReg = GatedValidRegNext(isModeVS)
 
   var csrRwMap: SeqMap[Int, (CSRAddrWriteBundle[_], UInt)] =
     machineLevelCSRMap ++
@@ -429,21 +425,20 @@ class NewCSR(implicit val p: Parameters) extends Module
   pmpEntryMod.io.in.ren   := ren
   pmpEntryMod.io.in.wen   := wenLegalReg
   pmpEntryMod.io.in.addr  := addr
-  pmpEntryMod.io.in.waddr := waddrReg
-  pmpEntryMod.io.in.wdata := wdataReg
+  pmpEntryMod.io.in.wdata := wdata
 
   // Todo: all wen and wdata of CSRModule assigned in this for loop
   for ((id, (wBundle, _)) <- csrRwMap) {
     if (vsMapS.contains(id)) {
       // VS access CSR by S: privState.isModeVS && addrMappedToVS === sMapVS(id).U
-      wBundle.wen := wenLegalReg && ((isModeVSReg && waddrReg === vsMapS(id).U) || (!isModeVSReg && waddrReg === id.U))
-      wBundle.wdata := wdataReg
+      wBundle.wen := wenLegalReg && ((isModeVS && addr === vsMapS(id).U) || (!isModeVS && addr === id.U))
+      wBundle.wdata := wdata
     } else if (sMapVS.contains(id)) {
-      wBundle.wen := wenLegalReg && !isModeVSReg && waddrReg === id.U
-      wBundle.wdata := wdataReg
+      wBundle.wen := wenLegalReg && !isModeVS && addr === id.U
+      wBundle.wdata := wdata
     } else {
-      wBundle.wen := wenLegalReg && waddrReg === id.U
-      wBundle.wdata := wdataReg
+      wBundle.wen := wenLegalReg && addr === id.U
+      wBundle.wdata := wdata
     }
   }
 
@@ -504,23 +499,23 @@ class NewCSR(implicit val p: Parameters) extends Module
 
   miregiprios.foreach { mod =>
     mod.w.wen := mireg.w.wen && (miselect.regOut.ALL.asUInt === mod.addr.U)
-    mod.w.wdata := wdataReg
+    mod.w.wdata := wdata
   }
 
   siregiprios.foreach { mod =>
     mod.w.wen := sireg.w.wen && (siselect.regOut.ALL.asUInt === mod.addr.U)
-    mod.w.wdata := wdataReg
+    mod.w.wdata := wdata
   }
 
   mhartid.hartid := this.io.fromTop.hartId
 
   cfgs.zipWithIndex.foreach { case (mod, i) =>
-    mod.w.wen := wenLegalReg && (waddrReg === (0x3A0 + i / 8 * 2).U)
+    mod.w.wen := wenLegalReg && (addr === (0x3A0 + i / 8 * 2).U)
     mod.w.wdata := pmpEntryMod.io.out.pmpCfgWData(8*((i%8)+1)-1,8*(i%8))
   }
 
   pmpaddr.zipWithIndex.foreach{ case(mod, i) =>
-    mod.w.wen := wenLegalReg && (waddrReg === (0x3B0 + i).U)
+    mod.w.wen := wenLegalReg && (addr === (0x3B0 + i).U)
     mod.w.wdata := pmpEntryMod.io.out.pmpAddrWData(i)
   }
 
@@ -869,7 +864,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   )
 
   // flush
-  val resetSatp = Cat(Seq(satp, vsatp, hgatp).map(_.addr.U === waddrReg)).orR && wenLegalReg // write to satp will cause the pipeline be flushed
+  val resetSatp = Cat(Seq(satp, vsatp, hgatp).map(_.addr.U === addr)).orR && wenLegalReg // write to satp will cause the pipeline be flushed
 
   val floatStatusOnOff = mstatus.w.wen && (
     mstatus.w.wdataFields.FS === ContextStatus.Off && mstatus.regOut.FS =/= ContextStatus.Off ||
@@ -1088,7 +1083,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   debugMod.io.in.tdata2Selected            := tdata2.rdata
   debugMod.io.in.tdata1Update              := tdata1Update
   debugMod.io.in.tdata2Update              := tdata2Update
-  debugMod.io.in.tdata1Wdata               := wdataReg
+  debugMod.io.in.tdata1Wdata               := wdata
   debugMod.io.in.triggerCanRaiseBpExp      := triggerCanRaiseBpExp
 
   entryDebugMode := debugMod.io.out.hasDebugTrap && !debugMode
@@ -1113,9 +1108,9 @@ class NewCSR(implicit val p: Parameters) extends Module
   }
   tdata1RegVec.zip(tdata2RegVec).zipWithIndex.map { case ((mod1, mod2), idx) => {
     mod1.w.wen    := tdata1Update && (tselect.rdata === idx.U)
-    mod1.w.wdata  := wdataReg
+    mod1.w.wdata  := wdata
     mod2.w.wen    := tdata2Update && (tselect.rdata === idx.U)
-    mod2.w.wdata  := wdataReg
+    mod2.w.wdata  := wdata
   }}
 
   triggerFrontendChange := debugMod.io.out.triggerFrontendChange

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/PMPEntryModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/PMPEntryModule.scala
@@ -23,7 +23,6 @@ class PMPEntryHandleModule(implicit p: Parameters) extends PMPModule {
   val ren   = io.in.ren
   val wen   = io.in.wen
   val addr  = io.in.addr
-  val waddr = io.in.waddr
   val wdata = io.in.wdata
 
   val pmpMask  = RegInit(VecInit(Seq.fill(p(PMParameKey).NumPMP)(0.U(PMPAddrBits.W))))
@@ -36,7 +35,7 @@ class PMPEntryHandleModule(implicit p: Parameters) extends PMPModule {
   // write pmpCfg
   val cfgVec = WireInit(VecInit(Seq.fill(8)(0.U.asTypeOf(new PMPCfgBundle))))
   for (i <- 0 until (p(PMParameKey).NumPMP/8+1) by 2) {
-    when (wen && (waddr === (0x3A0 + i).U)) {
+    when (wen && (addr === (0x3A0 + i).U)) {
       for (j <- cfgVec.indices) {
         val cfgOldTmp = pmpEntry(8*i/2+j).cfg
         val cfgNewTmp = Wire(new PMPCfgBundle)
@@ -65,7 +64,7 @@ class PMPEntryHandleModule(implicit p: Parameters) extends PMPModule {
     pmpAddrW(i) := pmpEntry(i).addr.ADDRESS.asUInt
     pmpAddrR(i) := pmpEntry(i).addr.ADDRESS.asUInt
     // write pmpAddr
-    when (wen && (waddr === (0x3B0 + i).U)) {
+    when (wen && (addr === (0x3B0 + i).U)) {
       if (i != (p(PMParameKey).NumPMP - 1)) {
         val addrNextLocked: Bool = PMPCfgLField.addrLocked(pmpEntry(i).cfg, pmpEntry(i + 1).cfg)
         pmpMask(i) := Mux(!addrNextLocked, pmpEntry(i).matchMask(wdata), pmpEntry(i).mask)
@@ -92,7 +91,6 @@ class PMPEntryHandleIOBundle(implicit p: Parameters) extends PMPBundle {
     val wen   = Bool()
     val ren   = Bool()
     val addr  = UInt(12.W)
-    val waddr = UInt(12.W)
     val wdata = UInt(64.W)
     val pmpCfg  = Vec(NumPMP, new PMPCfgBundle)
     val pmpAddr = Vec(NumPMP, new PMPAddrBundle)

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/TrapHandleModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/TrapHandleModule.scala
@@ -37,19 +37,6 @@ class TrapHandleModule extends Module {
   private val irToHS = io.in.trapInfo.bits.irToHS
   private val irToVS = io.in.trapInfo.bits.irToVS
 
-  private val highestPrioNMIVec = Wire(Vec(64, Bool()))
-  highestPrioNMIVec.zipWithIndex.foreach { case (irq, i) =>
-    if (NonMaskableIRNO.interruptDefaultPrio.contains(i)) {
-      val higherIRSeq = NonMaskableIRNO.getIRQHigherThan(i)
-      irq := (
-        higherIRSeq.nonEmpty.B && Cat(higherIRSeq.map(num => !hasIRVec(num))).andR ||
-          higherIRSeq.isEmpty.B
-        ) && hasIRVec(i)
-      dontTouch(irq)
-    } else
-      irq := false.B
-  }
-
   private val highestPrioEXVec = Wire(Vec(64, Bool()))
   highestPrioEXVec.zipWithIndex.foreach { case (excp, i) =>
     if (ExceptionNO.priorities.contains(i)) {
@@ -63,7 +50,6 @@ class TrapHandleModule extends Module {
   }
 
   private val highestPrioIR  = hasIRVec.asUInt
-  private val highestPrioNMI = highestPrioNMIVec.asUInt
   private val highestPrioEX  = highestPrioEXVec.asUInt
 
   private val mEXVec  = highestPrioEX
@@ -89,7 +75,7 @@ class TrapHandleModule extends Module {
 
   // Todo: support more interrupt and exception
   private val exceptionRegular = OHToUInt(highestPrioEX)
-  private val interruptNO = OHToUInt(Mux(hasNMI, highestPrioNMI, highestPrioIR))
+  private val interruptNO = highestPrioIR
   private val exceptionNO = Mux(trapInfo.bits.singleStep, ExceptionNO.breakPoint.U, exceptionRegular)
 
   private val causeNO = Mux(hasIR, interruptNO, exceptionNO)
@@ -129,7 +115,7 @@ class TrapHandleIO extends Bundle {
     val trapInfo = ValidIO(new Bundle {
       val trapVec = UInt(64.W)
       val nmi = Bool()
-      val intrVec = UInt(64.W)
+      val intrVec = UInt(8.W)
       val isInterrupt = Bool()
       val singleStep = Bool()
       // trap to x mode

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -89,8 +89,6 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
     CSROpType.isCSRRSorRC(func)
   )
 
-  private val waddrReg = RegEnable(addr, 0.U(12.W), io.in.fire)
-  private val wdataReg = RegEnable(wdata, 0.U(64.W), io.in.fire)
 
   csrMod.io.in match {
     case in =>
@@ -99,9 +97,8 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
       in.bits.ren := csrRen
       in.bits.op  := CSROpType.getCSROp(func)
       in.bits.addr := addr
-      in.bits.waddrReg := waddrReg
       in.bits.src := src
-      in.bits.wdata := wdataReg
+      in.bits.wdata := wdata
       in.bits.mret := isMret
       in.bits.mnret := isMNret
       in.bits.sret := isSret
@@ -347,8 +344,8 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
       // distribute csr write signal
       // write to frontend and memory
       custom.distribute_csr.w.valid := csrMod.io.distributedWenLegal
-      custom.distribute_csr.w.bits.addr := waddrReg
-      custom.distribute_csr.w.bits.data := wdataReg
+      custom.distribute_csr.w.bits.addr := addr
+      custom.distribute_csr.w.bits.data := wdata
       // rename single step
       custom.singlestep := csrMod.io.status.singleStepFlag
       // trigger


### PR DESCRIPTION
* Currently we support 61 major interrupts, and 8 bits are sufficient. 
* There is no need to use 64 bits to store the intermediate data of the `interrupt NO`.

* In order to save area, we only need to add 1 cycle to `wen`, not `waddr` and `wdata`.