### PR TITLE
submodule(utility), XSDebug: support collecting missing XSDebug

### DIFF
--- a/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
@@ -711,10 +711,10 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     }
     // // update singleStep, singleStep exception only enable in next machine instruction.
     updatedUop(i).singleStep := io.singleStep && (fromRename(i).bits.robIdx =/= robidxCanCommitStepping)
-    when (fromRename(i).fire) {
-      XSDebug(TriggerAction.isDmode(updatedUop(i).trigger) || updatedUop(i).exceptionVec(breakPoint), s"Debug Mode: inst ${i} has frontend trigger exception\n")
-      XSDebug(updatedUop(i).singleStep, s"Debug Mode: inst ${i} has single step exception\n")
-    }
+    XSDebug(
+      fromRename(i).fire &&
+        (TriggerAction.isDmode(updatedUop(i).trigger) || updatedUop(i).exceptionVec(breakPoint)), s"Debug Mode: inst ${i} has frontend trigger exception\n")
+    XSDebug(fromRename(i).fire && updatedUop(i).singleStep, s"Debug Mode: inst ${i} has single step exception\n")
     if (env.EnableDifftest) {
       // debug runahead hint
       val debug_runahead_checkpoint_id = Wire(checkpoint_id.cloneType)

--- a/src/main/scala/xiangshan/cache/dcache/Uncache.scala
+++ b/src/main/scala/xiangshan/cache/dcache/Uncache.scala
@@ -519,14 +519,14 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
     f1_tagMismatchVec(i) := sizeMap(w =>
       RegEnable(f0_vtagMatches(w), f0_fwdValid) =/= f1_ptagMatches(w) && RegEnable(f0_validMask(w), f0_fwdValid) && f1_fwdValid
     ).asUInt.orR
-    when(f1_tagMismatchVec(i)) {
-      XSDebug("forward tag mismatch: pmatch %x vmatch %x vaddr %x paddr %x\n",
-        f1_ptagMatches.asUInt,
-        RegEnable(f0_vtagMatches.asUInt, f0_fwdValid),
-        RegEnable(forward.vaddr, f0_fwdValid),
-        RegEnable(forward.paddr, f0_fwdValid)
-      )
-    }
+    XSDebug(
+      f1_tagMismatchVec(i),
+      "forward tag mismatch: pmatch %x vmatch %x vaddr %x paddr %x\n",
+      f1_ptagMatches.asUInt,
+      RegEnable(f0_vtagMatches.asUInt, f0_fwdValid),
+      RegEnable(forward.vaddr, f0_fwdValid),
+      RegEnable(forward.paddr, f0_fwdValid)
+    )
     // response
     forward.addrInvalid := false.B // addr in ubuffer is always ready
     forward.dataInvalid := false.B // data in ubuffer is always ready

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -916,8 +916,8 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   ncResp.bits <> io.uncache.resp.bits
   when (ncDeqTrigger) {
     allocated(ncPtr) := false.B
-    XSDebug("nc fire: ptr %d\n", ncPtr)
   }
+  XSDebug(ncDeqTrigger,"nc fire: ptr %d\n", ncPtr)
 
   mmioReq.ready := io.uncache.req.ready
   ncReq.ready := io.uncache.req.ready && !mmioReq.valid

--- a/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
@@ -246,32 +246,29 @@ class VirtualLoadQueue(implicit p: Parameters) extends XSModule
     io.ldin(i).ready := true.B
     val loadWbIndex = io.ldin(i).bits.uop.lqIdx.value
 
+    val need_rep = io.ldin(i).bits.rep_info.need_rep
+    val need_valid = io.ldin(i).bits.updateAddrValid
     when (io.ldin(i).valid) {
       val hasExceptions = ExceptionNO.selectByFu(io.ldin(i).bits.uop.exceptionVec, LduCfg).asUInt.orR
-      val need_rep = io.ldin(i).bits.rep_info.need_rep
-      val need_valid = io.ldin(i).bits.updateAddrValid
-
       when (!need_rep && need_valid && !io.ldin(i).bits.isvec) {
         committed(loadWbIndex) := true.B
-
         //  Debug info
         debug_mmio(loadWbIndex) := io.ldin(i).bits.mmio
         debug_paddr(loadWbIndex) := io.ldin(i).bits.paddr
       }
-
-      XSInfo(!need_rep && need_valid,
-        "load hit write to lq idx %d pc 0x%x vaddr %x paddr %x mask %x forwardData %x forwardMask: %x mmio %x isvec %x\n",
-        io.ldin(i).bits.uop.lqIdx.asUInt,
-        io.ldin(i).bits.uop.pc,
-        io.ldin(i).bits.vaddr,
-        io.ldin(i).bits.paddr,
-        io.ldin(i).bits.mask,
-        io.ldin(i).bits.forwardData.asUInt,
-        io.ldin(i).bits.forwardMask.asUInt,
-        io.ldin(i).bits.mmio,
-        io.ldin(i).bits.isvec
-      )
     }
+    XSInfo(io.ldin(i).valid && !need_rep && need_valid,
+      "load hit write to lq idx %d pc 0x%x vaddr %x paddr %x mask %x forwardData %x forwardMask: %x mmio %x isvec %x\n",
+      io.ldin(i).bits.uop.lqIdx.asUInt,
+      io.ldin(i).bits.uop.pc,
+      io.ldin(i).bits.vaddr,
+      io.ldin(i).bits.paddr,
+      io.ldin(i).bits.mask,
+      io.ldin(i).bits.forwardData.asUInt,
+      io.ldin(i).bits.forwardMask.asUInt,
+      io.ldin(i).bits.mmio,
+      io.ldin(i).bits.isvec
+    )
   }
 
   //  perf counter

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -459,14 +459,6 @@ class Sbuffer(implicit p: Parameters)
           merge_need_uarch_drain := true.B
         }
       }
-      XSDebug(
-        mergeVec(entryIdx) && reqvtag =/= vtag(entryIdx),
-        "reqvtag =/= sbufvtag req(vtag %x ptag %x) sbuffer(vtag %x ptag %x)\n",
-        reqvtag << OffsetWidth,
-        reqptag << OffsetWidth,
-        vtag(entryIdx) << OffsetWidth,
-        ptag(entryIdx) << OffsetWidth
-      )
     })
   }
 
@@ -496,6 +488,18 @@ class Sbuffer(implicit p: Parameters)
         assert(debug_insertIdx === insertIdx)
       })
     }
+    // XSDebug of mergeWordReq
+    (0 until StoreBufferSize).map(entryIdx => {
+      XSDebug(
+        accessValid && canMerge(i) &&
+          mergeVec(i)(entryIdx) && invtags(i) =/= vtag(entryIdx),
+        "reqvtag =/= sbufvtag req(vtag %x ptag %x) sbuffer(vtag %x ptag %x)\n",
+        invtags(i) << OffsetWidth,
+        inptags(i) << OffsetWidth,
+        vtag(entryIdx) << OffsetWidth,
+        ptag(entryIdx) << OffsetWidth
+      )
+    })
   }
 
 


### PR DESCRIPTION
Previous in PR#3982, we support collecting XSLogs to LogPerfEndpoint. However with --enable-log, we should also collect some missing XSDebug.

This change move these missing XSDebug outside WhenContext, and add WireInit to LogUtils' apply, to enable probing some subaccessed data, like a vec elem with dynamic index.