### PR TITLE
fix(LoadUnit): use `lqIdx` to determine age

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -292,8 +292,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   // src 9: load try pointchaising when no issued or replayed load (io.fastpath)
   // src10: hardware prefetch from prefetchor (high confidence) (io.prefetch)
   // priority: high to low
-  val s0_rep_stall           = io.ldin.valid && isAfter(io.replay.bits.uop.robIdx, io.ldin.bits.uop.robIdx) ||
-                               io.vecldin.valid && isAfter(io.replay.bits.uop.robIdx, io.vecldin.bits.uop.robIdx)
+  val s0_rep_stall           = io.ldin.valid && isAfter(io.replay.bits.uop.lqIdx, io.ldin.bits.uop.lqIdx) ||
+                               io.vecldin.valid && isAfter(io.replay.bits.uop.lqIdx, io.vecldin.bits.uop.lqIdx)
   private val SRC_NUM = 11
   private val Seq(
     mab_idx, super_rep_idx, fast_rep_idx, mmio_idx, nc_idx, lsq_rep_idx,


### PR DESCRIPTION
1. `lqIdx` has less bit width.
2. for vectors, the `robIdx` is the same for multiple `flow`s. Previously, for vectors, we would additionally use `uopIdx` for judgement. But actually, in theory, we only need to use `lqIdx/sqIdx`.

Here we change the age judgement for vectors to `lqIdx` to ensure accurate age judgement. And change the age judgement of scalar to `lqIdx` as well to reduce the cost.