### PR TITLE
fix(LoadUnit): `dcache_kill` if `prf_wr` has no permissions

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1451,7 +1451,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     io.dcache.s1_pc := s1_out.uop.pc
     io.dcache.s2_pc := s2_out.uop.pc
   }
-  io.dcache.s2_kill := s2_pmp.ld || s2_actually_uncache || s2_kill
+  io.dcache.s2_kill := s2_pmp.ld || s2_pmp.st || s2_actually_uncache || s2_kill
 
   val s1_ld_left_fire = s1_valid && !s1_kill && s2_ready
   val s2_ld_valid_dup = RegInit(0.U(6.W))


### PR DESCRIPTION
`prefetch.w` sends a write request to `TLB/PMA/PMP`.
As a result, `PMA/PMP` returns a permission check (`io.pmp.st`) for the write request.

---

Previously, we only handled the case where `prefetch.r` did not have read permissions, not handled  the case where  `prefetch.w` did not have write permissions.
**So, when `prefetch.w` has an address without write permissions, the request will still be sent to `Dcache`, which generates an error.**

**This pr fixes that, when `PMA/PMP` returns `io.pmp.st`, we generate `dcache.s2_kill`.**