### PR TITLE
style(LoadUnit): removes redundant 'fast_rep_out' assignments

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1508,10 +1508,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   // forwrad last beat
   val s3_fast_rep_canceled = io.replay.valid && io.replay.bits.forward_tlDchannel || io.misalign_ldin.valid || !io.dcache.req.ready
 
-  // s3 load fast replay
-  io.fast_rep_out.valid := s3_valid && s3_fast_rep && !s3_in.uop.robIdx.needFlush(io.redirect)
-  io.fast_rep_out.bits := s3_in
-
   val s3_can_enter_lsq_valid = s3_valid && (!s3_fast_rep || s3_fast_rep_canceled) && !s3_in.feedbacked && !s3_nc_with_data && !s3_in.misalignNeedWakeUp
   io.lsq.ldin.valid := s3_can_enter_lsq_valid
   // TODO: check this --by hx
@@ -1533,7 +1529,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   io.s3_dly_ld_err := false.B // s3_dly_ld_err && s3_valid
   io.lsq.ldin.bits.dcacheRequireReplay  := s3_dcache_rep
-  io.fast_rep_out.bits.delayedLoadError := s3_hw_err
 
   val s3_vp_match_fail = GatedValidRegNext(s2_fwd_vp_match_invalid) && s3_troublem
   val s3_rep_frm_fetch = s3_vp_match_fail


### PR DESCRIPTION
In the code that follows, overriding assignments exist below：

https://github.com/OpenXiangShan/XiangShan/blob/23767fc38e3f03726f910926add24b7f85db5eab/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala#L1771-L1775