### PR TITLE
feat(PTWCache): Support a more precise flush for L2 TLB entries

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
@@ -69,6 +69,10 @@ case class L2TLBParameters
   // sp
   spSize: Int = 16,
   spReplacer: Option[String] = Some("plru"),
+  // hash asid width
+  hashAsidWidth: Int = 3,
+  // hash vpn width
+  hashVpnWidth: Int = 6,
   // filter
   ifilterSize: Int = 8,
   dfilterSize: Int = 32,


### PR DESCRIPTION
In the previous design, since we stored asid/vmid and vaddr information in SRAM, it was not possible to simply read out all the information in a single cycle for comparison with the parameters of sfence/hfence. As a result, for L2 TLB entries, we ignored the rs1/rs2 parameters passed by sfence/hfence and instead flushed all valid entries, regardless of asid/vmid or vaddr.

However, this caused unnecessary flushing of a large number of entries during process switching in virtualized environments, leading to L2 TLB misses after a process switch. This forced the processor to perform a page table walk in memory again, negatively impacting performance.

In this commit, asid/vmid and vaddr are hashed and stored in the register file. When an sfence/hfence signal is received, these stored values are compared against the incoming parameters, allowing for a more precise TLB flush.