### PR TITLE
power(SC): dynamically close SC

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -85,6 +85,7 @@ case class XSCoreParameters
   EnableLB: Boolean = false,
   EnableLoop: Boolean = true,
   EnableSC: Boolean = true,
+  DynCloseSC: Boolean = true,
   EnbaleTlbDebug: Boolean = false,
   EnableClockGate: Boolean = true,
   EnableJal: Boolean = false,
@@ -658,6 +659,7 @@ trait HasXSParameter {
   def EnableLB = coreParams.EnableLB
   def EnableLoop = coreParams.EnableLoop
   def EnableSC = coreParams.EnableSC
+  def DynCloseSC = coreParams.DynCloseSC
   def EnbaleTlbDebug = coreParams.EnbaleTlbDebug
   def HistoryLength = coreParams.HistoryLength
   def EnableGHistDiff = coreParams.EnableGHistDiff

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -85,7 +85,7 @@ case class XSCoreParameters
   EnableLB: Boolean = false,
   EnableLoop: Boolean = true,
   EnableSC: Boolean = true,
-  DynCloseSC: Boolean = true,
+  DynCloseSC: Boolean = false,
   SCCloseConfIncWhenSCAgreeAndCorrect: Int = 1,
   SCCloseConfIncWhenSCAgreeButWrong: Int = 1,
   SCCloseConfIncWhenSCDisagreeButTAGECorrect: Int = 5,

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -86,6 +86,12 @@ case class XSCoreParameters
   EnableLoop: Boolean = true,
   EnableSC: Boolean = true,
   DynCloseSC: Boolean = true,
+  SCCloseConfIncWhenSCAgreeAndCorrect: Int = 1,
+  SCCloseConfIncWhenSCAgreeButWrong: Int = 1,
+  SCCloseConfIncWhenSCDisagreeButTAGECorrect: Int = 5,
+  SCCloseConfDecWhenSCDisagreeAndSCCorrect: Int = -50,
+  SCCloseConfIncWhenSCClosedAndTAGECorrect: Int = 1,
+  SCCloseConfIncWhenSCClosedAndTAGEWrong: Int = -30,
   EnbaleTlbDebug: Boolean = false,
   EnableClockGate: Boolean = true,
   EnableJal: Boolean = false,
@@ -660,6 +666,12 @@ trait HasXSParameter {
   def EnableLoop = coreParams.EnableLoop
   def EnableSC = coreParams.EnableSC
   def DynCloseSC = coreParams.DynCloseSC
+  def SCCloseConfIncWhenSCAgreeAndCorrect = coreParams.SCCloseConfIncWhenSCAgreeAndCorrect
+  def SCCloseConfIncWhenSCAgreeButWrong = coreParams.SCCloseConfIncWhenSCAgreeButWrong
+  def SCCloseConfIncWhenSCDisagreeButTAGECorrect = coreParams.SCCloseConfIncWhenSCDisagreeButTAGECorrect
+  def SCCloseConfDecWhenSCDisagreeAndSCCorrect = coreParams.SCCloseConfDecWhenSCDisagreeAndSCCorrect
+  def SCCloseConfIncWhenSCClosedAndTAGECorrect = coreParams.SCCloseConfIncWhenSCClosedAndTAGECorrect
+  def SCCloseConfIncWhenSCClosedAndTAGEWrong = coreParams.SCCloseConfIncWhenSCClosedAndTAGEWrong
   def EnbaleTlbDebug = coreParams.EnbaleTlbDebug
   def HistoryLength = coreParams.HistoryLength
   def EnableGHistDiff = coreParams.EnableGHistDiff

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -91,7 +91,7 @@ case class XSCoreParameters
   SCCloseConfIncWhenSCDisagreeButTAGECorrect: Int = 5,
   SCCloseConfDecWhenSCDisagreeAndSCCorrect: Int = -50,
   SCCloseConfIncWhenSCClosedAndTAGECorrect: Int = 1,
-  SCCloseConfIncWhenSCClosedAndTAGEWrong: Int = -30,
+  SCCloseConfDecWhenSCClosedAndTAGEWrong: Int = -30,
   EnbaleTlbDebug: Boolean = false,
   EnableClockGate: Boolean = true,
   EnableJal: Boolean = false,
@@ -671,7 +671,7 @@ trait HasXSParameter {
   def SCCloseConfIncWhenSCDisagreeButTAGECorrect = coreParams.SCCloseConfIncWhenSCDisagreeButTAGECorrect
   def SCCloseConfDecWhenSCDisagreeAndSCCorrect = coreParams.SCCloseConfDecWhenSCDisagreeAndSCCorrect
   def SCCloseConfIncWhenSCClosedAndTAGECorrect = coreParams.SCCloseConfIncWhenSCClosedAndTAGECorrect
-  def SCCloseConfIncWhenSCClosedAndTAGEWrong = coreParams.SCCloseConfIncWhenSCClosedAndTAGEWrong
+  def SCCloseConfDecWhenSCClosedAndTAGEWrong = coreParams.SCCloseConfDecWhenSCClosedAndTAGEWrong
   def EnbaleTlbDebug = coreParams.EnbaleTlbDebug
   def HistoryLength = coreParams.HistoryLength
   def EnableGHistDiff = coreParams.EnableGHistDiff

--- a/src/main/scala/xiangshan/frontend/BPU.scala
+++ b/src/main/scala/xiangshan/frontend/BPU.scala
@@ -115,12 +115,12 @@ trait BPUUtils extends HasXSParameter {
 
     val finalDelta = MuxLookup(deltaType(uIdx), 0.S)(
       Seq(
-        0.U -> SCCloseConfIncWhenSCAgreeAndCorrect.S,   // SC opened, SC agree and correct, can be closed
+        0.U -> SCCloseConfIncWhenSCAgreeAndCorrect.S, // SC opened, SC agree and correct, can be closed
         1.U -> SCCloseConfIncWhenSCAgreeButWrong.S,   // SC opened, SC agree but wrong, should be closed more
-        2.U -> SCCloseConfIncWhenSCDisagreeButTAGECorrect.S,   // SC opened, SC disagree and wrong, should definitely be closed
+        2.U -> SCCloseConfIncWhenSCDisagreeButTAGECorrect.S, // SC opened, SC disagree and wrong, should definitely be closed
         3.U -> SCCloseConfDecWhenSCDisagreeAndSCCorrect.S, // SC opened, SC disagree but correct, should stay open
-        4.U -> SCCloseConfIncWhenSCClosedAndTAGECorrect.S,   // SC closed, TAGE pred correct, SC can be closed
-        5.U -> SCCloseConfIncWhenSCClosedAndTAGEWrong.S  // SC closed, TAGE pred wrong, SC should be opened
+        4.U -> SCCloseConfIncWhenSCClosedAndTAGECorrect.S, // SC closed, TAGE pred correct, SC can be closed
+        5.U -> SCCloseConfDecWhenSCClosedAndTAGEWrong.S    // SC closed, TAGE pred wrong, SC should be opened
       )
     )
 

--- a/src/main/scala/xiangshan/frontend/BPU.scala
+++ b/src/main/scala/xiangshan/frontend/BPU.scala
@@ -115,12 +115,12 @@ trait BPUUtils extends HasXSParameter {
 
     val finalDelta = MuxLookup(deltaType(uIdx), 0.S)(
       Seq(
-        0.U -> 1.S,   // SC opened, SC agree and correct, can be closed
-        1.U -> 1.S,   // SC opened, SC agree but wrong, should be closed more
-        2.U -> 5.S,   // SC opened, SC disagree and wrong, should definitely be closed
-        3.U -> -50.S, // SC opened, SC disagree but correct, should stay open
-        4.U -> 1.S,   // SC closed, TAGE pred correct, SC can be closed
-        5.U -> -30.S  // SC closed, TAGE pred wrong, SC should be opened
+        0.U -> SCCloseConfIncWhenSCAgreeAndCorrect.S,   // SC opened, SC agree and correct, can be closed
+        1.U -> SCCloseConfIncWhenSCAgreeButWrong.S,   // SC opened, SC agree but wrong, should be closed more
+        2.U -> SCCloseConfIncWhenSCDisagreeButTAGECorrect.S,   // SC opened, SC disagree and wrong, should definitely be closed
+        3.U -> SCCloseConfDecWhenSCDisagreeAndSCCorrect.S, // SC opened, SC disagree but correct, should stay open
+        4.U -> SCCloseConfIncWhenSCClosedAndTAGECorrect.S,   // SC closed, TAGE pred correct, SC can be closed
+        5.U -> SCCloseConfIncWhenSCClosedAndTAGEWrong.S  // SC closed, TAGE pred wrong, SC should be opened
       )
     )
 

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -268,11 +268,11 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
   var sc_fh_info                          = Set[FoldedHistoryInfo]()
   if (EnableSC) {
     val scCloseConfCounter = WireInit(0.S(scCloseConfCounterWidth.W))
-    val s0_sc_closed       = if (DynCloseSC) { scCloseConfCounter >= 0.S }
-                             else { false.B }
-    val s1_sc_closed       = RegEnable(s0_sc_closed, io.s0_fire(3))
-    val s2_sc_closed       = RegEnable(s1_sc_closed, io.s1_fire(3))
-    val s3_sc_closed       = RegEnable(s2_sc_closed, io.s2_fire(3))
+    val s0_sc_closed = if (DynCloseSC) { scCloseConfCounter >= 0.S }
+    else { false.B }
+    val s1_sc_closed = RegEnable(s0_sc_closed, io.s0_fire(3))
+    val s2_sc_closed = RegEnable(s1_sc_closed, io.s1_fire(3))
+    val s3_sc_closed = RegEnable(s2_sc_closed, io.s2_fire(3))
 
     val scTables = SCTableInfos.map {
       case (nRows, ctrBits, histLen) => {
@@ -486,7 +486,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
     for (b <- 0 until TageBanks) {
       for (i <- 0 until SCNTables) {
         val realWen = if (DynCloseSC) { realWens(i) && !s0_sc_closed }
-                      else { realWens(i) }
+        else { realWens(i) }
         scTables(i).io.update.mask(b)      := RegNext(scUpdateMask(b)(i))
         scTables(i).io.update.tagePreds(b) := RegEnable(scUpdateTagePreds(b), realWen)
         scTables(i).io.update.takens(b)    := RegEnable(scUpdateTakens(b), realWen)


### PR DESCRIPTION
* SC is open by default and can be dynamically closed by setting `DynCloseSC` to true.
* SC closure is controlled by the value of `scCloseConfCounter`. 
When `scCloseConfCounter >= 0`, SC is closed. When it is less than 0, SC is enabled.
* To avoid affecting timing, the update of the scCloseConfCounter is placed on the next 
clock cycle after SC update
* The counter is adjusted based on the list for Agree and Disagree scenarios.

* Agree Scenarios  ( When SC opened ):
- When TAGE and SC pred both taken (√) and the actual condition is also taken (√), 
SC performs "Negative action No.3" and scCloseConf will be increased by 
+x1(`SCCloseConfIncWhenSCAgreeAndCorrect`).
- When TAGE and SC pred both taken (√) but the actual condition is not taken (×), 
SC performs  "Negative action No.2" and scCloseConf will be increased by 
+x2(`SCCloseConfIncWhenSCAgreeButWrong`).
- When neither TAGE nor SC pred taken (×) but the actual condition is taken (√), 
SC performs "Negative action No.2" and scCloseConf will be increased by 
+x2(`SCCloseConfIncWhenSCAgreeButWrong`).
- When neither TAGE nor SC pred taken (×) and the actual condition is not taken (×), 
SC  performs "Negative action No.3" and scCloseConf will be increased by 
+x1(`SCCloseConfIncWhenSCAgreeAndCorrect`).
* Disagree Scenarios ( When SC opened ):
- When TAGE pred taken (√) and SC is not taken (×), but the actual condition is taken (√), 
SC  performs  "Negative action No.1" and scCloseConf will be increased by
 +x3(`SCCloseConfIncWhenSCDisagreeButTAGECorrect`).
- When TAGE pred taken (√) and SC is not taken (×), and the actual condition is not taken (×), 
SC performs  "Positive action No.1" and scCloseConf will be decreased by 
-y(`SCCloseConfDecWhenSCDisagreeAndSCCorrect`).
- When TAGE pred not taken (×) but SC is taken (√), and the actual condition is taken (√),
SC performs "Positive action No.1" and scCloseConf will be decreased by 
-y(`SCCloseConfDecWhenSCDisagreeAndSCCorrect`).
- When TAGE pred not taken (×) but SC is taken (√), and the actual condition is not taken (×),
 SC performs "Negative action No.1" and scCloseConf will be increased by 
+x3(`SCCloseConfIncWhenSCDisagreeButTAGECorrect`).

* When SC Closed:
- If TAGE pred wrong, SC should be opened, so scCloseConf will be
 increased by `SCCloseConfIncWhenSCClosedAndTAGEWrong`
- If TAGE pred correct, SC can be closed, so scCloseConf will be
 decreased by `SCCloseConfDecWhenSCClosedAndTAGEWrong`

<img width="408" alt="{1F2C68E6-C46A-4C0B-B747-ED8F3C697702}" src="https://github.com/user-attachments/assets/2790b82a-342e-4464-a0e5-f70e6294121a" />

<img width="353" alt="1737004278808" src="https://github.com/user-attachments/assets/615269ec-bf53-4b92-8ca3-5b5fc634c5f2" />


