### PR TITLE
style(DebugModule): remove unnecessary `XSDebugModuleParams`

### DIFF
--- a/src/main/scala/device/RocketDebugWrapper.scala
+++ b/src/main/scala/device/RocketDebugWrapper.scala
@@ -1,5 +1,6 @@
 /***************************************************************************************
-* Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2021-2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 * Copyright (c) 2020-2021 Peng Cheng Laboratory
 *
 * XiangShan is licensed under Mulan PSL v2.
@@ -96,21 +97,6 @@ class DebugModule(numCores: Int)(implicit p: Parameters) extends LazyModule {
   }
 
   lazy val module = new DebugModuleImp(this)
-}
-
-object XSDebugModuleParams {
-
-  def apply(xlen:Int /*TODO , val configStringAddr: Int*/): DebugModuleParams = {
-    new DebugModuleParams().copy(
-      nAbstractDataWords   = (if (xlen == 32) 1 else if (xlen == 64) 2 else 4),
-      maxSupportedSBAccess = xlen,
-      hasBusMaster = true,
-      baseAddress = BigInt(0x38020000),
-      nScratch = 2,
-      crossingHasSafeReset = false,
-      hasHartResets = true,
-    )
-  }
 }
 
 case object EnableJtag extends Field[Bool]

--- a/src/main/scala/device/standalone/StandAloneDebugModule.scala
+++ b/src/main/scala/device/standalone/StandAloneDebugModule.scala
@@ -1,6 +1,6 @@
 /***************************************************************************************
-* Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
-* Copyright (c) 2020-2021 Peng Cheng Laboratory
+* Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2024-2025 Institute of Computing Technology, Chinese Academy of Sciences
 *
 * XiangShan is licensed under Mulan PSL v2.
 * You can use this software according to the terms and conditions of the Mulan PSL v2.
@@ -24,7 +24,6 @@ import freechips.rocketchip.devices.debug.DebugModuleKey
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.util.AsyncResetSynchronizerShiftReg
-import device.XSDebugModuleParams
 import system.SoCParamsKey
 import xiangshan.XSCoreParamsKey
 import xiangshan.XSTileKey


### PR DESCRIPTION
It is more straight-forward to use `DebugModuleParams` in `Config.scala`.