### PR TITLE
timing(frontend): remove bad timing clock gating

### DIFF
--- a/src/main/scala/xiangshan/frontend/ITTAGE.scala
+++ b/src/main/scala/xiangshan/frontend/ITTAGE.scala
@@ -499,7 +499,7 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
   )
   update.full_target := RegEnable(
     io.update.bits.full_target,
-    io.update.valid && (u_meta.provider.valid || io.update.bits.mispred_mask(numBr))
+    io.update.valid // not using mispred_mask, because mispred_mask timing is bad
   )
   update.cfi_idx.bits := RegEnable(io.update.bits.cfi_idx.bits, io.update.valid && io.update.bits.cfi_idx.valid)
   update.ghist        := RegEnable(io.update.bits.ghist, io.update.valid) // TODO: CGE

--- a/src/main/scala/xiangshan/frontend/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/Tage.scala
@@ -698,7 +698,7 @@ class Tage(implicit p: Parameters) extends BaseTage {
     updateMeta.altUsed(i) := RegEnable(u_meta.altUsed(i), u_valids_for_cge(i))
     updateMeta.allocates(i) := RegEnable(
       u_meta.allocates(i),
-      io.update.valid && io.update.bits.mispred_mask(i)
+      io.update.valid // not using mispred_mask, because mispred_mask timing is bad
     )
   }
   if (EnableSC) {

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -431,7 +431,7 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheArray with HasICache
         shouldReset = true,
         holdRead = true,
         singlePort = true,
-        withClockGate = true
+        withClockGate = false // enable signal timing is bad, no gating here
       ))
 
       // read


### PR DESCRIPTION
- Remove `mispred_mask` from ITTAGE update logic due to timing issues
- Remove `mispred_mask` from TAGE update logic due to timing issues
- Disable clock gating in ICacheDataArray to improve timing