### PR TITLE
feat(exception): divide the exceptions raised from CSR access into different sources.

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRPermitModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRPermitModule.scala
@@ -14,7 +14,7 @@ class CSRPermitModule extends Module {
   val mLevelPermitMod = Module(new MLevelPermitModule)
   val sLevelPermitMod = Module(new SLevelPermitModule)
   val privilegePermitMod = Module(new PrivilegePermitModule)
-  val hLevelPermitMod = Module(new HLevelPermitModule)
+  val virtualLevelPermitMod = Module(new VirtualLevelPermitModule)
   val indirectCSRPermitMod = Module(new IndirectCSRPermitModule)
 
   xRetPermitMod.io.in.privState := io.in.privState
@@ -39,13 +39,13 @@ class CSRPermitModule extends Module {
   privilegePermitMod.io.in.privState := io.in.privState
   privilegePermitMod.io.in.debugMode := io.in.debugMode
 
-  hLevelPermitMod.io.in.csrAccess   := io.in.csrAccess
-  hLevelPermitMod.io.in.privState   := io.in.privState
-  hLevelPermitMod.io.in.status      := io.in.status
-  hLevelPermitMod.io.in.xcounteren  := io.in.xcounteren
-  hLevelPermitMod.io.in.xenvcfg     := io.in.xenvcfg
-  hLevelPermitMod.io.in.xstateen    := io.in.xstateen
-  hLevelPermitMod.io.in.aia         := io.in.aia
+  virtualLevelPermitMod.io.in.csrAccess   := io.in.csrAccess
+  virtualLevelPermitMod.io.in.privState   := io.in.privState
+  virtualLevelPermitMod.io.in.status      := io.in.status
+  virtualLevelPermitMod.io.in.xcounteren  := io.in.xcounteren
+  virtualLevelPermitMod.io.in.xenvcfg     := io.in.xenvcfg
+  virtualLevelPermitMod.io.in.xstateen    := io.in.xstateen
+  virtualLevelPermitMod.io.in.aia         := io.in.aia
 
   indirectCSRPermitMod.io.in.csrAccess := io.in.csrAccess
   indirectCSRPermitMod.io.in.privState := io.in.privState
@@ -65,19 +65,19 @@ class CSRPermitModule extends Module {
   val pPermit_EX_II = privilegePermitMod.io.out.privilege_EX_II
   val pPermit_EX_VI = privilegePermitMod.io.out.privilege_EX_VI
 
-  val hPermit_EX_VI = hLevelPermitMod.io.out.privilege_EX_VI
+  val vPermit_EX_VI = virtualLevelPermitMod.io.out.virtualLevelPermit_EX_VI
 
   val indirectPermit_EX_II = indirectCSRPermitMod.io.out.indirectCSR_EX_II
   val indirectPermit_EX_VI = indirectCSRPermitMod.io.out.indirectCSR_EX_VI
 
-  val directPermit_illegal = mPermit_EX_II || sPermit_EX_II || pPermit_EX_II || pPermit_EX_VI || hPermit_EX_VI
+  val directPermit_illegal = mPermit_EX_II || sPermit_EX_II || pPermit_EX_II || pPermit_EX_VI || vPermit_EX_VI
 
   val csrAccess_EX_II = csrAccess && (
     (mPermit_EX_II || sPermit_EX_II || pPermit_EX_II) ||
     (!directPermit_illegal && indirectPermit_EX_II)
   )
   val csrAccess_EX_VI = csrAccess && (
-    (pPermit_EX_VI || hPermit_EX_VI) ||
+    (pPermit_EX_VI || vPermit_EX_VI) ||
     (!directPermit_illegal && indirectPermit_EX_VI)
   )
 
@@ -368,7 +368,7 @@ class PrivilegePermitModule extends Module {
   io.out.privilege_EX_VI := !privilegeLegal && privState.isVirtual && !csrIsM
 }
 
-class HLevelPermitModule extends Module {
+class VirtualLevelPermitModule extends Module {
   val io = IO(new Bundle() {
     val in = Input(new Bundle {
       val csrAccess = new csrAccessIO
@@ -380,7 +380,7 @@ class HLevelPermitModule extends Module {
       val aia = new aiaIO
     })
     val out = Output(new Bundle {
-      val privilege_EX_VI = Bool()
+      val virtualLevelPermit_EX_VI = Bool()
     })
   })
 
@@ -466,7 +466,7 @@ class HLevelPermitModule extends Module {
   private val xstateControlAccess_EX_VI = accessStateen0_EX_VI || accessEnvcfg_EX_VI || accessIND_EX_VI || accessAIA_EX_VI ||
     accessTopie_EX_VI || accessContext_EX_VI || accessCustom_EX_VI
 
-  io.out.privilege_EX_VI := rwSatp_EX_VI || rwSip_Sie_EX_VI || rwStimecmp_EX_VI || accessHPM_EX_VI || xstateControlAccess_EX_VI
+  io.out.virtualLevelPermit_EX_VI := rwSatp_EX_VI || rwSip_Sie_EX_VI || rwStimecmp_EX_VI || accessHPM_EX_VI || xstateControlAccess_EX_VI
 }
 
 class IndirectCSRPermitModule extends Module {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRPermitModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRPermitModule.scala
@@ -55,7 +55,7 @@ class CSRPermitModule extends Module {
   val s1_EX_II = mLevelPermitMod.io.out.mLevelPermit_EX_II
 
   val s2_EX_II = privilegePermitMod.io.out.privilege_EX_II
-  val s2_EX_VI = !privilegePermitMod.io.out.privilege_EX_VI
+  val s2_EX_VI = privilegePermitMod.io.out.privilege_EX_VI
 
   val s3_EX_VI = hLevelPermitMod.io.out.privilege_EX_VI
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRPermitModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRPermitModule.scala
@@ -45,14 +45,9 @@ class CSRPermitModule extends Module {
   indirectCSRPermitMod.io.in.privState := io.in.privState
   indirectCSRPermitMod.io.in.aia       := io.in.aia
 
-
-
-  private val (ren, wen, addr, privState, debugMode) = (
+  private val (ren, wen) = (
     io.in.csrAccess.ren,
     io.in.csrAccess.wen,
-    io.in.csrAccess.addr,
-    io.in.privState,
-    io.in.debugMode
   )
 
   private val csrAccess = WireInit(ren || wen)

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRPermitModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRPermitModule.scala
@@ -11,7 +11,10 @@ class CSRPermitModule extends Module {
   val io = IO(new CSRPermitIO)
 
   val xRetPermitMod = Module(new XRetPermitModule)
-  xRetPermitMod.io.in <> io.in
+  xRetPermitMod.io.in.privState := io.in.privState
+  xRetPermitMod.io.in.debugMode := io.in.debugMode
+  xRetPermitMod.io.in.xRet := io.in.xRet
+  xRetPermitMod.io.in.status := io.in.status
 
 
   private val (ren, wen, addr, privState, debugMode) = (

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -457,11 +457,10 @@ class NewCSR(implicit val p: Parameters) extends Module
   permitMod.io.in.privState := privState
   permitMod.io.in.debugMode := debugMode
 
-  permitMod.io.in.mnret := io.in.bits.mnret && valid
-  permitMod.io.in.mret  := io.in.bits.mret  && valid
-  permitMod.io.in.sret  := io.in.bits.sret  && valid
-  permitMod.io.in.dret  := io.in.bits.dret  && valid
-  permitMod.io.in.csrIsCustom := customCSRMods.map(_.addr.U === addr).reduce(_ || _).orR
+  permitMod.io.in.xRet.mnret := io.in.bits.mnret && valid
+  permitMod.io.in.xRet.mret  := io.in.bits.mret  && valid
+  permitMod.io.in.xRet.sret  := io.in.bits.sret  && valid
+  permitMod.io.in.xRet.dret  := io.in.bits.dret  && valid
 
   permitMod.io.in.status.tsr := mstatus.regOut.TSR.asBool
   permitMod.io.in.status.vtsr := hstatus.regOut.VTSR.asBool
@@ -469,16 +468,16 @@ class NewCSR(implicit val p: Parameters) extends Module
   permitMod.io.in.status.tvm  := mstatus.regOut.TVM.asBool
   permitMod.io.in.status.vtvm := hstatus.regOut.VTVM.asBool
 
-  permitMod.io.in.status.mcounteren := mcounteren.rdata
-  permitMod.io.in.status.hcounteren := hcounteren.rdata
-  permitMod.io.in.status.scounteren := scounteren.rdata
+  permitMod.io.in.xcounteren.mcounteren := mcounteren.rdata
+  permitMod.io.in.xcounteren.hcounteren := hcounteren.rdata
+  permitMod.io.in.xcounteren.scounteren := scounteren.rdata
 
-  permitMod.io.in.status.mstateen0 := mstateen0.rdata
-  permitMod.io.in.status.hstateen0 := hstateen0.rdata
-  permitMod.io.in.status.sstateen0 := sstateen0.rdata
+  permitMod.io.in.xstateen.mstateen0 := mstateen0.rdata
+  permitMod.io.in.xstateen.hstateen0 := hstateen0.rdata
+  permitMod.io.in.xstateen.sstateen0 := sstateen0.rdata
 
-  permitMod.io.in.status.menvcfg := menvcfg.rdata
-  permitMod.io.in.status.henvcfg := henvcfg.rdata
+  permitMod.io.in.xenvcfg.menvcfg := menvcfg.rdata
+  permitMod.io.in.xenvcfg.henvcfg := henvcfg.rdata
 
   permitMod.io.in.status.mstatusFSOff  :=  mstatus.regOut.FS === ContextStatus.Off
   permitMod.io.in.status.mstatusVSOff  :=  mstatus.regOut.VS === ContextStatus.Off


### PR DESCRIPTION
Before this, we assumed that all possible exceptions during CSR read and write operations should be handled according to their priority.

Therefore, we ensured that all illegal instruction exceptions take precedence over virtual instruction exceptions.

However, with the implementation of certain extensions like Smcsrind and Smstateen, we encounter scenarios where virtual instruction exceptions must take precedence over illegal instruction exceptions triggered.

For instance, when mstateen0.csrind is set to 1 and hstateen0.csrind is 0, a virtual instruction exception should be raised if VS mode attempts to access sireg. However, if the vsiselect value is reserved in this situation, an illegal instruction exception will be raised instead. If these checks are treated as being at the same priority level, an illegal instruction exception would ultimately be raised.

In reality, a virtual instruction exception should take precedence because when the extension is disabled, we should not even evaluate the value of vsiselect.

Therefore, we divided the sources of exceptions caused by CSR access into several categories: M-level, S-level, privilege level, virtualization level, and indirect access level.

Among them, M-level and S-level will only raise illegal instruction exceptions, the privilege level will raise both illegal instruction and virtual instruction exceptions, the virtualization level will raise virtual instruction exceptions, and indirect access will raise both illegal instruction and virtual instruction exceptions. Therefore, we handle the exceptions from the previous levels in the same way, and only check for exceptions caused by indirect access after ensuring that no exceptions were raised earlier.