### PR TITLE
fix(csr): update time reg when virtual mode changes

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/Unprivileged.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/Unprivileged.scala
@@ -151,7 +151,9 @@ trait Unprivileged { self: NewCSR with MachineLevel with SupervisorLevel =>
     val stimeTmp  = mHPM.time.bits
     val vstimeTmp = mHPM.time.bits + htimedelta
 
-    when(mHPM.time.valid && !debugModeStopTime) {
+    // Update when rtc clock tick and not dcsr.STOPTIME
+    // or virtual mode changed
+    when(mHPM.time.valid && !debugModeStopTime || this.nextV =/= this.v) {
       reg.time := Mux(v, vstimeTmp, stimeTmp)
     }.otherwise {
       reg := reg
@@ -268,6 +270,7 @@ trait HasMHPMSink { self: CSRModule[_] =>
     val hpmcounters = Vec(perfCntNum, UInt(XLEN.W))
   }))
   val v = IO(Input(Bool()))
+  val nextV = IO(Input(Bool()))
   val htimedelta = IO(Input(UInt(64.W)))
 }
 


### PR DESCRIPTION
* Since we only implement one time register to hold the value of `time`(used in non-virtual mode) and `time + htimedelta`(used in virtual mode), the value should be updated when virtual mode changes.
* Otherwise, when virtual mode changes and rtc clock tick does not assert, the value in `time` register does not match the current virtual mode.