### PR TITLE
fix(Smstateen): fix access check when Smstateen extension enable.

### DIFF
--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -351,7 +351,8 @@ class XiangShan(object):
             "asid/asid.bin",
             "isa_misc/xret_clear_mprv.bin",
             "isa_misc/satp_ppn.bin",
-            "cache-management/softprefetchtest-riscv64-xs.bin"
+            "cache-management/softprefetchtest-riscv64-xs.bin",
+            "smstateen/rvh_test.bin"
         ]
         misc_tests = map(lambda x: os.path.join(base_dir, x), workloads)
         return misc_tests


### PR DESCRIPTION
* fix the access check for custom CSR and remove the illegal instruction check when accessing S-mode custom CSR from VS mode. This is because we can now use the Smstateen extension to control access to custom content at different privilege levels.

* fix the misjudgment of the U-mode custom CSR.

* fix the missing access check for the stopi CSR in AIA.