### PR TITLE
fix(DCache): fix wrong condition for blocking lr

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -569,14 +569,14 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     // when we release this block,
     // we invalidate this reservation set
     lrsc_count := 0.U
-  }.elsewhen (lrsc_valid) {
+  }.elsewhen (lrsc_count > 0.U) {
     lrsc_count := lrsc_count - 1.U
   }
 
 
   io.lrsc_locked_block.valid := lrsc_valid
   io.lrsc_locked_block.bits  := lrsc_addr
-  io.block_lr := GatedValidRegNext(lrsc_valid)
+  io.block_lr := GatedValidRegNext(lrsc_count > 0.U)
 
   // When we update update_resv_set, block all probe req in the next cycle
   // It should give Probe reservation set addr compare an independent cycle,


### PR DESCRIPTION
Following lr should be blocked when previous lr's resv_set is still valid, which means `lrsc_count > 0`.

In previous PR #3017 and #4117, `lrsc_count > 8` is used as block condition, and stop update `lrsc_count` when it reaches 8, fix it now.