### PR TITLE
fix(StoreQueue): fix `difftestinfo` for store event

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -1298,7 +1298,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   // Only the vector store difftest required signal is separated from the rtl code.
   if (env.EnableDifftest) {
     for (i <- 0 until EnsbufferWidth) {
-      val ptr = rdataPtrExt(i).value
+      val ptr = dataBuffer.io.enq(i).bits.sqPtr.value
       difftestBuffer.get.io.enq(i).valid := dataBuffer.io.enq(i).valid
       difftestBuffer.get.io.enq(i).bits := uop(ptr)
     }


### PR DESCRIPTION
The acquisition of information related to the difftest when a non-aligned Store is split into a Sbuffer was not considered before. Use a more robust way to get the information needed for the difftest.