### PR TITLE
ci:Add the cvm-test workflow

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -203,6 +203,20 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 8 --numa --ci linux-hello-opensbi 2> perf.log
           cat perf.log | sort
+      - name: clean up
+        run: |
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
+      - name: build CVMConfig Release emu
+        run: |
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
+            --threads 8 --config CVMConfig --release
+      - name: run CVMConfig - cvm-test
+        run: |
+          python3 $GITHUB_WORKSPACE/scripts/xiangshan.py \
+            --wave-dump $WAVE_HOME --threads 8 --numa \
+            --diff ./ready-to-run/riscv64-nemu-interpreter-bitmap-so \
+            --ci cvm-test 2> perf.log
+          cat perf.log | sort
 
   emu-performance:
     runs-on: bosc

--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -504,6 +504,15 @@ class XiangShan(object):
         zcb_test = map(lambda x: os.path.join(base_dir, x), workloads)
         return zcb_test
 
+    def __get_ci_cvmtest(self, name=None):
+        base_dir = "/nfs/home/share/ci-workloads/bitmap-ci-workload"
+        workloads = [
+            "HS_bitmap_af.bin",
+            "VS_bitmap_af.bin"
+        ]
+        cvm_test = map(lambda x: os.path.join(base_dir, x), workloads)
+        return cvm_test
+
     def __get_ci_mc(self, name=None):
         base_dir = "/nfs/home/share/ci-workloads"
         workloads = [
@@ -578,7 +587,8 @@ class XiangShan(object):
             "rvv-bench": self.__get_ci_rvvbench,
             "rvv-test": self.__get_ci_rvvtest,
             "f16_test": self.__get_ci_F16test,
-            "zcb-test": self.__get_ci_zcbtest
+            "zcb-test": self.__get_ci_zcbtest,
+            "cvm-test": self.__get_ci_cvmtest
         }
         for target in all_tests.get(test, self.__get_ci_workloads)(test):
             print(target)

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -462,12 +462,12 @@ class DefaultConfig(n: Int = 1) extends Config(
 
 class CVMConfig(n: Int = 1) extends Config(
   new CVMCompile
-    ++ new DefaultConfig(n)
+    ++ new KunminghuV2Config(n)
 )
 
 class CVMTestConfig(n: Int = 1) extends Config(
   new CVMTestCompile
-    ++ new DefaultConfig(n)
+    ++ new KunminghuV2Config(n)
 )
 
 class WithCHI extends Config((_, _, _) => {


### PR DESCRIPTION
- The base of `CVMConfig` and `CVMTestConfig` is changed from `DefaultConfig` to `KunminghuV2Config`
- Put the ci process of `cvm-test` into the `emu-chi` job, compile `CVMConfig`, and run the test program.
- The test file directory for `cvm-test` is undecided due to lack of permissions in `/nfs/home/share/ci-workloads`.
- Difftest still needs an additional bitmap support `.so` file.