### PR TITLE
fix(Config): add the 'L3CacheCtrl' address space permission back

### DIFF
--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -6,6 +6,8 @@ PMAConfigs:
   - { base_addr: 0x80000000000, c: true, atomic: true, a: 1, x: true, w: true, r: true }
   - { base_addr: 0x80000000, a: 1, w: true, r: true }
   - { base_addr: 0x3A000000, a: 1 }
+  - { base_addr: 0x39002000, a: 1, w: true, r: true }
+  - { base_addr: 0x39000000, a: 1, w: true, r: true }
   - { base_addr: 0x38022000, a: 1, w: true, r: true }
   - { base_addr: 0x38021000, a: 1, x: true, w: true, r: true }
   - { base_addr: 0x30010000, a: 1, w: true, r: true }

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -49,6 +49,8 @@ case class SoCParameters
     PMAConfigEntry(0x80000000000L, c = true, atomic = true, a = 1, x = true, w = true, r = true),
     PMAConfigEntry(0x80000000L, a = 1, w = true, r = true),
     PMAConfigEntry(0x3A000000L, a = 1),
+    PMAConfigEntry(0x39002000L, a = 1, w = true, r = true),
+    PMAConfigEntry(0x39000000L, a = 1, w = true, r = true),
     PMAConfigEntry(0x38022000L, a = 1, w = true, r = true),
     PMAConfigEntry(0x38021000L, a = 1, x = true, w = true, r = true),
     PMAConfigEntry(0x38020000L, a = 1, w = true, r = true),


### PR DESCRIPTION
The previous PMA configuration was as follows, we should only remove useless GPU address space.

>     addPMA(0x0L, range = 0x1000000000000L, a = 3)
>     addPMA(PMPPmemHighBounds(0), c = true, atomic = true, a = 1, x = true, w = true, r = true) 
>     addPMA(PMPPmemLowBounds(0), a = 1, w = true, r = true) 
>     addPMA(0x3A000000L, a = 1)
>     addPMA(0x39002000L, a = 1, w = true, r = true)
>     addPMA(0x39000000L, a = 1, w = true, r = true)
>     addPMA(0x38022000L, a = 1, w = true, r = true)
>     addPMA(0x38021000L, a = 1, x = true, w = true, r = true)
>     addPMA(0x38020000L, a = 1, w = true, r = true)
>     addPMA(0x30050000L, a = 1, w = true, r = true) // FIXME: GPU space is cacheable?
>     addPMA(0x30010000L, a = 1, w = true, r = true)
>     addPMA(0x20000000L, a = 1, x = true, w = true, r = true)
>     addPMA(0x10000000L, a = 1, w = true, r = true)
>     addPMA(0)


---

**Removing the `L3CacheCtrl` address space caused an error.**

**This pr adds the `L3CacheCtrl` address space back into the `PMA` configuration.**