### PR TITLE
timing(StoreUnit, StoreMisalignBuffer): adjust misalign store enq logic

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -158,7 +158,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   when(canEnq) {
     connectSamePort(req, reqSelBits)
     req.portIndex := reqSelPort
-    req_valid := true.B
+    req_valid := !req.mmio
   }
   val cross4KBPageEnq = WireInit(false.B)
   when (cross4KBPageBoundary && !reqRedirect) {

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -465,7 +465,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
 
   val s2_mis_align = s2_valid && RegEnable(s1_mis_align, s1_fire) && !s2_exception
   // goto misalignBuffer
-  val toMisalignBufferValid = RegEnable(s1_valid && s1_mis_align && !s1_frm_mabuf, false.B, s1_fire)
+  val toMisalignBufferValid = RegEnable(s1_valid && s1_mis_align && !s1_frm_mabuf, false.B, s1_fire) && !s2_exception
   io.misalign_buf.valid := toMisalignBufferValid
   io.misalign_buf.bits  := s2_in
   io.misalign_buf.bits.mmio := s2_mmio


### PR DESCRIPTION
* The timing of the result returned by `PMA`  about `mmio`  is too bad to be used as a `hit` signal for feedback to the `backend`
