### PR TITLE
fix(ICache,ITLB): also flush itlb pipe when prefetchPipe s1_flush

### DIFF
--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -146,7 +146,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
   itlb.io.requestor.last <> ifu.io.iTLBInter // mmio may need re-tlb, blocked
   itlb.io.hartId := io.hartId
   itlb.io.base_connect(sfence, tlbCsr)
-  itlb.io.flushPipe.map(_ := needFlush)
+  itlb.io.flushPipe.foreach(_ := icache.io.itlbFlushPipe)
   itlb.io.redirect := DontCare // itlb has flushpipe, don't need redirect signal
 
   val itlb_ptw = Wire(new VectorTlbPtwIO(coreParams.itlbPortNum))

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -524,7 +524,8 @@ class ICacheIO(implicit p: Parameters) extends ICacheBundle {
   // PMP: mainPipe & prefetchPipe need PortNumber each
   val pmp: Vec[ICachePMPBundle] = Vec(2 * PortNumber, new ICachePMPBundle)
   // iTLB
-  val itlb: Vec[TlbRequestIO] = Vec(PortNumber, new TlbRequestIO)
+  val itlb:          Vec[TlbRequestIO] = Vec(PortNumber, new TlbRequestIO)
+  val itlbFlushPipe: Bool              = Bool()
   // backend/BEU
   val error: Valid[L1CacheErrorInfo] = ValidIO(new L1CacheErrorInfo)
   // backend/CSR
@@ -655,6 +656,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
 
   io.itlb(0) <> prefetcher.io.itlb(0)
   io.itlb(1) <> prefetcher.io.itlb(1)
+  io.itlbFlushPipe := prefetcher.io.itlbFlushPipe
 
   // notify IFU that Icache pipeline is available
   io.toIFU    := mainPipe.io.fetch.req.ready


### PR DESCRIPTION
ITLB does not store `gpaddr` to save resources, instead it takes `gpaddr` from L2TLB when gpf occurs, which poses a two-option requirement for the requestor (i.e. IPrefetchPipe):
1. resend the same `itlb.io.req.vaddr` until `itlb.io.resp.miss` is pulled down
2. flush gpf entry in ITLB by pulling up `itlb.io.flushPipe`

Otherwise, ITLB is unable to handle the next gpf and the core hangs.

However, the first point cannot be guaranteed during the speculative execution, as IPrefetchPipe sends request to ITLB at s0 stage and may receive a flush request from BPU s3 stage, IFU or Backend at s1 stage, then the same vaddr is never resend to ITLB.

Therefore, we must ensure that ITLB is flushed synchronously when IPrefetchPipe s1 stage is flushed, thus satisfying the second point. This PR implements this.