### PR TITLE
fix(VSplit): inactive elements of `UnitStride` are no longer executed

### DIFF
--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -283,9 +283,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
   // for pipeline writeback
   for((pipewb, i) <- io.fromPipeline.zipWithIndex){
     val wbIndex          = pipewb.bits.mBIndex
-    val flowNumOffset    = Mux(pipewb.bits.usSecondInv,
-                               2.U,
-                               PopCount(mergePortMatrix(i)))
+    val flowNumOffset    = PopCount(mergePortMatrix(i))
     val sourceTypeNext   = entries(wbIndex).sourceType | pipewb.bits.sourceType
     val hasExp           = ExceptionNO.selectByFu(pipewb.bits.exceptionVec, fuCfg).asUInt.orR
 


### PR DESCRIPTION
Now, we no longer have `inActive` is `unit-stride` sent to the pipeline.
This will fix some bugs caused by `inActive` not being handled properly in `LSU`.
And will theoretically result in some performance gains.