### PR TITLE
fix(MemBlock): fix misaligned exception and remove redundant reg from `SQ`

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - run: |
-          mkdir ~/.local/bin
+          mkdir -p ~/.local/bin
           sh -c "curl -L https://github.com/com-lihaoyi/mill/releases/download/0.11.7/0.11.7 > ~/.local/bin/mill && chmod +x ~/.local/bin/mill"
           export PATH=~/.local/bin:$PATH
       - run: make check-format

--- a/src/main/scala/xiangshan/mem/MemCommon.scala
+++ b/src/main/scala/xiangshan/mem/MemCommon.scala
@@ -120,6 +120,7 @@ class LsPipelineBundle(implicit p: Parameters) extends XSBundle
   val nc = Bool()
   val mmio = Bool()
   val atomic = Bool()
+  val hasException = Bool()
 
   val forwardMask = Vec(VLEN/8, Bool())
   val forwardData = Vec(VLEN/8, UInt(8.W))

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -502,7 +502,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
 
   io.splitStoreReq.valid := req_valid && (bufferState === s_req)
   io.splitStoreReq.bits  := splitStoreReqs(curPtr)
-  io.splitStoreReq.bits.is128bit  := req.isvec
+  io.splitStoreReq.bits.isvec  := req.isvec
   // Restore the information of H extension store
   // bit encoding: | hsv 1 | store 00 | size(2bit) |
   val reqIsHsv  = LSUOpType.isHsv(req.uop.fuOpType)


### PR DESCRIPTION
1. Fixed some exception handling logic for misalign access.

2. removed redundant registers in StoreQueue, roughly ‘9*64’ bits.

---

Forgive me for combining these two parts, as the changes to `1` are related to the changes to `2`.