### PR TITLE
fix(TLB): L1 TLB will not save the high bit of PPN

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -306,7 +306,7 @@ class TlbSectorEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parame
     val s2_valid = Mux(s2page_pageSuper, VecInit(Seq.fill(tlbcontiguous)(true.B)), VecInit(UIntToOH(item.s2.entry.tag(sectortlbwidth - 1, 0)).asBools))
     this.valididx := Mux(item.s2xlate === onlyStage2, s2_valid, item.s1.valididx)
     // if stage2 page is larger than stage1 page, need to merge s2tag and s2ppn to get a new s2ppn.
-    val s1ppn = item.s1.entry.ppn
+    val s1ppn = item.s1.entry.ppn(sectorppnLen - 1, 0)
     val s1ppn_low = item.s1.ppn_low
     val s2ppn = MuxLookup(item.s2.entry.level.getOrElse(0.U), item.s2.entry.ppn(ppnLen - 1, sectortlbwidth))(Seq(
       3.U -> Cat(item.s2.entry.ppn(ppnLen - 1, vpnnLen * 3), item.s2.entry.tag(vpnnLen * 3 - 1, sectortlbwidth)),


### PR DESCRIPTION
Actually, the bit-width of s1ppn is sectorppnLen, which is defined as PaddrBits(48) - Offset(12) - TLB compression(3). In contrast, the L2 TLB returns item.s1.entry.ppn with a bit-width of sectorptePPNLen, which equals ptePaddrLen(56) - Offset(12) - TLB compression(3).

The part of the PPN beyond PaddrBits is only used to generate gpaddr when a guest page fault occurs, so it isn’t stored in the L1 TLB entry. Here, we simply assign the lower (sectorppnLen - 1, 0) bits. In fact, the original implementation would also work correctly, as it automatically truncates the lower bits of item.s1.entry.ppn and assigns them to s1ppn.

TODO: Not storing gpaddr (the upper PPN bits) in the L1 TLB currently provides minimal benefits and significantly increases the complexity, scalability, and maintainability issues of the TLB. In the new architecture, we need to store gpaddr in the L1 TLB to avoid all the additional handling related to guest page faults (gpf).