### PR TITLE
ci: fix date error in performance regression

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "run_biweekly=true" >> $GITHUB_OUTPUT
-          elif [ $(( $(date +'%V') % 2 )) -eq 1 ]; then
+          elif [ $(( 10#$(date +'%V') % 2 )) -eq 1 ]; then
             echo "run_biweekly=true" >> $GITHUB_OUTPUT
           else
             echo "run_biweekly=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The workflow uses `date +'%V'` to get the week number, but the ISO week number has a leading zero, which is interpreted as an octal number by bash. This caused errors in weeks 08 and 09, which went unnoticed previously.

This patch fixes the issue by using `10#$(date +'%V')` to force the number to be interpreted as decimal.