### PR TITLE
fix(DCache): remove error wakeup signal for atomic resp

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -811,8 +811,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   atomic_replay_resp.ack_miss_queue := false.B
   atomic_replay_resp.id := DontCare
 
-  val atomic_replay_resp_valid = s2_valid && s2_can_go_to_mq && replay && (s2_req.isAMO || s2_req.miss)
-  val atomic_hit_resp_valid = s3_valid && (s3_amo_can_go || s3_miss_can_go && (s3_req.isAMO || s3_req.miss))
+  val atomic_replay_resp_valid = s2_valid && s2_can_go_to_mq && replay && s2_req.isAMO
+  val atomic_hit_resp_valid = s3_valid && (s3_amo_can_go || s3_miss_can_go && s3_req.isAMO)
 
   io.atomic_resp.valid := atomic_replay_resp_valid || atomic_hit_resp_valid
   io.atomic_resp.bits := Mux(atomic_replay_resp_valid, atomic_replay_resp, atomic_hit_resp)


### PR DESCRIPTION
The existence of `s2/s3_req.miss` in `atomic_resp_valid` will cause an error resp to AtomicsUnit by a normal refill_req from MissQueue. Remove it now to fix the problem.