### PR TITLE
timing(TLB): add tlb query use fast adder comparator support

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -167,7 +167,8 @@ class MinimalConfig(n: Int = 1) extends Config(
           partialStaticPMP = true,
           outsideRecvFlush = true,
           outReplace = false,
-          lgMaxSize = 4
+          lgMaxSize = 4,
+          useFac = true
         ),
         sttlbParameters = TLBParameters(
           name = "sttlb",
@@ -175,7 +176,8 @@ class MinimalConfig(n: Int = 1) extends Config(
           partialStaticPMP = true,
           outsideRecvFlush = true,
           outReplace = false,
-          lgMaxSize = 4
+          lgMaxSize = 4,
+          useFac = true
         ),
         hytlbParameters = TLBParameters(
           name = "hytlb",
@@ -183,7 +185,8 @@ class MinimalConfig(n: Int = 1) extends Config(
           partialStaticPMP = true,
           outsideRecvFlush = true,
           outReplace = false,
-          lgMaxSize = 4
+          lgMaxSize = 4,
+          useFac = true
         ),
         pftlbParameters = TLBParameters(
           name = "pftlb",

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -288,7 +288,8 @@ case class XSCoreParameters
     partialStaticPMP = true,
     outsideRecvFlush = true,
     saveLevel = false,
-    lgMaxSize = 4
+    lgMaxSize = 4,
+    useFac = true
   ),
   sttlbParameters: TLBParameters = TLBParameters(
     name = "sttlb",
@@ -297,7 +298,8 @@ case class XSCoreParameters
     partialStaticPMP = true,
     outsideRecvFlush = true,
     saveLevel = false,
-    lgMaxSize = 4
+    lgMaxSize = 4,
+    useFac = true
   ),
   hytlbParameters: TLBParameters = TLBParameters(
     name = "hytlb",
@@ -306,7 +308,8 @@ case class XSCoreParameters
     partialStaticPMP = true,
     outsideRecvFlush = true,
     saveLevel = false,
-    lgMaxSize = 4
+    lgMaxSize = 4,
+    useFac = true
   ),
   pftlbParameters: TLBParameters = TLBParameters(
     name = "pftlb",

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -1160,7 +1160,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   dtlb_reqs(L2toL1DLBPortIndex) <> io.l2_tlb_req
   dtlb_reqs(L2toL1DLBPortIndex).req.bits.facA := io.l2_tlb_req.req.bits.vaddr(VAddrBits-1, sectorvpnOffLen)
   dtlb_reqs(L2toL1DLBPortIndex).req.bits.facB := 0.U
-  dtlb_reqs(L2toL1DLBPortIndex).req.bits.facC0 := false.B
+  dtlb_reqs(L2toL1DLBPortIndex).req.bits.facCarry := false.B
   dtlb_reqs(L2toL1DLBPortIndex).resp.ready := true.B
   io.l2_pmp_resp := pmp_check(L2toL1DLBPortIndex).resp
 

--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -1158,6 +1158,9 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
         dtlb_reqs(StreamDTLBPortIndex).resp.ready := true.B
   }
   dtlb_reqs(L2toL1DLBPortIndex) <> io.l2_tlb_req
+  dtlb_reqs(L2toL1DLBPortIndex).req.bits.facA := io.l2_tlb_req.req.bits.vaddr(VAddrBits-1, sectorvpnOffLen)
+  dtlb_reqs(L2toL1DLBPortIndex).req.bits.facB := 0.U
+  dtlb_reqs(L2toL1DLBPortIndex).req.bits.facC0 := false.B
   dtlb_reqs(L2toL1DLBPortIndex).resp.ready := true.B
   io.l2_pmp_resp := pmp_check(L2toL1DLBPortIndex).resp
 

--- a/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
@@ -42,7 +42,8 @@ case class TLBParameters
   partialStaticPMP: Boolean = false, // partial static pmp result stored in entries
   outsideRecvFlush: Boolean = false, // if outside moudle waiting for tlb recv flush pipe
   saveLevel: Boolean = false,
-  lgMaxSize: Int = 3
+  lgMaxSize: Int = 3,
+  useFac: Boolean = false
 )
 
 case class L2TLBParameters
@@ -119,6 +120,7 @@ trait HasTlbConst extends HasXSParameter {
   val sectorgvpnLen = gvpnLen - sectortlbwidth
   val sectorvpnLen = vpnLen - sectortlbwidth
   val sectorptePPNLen = ptePPNLen - sectortlbwidth
+  val sectorvpnOffLen = sectortlbwidth + offLen
 
   val loadfiltersize = 16 // 4*3(LduCnt:2 + HyuCnt:1) + 4(prefetch:1)
   val storefiltersize = if (StorePipelineWidth >= 3) 16 else 8

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -216,7 +216,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   entries.io.base_connect(sfence, csr, satp)
   if (q.outReplace) { io.replace <> entries.io.replace }
   for (i <- 0 until Width) {
-    entries.io.r_req_apply(io.requestor(i).req.valid, get_pn(req_in(i).bits.vaddr), i, req_in_s2xlate(i))
+    entries.io.r_req_apply(io.requestor(i).req.valid, get_pn(req_in(i).bits.vaddr), req_in(i).bits.facA, req_in(i).bits.facB, req_in(i).bits.facCarry, i, req_in_s2xlate(i))
     entries.io.w_apply(refill, ptw.resp.bits)
     // TODO: RegNext enable:req.valid
     resp(i).bits.debug.isFirstIssue := RegEnable(req(i).bits.debug.isFirstIssue, req(i).valid)

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -851,6 +851,9 @@ class NewIFU(implicit p: Parameters) extends XSModule
   io.iTLBInter.req.bits.debug.robIdx       := DontCare
   io.iTLBInter.req.bits.debug.isFirstIssue := DontCare
   io.iTLBInter.req.bits.pmp_addr           := DontCare
+  io.iTLBInter.req.bits.facA               := DontCare
+  io.iTLBInter.req.bits.facB               := DontCare
+  io.iTLBInter.req.bits.facCarry           := DontCare
   // whats the difference between req_kill and req.bits.kill?
   io.iTLBInter.req_kill := false.B
   // wait for itlb response in m_tlbResp state

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -31,11 +31,12 @@ import xiangshan.backend.fu.FuType
 import xiangshan.backend.Bundles.{MemExuInput, MemExuOutput}
 import xiangshan.backend.fu.NewCSR.TriggerUtil
 import xiangshan.backend.fu.util.SdtrigExt
-import xiangshan.cache.mmu.Pbmt
+import xiangshan.cache.mmu.{HasTlbConst, Pbmt}
 
 class AtomicsUnit(implicit p: Parameters) extends XSModule
   with MemoryOpConstants
   with HasDCacheParameters
+  with HasTlbConst
   with SdtrigExt{
 
   val StdCnt  = backendParams.StdCnt

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -454,6 +454,9 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
   io.dtlb.req.bits.vaddr  := vaddr
   io.dtlb.req.bits.fullva := vaddr
   io.dtlb.req.bits.checkfullva := true.B
+  io.dtlb.req.bits.facA   := vaddr(VAddrBits-1, sectorvpnOffLen)
+  io.dtlb.req.bits.facB   := 0.U
+  io.dtlb.req.bits.facCarry := false.B
   io.dtlb.resp.ready      := true.B
   io.dtlb.req.bits.cmd    := Mux(isLr, TlbCmd.atom_read, TlbCmd.atom_write)
   io.dtlb.req.bits.debug.pc := uop.pc

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -204,7 +204,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   val s0_rep_stall           = io.lsin.valid && isAfter(io.ldu_io.replay.bits.uop.robIdx, io.lsin.bits.uop.robIdx)
   private val SRC_NUM = 8
   private val Seq(
-    super_rep_idx, fast_rep_idx, lsq_rep_idx, high_pf_idx, 
+    super_rep_idx, fast_rep_idx, lsq_rep_idx, high_pf_idx,
     int_iss_idx, vec_iss_idx, l2l_fwd_idx, low_pf_idx
   ) = (0 until SRC_NUM).toSeq
   // load flow source valid
@@ -274,6 +274,9 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.no_translate       := s0_hw_prf_select  // hw b.reqetch addr does not need to be translated
   io.tlb.req.bits.debug.pc           := s0_uop.pc
   io.tlb.req.bits.debug.isFirstIssue := s0_isFirstIssue
+  io.tlb.req.bits.facA               := DontCare
+  io.tlb.req.bits.facB               := DontCare
+  io.tlb.req.bits.facCarry           := DontCare
 
   // query DCache
   // for load
@@ -984,7 +987,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   // generate XLEN/8 Muxs
   for (i <- 0 until VLEN / 8) {
     s2_fwd_mask(i) := io.ldu_io.lsq.forward.forwardMask(i) || io.ldu_io.sbuffer.forwardMask(i) || io.ldu_io.vec_forward.forwardMask(i) || io.ldu_io.ubuffer.forwardMask(i)
-    s2_fwd_data(i) := 
+    s2_fwd_data(i) :=
       Mux(io.ldu_io.lsq.forward.forwardMask(i), io.ldu_io.lsq.forward.forwardData(i),
       Mux(io.ldu_io.vec_forward.forwardMask(i), io.ldu_io.vec_forward.forwardData(i),
       Mux(io.ldu_io.ubuffer.forwardMask(i), io.ldu_io.ubuffer.forwardData(i),

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -112,6 +112,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   with HasDCacheParameters
   with HasCircularQueuePtrHelper
   with HasVLSUParameters
+  with HasTlbConst
   with SdtrigExt
 {
   val io = IO(new Bundle() {
@@ -686,6 +687,36 @@ class LoadUnit(implicit p: Parameters) extends XSModule
       int_vec_vaddr
     )
   )
+
+  io.tlb.req.bits.facA := Mux(
+    s0_src_valid_vec(mab_idx),
+    io.misalign_ldin.bits.vaddr(VAddrBits-1, sectorvpnOffLen),
+    Mux(
+      s0_src_valid_vec(super_rep_idx) || s0_src_valid_vec(lsq_rep_idx),
+      io.replay.bits.vaddr(VAddrBits-1, sectorvpnOffLen),
+      io.ldin.bits.src(0)(VAddrBits-1, sectorvpnOffLen)
+    )
+  )
+  io.tlb.req.bits.facB := Mux(
+    s0_src_valid_vec(mab_idx),
+    0.U,
+    Mux(
+      s0_src_valid_vec(super_rep_idx) || s0_src_valid_vec(lsq_rep_idx),
+      0.U,
+      SignExt(io.ldin.bits.uop.imm(11, 0), VAddrBits)(VAddrBits-1, sectorvpnOffLen)
+    )
+  )
+  val s0_facCarry = io.ldin.bits.src(0)(sectorvpnOffLen - 1, 0) +& SignExt(io.ldin.bits.uop.imm(11, 0), sectorvpnOffLen)
+  io.tlb.req.bits.facCarry := Mux(
+    s0_src_valid_vec(mab_idx),
+    false.B,
+    Mux(
+      s0_src_valid_vec(super_rep_idx) || s0_src_valid_vec(lsq_rep_idx),
+      false.B,
+      s0_facCarry(s0_facCarry.getWidth-1)
+    )
+  )
+
   s0_dcache_vaddr := Mux(
     s0_src_select_vec(fast_rep_idx), io.fast_rep_in.bits.vaddr,
     Mux(s0_hw_prf_select, io.prefetch_req.bits.getVaddr(),

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -275,6 +275,9 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     val data          = UInt((VLEN+1).W)
   }
   val s0_sel_src = Wire(new FlowSource)
+  val s0_sel_facA = Wire(UInt(VAddrBits.W))
+  val s0_sel_facB = Wire(UInt(VAddrBits.W))
+  val s0_sel_facCarry = Wire(Bool())
 
   // load flow select/gen
   // src 0: misalignBuffer load (io.misalign_ldin)
@@ -388,6 +391,9 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.no_translate       := s0_tlb_no_query  // hardware prefetch and fast replay does not need to be translated, need this signal for pmp check
   io.tlb.req.bits.debug.pc           := s0_sel_src.uop.pc
   io.tlb.req.bits.debug.isFirstIssue := s0_sel_src.isFirstIssue
+  io.tlb.req.bits.facA               := s0_sel_facA(VAddrBits-1, sectorvpnOffLen)
+  io.tlb.req.bits.facB               := s0_sel_facB(VAddrBits-1, sectorvpnOffLen)
+  io.tlb.req.bits.facCarry           := s0_sel_facCarry
 
   // query DCache
   io.dcache.req.valid             := s0_valid && !s0_sel_src.prf_i && !s0_nc_with_data
@@ -688,34 +694,31 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     )
   )
 
-  io.tlb.req.bits.facA := Mux(
-    s0_src_valid_vec(mab_idx),
-    io.misalign_ldin.bits.vaddr(VAddrBits-1, sectorvpnOffLen),
+  s0_sel_facA := Mux(
+    s0_src_valid_vec(mab_idx) || s0_src_valid_vec(super_rep_idx) || s0_src_valid_vec(lsq_rep_idx),
     Mux(
-      s0_src_valid_vec(super_rep_idx) || s0_src_valid_vec(lsq_rep_idx),
-      io.replay.bits.vaddr(VAddrBits-1, sectorvpnOffLen),
-      io.ldin.bits.src(0)(VAddrBits-1, sectorvpnOffLen)
+      s0_src_valid_vec(mab_idx),
+      io.misalign_ldin.bits.vaddr,
+      io.replay.bits.vaddr
+    ),
+    Mux(
+      s0_src_valid_vec(vec_iss_idx),
+      io.vecldin.bits.vaddr,
+      io.ldin.bits.src(0)
     )
   )
-  io.tlb.req.bits.facB := Mux(
-    s0_src_valid_vec(mab_idx),
+  s0_sel_facB := Mux(
+    s0_src_valid_vec(mab_idx) || s0_src_valid_vec(super_rep_idx) || s0_src_valid_vec(lsq_rep_idx) || s0_src_valid_vec(vec_iss_idx),
     0.U,
-    Mux(
-      s0_src_valid_vec(super_rep_idx) || s0_src_valid_vec(lsq_rep_idx),
-      0.U,
-      SignExt(io.ldin.bits.uop.imm(11, 0), VAddrBits)(VAddrBits-1, sectorvpnOffLen)
-    )
+    SignExt(io.ldin.bits.uop.imm(11, 0), VAddrBits)
   )
   val s0_facCarry = io.ldin.bits.src(0)(sectorvpnOffLen - 1, 0) +& SignExt(io.ldin.bits.uop.imm(11, 0), sectorvpnOffLen)
-  io.tlb.req.bits.facCarry := Mux(
-    s0_src_valid_vec(mab_idx),
+  s0_sel_facCarry := Mux(
+    s0_src_valid_vec(mab_idx) || s0_src_valid_vec(super_rep_idx) || s0_src_valid_vec(lsq_rep_idx) || s0_src_valid_vec(vec_iss_idx),
     false.B,
-    Mux(
-      s0_src_valid_vec(super_rep_idx) || s0_src_valid_vec(lsq_rep_idx),
-      false.B,
-      s0_facCarry(s0_facCarry.getWidth-1)
-    )
+    s0_facCarry(s0_facCarry.getWidth-1)
   )
+
 
   s0_dcache_vaddr := Mux(
     s0_src_select_vec(fast_rep_idx), io.fast_rep_in.bits.vaddr,

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -29,11 +29,12 @@ import xiangshan.backend.fu.FuConfig._
 import xiangshan.backend.fu.FuType._
 import xiangshan.backend.ctrlblock.DebugLsInfoBundle
 import xiangshan.backend.fu.NewCSR._
-import xiangshan.cache.mmu.{TlbCmd, TlbReq, TlbRequestIO, TlbResp, Pbmt}
+import xiangshan.cache.mmu.{TlbCmd, TlbReq, TlbRequestIO, TlbResp, Pbmt, HasTlbConst}
 import xiangshan.cache.{DcacheStoreRequestIO, DCacheStoreIO, MemoryOpConstants, HasDCacheParameters, StorePrefetchReq}
 
 class StoreUnit(implicit p: Parameters) extends XSModule
   with HasDCacheParameters
+  with HasTlbConst
   with HasVLSUParameters
   {
   val io = IO(new Bundle() {
@@ -213,6 +214,38 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.hyperinst          := LSUOpType.isHsv(s0_uop.fuOpType)
   io.tlb.req.bits.hlvx               := false.B
   io.tlb.req.bits.pmp_addr           := DontCare
+  io.tlb.req.bits.facA := Mux(
+    s0_use_flow_ma,
+    io.misalign_stin.bits.vaddr(VAddrBits-1, sectorvpnOffLen),
+    Mux(
+      s0_use_flow_rs,
+      s0_stin.src(0)(VAddrBits-1, sectorvpnOffLen),
+      Mux(
+        s0_use_flow_vec,
+        s0_vecstin.vaddr(VAddrBits-1, sectorvpnOffLen),
+        io.prefetch_req.bits.vaddr(VAddrBits-1, sectorvpnOffLen)
+      )
+    )
+  )
+  io.tlb.req.bits.facB := Mux(
+    s0_use_flow_ma,
+    0.U,
+    Mux(
+      s0_use_flow_rs,
+      SignExt(s0_stin.uop.imm(11, 0), VAddrBits)(VAddrBits-1, sectorvpnOffLen),
+      0.U
+    )
+  )
+  val s0_facCarry = s0_stin.src(0)(sectorvpnOffLen - 1, 0)  +& SignExt(s0_stin.uop.imm(11, 0), sectorvpnOffLen)
+  io.tlb.req.bits.facCarry := Mux(
+    s0_use_flow_ma,
+    false.B,
+    Mux(
+      s0_use_flow_rs,
+      s0_facCarry(s0_facCarry.getWidth-1),
+      false.B
+    )
+  )
 
   // Dcache access here: not **real** dcache write
   // just read meta and tag in dcache, to find out the store will hit or miss
@@ -257,7 +290,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.st_mask_out.valid       := s0_use_flow_rs || s0_use_flow_vec
   io.st_mask_out.bits.mask   := s0_out.mask
   io.st_mask_out.bits.sqIdx  := s0_out.uop.sqIdx
-  
+
   io.stin.ready := s1_ready && s0_use_flow_rs
   io.vecstin.ready := s1_ready && s0_use_flow_vec
   io.prefetch_req.ready := s1_ready && io.dcache.req.ready && !s0_iss_valid && !s0_vec_valid && !s0_ma_st_valid
@@ -598,7 +631,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
       sx_in(i).isForVSnonLeafPTE     := s3_in.isForVSnonLeafPTE
       sx_in(i).vecTriggerMask := s3_in.vecTriggerMask
       sx_in(i).hasException := s3_exception
-      sx_in_vec(i)         := s3_in.isvec          
+      sx_in_vec(i)         := s3_in.isvec
       sx_ready(i) := !s3_valid(i) || sx_in(i).output.uop.robIdx.needFlush(io.redirect) || (if (TotalDelayCycles == 0) io.stout.ready else sx_ready(i+1))
     } else {
       val cur_kill   = sx_in(i).output.uop.robIdx.needFlush(io.redirect)

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -416,7 +416,8 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
   val realSegmentOffset               = Mux(isIndexed(issueInstType),
                                             indexStride,
                                             segmentOffset)
-  val vaddr                           = baseVaddr + (fieldIdx << alignedType).asUInt + realSegmentOffset
+  val offset                          = (fieldIdx << alignedType).asUInt + realSegmentOffset
+  val vaddr                           = baseVaddr + offset
   val tlb_req_facA                    = Wire(UInt(sectorvpnLen.W))
   val tlb_req_facB                    = Wire(UInt(sectorvpnLen.W))
   val tlb_req_facCarry                = Wire(Bool())
@@ -430,16 +431,16 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
   tlb_req_facA := Mux(
     isMisalignReg,
     misalignLowVaddr(VAddrBits-1, sectorvpnOffLen),
-    nextBaseVaddr(VAddrBits-1, sectorvpnOffLen)
+    baseVaddr(VAddrBits-1, sectorvpnOffLen)
   )
   tlb_req_facB := Mux(
     isMisalignReg,
     0.U,
-    realSegmentOffset(VAddrBits-1, sectorvpnOffLen)
+    offset(VAddrBits-1, sectorvpnOffLen)
   )
 
   val misalignCarry = misalignLowVaddr(sectorvpnOffLen-1, 0) +& 8.U
-  val facCarry = nextBaseVaddr(sectorvpnOffLen-1, 0) +& realSegmentOffset(sectorvpnOffLen-1, 0)
+  val facCarry = baseVaddr(sectorvpnOffLen-1, 0) +& offset(sectorvpnOffLen-1, 0)
   tlb_req_facCarry := Mux(
     isMisalignReg,
     Mux(

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -73,6 +73,7 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
   with MemoryOpConstants
   with SdtrigExt
   with HasLoadHelper
+  with HasTlbConst
 {
   val io               = IO(new VSegmentUnitIO)
 
@@ -446,6 +447,9 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
   io.dtlb.req.bits.no_translate       := false.B
   io.dtlb.req.bits.debug.pc           := instMicroOp.uop.pc
   io.dtlb.req.bits.debug.isFirstIssue := DontCare
+  io.dtlb.req.bits.facA               := tlbReqVaddr(VAddrBits-1, sectorvpnOffLen)
+  io.dtlb.req.bits.facB               := 0.U
+  io.dtlb.req.bits.facCarry           := false.B
   io.dtlb.req_kill                    := false.B
 
   val canTriggerException              = segmentIdx === 0.U || !instMicroOp.isFof // only elementIdx = 0 or is not fof can trigger


### PR DESCRIPTION
Add tlb query use fast adder comparator support
* reduce load/store unit s0 generate vaddr for tlb query, e.g. `src + imm = vaddr` as tag to query tlb use `===`, for better timing, use fast adder comparator `Fac(src, imm, tag).andR`eliminate adder carry delay.