### PR TITLE
fix(RAS): bos pointer needs to be updated when the instruction is committed

### DIFF
--- a/src/main/scala/xiangshan/frontend/newRAS.scala
+++ b/src/main/scala/xiangshan/frontend/newRAS.scala
@@ -733,9 +733,8 @@ class RAS(implicit p: Parameters) extends BasePredictor {
   val update_pc = io.update.bits.pc
 
   // To improve Clock Gating Efficiency
-  update.meta := RegEnable(io.update.bits.meta, io.update.valid && (io.update.bits.is_call || io.update.bits.is_ret))
-
-  val updateMeta = update.meta.asTypeOf(new RASMeta)
+  // update.meta := RegEnable(io.update.bits.meta, io.update.valid && (io.update.bits.is_call || io.update.bits.is_ret))
+  val updateMeta = RegEnable(io.update.bits.meta.asTypeOf(new RASMeta), io.update.valid)
 
   stack.commit_valid      := updateValid
   stack.commit_push_valid := updateValid && update.is_call_taken

--- a/src/main/scala/xiangshan/frontend/newRAS.scala
+++ b/src/main/scala/xiangshan/frontend/newRAS.scala
@@ -732,8 +732,10 @@ class RAS(implicit p: Parameters) extends BasePredictor {
   // so io.update.bits.pc is used directly here
   val update_pc = io.update.bits.pc
 
-  // To improve Clock Gating Efficiency
-  // update.meta := RegEnable(io.update.bits.meta, io.update.valid && (io.update.bits.is_call || io.update.bits.is_ret))
+  // full core power down sequence need 'val updateMeta = RegEnable(io.update.bits.meta.asTypeOf(new RASMeta), io.update.valid)' to be
+  // 'val updateMeta = RegEnable(io.update.bits.meta.asTypeOf(new RASMeta), io.update.valid && (io.update.bits.is_call || io.update.bits.is_ret))',
+  // but the fault-tolerance mechanism of the return stack needs to be updated in time. Using an unexpected old value on reset will cause errors.
+  // Only 9 registers have clock gate efficiency affected, so we relaxed the control signals.
   val updateMeta = RegEnable(io.update.bits.meta.asTypeOf(new RASMeta), io.update.valid)
 
   stack.commit_valid      := updateValid


### PR DESCRIPTION
During reset, the update registers related to the return stack are not reset. At the same time, the update of the update register value is subject to some signal restrictions, resulting in the BOS pointer being updated incorrectly with the old value.