### PR TITLE
fix(bank_conflict): Selecting the oldest Load causes a conflict

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -288,6 +288,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.banked_data_read.bits.kill := io.lsu.s1_kill_data_read
   io.banked_data_read.bits.way_en := s1_pred_tag_match_way_dup_dc
   io.banked_data_read.bits.bankMask := s1_bank_oh
+  io.banked_data_read.bits.lqIdx := s1_req.lqIdx
   io.is128Req := s1_load128Req
 
   // check ecc error


### PR DESCRIPTION
This modification changes `load bank conflict` from [default priority 0 1 2] to [so that the oldest Load does not have a `bank conflict`].

In the following, `Load 0` refers to `LoadUnit 0`.

For example, before:
Load 0 lqidx 5 
Load 1 lqidx 3
Load 2 lqidx 8
Assuming that three Loads have `bank conflict`, then we will default to making Load1 and Load2 have `bank conflict` so that they can be replayed.

---

However, this may lead to deadlocks in some cases.
For example:
Load  0 robidx 7
Store 0 robidx 6
Load  1 robidx 5

`Store 0` is dependent on `Load 1` for data, while `Load 0` is dependent on `Store 0` for data, and `Load 0` and `Load 1` will have a `bank conflict`.
In this case then, `Load 1` will `Replay` because of `bank conflict` and `Load 0` will `Replay` because of `forward fault`(because of misalign).

---

With the modification, we will choose to make the oldest Load not generate `bank conflict`, thus circumventing the jamming problem.
**Note !!! This may introduce performance fluctuations (up or down)**