### PR TITLE
fix(build): `gitStatus` should use `Task.Input`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -291,7 +291,8 @@ object xiangshan extends XiangShanModule with HasChisel with ScalafmtModule {
       LocalDateTime.now().format(DateTimeFormatter.ofPattern("MMM dd hh:mm:ss yyyy").withLocale(new Locale("en")))),
   )
 
-  def gitStatus: T[String] = {
+  // gitStatus changes frequently and unpredictably. Use `Task.Input` here.
+  def gitStatus: T[String] = Task.Input {
     val gitRevParseBuilder = new ProcessBuilder("git", "rev-parse", "HEAD")
     val gitRevParseProcess = gitRevParseBuilder.start()
     val shaReader = new BufferedReader(new InputStreamReader(gitRevParseProcess.getInputStream))


### PR DESCRIPTION
See https://mill-build.org/mill/fundamentals/tasks.html#_inputs.