### PR TITLE
submodule(utility), transforms: collect XSLogs to SimTop.LogPerfEndpoint

### DIFF
--- a/src/main/scala/device/AXI4SlaveModule.scala
+++ b/src/main/scala/device/AXI4SlaveModule.scala
@@ -62,27 +62,25 @@ class AXI4SlaveModuleImp[T<:Data](outer: AXI4SlaveModule[T])
 
 
 //  val timer = GTimer()
-  when(in.ar.fire){
-    XSDebug(p"[ar] addr: ${Hexadecimal(in.ar.bits.addr)} " +
-      p"arlen:${in.ar.bits.len} arsize:${in.ar.bits.size} " +
-      p"id: ${in.ar.bits.id}\n"
-    )
-  }
-  when(in.aw.fire){
-    XSDebug(p"[aw] addr: ${Hexadecimal(in.aw.bits.addr)} " +
-      p"awlen:${in.aw.bits.len} awsize:${in.aw.bits.size} " +
-      p"id: ${in.aw.bits.id}\n"
-    )
-  }
-  when(in.w.fire){
-    XSDebug(p"[w] wmask: ${Binary(in.w.bits.strb)} last:${in.w.bits.last} data:${Hexadecimal(in.w.bits.data)}\n")
-  }
-  when(in.b.fire){
-    XSDebug(p"[b] id: ${in.b.bits.id}\n")
-  }
-  when(in.r.fire){
-    XSDebug(p"[r] id: ${in.r.bits.id} data: ${Hexadecimal(in.r.bits.data)}\n")
-  }
+  XSDebug(in.ar.fire,
+    p"[ar] addr: ${Hexadecimal(in.ar.bits.addr)} " +
+    p"arlen:${in.ar.bits.len} arsize:${in.ar.bits.size} " +
+    p"id: ${in.ar.bits.id}\n"
+  )
+  XSDebug(in.aw.fire,
+    p"[aw] addr: ${Hexadecimal(in.aw.bits.addr)} " +
+    p"awlen:${in.aw.bits.len} awsize:${in.aw.bits.size} " +
+    p"id: ${in.aw.bits.id}\n"
+  )
+  XSDebug(in.w.fire,
+    p"[w] wmask: ${Binary(in.w.bits.strb)} last:${in.w.bits.last} data:${Hexadecimal(in.w.bits.data)}\n"
+  )
+  XSDebug(in.b.fire,
+    p"[b] id: ${in.b.bits.id}\n"
+  )
+  XSDebug(in.r.fire,
+    p"[r] id: ${in.r.bits.id} data: ${Hexadecimal(in.r.bits.data)}\n"
+  )
 
   when(in.aw.fire){
     assert(in.aw.bits.burst === AXI4Parameters.BURST_INCR, "only support busrt ince!")

--- a/src/main/scala/device/TLTimer.scala
+++ b/src/main/scala/device/TLTimer.scala
@@ -65,10 +65,8 @@ class TLTimer(address: Seq[AddressSet], sim: Boolean, numCores: Int)(implicit p:
     node.regmap( mapping = clintMapping:_* )
 
     val in = node.in.head._1
-    when(in.a.valid){
-      XSDebug("[A] channel valid ready=%d ", in.a.ready)
-      in.a.bits.dump
-    }
+    XSDebug(in.a.valid, "[A] channel valid ready=%d ", in.a.ready)
+    in.a.bits.dump(in.a.valid)
 
     for (i <- 0 until numCores) {
       io.mtip(i) := RegNext(mtime >= mtimecmp(i))

--- a/src/main/scala/utils/DebugIdentityNode.scala
+++ b/src/main/scala/utils/DebugIdentityNode.scala
@@ -40,12 +40,10 @@ class DebugIdentityNode()(implicit p: Parameters) extends LazyModule  {
     def debug(t: TLBundle, valid: Boolean = false): Unit ={
       def fire[T <: Data](x: DecoupledIO[T]) = if(valid) x.valid else x.fire
       val channels = Seq(t.a, t.b, t.c, t.d, t.e)
-      channels.foreach(c =>
-        when(fire(c)){
-          XSDebug(" isFire:%d ",c.fire)
-          c.bits.dump
-        }
-      )
+      channels.foreach { c =>
+        XSDebug(fire(c), " isFire:%d ", c.fire)
+        c.bits.dump(fire(c))
+      }
     }
     debug(in, false)
   }

--- a/src/main/scala/xiangshan/backend/issue/DataArray.scala
+++ b/src/main/scala/xiangshan/backend/issue/DataArray.scala
@@ -41,8 +41,6 @@ class DataArray[T <: Data](gen: T, numRead: Int, numWrite: Int, numEntries: Int)
   for (i <- 0 until numEntries) {
     val wCnt = VecInit(io.write.indices.map(j => dataModule.io.wen(j) && dataModule.io.wvec(j)(i)))
     XSError(RegNext(PopCount(wCnt) > 1.U), s"why not OH $i?")
-    when(PopCount(wCnt) > 1.U) {
-      XSDebug("ERROR: IssueQueue DataArray write overlap!\n")
-    }
+    XSDebug(PopCount(wCnt) > 1.U, "ERROR: IssueQueue DataArray write overlap!\n")
   }
 }

--- a/src/main/scala/xiangshan/backend/rename/Snapshot.scala
+++ b/src/main/scala/xiangshan/backend/rename/Snapshot.scala
@@ -58,8 +58,9 @@ class SnapshotGenerator[T <: Data](dataType: T)(implicit p: Parameters) extends 
   when(!io.redirect && io.deq) {
     snptValids(snptDeqPtr.value) := false.B
     snptDeqPtr := snptDeqPtr + 1.U
-    XSError(isEmpty(snptEnqPtr, snptDeqPtr), "snapshots should not be empty when dequeue!\n")
   }
+  XSError(!io.redirect && io.deq && isEmpty(snptEnqPtr, snptDeqPtr), "snapshots should not be empty when dequeue!\n")
+
   snptValids.zip(io.flushVec).foreach { case (valid, flush) =>
     when(flush) { valid := false.B }
   }

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -244,7 +244,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       connectCommitEntry(robDeqGroup(i), robBanksRdataNextLineUpdate(i))
     }
   }
-  
+
   // In each robentry, the ftqIdx and ftqOffset belong to the first instruction that was compressed,
   // That is Necessary when exceptions happen.
   // Update the ftqOffset to correctly notify the frontend which instructions have been committed.
@@ -520,8 +520,9 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
    * Writeback (from execution units)
    */
   for (wb <- exuWBs) {
+    val wbIdx = wb.bits.robIdx.value
+    val debug_Uop = debug_microOp(wbIdx)
     when(wb.valid) {
-      val wbIdx = wb.bits.robIdx.value
       debug_exuData(wbIdx) := wb.bits.data(0)
       debug_exuDebug(wbIdx) := wb.bits.debug
       debug_microOp(wbIdx).debugInfo.enqRsTime := wb.bits.debugInfo.enqRsTime
@@ -532,14 +533,12 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       // debug for lqidx and sqidx
       debug_microOp(wbIdx).lqIdx := wb.bits.lqIdx.getOrElse(0.U.asTypeOf(new LqPtr))
       debug_microOp(wbIdx).sqIdx := wb.bits.sqIdx.getOrElse(0.U.asTypeOf(new SqPtr))
-
-      val debug_Uop = debug_microOp(wbIdx)
-      XSInfo(true.B,
-        p"writebacked pc 0x${Hexadecimal(debug_Uop.pc)} wen ${debug_Uop.rfWen} " +
-          p"data 0x${Hexadecimal(wb.bits.data(0))} ldst ${debug_Uop.ldest} pdst ${debug_Uop.pdest} " +
-          p"skip ${wb.bits.debug.isSkipDiff} robIdx: ${wb.bits.robIdx}\n"
-      )
     }
+    XSInfo(wb.valid,
+      p"writebacked pc 0x${Hexadecimal(debug_Uop.pc)} wen ${debug_Uop.rfWen} " +
+        p"data 0x${Hexadecimal(wb.bits.data(0))} ldst ${debug_Uop.ldest} pdst ${debug_Uop.pdest} " +
+        p"skip ${wb.bits.debug.isSkipDiff} robIdx: ${wb.bits.robIdx}\n"
+    )
   }
 
   val writebackNum = PopCount(exuWBs.map(_.valid))
@@ -772,11 +771,11 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     io.commits.robIdx(i) := deqPtrVec(i)
 
     io.commits.walkValid(i) := shouldWalkVec(i)
