### PR TITLE
fix(LoadPipe): fix s1 bank addr generate logic

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -182,8 +182,8 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // LSU may update the address from io.lsu.s1_paddr, which affects the bank read enable only.
   val s1_vaddr_update = Cat(s1_req.vaddr(VAddrBits - 1, blockOffBits), io.lsu.s1_paddr_dup_lsu(blockOffBits - 1, 0))
   val s1_vaddr_update_dup = Cat(s1_req.vaddr_dup(VAddrBits - 1, blockOffBits), io.lsu.s1_paddr_dup_dcache(blockOffBits - 1, 0))
-  val s1_vaddr = Mux(s1_load128Req, Cat(s1_vaddr_update(VAddrBits - 1, 4), 0.U(4.W)), s1_vaddr_update)
-  val s1_vaddr_dup = Mux(s1_load128Req, Cat(s1_vaddr_update_dup(VAddrBits - 1, 4), 0.U(4.W)), s1_vaddr_update_dup)
+  val s1_vaddr = s1_vaddr_update
+  val s1_vaddr_dup = s1_vaddr_update_dup
   val s1_bank_oh = RegEnable(s0_bank_oh, s0_fire)
   val s1_nack = RegNext(io.nack)
   val s1_fire = s1_valid && s2_ready

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -112,8 +112,8 @@ trait HasLoadHelper { this: XSModule =>
   }
 
   def genDataSelectByOffset(addrOffset: UInt): Vec[Bool] = {
-    require(addrOffset.getWidth == 4)
-    VecInit((0 until 16).map{ case i =>
+    require(addrOffset.getWidth == 3)
+    VecInit((0 until 8).map{ case i =>
       addrOffset === i.U
     })
   }

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1152,7 +1152,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s2_vecActive = RegEnable(s1_out.vecActive, true.B, s1_fire)
   val s2_isvec  = RegEnable(s1_out.isvec, false.B, s1_fire)
   val s2_data_select  = genRdataOH(s2_out.uop)
-  val s2_data_select_by_offset = genDataSelectByOffset(s2_out.paddr(3, 0))
+  val s2_data_select_by_offset = genDataSelectByOffset(s2_out.paddr(2, 0))
   val s2_frm_mabuf = s2_in.isFrmMisAlignBuf
   val s2_pbmt = RegEnable(s1_pbmt, s1_fire)
   val s2_trigger_debug_mode = RegEnable(s1_trigger_debug_mode, false.B, s1_fire)
@@ -1717,15 +1717,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
       s3_merged_data_frm_pipe(95,     32),
       s3_merged_data_frm_pipe(103,    40),
       s3_merged_data_frm_pipe(111,    48),
-      s3_merged_data_frm_pipe(119,    56),
-      s3_merged_data_frm_pipe(127,    64),
-      s3_merged_data_frm_pipe(127,    72),
-      s3_merged_data_frm_pipe(127,    80),
-      s3_merged_data_frm_pipe(127,    88),
-      s3_merged_data_frm_pipe(127,    96),
-      s3_merged_data_frm_pipe(127,   104),
-      s3_merged_data_frm_pipe(127,   112),
-      s3_merged_data_frm_pipe(127,   120),
+      s3_merged_data_frm_pipe(119,    56)
     ))
   }))
   val s3_picked_data_frm_pipe = VecInit((0 until LdDataDup).map(i => {


### PR DESCRIPTION
* when 128 bits request, `LoadPipe` will clean lower 5 bits, but `BankedDataArray` should use bit [5 : 3] for bank addr generate, hence, load will read wrong bank of `BankedDataArray`

https://github.com/OpenXiangShan/XiangShan/blob/aa3402616480a40eb5e7e81c9bef45a7d0cf4987/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala#L398-L399