### PR TITLE
fix(Unprivileged): wait a cycle to update `time` when `nextV =/= v`

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/Unprivileged.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/Unprivileged.scala
@@ -153,7 +153,9 @@ trait Unprivileged { self: NewCSR with MachineLevel with SupervisorLevel =>
 
     // Update when rtc clock tick and not dcsr.STOPTIME
     // or virtual mode changed
-    when(mHPM.time.valid && !debugModeStopTime || this.nextV =/= this.v) {
+    // Note: we delay a cycle and use `v` for better timing
+    val virtModeChanged = RegNext(nextV =/= v, false.B)
+    when(mHPM.time.valid && !debugModeStopTime || virtModeChanged) {
       reg.time := Mux(v, vstimeTmp, stimeTmp)
     }.otherwise {
       reg := reg


### PR DESCRIPTION
When virt mode changed, `time` should be updated because we may need a offset version with `htimedelta`. This commit delays a cycle to update `time` register because `v` is actually changed a cycle after `nextV =/= v`.