### PR TITLE
fix(BankedDataArray): fix `oldest` selection logic

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -419,7 +419,7 @@ class SramedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   val load_req_index = (0 until LoadPipelineWidth).map(_.asUInt)
 
 
-  val load_req_bank_conflict_selcet = selcetOldestPort(load_req_valid, load_req_lqIdx, load_req_index)
+  val load_req_bank_conflict_selcet = selcetOldestPort(load_req_with_bank_conflict, load_req_lqIdx, load_req_index)
   val load_req_bank_select_port  = UIntToOH(load_req_bank_conflict_selcet._2).asBools
 
   val rr_bank_conflict_oldest = (0 until LoadPipelineWidth).map(i =>
@@ -698,7 +698,7 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   val load_req_lqIdx = io.read.map(_.bits.lqIdx)
   val load_req_index = (0 until LoadPipelineWidth).map(_.asUInt)
 
-  val load_req_bank_conflict_selcet = selcetOldestPort(load_req_valid, load_req_lqIdx, load_req_index)
+  val load_req_bank_conflict_selcet = selcetOldestPort(load_req_with_bank_conflict, load_req_lqIdx, load_req_index)
   val load_req_bank_select_port  = UIntToOH(load_req_bank_conflict_selcet._2).asBools
 
   val rr_bank_conflict_oldest = (0 until LoadPipelineWidth).map(i =>


### PR DESCRIPTION
Changes in this Commit(8ffb12e45361b854daf46d200530e9b2b01e4a9c) will make: 
In this case, there will be multiple replay: ldu0,1,2's lqptr= [5,7,6], bank_conflict only in ldu1 and ldu2. Ideally only replay ldu1, but here both ldu1 and ldu2 will replay.

This mod fixes the issue and theoretically performance will improve again.