### PR TITLE
fix(DecodeUnit): add `II exception` to the `TileLink` of the cbo instr

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -899,9 +899,9 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
     io.fromCSR.illegalInst.wrs_nto    && FuType.FuTypeOrR(decodedInst.fuType, FuType.csr)   && CSROpType.isWrsNto(decodedInst.fuOpType) ||
     (decodedInst.needFrm.scalaNeedFrm || FuType.isScalaNeedFrm(decodedInst.fuType)) && (((decodedInst.fpu.rm === 5.U) || (decodedInst.fpu.rm === 6.U)) || ((decodedInst.fpu.rm === 7.U) && io.fromCSR.illegalInst.frm)) ||
     (decodedInst.needFrm.vectorNeedFrm || FuType.isVectorNeedFrm(decodedInst.fuType)) && io.fromCSR.illegalInst.frm ||
-    io.fromCSR.illegalInst.cboZ       && isCboZero ||
-    io.fromCSR.illegalInst.cboCF      && (isCboClean || isCboFlush) ||
-    io.fromCSR.illegalInst.cboI       && isCboInval ||
+    (io.fromCSR.illegalInst.cboZ  || !HasCMO.B) && isCboZero ||
+    (io.fromCSR.illegalInst.cboCF || !HasCMO.B) && (isCboClean || isCboFlush) ||
+    (io.fromCSR.illegalInst.cboI  || !HasCMO.B) && isCboInval ||
     isAes64ks1iIllegal ||
     isAmocasQIllegal
 


### PR DESCRIPTION
Currently, only the CHI version of XS supports the CBO instruction , so we are adding the illegal instruction to the TlieLink version of XS.