### PR TITLE
deps: add ivy dependency for sourcecode library

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -117,6 +117,10 @@ object utility extends HasChisel {
     rocketchip
   )
 
+  override def ivyDeps = super.ivyDeps() ++ Agg(
+    ivy"com.lihaoyi::sourcecode:0.4.2",
+  )
+
 }
 
 object yunsuan extends HasChisel {


### PR DESCRIPTION
Since #4312 merged, we need sourcecode library as an ivy dependency.

This library will no longer be included in chisel, see: https://github.com/chipsalliance/chisel/pull/3855