### PR TITLE
fix(LQUncache): consider offset when allocating

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -357,9 +357,8 @@ class LoadQueueUncache(implicit p: Parameters) extends XSModule
   }
 
   for (w <- 0 until LoadPipelineWidth) {
-    s2_enqValidVec(w) := s2_enqueue(w) && freeList.io.canAllocate(w)
-
     val offset = PopCount(s2_enqueue.take(w))
+    s2_enqValidVec(w) := s2_enqueue(w) && freeList.io.canAllocate(offset)
     s2_enqIndexVec(w) := freeList.io.allocateSlot(offset)
   }
 


### PR DESCRIPTION
bug scene:

When the valid vector of ldu0-2 is [0, 0, 1], and the freelist can only allocate one entry (when the `canAllocate` vector is [1, 0, 0]), the ldu2's request can not be allocated and then be rollbacked. This is because the allocation did not take into account the valid offset.
