### PR TITLE
fix(FPGADiffDefaultConfig): set WithNKBL1D ways as default

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -507,7 +507,7 @@ class FpgaDefaultConfig(n: Int = 1) extends Config(
 class FpgaDiffDefaultConfig(n: Int = 1) extends Config(
   (L3CacheConfig("3MB", inclusive = false, banks = 1, ways = 6)
     ++ L2CacheConfig("1MB", inclusive = true, banks = 4)
-    ++ WithNKBL1D(64, ways = 8)
+    ++ WithNKBL1D(64, ways = 4)
     ++ new BaseConfig(n)).alter((site, here, up) => {
     case DebugOptionsKey => up(DebugOptionsKey).copy(
       AlwaysBasicDiff = true,


### PR DESCRIPTION
Previous this config set WithNKBL1D ways to 8, resulting in compile error. This change make it same as FPGADefaultConfig.