### PR TITLE
perf(VlMergeBuffer): change `VlMergeBufferSize` to `24`

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -234,7 +234,7 @@ case class XSCoreParameters
   EnsbufferWidth: Int = 2,
   LoadDependencyWidth: Int = 2,
   // ============ VLSU ============
-  VlMergeBufferSize: Int = 16,
+  VlMergeBufferSize: Int = 24,
   VsMergeBufferSize: Int = 16,
   UopWritebackWidth: Int = 2,
   VLUopWritebackWidth: Int = 2,


### PR DESCRIPTION
https://github.com/OpenXiangShan/XiangShan/pull/4103 This `pr` causes the actual number of valid items in the `mergebuffer` to decrease.
This `pr` tries to offset the performance loss by increasing `VlMergeBufferSize`.

---

**However, it may not really be needed, so please consider whether you need to merge this modification.**
