### PR TITLE
ci(check-format): make sure ~/.local/bin exists

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -4,6 +4,7 @@ core:
   - "!.github/filters.yaml"
   - "!.github/workflows/nightly.yml"
   - "!.github/workflows/perf.yml"
+  - "!.github/workflows/format.yml"
   - "!.gitignore"
   - "!**/*.md"
   - "!LICENSE"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - run: |
-          mkdir ~/.local/bin
+          mkdir -p ~/.local/bin
           sh -c "curl -L https://github.com/com-lihaoyi/mill/releases/download/0.11.7/0.11.7 > ~/.local/bin/mill && chmod +x ~/.local/bin/mill"
           export PATH=~/.local/bin:$PATH
       - run: make check-format


### PR DESCRIPTION
Github automatically updates ubuntu-latest from 22.04 to 24.04, which does not contain .local at the home directory anymore.