### PR TITLE
fix(PerfCCT): fix inst seqNum when inst fusion and uop split

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -437,6 +437,12 @@ class CtrlBlockImp(
     rename.io.in(i).bits := decodePipeRename(i).bits
   }
 
+  for (i <- 1 until RenameWidth) {
+    when(fusionDecoder.io.clear(i)) {
+      rename.io.in(i - 1).bits.seqNum := decodePipeRename(i).bits.seqNum
+    }
+  }
+
   for (i <- 0 until RenameWidth - 1) {
     fusionDecoder.io.dec(i) := decodePipeRename(i).bits
     rename.io.fusionInfo(i) := fusionDecoder.io.info(i)

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -192,6 +192,9 @@ class DecodeStage(implicit p: Parameters) extends XSModule
       SrcType.isVp(s) && (l === 0.U)
     }.reduce(_ || _)
     inst.bits.srcType(3) := Mux(srcType0123HasV0, SrcType.v0, finalDecodedInst(i).srcType(3))
+    when (!inst.bits.lastUop) {
+      inst.bits.seqNum := "hffffffffffffffff".U
+    }
   }
 
   io.out.map(x =>


### PR DESCRIPTION
* For inst fusion, we keep the seqNum of the inst before and after the fusion consistent, both of which are the SeqNum of the latter inst.

* For uop split, we keep the seqNum of the last uop and set the seqNum of the remaining uops to all 1s.