### PR TITLE
feat(XSNoCDiffTop): wrap XSNoCTop with Difftest Interface

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -86,6 +86,21 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 8 --numa --ci linux-hello-opensbi 2> perf.log
           cat perf.log | sort
+      - name: generate NOC XiangShan
+        run: |
+          make clean
+          make verilog PLDM=1 PLDM_ARGS="--difftest-config H" CONFIG=XSNoCDiffTopConfig
+      - name: generate NOC Difftest
+        run: |
+          export NOOP_HOME=$GITHUB_WORKSPACE/difftest
+          cd difftest && make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUM_CORES=2 CONFIG=ZESNH
+      - name: check interface between XSNoCDiffTop and Difftest
+        run: |
+          cd $GITHUB_WORKSPACE
+          python3 ./difftest/scripts/st_tools/interface.py ./difftest/build/rtl/GatewayEndpoint.sv
+          python3 ./difftest/scripts/st_tools/interface.py ./build/rtl/XSDiffTop.sv --core --filelist ./build/rtl/filelist.f --simtop ./difftest/build/rtl/SimTop.sv
+          cp -r -v ./difftest/build/* ./build/
+          verilator --lint-only -Wno-fatal --top-module XSDiffTopChecker build/XSDiffTopChecker.sv build/rtl/*sv build/rtl/*v -Ibuild/generated-src/ -LDFLAGS -"lreadline"
   emu-basics:
     runs-on: bosc
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 # public args sumup
 RELEASE_ARGS += $(MFC_ARGS) $(COMMON_EXTRA_ARGS)
 DEBUG_ARGS += $(MFC_ARGS) $(COMMON_EXTRA_ARGS)
-PLDM_ARGS += $(MFC_ARGS) $(COMMON_EXTRA_ARGS)
+override PLDM_ARGS += $(MFC_ARGS) $(COMMON_EXTRA_ARGS)
 
 # co-simulation with DRAMsim3
 ifeq ($(WITH_DRAMSIM3),1)
@@ -138,13 +138,20 @@ endif
 # emu for the release version
 RELEASE_ARGS += --fpga-platform --disable-all --remove-assert --reset-gen --firtool-opt --ignore-read-enable-mem
 DEBUG_ARGS   += --enable-difftest
-PLDM_ARGS    += --fpga-platform --enable-difftest
+override PLDM_ARGS += --enable-difftest
 ifeq ($(RELEASE),1)
 override SIM_ARGS += $(RELEASE_ARGS)
 else ifeq ($(PLDM),1)
 override SIM_ARGS += $(PLDM_ARGS)
 else
 override SIM_ARGS += $(DEBUG_ARGS)
+endif
+
+# use RELEASE_ARGS for TopMain by default
+ifeq ($(PLDM), 1)
+TOPMAIN_ARGS += $(PLDM_ARGS)
+else
+TOPMAIN_ARGS += $(RELEASE_ARGS)
 endif
 
 TIMELOG = $(BUILD_DIR)/time.log
@@ -173,7 +180,7 @@ $(TOP_V): $(SCALA_FILE)
 	mkdir -p $(@D)
 	$(TIME_CMD) mill -i $(MILL_BUILD_ARGS) xiangshan.runMain $(FPGATOP)   \
 		--target-dir $(@D) --config $(CONFIG) --issue $(ISSUE) $(FPGA_MEM_ARGS)		\
-		--num-cores $(NUM_CORES) $(RELEASE_ARGS)
+		--num-cores $(NUM_CORES) $(TOPMAIN_ARGS)
 ifeq ($(CHISEL_TARGET),systemverilog)
 	$(MEM_GEN_SEP) "$(MEM_GEN)" "$@.conf" "$(@D)"
 	@git log -n 1 >> .__head__

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -81,6 +81,7 @@ case class SoCParameters
   NumIRFiles: Int = 7,
   NumIRSrc: Int = 256,
   UseXSNoCTop: Boolean = false,
+  UseXSNoCDiffTop: Boolean = false,
   IMSICUseTL: Boolean = false,
   EnableCHIAsyncBridge: Option[AsyncQueueParams] = Some(AsyncQueueParams(depth = 16, sync = 3, safe = false)),
   EnableClintAsyncBridge: Option[AsyncQueueParams] = Some(AsyncQueueParams(depth = 1, sync = 3, safe = false))

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -475,6 +475,18 @@ class XSNoCTopMinimalConfig(n: Int = 1) extends Config(
   })
 )
 
+class XSNoCDiffTopConfig(n: Int = 1) extends Config(
+  (new XSNoCTopConfig(n)).alter((site, here, up) => {
+    case SoCParamsKey => up(SoCParamsKey).copy(UseXSNoCDiffTop = true)
+  })
+)
+
+class XSNoCDiffTopMinimalConfig(n: Int = 1) extends Config(
+  (new XSNoCTopConfig(n)).alter((site, here, up) => {
+    case SoCParamsKey => up(SoCParamsKey).copy(UseXSNoCDiffTop = true)
+  })
+)
+
 class FpgaDefaultConfig(n: Int = 1) extends Config(
   (L3CacheConfig("3MB", inclusive = false, banks = 1, ways = 6)
     ++ L2CacheConfig("1MB", inclusive = true, banks = 4)

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -446,16 +446,20 @@ object TopMain extends App {
   Constantin.init(enableConstantin && !envInFPGA)
   ChiselDB.init(enableChiselDB && !envInFPGA)
 
-  val soc = if (config(SoCParamsKey).UseXSNoCTop)
-    DisableMonitors(p => LazyModule(new XSNoCTop()(p)))(config)
-  else
-    DisableMonitors(p => LazyModule(new XSTop()(p)))(config)
+  if (config(SoCParamsKey).UseXSNoCDiffTop) {
+    Generator.execute(firrtlOpts, DisableMonitors(p => new XSNoCDiffTop()(p))(config), firtoolOpts)
+  } else {
+    val soc = if (config(SoCParamsKey).UseXSNoCTop)
+      DisableMonitors(p => LazyModule(new XSNoCTop()(p)))(config)
+    else
+      DisableMonitors(p => LazyModule(new XSTop()(p)))(config)
 
-  Generator.execute(firrtlOpts, soc.module, firtoolOpts)
+    Generator.execute(firrtlOpts, soc.module, firtoolOpts)
 
-  // generate difftest bundles (w/o DifftestTopIO)
-  if (enableDifftest) {
-    DifftestModule.finish("XiangShan", false)
+    // generate difftest bundles (w/o DifftestTopIO)
+    if (enableDifftest) {
+      DifftestModule.finish("XiangShan", false)
+    }
   }
 
   FileRegisters.write(fileDir = "./build", filePrefix = "XSTop.")

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -34,6 +34,9 @@ import freechips.rocketchip.util.{AsyncQueueSource, AsyncQueueParams}
 import chisel3.experimental.{annotate, ChiselAnnotation}
 import sifive.enterprise.firrtl.NestedPrefixModulesAnnotation
 
+import difftest.common.DifftestWiring
+import difftest.util.Profile
+
 class XSNoCTop()(implicit p: Parameters) extends BaseXSSoc with HasSoCParameter
 {
   override lazy val desiredName: String = "XSTop"
@@ -211,4 +214,109 @@ class XSNoCTop()(implicit p: Parameters) extends BaseXSSoc with HasSoCParameter
   }
 
   lazy val module = new XSNoCTopImp(this)
+}
+
+class XSNoCDiffTop(implicit p: Parameters) extends Module {
+  override val desiredName: String = "XSDiffTop"
+  val l_soc = LazyModule(new XSNoCTop())
+  val soc = Module(l_soc.module)
+
+  // Expose XSTop IOs outside, i.e. io
+  def exposeIO(data: Data, name: String): Unit = {
+    val dummy = IO(chiselTypeOf(data)).suggestName(name)
+    dummy <> data
+  }
+  def exposeOptionIO(data: Option[Data], name: String): Unit = {
+    if (data.isDefined) {
+      val dummy = IO(chiselTypeOf(data.get)).suggestName(name)
+      dummy <> data.get
+    }
+  }
+  exposeIO(l_soc.clint, "clint")
+  exposeIO(l_soc.debug, "debug")
+  exposeIO(l_soc.plic, "plic")
+  exposeIO(l_soc.beu, "beu")
+  exposeIO(l_soc.nmi, "nmi")
+  soc.clock := clock
+  soc.reset := reset.asAsyncReset
+  exposeIO(soc.soc_clock, "soc_clock")
+  exposeIO(soc.soc_reset, "soc_reset")
+  exposeIO(soc.io, "io")
+  exposeOptionIO(soc.noc_clock, "noc_clock")
+  exposeOptionIO(soc.noc_reset, "noc_reset")
+  exposeOptionIO(soc.imsic_axi4lite, "imsic_axi4lite")
+
+  // TODO:
+  // XSDiffTop is only part of DUT, we can not instantiate difftest here.
+  // Temporarily we collect Performance counters for each DiffTop, need control signals passed from Difftest
+  val timer = IO(Input(UInt(64.W)))
+  val logEnable = IO(Input(Bool()))
+  val clean = IO(Input(Bool()))
+  val dump = IO(Input(Bool()))
+  XSLog.collect(timer, logEnable, clean, dump)
+  DifftestWiring.createAndConnectExtraIOs()
+  Profile.generateJson("XiangShan")
+  XSNoCDiffTopChecker()
+}
+
+//TODO:
+//Currently we use two-step XiangShan-Difftest, generating XS(with Diff Interface only) and Difftest seperately
+//To avoid potential interface problem between XS and Diff, we add Checker and CI(dual-core)
+//We will try one-step XS-Diff later
+object XSNoCDiffTopChecker {
+  def apply(): Unit = {
+    val verilog =
+      """
+        |`define CONFIG_XSCORE_NR 2
+        |`include "gateway_interface.svh"
+        |module XSDiffTopChecker(
+        | input                                 cpu_clk,
+        | input                                 cpu_rstn,
+        | input                                 sys_clk,
+        | input                                 sys_rstn
+        |);
+        |wire [63:0] timer;
+        |wire logEnable;
+        |wire clean;
+        |wire dump;
+        |// FIXME: use siganls from Difftest rather than default value
+        |assign timer = 64'b0;
+        |assign logEnable = 1'b0;
+        |assign clean = 1'b0;
+        |assign dump = 1'b0;
+        |gateway_if gateway_if_i();
+        |core_if core_if_o[`CONFIG_XSCORE_NR]();
+        |generate
+        |    genvar i;
+        |    for (i = 0; i < `CONFIG_XSCORE_NR; i = i+1)
+        |    begin: u_CPU_TOP
+        |    // FIXME: add missing ports
+        |    XSDiffTop u_XSTop (
+        |        .clock                   (cpu_clk),
+        |        .noc_clock               (sys_clk),
+        |        .soc_clock               (sys_clk),
+        |        .io_hartId               (6'h0 + i),
+        |        .timer                   (timer),
+        |        .logEnable               (logEnable),
+        |        .clean                   (clean),
+        |        .dump                    (dump),
+        |        .gateway_out             (core_if_o[i])
+        |    );
+        |    end
+        |endgenerate
+        |    CoreToGateway u_CoreToGateway(
+        |    .gateway_out (gateway_if_i.out),
+        |    .core_in (core_if_o)
+        |    );
+        |    GatewayEndpoint u_GatewayEndpoint(
+        |    .clock (sys_clk),
+        |    .reset (sys_rstn),
+        |    .gateway_in (gateway_if_i.in),
+        |    .step ()
+        |    );
+        |
+        |endmodule
+      """.stripMargin
+    FileRegisters.writeOutputFile("./build", "XSDiffTopChecker.sv", verilog)
+  }
 }


### PR DESCRIPTION
build(Makefile): support PLDM_ARGS for make verilog

For PLDM_ARGS, we make it consistent with DEBUG_ARGS by default. User can set PLDM_ARGS in command line to extend it.
Examples as follows:
1. By set PLDM_ARGS="--fpga-platform" and PLDM=1, we will disable
XSLog(including PerfCounters) for both verilog and sim-verilog.
2. By set PLDM_ARGS="--diffest-config ESBINP" and PLDM=1, we can
accelerate Difftest in Palladium through some optimization feature.

-------------------
feat(XSNoCDiffTop): wrap XSNoCTop with Difftest Interface

To apply Difftest framework for CHI NoC, we wrapper lazy XSNoCTop inside XSNoCDiffTop when difftest enabled, and expose necessary soc/core/difftest IOs.

Currently we use two-step flow for CHI-NoC-XS as follow:
Step1. Generate single-core XSNoCDiffTop with JsonProfile, which support generate another DifftestEndpoint seperately.
Step2. Generate n-core Difftest according to JsonProfile
Step3. Connect XS and Difftest manually or by some scripts.

As XSNoCDiffTop is only part of Difftest, we collect PerfCounters for each DiffTop, need control signals passed from Outer module. And to avoid potential connection problem, we add checker module and CI test.

An example usage:
make verilog PLDM=1 PLDM_ARGS=“--difftest-config H” CONFIG=XSNoCDiffTopConfig