### PR TITLE
area(PTWCache): reduce l2tlb entries from 2k to 1k

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
@@ -58,12 +58,12 @@ case class L2TLBParameters
   l2Replacer: Option[String] = Some("plru"),
   // l1
   l1nSets: Int = 8,
-  l1nWays: Int = 4,
+  l1nWays: Int = 2,
   l1ReservedBits: Int = 10,
   l1Replacer: Option[String] = Some("setplru"),
   // l0
   l0nSets: Int = 32,
-  l0nWays: Int = 8,
+  l0nWays: Int = 4,
   l0ReservedBits: Int = 3,
   l0Replacer: Option[String] = Some("setplru"),
   // sp

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -211,7 +211,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     l1EntryType,
     set = l2tlbParams.l1nSets,
     way = l2tlbParams.l1nWays,
-    waySplit = 2,
+    waySplit = 1,
     dataSplit = 4,
     singlePort = sramSinglePort,
     readMCP2 = false
@@ -238,7 +238,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     l0EntryType,
     set = l2tlbParams.l0nSets,
     way = l2tlbParams.l0nWays,
-    waySplit = 4,
+    waySplit = 2,
     dataSplit = 4,
     singlePort = sramSinglePort,
     readMCP2 = false


### PR DESCRIPTION
Previous design: l0 32 sets * 8 ways * 8 entries = 2048; l1 8 sets * 4 ways * 8 entries = 512 

Modified: l0 32 sets * 4 ways * 8 entries = 1024; l1 8 sets * 2 ways * 8 entries = 256

Performance drops by 0.09% in spec06 with 0.3 coverage.