### PR TITLE
fix(LQUncache): fix a potential deadblock when enqueue

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -324,11 +324,12 @@ class LoadQueueUncache(implicit p: Parameters) extends XSModule
    *    ready: freelist can allocate
    ******************************************************************/
   
-  val s1_req = VecInit(io.req.map(_.bits))
-  val s1_valid = VecInit(io.req.map(_.valid))
+  val s1_sortedVec = HwSort(VecInit(io.req.map { case x => DataWithPtr(x.valid, x.bits, x.bits.uop.robIdx) }))
+  val s1_req = VecInit(s1_sortedVec.map(_.bits))
+  val s1_valid = VecInit(s1_sortedVec.map(_.valid))
   val s2_enqueue = Wire(Vec(LoadPipelineWidth, Bool()))
   io.req.zipWithIndex.foreach{ case (r, i) =>
-    r.ready := !s2_enqueue(i) || freeList.io.canAllocate(i)
+    r.ready := true.B
   }
 
   // s2: enqueue


### PR DESCRIPTION
**Old design**:
When enqueuing, it is in the order of ldu0-1, i.e. ldu0 is allocated first.

**Bug scene:**
LQUncacheBuffer is small. The enqueue `robIdx` of ldu0-1 is [57, 56, 55], the [57, 56] can enqueue, and [55] can not because buffer is full. 57/56 send the `NC` request after enqueuing. 55 is rollbacked. In principle, 57 and 56 need be flushed. But to ensure the correspondence between requests and responses of uncache, 57 is flushed when getting the uncache response. So when the same sequence [57, 56, 55] is coming, there is still no space to allocate 55, which causes that it is rollbacked again. Then a deadblock emerged.
This bug is triggered after cutting `LoadUncacheBufferSize` from 20 to 4.

**One way to fix**:
When enqueuing, it is in the order of `robIdx`, i.e. the oldest is allocated first.