### PR TITLE
timing(STU, StoreMisalignBuffer): adjust misalign buffer enq logic

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -159,12 +159,12 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   when(canEnq) {
     connectSamePort(req, reqSelBits)
     req.portIndex := reqSelPort
-    req_valid := true.B
+    req_valid := !reqSelBits.hasException
   }
   val cross4KBPageEnq = WireInit(false.B)
   when (cross4KBPageBoundary && !reqRedirect) {
     when(
-      reqSelValid &&
+      reqSelValid && !reqSelBits.hasException &&
       (isAfter(req.uop.robIdx, reqSelBits.uop.robIdx) || (isNotBefore(req.uop.robIdx, reqSelBits.uop.robIdx) && req.uop.uopIdx > reqSelBits.uop.uopIdx)) &&
       bufferState === s_idle
     ) {

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -469,9 +469,10 @@ class StoreUnit(implicit p: Parameters) extends XSModule
 
   val s2_mis_align = s2_valid && RegEnable(s1_mis_align, s1_fire) && !s2_exception
   // goto misalignBuffer
-  val toMisalignBufferValid =  s2_mis_align && !s2_frm_mabuf
+  val toMisalignBufferValid = s2_valid && GatedValidRegNext(s1_mis_align && !s1_frm_mabuf)
   io.misalign_buf.valid := toMisalignBufferValid
   io.misalign_buf.bits  := s2_in
+  io.misalign_buf.bits.hasException := s2_exception
   val misalignBufferNack = toMisalignBufferValid && !io.misalign_buf.ready
 
   // feedback tlb miss to RS in store_s2


### PR DESCRIPTION
There is no exception misaligned store instruction  enters the misalignbuffer. Due to the exception timing difference generated by the `PMA`, the timing of the misalignbuffer rejection condition is bad timing, which in turn leads to the bad timing of `feedback_slow.hit`.