### PR TITLE
fix(Soc, CoupledL2): correct port width of CHI Issue C

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -77,7 +77,7 @@ case class SoCParameters
   XSTopPrefix: Option[String] = None,
   NodeIDWidthList: Map[String, Int] = Map(
     "B" -> 7,
-    "C" -> 7,
+    "C" -> 9,
     "E.b" -> 11
   ),
   NumHart: Int = 64,


### PR DESCRIPTION
* Correct port width of CHI Issue C:
   * NodeID Width = 9 bits
   * (Physical) Address Width = 44bits
* Bump CoupledL2, including:
   * Fix a bug where the WriteEvictOrEvict response state did not comply with the manual standard
   * Fix a bug when SnpQuery/SnpStash nesting Evict
   * Fix problems of L2 RAS
   * Use RRArbiter to avoid starvation of txreq 
   * Correct port width of CHI Issue C