### PR TITLE
chore(scalastyle): allow newline after operators

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -105,9 +105,9 @@
  <check enabled="true" class="org.scalastyle.file.RegexChecker" level="warning">
   <parameters>
    <!-- :=, :<=, :>=, :<>=, :#=, <>, ===, =/=, <<, >>, <=, >= -->
-   <parameter name="regex"><![CDATA[(:<?#?>?=|<>|=[=/]=|<<|>>|[<>]=)[^ ]]]></parameter>
+   <parameter name="regex"><![CDATA[(:<?#?>?=|<>|=[=/]=|<<|>>|[<>]=)[^ \n]]]></parameter>
   </parameters>
-  <customMessage>No space after operators</customMessage>
+  <customMessage>No space or newline after operators</customMessage>
  </check>
 
  <!-- ===== imports ===== -->


### PR DESCRIPTION
e.g.
```scala
some_wire :=
  super && loooooooooooooooooong && logic ||
    other && logic
```