### PR TITLE
style(MemBlock): wipe out `selectOldest` and `selectOldestRedirect`

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -299,9 +299,11 @@ class MicroOp(implicit p: Parameters) extends CfCtrl {
   }
 }
 
-class XSBundleWithMicroOp(implicit p: Parameters) extends XSBundle {
+trait HasMicroOp { this: XSBundle =>
   val uop = new DynInst
 }
+
+class XSBundleWithMicroOp(implicit p: Parameters) extends XSBundle with HasMicroOp
 
 class MicroOpRbExt(implicit p: Parameters) extends XSBundleWithMicroOp {
   val flag = UInt(1.W)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadExceptionBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadExceptionBuffer.scala
@@ -69,29 +69,7 @@ class LqExceptionBuffer(implicit p: Parameters) extends XSModule with HasCircula
     req_valid := true.B
   }
 
-  def selectOldest[T <: LqWriteBundle](valid: Seq[Bool], bits: Seq[T]): (Seq[Bool], Seq[T]) = {
-    assert(valid.length == bits.length)
-    if (valid.length == 0 || valid.length == 1) {
-      (valid, bits)
-    } else if (valid.length == 2) {
-      val res = Seq.fill(2)(Wire(ValidIO(chiselTypeOf(bits(0)))))
-      for (i <- res.indices) {
-        res(i).valid := valid(i)
-        res(i).bits := bits(i)
-      }
-      val oldest = Mux(valid(0) && valid(1),
-        Mux(isAfter(bits(0).uop.robIdx, bits(1).uop.robIdx) ||
-          (bits(0).uop.robIdx === bits(1).uop.robIdx && bits(0).uop.uopIdx > bits(1).uop.uopIdx), res(1), res(0)),
-        Mux(valid(0) && !valid(1), res(0), res(1)))
-      (Seq(oldest.valid), Seq(oldest.bits))
-    } else {
-      val left = selectOldest(valid.take(valid.length / 2), bits.take(bits.length / 2))
-      val right = selectOldest(valid.takeRight(valid.length - (valid.length / 2)), bits.takeRight(bits.length - (bits.length / 2)))
-      selectOldest(left._1 ++ right._1, left._2 ++ right._2)
-    }
-  }
-
-  val reqSel = selectOldest(s2_enqueue, s2_req)
+  val reqSel = SelectOldestUopIdx(s2_enqueue, s2_req)
 
   when (req_valid) {
     req := Mux(

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
@@ -91,28 +91,6 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
     truncateData(XLEN - 1, 0)
   }
 
-  def selectOldest[T <: LqWriteBundle](valid: Seq[Bool], bits: Seq[T]): (Seq[Bool], Seq[T]) = {
-    assert(valid.length == bits.length)
-    if (valid.length == 0 || valid.length == 1) {
-      (valid, bits)
-    } else if (valid.length == 2) {
-      val res = Seq.fill(2)(Wire(ValidIO(chiselTypeOf(bits(0)))))
-      for (i <- res.indices) {
-        res(i).valid := valid(i)
-        res(i).bits := bits(i)
-      }
-      val oldest = Mux(valid(0) && valid(1),
-        Mux(isAfter(bits(0).uop.robIdx, bits(1).uop.robIdx) ||
-          (bits(0).uop.robIdx === bits(1).uop.robIdx && bits(0).uop.uopIdx > bits(1).uop.uopIdx), res(1), res(0)),
-        Mux(valid(0) && !valid(1), res(0), res(1)))
-      (Seq(oldest.valid), Seq(oldest.bits))
-    } else {
-      val left = selectOldest(valid.take(valid.length / 2), bits.take(bits.length / 2))
-      val right = selectOldest(valid.takeRight(valid.length - (valid.length / 2)), bits.takeRight(bits.length - (bits.length / 2)))
-      selectOldest(left._1 ++ right._1, left._2 ++ right._2)
-    }
-  }
-
   val io = IO(new Bundle() {
     val redirect        = Flipped(Valid(new Redirect))
     val req             = Vec(enqPortNum, Flipped(Decoupled(new LqWriteBundle)))

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -136,6 +136,13 @@ class VecPipelineFeedbackIO(isVStore: Boolean=false) (implicit p: Parameters) ex
   val vecdata              = OptionWrapper(!isVStore, UInt(VLEN.W))
 }
 
+trait HasElemIdxInField { this: VLSUBundle =>
+  val wbElemIdxInField = UInt()
+}
+
+class VecPipelineFeedbackIOWithElemIdx(isVStore: Boolean = false)(implicit p: Parameters) extends
+  VecPipelineFeedbackIO(isVStore) with HasElemIdxInField
+
 class VecPipeBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle {
   val vaddr               = UInt(XLEN.W)
   val basevaddr           = UInt(VAddrBits.W)


### PR DESCRIPTION
This commit clears up `selectOldest` and `selectOldestRedirect` function that repeatedly appear in MemBlock and abstract them into one object in `MemCommon`.