### PR TITLE
feat(commit): complete rewrite of commit mechanism

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -902,7 +902,8 @@ trait HasXSParameter {
   def PrivWidth              = coreParams.traceParams.PrivWidth
   def IaddrWidth             = coreParams.traceParams.IaddrWidth
   def ItypeWidth             = coreParams.traceParams.ItypeWidth
-  def IretireWidthInPipe     = log2Up(RenameWidth * 2)
+  def IretireWidthEncoded    = log2Up((2 + RenameWidth + 1) * RenameWidth / 2) // 2 + 3 + ... + (RenameWidth + 1)
+  def IretireWidthCommited   = log2Up(RenameWidth * 2)
   def IretireWidthCompressed = log2Up(RenameWidth * CommitWidth * 2)
   def IlastsizeWidth         = coreParams.traceParams.IlastsizeWidth
 

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -117,6 +117,7 @@ object Bundles {
     val numWB           = UInt(log2Up(MaxUopSize).W) // rob need this
     val commitType      = CommitType() // Todo: remove it
     val needFrm         = new NeedFrmBundle
+    val lastInFtqEntry  = Bool()
 
     val debug_fuType    = OptionWrapper(backendParams.debugEn, FuType())
 
@@ -195,6 +196,7 @@ object Bundles {
     val blockBackward   = Bool()
     val flushPipe       = Bool() // This inst will flush all the pipe when commit, like exception but can commit
     val canRobCompress  = Bool()
+    val crossFtq        = Bool()
     val selImm          = SelImm()
     val imm             = UInt(32.W)
     val fpu             = new FPUCtrlSignals

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -181,6 +181,7 @@ object Bundles {
     val crossPageIPFFix = Bool()
     val ftqPtr          = new FtqPtr
     val ftqOffset       = UInt(log2Up(PredictWidth).W)
+    val ftqLastOffset   = UInt(log2Up(PredictWidth).W)
     // passed from DecodedInst
     val srcType         = Vec(numSrc, SrcType())
     val ldest           = UInt(LogicRegsWidth.W)
@@ -196,6 +197,7 @@ object Bundles {
     val blockBackward   = Bool()
     val flushPipe       = Bool() // This inst will flush all the pipe when commit, like exception but can commit
     val canRobCompress  = Bool()
+    val crossFtqCommit  = Bool()
     val crossFtq        = Bool()
     val selImm          = SelImm()
     val imm             = UInt(32.W)

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -200,6 +200,7 @@ object Bundles {
     val canRobCompress  = Bool()
     val crossFtqCommit  = UInt(2.W) // use to caculate the ftq idx of ftqentry when commit
     val crossFtq        = Bool() // use to caculate the ftq idx of brh instructions when pass to exu
+    val fusionNum       = UInt(2.W)
     val selImm          = SelImm()
     val imm             = UInt(32.W)
     val fpu             = new FPUCtrlSignals

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -197,8 +197,8 @@ object Bundles {
     val blockBackward   = Bool()
     val flushPipe       = Bool() // This inst will flush all the pipe when commit, like exception but can commit
     val canRobCompress  = Bool()
-    val crossFtqCommit  = Bool()
-    val crossFtq        = Bool()
+    val crossFtqCommit  = UInt(2.W) // use to caculate the ftq idx of ftqentry when commit
+    val crossFtq        = Bool() // use to caculate the ftq idx of brh instructions when pass to exu
     val selImm          = SelImm()
     val imm             = UInt(32.W)
     val fpu             = new FPUCtrlSignals

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -181,7 +181,8 @@ object Bundles {
     val crossPageIPFFix = Bool()
     val ftqPtr          = new FtqPtr
     val ftqOffset       = UInt(log2Up(PredictWidth).W)
-    val ftqLastOffset   = UInt(log2Up(PredictWidth).W)
+    val ftqLastOffset   = UInt(log2Up(PredictWidth).W) // store ftqoffset before channge in rename
+    val stdwriteNeed    = Bool()
     // passed from DecodedInst
     val srcType         = Vec(numSrc, SrcType())
     val ldest           = UInt(LogicRegsWidth.W)

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -224,10 +224,9 @@ object Bundles {
     val useRegCache     = Vec(backendParams.numIntRegSrc, Bool())
     val regCacheIdx     = Vec(backendParams.numIntRegSrc, UInt(RegCacheIdxWidth.W))
     val robIdx          = new RobPtr
-    val instrSize       = UInt(log2Ceil(RenameWidth + 1).W)
     val dirtyFs         = Bool()
     val dirtyVs         = Bool()
-    val traceBlockInPipe = new TracePipe(IretireWidthInPipe)
+    val traceBlockInPipe = new TracePipe(IretireWidthEncoded)
 
     val eliminatedMove  = Bool()
     // Take snapshot at this CFI inst

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -592,15 +592,6 @@ class CtrlBlockImp(
 
     // update the first RenameWidth - 1 instructions
     decode.io.fusion(i) := fusionDecoder.io.out(i).valid && rename.io.out(i).fire
-    // TODO: remove this dirty code for ftq update
-    val sameFtqPtr = rename.io.in(i).bits.ftqPtr.value === rename.io.in(i + 1).bits.ftqPtr.value
-    val ftqOffset0 = rename.io.in(i).bits.ftqOffset
-    val ftqOffset1 = rename.io.in(i + 1).bits.ftqOffset
-    val ftqOffsetDiff = ftqOffset1 - ftqOffset0
-    val cond1 = sameFtqPtr && ftqOffsetDiff === 1.U
-    val cond2 = sameFtqPtr && ftqOffsetDiff === 2.U
-    val cond3 = !sameFtqPtr && ftqOffset1 === 0.U
-    val cond4 = !sameFtqPtr && ftqOffset1 === 1.U
     when (fusionDecoder.io.out(i).valid) {
       fusionDecoder.io.out(i).bits.update(rename.io.in(i).bits)
       fusionDecoder.io.out(i).bits.update(dispatch.io.renameIn(i).bits)
@@ -615,7 +606,6 @@ class CtrlBlockImp(
       rename.io.isFusionVec(i) := true.B
       rename.io.fusionCross2FtqVec(i) := cross2Ftq
     }
-    XSError(fusionDecoder.io.out(i).valid && !cond1 && !cond2 && !cond3 && !cond4, p"new condition $sameFtqPtr $ftqOffset0 $ftqOffset1\n")
   }
 
   // memory dependency predict

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -579,6 +579,9 @@ class CtrlBlockImp(
     rename.io.in(i).bits := decodePipeRename(i).bits
     dispatch.io.renameIn(i).valid := decodePipeRename(i).valid && !fusionDecoder.io.clear(i) && !decodePipeRename(i).bits.isMove
     dispatch.io.renameIn(i).bits := decodePipeRename(i).bits
+    rename.io.validVec(i) := decodePipeRename(i).valid
+    rename.io.isFusionVec(i) := false.B
+    rename.io.fusionCross2FtqVec(i) := false.B
   }
 
   for (i <- 0 until RenameWidth - 1) {
@@ -599,7 +602,14 @@ class CtrlBlockImp(
     when (fusionDecoder.io.out(i).valid) {
       fusionDecoder.io.out(i).bits.update(rename.io.in(i).bits)
       fusionDecoder.io.out(i).bits.update(dispatch.io.renameIn(i).bits)
-      rename.io.in(i).bits.commitType := Mux(cond1, 4.U, Mux(cond2, 5.U, Mux(cond3, 6.U, 7.U)))
+      val cross2Ftq = decodePipeRename(i).bits.lastInFtqEntry && decodePipeRename(i + 1).bits.lastInFtqEntry
+      val cross1Ftq = decodePipeRename(i).bits.lastInFtqEntry || decodePipeRename(i + 1).bits.lastInFtqEntry
+      rename.io.in(i + 1).bits.lastInFtqEntry := cross1Ftq
+      rename.io.in(i + 1).bits.canRobCompress := !cross2Ftq
+      rename.io.in(i).bits.lastInFtqEntry := false.B
+      rename.io.in(i).bits.canRobCompress := !cross2Ftq
+      rename.io.isFusionVec(i) := true.B
+      rename.io.fusionCross2FtqVec(i) := cross2Ftq
     }
     XSError(fusionDecoder.io.out(i).valid && !cond1 && !cond2 && !cond3 && !cond4, p"new condition $sameFtqPtr $ftqOffset0 $ftqOffset1\n")
   }

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -164,15 +164,15 @@ class CtrlBlockImp(
     val canSameRobidxWbData = if(isVfSche) {
       i2vWbData ++ f2vWbData ++ vfScheWbData
     } else if(isi2v) {
-      intScheWbData ++ fpScheWbData ++ vfScheWbData ++ staScheWbData
+      intScheWbData ++ fpScheWbData ++ vfScheWbData
     } else if (isf2v) {
-      intScheWbData ++ fpScheWbData ++ vfScheWbData ++ staScheWbData
+      intScheWbData ++ fpScheWbData ++ vfScheWbData
     } else if (isIntSche) {
-      intScheWbData ++ fpScheWbData ++ staScheWbData
+      intScheWbData ++ fpScheWbData
     } else if (isFpSche) {
-      intScheWbData ++ fpScheWbData ++ staScheWbData
-    } else if (isStaSche) {
-      intScheWbData ++ fpScheWbData ++ staScheWbData
+      intScheWbData ++ fpScheWbData
+//    } else if (isStaSche) {
+//      intScheWbData ++ fpScheWbData ++ staScheWbData
     } else if (isMemVload) {
       memVloadWbData
     } else {
@@ -608,6 +608,8 @@ class CtrlBlockImp(
       val cross1Ftq = decodePipeRename(i).bits.lastInFtqEntry || decodePipeRename(i + 1).bits.lastInFtqEntry
       rename.io.in(i + 1).bits.lastInFtqEntry := cross1Ftq
       rename.io.in(i + 1).bits.canRobCompress := !cross2Ftq
+      // if second instruciton of fusion is move and it can also be fusion, it will not act as a move
+      rename.io.in(i + 1).bits.isMove := false.B
       rename.io.in(i).bits.lastInFtqEntry := false.B
       rename.io.in(i).bits.canRobCompress := !cross2Ftq
       rename.io.isFusionVec(i) := true.B

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -145,7 +145,7 @@ class CtrlBlockImp(
   val intScheWbData = io.fromWB.wbData.filter(_.bits.params.schdType.isInstanceOf[IntScheduler])
   val fpScheWbData = io.fromWB.wbData.filter(_.bits.params.schdType.isInstanceOf[FpScheduler])
   val vfScheWbData = io.fromWB.wbData.filter(_.bits.params.schdType.isInstanceOf[VfScheduler])
-  val intCanCompress = intScheWbData.filter(_.bits.params.CanCompress)
+  val staScheWbData = io.fromWB.wbData.filter(_.bits.params.hasStoreAddrFu)
   val i2vWbData = intScheWbData.filter(_.bits.params.writeVecRf)
   val f2vWbData = fpScheWbData.filter(_.bits.params.writeVecRf)
   val memVloadWbData = io.fromWB.wbData.filter(x => x.bits.params.schdType.isInstanceOf[MemScheduler] && x.bits.params.hasVLoadFu)
@@ -154,22 +154,23 @@ class CtrlBlockImp(
     val killedByOlder = x.bits.robIdx.needFlush(Seq(s1_s3_redirect, s2_s4_redirect, s3_s5_redirect))
     val delayed = Wire(Valid(UInt(io.fromWB.wbData.size.U.getWidth.W)))
     delayed.valid := GatedValidRegNext(valid && !killedByOlder)
-    val isIntSche = intCanCompress.contains(x)
+    val isIntSche = intScheWbData.contains(x)
     val isFpSche = fpScheWbData.contains(x)
     val isVfSche = vfScheWbData.contains(x)
     val isMemVload = memVloadWbData.contains(x)
     val isi2v = i2vWbData.contains(x)
     val isf2v = f2vWbData.contains(x)
+    val isStaSche = staScheWbData.contains(x)
     val canSameRobidxWbData = if(isVfSche) {
       i2vWbData ++ f2vWbData ++ vfScheWbData
     } else if(isi2v) {
-      intCanCompress ++ fpScheWbData ++ vfScheWbData
+      intScheWbData ++ fpScheWbData ++ vfScheWbData ++ staScheWbData
     } else if (isf2v) {
-      intCanCompress ++ fpScheWbData ++ vfScheWbData
+      intScheWbData ++ fpScheWbData ++ vfScheWbData ++ staScheWbData
     } else if (isIntSche) {
-      intCanCompress ++ fpScheWbData
+      intScheWbData ++ fpScheWbData ++ staScheWbData
     } else if (isFpSche) {
-      intCanCompress ++ fpScheWbData
+      intScheWbData ++ fpScheWbData ++ staScheWbData
     }  else if (isMemVload) {
       memVloadWbData
     } else {

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -171,7 +171,9 @@ class CtrlBlockImp(
       intScheWbData ++ fpScheWbData ++ staScheWbData
     } else if (isFpSche) {
       intScheWbData ++ fpScheWbData ++ staScheWbData
-    }  else if (isMemVload) {
+    } else if (isStaSche) {
+      intScheWbData ++ fpScheWbData ++ staScheWbData
+    } else if (isMemVload) {
       memVloadWbData
     } else {
       Seq(x)

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -832,6 +832,7 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
 
   decodedInst.connectStaticInst(io.enq.ctrlFlow)
 
+  decodedInst.lastInFtqEntry := ctrl_flow.isLastInFtqEntry
   decodedInst.uopIdx := 0.U
   decodedInst.firstUop := true.B
   decodedInst.lastUop := true.B

--- a/src/main/scala/xiangshan/backend/fu/FuType.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuType.scala
@@ -134,6 +134,7 @@ object FuType extends OHEnumeration {
   val fpOP = fpArithAll ++ Seq(i2f, i2v)
   val scalaNeedFrm = Seq(i2f, fmac, fDivSqrt)
   val vectorNeedFrm = Seq(vfalu, vfma, vfdiv, vfcvt)
+  val blockBackCompress = Seq(brh, jmp, stu)
 
   def X = BitPat.N(num) // Todo: Don't Care
 
@@ -210,6 +211,8 @@ object FuType extends OHEnumeration {
   def isScalaNeedFrm(fuType: UInt): Bool = FuTypeOrR(fuType, scalaNeedFrm)
 
   def isVectorNeedFrm(fuType: UInt): Bool = FuTypeOrR(fuType, vectorNeedFrm)
+
+  def isBlockBackCompress(fuType: UInt): Bool = FuTypeOrR(fuType, blockBackCompress)
 
   object FuTypeOrR {
     def apply(fuType: UInt, fu0: OHType, fus: OHType*): Bool = {

--- a/src/main/scala/xiangshan/backend/fu/FuType.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuType.scala
@@ -134,7 +134,7 @@ object FuType extends OHEnumeration {
   val fpOP = fpArithAll ++ Seq(i2f, i2v)
   val scalaNeedFrm = Seq(i2f, fmac, fDivSqrt)
   val vectorNeedFrm = Seq(vfalu, vfma, vfdiv, vfcvt)
-  val blockBackCompress = Seq(brh, jmp, stu)
+  val blockBackCompress = Seq(brh, jmp)
 
   def X = BitPat.N(num) // Todo: Don't Care
 

--- a/src/main/scala/xiangshan/backend/rename/CompressUnit.scala
+++ b/src/main/scala/xiangshan/backend/rename/CompressUnit.scala
@@ -34,6 +34,7 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.rocket.DecodeLogic
 import xiangshan._
+import xiangshan.backend.fu.FuType
 
 class CompressUnit(implicit p: Parameters) extends XSModule{
   val io = IO(new Bundle {
@@ -49,28 +50,43 @@ class CompressUnit(implicit p: Parameters) extends XSModule{
 
   val noExc = io.in.map(in => !in.bits.exceptionVec.asUInt.orR && !TriggerAction.isDmode(in.bits.trigger))
   val uopCanCompress = io.in.map(_.bits.canRobCompress)
-  val canCompress = io.in.zip(noExc).zip(uopCanCompress).zip(io.oddFtqVec)map { case (((in, noExc), canComp), oddFtq) =>
-    in.valid && !CommitType.isFused(in.bits.commitType) && in.bits.lastUop && noExc && canComp && oddFtq
+  val canCompress = io.in.zip(noExc).zip(uopCanCompress).map { case ((in, noExc), canComp) =>
+    in.valid && !CommitType.isFused(in.bits.commitType) && in.bits.lastUop && noExc && canComp
+  }
+  val extendedCanCompress = canCompress.zip(io.in).zip(io.oddFtqVec).flatMap { case ((canComp, in), oddFtq) =>
+    Seq(FuType.isBlockBackCompress(in.bits.fuType) || canComp ,canComp && !oddFtq)
   }
 
-  val compressTable = (0 until 1 << RenameWidth).map { case keyCandidate =>
+  val compressTable = (0 until 1 << (2 * RenameWidth)).filter { baseCandidate =>
+    // check exist 01 pair
+    !(0 until RenameWidth).exists { i =>
+      val bitPair = (baseCandidate >> (2 * i)) & 0x3
+      bitPair == 0x2
+    }
+  }.zipWithIndex.map{ case (keyCandidate, index) =>
     // padding 0s at each side for convenience
-    val key = 0 +: (0 until RenameWidth).map(idx => (keyCandidate >> idx) & 1) :+ 0
+    val key = 0 +: (0 until RenameWidth * 2).map(idx => (keyCandidate >> idx) & 1) :+ 0
     // count 1s on the left side of key (including itself)
     def cntL(idx: Int): Int = (if (key(idx - 1) == 1) cntL(idx - 1) else 0) + key(idx)
     // count 1s on the right side of key (including itself)
     def cntR(idx: Int): Int = (if (key(idx + 1) == 1) cntR(idx + 1) else 0) + key(idx)
     // the last instruction among consecutive rob-compressed instructions is marked
-    val needRobs = (0 until RenameWidth).map(idx => ~(key.tail(idx) & key.tail(idx + 1)) & 1)
+    val needRobsExpand = (0 until RenameWidth * 2).map( idx => ~(key.tail(idx) & key.tail(idx + 1)) & 1)
+    val needRobs = needRobsExpand.grouped(2).map(group => group.reduce(_ | _)).toIndexedSeq
     // how many instructions are rob-compressed with this instruction (including itself)
-    val uopSizes = (1 to RenameWidth).map(idx => if (key(idx) == 0) 1 else cntL(idx) + cntR(idx) - 1)
+    val uopSizes = (1 to RenameWidth).map{ idx =>
+      val i = idx * 2 - 1
+      if (key(i) == 0) 1 else (cntL(i) + cntR(i)) / 2
+    }
     // which instructions are rob-compressed with this instruction
     val masks = uopSizes.zip(1 to RenameWidth).map { case (size, idx) => // compress masks
-      if (key(idx) == 0) Seq.fill(RenameWidth)(0).updated(idx - 1, 1)
-      else Seq.fill(RenameWidth)(0).patch(idx - cntL(idx), Seq.fill(size)(1), size)
+      val i = idx * 2 - 1
+      if (key(i) == 0) Seq.fill(RenameWidth)(0).updated(idx - 1, 1)
+      else Seq.fill(RenameWidth)(0).patch(idx - (cntL(i) + 1)/2, Seq.fill(size)(1), size)
     }
 
     println("[Rename.Compress]" +
+      " index: "    + index +
       " i: "        + keyCandidate +
       " key: "      + key.tail.dropRight(1) +
       " needRobs: " + needRobs +
@@ -87,7 +103,7 @@ class CompressUnit(implicit p: Parameters) extends XSModule{
   }
 
   val default = Seq.fill(3 * RenameWidth)(BitPat.N())
-  val decoder = DecodeLogic(VecInit(canCompress).asUInt, default, compressTable)
+  val decoder = DecodeLogic(VecInit(extendedCanCompress).asUInt, default, compressTable)
   (io.out.needRobFlags ++ io.out.instrSizes ++ io.out.masks).zip(decoder).foreach {
     case (sink, source) => sink := source
   }

--- a/src/main/scala/xiangshan/backend/rename/CompressUnit.scala
+++ b/src/main/scala/xiangshan/backend/rename/CompressUnit.scala
@@ -51,7 +51,7 @@ class CompressUnit(implicit p: Parameters) extends XSModule{
   val noExc = io.in.map(in => !in.bits.exceptionVec.asUInt.orR && !TriggerAction.isDmode(in.bits.trigger))
   val uopCanCompress = io.in.map(_.bits.canRobCompress)
   val canCompress = io.in.zip(noExc).zip(uopCanCompress).map { case ((in, noExc), canComp) =>
-    in.valid && !CommitType.isFused(in.bits.commitType) && in.bits.lastUop && noExc && canComp
+    in.valid && in.bits.lastUop && noExc && canComp
   }
   val extendedCanCompress = canCompress.zip(io.in).zip(io.oddFtqVec).flatMap { case ((canComp, in), oddFtq) =>
     Seq(FuType.isBlockBackCompress(in.bits.fuType) || canComp ,canComp && !oddFtq)

--- a/src/main/scala/xiangshan/backend/rename/CompressUnit.scala
+++ b/src/main/scala/xiangshan/backend/rename/CompressUnit.scala
@@ -54,7 +54,7 @@ class CompressUnit(implicit p: Parameters) extends XSModule{
     in.valid && in.bits.lastUop && noExc && canComp
   }
   val extendedCanCompress = canCompress.zip(io.in).zip(io.oddFtqVec).flatMap { case ((canComp, in), oddFtq) =>
-    Seq(FuType.isBlockBackCompress(in.bits.fuType) || canComp ,canComp && !oddFtq)
+    Seq((FuType.isBlockBackCompress(in.bits.fuType) && in.valid ) || canComp ,canComp && !oddFtq)
   }
 
   val compressTable = (0 until 1 << (2 * RenameWidth)).filter { baseCandidate =>

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -333,7 +333,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     uops(i).replayInst := false.B // set by IQ or MemQ
     uops(i).crossFtq := false.B
     uops(i).crossFtqCommit := false.B
-    uops(i).ftqLastOffset := uops(i).ftqOffset
+    uops(i).ftqLastOffset := io.in(i).bits.ftqOffset
     // alloc a new phy reg
     needV0Dest(i) := io.in(i).valid && needDestReg(Reg_V0, io.in(i).bits)
     needVlDest(i) := io.in(i).valid && needDestReg(Reg_Vl, io.in(i).bits)
@@ -389,7 +389,6 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
       if (i < RenameWidth - 1) {
         uops(i).crossFtqCommit := uops(i + 1).crossFtqCommit
         uops(i).crossFtq := uops(i + 1).crossFtq
-        uops(i).ftqLastOffset := uops(i + 1).ftqLastOffset
       }
     }.elsewhen(needRobFlags(i)) {
       uops(i).crossFtqCommit := PopCount(compressMasksVec(i) & Cat(isLastFtqVec.reverse))(1)

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -172,7 +172,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   val crossFtqNumVec = Wire(Vec(RenameWidth, Bool()))
   // identify cross odd ftqentry
   val oddFtqVec = Wire(Vec(RenameWidth, Bool()))
-  val fusionValidVec = isFusionVec.zip(io.fusionCross2FtqVec).map { case (isFusion, cross2Ftq) => isFusion & cross2Ftq }
+  val fusionValidVec = isFusionVec.zip(io.fusionCross2FtqVec).map { case (isFusion, cross2Ftq) => isFusion & !cross2Ftq }
     for (i <- 0 until RenameWidth) {
     if (i == 0) {
       crossFtqNumVec(i) := canRobCompressVec(i) && isLastFtqVec(i)

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -161,10 +161,28 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   //           dispatch1 ready ++ float point free list ready ++ int free list ready ++ vec free list ready     ++ not walk
   val canOut = dispatchCanAcc && fpFreeList.io.canAllocate && intFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !io.rabCommits.isWalk
 
+  val isLastFtqVec = io.in.map(_.bits.lastInFtqEntry)
+  val canRobCompressVec = io.in.map(_.bits.canRobCompress)
+  // count crossftq num in may same robentry
+  val crossFtqNumVec = Wire(Vec(RenameWidth, Bool()))
+  // identify cross odd ftqentry
+  val oddFtqVec = Wire(Vec(RenameWidth, Bool()))
+  for (i <- 0 until RenameWidth) {
+    if (i == 0) {
+      crossFtqNumVec(i) := canRobCompressVec(i) && isLastFtqVec(i)
+      oddFtqVec(i) := false.B
+    } else {
+      crossFtqNumVec(i) := (crossFtqNumVec(i - 1) ^ isLastFtqVec(i)) && canRobCompressVec(i)
+      oddFtqVec(i) := crossFtqNumVec(i - 1) && isLastFtqVec(i)
+    }
+  }
+  dontTouch(crossFtqNumVec)
+  dontTouch(oddFtqVec)
   compressUnit.io.in.zip(io.in).foreach{ case(sink, source) =>
     sink.valid := source.valid && !io.singleStep
     sink.bits := source.bits
   }
+  compressUnit.io.oddFtqVec := oddFtqVec
   val needRobFlags = compressUnit.io.out.needRobFlags
   val instrSizesVec = compressUnit.io.out.instrSizes
   val compressMasksVec = compressUnit.io.out.masks
@@ -307,6 +325,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     uops(i).loadWaitBit := io.waittable(i)
 
     uops(i).replayInst := false.B // set by IQ or MemQ
+    uops(i).crossFtq := false.B
     // alloc a new phy reg
     needV0Dest(i) := io.in(i).valid && needDestReg(Reg_V0, io.in(i).bits)
     needVlDest(i) := io.in(i).valid && needDestReg(Reg_Vl, io.in(i).bits)
@@ -355,6 +374,11 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
       uops(i).lastUop := false.B
       uops(i).numUops := instrSizesVec(i) - PopCount(compressMasksVec(i) & Cat(isMove.reverse))
       uops(i).numWB := instrSizesVec(i) - PopCount(compressMasksVec(i) & Cat(isMove.reverse))
+      if (i < RenameWidth - 1) {
+        uops(i).crossFtq := uops(i + 1).crossFtq
+      }
+    }.elsewhen(needRobFlags(i)) {
+      uops(i).crossFtq := PopCount(compressMasksVec(i) & Cat(isLastFtqVec.reverse))(1)
     }
     uops(i).wfflags := (compressMasksVec(i) & Cat(io.in.map(_.bits.wfflags).reverse)).orR
     uops(i).dirtyFs := (compressMasksVec(i) & Cat(io.in.map(_.bits.fpWen).reverse)).orR

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -368,6 +368,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
 
     uops(i).robIdx := robIdxHead + PopCount(io.in.zip(needRobFlags).zip(io.validVec).take(i).map{ case((in, needRobFlag), valid) => valid && in.bits.lastUop && needRobFlag})
     instrSize(i) := instrSizesVec(i) + io.fusionCross2FtqVec(i)
+    uops(i).fusionNum := PopCount(compressMasksVec(i) & Cat(io.isFusionVec.reverse))
     val hasExceptionExceptFlushPipe = Cat(selectFrontend(uops(i).exceptionVec) :+ uops(i).exceptionVec(illegalInstr) :+ uops(i).exceptionVec(virtualInstr)).orR || TriggerAction.isDmode(uops(i).trigger)
     when(isMove(i) || hasExceptionExceptFlushPipe) {
       uops(i).numUops := 0.U

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -326,6 +326,8 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
 
     uops(i).replayInst := false.B // set by IQ or MemQ
     uops(i).crossFtq := false.B
+    uops(i).crossFtqCommit := false.B
+    uops(i).ftqLastOffset := uops(i).ftqOffset
     // alloc a new phy reg
     needV0Dest(i) := io.in(i).valid && needDestReg(Reg_V0, io.in(i).bits)
     needVlDest(i) := io.in(i).valid && needDestReg(Reg_Vl, io.in(i).bits)
@@ -375,10 +377,13 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
       uops(i).numUops := instrSizesVec(i) - PopCount(compressMasksVec(i) & Cat(isMove.reverse))
       uops(i).numWB := instrSizesVec(i) - PopCount(compressMasksVec(i) & Cat(isMove.reverse))
       if (i < RenameWidth - 1) {
+        uops(i).crossFtqCommit := uops(i + 1).crossFtqCommit
         uops(i).crossFtq := uops(i + 1).crossFtq
+        uops(i).ftqLastOffset := uops(i + 1).ftqLastOffset
       }
     }.elsewhen(needRobFlags(i)) {
-      uops(i).crossFtq := PopCount(compressMasksVec(i) & Cat(isLastFtqVec.reverse))(1)
+      uops(i).crossFtqCommit := PopCount(compressMasksVec(i) & Cat(isLastFtqVec.reverse))(1)
+      uops(i).crossFtq := uops(i).crossFtqCommit || ((compressMasksVec(i) & Cat(isLastFtqVec.reverse)).orR && !isLastFtqVec(i))
     }
     uops(i).wfflags := (compressMasksVec(i) & Cat(io.in.map(_.bits.wfflags).reverse)).orR
     uops(i).dirtyFs := (compressMasksVec(i) & Cat(io.in.map(_.bits.fpWen).reverse)).orR
@@ -492,23 +497,17 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
 
   for (i <- 0 until RenameWidth) {
     // iretire
-    uops(i).traceBlockInPipe.iretire := Mux(canRobCompressVec(i),
-      halfWordNumMatrix(i).reduce(_ +& _),
-      (if(i < RenameWidth -1) Mux(isFusionVec(i), halfWordNumVec(i+1), 0.U) else 0.U) +& halfWordNumVec(i)
-    )
+    uops(i).traceBlockInPipe.iretire := halfWordNumVec(i).reduce(_ +& _)
 
     // ilastsize
-    val tmp = i
-    val lastIsRVC = WireInit(false.B)
-    (tmp until RenameWidth).map { j =>
-      when(compressMasksVec(i)(j)) {
-        lastIsRVC := io.in(j).bits.preDecodeInfo.isRVC
+    val lastIsRVC = isRVCVec(i) && needRobFlags(i)
+    when (!needRobFlags(i)) {
+      if (i + 1 < RenameWidth) {
+        uops(i).traceBlockInPipe.ilastsize := uops(i + 1).traceBlockInPipe.ilastsize
       }
+    }.elsewhen(needRobFlags(i)) {
+      uops(i).traceBlockInPipe.ilastsize := Mux(lastIsRVC, Ilastsize.HalfWord, Ilastsize.Word)
     }
-    uops(i).traceBlockInPipe.ilastsize := Mux(canRobCompressVec(i),
-      Mux(lastIsRVC, Ilastsize.HalfWord, Ilastsize.Word),
-      (if(i < RenameWidth -1) Mux(isFusionVec(i), iLastSizeVec(i+1), iLastSizeVec(i)) else iLastSizeVec(i))
-    )
 
     // itype
     uops(i).traceBlockInPipe.itype := Itype.jumpTypeGen(inVec(i).preDecodeInfo.brType, inVec(i).ldest.asTypeOf(new OpRegType), inVec(i).lsrc(0).asTypeOf((new OpRegType)))

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -53,6 +53,10 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     val singleStep = Input(Bool())
     // from decode
     val in = Vec(RenameWidth, Flipped(DecoupledIO(new DecodedInst)))
+    // valid vec not clear by fusion(used by compress)
+    val validVec = Vec(RenameWidth, Input(Bool()))
+    val isFusionVec = Vec(RenameWidth, Input(Bool()))
+    val fusionCross2FtqVec = Vec(RenameWidth, Input(Bool()))
     val fusionInfo = Vec(DecodeWidth - 1, Flipped(new FusionDecodeInfo))
     // ssit read result
     val ssit = Flipped(Vec(RenameWidth, Output(new SSITEntry)))
@@ -162,12 +166,14 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   val canOut = dispatchCanAcc && fpFreeList.io.canAllocate && intFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !io.rabCommits.isWalk
 
   val isLastFtqVec = io.in.map(_.bits.lastInFtqEntry)
+  val isFusionVec = io.isFusionVec
   val canRobCompressVec = io.in.map(_.bits.canRobCompress)
   // count crossftq num in may same robentry
   val crossFtqNumVec = Wire(Vec(RenameWidth, Bool()))
   // identify cross odd ftqentry
   val oddFtqVec = Wire(Vec(RenameWidth, Bool()))
-  for (i <- 0 until RenameWidth) {
+  val fusionValidVec = isFusionVec.zip(io.fusionCross2FtqVec).map { case (isFusion, cross2Ftq) => isFusion & cross2Ftq }
+    for (i <- 0 until RenameWidth) {
     if (i == 0) {
       crossFtqNumVec(i) := canRobCompressVec(i) && isLastFtqVec(i)
       oddFtqVec(i) := false.B
@@ -178,8 +184,8 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   }
   dontTouch(crossFtqNumVec)
   dontTouch(oddFtqVec)
-  compressUnit.io.in.zip(io.in).foreach{ case(sink, source) =>
-    sink.valid := source.valid && !io.singleStep
+  compressUnit.io.in.zip(io.in).zip(io.validVec).foreach{ case((sink, source), valid) =>
+    sink.valid := valid && !io.singleStep
     sink.bits := source.bits
   }
   compressUnit.io.oddFtqVec := oddFtqVec
@@ -188,7 +194,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   val compressMasksVec = compressUnit.io.out.masks
 
   // speculatively assign the instruction with an robIdx
-  val validCount = PopCount(io.in.zip(needRobFlags).map{ case(in, needRobFlag) => in.valid && in.bits.lastUop && needRobFlag}) // number of instructions waiting to enter rob (from decode)
+  val validCount = PopCount(io.in.zip(needRobFlags).zip(io.validVec).map{ case((in, needRobFlag), valid) => valid && in.bits.lastUop && needRobFlag}) // number of instructions waiting to enter rob (from decode)
   val robIdxHead = RegInit(0.U.asTypeOf(new RobPtr))
   val lastCycleMisprediction = GatedValidRegNext(io.redirect.valid && !io.redirect.bits.flushItself())
   val robIdxHeadNext = Mux(io.redirect.valid, io.redirect.bits.robIdx, // redirect: move ptr to given rob index
@@ -356,8 +362,8 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     // no valid instruction from decode stage || all resources (dispatch1 + both free lists) ready
     io.in(i).ready := !io.in(0).valid || canOut
 
-    uops(i).robIdx := robIdxHead + PopCount(io.in.zip(needRobFlags).take(i).map{ case(in, needRobFlag) => in.valid && in.bits.lastUop && needRobFlag})
-    uops(i).instrSize := instrSizesVec(i)
+    uops(i).robIdx := robIdxHead + PopCount(io.in.zip(needRobFlags).zip(io.validVec).take(i).map{ case((in, needRobFlag), valid) => valid && in.bits.lastUop && needRobFlag})
+    uops(i).instrSize := instrSizesVec(i) + io.fusionCross2FtqVec(i)
     val hasExceptionExceptFlushPipe = Cat(selectFrontend(uops(i).exceptionVec) :+ uops(i).exceptionVec(illegalInstr) :+ uops(i).exceptionVec(virtualInstr)).orR || TriggerAction.isDmode(uops(i).trigger)
     when(isMove(i) || hasExceptionExceptFlushPipe) {
       uops(i).numUops := 0.U
@@ -365,17 +371,21 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     }
     if (i > 0) {
       when(!needRobFlags(i - 1)) {
+        val numFusion = PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(fusionValidVec.reverse)))
+        val numuops = instrSizesVec(i) - numFusion
+        dontTouch(numFusion)
+        dontTouch(numuops)
         uops(i).firstUop := false.B
         uops(i).ftqPtr := uops(i - 1).ftqPtr
         uops(i).ftqOffset := uops(i - 1).ftqOffset
-        uops(i).numUops := instrSizesVec(i) - PopCount(compressMasksVec(i) & Cat(isMove.reverse))
-        uops(i).numWB := instrSizesVec(i) - PopCount(compressMasksVec(i) & Cat(isMove.reverse))
+        uops(i).numUops := instrSizesVec(i) - PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(fusionValidVec.reverse)))
+        uops(i).numWB := instrSizesVec(i) - PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(fusionValidVec.reverse)))
       }
     }
     when(!needRobFlags(i)) {
       uops(i).lastUop := false.B
-      uops(i).numUops := instrSizesVec(i) - PopCount(compressMasksVec(i) & Cat(isMove.reverse))
-      uops(i).numWB := instrSizesVec(i) - PopCount(compressMasksVec(i) & Cat(isMove.reverse))
+      uops(i).numUops := instrSizesVec(i) - PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(fusionValidVec.reverse)))
+      uops(i).numWB := instrSizesVec(i) - PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(fusionValidVec.reverse)))
       if (i < RenameWidth - 1) {
         uops(i).crossFtqCommit := uops(i + 1).crossFtqCommit
         uops(i).crossFtq := uops(i + 1).crossFtq
@@ -384,6 +394,11 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     }.elsewhen(needRobFlags(i)) {
       uops(i).crossFtqCommit := PopCount(compressMasksVec(i) & Cat(isLastFtqVec.reverse))(1)
       uops(i).crossFtq := uops(i).crossFtqCommit || ((compressMasksVec(i) & Cat(isLastFtqVec.reverse)).orR && !isLastFtqVec(i))
+    }
+    if (i < RenameWidth - 1){
+      when(!needRobFlags(i)) {
+        uops(i).commitType := uops(i + 1).commitType
+      }
     }
     uops(i).wfflags := (compressMasksVec(i) & Cat(io.in.map(_.bits.wfflags).reverse)).orR
     uops(i).dirtyFs := (compressMasksVec(i) & Cat(io.in.map(_.bits.fpWen).reverse)).orR
@@ -484,33 +499,27 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   // note: fusionInst can't robcompress
   val inVec = io.in.map(_.bits)
   val isRVCVec = inVec.map(_.preDecodeInfo.isRVC)
-  val isFusionVec = inVec.map(_.commitType).map(ctype => CommitType.isFused(ctype))
-
-  val canRobCompressVec = compressUnit.io.out.canCompressVec
-  val iLastSizeVec = isRVCVec.map(isRVC => Mux(isRVC, Ilastsize.HalfWord, Ilastsize.Word))
-  val halfWordNumVec = isRVCVec.map(isRVC => Mux(isRVC, 1.U, 2.U))
-  val halfWordNumMatrix = (0 until RenameWidth).map(
-    i => compressMasksVec(i).asBools.zipWithIndex.map{ case(mask, j) =>
-      Mux(mask, halfWordNumVec(j), 0.U)
+  val halfWordNumVec = (0 until RenameWidth).map{
+    i => compressMasksVec(i).asBools.zip(isRVCVec).map{
+      case (mask, isRVC) => Mux(mask, Mux(isRVC, 1.U, 2.U), 0.U)
     }
-  )
+  }
 
   for (i <- 0 until RenameWidth) {
     // iretire
     uops(i).traceBlockInPipe.iretire := halfWordNumVec(i).reduce(_ +& _)
 
     // ilastsize
-    val lastIsRVC = isRVCVec(i) && needRobFlags(i)
+    val lastIsRVC = isRVCVec(i)
     when (!needRobFlags(i)) {
       if (i + 1 < RenameWidth) {
         uops(i).traceBlockInPipe.ilastsize := uops(i + 1).traceBlockInPipe.ilastsize
+        uops(i).traceBlockInPipe.itype := uops(i + 1).traceBlockInPipe.itype
       }
     }.elsewhen(needRobFlags(i)) {
       uops(i).traceBlockInPipe.ilastsize := Mux(lastIsRVC, Ilastsize.HalfWord, Ilastsize.Word)
+      uops(i).traceBlockInPipe.itype := Itype.jumpTypeGen(inVec(i).preDecodeInfo.brType, inVec(i).ldest.asTypeOf(new OpRegType), inVec(i).lsrc(0).asTypeOf((new OpRegType)))
     }
-
-    // itype
-    uops(i).traceBlockInPipe.itype := Itype.jumpTypeGen(inVec(i).preDecodeInfo.brType, inVec(i).ldest.asTypeOf(new OpRegType), inVec(i).lsrc(0).asTypeOf((new OpRegType)))
   }
   /**
    * trace end
@@ -616,6 +625,9 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     dontTouch(robIdxHeadNext)
     dontTouch(notInSameSnpt)
     dontTouch(genSnapshot)
+    fusionValidVec.foreach{ fusionValid =>
+      dontTouch(fusionValid)
+    }
   }
   intFreeList.io.snpt := io.snpt
   fpFreeList.io.snpt := io.snpt

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -332,7 +332,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
 
     uops(i).replayInst := false.B // set by IQ or MemQ
     uops(i).crossFtq := false.B
-    uops(i).crossFtqCommit := false.B
+    uops(i).crossFtqCommit := 0.U
     uops(i).ftqLastOffset := io.in(i).bits.ftqOffset
     // alloc a new phy reg
     needV0Dest(i) := io.in(i).valid && needDestReg(Reg_V0, io.in(i).bits)
@@ -391,8 +391,8 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
         uops(i).crossFtq := uops(i + 1).crossFtq
       }
     }.elsewhen(needRobFlags(i)) {
-      uops(i).crossFtqCommit := PopCount(compressMasksVec(i) & Cat(isLastFtqVec.reverse))(1)
-      uops(i).crossFtq := uops(i).crossFtqCommit || ((compressMasksVec(i) & Cat(isLastFtqVec.reverse)).orR && !isLastFtqVec(i))
+      uops(i).crossFtqCommit := PopCount(compressMasksVec(i) & Cat(isLastFtqVec.reverse))
+      uops(i).crossFtq := uops(i).crossFtqCommit(1) || (uops(i).crossFtqCommit(0) && !isLastFtqVec(i))
     }
     if (i < RenameWidth - 1){
       when(!needRobFlags(i)) {

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -974,10 +974,8 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val enqRobIdxSeq = io.enq.req.map(req => req.bits.robIdx.value)
   val enqUopNumVec = VecInit(io.enq.req.map(req => req.bits.numUops))
   val enqWBNumVec = VecInit(io.enq.req.map(req => req.bits.numWB))
+  private val enqWriteStdVec = VecInit(io.enq.req.map(req => req.bits.stdwriteNeed))
 
-  private val enqWriteStdVec: Vec[Bool] = VecInit(io.enq.req.map {
-    req => FuType.isStore(req.bits.fuType)
-  })
   val fflags_wb = fflagsWBs
   val vxsat_wb = vxsatWBs
   for (i <- 0 until RobSize) {

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -254,7 +254,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   // Instructions in multiple Ftq entries compressed to one RobEntry do not occur.
   for (i <- 0 until CommitWidth) {
     commitInfo(i).ftqOffset := 0.U
-    commitInfo(i).ftqIdx := rawInfo(i).ftqIdx + rawInfo(i).crossFtq
+    commitInfo(i).ftqIdx := rawInfo(i).ftqIdx + rawInfo(i).crossFtqCommit
   }
 
   // data for debug

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1218,7 +1218,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val isCommitReg = GatedValidRegNext(io.commits.isCommit)
   val instrCntReg = RegInit(0.U(64.W))
   val fuseCommitCnt = PopCount(io.commits.commitValid.zip(io.commits.info).map { case (v, i) => RegEnable(v && CommitType.isFused(i.commitType), isCommit) })
-  val trueCommitCnt = RegEnable(io.commits.commitValid.zip(io.commits.info).map { case (v, i) => Mux(v, i.instrSize, 0.U) }.reduce(_ +& _), isCommit) +& fuseCommitCnt
+  val trueCommitCnt = RegEnable(io.commits.commitValid.zip(io.commits.info).map { case (v, i) => Mux(v, i.instrSize, 0.U) }.reduce(_ +& _), isCommit)
   val retireCounter = Mux(isCommitReg, trueCommitCnt, 0.U)
   val instrCnt = instrCntReg + retireCounter
   when(isCommitReg){
@@ -1518,9 +1518,9 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       difftest.wpdest := commitInfo.debug_pdest.get
       difftest.wdest := Mux(isVLoad, instr.VD, commitInfo.debug_ldest.get)
       difftest.otherwpdest := debug_VecOtherPdest(ptr)
-      difftest.nFused := CommitType.isFused(commitInfo.commitType).asUInt + commitInfo.instrSize - 1.U
+      difftest.nFused := commitInfo.instrSize - 1.U
       when(difftest.valid) {
-        assert(CommitType.isFused(commitInfo.commitType).asUInt + commitInfo.instrSize >= 1.U)
+        assert(commitInfo.instrSize >= 1.U)
       }
       if (env.EnableDifftest) {
         val uop = commitDebugUop(i)

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -48,6 +48,7 @@ import yunsuan.VfaluType
 import xiangshan.backend.rob.RobBundles._
 import xiangshan.backend.trace._
 import chisel3.experimental.BundleLiterals._
+import chisel3.util.experimental.decode.TruthTable
 
 class Rob(params: BackendParams)(implicit p: Parameters) extends LazyModule with HasXSParameter {
   override def shouldBeInlined: Boolean = false
@@ -76,7 +77,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     val commits = Output(new RobCommitIO)
     val trace = new Bundle {
       val blockCommit = Input(Bool())
-      val traceCommitInfo = new TraceBundle(hasIaddr = false, CommitWidth, IretireWidthInPipe)
+      val traceCommitInfo = new TraceBundle(hasIaddr = false, CommitWidth, IretireWidthCommited)
     }
     val rabCommits = Output(new RabCommitIO)
     val diffCommits = if (backendParams.basicDebugEn) Some(Output(new DiffCommitIO)) else None
@@ -248,10 +249,39 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     }
   }
 
-  // In each robentry, the ftqIdx and ftqOffset belong to the first instruction that was compressed,
-  // That is Necessary when exceptions happen.
-  // Update the ftqOffset to correctly notify the frontend which instructions have been committed.
-  // Instructions in multiple Ftq entries compressed to one RobEntry do not occur.
+  /*
+    decode iretireEncoded => iretires, instrSize
+    (instrNum((log2Ceil(RenameWidth + 1)).W), iretire(IretireWidthInPipe.W), encode(IretireWidthEncode.W))
+    val instrSizeTable = Seq(
+      (1, 1, 1), (1, 2, 2),
+      (2, 2, 3), (2, 3, 4), (2, 4, 5),
+      (3, 3, 6), (3, 4, 7), (3, 5, 8), (3, 6, 9),
+      (4, 4, 10), (4, 5, 11), (4, 6, 12), (4, 7, 13), (4, 8, 14),
+      (5, 5, 15), (5, 6, 16), (5, 7, 17), (5, 8, 18), (5, 9, 19), (5, 10, 20),
+      (6, 6, 21), (6, 7, 22), (6, 8, 23), (6, 9, 24), (6, 10, 25), (6, 11, 26), (6, 12, 27),
+    )
+  */
+  val iretireCommit = Wire(Vec(CommitWidth, UInt(IretireWidthCommited.W)))
+  val instrSizeCommit   = Wire(Vec(CommitWidth, UInt((log2Ceil(RenameWidth + 1)).W)))
+  val instrSizeTable = (1 to RenameWidth).map( instrNum =>
+    (instrNum to (2 * instrNum)).map(iretireNum => (instrNum, iretireNum))
+  ).flatten
+
+  rawInfo.zip(instrSizeCommit).zip(iretireCommit).map { case((raw, instr), iretire) =>
+    iretire := chisel3.util.experimental.decode.decoder(
+      raw.traceBlockInPipe.iretire,
+      TruthTable(
+        instrSizeTable.zipWithIndex.map{case(table, encode) => (BitPat((encode + 1).U(IretireWidthEncoded.W)), BitPat(table._2.U(IretireWidthCommited.W)))},
+        BitPat.N(IretireWidthCommited))
+    )
+    instr := chisel3.util.experimental.decode.decoder(
+      raw.traceBlockInPipe.iretire,
+      TruthTable(
+        instrSizeTable.zipWithIndex.map{case(table, encode) => (BitPat((encode + 1).U(IretireWidthEncoded.W)), BitPat(table._1.U((log2Ceil(RenameWidth + 1)).W)))},
+        BitPat.N((log2Ceil(RenameWidth + 1))))
+    )
+  }
+
   for (i <- 0 until CommitWidth) {
     commitInfo(i).ftqOffset := 0.U
     commitInfo(i).ftqIdx := rawInfo(i).ftqIdx - 1.U + rawInfo(i).crossFtqCommit
@@ -1216,7 +1246,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val isCommitReg = GatedValidRegNext(io.commits.isCommit)
   val instrCntReg = RegInit(0.U(64.W))
   val fuseCommitCnt = PopCount(io.commits.commitValid.zip(io.commits.info).map { case (v, i) => RegEnable(v && CommitType.isFused(i.commitType), isCommit) })
-  val trueCommitCnt = RegEnable(io.commits.commitValid.zip(io.commits.info).map { case (v, i) => Mux(v, i.instrSize, 0.U) }.reduce(_ +& _), isCommit)
+  val trueCommitCnt = RegEnable(io.commits.commitValid.zip(instrSizeCommit).map { case (v, instrSize) => Mux(v, instrSize, 0.U) }.reduce(_ +& _), isCommit)
   val retireCounter = Mux(isCommitReg, trueCommitCnt, 0.U)
   val instrCnt = instrCntReg + retireCounter
   when(isCommitReg){
@@ -1250,7 +1280,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     traceBlocks(i).bits.ftqIdx.foreach(_ := rawInfo(i).ftqIdx)
     traceBlocks(i).bits.ftqOffset.foreach(_ := rawInfo(i).ftqOffset)
     traceBlockInPipe(i).itype := rawInfo(i).traceBlockInPipe.itype
-    traceBlockInPipe(i).iretire := rawInfo(i).traceBlockInPipe.iretire
+    traceBlockInPipe(i).iretire := iretireCommit(i)
     traceBlockInPipe(i).ilastsize := rawInfo(i).traceBlockInPipe.ilastsize
     traceValids(i) := io.commits.isCommit && io.commits.commitValid(i)
     // exception/xret only occur in block(0).
@@ -1364,11 +1394,11 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   XSPerfAccumulate("waitLoadCycle", deqNotWritebacked && deqUopCommitType === CommitType.LOAD)
   XSPerfAccumulate("waitStoreCycle", deqNotWritebacked && deqUopCommitType === CommitType.STORE)
   XSPerfAccumulate("robHeadPC", io.commits.info(0).debug_pc.getOrElse(0.U))
-  XSPerfAccumulate("commitCompressCntAll", PopCount(io.commits.commitValid.zip(io.commits.info).map { case (valid, info) => io.commits.isCommit && valid && info.instrSize > 1.U }))
-  (2 to RenameWidth).foreach(i =>
-    XSPerfAccumulate(s"commitCompressCnt${i}", PopCount(io.commits.commitValid.zip(io.commits.info).map { case (valid, info) => io.commits.isCommit && valid && info.instrSize === i.U }))
+  XSPerfAccumulate("commitCompressCntAll", PopCount(io.commits.commitValid.zip(instrSizeCommit).map { case (valid, instrSize) => io.commits.isCommit && valid && instrSize > 1.U }))
+  (1 to RenameWidth).foreach(i =>
+    XSPerfAccumulate(s"commitCompressCnt${i}", PopCount(io.commits.commitValid.zip(instrSizeCommit).map { case (valid, instrSize) => io.commits.isCommit && valid && instrSize === i.U }))
   )
-  XSPerfAccumulate("compressSize", io.commits.commitValid.zip(io.commits.info).map { case (valid, info) => Mux(io.commits.isCommit && valid && info.instrSize > 1.U, info.instrSize, 0.U) }.reduce(_ +& _))
+  XSPerfAccumulate("compressSize", io.commits.commitValid.zip(instrSizeCommit).map { case (valid, instrSize) => Mux(io.commits.isCommit && valid && instrSize > 1.U, instrSize, 0.U) }.reduce(_ +& _))
   val dispatchLatency = commitDebugUop.map(uop => uop.debugInfo.dispatchTime - uop.debugInfo.renameTime)
   val enqRsLatency = commitDebugUop.map(uop => uop.debugInfo.enqRsTime - uop.debugInfo.dispatchTime)
   val selectLatency = commitDebugUop.map(uop => uop.debugInfo.selectTime - uop.debugInfo.enqRsTime)
@@ -1495,6 +1525,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     for (i <- 0 until CommitWidth) {
       val uop = commitDebugUop(i)
       val commitInfo = io.commits.info(i)
+      val instrSize = instrSizeCommit(i)
       val ptr = deqPtrVec(i).value
       val exuOut = dt_exuDebug(ptr)
       val eliminatedMove = dt_eliminatedMove(ptr)
@@ -1516,9 +1547,9 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       difftest.wpdest := commitInfo.debug_pdest.get
       difftest.wdest := Mux(isVLoad, instr.VD, commitInfo.debug_ldest.get)
       difftest.otherwpdest := debug_VecOtherPdest(ptr)
-      difftest.nFused := commitInfo.instrSize - 1.U
+      difftest.nFused := instrSize - 1.U
       when(difftest.valid) {
-        assert(commitInfo.instrSize >= 1.U)
+        assert(instrSize >= 1.U)
       }
       if (env.EnableDifftest) {
         val uop = commitDebugUop(i)

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -254,7 +254,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   // Instructions in multiple Ftq entries compressed to one RobEntry do not occur.
   for (i <- 0 until CommitWidth) {
     commitInfo(i).ftqOffset := 0.U
-    commitInfo(i).ftqIdx := rawInfo(i).ftqIdx + rawInfo(i).crossFtqCommit
+    commitInfo(i).ftqIdx := rawInfo(i).ftqIdx - 1.U + rawInfo(i).crossFtqCommit
   }
 
   // data for debug

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -253,8 +253,8 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   // Update the ftqOffset to correctly notify the frontend which instructions have been committed.
   // Instructions in multiple Ftq entries compressed to one RobEntry do not occur.
   for (i <- 0 until CommitWidth) {
-    val lastOffset = (rawInfo(i).traceBlockInPipe.iretire - (1.U << rawInfo(i).traceBlockInPipe.ilastsize.asUInt).asUInt) + rawInfo(i).ftqOffset
-    commitInfo(i).ftqOffset := Mux(CommitType.isFused(rawInfo(i).commitType), rawInfo(i).ftqOffset, lastOffset)
+    commitInfo(i).ftqOffset := 0.U
+    commitInfo(i).ftqIdx := rawInfo(i).ftqIdx + rawInfo(i).crossFtq
   }
 
   // data for debug

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1245,7 +1245,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val isCommit = io.commits.isCommit
   val isCommitReg = GatedValidRegNext(io.commits.isCommit)
   val instrCntReg = RegInit(0.U(64.W))
-  val fuseCommitCnt = PopCount(io.commits.commitValid.zip(io.commits.info).map { case (v, i) => RegEnable(v && CommitType.isFused(i.commitType), isCommit) })
+  val fuseCommitCnt = RegEnable(io.commits.commitValid.zip(io.commits.info).map { case (v, i) => Mux(v, i.debug_fusionNum.getOrElse(0.U), 0.U) }.reduce(_ +& _), isCommit)
   val trueCommitCnt = RegEnable(io.commits.commitValid.zip(instrSizeCommit).map { case (v, instrSize) => Mux(v, instrSize, 0.U) }.reduce(_ +& _), isCommit)
   val retireCounter = Mux(isCommitReg, trueCommitCnt, 0.U)
   val instrCnt = instrCntReg + retireCounter

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -75,7 +75,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val realDestSize = UInt(log2Up(MaxUopSize + 1).W)
     val uopNum = UInt(log2Up(MaxUopSize + 1).W)
     val needFlush = Bool()
-    val crossFtqCommit = Bool() // 59 bit
+    val crossFtqCommit = UInt(2.W) // 59 bit
     // status end
 
     // debug_begin
@@ -113,7 +113,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val fpWen = Bool()
     val rfWen = Bool()
     val needFlush = Bool()
-    val crossFtqCommit = Bool()
+    val crossFtqCommit = UInt(2.W)
     // trace
     val traceBlockInPipe = new TracePipe(IretireWidthInPipe)
     // debug_begin

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -75,6 +75,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val realDestSize = UInt(log2Up(MaxUopSize + 1).W)
     val uopNum = UInt(log2Up(MaxUopSize + 1).W)
     val needFlush = Bool()
+    val crossFtq = Bool() // 59 bit
     // status end
 
     // debug_begin
@@ -112,6 +113,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val fpWen = Bool()
     val rfWen = Bool()
     val needFlush = Bool()
+    val crossFtq = Bool()
     // trace
     val traceBlockInPipe = new TracePipe(IretireWidthInPipe)
     // debug_begin
@@ -140,6 +142,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robEntry.dirtyVs := robEnq.dirtyVs
     // flushPipe needFlush but not exception
     robEntry.needFlush := robEnq.hasException || robEnq.flushPipe
+    robEntry.crossFtq := robEnq.crossFtq
     // trace
     robEntry.traceBlockInPipe := robEnq.traceBlockInPipe
     robEntry.debug_pc.foreach(_ := robEnq.pc)
@@ -173,6 +176,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robCommitEntry.dirtyFs := robEntry.fpWen || robEntry.wflags
     robCommitEntry.dirtyVs := robEntry.dirtyVs
     robCommitEntry.needFlush := robEntry.needFlush
+    robCommitEntry.crossFtq := robEntry.crossFtq
     robCommitEntry.traceBlockInPipe := robEntry.traceBlockInPipe
     robCommitEntry.debug_pc.foreach(_ := robEntry.debug_pc.get)
     robCommitEntry.debug_instr.foreach(_ := robEntry.debug_instr.get)

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -83,6 +83,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val debug_ldest = OptionWrapper(backendParams.basicDebugEn, UInt(LogicRegsWidth.W))
     val debug_pdest = OptionWrapper(backendParams.basicDebugEn, UInt(PhyRegIdxWidth.W))
     val debug_fuType = OptionWrapper(backendParams.debugEn, FuType())
+    val debug_fusionNum = OptionWrapper(backendParams.debugEn, UInt(2.W))
     // debug_end
 
     def isWritebacked: Bool = !uopNum.orR && stdWritebacked
@@ -121,6 +122,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val debug_pdest = OptionWrapper(backendParams.basicDebugEn, UInt(PhyRegIdxWidth.W))
     val debug_otherPdest = OptionWrapper(backendParams.basicDebugEn, Vec(7, UInt(PhyRegIdxWidth.W)))
     val debug_fuType = OptionWrapper(backendParams.debugEn, FuType())
+    val debug_fusionNum = OptionWrapper(backendParams.debugEn, UInt(2.W))
     // debug_end
     val dirtyFs = Bool()
     val dirtyVs = Bool()
@@ -147,6 +149,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robEntry.debug_ldest.foreach(_ := robEnq.ldest)
     robEntry.debug_pdest.foreach(_ := robEnq.pdest)
     robEntry.debug_fuType.foreach(_ := robEnq.fuType)
+    robEntry.debug_fusionNum.foreach(_ := robEnq.fusionNum)
   }
 
   def connectCommitEntry(robCommitEntry: RobCommitEntryBundle, robEntry: RobEntryBundle): Unit = {
@@ -179,6 +182,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robCommitEntry.debug_ldest.foreach(_ := robEntry.debug_ldest.get)
     robCommitEntry.debug_pdest.foreach(_ := robEntry.debug_pdest.get)
     robCommitEntry.debug_fuType.foreach(_ := robEntry.debug_fuType.get)
+    robCommitEntry.debug_fusionNum.foreach(_ := robEntry.debug_fusionNum.get)
   }
 }
 

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -75,7 +75,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val realDestSize = UInt(log2Up(MaxUopSize + 1).W)
     val uopNum = UInt(log2Up(MaxUopSize + 1).W)
     val needFlush = Bool()
-    val crossFtq = Bool() // 59 bit
+    val crossFtqCommit = Bool() // 59 bit
     // status end
 
     // debug_begin
@@ -113,7 +113,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val fpWen = Bool()
     val rfWen = Bool()
     val needFlush = Bool()
-    val crossFtq = Bool()
+    val crossFtqCommit = Bool()
     // trace
     val traceBlockInPipe = new TracePipe(IretireWidthInPipe)
     // debug_begin
@@ -142,7 +142,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robEntry.dirtyVs := robEnq.dirtyVs
     // flushPipe needFlush but not exception
     robEntry.needFlush := robEnq.hasException || robEnq.flushPipe
-    robEntry.crossFtq := robEnq.crossFtq
+    robEntry.crossFtqCommit := robEnq.crossFtqCommit
     // trace
     robEntry.traceBlockInPipe := robEnq.traceBlockInPipe
     robEntry.debug_pc.foreach(_ := robEnq.pc)
@@ -176,7 +176,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robCommitEntry.dirtyFs := robEntry.fpWen || robEntry.wflags
     robCommitEntry.dirtyVs := robEntry.dirtyVs
     robCommitEntry.needFlush := robEntry.needFlush
-    robCommitEntry.crossFtq := robEntry.crossFtq
+    robCommitEntry.crossFtqCommit := robEntry.crossFtqCommit
     robCommitEntry.traceBlockInPipe := robEntry.traceBlockInPipe
     robCommitEntry.debug_pc.foreach(_ := robEntry.debug_pc.get)
     robCommitEntry.debug_instr.foreach(_ := robEntry.debug_instr.get)

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -60,11 +60,10 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val isRVC = Bool()
     val isVset = Bool()
     val isHls = Bool()
-    val instrSize = UInt(log2Ceil(RenameWidth + 1).W)
     // data end
     
     // trace
-    val traceBlockInPipe = new TracePipe(IretireWidthInPipe)
+    val traceBlockInPipe = new TracePipe(IretireWidthEncoded)
     // status begin
     val valid = Bool()
     val fflags = UInt(5.W)
@@ -109,13 +108,12 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val commitType = CommitType()
     val ftqIdx = new FtqPtr
     val ftqOffset = UInt(log2Up(PredictWidth).W)
-    val instrSize = UInt(log2Ceil(RenameWidth + 1).W)
     val fpWen = Bool()
     val rfWen = Bool()
     val needFlush = Bool()
     val crossFtqCommit = UInt(2.W)
     // trace
-    val traceBlockInPipe = new TracePipe(IretireWidthInPipe)
+    val traceBlockInPipe = new TracePipe(IretireWidthEncoded)
     // debug_begin
     val debug_pc = OptionWrapper(backendParams.debugEn, UInt(VAddrBits.W))
     val debug_instr = OptionWrapper(backendParams.debugEn, UInt(32.W))
@@ -136,7 +134,6 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robEntry.isRVC := robEnq.preDecodeInfo.isRVC
     robEntry.isVset := robEnq.isVset
     robEntry.isHls := robEnq.isHls
-    robEntry.instrSize := robEnq.instrSize
     robEntry.rfWen := robEnq.rfWen
     robEntry.fpWen := robEnq.dirtyFs
     robEntry.dirtyVs := robEnq.dirtyVs
@@ -172,7 +169,6 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robCommitEntry.ftqIdx := robEntry.ftqIdx
     robCommitEntry.ftqOffset := robEntry.ftqOffset
     robCommitEntry.commitType := robEntry.commitType
-    robCommitEntry.instrSize := robEntry.instrSize
     robCommitEntry.dirtyFs := robEntry.fpWen || robEntry.wflags
     robCommitEntry.dirtyVs := robEntry.dirtyVs
     robCommitEntry.needFlush := robEntry.needFlush

--- a/src/main/scala/xiangshan/backend/trace/Trace.scala
+++ b/src/main/scala/xiangshan/backend/trace/Trace.scala
@@ -16,7 +16,7 @@ class TraceParams(
 class TraceIO(implicit val p: Parameters) extends Bundle with HasXSParameter {
   val in = new Bundle {
     val fromEncoder    = Input(new FromEncoder)
-    val fromRob        = Flipped(new TraceBundle(hasIaddr = false, CommitWidth, IretireWidthInPipe))
+    val fromRob        = Flipped(new TraceBundle(hasIaddr = false, CommitWidth, IretireWidthCommited))
   }
   val out = new Bundle {
     val toPcMem        = new TraceBundle(hasIaddr = false, TraceGroupNum, IretireWidthCompressed)

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -233,11 +233,7 @@ class FtqToPrefetchIO(implicit p: Parameters) extends XSBundle {
   val backendException = UInt(ExceptionType.width.W)
 }
 
-trait HasBackendRedirectInfo extends HasXSParameter {
-  def isLoadReplay(r: Valid[Redirect]) = r.bits.flushItself()
-}
-
-class FtqToCtrlIO(implicit p: Parameters) extends XSBundle with HasBackendRedirectInfo {
+class FtqToCtrlIO(implicit p: Parameters) extends XSBundle {
   // write to backend pc mem
   val pc_mem_wen   = Output(Bool())
   val pc_mem_waddr = Output(UInt(log2Ceil(FtqSize).W))
@@ -248,7 +244,7 @@ class FtqToCtrlIO(implicit p: Parameters) extends XSBundle with HasBackendRedire
   val newest_entry_ptr    = Output(new FtqPtr)
 }
 
-class FTBEntryGen(implicit p: Parameters) extends XSModule with HasBackendRedirectInfo with HasBPUParameter {
+class FTBEntryGen(implicit p: Parameters) extends XSModule with HasBPUParameter {
   val io = IO(new Bundle {
     val start_addr     = Input(UInt(VAddrBits.W))
     val old_entry      = Input(new FTBEntry)
@@ -442,7 +438,7 @@ class FTBEntryGen(implicit p: Parameters) extends XSModule with HasBackendRedire
   io.is_br_full              := hit && is_new_br && may_have_to_replace
 }
 
-class FtqPcMemWrapper(numOtherReads: Int)(implicit p: Parameters) extends XSModule with HasBackendRedirectInfo {
+class FtqPcMemWrapper(numOtherReads: Int)(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle {
     val ifuPtr_w           = Input(new FtqPtr)
     val ifuPtrPlus1_w      = Input(new FtqPtr)
@@ -493,7 +489,7 @@ class FtqPcMemWrapper(numOtherReads: Int)(implicit p: Parameters) extends XSModu
 }
 
 class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelper
-    with HasBackendRedirectInfo with BPUUtils with HasBPUConst with HasPerfEvents
+    with BPUUtils with HasBPUConst with HasPerfEvents
     with HasICacheParameters {
   val io = IO(new Bundle {
     val fromBpu     = Flipped(new BpuToFtqIO)
@@ -554,39 +550,37 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   allowBpuIn := !ifuFlush && !backendRedirect.valid && !backendRedirectReg.valid
   allowToIfu := !ifuFlush && !backendRedirect.valid && !backendRedirectReg.valid
 
-  def copyNum                                              = 5
-  val bpuPtr, ifuPtr, pfPtr, ifuWbPtr, commPtr, robCommPtr = RegInit(FtqPtr(false.B, 0.U))
-  val ifuPtrPlus1                                          = RegInit(FtqPtr(false.B, 1.U))
-  val ifuPtrPlus2                                          = RegInit(FtqPtr(false.B, 2.U))
-  val pfPtrPlus1                                           = RegInit(FtqPtr(false.B, 1.U))
-  val commPtrPlus1                                         = RegInit(FtqPtr(false.B, 1.U))
-  val copied_ifu_ptr                                       = Seq.fill(copyNum)(RegInit(FtqPtr(false.B, 0.U)))
-  val copied_bpu_ptr                                       = Seq.fill(copyNum)(RegInit(FtqPtr(false.B, 0.U)))
+  def copyNum = 5
+  val bpuPtr, ifuPtr, pfPtr, ifuWbPtr, commitPtr: FtqPtr      = RegInit(FtqPtr(false.B, 0.U))
+  val ifuPtrPlus1:                                FtqPtr      = RegInit(FtqPtr(false.B, 1.U))
+  val ifuPtrPlus2:                                FtqPtr      = RegInit(FtqPtr(false.B, 2.U))
+  val pfPtrPlus1:                                 FtqPtr      = RegInit(FtqPtr(false.B, 1.U))
+  val commitPtrPlus1:                             FtqPtr      = RegInit(FtqPtr(false.B, 1.U))
+  val copied_ifu_ptr:                             Seq[FtqPtr] = Seq.fill(copyNum)(RegInit(FtqPtr(false.B, 0.U)))
+  val copied_bpu_ptr:                             Seq[FtqPtr] = Seq.fill(copyNum)(RegInit(FtqPtr(false.B, 0.U)))
   require(FtqSize >= 4)
-  val ifuPtr_write       = WireInit(ifuPtr)
-  val ifuPtrPlus1_write  = WireInit(ifuPtrPlus1)
-  val ifuPtrPlus2_write  = WireInit(ifuPtrPlus2)
-  val pfPtr_write        = WireInit(pfPtr)
-  val pfPtrPlus1_write   = WireInit(pfPtrPlus1)
-  val ifuWbPtr_write     = WireInit(ifuWbPtr)
-  val commPtr_write      = WireInit(commPtr)
-  val commPtrPlus1_write = WireInit(commPtrPlus1)
-  val robCommPtr_write   = WireInit(robCommPtr)
-  ifuPtr       := ifuPtr_write
-  ifuPtrPlus1  := ifuPtrPlus1_write
-  ifuPtrPlus2  := ifuPtrPlus2_write
-  pfPtr        := pfPtr_write
-  pfPtrPlus1   := pfPtrPlus1_write
-  ifuWbPtr     := ifuWbPtr_write
-  commPtr      := commPtr_write
-  commPtrPlus1 := commPtrPlus1_write
+  val ifuPtr_write:         FtqPtr = WireInit(ifuPtr)
+  val ifuPtrPlus1_write:    FtqPtr = WireInit(ifuPtrPlus1)
+  val ifuPtrPlus2_write:    FtqPtr = WireInit(ifuPtrPlus2)
+  val pfPtr_write:          FtqPtr = WireInit(pfPtr)
+  val pfPtrPlus1_write:     FtqPtr = WireInit(pfPtrPlus1)
+  val ifuWbPtr_write:       FtqPtr = WireInit(ifuWbPtr)
+  val commitPtr_write:      FtqPtr = WireInit(commitPtr)
+  val commitPtrPlus1_write: FtqPtr = WireInit(commitPtrPlus1)
+  ifuPtr         := ifuPtr_write
+  ifuPtrPlus1    := ifuPtrPlus1_write
+  ifuPtrPlus2    := ifuPtrPlus2_write
+  pfPtr          := pfPtr_write
+  pfPtrPlus1     := pfPtrPlus1_write
+  ifuWbPtr       := ifuWbPtr_write
+  commitPtr      := commitPtr_write
+  commitPtrPlus1 := commitPtrPlus1_write
   copied_ifu_ptr.map { ptr =>
     ptr := ifuPtr_write
     dontTouch(ptr)
   }
-  robCommPtr := robCommPtr_write
-  val validEntries = distanceBetween(bpuPtr, commPtr)
-  val canCommit    = Wire(Bool())
+  val validEntries  = distanceBetween(bpuPtr, commitPtr)
+  val backendCommit = Wire(Bool())
 
   // Instruction page fault and instruction access fault are sent from backend with redirect requests.
   // When IPF and IAF are sent, backendPcFaultIfuPtr points to the FTQ entry whose first instruction
@@ -614,7 +608,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   // **********************************************************************
   // **************************** enq from bpu ****************************
   // **********************************************************************
-  val new_entry_ready = validEntries < FtqSize.U || canCommit
+  val new_entry_ready = validEntries < FtqSize.U || backendCommit
   io.fromBpu.resp.ready := new_entry_ready
 
   val bpu_s2_resp     = io.fromBpu.resp.bits.s2
@@ -682,19 +676,6 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val pred_stage                   = Reg(Vec(FtqSize, UInt(2.W)))
   val pred_s1_cycle                = if (!env.FPGAPlatform) Some(Reg(Vec(FtqSize, UInt(64.W)))) else None
 
-  val c_empty :: c_toCommit :: c_committed :: c_flushed :: Nil = Enum(4)
-  val commitStateQueueReg = RegInit(VecInit(Seq.fill(FtqSize) {
-    VecInit(Seq.fill(PredictWidth)(c_empty))
-  }))
-  val commitStateQueueEnable = WireInit(VecInit(Seq.fill(FtqSize)(false.B)))
-  val commitStateQueueNext   = WireInit(commitStateQueueReg)
-
-  for (f <- 0 until FtqSize) {
-    when(commitStateQueueEnable(f)) {
-      commitStateQueueReg(f) := commitStateQueueNext(f)
-    }
-  }
-
   val f_to_send :: f_sent :: Nil = Enum(2)
   val entry_fetch_status         = RegInit(VecInit(Seq.fill(FtqSize)(f_sent)))
 
@@ -709,11 +690,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val last_cycle_cfiIndex     = RegEnable(bpu_in_resp.cfiIndex(3), bpu_in_fire)
   val last_cycle_bpu_in_stage = RegEnable(bpu_in_stage, bpu_in_fire)
 
-  def extra_copyNum_for_commitStateQueue = 2
-  val copied_last_cycle_bpu_in =
-    VecInit(Seq.fill(copyNum + extra_copyNum_for_commitStateQueue)(RegNext(bpu_in_fire)))
-  val copied_last_cycle_bpu_in_ptr_for_ftq =
-    VecInit(Seq.fill(extra_copyNum_for_commitStateQueue)(RegEnable(bpu_in_resp_ptr, bpu_in_fire)))
+  val copied_last_cycle_bpu_in = VecInit(Seq.fill(copyNum)(RegNext(bpu_in_fire)))
 
   newest_entry_target_modified := false.B
   newest_entry_ptr_modified    := false.B
@@ -740,23 +717,6 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
     when(bpu_in_fire && (bpu_in_stage === BP_S1)) {
       vec(bpu_in_resp_ptr.value) := bpu_in_resp.full_pred(0).predCycle.getOrElse(0.U)
     }
-  }
-
-  // reduce fanout using copied last_cycle_bpu_in and copied last_cycle_bpu_in_ptr
-  val copied_last_cycle_bpu_in_for_ftq = copied_last_cycle_bpu_in.takeRight(extra_copyNum_for_commitStateQueue)
-  copied_last_cycle_bpu_in_for_ftq.zip(copied_last_cycle_bpu_in_ptr_for_ftq).zipWithIndex.map {
-    case ((in, ptr), i) =>
-      when(in) {
-        val perSetEntries = FtqSize / extra_copyNum_for_commitStateQueue // 32
-        require(FtqSize % extra_copyNum_for_commitStateQueue == 0)
-        for (j <- 0 until perSetEntries) {
-          when(ptr.value === (i * perSetEntries + j).U) {
-            commitStateQueueNext(i * perSetEntries + j) := VecInit(Seq.fill(PredictWidth)(c_empty))
-            // Clock gating optimization, use 1 gate cell to control a row
-            commitStateQueueEnable(i * perSetEntries + j) := true.B
-          }
-        }
-      }
   }
 
   bpuPtr := bpuPtr + enq_fire
@@ -816,7 +776,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
 
   XSError(isBefore(bpuPtr, ifuPtr) && !isFull(bpuPtr, ifuPtr), "\nifuPtr is before bpuPtr!\n")
   XSError(isBefore(bpuPtr, pfPtr) && !isFull(bpuPtr, pfPtr), "\npfPtr is before bpuPtr!\n")
-  XSError(isBefore(ifuWbPtr, commPtr) && !isFull(ifuWbPtr, commPtr), "\ncommPtr is before ifuWbPtr!\n")
+  XSError(isBefore(ifuWbPtr, commitPtr) && !isFull(ifuWbPtr, commitPtr), "\ncommPtr is before ifuWbPtr!\n")
 
   (0 until copyNum).map(i => XSError(copied_bpu_ptr(i) =/= bpuPtr, "\ncopiedBpuPtr is different from bpuPtr!\n"))
 
@@ -840,8 +800,8 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   ftq_pc_mem.io.ifuPtrPlus2_w  := ifuPtrPlus2_write
   ftq_pc_mem.io.pfPtr_w        := pfPtr_write
   ftq_pc_mem.io.pfPtrPlus1_w   := pfPtrPlus1_write
-  ftq_pc_mem.io.commPtr_w      := commPtr_write
-  ftq_pc_mem.io.commPtrPlus1_w := commPtrPlus1_write
+  ftq_pc_mem.io.commPtr_w      := commitPtr_write
+  ftq_pc_mem.io.commPtrPlus1_w := commitPtrPlus1_write
 
   io.toIfu.req.bits.ftqIdx := ifuPtr
 
@@ -1002,18 +962,6 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val pd_reg             = RegEnable(pds, pdWb.valid)
   val start_pc_reg       = RegEnable(pdWb.bits.pc(0), pdWb.valid)
   val wb_idx_reg         = RegEnable(ifu_wb_idx, pdWb.valid)
-
-  when(ifu_wb_valid) {
-    val comm_stq_wen = VecInit(pds.map(_.valid).zip(pdWb.bits.instrRange).map {
-      case (v, inRange) => v && inRange
-    })
-    commitStateQueueEnable(ifu_wb_idx) := true.B
-    (commitStateQueueNext(ifu_wb_idx) zip comm_stq_wen).map {
-      case (qe, v) => when(v) {
-          qe := c_toCommit
-        }
-    }
-  }
 
   when(ifu_wb_valid) {
     ifuWbPtr_write := ifuWbPtr + 1.U
@@ -1229,7 +1177,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
 
     update_target(r_idx) := redirect.bits.cfiUpdate.target // TODO: remove this
     if (isBackend) {
-      mispredict_vec(r_idx)(r_offset) := r_mispred
+      mispredict_vec(r_idx)(r_offset) := r_mispred && redirect.bits.level === RedirectLevel.flushAfter
     }
   }
 
@@ -1300,50 +1248,11 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
     pfPtr_write       := next
     pfPtrPlus1_write  := idx + 2.U
   }
-  when(RegNext(redirectVec.map(r => r.valid).reduce(_ || _))) {
-    val r                          = PriorityMux(redirectVec.map(r => r.valid -> r.bits))
-    val notIfu                     = redirectVec.dropRight(1).map(r => r.valid).reduce(_ || _)
-    val (idx, offset, flushItSelf) = (r.ftqIdx, r.ftqOffset, RedirectLevel.flushItself(r.level))
-    when(RegNext(notIfu)) {
-      commitStateQueueEnable(RegNext(idx.value)) := true.B
-      commitStateQueueNext(RegNext(idx.value)).zipWithIndex.foreach { case (s, i) =>
-        when(i.U > RegNext(offset)) {
-          s := c_empty
-        }
-        when(i.U === RegNext(offset) && RegNext(flushItSelf)) {
-          s := c_flushed
-        }
-      }
-    }
-  }
 
   // only the valid bit is actually needed
   io.toIfu.redirect.bits    := backendRedirect.bits
   io.toIfu.redirect.valid   := stage2Flush
   io.toIfu.topdown_redirect := fromBackendRedirect
-
-  // commit
-  for (c <- io.fromBackend.rob_commits) {
-    when(c.valid) {
-      commitStateQueueEnable(c.bits.ftqIdx.value)                 := true.B
-      commitStateQueueNext(c.bits.ftqIdx.value)(c.bits.ftqOffset) := c_committed
-      // TODO: remove this
-      // For instruction fusions, we also update the next instruction
-      when(c.bits.commitType === 4.U) {
-        commitStateQueueNext(c.bits.ftqIdx.value)(c.bits.ftqOffset + 1.U) := c_committed
-      }.elsewhen(c.bits.commitType === 5.U) {
-        commitStateQueueNext(c.bits.ftqIdx.value)(c.bits.ftqOffset + 2.U) := c_committed
-      }.elsewhen(c.bits.commitType === 6.U) {
-        val index = (c.bits.ftqIdx + 1.U).value
-        commitStateQueueEnable(index)  := true.B
-        commitStateQueueNext(index)(0) := c_committed
-      }.elsewhen(c.bits.commitType === 7.U) {
-        val index = (c.bits.ftqIdx + 1.U).value
-        commitStateQueueEnable(index)  := true.B
-        commitStateQueueNext(index)(1) := c_committed
-      }
-    }
-  }
 
   // ****************************************************************
   // **************************** to bpu ****************************
@@ -1365,7 +1274,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   )
 
   XSError(
-    io.toBpu.redirect.valid && isBefore(io.toBpu.redirect.bits.ftqIdx, commPtr),
+    io.toBpu.redirect.valid && isBefore(io.toBpu.redirect.bits.ftqIdx, commitPtr),
     "Ftq received a redirect after its commit, check backend or replay"
   )
 
@@ -1373,90 +1282,64 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val bpu_ftb_update_stall    = RegInit(0.U(2.W)) // 2-cycle stall, so we need 3 states
   may_have_stall_from_bpu := bpu_ftb_update_stall =/= 0.U
 
-  val validInstructions     = commitStateQueueReg(commPtr.value).map(s => s === c_toCommit || s === c_committed)
-  val lastInstructionStatus = PriorityMux(validInstructions.reverse.zip(commitStateQueueReg(commPtr.value).reverse))
-  val firstInstructionFlushed = commitStateQueueReg(commPtr.value)(0) === c_flushed ||
-    commitStateQueueReg(commPtr.value)(0) === c_empty && commitStateQueueReg(commPtr.value)(1) === c_flushed
-  canCommit := commPtr =/= ifuWbPtr && !may_have_stall_from_bpu &&
-    (isAfter(robCommPtr, commPtr) ||
-      validInstructions.reduce(_ || _) && lastInstructionStatus === c_committed)
-  val canMoveCommPtr = commPtr =/= ifuWbPtr && !may_have_stall_from_bpu &&
-    (isAfter(robCommPtr, commPtr) ||
-      validInstructions.reduce(_ || _) && lastInstructionStatus === c_committed ||
-      firstInstructionFlushed)
-
+  // TODO: frontend does not need this many rob commit channels
+  private val robCommitPtr: FtqPtr = WireInit(FtqPtr(false.B, 0.U))
   when(io.fromBackend.rob_commits.map(_.valid).reduce(_ | _)) {
-    robCommPtr_write := ParallelPriorityMux(
+    robCommitPtr := ParallelPriorityMux(
       io.fromBackend.rob_commits.map(_.valid).reverse,
       io.fromBackend.rob_commits.map(_.bits.ftqIdx).reverse
     )
-  }.elsewhen(isAfter(commPtr, robCommPtr)) {
-    robCommPtr_write := commPtr
-  }.otherwise {
-    robCommPtr_write := robCommPtr
   }
+  backendCommit := commitPtr =/= ifuWbPtr && !may_have_stall_from_bpu && isAfter(robCommitPtr, commitPtr)
+  when(backendCommit) {
+    commitPtr_write      := commitPtrPlus1
+    commitPtrPlus1_write := commitPtrPlus1 + 1.U
+  }
+  // frontend commit is one cycle later than backend commit because reading srams needs one cycle
+  val s2_commitPtr     = RegEnable(commitPtr, backendCommit)
+  val s2_backendCommit = RegNext(backendCommit, init = false.B)
 
   /**
     *************************************************************************************
     * MMIO instruction fetch is allowed only if MMIO is the oldest instruction.
     *************************************************************************************
     */
-  val mmioReadPtr = io.mmioCommitRead.mmioFtqPtr
-  val mmioLastCommit = isAfter(commPtr, mmioReadPtr) ||
-    commPtr === mmioReadPtr && validInstructions.reduce(_ || _) && lastInstructionStatus === c_committed
+  val mmioReadPtr    = io.mmioCommitRead.mmioFtqPtr
+  val mmioLastCommit = isAfter(commitPtr, mmioReadPtr) || commitPtr === mmioReadPtr && backendCommit
   io.mmioCommitRead.mmioLastCommit := RegNext(mmioLastCommit)
 
   // commit reads
-  val commit_pc_bundle = RegNext(ftq_pc_mem.io.commPtr_rdata)
-  val commit_target =
+  val s2_commitPcBundle = RegNext(ftq_pc_mem.io.commPtr_rdata)
+  val s2_commitTarget =
     Mux(
-      RegNext(commPtr === newest_entry_ptr),
+      RegNext(commitPtr === newest_entry_ptr),
       RegEnable(newest_entry_target, newest_entry_target_modified),
       RegNext(ftq_pc_mem.io.commPtrPlus1_rdata.startAddr)
     )
-  ftq_pd_mem.io.ren.get.last := canCommit
-  ftq_pd_mem.io.raddr.last   := commPtr.value
-  val commit_pd = ftq_pd_mem.io.rdata.last
-  ftq_redirect_mem.io.ren.get.last := canCommit
-  ftq_redirect_mem.io.raddr.last   := commPtr.value
-  val commit_spec_meta = ftq_redirect_mem.io.rdata.last
-  ftq_meta_1r_sram.io.ren(0)   := canCommit
-  ftq_meta_1r_sram.io.raddr(0) := commPtr.value
-  val commit_meta      = ftq_meta_1r_sram.io.rdata(0).meta
-  val commit_ftb_entry = ftq_meta_1r_sram.io.rdata(0).ftb_entry
+  ftq_pd_mem.io.ren.get.last := backendCommit
+  ftq_pd_mem.io.raddr.last   := commitPtr.value
+  val s2_commitPd = ftq_pd_mem.io.rdata.last
+  ftq_redirect_mem.io.ren.get.last := backendCommit
+  ftq_redirect_mem.io.raddr.last   := commitPtr.value
+  val s2_commitSpecMeta = ftq_redirect_mem.io.rdata.last
+  ftq_meta_1r_sram.io.ren(0)   := backendCommit
+  ftq_meta_1r_sram.io.raddr(0) := commitPtr.value
+  val s2_commitMeta     = ftq_meta_1r_sram.io.rdata(0).meta
+  val s2_commitFtbEntry = ftq_meta_1r_sram.io.rdata(0).ftb_entry
 
-  // need one cycle to read mem and srams
-  val do_commit_ptr = RegEnable(commPtr, canCommit)
-  val do_commit     = RegNext(canCommit, init = false.B)
-  when(canMoveCommPtr) {
-    commPtr_write      := commPtrPlus1
-    commPtrPlus1_write := commPtrPlus1 + 1.U
-  }
-  val commit_state   = RegEnable(commitStateQueueReg(commPtr.value), canCommit)
-  val can_commit_cfi = WireInit(cfiIndex_vec(commPtr.value))
-  val do_commit_cfi  = WireInit(cfiIndex_vec(do_commit_ptr.value))
-  //
-  // when (commitStateQueue(commPtr.value)(can_commit_cfi.bits) =/= c_commited) {
-  //  can_commit_cfi.valid := false.B
-  // }
-  val commit_cfi = RegEnable(can_commit_cfi, canCommit)
-  val debug_cfi  = commitStateQueueReg(do_commit_ptr.value)(do_commit_cfi.bits) =/= c_committed && do_commit_cfi.valid
+  val s1_commitCfi = WireInit(cfiIndex_vec(commitPtr.value))
+  val s2_commitCfi = RegEnable(s1_commitCfi, backendCommit)
 
-  val commit_mispredict: Vec[Bool] =
-    VecInit((RegEnable(mispredict_vec(commPtr.value), canCommit) zip commit_state).map {
-      case (mis, state) => mis && state === c_committed
-    })
-  val commit_instCommited: Vec[Bool] = VecInit(commit_state.map(_ === c_committed)) // [PredictWidth]
-  val can_commit_hit     = entry_hit_status(commPtr.value)
-  val commit_hit         = RegEnable(can_commit_hit, canCommit)
-  val diff_commit_target = RegEnable(update_target(commPtr.value), canCommit) // TODO: remove this
-  val commit_stage       = RegEnable(pred_stage(commPtr.value), canCommit)
-  val commit_valid       = commit_hit === h_hit || commit_cfi.valid           // hit or taken
+  val s2_commitMispredict: Vec[Bool] = RegEnable(mispredict_vec(commitPtr.value), backendCommit)
+  val s1_commitHit   = entry_hit_status(commitPtr.value)
+  val s2_commitHit   = RegEnable(s1_commitHit, backendCommit)
+  val s2_commitStage = RegEnable(pred_stage(commitPtr.value), backendCommit)
+  val s2_commitValid = s2_commitHit === h_hit || s2_commitCfi.valid // hit or taken
 
-  val to_bpu_hit = can_commit_hit === h_hit || can_commit_hit === h_false_hit
+  val to_bpu_hit = s1_commitHit === h_hit || s1_commitHit === h_false_hit
   switch(bpu_ftb_update_stall) {
     is(0.U) {
-      when(can_commit_cfi.valid && !to_bpu_hit && canCommit) {
+      when(s1_commitCfi.valid && !to_bpu_hit && backendCommit) {
         bpu_ftb_update_stall := 2.U // 2-cycle stall
       }
     }
@@ -1472,68 +1355,55 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   }
   XSError(bpu_ftb_update_stall === 3.U, "bpu_ftb_update_stall should be 0, 1 or 2")
 
-  // TODO: remove this
-  XSError(do_commit && diff_commit_target =/= commit_target, "\ncommit target should be the same as update target\n")
-
   // update latency stats
-  val update_latency = GTimer() - pred_s1_cycle.getOrElse(dummy_s1_pred_cycle_vec)(do_commit_ptr.value) + 1.U
+  val update_latency = GTimer() - pred_s1_cycle.getOrElse(dummy_s1_pred_cycle_vec)(s2_commitPtr.value) + 1.U
   XSPerfHistogram("bpu_update_latency", update_latency, io.toBpu.update.valid, 0, 64, 2)
 
   io.toBpu.update       := DontCare
-  io.toBpu.update.valid := commit_valid && do_commit
+  io.toBpu.update.valid := s2_commitValid && s2_backendCommit
   val update = io.toBpu.update.bits
-  update.false_hit   := commit_hit === h_false_hit
-  update.pc          := commit_pc_bundle.startAddr
-  update.meta        := commit_meta
-  update.cfi_idx     := commit_cfi
-  update.full_target := commit_target
-  update.from_stage  := commit_stage
-  update.spec_info   := commit_spec_meta
-  XSError(commit_valid && do_commit && debug_cfi, "\ncommit cfi can be non c_commited\n")
+  update.false_hit   := s2_commitHit === h_false_hit
+  update.pc          := s2_commitPcBundle.startAddr
+  update.meta        := s2_commitMeta
+  update.cfi_idx     := s2_commitCfi
+  update.full_target := s2_commitTarget
+  update.from_stage  := s2_commitStage
+  update.spec_info   := s2_commitSpecMeta
 
-  val commit_real_hit  = commit_hit === h_hit
+  val s2_commitRealHit = s2_commitHit === h_hit
   val update_ftb_entry = update.ftb_entry
 
   val ftbEntryGen = Module(new FTBEntryGen).io
-  ftbEntryGen.start_addr     := commit_pc_bundle.startAddr
-  ftbEntryGen.old_entry      := commit_ftb_entry
-  ftbEntryGen.pd             := commit_pd
-  ftbEntryGen.cfiIndex       := commit_cfi
-  ftbEntryGen.target         := commit_target
-  ftbEntryGen.hit            := commit_real_hit
-  ftbEntryGen.mispredict_vec := commit_mispredict
+  ftbEntryGen.start_addr     := s2_commitPcBundle.startAddr
+  ftbEntryGen.old_entry      := s2_commitFtbEntry
+  ftbEntryGen.pd             := s2_commitPd
+  ftbEntryGen.cfiIndex       := s2_commitCfi
+  ftbEntryGen.target         := s2_commitTarget
+  ftbEntryGen.hit            := s2_commitRealHit
+  ftbEntryGen.mispredict_vec := s2_commitMispredict
 
   update_ftb_entry         := ftbEntryGen.new_entry
   update.new_br_insert_pos := ftbEntryGen.new_br_insert_pos
   update.mispred_mask      := ftbEntryGen.mispred_mask
   update.old_entry         := ftbEntryGen.is_old_entry
-  update.pred_hit          := commit_hit === h_hit || commit_hit === h_false_hit
+  update.pred_hit          := s2_commitHit === h_hit || s2_commitHit === h_false_hit
   update.br_taken_mask     := ftbEntryGen.taken_mask
-  update.br_committed := (ftbEntryGen.new_entry.brValids zip ftbEntryGen.new_entry.brOffset) map {
-    case (valid, offset) => valid && commit_instCommited(offset)
-  }
-  update.jmp_taken := ftbEntryGen.jmp_taken
-
-  // update.full_pred.fromFtbEntry(ftbEntryGen.new_entry, update.pc)
-  // update.full_pred.jalr_target := commit_target
-  // update.full_pred.hit := true.B
-  // when (update.full_pred.is_jalr) {
-  //   update.full_pred.targets.last := commit_target
-  // }
+  update.br_committed      := ftbEntryGen.new_entry.brValids
+  update.jmp_taken         := ftbEntryGen.jmp_taken
 
   // ******************************************************************************
   // **************************** commit perf counters ****************************
   // ******************************************************************************
 
-  val commit_inst_mask        = VecInit(commit_state.map(c => c === c_committed && do_commit)).asUInt
-  val commit_mispred_mask     = commit_mispredict.asUInt
+  val commit_mispred_mask     = s2_commitMispredict.asUInt
   val commit_not_mispred_mask = ~commit_mispred_mask
 
-  val commit_br_mask  = commit_pd.brMask.asUInt
-  val commit_jmp_mask = UIntToOH(commit_pd.jmpOffset) & Fill(PredictWidth, commit_pd.jmpInfo.valid.asTypeOf(UInt(1.W)))
+  val commit_br_mask = s2_commitPd.brMask.asUInt
+  val commit_jmp_mask =
+    UIntToOH(s2_commitPd.jmpOffset) & Fill(PredictWidth, s2_commitPd.jmpInfo.valid.asTypeOf(UInt(1.W)))
   val commit_cfi_mask = commit_br_mask | commit_jmp_mask
 
-  val mbpInstrs = commit_inst_mask & commit_cfi_mask
+  val mbpInstrs = commit_cfi_mask
 
   val mbpRights = mbpInstrs & commit_not_mispred_mask
   val mbpWrongs = mbpInstrs & commit_mispred_mask
@@ -1546,17 +1416,16 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val ftqBranchTraceDB = ChiselDB.createTable(s"FTQTable$hartId", new FtqDebugBundle)
   // Cfi Info
   for (i <- 0 until PredictWidth) {
-    val pc      = commit_pc_bundle.startAddr + (i * instBytes).U
-    val v       = commit_state(i) === c_committed
-    val isBr    = commit_pd.brMask(i)
-    val isJmp   = commit_pd.jmpInfo.valid && commit_pd.jmpOffset === i.U
+    val pc      = s2_commitPcBundle.startAddr + (i * instBytes).U
+    val isBr    = s2_commitPd.brMask(i)
+    val isJmp   = s2_commitPd.jmpInfo.valid && s2_commitPd.jmpOffset === i.U
     val isCfi   = isBr || isJmp
-    val isTaken = commit_cfi.valid && commit_cfi.bits === i.U
-    val misPred = commit_mispredict(i)
+    val isTaken = s2_commitCfi.valid && s2_commitCfi.bits === i.U
+    val misPred = s2_commitMispredict(i)
     // val ghist = commit_spec_meta.ghist.predHist
-    val histPtr   = commit_spec_meta.histPtr
-    val predCycle = commit_meta(63, 0)
-    val target    = commit_target
+    val histPtr   = s2_commitSpecMeta.histPtr
+    val predCycle = s2_commitMeta(63, 0)
+    val target    = s2_commitTarget
 
     val brIdx = OHToUInt(Reverse(Cat(update_ftb_entry.brValids.zip(update_ftb_entry.brOffset).map { case (v, offset) =>
       v && offset === i.U
@@ -1565,12 +1434,12 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
       v && offset === i.U
     }.reduce(_ || _)
     val addIntoHist =
-      ((commit_hit === h_hit) && inFtbEntry) || (!(commit_hit === h_hit) && i.U === commit_cfi.bits && isBr && commit_cfi.valid)
+      ((s2_commitHit === h_hit) && inFtbEntry) || (!(s2_commitHit === h_hit) && i.U === s2_commitCfi.bits && isBr && s2_commitCfi.valid)
     XSDebug(
-      v && do_commit && isCfi,
+      s2_backendCommit && isCfi,
       p"cfi_update: isBr(${isBr}) pc(${Hexadecimal(pc)}) " +
         p"taken(${isTaken}) mispred(${misPred}) cycle($predCycle) hist(${histPtr.value}) " +
-        p"startAddr(${Hexadecimal(commit_pc_bundle.startAddr)}) AddIntoHist(${addIntoHist}) " +
+        p"startAddr(${Hexadecimal(s2_commitPcBundle.startAddr)}) AddIntoHist(${addIntoHist}) " +
         p"brInEntry(${inFtbEntry}) brIdx(${brIdx}) target(${Hexadecimal(target)})\n"
     )
 
@@ -1579,15 +1448,15 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
     logbundle.target    := target
     logbundle.isBr      := isBr
     logbundle.isJmp     := isJmp
-    logbundle.isCall    := isJmp && commit_pd.hasCall
-    logbundle.isRet     := isJmp && commit_pd.hasRet
+    logbundle.isCall    := isJmp && s2_commitPd.hasCall
+    logbundle.isRet     := isJmp && s2_commitPd.hasRet
     logbundle.misPred   := misPred
     logbundle.isTaken   := isTaken
-    logbundle.predStage := commit_stage
+    logbundle.predStage := s2_commitStage
 
     ftqBranchTraceDB.log(
       data = logbundle /* hardware of type T */,
-      en = isWriteFTQTable.orR && v && do_commit && isCfi,
+      en = isWriteFTQTable.orR && s2_backendCommit && isCfi,
       site = "FTQ" + p(XSCoreParamsKey).HartId.toString,
       clock = clock,
       reset = reset
@@ -1610,7 +1479,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   XSPerfAccumulate("bpu_to_ifu_bubble", bpuPtr === ifuPtr)
   XSPerfAccumulate(
     "bpu_to_ifu_bubble_when_ftq_full",
-    (bpuPtr === ifuPtr) && isFull(bpuPtr, commPtr) && io.toIfu.req.ready
+    (bpuPtr === ifuPtr) && isFull(bpuPtr, commitPtr) && io.toIfu.req.ready
   )
 
   XSPerfAccumulate("redirectAhead_ValidNum", ftqIdxAhead.map(_.valid).reduce(_ | _))
@@ -1620,12 +1489,10 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val from_bpu = io.fromBpu.resp.bits
   val to_ifu   = io.toIfu.req.bits
 
-  XSPerfHistogram("commit_num_inst", PopCount(commit_inst_mask), do_commit, 0, PredictWidth + 1, 1)
-
-  val commit_jal_mask  = UIntToOH(commit_pd.jmpOffset) & Fill(PredictWidth, commit_pd.hasJal.asTypeOf(UInt(1.W)))
-  val commit_jalr_mask = UIntToOH(commit_pd.jmpOffset) & Fill(PredictWidth, commit_pd.hasJalr.asTypeOf(UInt(1.W)))
-  val commit_call_mask = UIntToOH(commit_pd.jmpOffset) & Fill(PredictWidth, commit_pd.hasCall.asTypeOf(UInt(1.W)))
-  val commit_ret_mask  = UIntToOH(commit_pd.jmpOffset) & Fill(PredictWidth, commit_pd.hasRet.asTypeOf(UInt(1.W)))
+  val commit_jal_mask  = UIntToOH(s2_commitPd.jmpOffset) & Fill(PredictWidth, s2_commitPd.hasJal.asTypeOf(UInt(1.W)))
+  val commit_jalr_mask = UIntToOH(s2_commitPd.jmpOffset) & Fill(PredictWidth, s2_commitPd.hasJalr.asTypeOf(UInt(1.W)))
+  val commit_call_mask = UIntToOH(s2_commitPd.jmpOffset) & Fill(PredictWidth, s2_commitPd.hasCall.asTypeOf(UInt(1.W)))
+  val commit_ret_mask  = UIntToOH(s2_commitPd.jmpOffset) & Fill(PredictWidth, s2_commitPd.hasRet.asTypeOf(UInt(1.W)))
 
   val mbpBRights = mbpRights & commit_br_mask
   val mbpJRights = mbpRights & commit_jal_mask
@@ -1639,7 +1506,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val mbpCWrongs = mbpWrongs & commit_call_mask
   val mbpRWrongs = mbpWrongs & commit_ret_mask
 
-  val commit_pred_stage = RegNext(pred_stage(commPtr.value))
+  val commit_pred_stage = RegNext(pred_stage(commitPtr.value))
 
   def pred_stage_map(src: UInt, name: String) =
     (0 until numBpStages).map(i =>
@@ -1657,7 +1524,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   def u(cond: Bool) = update_valid && cond
   val ftb_false_hit = u(update.false_hit)
   // assert(!ftb_false_hit)
-  val ftb_hit = u(commit_hit === h_hit)
+  val ftb_hit = u(s2_commitHit === h_hit)
 
   val ftb_new_entry                = u(ftbEntryGen.is_init_entry)
   val ftb_new_entry_only_br        = ftb_new_entry && !update_ftb_entry.jmpValid
@@ -1669,7 +1536,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val ftb_modified_entry =
     u(ftbEntryGen.is_new_br || ftbEntryGen.is_jalr_target_modified || ftbEntryGen.is_strong_bias_modified)
   val ftb_modified_entry_new_br               = u(ftbEntryGen.is_new_br)
-  val ftb_modified_entry_ifu_redirected       = u(ifuRedirected(do_commit_ptr.value))
+  val ftb_modified_entry_ifu_redirected       = u(ifuRedirected(s2_commitPtr.value))
   val ftb_modified_entry_jalr_target_modified = u(ftbEntryGen.is_jalr_target_modified)
   val ftb_modified_entry_br_full              = ftb_modified_entry && ftbEntryGen.is_br_full
   val ftb_modified_entry_strong_bias          = ftb_modified_entry && ftbEntryGen.is_strong_bias_modified
@@ -1720,14 +1587,17 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   // --------------------------- Debug --------------------------------
   // XSDebug(enq_fire, p"enq! " + io.fromBpu.resp.bits.toPrintable)
   XSDebug(io.toIfu.req.fire, p"fire to ifu " + io.toIfu.req.bits.toPrintable)
-  XSDebug(do_commit, p"deq! [ptr] $do_commit_ptr\n")
-  XSDebug(true.B, p"[bpuPtr] $bpuPtr, [ifuPtr] $ifuPtr, [ifuWbPtr] $ifuWbPtr [commPtr] $commPtr\n")
+  XSDebug(s2_backendCommit, p"deq! [ptr] $s2_commitPtr\n")
+  XSDebug(true.B, p"[bpuPtr] $bpuPtr, [ifuPtr] $ifuPtr, [ifuWbPtr] $ifuWbPtr [commPtr] $commitPtr\n")
   XSDebug(
     true.B,
     p"[in] v:${io.fromBpu.resp.valid} r:${io.fromBpu.resp.ready} " +
       p"[out] v:${io.toIfu.req.valid} r:${io.toIfu.req.ready}\n"
   )
-  XSDebug(do_commit, p"[deq info] cfiIndex: $commit_cfi, $commit_pc_bundle, target: ${Hexadecimal(commit_target)}\n")
+  XSDebug(
+    s2_backendCommit,
+    p"[deq info] cfiIndex: $s2_commitCfi, $s2_commitPcBundle, target: ${Hexadecimal(s2_commitTarget)}\n"
+  )
 
   //   def ubtbCheck(commit: FtqEntry, predAns: Seq[PredictorAnswer], isWrong: Bool) = {
   //     commit.valids.zip(commit.pd).zip(predAns).zip(commit.takens).map {

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -1291,7 +1291,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
       io.fromBackend.rob_commits.map(_.bits.ftqIdx).reverse
     )
   }
-  private val robCommitPtrReg: FtqPtr = RegEnable(robCommitPtr, backendCommit)
+  private val robCommitPtrReg: FtqPtr = RegEnable(robCommitPtr, FtqPtr(false.B, 0.U), backendCommit)
   private val committedPtr = Mux(backendCommit, robCommitPtr, robCommitPtrReg)
   readyToCommit := commitPtr < committedPtr
   when(readyToCommit) {

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -162,17 +162,16 @@ package object xiangshan {
   }
 
   object CommitType {
-    def NORMAL = "b000".U  // int/fp
-    def BRANCH = "b001".U  // branch
-    def LOAD   = "b010".U  // load
-    def STORE  = "b011".U  // store
+    def NORMAL = "b00".U  // int/fp
+    def BRANCH = "b01".U  // branch
+    def LOAD   = "b10".U  // load
+    def STORE  = "b11".U  // store
 
-    def apply() = UInt(3.W)
-    def isFused(commitType: UInt): Bool = commitType(2)
-    def isLoadStore(commitType: UInt): Bool = !isFused(commitType) && commitType(1)
+    def apply() = UInt(2.W)
+    def isLoadStore(commitType: UInt): Bool = commitType(1)
     def lsInstIsStore(commitType: UInt): Bool = commitType(0)
     def isStore(commitType: UInt): Bool = isLoadStore(commitType) && lsInstIsStore(commitType)
-    def isBranch(commitType: UInt): Bool = commitType(0) && !commitType(1) && !isFused(commitType)
+    def isBranch(commitType: UInt): Bool = commitType(0) && !commitType(1)
   }
 
   object RedirectLevel {


### PR DESCRIPTION
This PR completely refactors the commit mechanism from frontend to backend, addressing the commit problem once and for all. Additionally, these changes are expected to save noticeable area for frontend.

The backend now guarantees that every FTQ entry is committed on time, rather than committing only a subset of instructions. To accomplish this, each ROB entry can now compress a maximum of two FTQ entries. As a result, the `commitStateQueue` is no longer needed in the FTQ.

During the refactoring process, some historical bugs were identified and fixed.

**Attention**: Modifications in the FTQ may lead to a noticeable drop in BP accuracy. Performance data should be checked before merging into master.