-    when(state === s_walk) {
-      when(io.commits.isWalk && state === s_walk && shouldWalkVec(i)) {
-        XSError(!walk_v(i), s"The walking entry($i) should be valid\n")
-      }
-    }
+    XSError(
+      state === s_walk &&
+      io.commits.isWalk && state === s_walk && shouldWalkVec(i) &&
+      !walk_v(i),
+      s"The walking entry($i) should be valid\n")
 
     XSInfo(io.commits.isCommit && io.commits.commitValid(i),
       "retired pc %x wen %d ldest %d pdest %x data %x fflags: %b vxsat: %b\n",

--- a/src/main/scala/xiangshan/backend/rob/RobDeqPtrWrapper.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobDeqPtrWrapper.scala
@@ -99,9 +99,8 @@ class NewRobDeqPtrWrapper(implicit p: Parameters) extends XSModule with HasCircu
   io.commitCnt := commitCnt
   io.commitEn := io.state === 0.U && !redirectOutValid && !io.blockCommit
 
-  when (io.state === 0.U) {
-    XSInfo(io.state === 0.U && commitCnt > 0.U, "retired %d insts\n", commitCnt)
-  }
+  XSInfo(io.state === 0.U && commitCnt > 0.U, "retired %d insts\n", commitCnt)
+
   if(backendParams.debugEn){
     dontTouch(commitDeqPtrVec)
     dontTouch(commitDeqPtrAll)

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -377,8 +377,8 @@ class DCacheWordReq(implicit p: Parameters) extends DCacheBundle
   val lqIdx = new LqPtr
 
   val debug_robIdx = UInt(log2Ceil(RobSize).W)
-  def dump() = {
-    XSDebug("DCacheWordReq: cmd: %x vaddr: %x data: %x mask: %x id: %d\n",
+  def dump(cond: Bool) = {
+    XSDebug(cond, "DCacheWordReq: cmd: %x vaddr: %x data: %x mask: %x id: %d\n",
       cmd, vaddr, data, mask, id)
   }
 }
@@ -392,8 +392,8 @@ class DCacheLineReq(implicit p: Parameters) extends DCacheBundle
   val data   = UInt((cfg.blockBytes * 8).W)
   val mask   = UInt(cfg.blockBytes.W)
   val id     = UInt(reqIdWidth.W)
-  def dump() = {
-    XSDebug("DCacheLineReq: cmd: %x addr: %x data: %x mask: %x id: %d\n",
+  def dump(cond: Bool) = {
+    XSDebug(cond, "DCacheLineReq: cmd: %x addr: %x data: %x mask: %x id: %d\n",
       cmd, addr, data, mask, id)
   }
   def idx: UInt = get_idx(vaddr)
@@ -444,8 +444,8 @@ class BaseDCacheWordResp(implicit p: Parameters) extends DCacheBundle
   val mshr_id = UInt(log2Up(cfg.nMissEntries).W)
 
   val debug_robIdx = UInt(log2Ceil(RobSize).W)
-  def dump() = {
-    XSDebug("DCacheWordResp: data: %x id: %d miss: %b replay: %b\n",
+  def dump(cond: Bool) = {
+    XSDebug(cond, "DCacheWordResp: data: %x id: %d miss: %b replay: %b\n",
       data, id, miss, replay)
   }
 }
@@ -482,8 +482,8 @@ class DCacheLineResp(implicit p: Parameters) extends DCacheBundle
   // cache req nacked, replay it later
   val replay = Bool()
   val id     = UInt(reqIdWidth.W)
-  def dump() = {
-    XSDebug("DCacheLineResp: data: %x id: %d miss: %b replay: %b\n",
+  def dump(cond: Bool) = {
+    XSDebug(cond, "DCacheLineResp: data: %x id: %d miss: %b replay: %b\n",
       data, id, miss, replay)
   }
 }
@@ -497,8 +497,8 @@ class Refill(implicit p: Parameters) extends DCacheBundle
   val data_raw = UInt((cfg.blockBytes * 8).W)
   val hasdata = Bool()
   val refill_done = Bool()
-  def dump() = {
-    XSDebug("Refill: addr: %x data: %x\n", addr, data)
+  def dump(cond: Bool) = {
+    XSDebug(cond, "Refill: addr: %x data: %x\n", addr, data)
   }
   val id     = UInt(log2Up(cfg.nMissEntries).W)
 }
@@ -506,8 +506,8 @@ class Refill(implicit p: Parameters) extends DCacheBundle
 class Release(implicit p: Parameters) extends DCacheBundle
 {
   val paddr  = UInt(PAddrBits.W)
-  def dump() = {
-    XSDebug("Release: paddr: %x\n", paddr(PAddrBits-1, DCacheTagOffset))
+  def dump(cond: Bool) = {
+    XSDebug(cond, "Release: paddr: %x\n", paddr(PAddrBits-1, DCacheTagOffset))
   }
 }
 
@@ -532,8 +532,8 @@ class UncacheWordReq(implicit p: Parameters) extends DCacheBundle
   val isFirstIssue = Bool()
   val replayCarry = new ReplayCarry(nWays)
 
-  def dump() = {
-    XSDebug("UncacheWordReq: cmd: %x addr: %x data: %x mask: %x id: %d\n",
+  def dump(cond: Bool) = {
+    XSDebug(cond, "UncacheWordReq: cmd: %x addr: %x data: %x mask: %x id: %d\n",
       cmd, addr, data, mask, id)
   }
 }
@@ -554,8 +554,8 @@ class UncacheWordResp(implicit p: Parameters) extends DCacheBundle
   val mshr_id = UInt(log2Up(cfg.nMissEntries).W)  // FIXME: why uncacheWordResp is not merged to baseDcacheResp
 
   val debug_robIdx = UInt(log2Ceil(RobSize).W)
-  def dump() = {
-    XSDebug("UncacheWordResp: data: %x id: %d miss: %b replay: %b, tag_error: %b, error: %b\n",
+  def dump(cond: Bool) = {
+    XSDebug(cond, "UncacheWordResp: data: %x id: %d miss: %b replay: %b, tag_error: %b, error: %b\n",
       data, id, miss, replay, tag_error, error)
   }
 }

--- a/src/main/scala/xiangshan/cache/dcache/Uncache.scala
+++ b/src/main/scala/xiangshan/cache/dcache/Uncache.scala
@@ -482,14 +482,11 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
     req.bits.cmd, req.bits.addr, req.bits.data, req.bits.mask)
   XSDebug(resp.fire, "data: %x\n", req.bits.data)
   // print tilelink messages
-  when(mem_acquire.valid){
-    XSDebug("mem_acquire valid, ready=%d ", mem_acquire.ready)
-    mem_acquire.bits.dump
-  }
-  when (mem_grant.fire) {
-    XSDebug("mem_grant fire ")
-    mem_grant.bits.dump
-  }
+  XSDebug(mem_acquire.valid, "mem_acquire valid, ready=%d ", mem_acquire.ready)
+  mem_acquire.bits.dump(mem_acquire.valid)
+
+  XSDebug(mem_grant.fire, "mem_grant fire ")
+  mem_grant.bits.dump(mem_grant.fire)
 
   /* Performance Counters */
   XSPerfAccumulate("uncache_mmio_store", io.lsq.req.fire && isStore(io.lsq.req.bits.cmd) && !io.lsq.req.bits.nc)

--- a/src/main/scala/xiangshan/cache/dcache/data/AbstractDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/AbstractDataArray.scala
@@ -53,22 +53,21 @@ abstract class AbstractDataArray(implicit p: Parameters) extends DCacheModule {
 
   def dumpRead = {
     (0 until 3) map { w =>
-      when(io.read(w).valid) {
-        XSDebug(s"DataArray Read channel: $w valid way_en: %x addr: %x\n",
-          io.read(w).bits.way_en, io.read(w).bits.addr)
-      }
+      XSDebug(io.read(w).valid,
+        s"DataArray Read channel: $w valid way_en: %x addr: %x\n",
+        io.read(w).bits.way_en, io.read(w).bits.addr)
     }
   }
 
   def dumpWrite = {
-    when(io.write.valid) {
-      XSDebug(s"DataArray Write valid way_en: %x addr: %x\n",
-        io.write.bits.way_en, io.write.bits.addr)
+    XSDebug(io.write.valid,
+      s"DataArray Write valid way_en: %x addr: %x\n",
+      io.write.bits.way_en, io.write.bits.addr)
 
-      (0 until blockRows) map { r =>
-        XSDebug(s"cycle: $r data: %x wmask: %x\n",
-          io.write.bits.data(r), io.write.bits.wmask(r))
-      }
+    (0 until blockRows) map { r =>
+      XSDebug(io.write.valid,
+        s"cycle: $r data: %x wmask: %x\n",
+        io.write.bits.data(r), io.write.bits.wmask(r))
     }
   }
 
@@ -83,9 +82,7 @@ abstract class AbstractDataArray(implicit p: Parameters) extends DCacheModule {
 
   def dumpNack = {
     (0 until 3) map { w =>
-      when(io.nacks(w)) {
-        XSDebug(s"DataArray NACK channel: $w\n")
-      }
+      XSDebug(io.nacks(w), s"DataArray NACK channel: $w\n")
     }
   }
 

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -131,25 +131,23 @@ class DataSRAM(bankIdx: Int, wayIdx: Int)(implicit p: Parameters) extends DCache
   XSPerfAccumulate("part_data_read_counter", data_sram.io.r.req.valid)
 
   def dump_r() = {
-    when(RegNext(io.r.en)) {
-      XSDebug("bank read set %x bank %x way %x data %x\n",
-        RegEnable(io.r.addr, io.r.en),
-        bankIdx.U,
-        wayIdx.U,
-        io.r.data
-      )
-    }
+    XSDebug(RegNext(io.r.en),
+      "bank read set %x bank %x way %x data %x\n",
+      RegEnable(io.r.addr, io.r.en),
+      bankIdx.U,
+      wayIdx.U,
+      io.r.data
+    )
   }
 
   def dump_w() = {
-    when(io.w.en) {
-      XSDebug("bank write set %x bank %x way %x data %x\n",
-        io.w.addr,
-        bankIdx.U,
-        wayIdx.U,
-        io.w.data
-      )
-    }
+    XSDebug(io.w.en,
+      "bank write set %x bank %x way %x data %x\n",
+      io.w.addr,
+      bankIdx.U,
+      wayIdx.U,
+      io.w.data
+    )
   }
 
   def dump() = {
@@ -205,22 +203,20 @@ class DataSRAMBank(index: Int)(implicit p: Parameters) extends DCacheModule {
   io.r.data := data_bank.map(_.io.r.resp.data(0))
 
   def dump_r() = {
-    when(RegNext(io.r.en)) {
-      XSDebug("bank read addr %x data %x\n",
-        RegEnable(io.r.addr, io.r.en),
-        io.r.data.asUInt
-      )
-    }
+    XSDebug(RegNext(io.r.en),
+      "bank read addr %x data %x\n",
+      RegEnable(io.r.addr, io.r.en),
+      io.r.data.asUInt
+    )
   }
 
   def dump_w() = {
-    when(io.w.en) {
-      XSDebug("bank write addr %x way_en %x data %x\n",
-        io.w.addr,
-        io.w.way_en,
-        io.w.data
-      )
-    }
+    XSDebug(io.w.en,
+      "bank write addr %x way_en %x data %x\n",
+      io.w.addr,
+      io.w.way_en,
+      io.w.data
+    )
   }
 
   def dump() = {
@@ -294,26 +290,24 @@ abstract class AbstractBankedDataArray(implicit p: Parameters) extends DCacheMod
 
   def dumpRead = {
     (0 until LoadPipelineWidth) map { w =>
-      when(io.read(w).valid) {
-        XSDebug(s"DataArray Read channel: $w valid way_en: %x addr: %x\n",
-          io.read(w).bits.way_en, io.read(w).bits.addr)
-      }
+      XSDebug(io.read(w).valid,
+        s"DataArray Read channel: $w valid way_en: %x addr: %x\n",
+        io.read(w).bits.way_en, io.read(w).bits.addr)
     }
-    when(io.readline.valid) {
-      XSDebug(s"DataArray Read Line, valid way_en: %x addr: %x rmask %x\n",
-        io.readline.bits.way_en, io.readline.bits.addr, io.readline.bits.rmask)
-    }
+    XSDebug(io.readline.valid,
+      s"DataArray Read Line, valid way_en: %x addr: %x rmask %x\n",
+      io.readline.bits.way_en, io.readline.bits.addr, io.readline.bits.rmask)
   }
 
   def dumpWrite = {
-    when(io.write.valid) {
-      XSDebug(s"DataArray Write valid way_en: %x addr: %x\n",
-        io.write.bits.way_en, io.write.bits.addr)
+    XSDebug(io.write.valid,
+      s"DataArray Write valid way_en: %x addr: %x\n",
+      io.write.bits.way_en, io.write.bits.addr)
 
-      (0 until DCacheBanks) map { r =>
-        XSDebug(s"cycle: $r data: %x wmask: %x\n",
-          io.write.bits.data(r), io.write.bits.wmask(r))
-      }
+    (0 until DCacheBanks) map { r =>
+      XSDebug(io.write.valid,
+        s"cycle: $r data: %x wmask: %x\n",
+        io.write.bits.data(r), io.write.bits.wmask(r))
     }
   }
 

--- a/src/main/scala/xiangshan/cache/dcache/data/DuplicatedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/DuplicatedDataArray.scala
@@ -128,9 +128,8 @@ class DuplicatedDataArray(implicit p: Parameters) extends AbstractDataArray {
         data = getECCFromRow(io.write.bits.data(r)),
         waymask = io.write.bits.way_en
       )
-      when(ecc_array.io.w.req.valid) {
-        XSDebug(p"write in ecc sram ${j.U} row ${r.U}: setIdx=${Hexadecimal(ecc_array.io.w.req.bits.setIdx)} ecc(0)=${Hexadecimal(getECCFromRow(io.write.bits.data(r))(0))} ecc(1)=${Hexadecimal(getECCFromRow(io.write.bits.data(r))(1))} waymask=${Hexadecimal(io.write.bits.way_en)}\n")
-      }
+      XSDebug(ecc_array.io.w.req.valid,
+        p"write in ecc sram ${j.U} row ${r.U}: setIdx=${Hexadecimal(ecc_array.io.w.req.bits.setIdx)} ecc(0)=${Hexadecimal(getECCFromRow(io.write.bits.data(r))(0))} ecc(1)=${Hexadecimal(getECCFromRow(io.write.bits.data(r))(1))} waymask=${Hexadecimal(io.write.bits.way_en)}\n")
       ecc_array.io.r.req.valid := io.read(j).valid && rmask(r)
       ecc_array.io.r.req.bits.apply(setIdx = raddr)
 

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -505,9 +505,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.lsu.resp.bits := resp.bits
   assert(RegNext(!(resp.valid && !io.lsu.resp.ready)), "lsu should be ready in s2")
 
-  when (resp.valid) {
-    resp.bits.dump()
-  }
+  resp.bits.dump(resp.valid)
 
   io.lsu.debug_s1_hit_way := s1_tag_match_way_dup_dc
   io.lsu.s1_disable_fast_wakeup := io.disable_ld_fast_wakeup
@@ -587,16 +585,12 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // Debug logging functions
   def dump_pipeline_reqs(pipeline_stage_name: String, valid: Bool,
     req: DCacheWordReq ) = {
-      when (valid) {
-        XSDebug(s"$pipeline_stage_name: ")
-        req.dump()
-      }
+      XSDebug(valid, s"$pipeline_stage_name: ")
+      req.dump(valid)
   }
 
   def dump_pipeline_valids(pipeline_stage_name: String, signal_name: String, valid: Bool) = {
-    when (valid) {
-      XSDebug(s"$pipeline_stage_name $signal_name\n")
-    }
+    XSDebug(valid, s"$pipeline_stage_name $signal_name\n")
   }
 
   val load_trace = Wire(new LoadPfDbBundle)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/AtomicsReplayUnit.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/AtomicsReplayUnit.scala
@@ -49,9 +49,7 @@ class AtomicsReplayEntry(implicit p: Parameters) extends DCacheModule
   io.block_addr.bits  := req.addr
 
 
-  when (state =/= s_invalid) {
-    XSDebug("AtomicsReplayEntry: state: %d block_addr: %x\n", state, io.block_addr.bits)
-  }
+  XSDebug(state =/= s_invalid, "AtomicsReplayEntry: state: %d block_addr: %x\n", state, io.block_addr.bits)
 
   // --------------------------------------------
   // s_invalid: receive requests

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -656,7 +656,6 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
       when (s3_sc_fail) {
         debug_sc_fail_addr := s3_req_addr_dup(2)
         debug_sc_fail_cnt  := 1.U
-        XSWarn(s3_sc_fail === 100.U, p"L1DCache failed too many SCs in a row 0x${Hexadecimal(debug_sc_fail_addr)}, check if sth went wrong\n")
       }
     }
   }

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
@@ -35,8 +35,8 @@ class ProbeReq(implicit p: Parameters) extends DCacheBundle
   // probe queue entry ID
   val id = UInt(log2Up(cfg.nProbeEntries).W)
 
-  def dump() = {
-    XSDebug("ProbeReq source: %d opcode: %d addr: %x param: %d\n",
+  def dump(cond: Bool) = {
+    XSDebug(cond, "ProbeReq source: %d opcode: %d addr: %x param: %d\n",
       source, opcode, addr, param)
   }
 }
@@ -72,13 +72,9 @@ class ProbeEntry(implicit p: Parameters) extends DCacheModule {
   io.block_addr.valid := state =/= s_invalid
   io.block_addr.bits  := req.addr
 
-  when (state =/= s_invalid) {
-    XSDebug("state: %d\n", state)
-  }
+  XSDebug(state =/= s_invalid, "state: %d\n", state)
 
-  when (state =/= s_invalid) {
-    XSDebug("ProbeEntry: state: %d block_addr: %x\n", state, io.block_addr.bits)
-  }
+  XSDebug(state =/= s_invalid, "ProbeEntry: state: %d block_addr: %x\n", state, io.block_addr.bits)
 
   when (state === s_invalid) {
     io.req.ready := true.B
@@ -219,18 +215,12 @@ class ProbeQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule w
   }
 
   // debug output
-  when (io.mem_probe.fire) {
-    XSDebug("mem_probe: ")
-    io.mem_probe.bits.dump
-  }
+  XSDebug(io.mem_probe.fire, "mem_probe: ")
+  io.mem_probe.bits.dump(io.mem_probe.fire)
 
-//  when (io.pipe_req.fire) {
-//    io.pipe_req.bits.dump()
-//  }
+// io.pipe_req.bits.dump(io.pipe_req.fire)
 
-  when (io.lrsc_locked_block.valid) {
-    XSDebug("lrsc_locked_block: %x\n", io.lrsc_locked_block.bits)
-  }
+  XSDebug(io.lrsc_locked_block.valid, "lrsc_locked_block: %x\n", io.lrsc_locked_block.bits)
   XSPerfAccumulate("ProbeL1DCache", io.mem_probe.fire)
 
   val perfValidCount = RegNext(PopCount(entries.map(e => e.io.block_addr.valid)))

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
@@ -39,8 +39,8 @@ class WritebackReqCtrl(implicit p: Parameters) extends DCacheBundle {
 class WritebackReqWodata(implicit p: Parameters) extends WritebackReqCtrl {
   val addr = UInt(PAddrBits.W)
 
-  def dump() = {
-    XSDebug("WritebackReq addr: %x param: %d voluntary: %b hasData: %b\n",
+  def dump(cond: Bool) = {
+    XSDebug(cond, "WritebackReq addr: %x param: %d voluntary: %b hasData: %b\n",
       addr, param, voluntary, hasData)
   }
 }
@@ -52,8 +52,8 @@ class WritebackReqData(implicit p: Parameters) extends DCacheBundle {
 class WritebackReq(implicit p: Parameters) extends WritebackReqWodata {
   val data = UInt((cfg.blockBytes * 8).W)
 
-  override def dump() = {
-    XSDebug("WritebackReq addr: %x param: %d voluntary: %b hasData: %b data: %x\n",
+  override def dump(cond: Bool) = {
+    XSDebug(cond, "WritebackReq addr: %x param: %d voluntary: %b hasData: %b data: %x\n",
       addr, param, voluntary, hasData, data)
   }
 
@@ -190,10 +190,7 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
   s_data_override := true.B // data_override takes only 1 cycle
   //s_data_merge := true.B // data_merge takes only 1 cycle
 
-  when (state =/= s_invalid) {
-    XSDebug("WritebackEntry: %d state: %d block_addr: %x\n", io.id, state, io.block_addr.bits)
-  }
-
+  XSDebug(state =/= s_invalid, "WritebackEntry: %d state: %d block_addr: %x\n", io.id, state, io.block_addr.bits)
 
   // --------------------------------------------------------------------------------
   // s_invalid: receive requests
@@ -393,21 +390,12 @@ class WritebackQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
   // sanity check
   // print all input/output requests for debug purpose
   // print req
-  when(io.req.fire) {
-    io.req.bits.dump()
-  }
+  io.req.bits.dump(io.req.fire)
 
-  when(io.mem_release.fire){
-    io.mem_grant.bits.dump
-  }
+  io.mem_grant.bits.dump(io.mem_release.fire)
 
-  // when (io.miss_req.valid) {
-  //   XSDebug("miss_req: addr: %x\n", io.miss_req.bits)
-  // }
-
-  // when (io.block_miss_req) {
-  //   XSDebug("block_miss_req\n")
-  // }
+  // XSDebug(io.miss_req.valid, "miss_req: addr: %x\n", io.miss_req.bits)
+  // XSDebug(io.block_miss_req, "block_miss_req\n")
 
   // performance counters
   XSPerfAccumulate("wb_req", io.req.fire)

--- a/src/main/scala/xiangshan/cache/dcache/meta/LegacyMetaArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/meta/LegacyMetaArray.scala
@@ -97,17 +97,15 @@ class L1MetadataArray(onReset: () => L1Metadata)(implicit p: Parameters) extends
   io.read.ready := !wen
 
   def dumpRead = {
-    when(io.read.fire) {
-      XSDebug("MetaArray Read: idx: %d way_en: %x tag: %x\n",
-        io.read.bits.idx, io.read.bits.way_en, io.read.bits.tag)
-    }
+    XSDebug(io.read.fire,
+      "MetaArray Read: idx: %d way_en: %x tag: %x\n",
+      io.read.bits.idx, io.read.bits.way_en, io.read.bits.tag)
   }
 
   def dumpWrite = {
-    when(io.write.fire) {
-      XSDebug("MetaArray Write: idx: %d way_en: %x tag: %x new_tag: %x new_coh: %x\n",
-        io.write.bits.idx, io.write.bits.way_en, io.write.bits.tag, io.write.bits.data.tag, io.write.bits.data.coh.state)
-    }
+    XSDebug(io.write.fire,
+      "MetaArray Write: idx: %d way_en: %x tag: %x new_tag: %x new_coh: %x\n",
+      io.write.bits.idx, io.write.bits.way_en, io.write.bits.tag, io.write.bits.data.tag, io.write.bits.data.coh.state)
   }
 
   // def dumpResp() = {
@@ -153,18 +151,16 @@ class DuplicatedMetaArray(numReadPorts: Int)(implicit p: Parameters) extends DCa
 
   def dumpRead = {
     (0 until numReadPorts) map { w =>
-      when(io.read(w).fire) {
-        XSDebug(s"MetaArray Read channel: $w idx: %d way_en: %x tag: %x\n",
-          io.read(w).bits.idx, io.read(w).bits.way_en, io.read(w).bits.tag)
-      }
+      XSDebug(io.read(w).fire,
+        s"MetaArray Read channel: $w idx: %d way_en: %x tag: %x\n",
+        io.read(w).bits.idx, io.read(w).bits.way_en, io.read(w).bits.tag)
     }
   }
 
   def dumpWrite = {
-    when(io.write.fire) {
-      XSDebug("MetaArray Write: idx: %d way_en: %x tag: %x new_tag: %x new_coh: %x\n",
-        io.write.bits.idx, io.write.bits.way_en, io.write.bits.tag, io.write.bits.data.tag, io.write.bits.data.coh.state)
-    }
+    XSDebug(io.write.fire,
+      "MetaArray Write: idx: %d way_en: %x tag: %x new_tag: %x new_coh: %x\n",
+      io.write.bits.idx, io.write.bits.way_en, io.write.bits.tag, io.write.bits.data.tag, io.write.bits.data.coh.state)
   }
 
   // def dumpResp() = {

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -685,16 +685,15 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
 
   // TODO: handle sfenceLatch outsize
   if (EnableSv48) {
-    when (
+    val l3Refill =
       !flush_dup(2) &&
       refill.levelOH.l3.get &&
       !memPte(2).isLeaf() &&
       memPte(2).canRefill(refill.level_dup(2), refill.req_info_dup(2).s2xlate, pbmte, io.csr_dup(2).vsatp.mode)
-    ) {
-      val refillIdx = replaceWrapper(l3v.get, ptwl3replace.get.way)
-      refillIdx.suggestName(s"Ptwl3RefillIdx")
-      val rfOH = UIntToOH(refillIdx)
-      l3.get(refillIdx).refill(
+    val l3RefillIdx = replaceWrapper(l3v.get, ptwl3replace.get.way).suggestName(s"l3_refillIdx")
+    val l3RfOH = UIntToOH(l3RefillIdx).asUInt.suggestName(s"l3_rfOH")
+    when (l3Refill) {
+      l3.get(l3RefillIdx).refill(
         refill.req_info_dup(2).vpn,
         Mux(refill.req_info_dup(2).s2xlate =/= noS2xlate, io.csr_dup(2).vsatp.asid, io.csr_dup(2).satp.asid),
         io.csr_dup(2).hgatp.vmid,
@@ -702,34 +701,31 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
         3.U,
         refill_prefetch_dup(2)
       )
-      ptwl2replace.access(refillIdx)
-      l3v.get := l3v.get | rfOH
-      l3g.get := (l3g.get & ~rfOH) | Mux(memPte(2).perm.g, rfOH, 0.U)
-      l3h.get(refillIdx) := refill_h(2)
+      ptwl2replace.access(l3RefillIdx)
+      l3v.get := l3v.get | l3RfOH
+      l3g.get := (l3g.get & ~l3RfOH) | Mux(memPte(2).perm.g, l3RfOH, 0.U)
+      l3h.get(l3RefillIdx) := refill_h(2)
 
       for (i <- 0 until l2tlbParams.l3Size) {
-        l3RefillPerf.get(i) := i.U === refillIdx
+        l3RefillPerf.get(i) := i.U === l3RefillIdx
       }
-
-      XSDebug(p"[l3 refill] refillIdx:${refillIdx} refillEntry:${l3.get(refillIdx).genPtwEntry(refill.req_info_dup(2).vpn, Mux(refill.req_info_dup(2).s2xlate =/= noS2xlate, io.csr_dup(2).vsatp.asid, io.csr_dup(2).satp.asid), memSelData(2), 0.U, prefetch = refill_prefetch_dup(2))}\n")
-      XSDebug(p"[l3 refill] l3v:${Binary(l3v.get)}->${Binary(l3v.get | rfOH)} l3g:${Binary(l3g.get)}->${Binary((l3g.get & ~rfOH) | Mux(memPte(2).perm.g, rfOH, 0.U))}\n")
-
-      refillIdx.suggestName(s"l3_refillIdx")
-      rfOH.suggestName(s"l3_rfOH")
     }
+    XSDebug(l3Refill, p"[l3 refill] refillIdx:${l3RefillIdx} refillEntry:${l3.get(l3RefillIdx).genPtwEntry(refill.req_info_dup(2).vpn, Mux(refill.req_info_dup(2).s2xlate =/= noS2xlate, io.csr_dup(2).vsatp.asid, io.csr_dup(2).satp.asid), memSelData(2), 0.U, prefetch = refill_prefetch_dup(2))}\n")
+    XSDebug(l3Refill, p"[l3 refill] l3v:${Binary(l3v.get)}->${Binary(l3v.get | l3RfOH)} l3g:${Binary(l3g.get)}->${Binary((l3g.get & ~l3RfOH) | Mux(memPte(2).perm.g, l3RfOH, 0.U))}\n")
   }
 
   // L2 refill
-  when (
+  val l2Refill =
     !flush_dup(2) &&
     refill.levelOH.l2 &&
     !memPte(2).isLeaf() &&
     memPte(2).canRefill(refill.level_dup(2), refill.req_info_dup(2).s2xlate, pbmte, io.csr_dup(2).vsatp.mode)
+  val l2RefillIdx = replaceWrapper(l2v, ptwl2replace.way).suggestName(s"l2_refillIdx")
+  val l2RfOH = UIntToOH(l2RefillIdx).asUInt.suggestName(s"l2_rfOH")
+  when (
+    l2Refill
   ) {
-    val refillIdx = replaceWrapper(l2v, ptwl2replace.way)
-    refillIdx.suggestName(s"Ptwl2RefillIdx")
-    val rfOH = UIntToOH(refillIdx)
-    l2(refillIdx).refill(
+    l2(l2RefillIdx).refill(
       refill.req_info_dup(2).vpn,
       Mux(refill.req_info_dup(2).s2xlate =/= noS2xlate, io.csr_dup(2).vsatp.asid, io.csr_dup(2).satp.asid),
       io.csr_dup(2).hgatp.vmid,
@@ -737,121 +733,107 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
       2.U,
       refill_prefetch_dup(2)
     )
-    ptwl2replace.access(refillIdx)
-    l2v := l2v | rfOH
-    l2g := (l2g & ~rfOH) | Mux(memPte(2).perm.g, rfOH, 0.U)
-    l2h(refillIdx) := refill_h(2)
+    ptwl2replace.access(l2RefillIdx)
+    l2v := l2v | l2RfOH
+    l2g := (l2g & ~l2RfOH) | Mux(memPte(2).perm.g, l2RfOH, 0.U)
+    l2h(l2RefillIdx) := refill_h(2)
 
     for (i <- 0 until l2tlbParams.l2Size) {
-      l2RefillPerf(i) := i.U === refillIdx
+      l2RefillPerf(i) := i.U === l2RefillIdx
     }
-
-    XSDebug(p"[l2 refill] refillIdx:${refillIdx} refillEntry:${l2(refillIdx).genPtwEntry(refill.req_info_dup(2).vpn, Mux(refill.req_info_dup(2).s2xlate =/= noS2xlate, io.csr_dup(2).vsatp.asid, io.csr_dup(2).satp.asid), memSelData(2), 0.U, prefetch = refill_prefetch_dup(2))}\n")
-    XSDebug(p"[l2 refill] l2v:${Binary(l2v)}->${Binary(l2v | rfOH)} l2g:${Binary(l2g)}->${Binary((l2g & ~rfOH) | Mux(memPte(2).perm.g, rfOH, 0.U))}\n")
-
-    refillIdx.suggestName(s"l2_refillIdx")
-    rfOH.suggestName(s"l2_rfOH")
   }
+  XSDebug(l2Refill, p"[l2 refill] refillIdx:${l2RefillIdx} refillEntry:${l2(l2RefillIdx).genPtwEntry(refill.req_info_dup(2).vpn, Mux(refill.req_info_dup(2).s2xlate =/= noS2xlate, io.csr_dup(2).vsatp.asid, io.csr_dup(2).satp.asid), memSelData(2), 0.U, prefetch = refill_prefetch_dup(2))}\n")
+  XSDebug(l2Refill, p"[l2 refill] l2v:${Binary(l2v)}->${Binary(l2v | l2RfOH)} l2g:${Binary(l2g)}->${Binary((l2g & ~l2RfOH) | Mux(memPte(2).perm.g, l2RfOH, 0.U))}\n")
 
   // L1 refill
-  when (!flush_dup(1) && refill.levelOH.l1) {
-    val refillIdx = genPtwL1SetIdx(refill.req_info_dup(1).vpn)
-    val victimWay = replaceWrapper(getl1vSet(refill.req_info_dup(1).vpn), ptwl1replace.way(refillIdx))
-    val victimWayOH = UIntToOH(victimWay)
-    val rfvOH = UIntToOH(Cat(refillIdx, victimWay))
-    val wdata = Wire(l1EntryType)
-    wdata.gen(
-      vpn = refill.req_info_dup(1).vpn,
-      asid = Mux(refill.req_info_dup(1).s2xlate =/= noS2xlate, io.csr_dup(1).vsatp.asid, io.csr_dup(1).satp.asid),
-      vmid = io.csr_dup(1).hgatp.vmid,
-      data = memRdata,
-      levelUInt = 1.U,
-      refill_prefetch_dup(1),
-      refill.req_info_dup(1).s2xlate,
-      pbmte,
-      io.csr_dup(1).vsatp.mode
-    )
+  val l1Refill = !flush_dup(1) && refill.levelOH.l1
+  val l1RefillIdx = genPtwL1SetIdx(refill.req_info_dup(1).vpn).suggestName(s"l1_refillIdx")
+  val l1VictimWay = replaceWrapper(getl1vSet(refill.req_info_dup(1).vpn), ptwl1replace.way(l1RefillIdx)).suggestName(s"l1_victimWay")
+  val l1VictimWayOH = UIntToOH(l1VictimWay).suggestName(s"l1_victimWayOH")
+  val l1RfvOH = UIntToOH(Cat(l1RefillIdx, l1VictimWay)).asUInt.suggestName(s"l1_rfvOH")
+  val l1Wdata = Wire(l1EntryType)
+  l1Wdata.gen(
+    vpn = refill.req_info_dup(1).vpn,
+    asid = Mux(refill.req_info_dup(1).s2xlate =/= noS2xlate, io.csr_dup(1).vsatp.asid, io.csr_dup(1).satp.asid),
+    vmid = io.csr_dup(1).hgatp.vmid,
+    data = memRdata,
+    levelUInt = 1.U,
+    refill_prefetch_dup(1),
+    refill.req_info_dup(1).s2xlate,
+    pbmte,
+    io.csr_dup(1).vsatp.mode
+  )
+  when (l1Refill) {
     l1.io.w.apply(
       valid = true.B,
-      setIdx = refillIdx,
-      data = wdata,
-      waymask = victimWayOH
+      setIdx = l1RefillIdx,
+      data = l1Wdata,
+      waymask = l1VictimWayOH
     )
-    ptwl1replace.access(refillIdx, victimWay)
-    l1v := l1v | rfvOH
-    l1g := l1g & ~rfvOH | Mux(Cat(memPtes.map(_.perm.g)).andR, rfvOH, 0.U)
-    l1h(refillIdx)(victimWay) := refill_h(1)
+    ptwl1replace.access(l1RefillIdx, l1VictimWay)
+    l1v := l1v | l1RfvOH
+    l1g := l1g & ~l1RfvOH | Mux(Cat(memPtes.map(_.perm.g)).andR, l1RfvOH, 0.U)
+    l1h(l1RefillIdx)(l1VictimWay) := refill_h(1)
 
     for (i <- 0 until l2tlbParams.l1nWays) {
-      l1RefillPerf(i) := i.U === victimWay
+      l1RefillPerf(i) := i.U === l1VictimWay
     }
-
-    XSDebug(p"[l1 refill] refillIdx:0x${Hexadecimal(refillIdx)} victimWay:${victimWay} victimWayOH:${Binary(victimWayOH)} rfvOH(in UInt):${Cat(refillIdx, victimWay)}\n")
-    XSDebug(p"[l1 refill] refilldata:0x${wdata}\n")
-    XSDebug(p"[l1 refill] l1v:${Binary(l1v)} -> ${Binary(l1v | rfvOH)}\n")
-    XSDebug(p"[l1 refill] l1g:${Binary(l1g)} -> ${Binary(l1g & ~rfvOH | Mux(Cat(memPtes.map(_.perm.g)).andR, rfvOH, 0.U))}\n")
-
-    refillIdx.suggestName(s"l1_refillIdx")
-    victimWay.suggestName(s"l1_victimWay")
-    victimWayOH.suggestName(s"l1_victimWayOH")
-    rfvOH.suggestName(s"l1_rfvOH")
   }
+  XSDebug(l1Refill, p"[l1 refill] refillIdx:0x${Hexadecimal(l1RefillIdx)} victimWay:${l1VictimWay} victimWayOH:${Binary(l1VictimWayOH)} rfvOH(in UInt):${Cat(l1RefillIdx, l1VictimWay)}\n")
+  XSDebug(l1Refill, p"[l1 refill] refilldata:0x${l1Wdata}\n")
+  XSDebug(l1Refill, p"[l1 refill] l1v:${Binary(l1v)} -> ${Binary(l1v | l1RfvOH)}\n")
+  XSDebug(l1Refill, p"[l1 refill] l1g:${Binary(l1g)} -> ${Binary(l1g & ~l1RfvOH | Mux(Cat(memPtes.map(_.perm.g)).andR, l1RfvOH, 0.U))}\n")
 
   // L0 refill
-  when (!flush_dup(0) && refill.levelOH.l0) {
-    val refillIdx = genPtwL0SetIdx(refill.req_info_dup(0).vpn)
-    val victimWay = replaceWrapper(getl0vSet(refill.req_info_dup(0).vpn), ptwl0replace.way(refillIdx))
-    val victimWayOH = UIntToOH(victimWay)
-    val rfvOH = UIntToOH(Cat(refillIdx, victimWay))
-    val wdata = Wire(l0EntryType)
-    wdata.gen(
-      vpn =  refill.req_info_dup(0).vpn,
-      asid = Mux(refill.req_info_dup(0).s2xlate =/= noS2xlate, io.csr_dup(0).vsatp.asid, io.csr_dup(0).satp.asid),
-      vmid = io.csr_dup(0).hgatp.vmid,
-      data = memRdata,
-      levelUInt = 0.U,
-      refill_prefetch_dup(0),
-      refill.req_info_dup(0).s2xlate,
-      pbmte,
-      io.csr_dup(0).vsatp.mode
-    )
+  val l0Refill = !flush_dup(0) && refill.levelOH.l0
+  val l0RefillIdx = genPtwL0SetIdx(refill.req_info_dup(0).vpn).suggestName(s"l0_refillIdx")
+  val l0VictimWay = replaceWrapper(getl0vSet(refill.req_info_dup(0).vpn), ptwl0replace.way(l0RefillIdx)).suggestName(s"l0_victimWay")
+  val l0VictimWayOH = UIntToOH(l0VictimWay).asUInt.suggestName(s"l0_victimWayOH")
+  val l0RfvOH = UIntToOH(Cat(l0RefillIdx, l0VictimWay)).suggestName(s"l0_rfvOH")
+  val l0Wdata = Wire(l0EntryType)
+  l0Wdata.gen(
+    vpn = refill.req_info_dup(0).vpn,
+    asid = Mux(refill.req_info_dup(0).s2xlate =/= noS2xlate, io.csr_dup(0).vsatp.asid, io.csr_dup(0).satp.asid),
+    vmid = io.csr_dup(0).hgatp.vmid,
+    data = memRdata,
+    levelUInt = 0.U,
+    refill_prefetch_dup(0),
+    refill.req_info_dup(0).s2xlate,
+    pbmte,
+    io.csr_dup(0).vsatp.mode
+  )
+  when (l0Refill) {
     l0.io.w.apply(
       valid = true.B,
-      setIdx = refillIdx,
-      data = wdata,
-      waymask = victimWayOH
+      setIdx = l0RefillIdx,
+      data = l0Wdata,
+      waymask = l0VictimWayOH
     )
-    ptwl0replace.access(refillIdx, victimWay)
-    l0v := l0v | rfvOH
-    l0g := l0g & ~rfvOH | Mux(Cat(memPtes.map(_.perm.g)).andR, rfvOH, 0.U)
-    l0h(refillIdx)(victimWay) := refill_h(0)
+    ptwl0replace.access(l0RefillIdx, l0VictimWay)
+    l0v := l0v | l0RfvOH
+    l0g := l0g & ~l0RfvOH | Mux(Cat(memPtes.map(_.perm.g)).andR, l0RfvOH, 0.U)
+    l0h(l0RefillIdx)(l0VictimWay) := refill_h(0)
 
     for (i <- 0 until l2tlbParams.l0nWays) {
-      l0RefillPerf(i) := i.U === victimWay
+      l0RefillPerf(i) := i.U === l0VictimWay
     }
-
-    XSDebug(p"[l0 refill] refillIdx:0x${Hexadecimal(refillIdx)} victimWay:${victimWay} victimWayOH:${Binary(victimWayOH)} rfvOH(in UInt):${Cat(refillIdx, victimWay)}\n")
-    XSDebug(p"[l0 refill] refilldata:0x${wdata}\n")
-    XSDebug(p"[l0 refill] l0v:${Binary(l0v)} -> ${Binary(l0v | rfvOH)}\n")
-    XSDebug(p"[l0 refill] l0g:${Binary(l0g)} -> ${Binary(l0g & ~rfvOH | Mux(Cat(memPtes.map(_.perm.g)).andR, rfvOH, 0.U))}\n")
-
-    refillIdx.suggestName(s"l0_refillIdx")
-    victimWay.suggestName(s"l0_victimWay")
-    victimWayOH.suggestName(s"l0_victimWayOH")
-    rfvOH.suggestName(s"l0_rfvOH")
   }
+  XSDebug(l0Refill, p"[l0 refill] refillIdx:0x${Hexadecimal(l0RefillIdx)} victimWay:${l0VictimWay} victimWayOH:${Binary(l0VictimWayOH)} rfvOH(in UInt):${Cat(l0RefillIdx, l0VictimWay)}\n")
+  XSDebug(l0Refill, p"[l0 refill] refilldata:0x${l0Wdata}\n")
+  XSDebug(l0Refill, p"[l0 refill] l0v:${Binary(l0v)} -> ${Binary(l0v | l0RfvOH)}\n")
+  XSDebug(l0Refill, p"[l0 refill] l0g:${Binary(l0g)} -> ${Binary(l0g & ~l0RfvOH | Mux(Cat(memPtes.map(_.perm.g)).andR, l0RfvOH, 0.U))}\n")
 
 
   // misc entries: super & invalid
-  when (
+  val spRefill =
     !flush_dup(0) &&
     refill.levelOH.sp &&
     ((memPte(0).isLeaf() && memPte(0).canRefill(refill.level_dup(0), refill.req_info_dup(0).s2xlate, pbmte, io.csr_dup(0).vsatp.mode)) ||
     memPte(0).onlyPf(refill.level_dup(0), refill.req_info_dup(0).s2xlate, pbmte))
-  ) {
-    val refillIdx = spreplace.way// LFSR64()(log2Up(l2tlbParams.spSize)-1,0) // TODO: may be LRU
-    val rfOH = UIntToOH(refillIdx)
-    sp(refillIdx).refill(
+  val spRefillIdx = spreplace.way.suggestName(s"sp_refillIdx") // LFSR64()(log2Up(l2tlbParams.spSize)-1,0) // TODO: may be LRU
+  val spRfOH = UIntToOH(spRefillIdx).asUInt.suggestName(s"sp_rfOH")
+  when (spRefill) {
+    sp(spRefillIdx).refill(
       refill.req_info_dup(0).vpn,
       Mux(refill.req_info_dup(0).s2xlate =/= noS2xlate, io.csr_dup(0).vsatp.asid, io.csr_dup(0).satp.asid),
       io.csr_dup(0).hgatp.vmid,
@@ -860,21 +842,17 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
       refill_prefetch_dup(0),
       !memPte(0).onlyPf(refill.level_dup(0), refill.req_info_dup(0).s2xlate, pbmte)
     )
-    spreplace.access(refillIdx)
-    spv := spv | rfOH
-    spg := spg & ~rfOH | Mux(memPte(0).perm.g, rfOH, 0.U)
-    sph(refillIdx) := refill_h(0)
+    spreplace.access(spRefillIdx)
+    spv := spv | spRfOH
+    spg := spg & ~spRfOH | Mux(memPte(0).perm.g, spRfOH, 0.U)
+    sph(spRefillIdx) := refill_h(0)
 
     for (i <- 0 until l2tlbParams.spSize) {
-      spRefillPerf(i) := i.U === refillIdx
+      spRefillPerf(i) := i.U === spRefillIdx
     }
-
-    XSDebug(p"[sp refill] refillIdx:${refillIdx} refillEntry:${sp(refillIdx).genPtwEntry(refill.req_info_dup(0).vpn, Mux(refill.req_info_dup(0).s2xlate =/= noS2xlate, io.csr_dup(0).vsatp.asid, io.csr_dup(0).satp.asid), memSelData(0), refill.level_dup(0), refill_prefetch_dup(0))}\n")
-    XSDebug(p"[sp refill] spv:${Binary(spv)}->${Binary(spv | rfOH)} spg:${Binary(spg)}->${Binary(spg & ~rfOH | Mux(memPte(0).perm.g, rfOH, 0.U))}\n")
-
-    refillIdx.suggestName(s"sp_refillIdx")
-    rfOH.suggestName(s"sp_rfOH")
   }
+  XSDebug(spRefill, p"[sp refill] refillIdx:${spRefillIdx} refillEntry:${sp(spRefillIdx).genPtwEntry(refill.req_info_dup(0).vpn, Mux(refill.req_info_dup(0).s2xlate =/= noS2xlate, io.csr_dup(0).vsatp.asid, io.csr_dup(0).satp.asid), memSelData(0), refill.level_dup(0), refill_prefetch_dup(0))}\n")
+  XSDebug(spRefill, p"[sp refill] spv:${Binary(spv)}->${Binary(spv | spRfOH)} spg:${Binary(spg)}->${Binary(spg & ~spRfOH | Mux(memPte(0).perm.g, spRfOH, 0.U))}\n")
 
   val l1eccFlush = resp_res.l1.ecc && stageResp_valid_1cycle_dup(0) // RegNext(l1eccError, init = false.B)
   val l0eccFlush = resp_res.l0.ecc && stageResp_valid_1cycle_dup(1) // RegNext(l0eccError, init = false.B)

--- a/src/main/scala/xiangshan/frontend/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/IBuffer.scala
@@ -441,12 +441,10 @@ class IBuffer(implicit p: Parameters) extends XSModule with HasCircularQueuePtrH
 
   XSDebug(io.flush, "IBuffer Flushed\n")
 
-  when(io.in.fire) {
-    XSDebug("Enque:\n")
-    XSDebug(p"MASK=${Binary(io.in.bits.valid)}\n")
-    for (i <- 0 until PredictWidth) {
-      XSDebug(p"PC=${Hexadecimal(io.in.bits.pc(i))} ${Hexadecimal(io.in.bits.instrs(i))}\n")
-    }
+  XSDebug(io.in.fire, "Enque:\n")
+  XSDebug(io.in.fire, p"MASK=${Binary(io.in.bits.valid)}\n")
+  for (i <- 0 until PredictWidth) {
+    XSDebug(io.in.fire, p"PC=${Hexadecimal(io.in.bits.pc(i))} ${Hexadecimal(io.in.bits.instrs(i))}\n")
   }
 
   for (i <- 0 until DecodeWidth) {

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -1129,15 +1129,14 @@ class NewIFU(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("predecode_flush_notCFIFault", checkNotCFIFault)
   XSPerfAccumulate("predecode_flush_incalidTakenFault", checkInvalidTaken)
 
-  when(checkRetFault) {
-    XSDebug(
-      "startAddr:%x  nextstartAddr:%x  taken:%d    takenIdx:%d\n",
-      wb_ftq_req.startAddr,
-      wb_ftq_req.nextStartAddr,
-      wb_ftq_req.ftqOffset.valid,
-      wb_ftq_req.ftqOffset.bits
-    )
-  }
+  XSDebug(
+    checkRetFault,
+    "startAddr:%x  nextstartAddr:%x  taken:%d    takenIdx:%d\n",
+    wb_ftq_req.startAddr,
+    wb_ftq_req.nextStartAddr,
+    wb_ftq_req.ftqOffset.valid,
+    wb_ftq_req.ftqOffset.bits
+  )
 
   /** performance counter */
   val f3_perf_info = RegEnable(f2_perf_info, f2_fire)

--- a/src/main/scala/xiangshan/frontend/newRAS.scala
+++ b/src/main/scala/xiangshan/frontend/newRAS.scala
@@ -766,9 +766,9 @@ class RAS(implicit p: Parameters) extends BasePredictor {
       spec_debug.spec_queue(i).ctr,
       spec_debug.spec_nos(i).value
     )
-    when(i.U === stack.TOSW.value)(XSDebug(io.s2_fire(2), "   <----TOSW"))
-    when(i.U === stack.TOSR.value)(XSDebug(io.s2_fire(2), "   <----TOSR"))
-    when(i.U === stack.BOS.value)(XSDebug(io.s2_fire(2), "   <----BOS"))
+    XSDebug(io.s2_fire(2) && i.U === stack.TOSW.value, "   <----TOSW")
+    XSDebug(io.s2_fire(2) && i.U === stack.TOSR.value, "   <----TOSR")
+    XSDebug(io.s2_fire(2) && i.U === stack.BOS.value, "   <----BOS")
     XSDebug(io.s2_fire(2), "\n")
   }
   XSDebug(io.s2_fire(2), "  index       addr           ctr   (committed part)\n")
@@ -780,8 +780,8 @@ class RAS(implicit p: Parameters) extends BasePredictor {
       spec_debug.commit_stack(i).retAddr,
       spec_debug.commit_stack(i).ctr
     )
-    when(i.U === stack.ssp)(XSDebug(io.s2_fire(2), "   <----ssp"))
-    when(i.U === stack.nsp)(XSDebug(io.s2_fire(2), "   <----nsp"))
+    XSDebug(io.s2_fire(2) && i.U === stack.ssp, "   <----ssp")
+    XSDebug(io.s2_fire(2) && i.U === stack.nsp, "   <----nsp")
     XSDebug(io.s2_fire(2), "\n")
   }
   /*

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
@@ -158,9 +158,6 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
     when (needEnqueue(w) && enq.ready) {
       acceptedVec(w) := true.B
 
-      val debug_robIdx = enq.bits.uop.robIdx.asUInt
-      XSError(allocated(enqIndex), p"LoadQueueRAR: You can not write an valid entry! check: ldu $w, robIdx $debug_robIdx")
-
       freeList.io.doAllocate(w) := true.B
       //  Allocate new entry
       allocated(enqIndex) := true.B
@@ -182,6 +179,10 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
         enq.bits.paddr(PAddrBits-1, DCacheLineOffset) === release1Cycle.bits.paddr(PAddrBits-1, DCacheLineOffset))
       )
     }
+    val debug_robIdx = enq.bits.uop.robIdx.asUInt
+    XSError(
+      needEnqueue(w) && enq.ready && allocated(enqIndex),
+      p"LoadQueueRAR: You can not write an valid entry! check: ldu $w, robIdx $debug_robIdx")
   }
 
   //  LoadQueueRAR deallocate

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
@@ -141,9 +141,6 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
     when (needEnqueue(w) && enq.ready) {
       acceptedVec(w) := true.B
 
-      val debug_robIdx = enq.bits.uop.robIdx.asUInt
-      XSError(allocated(enqIndex), p"LoadQueueRAW: You can not write an valid entry! check: ldu $w, robIdx $debug_robIdx")
-
       freeList.io.doAllocate(w) := true.B
 
       //  Allocate new entry
@@ -163,6 +160,8 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
       uop(enqIndex) := enq.bits.uop
       datavalid(enqIndex) := enq.bits.data_valid
     }
+    val debug_robIdx = enq.bits.uop.robIdx.asUInt
+    XSError(needEnqueue(w) && enq.ready && allocated(enqIndex), p"LoadQueueRAW: You can not write an valid entry! check: ldu $w, robIdx $debug_robIdx")
   }
 
   for ((query, w) <- io.query.map(_.resp).zipWithIndex) {

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -88,13 +88,13 @@ class UncacheEntry(entryIndex: Int)(implicit p: Parameters) extends XSModule
   when (flush) {
     req_valid := false.B
   } .elsewhen (io.req.valid) {
-    XSError(req_valid, p"LoadQueueUncache: You can not write an valid entry: $entryIndex")
     req_valid := true.B
     req := io.req.bits
     nderr := false.B
   } .elsewhen (writeback) {
     req_valid := false.B
   }
+  XSError(!flush && io.req.valid && req_valid, p"LoadQueueUncache: You can not write an valid entry: $entryIndex")
 
   /**
     * Memory mapped IO / NC operations
@@ -224,31 +224,28 @@ class UncacheEntry(entryIndex: Int)(implicit p: Parameters) extends XSModule
   io.exception.bits.uop.exceptionVec(loadAccessFault) := nderr
 
   /* debug log */
-  when (io.uncache.req.fire) {
-    XSDebug("uncache req: pc %x addr %x data %x op %x mask %x\n",
-      req.uop.pc,
-      io.uncache.req.bits.addr,
-      io.uncache.req.bits.data,
-      io.uncache.req.bits.cmd,
-      io.uncache.req.bits.mask
-    )
-  }
-  when(io.ncOut.fire) {
-    XSInfo("int load miss write to cbd robidx %d lqidx %d pc 0x%x mmio %x\n",
-      io.ncOut.bits.uop.robIdx.asUInt,
-      io.ncOut.bits.uop.lqIdx.asUInt,
-      io.ncOut.bits.uop.pc,
-      true.B
-    )
-  }
-  when(io.mmioOut.fire) {
-    XSInfo("int load miss write to cbd robidx %d lqidx %d pc 0x%x mmio %x\n",
-      io.mmioOut.bits.uop.robIdx.asUInt,
-      io.mmioOut.bits.uop.lqIdx.asUInt,
-      io.mmioOut.bits.uop.pc,
-      true.B
-    )
-  }
+  XSDebug(io.uncache.req.fire,
+    "uncache req: pc %x addr %x data %x op %x mask %x\n",
+    req.uop.pc,
+    io.uncache.req.bits.addr,
+    io.uncache.req.bits.data,
+    io.uncache.req.bits.cmd,
+    io.uncache.req.bits.mask
+  )
+  XSInfo(io.ncOut.fire,
+    "int load miss write to cbd robidx %d lqidx %d pc 0x%x mmio %x\n",
+    io.ncOut.bits.uop.robIdx.asUInt,
+    io.ncOut.bits.uop.lqIdx.asUInt,
+    io.ncOut.bits.uop.pc,
+    true.B
+  )
+  XSInfo(io.mmioOut.fire,
+    "int load miss write to cbd robidx %d lqidx %d pc 0x%x mmio %x\n",
+    io.mmioOut.bits.uop.robIdx.asUInt,
+    io.mmioOut.bits.uop.lqIdx.asUInt,
+    io.mmioOut.bits.uop.pc,
+    true.B
+  )
 
 }
 

--- a/src/main/scala/xiangshan/mem/mdp/StoreSet.scala
+++ b/src/main/scala/xiangshan/mem/mdp/StoreSet.scala
@@ -319,10 +319,8 @@ class SSIT(implicit p: Parameters) extends XSModule {
   ) // should be zero
 
   // debug
-  when (s2_mempred_update_req.valid) {
-    XSDebug("%d: SSIT update: load pc %x store pc %x\n", GTimer(), s2_mempred_update_req.ldpc, s2_mempred_update_req.stpc)
-    XSDebug("%d: SSIT update: load valid %b ssid %x  store valid %b ssid %x\n", GTimer(), s2_loadAssigned, s2_loadOldSSID, s2_storeAssigned, s2_storeOldSSID)
-  }
+  XSDebug(s2_mempred_update_req.valid, "%d: SSIT update: load pc %x store pc %x\n", GTimer(), s2_mempred_update_req.ldpc, s2_mempred_update_req.stpc)
+  XSDebug(s2_mempred_update_req.valid, "%d: SSIT update: load valid %b ssid %x  store valid %b ssid %x\n", GTimer(), s2_loadAssigned, s2_loadOldSSID, s2_storeAssigned, s2_storeOldSSID)
 }
 
 

--- a/src/main/scala/xiangshan/mem/mdp/WaitTable.scala
+++ b/src/main/scala/xiangshan/mem/mdp/WaitTable.scala
@@ -65,9 +65,7 @@ class WaitTable(implicit p: Parameters) extends XSModule {
   }
 
   // debug
-  when (io.update.valid) {
-    XSDebug("%d: waittable update: pc %x data: %x\n", GTimer(), io.update.waddr, io.update.wdata)
-  }
+  XSDebug(io.update.valid, "%d: waittable update: pc %x data: %x\n", GTimer(), io.update.waddr, io.update.wdata)
 
   XSPerfAccumulate("wait_table_bit_set", PopCount(data.map(d => d(1))))
 }

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -83,7 +83,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
     * (2) For AMOCAS.W/D, 2 std uops are wanted: X(rd), X(rs2) with uopIdx = 0, 1
     * (3) For AMOCAS.Q, 4 std uops are wanted: X(rd), X(rs2), X(rd+1), X(rs2+1) with uopIdx = 0, 1, 2, 3
     * stds are not needed for write-back.
-    * 
+    *
     * The # of sta uops that an atomic instruction require, also the # of write-back:
     * (1) For AMOs(except AMOCAS.Q) and LR/SC, 1 sta uop is wanted: X(rs1) with uopIdx = 0
     * (2) For AMOCAS.Q, 2 sta uop is wanted: X(rs1)*2 with uopIdx = 0, 2
@@ -230,7 +230,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
   TriggerUtil.triggerActionGen(triggerAction, backendTriggerCanFireVec, actionVec, triggerCanRaiseBpExp)
   val triggerDebugMode = TriggerAction.isDmode(triggerAction)
   val triggerBreakpoint = TriggerAction.isExp(triggerAction)
-  
+
   // tlb translation, manipulating signals && deal with exception
   // at the same time, flush sbuffer
   when (state === s_tlb_and_flush_sbuffer_req) {
@@ -258,7 +258,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
       exceptionVec(loadAccessFault)     := io.dtlb.resp.bits.excp(0).af.ld
       exceptionVec(storeGuestPageFault) := io.dtlb.resp.bits.excp(0).gpf.st
       exceptionVec(loadGuestPageFault)  := io.dtlb.resp.bits.excp(0).gpf.ld
-      
+
       exceptionVec(breakPoint) := triggerBreakpoint
       trigger                  := triggerAction
 
@@ -528,7 +528,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
   pipe_req.amo_data := genWdataAMO(rs2, uop.fuOpType)
   pipe_req.amo_mask := genWmaskAMO(paddr, uop.fuOpType)
   pipe_req.amo_cmp  := genWdataAMO(rd, uop.fuOpType)
-  
+
   if (env.EnableDifftest) {
     val difftest = DifftestModule(new DiffAtomicEvent)
     val en = io.dcache.req.fire

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1935,10 +1935,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   )
   generatePerfEvent()
 
-  when(io.ldout.fire){
-    XSDebug("ldout %x\n", io.ldout.bits.uop.pc)
-  }
-
   if (backendParams.debugEn){
     dontTouch(s0_src_valid_vec)
     dontTouch(s0_src_ready_vec)
@@ -1950,5 +1946,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     s3_picked_data_frm_pipe.map(x=> dontTouch(x))
   }
 
+  XSDebug(io.ldout.fire, "ldout %x\n", io.ldout.bits.uop.pc)
   // end
 }

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -347,10 +347,9 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
     )
   }.elsewhen(state === s_fof_fix_vl){ // writeback uop
     stateNext := Mux(!fofBufferValid, s_idle, s_fof_fix_vl)
-
-  }.otherwise{
+  }.otherwise{ // unknown state
     stateNext := s_idle
-    XSError(true.B, s"Unknown state!\n")
+    assert(false.B)
   }
 
   /*************************************************************************

--- a/src/main/scala/xiangshan/transforms/PrintModuleName.scala
+++ b/src/main/scala/xiangshan/transforms/PrintModuleName.scala
@@ -17,6 +17,8 @@
 
 package xiangshan.transforms
 
+import utility.XSLog
+
 class PrintModuleName extends firrtl.options.Phase {
 
   override def invalidates(a: firrtl.options.Phase) = false
@@ -33,7 +35,7 @@ class PrintModuleName extends firrtl.options.Phase {
 
     def onStmt(s: firrtl.ir.Statement): firrtl.ir.Statement = s match {
       case firrtl.ir.Print(info, firrtl.ir.StringLit(string), args, clk, en) =>
-        firrtl.ir.Print(info, firrtl.ir.StringLit(string.replace(utility.XSLog.MagicStr, "%m")), args, clk, en)
+        firrtl.ir.Print(info, firrtl.ir.StringLit(XSLog.replaceFIRStr(string)), args, clk, en)
       case other: firrtl.ir.Statement =>
         other.mapStmt(onStmt)
     }

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -26,7 +26,7 @@ import difftest._
 import freechips.rocketchip.amba.axi4.AXI4Bundle
 import freechips.rocketchip.diplomacy.{DisableMonitors, LazyModule}
 import freechips.rocketchip.util.HeterogeneousBag
-import utility.{ChiselDB, Constantin, FileRegisters, GTimer}
+import utility.{ChiselDB, Constantin, FileRegisters, GTimer, XSLog}
 import xiangshan.DebugOptionsKey
 import system.SoCParamsKey
 
@@ -100,10 +100,7 @@ class SimTop(implicit p: Parameters) extends Module {
   val clean = if (hasPerf) WireDefault(difftest.perfCtrl.clean) else WireDefault(false.B)
   val dump = if (hasPerf) WireDefault(difftest.perfCtrl.dump) else WireDefault(false.B)
 
-  dontTouch(timer)
-  dontTouch(logEnable)
-  dontTouch(clean)
-  dontTouch(dump)
+  XSLog.collect(timer, logEnable, clean, dump)
 }
 
 object SimTop extends App {


### PR DESCRIPTION
XSLog depends on LogPerfCtrl declared at Top Module. Previous we annotate such signal as dontTouch, and accessed through Hierarchical name like SimTop.xx by dummy LogPerfHelper.

However, as XSLog is called in many spaces in DUT, which are not visible to each other, especailly some in WhenContext. XS will generate thousands of LogPerfHelper to get same LogPerfCtrl. Too many module instantiations greately slow down compilation speed, especailly in Palladium (more than 5 times slower than same DUT without Log).

This change collect all XSLog to SimTop.LogPerfEndpoint, with LogPerfCtrl directly passed by IO. Some tips as follows:

1. Not call XSLog inside whenContext. To collect XSLogs, we should access Cond and Data from other module, but data in WhenContext is not accessible even through tap. Use XSLog(cond, pable) instead of when(cond) {XSLog(pable)}. We also add chisel Internal API currentWhen to check that.

2. Generate Hierarchical Module path through FIRRTL transforms. Sometimes we want to append module path for better debugging. XSCompatibility add a hacky way to use Chisel internal API to get tag of current Module. Then we will replace these tag with path during ChiselStage. Note path can only be acessed after circuit elaboration.

3. Register and invoke caller of XSPerf and related object. As XSPerf depends on LogPerfCtrl such as dump. We should deferred apply() until collect. So we regirster collect() method when firstly apply XSLog, then XSLog will automatically call XSPerf.collect() method during collection. Note deferred apply is called in another module, so original module tag should be recorded for path generation.

4. Concat XSLogs with same condition. Too many fwrites in same module  will cause UPOPTTHREADS warning with 16-threads Verilator. Consider many XSLogs have same condition (especailly XSPerfs), we reuse same condition and concat their printables to reduce fwrites. Note we also limit size of concatation to 1000 to avoid segmentation fault caused by too long printf.