### PR TITLE
fix(PTWRepeater): use PriorityMux for not one-hot vector

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/Repeater.scala
+++ b/src/main/scala/xiangshan/cache/mmu/Repeater.scala
@@ -545,9 +545,9 @@ class PTWFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameters) 
   io.tlb.resp.bits.data.s2xlate := ptwResp.s2xlate
   io.tlb.resp.bits.data.s1 := ptwResp.s1
   io.tlb.resp.bits.data.s2 := ptwResp.s2
-  io.tlb.resp.bits.data.memidx := memidx(OHToUInt(ptwResp_OldMatchVec))
+  io.tlb.resp.bits.data.memidx := RegNext(PriorityMux(ptwResp_OldMatchVec, memidx))
   io.tlb.resp.bits.vector := resp_vector
-  io.tlb.resp.bits.data.getGpa := RegNext(getGpa(OHToUInt(ptwResp_OldMatchVec)))
+  io.tlb.resp.bits.data.getGpa := RegNext(PriorityMux(ptwResp_OldMatchVec, getGpa))
   io.tlb.resp.bits.getGpa := DontCare
 
   val issue_valid = v(issPtr) && !isEmptyIss && !inflight_full


### PR DESCRIPTION
ptwResp_OldMatchVec is not a one-hot vector, so we should use PriorityMux rather than OHToUInt.