### PR TITLE
fix(XSTop): assign unique nodeID to each core

### DIFF
--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -387,9 +387,9 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc() with HasSoCParameter
       case _ =>
     }
 
-    core_with_l2.foreach { case tile =>
+    core_with_l2.zipWithIndex.foreach { case (tile, i) =>
       tile.module.io.nodeID.foreach { case nodeID =>
-        nodeID := DontCare
+        nodeID := i.U
         dontTouch(nodeID)
       }
     }


### PR DESCRIPTION
Without this commit, CHI messages cannot be correctly routed in multi-core scenarios, leading to simulation errors.