### PR TITLE
timing(VLSU): fix timing issues in `VLSU`

### DIFF
--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -38,6 +38,7 @@ class VLSBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBun
   val excp_eew_index      = UInt(elemIdxBits.W)
   // val exceptionVec   = ExceptionVec() // uop has exceptionVec
   val baseAddr            = UInt(XLEN.W)
+  val uopAddr             = UInt(XLEN.W)
   val stride              = UInt(VLEN.W)
   // val flow_counter = UInt(flowIdxBits.W)
 


### PR DESCRIPTION
## Two main issues were fixed:
**Timing issue caused by too long address calculations for vector modules:**
   - Solved by moving some of the logic to the previous cycle.

---

**Timing issue caused by long exception logic of load writeback to `VLMergeBuffer`:**
   - Add one cycle to the load writeback exception, now the same number of cycles as the load write back data.