### PR TITLE
fix(amocas): re-split uops for amocas to avoid stalls

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
@@ -212,65 +212,65 @@ class DecodeUnitComp()(implicit p : Parameters) extends XSModule with DecodeUnit
   switch(typeOfSplit) {
     is(UopSplitType.AMO_CAS_W) {
       csBundle(0).uopIdx := 0.U
-      csBundle(0).fuOpType := Cat(0.U(3.W), LSUOpType.amocas_w)
+      csBundle(0).fuOpType := Cat(1.U(3.W), LSUOpType.amocas_w)
       csBundle(0).lsrc(0) := src1
-      csBundle(0).lsrc(1) := dest
+      csBundle(0).lsrc(1) := src2
+      csBundle(0).rfWen := false.B
       csBundle(0).waitForward := true.B
       csBundle(0).blockBackward := false.B
 
       csBundle(1).uopIdx := 1.U
-      csBundle(1).fuOpType := Cat(1.U(3.W), LSUOpType.amocas_w)
+      csBundle(1).fuOpType := Cat(0.U(3.W), LSUOpType.amocas_w)
       csBundle(1).lsrc(0) := src1
-      csBundle(1).lsrc(1) := src2
-      csBundle(1).rfWen := false.B
+      csBundle(1).lsrc(1) := dest
       csBundle(1).waitForward := false.B
       csBundle(1).blockBackward := true.B
     }
     is(UopSplitType.AMO_CAS_D) {
       csBundle(0).uopIdx := 0.U
-      csBundle(0).fuOpType := Cat(0.U(3.W), LSUOpType.amocas_d)
+      csBundle(0).fuOpType := Cat(1.U(3.W), LSUOpType.amocas_d)
       csBundle(0).lsrc(0) := src1
-      csBundle(0).lsrc(1) := dest
+      csBundle(0).lsrc(1) := src2
+      csBundle(0).rfWen := false.B
       csBundle(0).waitForward := true.B
       csBundle(0).blockBackward := false.B
 
       csBundle(1).uopIdx := 1.U
-      csBundle(1).fuOpType := Cat(1.U(3.W), LSUOpType.amocas_d)
+      csBundle(1).fuOpType := Cat(0.U(3.W), LSUOpType.amocas_d)
       csBundle(1).lsrc(0) := src1
-      csBundle(1).lsrc(1) := src2
-      csBundle(1).rfWen := false.B
+      csBundle(1).lsrc(1) := dest
       csBundle(1).waitForward := false.B
       csBundle(1).blockBackward := true.B
     }
     is(UopSplitType.AMO_CAS_Q) {
       csBundle(0).uopIdx := 0.U
-      csBundle(0).fuOpType := Cat(0.U(3.W), LSUOpType.amocas_q)
+      csBundle(0).fuOpType := Cat(1.U(3.W), LSUOpType.amocas_q)
       csBundle(0).lsrc(0) := src1
-      csBundle(0).lsrc(1) := dest
+      csBundle(0).lsrc(1) := src2
+      csBundle(0).rfWen := false.B
       csBundle(0).waitForward := true.B
       csBundle(0).blockBackward := false.B
 
       csBundle(1).uopIdx := 1.U
-      csBundle(1).fuOpType := Cat(1.U(3.W), LSUOpType.amocas_q)
+      csBundle(1).fuOpType := Cat(0.U(3.W), LSUOpType.amocas_q)
       csBundle(1).lsrc(0) := src1
-      csBundle(1).lsrc(1) := src2
-      csBundle(1).rfWen := false.B
+      csBundle(1).lsrc(1) := dest
       csBundle(1).waitForward := false.B
       csBundle(1).blockBackward := false.B
 
       csBundle(2).uopIdx := 2.U
-      csBundle(2).fuOpType := Cat(2.U(3.W), LSUOpType.amocas_q)
+      csBundle(2).fuOpType := Cat(3.U(3.W), LSUOpType.amocas_q)
       csBundle(2).lsrc(0) := src1
-      csBundle(2).lsrc(1) := Mux(dest === 0.U, 0.U, dest + 1.U)
-      csBundle(2).ldest := Mux(dest === 0.U, 0.U, dest + 1.U)
+      csBundle(2).lsrc(1) := Mux(src2 === 0.U, 0.U, src2 + 1.U)
+      csBundle(2).rfWen := false.B
       csBundle(2).waitForward := false.B
       csBundle(2).blockBackward := false.B
 
       csBundle(3).uopIdx := 3.U
-      csBundle(3).fuOpType := Cat(3.U(3.W), LSUOpType.amocas_q)
+      csBundle(3).fuOpType := Cat(2.U(3.W), LSUOpType.amocas_q)
       csBundle(3).lsrc(0) := src1
-      csBundle(3).lsrc(1) := Mux(src2 === 0.U, 0.U, src2 + 1.U)
-      csBundle(3).rfWen := false.B
+      csBundle(3).lsrc(1) := Mux(dest === 0.U, 0.U, dest + 1.U)
+      csBundle(3).ldest := Mux(dest === 0.U, 0.U, dest + 1.U)
       csBundle(3).waitForward := false.B
       csBundle(3).blockBackward := true.B
     }

--- a/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
@@ -451,7 +451,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
   }
   for (i <- 0 until RenameWidth){
     // check is drop amocas sta
-    fromRenameUpdate(i).bits.isDropAmocasSta := fromRename(i).bits.isAMOCAS && fromRename(i).bits.uopIdx(0) === 1.U
+    fromRenameUpdate(i).bits.isDropAmocasSta := fromRename(i).bits.isAMOCAS && fromRename(i).bits.uopIdx(0) === 0.U
     // update singleStep
     fromRenameUpdate(i).bits.singleStep := io.singleStep && (fromRename(i).bits.robIdx =/= robidxCanCommitStepping)
   }


### PR DESCRIPTION
Re-split uops to avoid stalls caused by renaming when rd and rs2 are the same.

When rd and rs2 are the same, uop1'src will wait uop0'dest after rename, which cause stalls.

In this commit, we set src2 in uop0 and dest in uop1, avoiding stalls by renaming.