### PR TITLE
fix(arg): add L2/L3 configs for `--disable-perf`

### DIFF
--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -130,6 +130,16 @@ object ArgParser {
         case "--disable-perf" :: tail =>
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(EnablePerfDebug = false)
+            case SoCParamsKey => up(SoCParamsKey).copy(
+              L3CacheParamsOpt = up(SoCParamsKey).L3CacheParamsOpt.map(_.copy(
+                enablePerf = false,
+              )),
+            )
+            case XSTileKey => up(XSTileKey).map(p => p.copy(
+              L2CacheParamsOpt = p.L2CacheParamsOpt.map(_.copy(
+                enablePerf = false,
+              )),
+            ))
           }), tail)
         case "--disable-alwaysdb" :: tail =>
           nextOption(config.alter((site, here, up) => {


### PR DESCRIPTION
This commit fixes the support for `--disable-perf` of L2/L3 caches. Their `enablePerf` parameters should be set to false as well.