### PR TITLE
feat: support inst lifetime trace

### DIFF
--- a/scripts/perfcct.py
+++ b/scripts/perfcct.py
@@ -1,0 +1,92 @@
+import sqlite3 as sql
+import argparse
+
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('sqldb')
+parser.add_argument('-v', '--visual', action='store_true', default=False)
+parser.add_argument('-z', '--zoom', action='store', type=float, default=1)
+parser.add_argument('-p', '--period', action='store', default=333)
+
+args = parser.parse_args()
+
+sqldb = args.sqldb
+
+tick_per_cycle = int(args.period)
+cycle_per_line = int(100 * args.zoom)
+
+stages = ['f','d','r','D','i','a','g','e','b','w','c']
+
+
+def non_stage():
+    return '.'
+
+def stage(x):
+    return stages[x]
+
+def dump_visual(pos, records):
+    pos_start = pos[0] % cycle_per_line
+    line = ''
+    line += '[' + non_stage() * pos_start
+    pos_next = pos_start
+    last_index = 0
+    for i in range(1, len(pos)):
+        if (pos[i] == pos[last_index]) or pos[i] == 0:
+            continue
+        if pos[i] - pos[last_index] >= cycle_per_line - pos_next:
+            diff = cycle_per_line - pos_next
+            line += f'{stage(last_index)}' * diff + ']\n'
+            diff_line = ((pos[i] - pos[last_index]) - diff - 1) // cycle_per_line
+            if diff_line > 0:
+                line += '[' + f'{stage(last_index)}' * cycle_per_line + ']\n'
+
+            pos_next = pos[i] % cycle_per_line
+            line += '[' + f'{stage(last_index)}' * pos_next
+        else:
+            diff = pos[i] - pos[last_index]
+            pos_next = pos[i] % cycle_per_line
+            line += f'{stage(last_index)}' * diff
+        last_index = i
+    if cycle_per_line - pos_next == 0:
+        line += ']\n'
+        line += f'[{stage(i)}{non_stage() * (cycle_per_line - 1)}]\n'
+    else:
+        line += f'{stage(i)}' + non_stage() * (cycle_per_line - pos_next - 1) + ']'
+    line += str(records)
+    print(line)
+
+
+def dump_txt(pos, records):
+    for i in range(len(pos)):
+        print(f'{stage(i)}{pos[i]}', end=' ')
+    print(records)
+
+
+dump = dump_txt
+if args.visual:
+    dump = dump_visual
+
+with sql.connect(sqldb) as con:
+    cur = con.cursor()
+    cur.execute("SELECT * FROM LifeTimeCommitTrace")
+    col_name = [i[0] for i in cur.description]
+    col_name = col_name[1:]
+    col_name = [i.lower() for i in col_name]
+    rows = cur.fetchall()
+    for row in rows:
+        row = row[1:]
+        pos = []
+        records = []
+        i = 0
+        for val in row:
+            if col_name[i].startswith('at'):
+                pos.append(val//tick_per_cycle)
+            elif col_name[i].startswith('pc'):
+                if val < 0:
+                    val = val + 1 << 64
+                records.append(hex(val))
+            else:
+                records.append(val)
+            i += 1
+        dump(pos, records)

--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -164,6 +164,7 @@ class CtrlFlow(implicit p: Parameters) extends XSBundle {
   val ftqPtr = new FtqPtr
   val ftqOffset = UInt(log2Up(PredictWidth).W)
   val isLastInFtqEntry = Bool()
+  val debug_seqNum = InstSeqNum()
 }
 
 

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -682,6 +682,7 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
     sink.bits.replay.foreach(_ := source.bits.uop.replayInst)
     sink.bits.debug := source.bits.debug
     sink.bits.debugInfo := source.bits.uop.debugInfo
+    sink.bits.debug_seqNum := source.bits.uop.debug_seqNum
     sink.bits.lqIdx.foreach(_ := source.bits.uop.lqIdx)
     sink.bits.sqIdx.foreach(_ := source.bits.uop.sqIdx)
     sink.bits.predecodeInfo.foreach(_ := source.bits.uop.preDecodeInfo)
@@ -813,6 +814,7 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
     sink.bits.uop.ftqPtr         := source.bits.ftqIdx.getOrElse(0.U.asTypeOf(new FtqPtr))
     sink.bits.uop.ftqOffset      := source.bits.ftqOffset.getOrElse(0.U)
     sink.bits.uop.debugInfo      := source.bits.perfDebugInfo
+    sink.bits.uop.debug_seqNum   := source.bits.debug_seqNum
     sink.bits.uop.vpu            := source.bits.vpu.getOrElse(0.U.asTypeOf(new VPUCtrlSignals))
     sink.bits.uop.preDecodeInfo  := source.bits.preDecode.getOrElse(0.U.asTypeOf(new PreDecodeInfo))
     sink.bits.uop.numLsElem      := source.bits.numLsElem.getOrElse(0.U) // Todo: remove this bundle, keep only the one below

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -53,6 +53,7 @@ object Bundles {
     val ftqPtr           = new FtqPtr
     val ftqOffset        = UInt(log2Up(PredictWidth).W)
     val isLastInFtqEntry = Bool()
+    val debug_seqNum     = InstSeqNum()
 
     def connectCtrlFlow(source: CtrlFlow): Unit = {
       this.instr            := source.instr
@@ -67,6 +68,7 @@ object Bundles {
       this.ftqPtr           := source.ftqPtr
       this.ftqOffset        := source.ftqOffset
       this.isLastInFtqEntry := source.isLastInFtqEntry
+      this.debug_seqNum     := source.debug_seqNum
     }
   }
 
@@ -119,6 +121,7 @@ object Bundles {
     val needFrm         = new NeedFrmBundle
 
     val debug_fuType    = OptionWrapper(backendParams.debugEn, FuType())
+    val debug_seqNum    = InstSeqNum()
 
     private def allSignals = srcType.take(3) ++ Seq(fuType, fuOpType, rfWen, fpWen, vecWen,
       isXSTrap, waitForward, blockBackward, flushPipe, canRobCompress, uopSplitType, selImm)
@@ -228,6 +231,7 @@ object Bundles {
     // Take snapshot at this CFI inst
     val snapshot        = Bool()
     val debugInfo       = new PerfDebugInfo
+    val debug_seqNum    = InstSeqNum()
     val storeSetHit     = Bool() // inst has been allocated an store set
     val waitForRobIdx   = new RobPtr // store set predicted previous store robIdx
     // Load wait is needed
@@ -645,6 +649,7 @@ object Bundles {
     val loadDependency = OptionWrapper(params.needLoadDependency, Vec(LoadPipelineWidth, UInt(LoadDependencyWidth.W)))
 
     val perfDebugInfo = new PerfDebugInfo()
+    val debug_seqNum = InstSeqNum()
 
     def exuIdx = this.params.exuIdx
 
@@ -658,6 +663,7 @@ object Bundles {
       this.isFirstIssue  := source.common.isFirstIssue // Only used by mem debug log
       this.iqIdx         := source.common.iqIdx        // Only used by mem feedback
       this.dataSources   := source.common.dataSources
+      this.debug_seqNum  := source.common.debug_seqNum
       this.exuSources    .foreach(_ := source.common.exuSources.get)
       this.rfWen         .foreach(_ := source.common.rfWen.get)
       this.fpWen         .foreach(_ := source.common.fpWen.get)
@@ -728,6 +734,7 @@ object Bundles {
     })
     val debug = new DebugBundle
     val debugInfo = new PerfDebugInfo
+    val debug_seqNum = InstSeqNum()
   }
 
   // ExuOutput + DynInst --> WriteBackBundle
@@ -748,6 +755,7 @@ object Bundles {
     val exceptionVec = ExceptionVec()
     val debug = new DebugBundle
     val debugInfo = new PerfDebugInfo
+    val debug_seqNum = InstSeqNum()
 
     this.wakeupSource = s"WB(${params.toString})"
 
@@ -769,6 +777,7 @@ object Bundles {
       this.exceptionVec := source.exceptionVec.getOrElse(0.U.asTypeOf(this.exceptionVec))
       this.debug := source.debug
       this.debugInfo := source.debugInfo
+      this.debug_seqNum := source.debug_seqNum
     }
 
     def asIntRfWriteBundle(fire: Bool): RfWritePortWithConfig = {

--- a/src/main/scala/xiangshan/backend/datapath/DataPath.scala
+++ b/src/main/scala/xiangshan/backend/datapath/DataPath.scala
@@ -585,6 +585,8 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
       val s1_data = s1_toExuData(i)(j)
       val s1_addrOH = s1_addrOHs(i)(j)
       val s0 = fromIQ(i)(j) // s0
+      PerfCCT.updateInstPos(s0.bits.common.debug_seqNum, PerfCCT.InstPos.AtIssueArb.id.U, s0.valid, clock, reset)
+      PerfCCT.updateInstPos(s1_data.debug_seqNum, PerfCCT.InstPos.AtIssueReadReg.id.U, s1_valid, clock, reset)
 
       val srcNotBlock = Wire(Bool())
       srcNotBlock := s0.bits.common.dataSources.zip(intRdArbWinner(i)(j) zip fpRdArbWinner(i)(j) zip vfRdArbWinner(i)(j) zip v0RdArbWinner(i)(j) zip vlRdArbWinner(i)(j)).map {

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -85,6 +85,10 @@ class DecodeStage(implicit p: Parameters) extends XSModule
 
   val io = IO(new DecodeStageIO)
 
+  io.in.zipWithIndex.foreach{ case (d, i) => 
+    PerfCCT.updateInstPos(d.bits.debug_seqNum, PerfCCT.InstPos.AtDecode.id.U, d.valid, clock, reset)
+  }
+
   // io alias
   private val outReadys = io.out.map(_.ready)
   private val inValids = io.in.map(_.valid)
@@ -240,6 +244,9 @@ class DecodeStage(implicit p: Parameters) extends XSModule
       SrcType.isVp(s) && (l === 0.U)
     }.reduce(_ || _)
     inst.bits.srcType(3) := Mux(srcType0123HasV0, SrcType.v0, finalDecodedInst(i).srcType(3))
+    when (inst.bits.uopIdx =/= 0.U) {
+      inst.bits.debug_seqNum := 0.U
+    }
   }
 
   io.out.map(x =>

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -267,6 +267,7 @@ class ExeUnitImp(
       sink.bits.ctrl.vpu         .foreach(x => x.fpu.isFP32Instr   := 0.U)
       sink.bits.ctrl.vpu         .foreach(x => x.fpu.isFP64Instr   := 0.U)
       sink.bits.perfDebugInfo    := source.bits.perfDebugInfo
+      sink.bits.debug_seqNum     := source.bits.debug_seqNum
   }
   funcUnits.filter(_.cfg.latency.latencyVal.nonEmpty).map{ fu =>
     val latency = fu.cfg.latency.latencyVal.getOrElse(0)
@@ -405,6 +406,7 @@ class ExeUnitImp(
   io.out.bits.debug     := 0.U.asTypeOf(io.out.bits.debug)
   io.out.bits.debug.isPerfCnt := funcUnits.map(_.io.csrio.map(_.isPerfCnt)).map(_.getOrElse(false.B)).reduce(_ || _)
   io.out.bits.debugInfo := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.perfDebugInfo))
+  io.out.bits.debug_seqNum := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.debug_seqNum))
 }
 
 class DispatcherIO[T <: Data](private val gen: T, n: Int) extends Bundle {
@@ -451,6 +453,7 @@ class MemExeUnit(exuParams: ExeUnitParams)(implicit p: Parameters) extends XSMod
   fu.io.in.bits.data.imm       := io.in.bits.uop.imm
   fu.io.in.bits.data.src.zip(io.in.bits.src).foreach(x => x._1 := x._2)
   fu.io.in.bits.perfDebugInfo := io.in.bits.uop.debugInfo
+  fu.io.in.bits.debug_seqNum := io.in.bits.uop.debug_seqNum
 
   io.out.valid            := fu.io.out.valid
   fu.io.out.ready         := io.out.ready
@@ -463,6 +466,7 @@ class MemExeUnit(exuParams: ExeUnitParams)(implicit p: Parameters) extends XSMod
   io.out.bits.uop.fuOpType:= io.in.bits.uop.fuOpType
   io.out.bits.uop.sqIdx   := io.in.bits.uop.sqIdx
   io.out.bits.uop.debugInfo := fu.io.out.bits.perfDebugInfo
+  io.out.bits.uop.debug_seqNum := fu.io.out.bits.debug_seqNum
 
   io.out.bits.debug       := 0.U.asTypeOf(io.out.bits.debug)
 }

--- a/src/main/scala/xiangshan/backend/fu/Fence.scala
+++ b/src/main/scala/xiangshan/backend/fu/Fence.scala
@@ -88,6 +88,7 @@ class Fence(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
   io.out.bits.ctrl.flushPipe.get := uop.ctrl.flushPipe.get
   io.out.bits.ctrl.exceptionVec.get := 0.U.asTypeOf(io.out.bits.ctrl.exceptionVec.get)
   io.out.bits.perfDebugInfo := io.in.bits.perfDebugInfo
+  io.out.bits.debug_seqNum := io.in.bits.debug_seqNum
 
   XSDebug(io.in.valid, p"In(${io.in.valid} ${io.in.ready}) state:${state} InrobIdx:${io.in.bits.ctrl.robIdx}\n")
   XSDebug(state =/= s_idle, p"state:${state} sbuffer(flush:${sbuffer} empty:${sbEmpty}) fencei:${fencei} sfence:${sfence}\n")

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -77,12 +77,14 @@ class FuncUnitInput(cfg: FuConfig)(implicit p: Parameters) extends XSBundle {
   val data = new FuncUnitDataInput(cfg)
   val dataPipe = OptionWrapper(needCtrlPipe, Vec(cfg.latency.latencyVal.get + 1, new FuncUnitDataInput(cfg)))
   val perfDebugInfo = new PerfDebugInfo()
+  val debug_seqNum = InstSeqNum()
 }
 
 class FuncUnitOutput(cfg: FuConfig)(implicit p: Parameters) extends XSBundle {
   val ctrl = new FuncUnitCtrlOutput(cfg)
   val res = new FuncUnitDataOutput(cfg)
   val perfDebugInfo = new PerfDebugInfo()
+  val debug_seqNum = InstSeqNum()
 }
 
 class FuncUnitIO(cfg: FuConfig)(implicit p: Parameters) extends XSBundle {
@@ -103,6 +105,8 @@ class FuncUnitIO(cfg: FuConfig)(implicit p: Parameters) extends XSBundle {
 
 abstract class FuncUnit(val cfg: FuConfig)(implicit p: Parameters) extends XSModule with HasCriticalErrors {
   val io = IO(new FuncUnitIO(cfg))
+  PerfCCT.updateInstPos(io.in.bits.debug_seqNum, PerfCCT.InstPos.AtFU.id.U, io.in.valid, clock, reset)
+  PerfCCT.updateInstPos(io.out.bits.debug_seqNum, PerfCCT.InstPos.AtBypassVal.id.U, io.out.valid, clock, reset)
   val criticalErrors = Seq(("none", false.B))
 
   // should only be used in non-piped fu
@@ -119,6 +123,7 @@ abstract class FuncUnit(val cfg: FuConfig)(implicit p: Parameters) extends XSMod
     io.out.bits.ctrl.fpu      .foreach(_ := RegEnable(io.in.bits.ctrl.fpu.get, io.in.fire))
     io.out.bits.ctrl.vpu      .foreach(_ := RegEnable(io.in.bits.ctrl.vpu.get, io.in.fire))
     io.out.bits.perfDebugInfo := RegEnable(io.in.bits.perfDebugInfo, io.in.fire)
+    io.out.bits.debug_seqNum := RegEnable(io.in.bits.debug_seqNum, io.in.fire)
   }
 
   def connectNonPipedCtrlSingalForCSR: Unit = {
@@ -134,6 +139,7 @@ abstract class FuncUnit(val cfg: FuConfig)(implicit p: Parameters) extends XSMod
     io.out.bits.ctrl.fpu.foreach(_ := DataHoldBypass(io.in.bits.ctrl.fpu.get, io.in.fire))
     io.out.bits.ctrl.vpu.foreach(_ := DataHoldBypass(io.in.bits.ctrl.vpu.get, io.in.fire))
     io.out.bits.perfDebugInfo := DataHoldBypass(io.in.bits.perfDebugInfo, io.in.fire)
+    io.out.bits.debug_seqNum := DataHoldBypass(io.in.bits.debug_seqNum, io.in.fire)
   }
 
   def connect0LatencyCtrlSingal: Unit = {
@@ -149,6 +155,7 @@ abstract class FuncUnit(val cfg: FuConfig)(implicit p: Parameters) extends XSMod
     io.out.bits.ctrl.fpu.foreach(_ := io.in.bits.ctrl.fpu.get)
     io.out.bits.ctrl.vpu.foreach(_ := io.in.bits.ctrl.vpu.get)
     io.out.bits.perfDebugInfo := io.in.bits.perfDebugInfo
+    io.out.bits.debug_seqNum := io.in.bits.debug_seqNum
   }
 }
 
@@ -168,8 +175,7 @@ trait HasPipelineReg { this: FuncUnit =>
     val ctrlVec = init.ctrl +: Seq.fill(latency)(Reg(chiselTypeOf(io.in.bits.ctrl)))
     val dataVec = init.data +: Seq.fill(latency)(Reg(chiselTypeOf(io.in.bits.data)))
     val perfVec = init.perfDebugInfo +: Seq.fill(latency)(Reg(chiselTypeOf(io.in.bits.perfDebugInfo)))
-
-
+    val seqNumVec = init.debug_seqNum +: Seq.fill(latency)(Reg(chiselTypeOf(io.in.bits.debug_seqNum)))
 
     val robIdxVec = ctrlVec.map(_.robIdx)
 
@@ -185,11 +191,12 @@ trait HasPipelineReg { this: FuncUnit =>
         ctrlVec(i) := ctrlVec(i - 1)
         dataVec(i) := dataVec(i - 1)
         perfVec(i) := perfVec(i - 1)
+        seqNumVec(i) := seqNumVec(i-1)
       }
     }
 
-    (ctrlVec.zip(dataVec).zip(perfVec).map{
-      case(( ctrl,data), perf) => {
+    (ctrlVec.zip(dataVec).zip(perfVec).zip(seqNumVec).map{
+      case(((ctrl,data), perf), debug_seqNum) => {
         val out = Wire(new FuncUnitInput(cfg))
         out.ctrl := ctrl
         out.ctrlPipe.foreach(_ := 0.U.asTypeOf(out.ctrlPipe.get))
@@ -197,6 +204,7 @@ trait HasPipelineReg { this: FuncUnit =>
         out.dataPipe.foreach(_ := 0.U.asTypeOf(out.dataPipe.get))
         out.data := data
         out.perfDebugInfo := perf
+        out.debug_seqNum := debug_seqNum
         out
       }
     },validVec, rdyVec)
@@ -206,6 +214,7 @@ trait HasPipelineReg { this: FuncUnit =>
   val ctrlVec = io.in.bits.ctrlPipe.get
   val dataVec = io.in.bits.dataPipe.get
   val perfVec = pipeReg.map(_.perfDebugInfo)
+  val seqNumVec = pipeReg.map(_.debug_seqNum)
 
 
   val fixtiminginit = Wire(new FuncUnitInput(cfg))
@@ -215,11 +224,13 @@ trait HasPipelineReg { this: FuncUnit =>
   fixtiminginit.dataPipe.foreach(_ := 0.U.asTypeOf(fixtiminginit.dataPipe.get))
   fixtiminginit.data := dataVec.last
   fixtiminginit.perfDebugInfo := perfVec.last
+  fixtiminginit.debug_seqNum := seqNumVec.last
 
   // fixtiming pipelinereg
   val (fixpipeReg : Seq[FuncUnitInput], fixValidVec, fixRdyVec) = pipelineReg(fixtiminginit, validVec.last,rdyVec.head ,latdiff, io.flush)
   val fixDataVec = fixpipeReg.map(_.data)
   val fixPerfVec = fixpipeReg.map(_.perfDebugInfo)
+  val fixSeqNumVec = fixpipeReg.map(_.debug_seqNum)
   val pcVec = fixDataVec.map(_.pc)
 
   io.in.ready := fixRdyVec.head
@@ -235,6 +246,7 @@ trait HasPipelineReg { this: FuncUnit =>
   io.out.bits.ctrl.fpu.foreach(_ := ctrlVec.last.fpu.get)
   io.out.bits.ctrl.vpu.foreach(_ := ctrlVec.last.vpu.get)
   io.out.bits.perfDebugInfo := fixPerfVec.last
+  io.out.bits.debug_seqNum := fixSeqNumVec.last
 
   // vstart illegal
   if (cfg.exceptionOut.nonEmpty) {

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -95,6 +95,10 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     }
   })
 
+  io.in.zipWithIndex.map { case (o, i) =>
+    PerfCCT.updateInstPos(o.bits.debug_seqNum, PerfCCT.InstPos.AtRename.id.U, o.valid, clock, reset)
+  }
+
   // io alias
   private val dispatchCanAcc = io.out.head.ready
 
@@ -274,6 +278,10 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   val walkIntSpecWen = WireDefault(VecInit(Seq.fill(RenameWidth)(false.B)))
 
   val walkPdest = Wire(Vec(RenameWidth, UInt(PhyRegIdxWidth.W)))
+
+  io.out.zipWithIndex.foreach{ case (o, i) =>
+    o.bits.debug_seqNum := io.in(i).bits.debug_seqNum
+  }
 
   // uop calculation
   for (i <- 0 until RenameWidth) {

--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -250,6 +250,7 @@ class FetchToIBuffer(implicit p: Parameters) extends XSBundle {
   val isLastInFtqEntry = Vec(PredictWidth, Bool())
 
   val pc           = Vec(PredictWidth, UInt(VAddrBits.W))
+  val debug_seqNum = Vec(PredictWidth, InstSeqNum())
   val ftqPtr       = new FtqPtr
   val topdown_info = new FrontendTopDownBundle
 }

--- a/src/main/scala/xiangshan/frontend/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/IBuffer.scala
@@ -60,6 +60,7 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
   val backendException = Bool()
   val triggered        = TriggerAction()
   val isLastInFtqEntry = Bool()
+  val debug_seqNum     = InstSeqNum()
 
   def fromFetch(fetch: FetchToIBuffer, i: Int): IBufEntry = {
     inst       := fetch.instrs(i)
@@ -77,6 +78,7 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
     backendException := fetch.backendException(i)
     triggered        := fetch.triggered(i)
     isLastInFtqEntry := fetch.isLastInFtqEntry(i)
+    debug_seqNum     := fetch.debug_seqNum(i)
     this
   }
 
@@ -103,6 +105,7 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
     cf.ftqPtr                            := ftqPtr
     cf.ftqOffset                         := ftqOffset
     cf.isLastInFtqEntry                  := isLastInFtqEntry
+    cf.debug_seqNum                      := debug_seqNum
     cf
   }
 

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -381,6 +381,10 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     }
   })
 
+  io.mem_to_ooo.writeBack.zipWithIndex.foreach{ case (wb, i) =>
+    PerfCCT.updateInstPos(wb.bits.uop.debug_seqNum, PerfCCT.InstPos.AtBypassVal.id.U, wb.valid, clock, reset)
+  }
+
   dontTouch(io.inner_hartId)
   dontTouch(io.inner_reset_vector)
   dontTouch(io.outer_reset_vector)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -521,6 +521,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     when (io.storeAddrIn(i).fire) {
       uop(stWbIndex) := io.storeAddrIn(i).bits.uop
       uop(stWbIndex).debugInfo := io.storeAddrIn(i).bits.uop.debugInfo
+      uop(stWbIndex).debug_seqNum := io.storeAddrIn(i).bits.uop.debug_seqNum
     }
     XSInfo(io.storeAddrIn(i).fire && !io.storeAddrIn(i).bits.isFrmMisAlignBuf,
       "store addr write to sq idx %d pc 0x%x miss:%d vaddr %x paddr %x mmio %x isvec %x\n",

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -60,6 +60,8 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
     val csrCtrl       = Flipped(new CustomCSRCtrlIO)
   })
 
+  PerfCCT.updateInstPos(io.in.bits.uop.debug_seqNum, PerfCCT.InstPos.AtFU.id.U, io.in.valid, clock, reset)
+
   //-------------------------------------------------------
   // Atomics Memory Accsess FSM
   //-------------------------------------------------------

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -159,6 +159,8 @@ class HybridUnit(implicit p: Parameters) extends XSModule
     val fromCsrTrigger = Input(new CsrTriggerBundle)
   })
 
+  PerfCCT.updateInstPos(io.lsin.bits.uop.debug_seqNum, PerfCCT.InstPos.AtFU.id.U, io.lsin.valid, clock, reset)
+
   val StorePrefetchL1Enabled = EnableStorePrefetchAtCommit || EnableStorePrefetchAtIssue || EnableStorePrefetchSPB
   val s1_ready, s2_ready, s3_ready, sx_can_go = WireInit(false.B)
 

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -211,6 +211,9 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     val correctMissTrain = Input(Bool())
   })
 
+
+  PerfCCT.updateInstPos(io.ldin.bits.uop.debug_seqNum, PerfCCT.InstPos.AtFU.id.U, io.ldin.valid, clock, reset)
+
   val s1_ready, s2_ready, s3_ready = WireInit(false.B)
 
   // Pipeline

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -74,6 +74,8 @@ class StoreUnit(implicit p: Parameters) extends XSModule
     val s0_s1_valid = Output(Bool())
   })
 
