### PR TITLE
fix(LoadUnit): `fast replay` no longer requests to `RAR/RAW Queue`

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1266,8 +1266,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
                            !s2_dcache_miss &&
                            !s2_bank_conflict &&
                            !s2_wpu_pred_fail &&
-                           !s2_rar_nack &&
-                           !s2_raw_nack &&
                            s2_nuke
 
   val s2_fast_rep = !s2_in.isFastReplay &&
@@ -1283,6 +1281,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
                      !s2_tlb_miss &&
                      !s2_fwd_fail &&
                      !s2_frm_mabuf &&
+                     !s2_fast_rep &&
                      s2_troublem
 
   val s2_data_fwded = s2_dcache_miss && s2_full_fwd


### PR DESCRIPTION
For `fast replay`, there is no need to request access to the `RAW/RAW Queue`.
This prevents the `RAW Queue` from constantly ping-ponging between `not full/full` due to `revoke`.

These two lines were removed because it would lead to combinatorial logic loops and it was an unwanted condition:
https://github.com/OpenXiangShan/XiangShan/blob/dfc474ebe17bbfb1bf2ec4cc122301a9c7998e09/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala#L1269-L1270

---
Probably questions like this: https://github.com/OpenXiangShan/XiangShan/pull/4102
With the previous changes plus this one, i don't think a similar stuck will happen again. :raised_hands:

**This may result in some performance gains.**