### PR TITLE
perf(XSTop): improve concurrency of CHI-AXI bridge

### DIFF
--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -103,6 +103,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc() with HasSoCParameter
   val chi_llcBridge_opt = Option.when(enableCHI)(
     LazyModule(new OpenNCB()(p.alter((site, here, up) => {
       case NCBParametersKey => new NCBParameters(
+        outstandingDepth    = 64,
         axiMasterOrder      = EnumAXIMasterOrder.WriteAddress,
         readCompDMT         = false,
         writeCancelable     = false,
@@ -115,6 +116,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc() with HasSoCParameter
   val chi_mmioBridge_opt = Seq.fill(NumCores)(Option.when(enableCHI)(
     LazyModule(new OpenNCB()(p.alter((site, here, up) => {
       case NCBParametersKey => new NCBParameters(
+        outstandingDepth            = 32,
         axiMasterOrder              = EnumAXIMasterOrder.None,
         readCompDMT                 = false,
         writeCancelable             = false,


### PR DESCRIPTION
The previous design set OpenNCB concurrency to the default value of 15. This commit adjusts the configuration to align with the parallelism of L2 MSHR requests and MMIO requests, enhancing overall performance.