### PR TITLE
timing(LoadUnit): adjust rar/raw query valid generate logic

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1281,12 +1281,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
                     !s2_in.misalignNeedWakeUp
 
   // need allocate new entry
-  val s2_can_query = !s2_mem_amb &&
-                     !s2_tlb_miss &&
-                     !s2_fwd_fail &&
-                     !s2_frm_mabuf &&
-                     !s2_fast_rep &&
-                     s2_troublem
+  val s2_can_query = !((s2_dcache_fast_rep || s2_nuke) && !s2_in.misalignNeedWakeUp) && s2_troublem
 
   val s2_data_fwded = s2_dcache_miss && s2_full_fwd
 


### PR DESCRIPTION
`LoadQueueRAR` and `LoadQueueRAW` need to use the `valid` signal of the query to select the index of the queue at load unit `s2` from `FreeList` (because of `FreeList` set `enablePreAlloc`). It can put all conditions except `fast replay` in `s3` for judgment (`fast replay` can fix #4149). If other conditions are setted in `s3`, `LoadQueueRAR` and `LoadQueueRAW` can revoke the corresponding entry. This is timing friendly, can eliminate 4 levels of logic for query valid generate, and does not add additional logic in `s3`


