### PR TITLE
fix(vlbusytable): fix vlbusytable update

### DIFF
--- a/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
@@ -322,7 +322,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     val vma = fromRename(i).bits.vpu.vma
     val vm = fromRename(i).bits.vpu.vm
     val vlIsVlmax = vlBusyTable.io_vl_read.vlReadInfo(i).is_vlmax
-    val vlIsNonZero = !vlBusyTable.io_vl_read.vlReadInfo(i).is_zero
+    val vlIsNonZero = vlBusyTable.io_vl_read.vlReadInfo(i).is_nonzero
     val ignoreTail = vlIsVlmax && (vm =/= 0.U || vma) && !isWritePartVd
     val ignoreWhole = (vm =/= 0.U || vma) && vta
     val ignoreOldVd = vlBusyTable.io.read(i).resp && vlIsNonZero && !isDependOldVd && (ignoreTail || ignoreWhole)

--- a/src/main/scala/xiangshan/backend/rename/BusyTable.scala
+++ b/src/main/scala/xiangshan/backend/rename/BusyTable.scala
@@ -35,7 +35,7 @@ class BusyTableReadIO(implicit p: Parameters) extends XSBundle {
 
 
 class VlBusyTableReadIO(implicit p: Parameters) extends XSBundle {
-  val is_zero = Output(Bool())
+  val is_nonzero = Output(Bool())
   val is_vlmax = Output(Bool())
 }
 
@@ -207,13 +207,15 @@ class VlBusyTable(numReadPorts: Int, numWritePorts: Int, numPhyPregs: Int, pregW
   var intSchdVlWbPort = p(XSCoreParamsKey).intSchdVlWbPort
   var vfSchdVlWbPort = p(XSCoreParamsKey).vfSchdVlWbPort
 
-  val zeroTableUpdate = Wire(Vec(numPhyPregs, Bool()))
+  val nonzeroTableUpdate = Wire(Vec(numPhyPregs, Bool()))
   val vlmaxTableUpdate = Wire(Vec(numPhyPregs, Bool()))
 
   val intVlWb = Mux(io.wbPregs(intSchdVlWbPort).valid, UIntToOH(io.wbPregs(intSchdVlWbPort).bits), 0.U)
   val vfVlWb = Mux(io.wbPregs(vfSchdVlWbPort).valid, UIntToOH(io.wbPregs(vfSchdVlWbPort).bits), 0.U)
+  // when other ports write back, we cannot know the vl value, so we should set the vl table to busy
+  val otherPortsWb = io.wbPregs.zipWithIndex.filter(x => x._2 != intSchdVlWbPort && x._2 != vfSchdVlWbPort).map(x => Mux(x._1.valid, UIntToOH(x._1.bits), 0.U)).reduce(_ | _)
 
-  val zeroTable = VecInit((0 until numPhyPregs).zip(zeroTableUpdate).map{ case (idx, update) =>
+  val nonzeroTable = VecInit((0 until numPhyPregs).zip(nonzeroTableUpdate).map{ case (idx, update) =>
     RegEnable(update, 0.U(1.W), allocMask(idx) || ldCancelMask(idx) || intVlWb(idx) || vfVlWb(idx))
   }).asUInt
   val vlmaxTable = VecInit((0 until numPhyPregs).zip(vlmaxTableUpdate).map{ case (idx, update) =>
@@ -221,17 +223,17 @@ class VlBusyTable(numReadPorts: Int, numWritePorts: Int, numPhyPregs: Int, pregW
   }).asUInt
 
 
-  zeroTableUpdate.zipWithIndex.foreach{ case (update, idx) =>
+  nonzeroTableUpdate.zipWithIndex.foreach{ case (update, idx) =>
     when(intVlWb(idx)) {
       // int schd vl write back, check whether the vl is zero
-      update := !io_vl_Wb.vlWriteBackInfo.vlFromIntIsZero
+      update := io_vl_Wb.vlWriteBackInfo.vlFromIntIsZero
     }.elsewhen(vfVlWb(idx)) {
       // vf schd vl write back, check whether the vl is zero
-      update := !io_vl_Wb.vlWriteBackInfo.vlFromVfIsZero
-    }.elsewhen(allocMask(idx) || ldCancelMask(idx)) {
+      update := io_vl_Wb.vlWriteBackInfo.vlFromVfIsZero
+    }.elsewhen(otherPortsWb(idx) || allocMask(idx) || ldCancelMask(idx)) {
       update := true.B
     }.otherwise {
-      update := zeroTable(idx)
+      update := nonzeroTable(idx)
     }
   }
 
@@ -242,7 +244,7 @@ class VlBusyTable(numReadPorts: Int, numWritePorts: Int, numPhyPregs: Int, pregW
     }.elsewhen(vfVlWb(idx)) {
       // vf schd vl write back, check whether the vl is vlmax
       update := !io_vl_Wb.vlWriteBackInfo.vlFromVfIsVlmax
-    }.elsewhen(allocMask(idx) || ldCancelMask(idx)) {
+    }.elsewhen(otherPortsWb(idx) || allocMask(idx) || ldCancelMask(idx)) {
       update := true.B
     }.otherwise {
       update := vlmaxTable(idx)
@@ -250,7 +252,7 @@ class VlBusyTable(numReadPorts: Int, numWritePorts: Int, numPhyPregs: Int, pregW
   }
 
   io_vl_read.vlReadInfo.zip(io.read).foreach{ case (vlRes, res) =>
-    vlRes.is_zero := !zeroTable(res.req)
+    vlRes.is_nonzero := !nonzeroTable(res.req)
     vlRes.is_vlmax := !vlmaxTable(res.req)
   }
 }


### PR DESCRIPTION
* use nonzeroTable instead of zeroTable, because we need to assume vl is always 0
* when vleff instruction writeback, clear the bit store in nonzeroTable and vlmaxTable