### PR TITLE
fix(MMU): incorrect check for pre af/pf/gpf

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -118,13 +118,20 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
 
   val Sv39Enable = csr.satp.mode === 8.U
   val Sv48Enable = csr.satp.mode === 9.U
-  val Sv39x4Enable = csr.vsatp.mode === 8.U || csr.hgatp.mode === 8.U
-  val Sv48x4Enable = csr.vsatp.mode === 9.U || csr.hgatp.mode === 9.U
+  val Sv39vsEnable = csr.vsatp.mode === 8.U
+  val Sv48vsEnable = csr.vsatp.mode === 9.U
+  val Sv39x4Enable = csr.hgatp.mode === 8.U
+  val Sv48x4Enable = csr.hgatp.mode === 9.U
+
   val vmEnable = (0 until Width).map(i => !(isHyperInst(i) || virt_out(i)) && (
     if (EnbaleTlbDebug) (Sv39Enable || Sv48Enable)
     else (Sv39Enable || Sv48Enable) && (mode(i) < ModeM))
   )
-  val s2xlateEnable = (0 until Width).map(i => (isHyperInst(i) || virt_out(i)) && (Sv39x4Enable || Sv48x4Enable) && (mode(i) < ModeM))
+  val s2xlateEnable = (0 until Width).map(i =>
+    (isHyperInst(i) || virt_out(i)) &&
+    (Sv39vsEnable || Sv48vsEnable || Sv39x4Enable || Sv48x4Enable) &&
+    (mode(i) < ModeM)
+  )
   val portTranslateEnable = (0 until Width).map(i => (vmEnable(i) || s2xlateEnable(i)) && RegEnable(!req(i).bits.no_translate, req(i).valid))
 
   // pre fault: check fault before real do translate
@@ -139,7 +146,11 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     if (EnbaleTlbDebug) (Sv39Enable || Sv48Enable)
     else (Sv39Enable || Sv48Enable) && (premode(i) < ModeM))
   )
-  val pres2xlateEnable = (0 until Width).map(i => (virt_in || req_in(i).bits.hyperinst) && (Sv39x4Enable || Sv48x4Enable) && (premode(i) < ModeM))
+  val pres2xlateEnable = (0 until Width).map(i =>
+    (virt_in || req_in(i).bits.hyperinst) &&
+    (Sv39vsEnable || Sv48vsEnable || Sv39x4Enable || Sv48x4Enable) &&
+    (premode(i) < ModeM)
+  )
 
   (0 until Width).foreach{i =>
 
@@ -190,7 +201,13 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
           } .elsewhen (Sv39x4Enable) {
             pregpf(i) := gpf39
           }
-        } .otherwise {
+        } .elsewhen (req_in_s2xlate(i) === onlyStage1 || req_in_s2xlate(i) === allStage) {
+          when (Sv48vsEnable) {
+            prepf(i) := pf48
+          } .elsewhen (Sv39vsEnable) {
+            prepf(i) := pf39
+          }
+        } .otherwise { // noS2xlate
           when (Sv48Enable) {
             prepf(i) := pf48
           } .elsewhen (Sv39Enable) {


### PR DESCRIPTION
Pre af/pf/gpf means the exceptions before real translating, such as high bits exception. There is some mistakes in choosing the translation mode, which may causes problems in which different mode are used for Non-virt S-stage and Virt VS-Stage.

This patch fixes the problems by smallest changes. There is too many debts in L1TLB.