### PR TITLE
timing(LoadQueueRAR, LoadUnit): adjust rar/raw query logic

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
@@ -114,7 +114,7 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
     size = LoadQueueRARSize,
     allocWidth = LoadPipelineWidth,
     freeWidth = 4,
-    enablePreAlloc = true,
+    enablePreAlloc = false,
     moduleName = "LoadQueueRAR freelist"
   ))
   freeList.io := DontCare
@@ -140,6 +140,7 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
   // Allocate logic
   val acceptedVec = Wire(Vec(LoadPipelineWidth, Bool()))
   val enqIndexVec = Wire(Vec(LoadPipelineWidth, UInt(log2Up(LoadQueueRARSize).W)))
+  require(LoadQueueRARSize == VirtualLoadQueueSize, "LoadQueueRARSize should be equal to VirtualLoadQueueSize for timing!")
 
   for ((enq, w) <- io.query.map(_.req).zipWithIndex) {
     acceptedVec(w) := false.B

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1283,12 +1283,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
                     !s2_in.misalignNeedWakeUp
 
   // need allocate new entry
-  val s2_can_query = !s2_mem_amb &&
-                     !s2_tlb_miss &&
-                     !s2_fwd_fail &&
-                     !s2_frm_mabuf &&
-                     !s2_fast_rep &&
-                     s2_troublem
+  val s2_can_query = !((s2_dcache_fast_rep || s2_nuke) && !s2_in.misalignNeedWakeUp) && s2_troublem
 
   val s2_data_fwded = s2_dcache_miss && s2_full_fwd
 

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1304,7 +1304,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s2_safe_writeback = s2_real_exception || s2_safe_wakeup || s2_vp_match_fail || s2_in.misalignNeedWakeUp
 
   // ld-ld violation require
-  io.lsq.ldld_nuke_query.req.valid           := s2_valid && s2_can_query
+  io.lsq.ldld_nuke_query.req.valid           := s2_valid
   io.lsq.ldld_nuke_query.req.bits.uop        := s2_in.uop
   io.lsq.ldld_nuke_query.req.bits.mask       := s2_in.mask
   io.lsq.ldld_nuke_query.req.bits.paddr      := s2_in.paddr


### PR DESCRIPTION
* Because of `LoadQueueRARSize == VirtualLoadQueueSize`, so no need to add additional logic for rar enq
* When no need fast replay, loadunit allocate raw entry