### PR TITLE
fix(hideleg): fix the read value of the LCOFI bit of hideleg.

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
@@ -23,7 +23,15 @@ trait HypervisorLevel { self: NewCSR =>
   val hedeleg = Module(new CSRModule("Hedeleg", new HedelegBundle))
     .setAddr(CSRs.hedeleg)
 
-  val hideleg = Module(new CSRModule("Hideleg", new HidelegBundle))
+  val hideleg = Module(new CSRModule("Hideleg", new HidelegBundle)
+    with HasIpIeBundle
+  {
+    regOut := reg & mideleg
+    regOut.getLocal.zip(reg.getLocal).zip(mideleg.getLocal).zip(mvien.getLocal).foreach {
+      case (((regOutLCI, regLCI), midelegLCI), mvienLCI) =>
+        regOutLCI := regLCI && (midelegLCI || mvienLCI)
+    }
+  })
     .setAddr(CSRs.hideleg)
 
   val hie = Module(new CSRModule("Hie", new HieBundle)


### PR DESCRIPTION
For bits of mideleg that are zero, the corresponding bits in hideleg, hip, and hie are read-only zeros.

The VSSIP, VSTIP, VSEIP in mideleg are read-only ones when the H extension is implemented.

When the hypervisor extension is implemented, if a bit is zero in the same position in both mideleg
and mvien, then that bit is read-only zero in hideleg (in addition to being read-only zero in sip, sie,
hip, and hie). But if a bit for one of interrupts 13-63 is a one in either mideleg or mvien, then the same
bit in hideleg may be writable or may be read-only zero, depending on the implementation. No bits in
hideleg are ever read-only ones. The RISC-V Privileged Architecture further constrains bits 12:0 of
hideleg.