### PR TITLE
config: add fpga diff top on tilelink for diff_top

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -84,6 +84,7 @@ case class SoCParameters
   NumIRSrc: Int = 256,
   UseXSNoCTop: Boolean = false,
   UseXSNoCDiffTop: Boolean = false,
+  UseXSTileDiffTop: Boolean = false,
   IMSICUseTL: Boolean = false,
   EnableCHIAsyncBridge: Option[AsyncQueueParams] = Some(AsyncQueueParams(depth = 16, sync = 3, safe = false)),
   EnableClintAsyncBridge: Option[AsyncQueueParams] = Some(AsyncQueueParams(depth = 1, sync = 3, safe = false))

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -515,6 +515,22 @@ class FpgaDiffDefaultConfig(n: Int = 1) extends Config(
       AlwaysBasicDB = false
     )
     case SoCParamsKey => up(SoCParamsKey).copy(
+      UseXSTileDiffTop = true,
+      L3CacheParamsOpt = Some(up(SoCParamsKey).L3CacheParamsOpt.get.copy(
+        sramClkDivBy2 = false,
+      )),
+    )
+  })
+)
+
+class FpgaDiffMinimalConfig(n: Int = 1) extends Config(
+  (new MinimalConfig(n)).alter((site, here, up) => {
+    case DebugOptionsKey => up(DebugOptionsKey).copy(
+      AlwaysBasicDiff = true,
+      AlwaysBasicDB = false
+    )
+    case SoCParamsKey => up(SoCParamsKey).copy(
+      UseXSTileDiffTop = true,
       L3CacheParamsOpt = Some(up(SoCParamsKey).L3CacheParamsOpt.get.copy(
         sramClkDivBy2 = false,
       )),


### PR DESCRIPTION
In order to be compatible with st's environment, the fpga difftest project in tilelink is generated in the same way as noc top, which leads tilelink top and difftest signals to difftop together