### PR TITLE
fix(scripts): fix calculation of `BadSpecInst` in topdown scripts.

### DIFF
--- a/scripts/top-down/configs.py
+++ b/scripts/top-down/configs.py
@@ -27,6 +27,10 @@ xs_coarse_rename_map = {
 
     'IntFlStall': 'MergeFreelistStall',
     'FpFlStall': 'MergeFreelistStall',
+    'VecFlStall': 'MergeFreelistStall',
+    'V0FlStall': 'MergeFreelistStall',
+    'VlFlStall': 'MergeFreelistStall',
+    'MultiFlStall': 'MergeFreelistStall',
 
     'LoadTLBStall': 'MergeLoad',
     'LoadL1Stall': 'MergeLoad',
@@ -133,6 +137,10 @@ targets = {
 
     'IntFlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: IntFlStall,\s+(\d+)',
     'FpFlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: FpFlStall,\s+(\d+)',
+    'VecFlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: VecFlStall,\s+(\d+)',
+    'V0FlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: V0FlStall,\s+(\d+)',
+    'VlFlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: VlFlStall,\s+(\d+)',
+    'MultiFlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: MultiFlStall,\s+(\d+)',
 
     'LoadTLBStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: LoadTLBStall,\s+(\d+)',
     'LoadL1Stall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: LoadL1Stall,\s+(\d+)',

--- a/scripts/top-down/draw.py
+++ b/scripts/top-down/draw.py
@@ -67,12 +67,12 @@ def draw():
             else:
                 rename_with_map(df, cf.xs_coarse_rename_map)
 
-                icount = 20 * 10 ** 6
-                if 'BadSpecInst' in df.columns:
-                    df['BadSpecInst'] += df['Base'] - icount
-                else:
-                    df['BadSpecInst'] = df['Base'] - icount
-                df['Base'] = icount
+            icount = 20 * 10 ** 6
+            if 'BadSpecInst' in df.columns:
+                df['BadSpecInst'] += df['Base'] - icount
+            else:
+                df['BadSpecInst'] = df['Base'] - icount
+            df['Base'] = icount
 
         df = df.astype(float)
         renamed_dfs.append(df)
@@ -128,7 +128,7 @@ def draw():
     ax.set_xlabel('SPECCPU 2006 Benchmarks')
 
     handles, labels = plt.gca().get_legend_handles_labels()
-    ax.legend(reversed(handles), reversed(labels), fancybox=True,
+    ax.legend(list(reversed(handles)), list(reversed(labels)), fancybox=True,
               framealpha=0.3,
               loc='best',
               ncol=3,


### PR DESCRIPTION
The flushed Inst is counted in two ways, including a hardware accumulation counter and a software script counting uOPs that exceed the length of the checkpoint. Due to indentation issues, the latter one is not correctly calculated.

This pull request accomplishes the following:
* fix bad speculation instructions calculation.
* add vector freelist stalls, which are already supported by hardware perf counters but are not analyzed by software scripts.