### PR TITLE
feat(Config): add yaml parser for complicated parametrization

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -213,6 +213,7 @@ jobs:
       - name: Build EMU
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
+            --yaml-config $GITHUB_WORKSPACE/src/main/resources/config/Default.yml \
             --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3            \
             --with-dramsim3 --threads 16 \
             --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin --llvm-profdata llvm-profdata

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,11 @@ ifneq ($(L3_CACHE_SIZE),)
 COMMON_EXTRA_ARGS += --l3-cache-size $(L3_CACHE_SIZE)
 endif
 
+# configuration from yaml file
+ifneq ($(YAML_CONFIG),)
+COMMON_EXTRA_ARGS += --yaml-config $(YAML_CONFIG)
+endif
+
 # public args sumup
 RELEASE_ARGS += $(MFC_ARGS) $(COMMON_EXTRA_ARGS)
 DEBUG_ARGS += $(MFC_ARGS) $(COMMON_EXTRA_ARGS)

--- a/build.sc
+++ b/build.sc
@@ -270,7 +270,8 @@ object xiangshan extends XiangShanModule with HasChisel with ScalafmtModule {
 
   override def ivyDeps = super.ivyDeps() ++ Agg(
     defaultVersions("chiseltest"),
-    ivy"org.yaml:snakeyaml:2.3"
+    ivy"io.circe::circe-yaml:1.15.0",
+    ivy"io.circe::circe-generic-extras:0.14.4"
   )
 
   override def scalacOptions = super.scalacOptions() ++ Agg("-deprecation", "-feature")
@@ -343,11 +344,6 @@ object xiangshan extends XiangShanModule with HasChisel with ScalafmtModule {
     )
 
     override def forkArgs = forkArgsTask()
-
-    override def ivyDeps = super.ivyDeps() ++ Agg(
-      defaultVersions("chiseltest"),
-      ivy"org.yaml:snakeyaml:2.3"
-    )
 
     override def scalacOptions = super.scalacOptions() ++ Agg("-deprecation", "-feature")
 

--- a/build.sc
+++ b/build.sc
@@ -177,7 +177,7 @@ object difftest extends HasChisel {
 
   object test extends SbtTests with TestModule.ScalaTest {
     override def sources = T.sources {
-      super.sources() ++ Seq(PathRef(millSourcePath / "src" / "generator" / "chisel"))
+      super.sources() ++ Seq(PathRef(this.millSourcePath / "src" / "generator" / "chisel"))
     }
   }
 
@@ -270,6 +270,7 @@ object xiangshan extends XiangShanModule with HasChisel with ScalafmtModule {
 
   override def ivyDeps = super.ivyDeps() ++ Agg(
     defaultVersions("chiseltest"),
+    ivy"org.yaml:snakeyaml:2.3"
   )
 
   override def scalacOptions = super.scalacOptions() ++ Agg("-deprecation", "-feature")
@@ -344,7 +345,8 @@ object xiangshan extends XiangShanModule with HasChisel with ScalafmtModule {
     override def forkArgs = forkArgsTask()
 
     override def ivyDeps = super.ivyDeps() ++ Agg(
-      defaultVersions("chiseltest")
+      defaultVersions("chiseltest"),
+      ivy"org.yaml:snakeyaml:2.3"
     )
 
     override def scalacOptions = super.scalacOptions() ++ Agg("-deprecation", "-feature")

--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -78,6 +78,7 @@ class XSArgs(object):
         self.trace = 1 if args.trace or not args.disable_fork and not args.trace_fst else None
         self.trace_fst = "fst" if args.trace_fst else None
         self.config = args.config
+        self.yaml_config = args.yaml_config
         self.emu_optimize = args.emu_optimize
         self.xprop = 1 if args.xprop else None
         self.with_chiseldb = 0 if args.no_db else 1
@@ -136,6 +137,7 @@ class XSArgs(object):
             (self.emu_optimize,  "EMU_OPTIMIZE"),
             (self.xprop,         "ENABLE_XPROP"),
             (self.with_chiseldb, "WITH_CHISELDB"),
+            (self.yaml_config,   "YAML_CONFIG"),
             (self.pgo,           "PGO_WORKLOAD"),
             (self.pgo_max_cycle, "PGO_MAX_CYCLE"),
             (self.pgo_emu_args,  "PGO_EMU_ARGS"),
@@ -670,6 +672,7 @@ if __name__ == "__main__":
     parser.add_argument('--trace', action='store_true', help='enable vcd waveform')
     parser.add_argument('--trace-fst', action='store_true', help='enable fst waveform')
     parser.add_argument('--config', nargs='?', type=str, help='config')
+    parser.add_argument('--yaml-config', nargs='?', type=str, help='yaml config')
     parser.add_argument('--emu-optimize', nargs='?', type=str, help='verilator optimization letter')
     parser.add_argument('--xprop', action='store_true', help='enable xprop for vcs')
     # emu arguments

--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -3,8 +3,8 @@ PmemRanges:
 
 PMAConfigs:
   - { base_addr: 0x0, range: 0x1000000000000, a: 3 }
-  - { base_addr: PmemRanges(0).upper, c: true, atomic: true, a: 1, x: true, w: true, r: true }
-  - { base_addr: PmemRanges(0).lower, a: 1, w: true, r: true }
+  - { base_addr: 0x80000000000, c: true, atomic: true, a: 1, x: true, w: true, r: true }
+  - { base_addr: 0x80000000, a: 1, w: true, r: true }
   - { base_addr: 0x3A000000, a: 1 }
   - { base_addr: 0x38022000, a: 1, w: true, r: true }
   - { base_addr: 0x38021000, a: 1, x: true, w: true, r: true }

--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -1,0 +1,14 @@
+PmemRanges:
+  - { lower: 0x80000000, upper: 0x80000000000 }
+
+PMAConfigs:
+  - { base_addr: 0x0, range: 0x1000000000000, a: 3 }
+  - { base_addr: PmemRanges(0).upper, c: true, atomic: true, a: 1, x: true, w: true, r: true }
+  - { base_addr: PmemRanges(0).lower, a: 1, w: true, r: true }
+  - { base_addr: 0x3A000000, a: 1 }
+  - { base_addr: 0x38022000, a: 1, w: true, r: true }
+  - { base_addr: 0x38021000, a: 1, x: true, w: true, r: true }
+  - { base_addr: 0x30010000, a: 1, w: true, r: true }
+  - { base_addr: 0x20000000, a: 1, x: true, w: true, r: true }
+  - { base_addr: 0x10000000, a: 1, w: true, r: true }
+  - { base_addr: 0 }

--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -13,5 +13,10 @@ PMAConfigs:
   - { base_addr: 0x10000000, a: 1, w: true, r: true }
   - { base_addr: 0 }
 
-CHIAsyncBridge:
-  { depth: 16, sync: 3, safe: false }
+CHIAsyncBridge: { depth: 16, sync: 3, safe: false }
+
+L2CacheConfig: { size: 1 MB, ways: 8, inclusive: true, banks: 4, tp: true }
+
+L3CacheConfig: { size: 16 MB, ways: 16, inclusive: false, banks: 4 }
+
+DebugModuleBaseAddr: 0x38020000

--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -12,3 +12,6 @@ PMAConfigs:
   - { base_addr: 0x20000000, a: 1, x: true, w: true, r: true }
   - { base_addr: 0x10000000, a: 1, w: true, r: true }
   - { base_addr: 0 }
+
+CHIAsyncBridge:
+  { depth: 16, sync: 3, safe: false }

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -31,12 +31,11 @@ import freechips.rocketchip.util.AsyncQueueParams
 import huancun._
 import top.BusPerfMonitor
 import utility.{ReqSourceKey, TLClientsMerger, TLEdgeBuffer, TLLogger}
-import xiangshan.backend.fu.PMAConst
-import xiangshan.{DebugOptionsKey, XSTileKey}
+import xiangshan.backend.fu.{PMAConfigEntry, PMAConst}
+import xiangshan.{DebugOptionsKey, PMParameKey, XSTileKey}
 import coupledL2.{EnableCHI, L2Param}
 import coupledL2.tl2chi.CHIIssue
 import openLLC.OpenLLCParam
-import xiangshan.PMParameKey
 
 case object SoCParamsKey extends Field[SoCParameters]
 
@@ -45,6 +44,20 @@ case class SoCParameters
   EnableILA: Boolean = false,
   PAddrBits: Int = 48,
   PmemRanges: Seq[(BigInt, BigInt)] = Seq((0x80000000L, 0x80000000000L)),
+  PMAConfigs: Seq[PMAConfigEntry] = Seq(
+    PMAConfigEntry(0x0L, range = 0x1000000000000L, a = 3),
+    PMAConfigEntry(0x80000000000L, c = true, atomic = true, a = 1, x = true, w = true, r = true),
+    PMAConfigEntry(0x80000000L, a = 1, w = true, r = true),
+    PMAConfigEntry(0x3A000000L, a = 1),
+    PMAConfigEntry(0x38022000L, a = 1, w = true, r = true),
+    PMAConfigEntry(0x38021000L, a = 1, x = true, w = true, r = true),
+    PMAConfigEntry(0x38020000L, a = 1, w = true, r = true),
+    PMAConfigEntry(0x30050000L, a = 1, w = true, r = true), // FIXME: GPU space is cacheable?
+    PMAConfigEntry(0x30010000L, a = 1, w = true, r = true),
+    PMAConfigEntry(0x20000000L, a = 1, x = true, w = true, r = true),
+    PMAConfigEntry(0x10000000L, a = 1, w = true, r = true),
+    PMAConfigEntry(0)
+  ),
   CLINTRange: AddressSet = AddressSet(0x38000000L, CLINTConsts.size - 1),
   BEURange: AddressSet = AddressSet(0x38010000L, 0xfff),
   PLICRange: AddressSet = AddressSet(0x3c000000L, PLICConsts.size(PLICConsts.maxMaxHarts) - 1),

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -31,7 +31,7 @@ import freechips.rocketchip.util.AsyncQueueParams
 import huancun._
 import top.BusPerfMonitor
 import utility.{ReqSourceKey, TLClientsMerger, TLEdgeBuffer, TLLogger}
-import xiangshan.backend.fu.{PMAConfigEntry, PMAConst}
+import xiangshan.backend.fu.{MemoryRange, PMAConfigEntry, PMAConst}
 import xiangshan.{DebugOptionsKey, PMParameKey, XSTileKey}
 import coupledL2.{EnableCHI, L2Param}
 import coupledL2.tl2chi.CHIIssue
@@ -43,7 +43,7 @@ case class SoCParameters
 (
   EnableILA: Boolean = false,
   PAddrBits: Int = 48,
-  PmemRanges: Seq[(BigInt, BigInt)] = Seq((0x80000000L, 0x80000000000L)),
+  PmemRanges: Seq[MemoryRange] = Seq(MemoryRange(0x80000000L, 0x80000000000L)),
   PMAConfigs: Seq[PMAConfigEntry] = Seq(
     PMAConfigEntry(0x0L, range = 0x1000000000000L, a = 3),
     PMAConfigEntry(0x80000000000L, c = true, atomic = true, a = 1, x = true, w = true, r = true),

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -184,6 +184,8 @@ object ArgParser {
                 OpenLLCParamsOpt = openLLCParam
               )
           }), tail)
+        case "--yaml-config" :: yamlFile :: tail =>
+          nextOption(YamlParser.parseYaml(config, yamlFile), tail)
         case option :: tail =>
           // unknown option, maybe a firrtl option, skip
           firrtlOpts :+= option

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -288,7 +288,7 @@ case class L2CacheConfig
 ) extends Config((site, here, up) => {
   case XSTileKey =>
     require(inclusive, "L2 must be inclusive")
-    val nKB = size match {
+    val nKB = size.toUpperCase() match {
       case s"${k}KB" => k.strip().toInt
       case s"${m}MB" => (m.strip().toDouble * 1024).toInt
     }
@@ -328,7 +328,7 @@ case class L2CacheConfig
 
 case class L3CacheConfig(size: String, ways: Int = 8, inclusive: Boolean = true, banks: Int = 1) extends Config((site, here, up) => {
   case SoCParamsKey =>
-    val nKB = size match {
+    val nKB = size.toUpperCase() match {
       case s"${k}KB" => k.strip().toInt
       case s"${m}MB" => (m.strip().toDouble * 1024).toInt
     }

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -1,6 +1,6 @@
 /***************************************************************************************
-* Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-* Copyright (c) 2024 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
 *
 * XiangShan is licensed under Mulan PSL v2.
 * You can use this software according to the terms and conditions of the Mulan PSL v2.
@@ -18,60 +18,52 @@ package top
 
 import org.chipsalliance.cde.config.{Config, Parameters}
 
-import org.yaml.snakeyaml.Yaml
 import scala.jdk.CollectionConverters._
 import scala.annotation.tailrec
+import java.util.{List => JList, Map => JMap}
 import system.SoCParamsKey
 import xiangshan.backend.fu.PMAConfigEntry
+import freechips.rocketchip.devices.debug.DebugModuleKey
 import freechips.rocketchip.util.AsyncQueueParams
 
 object YamlParser {
+  private def getSizeInKB(a: String): Int = a match {
+    case s"${k}KB" => k.strip().toInt
+    case s"${m}MB" => (m.strip().toDouble * 1024).toInt
+  }
   def parseYaml(config: Parameters, yamlFile: String): Parameters = {
     val file = new java.io.File(yamlFile)
     val inputStream = new java.io.FileInputStream(file)
-    val yamlSeq = (new Yaml()).load(inputStream).asInstanceOf[java.util.Map[String, Any]].asScala.toSeq
+    val yaml = new org.yaml.snakeyaml.Yaml()
+    val yamlSeq = yaml.load(inputStream).asInstanceOf[JMap[String, Any]].asScala.toSeq
     @tailrec
     def nextConfig(config: Parameters, yamlSeq: Seq[(String, Any)]): Parameters = {
+      def toBigInt(a: Any): BigInt = a match {
+        case i: Int => BigInt(i)
+        case l: Long => BigInt(l)
+        case s"PmemRanges($i).lower" => config(SoCParamsKey).PmemRanges(i.toInt)._1
+        case s"PmemRanges($i).upper" => config(SoCParamsKey).PmemRanges(i.toInt)._2
+      }
       yamlSeq match {
         case Nil => config
         case ("PmemRanges", pmemRanges) :: tail =>
-          val param = pmemRanges.asInstanceOf[java.util.List[java.util.Map[String, Any]]].asScala.map { range =>
-            val Seq(lower, upper) = Seq("lower", "upper").map { key =>
-              range.asScala(key) match {
-                case i: Int => BigInt(i)
-                case l: Long => BigInt(l)
-              }
-            }
+          val param = pmemRanges.asInstanceOf[JList[JMap[String, Any]]].asScala.map { range =>
+            val Seq(lower, upper) = Seq("lower", "upper").map(key => toBigInt(range.asScala(key)))
             (lower, upper)
           }.toSeq
           nextConfig(config.alter((site, here, up) => {
             case SoCParamsKey => up(SoCParamsKey).copy(PmemRanges = param)
           }), tail)
         case ("PMAConfigs", pmaConfigs) :: tail =>
-          val param = pmaConfigs.asInstanceOf[java.util.List[java.util.Map[String, Any]]].asScala.map { pmaConfig =>
+          val param = pmaConfigs.asInstanceOf[JList[JMap[String, Any]]].asScala.map { pmaConfig =>
             require(pmaConfig.containsKey("base_addr"), "base_addr is required in every PMAConfigs")
-            val conf = pmaConfig.asScala.withDefaultValue(0)
-            val base_addr = conf("base_addr") match {
-              case i: Int => BigInt(i)
-              case l: Long => BigInt(l)
-              case s"PmemRanges($i).lower" => config(SoCParamsKey).PmemRanges(i.toInt)._1
-              case s"PmemRanges($i).upper" => config(SoCParamsKey).PmemRanges(i.toInt)._2
-            }
-            val range = conf("range") match {
-              case i: Int => BigInt(i)
-              case l: Long => BigInt(l)
-            }
-            val a = conf("a") match {
-              case i: Int => i.toInt
-              case l: Long => l.toInt
-            }
+            val conf = pmaConfig.asScala
+            val base_addr = toBigInt(conf.withDefaultValue(0)("base_addr"))
+            val range = toBigInt(conf.withDefaultValue(0)("range"))
+            val a = conf.withDefaultValue(0)("a").asInstanceOf[Int]
             require(a == 0 || a == 1 || a == 3, "a should be 0, 1 or 3")
             val Seq(l, c, atomic, x, w, r) = Seq("l", "c", "atomic", "x", "w", "r").map { key =>
-              conf(key) match {
-                case i: Int => i != 0
-                case i: Long => i != 0
-                case b: Boolean => b
-              }
+              conf.withDefaultValue(false)(key).asInstanceOf[Boolean]
             }
             PMAConfigEntry(base_addr, range, l, c, atomic, a, x, w, r)
           }.toSeq
@@ -79,16 +71,36 @@ object YamlParser {
             case SoCParamsKey => up(SoCParamsKey).copy(PMAConfigs = param)
           }), tail)
         case ("CHIAsyncBridge", chiAsyncBridge) :: tail =>
-          val paramCHIAsyncBridge = chiAsyncBridge.asInstanceOf[java.util.Map[String, Any]].asScala
-          require(paramCHIAsyncBridge.contains("depth"), "depth is required in CHIAsyncBridge")
-          val depth = paramCHIAsyncBridge("depth").asInstanceOf[Int]
-          val param = if (depth != 0) {
-            val sync = paramCHIAsyncBridge.withDefaultValue(3)("sync").asInstanceOf[Int]
-            val safe = paramCHIAsyncBridge.withDefaultValue(false)("safe").asInstanceOf[Boolean]
+          val param = chiAsyncBridge.asInstanceOf[JMap[String, Any]].asScala
+          require(param.contains("depth"), "depth is required in CHIAsyncBridge")
+          val depth = param("depth").asInstanceOf[Int]
+          val enableCHIAsyncBridge = if (depth != 0) {
+            val sync = param.withDefaultValue(3)("sync").asInstanceOf[Int]
+            val safe = param.withDefaultValue(false)("safe").asInstanceOf[Boolean]
             Some(AsyncQueueParams(depth, sync, safe))
           } else None
           nextConfig(config.alter((site, here, up) => {
-            case SoCParamsKey => up(SoCParamsKey).copy(EnableCHIAsyncBridge = param)
+            case SoCParamsKey => up(SoCParamsKey).copy(EnableCHIAsyncBridge = enableCHIAsyncBridge)
+          }), tail)
+        case ("L2CacheConfig", l2CacheConfig) :: tail =>
+          val param = l2CacheConfig.asInstanceOf[JMap[String, Any]].asScala
+          val n = getSizeInKB(param("size").asInstanceOf[String])
+          val ways = param.withDefaultValue(8)("ways").asInstanceOf[Int]
+          val inclusive = param.withDefaultValue(true)("inclusive").asInstanceOf[Boolean]
+          val banks = param.withDefaultValue(1)("banks").asInstanceOf[Int]
+          val tp = param.withDefaultValue(true)("tp").asInstanceOf[Boolean]
+          nextConfig(config.alter(new WithNKBL2(n, ways, inclusive, banks, tp)), tail)
+        case ("L3CacheConfig", l3CacheConfig) :: tail =>
+          val param = l3CacheConfig.asInstanceOf[JMap[String, Any]].asScala
+          val n = getSizeInKB(param("size").asInstanceOf[String])
+          val ways = param.withDefaultValue(8)("ways").asInstanceOf[Int]
+          val inclusive = param.withDefaultValue(true)("inclusive").asInstanceOf[Boolean]
+          val banks = param.withDefaultValue(1)("banks").asInstanceOf[Int]
+          nextConfig(config.alter(new WithNKBL3(n, ways, inclusive, banks)), tail)
+        case ("DebugModuleBaseAddr", debugModuleBaseAddr) :: tail =>
+          val param = toBigInt(debugModuleBaseAddr)
+          nextConfig(config.alter((site, here, up) => {
+            case DebugModuleKey => up(DebugModuleKey).map(_.copy(baseAddress = param))
           }), tail)
         case (s, _) :: tail =>
           println(s"Warning: $s is not supported in Yaml Config")

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -1,0 +1,87 @@
+/***************************************************************************************
+* Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2024 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+package top
+
+import org.chipsalliance.cde.config.{Config, Parameters}
+
+import org.yaml.snakeyaml.Yaml
+import scala.jdk.CollectionConverters._
+import scala.annotation.tailrec
+import system.SoCParamsKey
+import xiangshan.backend.fu.PMAConfigEntry
+
+object YamlParser {
+  def parseYaml(config: Parameters, yamlFile: String): Parameters = {
+    val file = new java.io.File(yamlFile)
+    val inputStream = new java.io.FileInputStream(file)
+    val yamlSeq = (new Yaml()).load(inputStream).asInstanceOf[java.util.Map[String, Any]].asScala.toSeq
+    @tailrec
+    def nextConfig(config: Parameters, yamlSeq: Seq[(String, Any)]): Parameters = {
+      yamlSeq match {
+        case Nil => config
+        case ("PmemRanges", pmemRanges) :: tail =>
+          val param = pmemRanges.asInstanceOf[java.util.List[java.util.Map[String, Any]]].asScala.map { range =>
+            val Seq(lower, upper) = Seq("lower", "upper").map { key =>
+              range.asScala(key) match {
+                case i: Int => BigInt(i)
+                case l: Long => BigInt(l)
+              }
+            }
+            (lower, upper)
+          }.toSeq
+          nextConfig(config.alter((site, here, up) => {
+            case SoCParamsKey => up(SoCParamsKey).copy(PmemRanges = param)
+          }), tail)
+        case ("PMAConfigs", pmaConfigs) :: tail =>
+          val param = pmaConfigs.asInstanceOf[java.util.List[java.util.Map[String, Any]]].asScala.map { pmaConfig =>
+            require(pmaConfig.containsKey("base_addr"), "base_addr is required in every PMAConfigs")
+            val conf = pmaConfig.asScala.withDefaultValue(0)
+            val base_addr = conf("base_addr") match {
+              case i: Int => BigInt(i)
+              case l: Long => BigInt(l)
+              case s"PmemRanges($i).lower" => config(SoCParamsKey).PmemRanges(i.toInt)._1
+              case s"PmemRanges($i).upper" => config(SoCParamsKey).PmemRanges(i.toInt)._2
+            }
+            val range = conf("range") match {
+              case i: Int => BigInt(i)
+              case l: Long => BigInt(l)
+            }
+            val a = conf("a") match {
+              case i: Int => i.toInt
+              case l: Long => l.toInt
+            }
+            require(a == 0 || a == 1 || a == 3, "a should be 0, 1 or 3")
+            val Seq(l, c, atomic, x, w, r) = Seq("l", "c", "atomic", "x", "w", "r").map { key =>
+              conf(key) match {
+                case i: Int => i != 0
+                case i: Long => i != 0
+                case b: Boolean => b
+              }
+            }
+            PMAConfigEntry(base_addr, range, l, c, atomic, a, x, w, r)
+          }.toSeq
+          nextConfig(config.alter((site, here, up) => {
+            case SoCParamsKey => up(SoCParamsKey).copy(PMAConfigs = param)
+          }), tail)
+        case (s, _) :: tail =>
+          println(s"Warning: $s is not supported in Yaml Config")
+          nextConfig(config, tail)
+      }
+    }
+    nextConfig(config, yamlSeq)
+  }
+}

--- a/src/main/scala/xiangshan/PMParameters.scala
+++ b/src/main/scala/xiangshan/PMParameters.scala
@@ -44,8 +44,6 @@ trait HasPMParameters {
 
   def PMPAddrBits = p(SoCParamsKey).PAddrBits
   def PMPPmemRanges = p(SoCParamsKey).PmemRanges
-  def PMPPmemLowBounds = PMPPmemRanges.unzip._1
-  def PMPPmemHighBounds = PMPPmemRanges.unzip._2
   def PMAConfigs = p(SoCParamsKey).PMAConfigs
   def PMXLEN = p(XLen)
   def pmParams = p(PMParameKey)

--- a/src/main/scala/xiangshan/PMParameters.scala
+++ b/src/main/scala/xiangshan/PMParameters.scala
@@ -46,6 +46,7 @@ trait HasPMParameters {
   def PMPPmemRanges = p(SoCParamsKey).PmemRanges
   def PMPPmemLowBounds = PMPPmemRanges.unzip._1
   def PMPPmemHighBounds = PMPPmemRanges.unzip._2
+  def PMAConfigs = p(SoCParamsKey).PMAConfigs
   def PMXLEN = p(XLen)
   def pmParams = p(PMParameKey)
   def NumPMP = pmParams.NumPMP

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -582,8 +582,6 @@ trait HasXSParameter {
 
   def PAddrBits = p(SoCParamsKey).PAddrBits // PAddrBits is Phyical Memory addr bits
   def PmemRanges = p(SoCParamsKey).PmemRanges
-  def PmemLowBounds = PmemRanges.unzip._1
-  def PmemHighBounds = PmemRanges.unzip._2
   final val PageOffsetWidth = 12
   def NodeIDWidth = p(SoCParamsKey).NodeIDWidthList(p(CHIIssue)) // NodeID width among NoC
 

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -31,7 +31,6 @@ import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.backend.trace.TraceCoreInterface
 import xiangshan.cache.mmu._
 import xiangshan.frontend._
-import xiangshan.mem.L1PrefetchFuzzer
 import scala.collection.mutable.ListBuffer
 import xiangshan.cache.mmu.TlbRequestIO
 

--- a/src/main/scala/xiangshan/backend/fu/PMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMA.scala
@@ -34,6 +34,11 @@ case class MMPMAConfig
   num: Int
 )
 
+case class MemoryRange(lower: BigInt, upper: BigInt) {
+  def cover(addr: BigInt): Boolean = addr >= lower && addr < upper
+  def cover(addr: UInt): Bool = addr >= lower.U && addr < upper.U
+}
+
 case class PMAConfigEntry(
   base_addr: BigInt,
   range: BigInt = 0L, // only use for napot mode

--- a/src/main/scala/xiangshan/backend/fu/PMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMA.scala
@@ -34,6 +34,18 @@ case class MMPMAConfig
   num: Int
 )
 
+case class PMAConfigEntry(
+  base_addr: BigInt,
+  range: BigInt = 0L, // only use for napot mode
+  l: Boolean = false,
+  c: Boolean = false,
+  atomic: Boolean = false,
+  a: Int = 0,
+  x: Boolean = false,
+  w: Boolean = false,
+  r: Boolean = false
+)
+
 trait PMAConst extends PMPConst
 
 trait MMPMAMethod extends PMAConst with PMAMethod with PMPReadWriteMethodBare {
@@ -142,38 +154,18 @@ trait PMAMethod extends PMAConst {
     val cfg_list = ListBuffer[UInt]()
     val addr_list = ListBuffer[UInt]()
     val mask_list = ListBuffer[UInt]()
-    def addPMA(base_addr: BigInt,
-               range: BigInt = 0L, // only use for napot mode
-               l: Boolean = false,
-               c: Boolean = false,
-               atomic: Boolean = false,
-               a: Int = 0,
-               x: Boolean = false,
-               w: Boolean = false,
-               r: Boolean = false) = {
-      val addr = if (a < 2) { shift_addr(base_addr) }
-        else { get_napot(base_addr, range) }
-      cfg_list.append(PMPConfigUInt(l, c, atomic, a, x, w, r))
+
+    def addPMA(conf: PMAConfigEntry) = {
+      val addr = if (conf.a < 2) { shift_addr(conf.base_addr) }
+        else { get_napot(conf.base_addr, conf.range) }
+      cfg_list.append(PMPConfigUInt(conf.l, conf.c, conf.atomic, conf.a, conf.x, conf.w, conf.r))
       addr_list.append(genAddr(addr))
-      mask_list.append(genMask(addr, a))
+      mask_list.append(genMask(addr, conf.a))
     }
 
-    addPMA(0x0L, range = 0x1000000000000L, a = 3)
-    addPMA(PMPPmemHighBounds(0), c = true, atomic = true, a = 1, x = true, w = true, r = true)
-    addPMA(PMPPmemLowBounds(0), a = 1, w = true, r = true)
-    addPMA(0x3A000000L, a = 1)
-    addPMA(0x39002000L, a = 1, w = true, r = true)
-    addPMA(0x39000000L, a = 1, w = true, r = true)
-    addPMA(0x38022000L, a = 1, w = true, r = true)
-    addPMA(0x38021000L, a = 1, x = true, w = true, r = true)
-    addPMA(0x38020000L, a = 1, w = true, r = true)
-    addPMA(0x30050000L, a = 1, w = true, r = true) // FIXME: GPU space is cacheable?
-    addPMA(0x30010000L, a = 1, w = true, r = true)
-    addPMA(0x20000000L, a = 1, x = true, w = true, r = true)
-    addPMA(0x10000000L, a = 1, w = true, r = true)
-    addPMA(0)
+    PMAConfigs.foreach(addPMA)
     while (cfg_list.length < 16) {
-      addPMA(0)
+      addPMA(PMAConfigEntry(0))
     }
 
     val cfgInitMerge = Seq.tabulate(num / 8)(i => {

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1653,13 +1653,13 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   // dcache should only deal with DRAM addresses
   import freechips.rocketchip.util._
   when (bus.a.fire) {
-    assert(PmemRanges.map(range => bus.a.bits.address.inRange(range._1.U, range._2.U)).reduce(_ || _))
+    assert(PmemRanges.map(_.cover(bus.a.bits.address)).reduce(_ || _))
   }
   when (bus.b.fire) {
-    assert(PmemRanges.map(range => bus.b.bits.address.inRange(range._1.U, range._2.U)).reduce(_ || _))
+    assert(PmemRanges.map(_.cover(bus.b.bits.address)).reduce(_ || _))
   }
   when (bus.c.fire) {
-    assert(PmemRanges.map(range => bus.c.bits.address.inRange(range._1.U, range._2.U)).reduce(_ || _))
+    assert(PmemRanges.map(_.cover(bus.c.bits.address)).reduce(_ || _))
   }
 
   //----------------------------------------

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -717,7 +717,7 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
     l1_array(s1_pf_index).bit_vec := l1_array(s1_pf_index).bit_vec & ~s1_pf_candidate_oh
   }
 
-  val in_pmem = PmemRanges.map(range => s1_pf_bits.req.paddr.inRange(range._1.U, range._2.U)).reduce(_ || _)
+  val in_pmem = PmemRanges.map(_.cover(s1_pf_bits.req.paddr)).reduce(_ || _)
   io.l1_req.valid := s1_pf_valid && !s1_pf_evict && !s1_pf_update && in_pmem && io.enable
   io.l1_req.bits := s1_pf_bits.req
 
@@ -886,11 +886,11 @@ class L1Prefetcher(implicit p: Parameters) extends BasePrefecher with HasStreamP
   pf_queue_filter.io.confidence := pf_ctrl.confidence
   pf_queue_filter.io.l2PfqBusy := l2PfqBusy
 
-  val l2_in_pmem = PmemRanges.map(range => pf_queue_filter.io.l2_pf_addr.bits.addr.inRange(range._1.U, range._2.U)).reduce(_ || _)
+  val l2_in_pmem = PmemRanges.map(_.cover(pf_queue_filter.io.l2_pf_addr.bits.addr)).reduce(_ || _)
   io.l2_req.valid := pf_queue_filter.io.l2_pf_addr.valid && l2_in_pmem && enable && pf_ctrl.enable
   io.l2_req.bits := pf_queue_filter.io.l2_pf_addr.bits
 
-  val l3_in_pmem = PmemRanges.map(range => pf_queue_filter.io.l3_pf_addr.bits.inRange(range._1.U, range._2.U)).reduce(_ || _)
+  val l3_in_pmem = PmemRanges.map(_.cover(pf_queue_filter.io.l3_pf_addr.bits)).reduce(_ || _)
   io.l3_req.valid := pf_queue_filter.io.l3_pf_addr.valid && l3_in_pmem && enable && pf_ctrl.enable
   io.l3_req.bits := pf_queue_filter.io.l3_pf_addr.bits
 }

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchInterface.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchInterface.scala
@@ -94,7 +94,7 @@ class L1PrefetchFuzzer(implicit p: Parameters) extends DCacheModule{
   val rand_vaddr = DelayN(io.vaddr, 2)
   val rand_paddr = DelayN(io.paddr, 2)
 
-  io.req.bits.paddr := PmemLowBounds.min.U + rand_offset
+  io.req.bits.paddr := PmemRanges.map(_.lower).min.U + rand_offset
   io.req.bits.alias := io.req.bits.paddr(13,12)
   io.req.bits.confidence := LFSR64(seed=Some(789L))(4,0) === 0.U
   io.req.bits.is_store := LFSR64(seed=Some(890L))(4,0) === 0.U

--- a/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
@@ -1282,7 +1282,7 @@ class SMSPrefetcher()(implicit p: Parameters) extends BasePrefecher with HasSMSM
   pf_filter.io.gen_req.valid := pht_gen_valid || agt_gen_valid || stride_gen_valid
   pf_filter.io.gen_req.bits := pf_gen_req
   io.tlb_req <> pf_filter.io.tlb_req
-  val is_valid_address = PmemRanges.map(range => pf_filter.io.l2_pf_addr.bits.inRange(range._1.U, range._2.U)).reduce(_ || _)
+  val is_valid_address = PmemRanges.map(_.cover(pf_filter.io.l2_pf_addr.bits)).reduce(_ || _)
 
   io.l2_req.valid := pf_filter.io.l2_pf_addr.valid && io.enable && is_valid_address
   io.l2_req.bits.addr := pf_filter.io.l2_pf_addr.bits


### PR DESCRIPTION
This commit enables complicated parameterization by yaml parsing. We use circe to do this.

In this commit, we implement 6 configurations:

- PmemRanges: physical memory ranges
- PMAConfigs
- CHIAsyncBridge: set depth to 0 to disable it
- L2CacheConfig
- L3CacheConfig
- DebugModuleBaseAddr

For better human-readability, this commit changes `WithNKBL2/3` to `L2/3CacheConfig`, changing to case classes, and making the first parameter only accept human-readable size configuration like `0.5 MB` or `256KB`.

This commit also changes PMAConfigs and PmemRanges into List of case classes.