### PR TITLE
fix(LoadUnit): exclude prefetch requests

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
@@ -142,7 +142,6 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
   // Allocate logic
   val acceptedVec = Wire(Vec(LoadPipelineWidth, Bool()))
   val enqIndexVec = Wire(Vec(LoadPipelineWidth, UInt(log2Up(LoadQueueRARSize).W)))
-  require(LoadQueueRARSize == VirtualLoadQueueSize, "LoadQueueRARSize should be equal to VirtualLoadQueueSize for timing!")
 
   for ((enq, w) <- io.query.map(_.req).zipWithIndex) {
     acceptedVec(w) := false.B

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1314,6 +1314,11 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s2_safe_writeback = s2_real_exception || s2_safe_wakeup || s2_vp_match_fail
 
   // ld-ld violation require
+  /**
+    * In order to ensure timing, the RAR enqueue conditions need to be compromised, worst source of timing from pmp and missQueue.
+    *   * if LoadQueueRARSize == VirtualLoadQueueSize, just need to exclude prefetching.
+    *   * if LoadQueueRARSize < VirtualLoadQueueSize, need to consider the situation of s2_can_query
+    */
   if (LoadQueueRARSize == VirtualLoadQueueSize) {
     io.lsq.ldld_nuke_query.req.valid           := s2_valid && !s2_prf
   } else {

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1314,7 +1314,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s2_safe_writeback = s2_real_exception || s2_safe_wakeup || s2_vp_match_fail
 
   // ld-ld violation require
-  io.lsq.ldld_nuke_query.req.valid           := s2_valid
+  io.lsq.ldld_nuke_query.req.valid           := s2_valid && !s2_prf
   io.lsq.ldld_nuke_query.req.bits.uop        := s2_in.uop
   io.lsq.ldld_nuke_query.req.bits.mask       := s2_in.mask
   io.lsq.ldld_nuke_query.req.bits.paddr      := s2_in.paddr

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1314,7 +1314,11 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s2_safe_writeback = s2_real_exception || s2_safe_wakeup || s2_vp_match_fail
 
   // ld-ld violation require
-  io.lsq.ldld_nuke_query.req.valid           := s2_valid && !s2_prf
+  if (LoadQueueRARSize == VirtualLoadQueueSize) {
+    io.lsq.ldld_nuke_query.req.valid           := s2_valid && !s2_prf
+  } else {
+    io.lsq.ldld_nuke_query.req.valid           := s2_valid && s2_can_query
+  }
   io.lsq.ldld_nuke_query.req.bits.uop        := s2_in.uop
   io.lsq.ldld_nuke_query.req.bits.mask       := s2_in.mask
   io.lsq.ldld_nuke_query.req.bits.paddr      := s2_in.paddr


### PR DESCRIPTION
* In order to ensure timing, the RAR enqueue conditions need to be compromised, worst source of timing from `pmp` and `missQueue`.

    * if `LoadQueueRARSize` == `VirtualLoadQueueSize`,  just need to exclude prefetching.
    
    * if `LoadQueueRARSize` < `VirtualLoadQueueSize`, need to consider the situation of `s2_can_query`