### PR TITLE
fix(AXI4Memory): remove `AWLEN == 0` Check

### DIFF
--- a/src/main/scala/device/AXI4Memory.scala
+++ b/src/main/scala/device/AXI4Memory.scala
@@ -175,7 +175,6 @@ class AXI4MemoryImp[T <: Data](outer: AXI4Memory) extends AXI4SlaveModuleImp(out
   val pending_write_req_valid = RegInit(VecInit.fill(2)(false.B))
   val pending_write_req_bits  = RegEnable(in.aw.bits, in.aw.fire)
   val pending_write_req_data  = RegEnable(in.w.bits, in.w.fire)
-  XSError(in.aw.fire && in.aw.bits.len === 0.U, "data must have more than one beat now")
   val pending_write_req_ready = Wire(Bool())
   val pending_write_need_req = pending_write_req_valid.last && !pending_write_req_ready
   val write_req_valid = pending_write_req_valid.head && (pending_write_need_req || in.w.valid && in.w.bits.last)


### PR DESCRIPTION
According to AXI4 spec, the total number of transfers in a transaction is encoded as Length = AxLEN + 1. Therefore the XSError assertion is incorrect and is removed in this pr.
<img width="679" alt="image" src="https://github.com/user-attachments/assets/c1a75035-ff01-41e7-a41d-12ebd7c2e8ea" />
 