### PR TITLE
fix(PTW): clear reg after resp to prevent problem

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -444,6 +444,11 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     }
   }
 
+  when (io.resp.fire) {
+    // After io.resp.fire, full_gvpn_reg is no longer valid. 
+    // Clear it to prevent nonsense guest page fault from it.
+    full_gvpn_reg := 0.U
+  }
 
   when (flush) {
     idle := true.B


### PR DESCRIPTION
PTW use reg full_gvpn_reg to generate GPF for out-of-range gpaddr, but this reg is not cleared after PTW response. If the last PTW request got a bad full_gvpn_reg, the gvpn_gpf and guestFault keeps until next PTW request, resulting in the total mess of state machine.

This patch clears full_gvpn_reg at the response of PTW. As PTW could response in two state paths, this patch adds an independent condition to achieve this.