### PR TITLE
feat(DCache): refactor the implementation of 'lr/sc'

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -588,7 +588,6 @@ class AtomicWordIO(implicit p: Parameters) extends DCacheBundle
 {
   val req  = DecoupledIO(new MainPipeReq)
   val resp = Flipped(ValidIO(new MainPipeResp))
-  val block_lr = Input(Bool())
 }
 
 class CMOReq(implicit p: Parameters) extends Bundle {
@@ -1418,7 +1417,6 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   val atomic_resp_valid = mainPipe.io.atomic_resp.valid && mainPipe.io.atomic_resp.bits.isAMO
   io.lsu.atomics.resp.valid := RegNext(atomic_resp_valid)
   io.lsu.atomics.resp.bits := RegEnable(mainPipe.io.atomic_resp.bits, atomic_resp_valid)
-  io.lsu.atomics.block_lr := mainPipe.io.block_lr
 
   // Request
   val missReqArb = Module(new TreeArbiter(new MissReq, MissReqPortCount))
@@ -1511,8 +1509,6 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   // probe
   // probeQueue.io.mem_probe <> bus.b
   block_decoupled(bus.b, probeQueue.io.mem_probe, missQueue.io.probe_block)
-  probeQueue.io.lrsc_locked_block <> mainPipe.io.lrsc_locked_block
-  probeQueue.io.update_resv_set <> mainPipe.io.update_resv_set
 
   val refill_req = RegNext(missQueue.io.main_pipe_req.valid && ((missQueue.io.main_pipe_req.bits.isLoad) | (missQueue.io.main_pipe_req.bits.isStore)))
   //----------------------------------------

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -481,11 +481,8 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
   io.out.bits.debug.isMMIO := is_mmio
   io.out.bits.debug.paddr := paddr
 
-  io.dcache.req.valid := Mux(
-    io.dcache.req.bits.cmd === M_XLR,
-    !io.dcache.block_lr, // block lr to survive in lr storm
-    data_valid // wait until src(1) is ready
-  ) && state === s_cache_req
+  //                                                          wait until src(1) is ready
+  io.dcache.req.valid := (io.dcache.req.bits.cmd === M_XLR || data_valid) && state === s_cache_req
   val pipe_req = io.dcache.req.bits
   pipe_req := DontCare
   pipe_req.cmd := LookupTree(uop.fuOpType, List(


### PR DESCRIPTION
We refactored the `LR/SC` implementation.

---

Now, the following conditions cause SC to fail:

1. There is no identical `reservation set`.
2. The `SC` instruction encounters a `DCache miss`.

We believe that the `SC` instruction should not encounter a `DCache miss`, for whatever reason. Therefore, the `SC` directive does not issue a request to `MissQueue`. Since `SC` is supposed to fail at this point, we don't expect him to have any other side effects. And the `SC` directive generates a `fail` when a `DCache miss` occurs.

---

We will empty the `reservation set` in the following cases:

1. `Probe` the `cache line`.
2. `WriteBack` that `cache line`.
3. Execute any of the `SC` instructions.

Other than that, we will not empty `reservation set`.

---

Also:
`SC` or `CAS` directives that fail now no longer update the `meta`.
The `reservation set` no longer blocks the `Probe`.
'LR' no longer blocks subsequent 'LR'.