### PR TITLE
feat: support seperate DebugModule TileLink bus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,11 @@ ifneq ($(L3_CACHE_SIZE),)
 COMMON_EXTRA_ARGS += --l3-cache-size $(L3_CACHE_SIZE)
 endif
 
+# seperate bus for DebugModule
+ifeq ($(SEPERATE_DM_BUS),1)
+COMMON_EXTRA_ARGS += --seperate-dm-bus
+endif
+
 # configuration from yaml file
 ifneq ($(YAML_CONFIG),)
 COMMON_EXTRA_ARGS += --yaml-config $(YAML_CONFIG)

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -188,6 +188,10 @@ object ArgParser {
                 OpenLLCParamsOpt = openLLCParam
               )
           }), tail)
+        case "--seperate-dm-bus" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case SoCParamsKey => up(SoCParamsKey).copy(SeperateDMBus = true)
+          }), tail)
         case "--yaml-config" :: yamlFile :: tail =>
           nextOption(YamlParser.parseYaml(config, yamlFile), tail)
         case option :: tail =>

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -158,6 +158,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc() with HasSoCParameter
       println(s"Connecting Core_${i}'s L1 pf source to L3!")
       recv := core_with_l2(i).core_l3_pf_port.get
     })
+    misc.debugModuleXbarOpt.foreach(_ := core_with_l2(i).sep_dm_opt.get)
   }
 
   l3cacheOpt.map(_.ctlnode.map(_ := misc.peripheralXbar.get))

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -46,7 +46,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
   val core_l3_pf_port = memBlock.l3_pf_sender_opt
   val memory_port = if (enableCHI && enableL2) None else Some(l2top.inner.memory_port.get)
   val tl_uncache = l2top.inner.mmio_port
-  // val axi4_uncache = if (enableCHI) Some(AXI4UserYanker()) else None
+  val sep_dm_opt = l2top.inner.sep_dm_port_opt
   val beu_int_source = l2top.inner.beu.intNode
   val core_reset_sink = BundleBridgeSink(Some(() => Reset()))
   val clint_int_node = l2top.inner.clint_int_node


### PR DESCRIPTION
This commit supports a configurable extra TileLink bus for DebugModule besides the peripheral device bus. This involves all 3 environments including TileLink-XSTop, CHI-XSTop, CHI-XSNoCTop. The feature is disabled by default. To enable it, you can add `SEPERATE_DM_BUS=1` in the make command line.