### PR TITLE
ppa(LRQ): optimise LRQ entries for ppa

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -167,7 +167,7 @@ case class XSCoreParameters
   LoadQueueRARSize: Int = 72,
   LoadQueueRAWSize: Int = 32, // NOTE: make sure that LoadQueueRAWSize is power of 2.
   RollbackGroupSize: Int = 8,
-  LoadQueueReplaySize: Int = 72,
+  LoadQueueReplaySize: Int = 48,
   LoadUncacheBufferSize: Int = 4,
   LoadQueueNWriteBanks: Int = 8, // NOTE: make sure that LoadQueueRARSize/LoadQueueRAWSize is divided by LoadQueueNWriteBanks
   StoreQueueSize: Int = 56,

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -889,6 +889,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
       loadUnits(i).io.stld_nuke_query(s) := stld_nuke_query(s)
     }
     loadUnits(i).io.lq_rep_full <> lsq.io.lq_rep_full
+    loadUnits(i).io.lqRepThreshold.valid := lsq.io.lqRepThreshold
+    loadUnits(i).io.lqRepThreshold.bits := lsq.io.lqDeqPtr
     // load prefetch train
     prefetcherOpt.foreach(pf => {
       // sms will train on all miss load sources
@@ -1527,7 +1529,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vlSplit(i).io.in.valid := io.ooo_to_mem.issueVldu(i).valid &&
                               vLoadCanAccept(i) && !isSegment && !isFixVlUop(i)
     vlSplit(i).io.toMergeBuffer <> vlMergeBuffer.io.fromSplit(i)
-    vlSplit(i).io.threshold.get.valid := vlMergeBuffer.io.toSplit.get.threshold
+    vlSplit(i).io.threshold.get.valid := vlMergeBuffer.io.toSplit.get.threshold || lsq.io.lqRepThreshold
     vlSplit(i).io.threshold.get.bits  := lsq.io.lqDeqPtr
     NewPipelineConnect(
       vlSplit(i).io.out, loadUnits(i).io.vecldin, loadUnits(i).io.vecldin.fire,

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -104,6 +104,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
     // TODO: implement vector store
     val vecmmioStout = DecoupledIO(new MemExuOutput(isVector = true)) // vec writeback uncached store
     val sqEmpty = Output(Bool())
+    val lqRepThreshold = Output(Bool())
     val lq_rep_full = Output(Bool())
     val sqFull = Output(Bool())
     val lqFull = Output(Bool())
@@ -221,6 +222,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   loadQueue.io.std.storeDataIn     <> io.std.storeDataIn // store_s0
   loadQueue.io.lqFull              <> io.lqFull
   loadQueue.io.lq_rep_full         <> io.lq_rep_full
+  loadQueue.io.lqRepThreshold      <> io.lqRepThreshold
   loadQueue.io.lqDeq               <> io.lqDeq
   loadQueue.io.l2_hint             <> io.l2_hint
   loadQueue.io.tlb_hint            <> io.tlb_hint

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -197,6 +197,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     val lqDeq = Output(UInt(log2Up(CommitWidth + 1).W))
     val lqCancelCnt = Output(UInt(log2Up(VirtualLoadQueueSize+1).W))
     val lq_rep_full = Output(Bool())
+    val lqRepThreshold = Output(Bool())
     val tlbReplayDelayCycleCtrl = Vec(4, Input(UInt(ReSelectLen.W)))
     val l2_hint = Input(Valid(new L2ToL1Hint()))
     val tlb_hint = Flipped(new TlbHintIO)
@@ -322,6 +323,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   loadQueueReplay.io.stDataReadyVec   <> io.sq.stDataReadyVec
   loadQueueReplay.io.sqEmpty          <> io.sq.sqEmpty
   loadQueueReplay.io.lqFull           <> io.lq_rep_full
+  loadQueueReplay.io.lqThreshold      <> io.lqRepThreshold
   loadQueueReplay.io.ldWbPtr          <> virtualLoadQueue.io.ldWbPtr
   loadQueueReplay.io.rarFull          <> loadQueueRAR.io.lqFull
   loadQueueReplay.io.rawFull          <> loadQueueRAW.io.lqFull

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -202,6 +202,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     //
     val sqEmpty = Input(Bool())
     val lqFull  = Output(Bool())
+    val lqThreshold  = Output(Bool())
     val ldWbPtr = Input(new LqPtr)
     val rarFull = Input(Bool())
     val rawFull = Input(Bool())
@@ -287,6 +288,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
 
   // select LoadPipelineWidth valid index.
   val lqFull = freeList.io.empty
+  val lqThreshold = (LoadQueueReplaySize.U - freeList.io.validCount) <= 12.U
   val lqFreeNums = freeList.io.validCount
 
   // replay logic
@@ -603,9 +605,6 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   // init
   freeMaskVec.map(e => e := false.B)
 
-  // LoadQueueReplay can't backpressure.
-  // We think LoadQueueReplay can always enter, as long as it is the same size as VirtualLoadQueue.
-  assert(freeList.io.canAllocate.reduce(_ || _) || !io.enq.map(_.valid).reduce(_ || _), s"LoadQueueReplay Overflow")
 
   // Allocate logic
   needEnqueue.zip(newEnqueue).zip(io.enq).map {
@@ -759,6 +758,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   freeList.io.free := freeMaskVec.asUInt
 
   io.lqFull := lqFull
+  io.lqThreshold := lqThreshold
 
   // Topdown
   val robHeadVaddr = io.debugTopDown.robHeadVaddr

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -188,6 +188,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     // queue-based replay
     val replay       = Flipped(Decoupled(new LsPipelineBundle))
     val lq_rep_full  = Input(Bool())
+    // backpressure IQ when LRQ threshold is reached
+    val lqRepThreshold = Flipped(ValidIO(new LqPtr))
 
     // misc
     val s2_ptr_chasing = Output(Bool()) // provide right pc for hw prefetch
@@ -209,7 +211,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   })
 
   val s1_ready, s2_ready, s3_ready = WireInit(false.B)
-
+  val lqNack = io.lqRepThreshold.valid && io.lqRepThreshold.bits =/= io.ldin.bits.uop.lqIdx
   // Pipeline
   // --------------------------------------------------------------------------------
   // stage 0
@@ -221,7 +223,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s0_misalign_select= Wire(Bool())
   val s0_kill          = Wire(Bool())
   val s0_can_go        = s1_ready
-  val s0_fire          = s0_valid && s0_can_go
+  val s0_fire          = Wire(Bool())
   val s0_mmio_fire     = s0_mmio_select && s0_can_go
   val s0_nc_fire       = s0_nc_select && s0_can_go
   val s0_out           = Wire(new LqWriteBundle)
@@ -362,6 +364,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s0_ptr_chasing_vaddr    = io.l2l_fwd_in.data(5, 0) +& io.ld_fast_imm(5, 0)
   val s0_ptr_chasing_canceled = WireInit(false.B)
   s0_kill := s0_ptr_chasing_canceled
+  s0_fire := s0_valid && s0_can_go && !(s0_src_select_vec(int_iss_idx) && lqNack)
 
   // prefetch related ctrl signal
   io.canAcceptLowConfPrefetch  := s0_src_ready_vec(low_pf_idx) && io.dcache.req.ready
@@ -390,7 +393,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.debug.isFirstIssue := s0_sel_src.isFirstIssue
 
   // query DCache
-  io.dcache.req.valid             := s0_valid && !s0_sel_src.prf_i && !s0_nc_with_data
+  io.dcache.req.valid             := s0_valid && !s0_sel_src.prf_i && !s0_nc_with_data && !(s0_src_select_vec(int_iss_idx) && lqNack)
   io.dcache.req.bits.cmd          := Mux(s0_sel_src.prf_rd,
                                       MemoryOpConstants.M_PFR,
                                       Mux(s0_sel_src.prf_wr, MemoryOpConstants.M_PFW, MemoryOpConstants.M_XRD)
@@ -832,7 +835,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   // 2) there is no fast replayed load
   // 3) there is no high confidence prefetch request
   io.vecldin.ready := s0_can_go && io.dcache.req.ready && s0_src_ready_vec(vec_iss_idx)
-  io.ldin.ready := s0_can_go && io.dcache.req.ready && s0_src_ready_vec(int_iss_idx)
+  io.ldin.ready := s0_can_go && io.dcache.req.ready && s0_src_ready_vec(int_iss_idx) && !lqNack
   io.misalign_ldin.ready := s0_can_go && io.dcache.req.ready && s0_src_ready_vec(mab_idx)
 
   // for hw prefetch load flow feedback, to be added later


### PR DESCRIPTION
Previously, due to LRQ can't backpressure, we set LoadQueueReplaySize no smaller than VirtualLoadQueueSize to ensure uop can always enter LRQ. But LRQ is very redundant, so it cause an increase in area and power.

Now, in order to optimize power and area, we need to reduce LRQ redundant entries.

We should resolve this constraint at first.
Use "lqThreshold" to control the execution of load instructions. When the free entries in LRQ reaches the "lqThreshold", we backpressure to make IssueQueue send the oldest uop to LDU.

And then, reduce LoadQueueReplaySize from 72 to 48.