### PR TITLE
fix(StoreQueue): cbo.zero is written to sbuffer only if allocated

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -931,7 +931,9 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   val deqCanDoCbo = GatedRegNext(LSUOpType.isCbo(uop(deqPtr).fuOpType) && allocated(deqPtr) && addrvalid(deqPtr) && !hasException(deqPtr))
 
   // RegNext(io.sbuffer(i).fire) is used to alignment timing
-  val isCboZeroToSbVec   = (0 until EnsbufferWidth).map{ i => RegNext(io.sbuffer(i).fire) && uop(deqPtrExt(i).value).fuOpType === LSUOpType.cbo_zero }
+  val isCboZeroToSbVec = (0 until EnsbufferWidth).map{ i =>
+    RegNext(io.sbuffer(i).fire) && uop(deqPtrExt(i).value).fuOpType === LSUOpType.cbo_zero && allocated(deqPtrExt(i).value)
+  }
   val cboZeroToSb        = isCboZeroToSbVec.reduce(_ || _)
   val cboZeroFlushSb     = GatedRegNext(cboZeroToSb)
 


### PR DESCRIPTION
For misalign store that crosses 16-byte boundary, a store would write sbuffer twice in one cycle but only takes up one SQ entry. If there is only one misalign store in SQ, `isCboZeroToSbVec`, which is used to check if there is any cbo.zero written to sbuffer based on `fuOpType` in `uop`, may apply wrong `fuOpType` in an empty SQ entry, or lead to X-state propogation in VCS simulaition.