### PR TITLE
fix(PTWCache): avoid X-prop of spRefill

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -831,7 +831,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   // misc entries: super & invalid
   val spRefill =
     !flush_dup(0) &&
-    (refill.levelOH.sp || memPte(0).isNapot(refill.level_dup(0))) &&
+    (refill.levelOH.sp || (refill.levelOH.l0 && memPte(0).isNapot(refill.level_dup(0)))) &&
     ((memPte(0).isLeaf() && memPte(0).canRefill(refill.level_dup(0), refill.req_info_dup(0).s2xlate, pbmte, io.csr_dup(0).vsatp.mode)) ||
     memPte(0).onlyPf(refill.level_dup(0), refill.req_info_dup(0).s2xlate, pbmte))
   val spRefillIdx = spreplace.way.suggestName(s"sp_refillIdx") // LFSR64()(log2Up(l2tlbParams.spSize)-1,0) // TODO: may be LRU


### PR DESCRIPTION
In the previous design, the `spRefill` signal will be true when the `refill.levelOH.sp` or `memPte(0).isNapot(refill.level_dup(0))` conditions is met, and acted as a control signal to control the refill of the sp entries. However, `memPte(0).isNapot(refill.level_dup(0))` does not determine whether `refill.level_dup(0)` is valid. When `refill.level_dup(0)` is X, it causes `spRefill` to also be X, which in turn causes X-prop.

This commit adds `refill.levelOH.l0` to `isNapot`. On the one hand, only `levelOH.l0` (4KB page) can be a Svnapot page; on the other hand, the assignment of `refill.levelOH.l0` takes `refill.valid` into account, thus avoiding X-prop.