### PR TITLE
ci(artifacts): use GitHub-hosted runner to generate and upload artifacts

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,59 @@
+# This file describes the GitHub Actions workflow for artifacts uploading.
+name: Upload Artifacts
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  generate-verilog:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    timeout-minutes: 30
+    name: Upload Artifacts
+    steps:
+      - uses: actions/checkout@v4
+      - name: set env
+        run: echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+      - name: psutil
+        run: sudo apt install python3-psutil
+      - name: init
+        run: make init
+      - name: mill
+        uses: jodersky/setup-mill@v0.3.0
+        with:
+          mill-version: 0.12.3
+      - name: swapfile
+        run: |
+          sudo fallocate -l 10G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+      - name: clean up
+        run: python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+      - name: generate standalone devices for AXI4
+        run: |
+          make StandAloneCLINT DEVICE_BASE_ADDR=0x38000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=CLINT_
+          make StandAloneDebugModule DEVICE_BASE_ADDR=0x38020000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=DM_
+          make StandAlonePLIC DEVICE_BASE_ADDR=0x3C000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=PLIC_
+      - name: generate CHI Issue B XSNoCTop verilog with difftest and filelist
+        run: |
+          make verilog WITH_CONSTANTIN=0 WITH_CHISELDB=0 CONFIG='XSNoCTopConfig --enable-difftest' ISSUE=B XSTOP_PREFIX=bosc_ JVM_XMX=16g
+          rm `find $GITHUB_WORKSPACE/build -name "*.fir"`
+          cd $GITHUB_WORKSPACE/build/rtl && find . -name "*.*v" > filelist.f
+      - name: acrhive issue B verilog artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: xs-issue-b-difftest-verilog
+          path: build
+      - name: generate test-jar
+        run: |
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+          make test-jar
+      - name: acrhive test jar artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: xsgen
+          path: out/xiangshan/test/assembly.dest/out.jar

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -48,7 +48,7 @@ jobs:
       - name: check top wiring
         run:
           bash .github/workflows/check-usage.sh "BoringUtils" $GITHUB_WORKSPACE
-      - name: generate standalone devices for TL and clean
+      - name: generate standalone devices for TL
         run: |
           make StandAloneCLINT DEVICE_BASE_ADDR=0x38000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=1 DEVICE_PREFIX=CLINT_
           make StandAloneDebugModule DEVICE_BASE_ADDR=0x38020000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=1 DEVICE_PREFIX=DM_
@@ -59,25 +59,14 @@ jobs:
           make StandAloneCLINT DEVICE_BASE_ADDR=0x38000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=CLINT_
           make StandAloneDebugModule DEVICE_BASE_ADDR=0x38020000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=DM_
           make StandAlonePLIC DEVICE_BASE_ADDR=0x3C000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=PLIC_
-      - name: generate CHI Issue B XSNoCTop verilog with difftest and filelist
+          make clean
+      - name: generate XSNoCTop verilog file
         run: |
-          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --generate --config 'XSNoCTopConfig --enable-difftest' --issue B --no-db
-          rm `find $GITHUB_WORKSPACE/build -name "*.fir"`
-          cd $GITHUB_WORKSPACE/build/rtl && find . -name "*.*v" > filelist.f
-      - name: acrhive issue B verilog artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: xs-issue-b-difftest-verilog
-          path: build
-      - name: generate test-jar
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --generate --config XSNoCTopConfig
+      - name: check XSNoCTop verilog
         run: |
+          python3 $GITHUB_WORKSPACE/.github/workflows/check_verilog.py build/rtl
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
-          make test-jar
-      - name: acrhive test jar artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: xsgen
-          path: out/xiangshan/test/assembly.dest/out.jar
       - name: generate verilog file
         run:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --generate --num-cores 2


### PR DESCRIPTION
Self-hosted runners sometimes fail to upload artifacts due to special network environment. To make use of free machines, we allocate a 10 GB swapfile to avoid oom failure.