### PR TITLE
fix(CSR): add VTYPE to in-order read CSRs

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSROoORead.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSROoORead.scala
@@ -19,5 +19,6 @@ object CSROoORead {
     CSRs.hstatus,
     CSRs.mnstatus,
     CSRs.dcsr,
+    CSRs.vtype,
   )
 }


### PR DESCRIPTION
Since CSR VTYPE is not renamed (VL is renamed), the instruction CSRR with VTYPE cannot be executed out-of-order.