### PR TITLE
fix(LSQ): modify misaligned `forward fault` detection

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -305,8 +305,8 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   for (i <- 0 until LoadQueueReplaySize) {
     // dequeue
     //  FIXME: store*Ptr is not accurate
-    dataNotBlockVec(i) := isNotBefore(io.stDataReadySqPtr, blockSqIdx(i)) || stDataReadyVec(blockSqIdx(i).value) || io.sqEmpty // for better timing
-    addrNotBlockVec(i) := isNotBefore(io.stAddrReadySqPtr, blockSqIdx(i)) || !strict(i) && stAddrReadyVec(blockSqIdx(i).value) || io.sqEmpty // for better timing
+    dataNotBlockVec(i) := isAfter(io.stDataReadySqPtr, blockSqIdx(i)) || stDataReadyVec(blockSqIdx(i).value) || io.sqEmpty // for better timing
+    addrNotBlockVec(i) := isAfter(io.stAddrReadySqPtr, blockSqIdx(i)) || !strict(i) && stAddrReadyVec(blockSqIdx(i).value) || io.sqEmpty // for better timing
     // store address execute
     storeAddrInSameCycleVec(i) := VecInit((0 until StorePipelineWidth).map(w => {
       io.storeAddrIn(w).valid &&


### PR DESCRIPTION
Previously, I used an inappropriate way for another misalign to trigger a `forward fault`:

https://github.com/OpenXiangShan/XiangShan/blob/38d0d7c5a34a23dfdb58a3cb2737c3cfddb3ec9d/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala#L684-L711

This would cause the `BlockSqIdx` passed to `LoadQueueReplay` to use the `sqIdx` from `uop` instead of the `sqIdx` with the unalign flag bit:
https://github.com/OpenXiangShan/XiangShan/blob/38d0d7c5a34a23dfdb58a3cb2737c3cfddb3ec9d/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala#L776-L782

**This leads to a possible stuck in `LoadQueueReplay`.**

And to resolve the stuck, we incorrectly introduced this Commit(af757d1b973e03dae3ce0078a4a8249b593188ec).

This Commit(af757d1b973e03dae3ce0078a4a8249b593188ec) causes `BlockSqIdx` to unblock without `DataValid`.
This leads to certain performance issues.

This revision fixes the inappropriate `forward fault` triggering method and reverses the Commit(af757d1b973e03dae3ce0078a4a8249b593188ec).

**This should bring performance back up again.**
### Apologies for my mistake.