### PR TITLE
submodule(utility): introduce XSPerfLevel for performance counter

### DIFF
--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -131,6 +131,10 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(EnablePerfDebug = false)
           }), tail)
+        case "--perf-level" :: value :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(PerfLevel = value)
+          }), tail)
         case "--disable-alwaysdb" :: tail =>
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(AlwaysBasicDB = false)
@@ -202,6 +206,7 @@ object ArgParser {
       case PerfCounterOptionsKey => PerfCounterOptions(
         here(DebugOptionsKey).EnablePerfDebug && !here(DebugOptionsKey).FPGAPlatform,
         here(DebugOptionsKey).EnableRollingDB && !here(DebugOptionsKey).FPGAPlatform,
+        XSPerfLevel.withName(here(DebugOptionsKey).PerfLevel),
         0
       )
     })

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -569,6 +569,7 @@ case class DebugOptions
   AlwaysBasicDiff: Boolean = true,
   EnableDebug: Boolean = false,
   EnablePerfDebug: Boolean = true,
+  PerfLevel: String = "VERBOSE",
   UseDRAMSim: Boolean = false,
   EnableConstantin: Boolean = false,
   EnableChiselDB: Boolean = false,


### PR DESCRIPTION
This change introduce XSPerfLevel, including `VERBOSE`/`NORMAL`/`CRITICAL`. Only counters with level greater or equal than threhold will be instantiated, which will reduce utilization and compile time on Pallaium.

PerfLevel therhold can be set in command line, `VERBOSE` by default to apply all counters.
An example usage as follows:
SIM_ARGS="--perf-level CRITICAL" or
PLDM_ARGS="--perf-level CRITICAL" PLDM=1

PerfLevel param is also `VERBOSE` by default, which means all counters will be ignored now if threhold greater than that. User can explicitly set params to keep some important counters instantiated, as follows: XSPerfAccumulate(xx, yy, perfLevel = XSPerfLevel.CRITICAL)