### PR TITLE
fix(CSREnumType): override _fromUInt method to make Mux1H etc function get return type CSREnumType

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRFields.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRFields.scala
@@ -1,10 +1,11 @@
 package xiangshan.backend.fu.NewCSR
 
 import chisel3._
+import chisel3.experimental.SourceInfo
 import chisel3.util.Fill
 import xiangshan.backend.fu.NewCSR.CSRFunc._
-import scala.collection.mutable
 
+import scala.collection.mutable
 import scala.language.implicitConversions
 
 abstract class CSRRWType {
@@ -323,6 +324,13 @@ class CSREnumType(
 
   // override cloneType to make ValidIO etc function return CSREnumType not EnumType
   override def cloneType: this.type = factory.asInstanceOf[CSREnum].makeType.asInstanceOf[this.type].setRwType(this.rwType)
+
+  // override _fromUInt to make Mux1H etc function get correct return type CSREnumType not EnumType
+  override def _fromUInt(that: UInt)(implicit sourceInfo: experimental.SourceInfo): Data = {
+    val result = Wire(factory.asInstanceOf[CSREnum].makeType.asInstanceOf[this.type].setRwType(this.rwType))
+    result := that
+    result
+  }
 }
 
 class CSREnum extends ChiselEnum {


### PR DESCRIPTION
Fix following elaboration exception when try to bump chisel-7.0.0-M2.

```
[676] [warn] There were 46 warning(s) during hardware elaboration.
[676] Exception in thread "main" java.lang.ClassCastException: class chisel3.ChiselEnumImpl$Type cannot be cast to class xiangshan.backend.fu.NewCSR.CSREnumType (chisel3.ChiselEnumImpl$Type and xiangshan.backend.fu.NewCSR.CSREnumType are in unnamed module of loader 'app')
[676]   at xiangshan.backend.fu.NewCSR.MachineLevel$$anon$1.$anonfun$new$9(MachineLevel.scala:63)
[676]   at chisel3.DataImpl.$anonfun$$colon$eq$1(DataImpl.scala:820)
[676]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
[676]   at chisel3.experimental.prefix$.apply(prefix.scala:33)
[676]   at chisel3.DataImpl.$colon$eq(DataImpl.scala:820)
[676]   at chisel3.DataImpl.$colon$eq$(DataImpl.scala:818)
[676]   at chisel3.Data.$colon$eq(Data.scala:31)
[676]   at xiangshan.backend.fu.NewCSR.MachineLevel$$anon$1.$anonfun$new$8(MachineLevel.scala:63)
```