### PR TITLE
fix(LoadUnit): misalign wakeup should not set s0 valid

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -330,7 +330,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     s0_src_select_vec(fast_rep_idx) || s0_src_select_vec(mmio_idx) ||
     s0_src_select_vec(nc_idx)
   s0_valid := !s0_kill && (s0_src_select_vec(nc_idx) || ((
-    s0_src_valid_vec(mab_idx) && !io.misalign_ldin.bits.misalignNeedWakeUp ||
+    s0_src_valid_vec(mab_idx) ||
     s0_src_valid_vec(super_rep_idx) ||
     s0_src_valid_vec(fast_rep_idx) ||
     s0_src_valid_vec(lsq_rep_idx) ||
@@ -339,7 +339,9 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     s0_src_valid_vec(int_iss_idx) ||
     s0_src_valid_vec(l2l_fwd_idx) ||
     s0_src_valid_vec(low_pf_idx)
-  ) && !s0_src_select_vec(mmio_idx) && io.dcache.req.ready))
+  ) && !s0_src_select_vec(mmio_idx) && io.dcache.req.ready &&
+    !(io.misalign_ldin.fire && io.misalign_ldin.bits.misalignNeedWakeUp) // Currently, misalign is the highest priority
+  ))
 
   s0_mmio_select := s0_src_select_vec(mmio_idx) && !s0_kill
   s0_nc_select := s0_src_select_vec(nc_idx) && !s0_kill


### PR DESCRIPTION
`s0_src_valid_vec` is not `s0_src_select_vec`, and bit corresponding to `s0_src_valid_vec` is valid when any of the inputs `valid`. Therefore, `misalign wakeup` needs to globally control `s0_valid`.