+  PerfCCT.updateInstPos(io.stin.bits.uop.debug_seqNum, PerfCCT.InstPos.AtFU.id.U, io.stin.valid, clock, reset)
+
   val s1_ready, s2_ready, s3_ready = WireInit(false.B)
 
   // Pipeline

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -16,6 +16,7 @@
 
 import chisel3._
 import chisel3.util._
+import utils.NamedUInt
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.tile.XLen
 import xiangshan.ExceptionNO._
@@ -938,6 +939,8 @@ package object xiangshan {
     def selectByFuAndUnSelect(vec:Vec[Bool], fuConfig: FuConfig, unSelect: Seq[Int]): Vec[Bool] =
       partialSelect(vec, fuConfig.exceptionOut, unSelect)
   }
+
+  object InstSeqNum extends NamedUInt(64)
 
   object TopDownCounters extends Enumeration {
     val NoStall = Value("NoStall") // Base


### PR DESCRIPTION
PerfCCT(performance counter commit trace) is a Instruction-level granularity perfCounter like GEM5
How to use this:
1. Make with "WITH_CHISELDB=1" argument
2. Run with "--dump-db --dump-select-db lifetime", then get the database
3. Instruction lifetime visualize run "python3 scripts/perfcct.py "the-db-file-path" -p 1 -v  | less"
4. Analysis script now is in XS-GEM5 repo, see https://github.com/OpenXiangShan/GEM5/blob/xs-dev/util/ClockAnalysis.py

How it works:
1. Allocate one unique tag "seqNum" like GEM5 for each instruction at fetch stage
2. Passing the "seqNum" in each pipeline
3. Recording perf data through the DPIC interface