### PR TITLE
fix(DCache): use `ParallelMux` instead of `Mux1H`

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1066,7 +1066,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     Seq(mainPipe.io.error) // store / misc error
   val error_valid = errors.map(e => e.valid).reduce(_|_)
   io.error.bits <> RegEnable(
-    Mux1H(errors.map(e => RegNext(e.valid) -> RegEnable(e.bits, e.valid))),
+    ParallelMux(errors.map(e => RegNext(e.valid) -> RegEnable(e.bits, e.valid))),
     RegNext(error_valid))
   io.error.valid := RegNext(RegNext(error_valid, init = false.B), init = false.B)
 


### PR DESCRIPTION
* When there are multiple errors，`Mux1H` is equivalent to using `|`,  for example 

    * error 0, valid = 1, addr0 = 0x1000
    * error 1, valid = 1, addr1 = 0x0ffff
    * the result is `io.error.valid == 1`, but `io.error.bits.addr == (addr0 | addr1)`,  cause `Mux1H` will generate circuit like this:
     ```
      addr = (valid0 ? addr0 : 'h0) |
                  (valid1 ? addr1 : 'h0)
     ```
     * This problem can be avoided by using `ParallelMux`