### PR TITLE
power(SC): dynamically close SC in KMH-V3

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -88,6 +88,12 @@ case class XSCoreParameters
   EnableLoop: Boolean = true,
   EnableSC: Boolean = true,
   DynCloseSC: Boolean = true,
+  SCCloseConfIncWhenSCAgreeAndCorrect: Int = 1,
+  SCCloseConfIncWhenSCAgreeButWrong: Int = 1,
+  SCCloseConfIncWhenSCDisagreeButTAGECorrect: Int = 5,
+  SCCloseConfDecWhenSCDisagreeAndSCCorrect: Int = -50,
+  SCCloseConfIncWhenSCClosedAndTAGECorrect: Int = 1,
+  SCCloseConfIncWhenSCClosedAndTAGEWrong: Int = -30,
   EnbaleTlbDebug: Boolean = false,
   EnableClockGate: Boolean = true,
   EnableJal: Boolean = false,
@@ -654,6 +660,12 @@ trait HasXSParameter {
   def EnableLoop = coreParams.EnableLoop
   def EnableSC = coreParams.EnableSC
   def DynCloseSC = coreParams.DynCloseSC
+  def SCCloseConfIncWhenSCAgreeAndCorrect = coreParams.SCCloseConfIncWhenSCAgreeAndCorrect
+  def SCCloseConfIncWhenSCAgreeButWrong = coreParams.SCCloseConfIncWhenSCAgreeButWrong
+  def SCCloseConfIncWhenSCDisagreeButTAGECorrect = coreParams.SCCloseConfIncWhenSCDisagreeButTAGECorrect
+  def SCCloseConfDecWhenSCDisagreeAndSCCorrect = coreParams.SCCloseConfDecWhenSCDisagreeAndSCCorrect
+  def SCCloseConfIncWhenSCClosedAndTAGECorrect = coreParams.SCCloseConfIncWhenSCClosedAndTAGECorrect
+  def SCCloseConfIncWhenSCClosedAndTAGEWrong = coreParams.SCCloseConfIncWhenSCClosedAndTAGEWrong
   def EnbaleTlbDebug = coreParams.EnbaleTlbDebug
   def HistoryLength = coreParams.HistoryLength
   def EnableGHistDiff = coreParams.EnableGHistDiff

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -87,7 +87,7 @@ case class XSCoreParameters
   EnableLB: Boolean = false,
   EnableLoop: Boolean = true,
   EnableSC: Boolean = true,
-  DynCloseSC: Boolean = true,
+  DynCloseSC: Boolean = false,
   SCCloseConfIncWhenSCAgreeAndCorrect: Int = 1,
   SCCloseConfIncWhenSCAgreeButWrong: Int = 1,
   SCCloseConfIncWhenSCDisagreeButTAGECorrect: Int = 5,

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -87,6 +87,7 @@ case class XSCoreParameters
   EnableLB: Boolean = false,
   EnableLoop: Boolean = true,
   EnableSC: Boolean = true,
+  DynCloseSC: Boolean = true,
   EnbaleTlbDebug: Boolean = false,
   EnableClockGate: Boolean = true,
   EnableJal: Boolean = false,
@@ -652,6 +653,7 @@ trait HasXSParameter {
   def EnableLB = coreParams.EnableLB
   def EnableLoop = coreParams.EnableLoop
   def EnableSC = coreParams.EnableSC
+  def DynCloseSC = coreParams.DynCloseSC
   def EnbaleTlbDebug = coreParams.EnbaleTlbDebug
   def HistoryLength = coreParams.HistoryLength
   def EnableGHistDiff = coreParams.EnableGHistDiff

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -93,7 +93,7 @@ case class XSCoreParameters
   SCCloseConfIncWhenSCDisagreeButTAGECorrect: Int = 5,
   SCCloseConfDecWhenSCDisagreeAndSCCorrect: Int = -50,
   SCCloseConfIncWhenSCClosedAndTAGECorrect: Int = 1,
-  SCCloseConfIncWhenSCClosedAndTAGEWrong: Int = -30,
+  SCCloseConfDecWhenSCClosedAndTAGEWrong: Int = -30,
   EnbaleTlbDebug: Boolean = false,
   EnableClockGate: Boolean = true,
   EnableJal: Boolean = false,
@@ -665,7 +665,7 @@ trait HasXSParameter {
   def SCCloseConfIncWhenSCDisagreeButTAGECorrect = coreParams.SCCloseConfIncWhenSCDisagreeButTAGECorrect
   def SCCloseConfDecWhenSCDisagreeAndSCCorrect = coreParams.SCCloseConfDecWhenSCDisagreeAndSCCorrect
   def SCCloseConfIncWhenSCClosedAndTAGECorrect = coreParams.SCCloseConfIncWhenSCClosedAndTAGECorrect
-  def SCCloseConfIncWhenSCClosedAndTAGEWrong = coreParams.SCCloseConfIncWhenSCClosedAndTAGEWrong
+  def SCCloseConfDecWhenSCClosedAndTAGEWrong = coreParams.SCCloseConfDecWhenSCClosedAndTAGEWrong
   def EnbaleTlbDebug = coreParams.EnbaleTlbDebug
   def HistoryLength = coreParams.HistoryLength
   def EnableGHistDiff = coreParams.EnableGHistDiff

--- a/src/main/scala/xiangshan/frontend/BPU.scala
+++ b/src/main/scala/xiangshan/frontend/BPU.scala
@@ -115,12 +115,12 @@ trait BPUUtils extends HasXSParameter {
 
     val finalDelta = MuxLookup(deltaType(uIdx), 0.S)(
       Seq(
-        0.U -> SCCloseConfIncWhenSCAgreeAndCorrect.S,   // SC opened, SC agree and correct, can be closed
+        0.U -> SCCloseConfIncWhenSCAgreeAndCorrect.S, // SC opened, SC agree and correct, can be closed
         1.U -> SCCloseConfIncWhenSCAgreeButWrong.S,   // SC opened, SC agree but wrong, should be closed more
-        2.U -> SCCloseConfIncWhenSCDisagreeButTAGECorrect.S,   // SC opened, SC disagree and wrong, should definitely be closed
+        2.U -> SCCloseConfIncWhenSCDisagreeButTAGECorrect.S, // SC opened, SC disagree and wrong, should definitely be closed
         3.U -> SCCloseConfDecWhenSCDisagreeAndSCCorrect.S, // SC opened, SC disagree but correct, should stay open
-        4.U -> SCCloseConfIncWhenSCClosedAndTAGECorrect.S,   // SC closed, TAGE pred correct, SC can be closed
-        5.U -> SCCloseConfIncWhenSCClosedAndTAGEWrong.S  // SC closed, TAGE pred wrong, SC should be opened
+        4.U -> SCCloseConfIncWhenSCClosedAndTAGECorrect.S, // SC closed, TAGE pred correct, SC can be closed
+        5.U -> SCCloseConfDecWhenSCClosedAndTAGEWrong.S    // SC closed, TAGE pred wrong, SC should be opened
       )
     )
 

--- a/src/main/scala/xiangshan/frontend/BPU.scala
+++ b/src/main/scala/xiangshan/frontend/BPU.scala
@@ -115,12 +115,12 @@ trait BPUUtils extends HasXSParameter {
 
     val finalDelta = MuxLookup(deltaType(uIdx), 0.S)(
       Seq(
-        0.U -> 1.S,   // SC opened, SC agree and correct, can be closed
-        1.U -> 1.S,   // SC opened, SC agree but wrong, should be closed more
-        2.U -> 5.S,   // SC opened, SC disagree and wrong, should definitely be closed
-        3.U -> -50.S, // SC opened, SC disagree but correct, should stay open
-        4.U -> 1.S,   // SC closed, TAGE pred correct, SC can be closed
-        5.U -> -30.S  // SC closed, TAGE pred wrong, SC should be opened
+        0.U -> SCCloseConfIncWhenSCAgreeAndCorrect.S,   // SC opened, SC agree and correct, can be closed
+        1.U -> SCCloseConfIncWhenSCAgreeButWrong.S,   // SC opened, SC agree but wrong, should be closed more
+        2.U -> SCCloseConfIncWhenSCDisagreeButTAGECorrect.S,   // SC opened, SC disagree and wrong, should definitely be closed
+        3.U -> SCCloseConfDecWhenSCDisagreeAndSCCorrect.S, // SC opened, SC disagree but correct, should stay open
+        4.U -> SCCloseConfIncWhenSCClosedAndTAGECorrect.S,   // SC closed, TAGE pred correct, SC can be closed
+        5.U -> SCCloseConfIncWhenSCClosedAndTAGEWrong.S  // SC closed, TAGE pred wrong, SC should be opened
       )
     )
 

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -271,11 +271,11 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
   var sc_fh_info                          = Set[FoldedHistoryInfo]()
   if (EnableSC) {
     val scCloseConfCounter = WireInit(0.S(scCloseConfCounterWidth.W))
-    val s0_sc_closed       = if (DynCloseSC) { scCloseConfCounter >= 0.S }
-                             else { false.B }
-    val s1_sc_closed       = RegEnable(s0_sc_closed, io.s0_fire(3))
-    val s2_sc_closed       = RegEnable(s1_sc_closed, io.s1_fire(3))
-    val s3_sc_closed       = RegEnable(s2_sc_closed, io.s2_fire(3))
+    val s0_sc_closed = if (DynCloseSC) { scCloseConfCounter >= 0.S }
+    else { false.B }
+    val s1_sc_closed = RegEnable(s0_sc_closed, io.s0_fire(3))
+    val s2_sc_closed = RegEnable(s1_sc_closed, io.s1_fire(3))
+    val s3_sc_closed = RegEnable(s2_sc_closed, io.s2_fire(3))
 
     val scTables = SCTableInfos.map {
       case (nRows, ctrBits, histLen) => {
@@ -489,7 +489,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
     for (b <- 0 until TageBanks) {
       for (i <- 0 until SCNTables) {
         val realWen = if (DynCloseSC) { realWens(i) && !s0_sc_closed }
-                      else { realWens(i) }
+        else { realWens(i) }
         scTables(i).io.update.mask(b)      := RegNext(scUpdateMask(b)(i))
         scTables(i).io.update.tagePreds(b) := RegEnable(scUpdateTagePreds(b), realWen)
         scTables(i).io.update.takens(b)    := RegEnable(scUpdateTakens(b), realWen)

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -37,7 +37,9 @@ import utility.mbist.MbistPipeline
 import utility.sram.SRAMTemplate
 import xiangshan._
 
-trait HasSCParameter extends TageParams {}
+trait HasSCParameter extends TageParams {
+  val scCloseConfCounterWidth = 10 // SInt Width
+}
 
 class SCReq(implicit p: Parameters) extends TageReq
 
@@ -45,7 +47,8 @@ abstract class SCBundle(implicit p: Parameters) extends TageBundle with HasSCPar
 abstract class SCModule(implicit p: Parameters) extends TageModule with HasSCParameter {}
 
 class SCMeta(val ntables: Int)(implicit p: Parameters) extends XSBundle with HasSCParameter {
-  val scPreds = Vec(numBr, Bool())
+  val scClosed = Bool()
+  val scPreds  = Vec(numBr, Bool())
   // Suppose ctrbits of all tables are identical
   val ctrs = Vec(numBr, Vec(ntables, SInt(SCCtrBits.W)))
 }
@@ -267,11 +270,19 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
   val update_on_mispred, update_on_unconf = WireInit(0.U.asTypeOf(Vec(TageBanks, Bool())))
   var sc_fh_info                          = Set[FoldedHistoryInfo]()
   if (EnableSC) {
+    val scCloseConfCounter = WireInit(0.S(scCloseConfCounterWidth.W))
+    val s0_sc_closed       = if (DynCloseSC) { scCloseConfCounter >= 0.S }
+                             else { false.B }
+    val s1_sc_closed       = RegEnable(s0_sc_closed, io.s0_fire(3))
+    val s2_sc_closed       = RegEnable(s1_sc_closed, io.s1_fire(3))
+    val s3_sc_closed       = RegEnable(s2_sc_closed, io.s2_fire(3))
+
     val scTables = SCTableInfos.map {
       case (nRows, ctrBits, histLen) => {
         val t   = Module(new SCTable(nRows / TageBanks, ctrBits, histLen))
         val req = t.io.req
-        req.valid            := io.s0_fire(3)
+        req.valid := (if (DynCloseSC) { io.s0_fire(3) && !s0_sc_closed }
+                      else { io.s0_fire(3) })
         req.bits.pc          := s0_pc_dup(3)
         req.bits.folded_hist := io.in.bits.folded_hist(3)
         req.bits.ghist       := DontCare
@@ -321,7 +332,8 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
     def getPvdrCentered(ctr: UInt): SInt = Cat(ctr ^ (1 << (TageCtrBits - 1)).U, 1.U(1.W), 0.U(3.W)).asSInt
 
     val scMeta = resp_meta.scMeta.get
-    scMeta := DontCare
+    scMeta          := DontCare
+    scMeta.scClosed := RegEnable(s2_sc_closed, io.s2_fire(3))
     for (w <- 0 until TageBanks) {
       // do summation in s2
       val s1_scTableSums = VecInit(
@@ -329,32 +341,63 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
           ParallelSingedExpandingAdd(s1_scResps map (r => getCentered(r.ctrs(w)(i)))) // TODO: rewrite with wallace tree
         }
       )
-      val s2_scTableSums         = RegEnable(s1_scTableSums, io.s1_fire(3))
-      val s2_tagePrvdCtrCentered = getPvdrCentered(RegEnable(s1_providerResps(w).ctr, io.s1_fire(3)))
-      val s2_totalSums           = s2_scTableSums.map(_ +& s2_tagePrvdCtrCentered)
+      val s2_scTableSums = RegEnable(
+        s1_scTableSums,
+        if (DynCloseSC) { io.s1_fire(3) && !s1_sc_closed }
+        else { io.s1_fire(3) }
+      )
+      val s2_tagePrvdCtrCentered = getPvdrCentered(RegEnable(
+        s1_providerResps(w).ctr,
+        if (DynCloseSC) { io.s1_fire(3) && !s1_sc_closed }
+        else { io.s1_fire(3) }
+      ))
+
+      val s2_totalSums = s2_scTableSums.map(_ +& s2_tagePrvdCtrCentered)
       val s2_sumAboveThresholds =
         VecInit((0 to 1).map(i => aboveThreshold(s2_scTableSums(i), s2_tagePrvdCtrCentered, useThresholds(w))))
       val s2_scPreds = VecInit(s2_totalSums.map(_ >= 0.S))
 
-      val s2_scResps   = VecInit(RegEnable(s1_scResps, io.s1_fire(3)).map(_.ctrs(w)))
+      val s2_scResps = VecInit(RegEnable(
+        s1_scResps,
+        if (DynCloseSC) { io.s1_fire(3) && !s1_sc_closed }
+        else { io.s1_fire(3) }
+      ).map(_.ctrs(w)))
       val s2_scCtrs    = VecInit(s2_scResps.map(_(s2_tageTakens_dup(3)(w).asUInt)))
       val s2_chooseBit = s2_tageTakens_dup(3)(w)
 
-      val s2_pred =
-        Mux(s2_provideds(w) && s2_sumAboveThresholds(s2_chooseBit), s2_scPreds(s2_chooseBit), s2_tageTakens_dup(3)(w))
+      // If SC was closed, use TAGE's pred
+      val s2_pred = Mux(
+        s2_provideds(w) && s2_sumAboveThresholds(s2_chooseBit) && (if (DynCloseSC) { !s2_sc_closed }
+                                                                   else { true.B }),
+        s2_scPreds(s2_chooseBit),
+        s2_tageTakens_dup(3)(w)
+      )
 
-      val s3_disagree = RegEnable(s2_disagree, io.s2_fire(3))
+      val s3_disagree = RegEnable(
+        s2_disagree,
+        if (DynCloseSC) { io.s2_fire(3) && !s2_sc_closed }
+        else { io.s2_fire(3) }
+      )
       io.out.last_stage_spec_info.sc_disagree.map(_ := s3_disagree)
 
-      scMeta.scPreds(w) := RegEnable(s2_scPreds(s2_chooseBit), io.s2_fire(3))
-      scMeta.ctrs(w)    := RegEnable(s2_scCtrs, io.s2_fire(3))
+      scMeta.scPreds(w) := RegEnable(
+        s2_scPreds(s2_chooseBit),
+        if (DynCloseSC) { io.s2_fire(3) && !s2_sc_closed }
+        else { io.s2_fire(3) }
+      )
+      scMeta.ctrs(w) := RegEnable(
+        s2_scCtrs,
+        if (DynCloseSC) { io.s2_fire(3) && !s2_sc_closed }
+        else { io.s2_fire(3) }
+      )
 
       val pred     = s2_scPreds(s2_chooseBit)
       val debug_pc = Cat(debug_pc_s2, w.U, 0.U(instOffsetBits.W))
       when(s2_provideds(w)) {
-        s2_sc_used(w) := true.B
-        s2_unconf(w)  := !s2_sumAboveThresholds(s2_chooseBit)
-        s2_conf(w)    := s2_sumAboveThresholds(s2_chooseBit)
+        s2_sc_used(w) := (if (DynCloseSC) { !s2_sc_closed }
+                          else { true.B })
+        s2_unconf(w) := !s2_sumAboveThresholds(s2_chooseBit)
+        s2_conf(w)   := s2_sumAboveThresholds(s2_chooseBit)
         // Use prediction from Statistical Corrector
         when(s2_sumAboveThresholds(s2_chooseBit)) {
           s2_agree(w)    := s2_tageTakens_dup(3)(w) === pred
@@ -363,9 +406,9 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
           // io.out.s2.full_pred.br_taken_mask(w) := pred
         }
       }
-      XSDebug(s2_provideds(w), p"---------tage_bank_${w} provided so that sc used---------\n")
+      XSDebug(s2_provideds(w) && !s2_sc_closed, p"---------tage_bank_${w} provided so that sc used---------\n")
       XSDebug(
-        s2_provideds(w) && s2_sumAboveThresholds(s2_chooseBit),
+        s2_provideds(w) && s2_sumAboveThresholds(s2_chooseBit) && !s2_sc_closed,
         p"pc(${Hexadecimal(debug_pc)}) SC(${w.U}) overriden pred to ${pred}\n"
       )
 
@@ -381,6 +424,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
       }
 
       val updateTageMeta    = updateMeta
+      val scClosed          = updateSCMeta.scClosed
       val scPred            = updateSCMeta.scPreds(w)
       val tagePred          = updateTageMeta.takens(w)
       val taken             = update.br_taken_mask(w)
@@ -397,7 +441,7 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         scUpdateTakens(w)    := taken
         (scUpdateOldCtrs(w) zip scOldCtrs).foreach { case (t, c) => t := c }
 
-        update_sc_used(w)    := true.B
+        update_sc_used(w)    := !scClosed
         update_unconf(w)     := !sumAboveThreshold
         update_conf(w)       := sumAboveThreshold
         update_agree(w)      := scPred === tagePred
@@ -405,12 +449,12 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         sc_corr_tage_misp(w) := scPred === taken && tagePred =/= taken && update_conf(w)
         sc_misp_tage_corr(w) := scPred =/= taken && tagePred === taken && update_conf(w)
 
-        when(scPred =/= tagePred && totalSumAbs >= thres - 4.U && totalSumAbs <= thres - 2.U) {
+        when(!scClosed && scPred =/= tagePred && totalSumAbs >= thres - 4.U && totalSumAbs <= thres - 2.U) {
           scThresholds(w) := newThres
         }
 
         when(scPred =/= taken || !sumAboveThreshold) {
-          scUpdateMask(w).foreach(_ := true.B)
+          scUpdateMask(w).foreach(_ := !scClosed)
           update_on_mispred(w) := scPred =/= taken
           update_on_unconf(w)  := scPred === taken
         }
@@ -418,33 +462,34 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
       XSDebug(
         updateValids(w) && updateTageMeta.providers(w).valid &&
           scPred =/= tagePred && totalSumAbs >= thres - 4.U && totalSumAbs <= thres - 2.U,
-        p"scThres $w update: old ${useThresholds(w)} --> new ${newThres.thres}\n"
+        p"scClosed: ${scClosed}, scThres $w update: old ${useThresholds(w)} --> new ${newThres.thres}\n"
       )
       XSDebug(
         updateValids(w) && updateTageMeta.providers(w).valid &&
           (scPred =/= taken || !sumAboveThreshold) &&
           tableSum < 0.S,
-        p"scUpdate: bank(${w}), scPred(${scPred}), tagePred(${tagePred}), " +
+        p"scClosed: ${scClosed}, scUpdate: bank(${w}), scPred(${scPred}), tagePred(${tagePred}), " +
           p"scSum(-${tableSum.abs}), mispred: sc(${scPred =/= taken}), tage(${updateMisPreds(w)})\n"
       )
       XSDebug(
         updateValids(w) && updateTageMeta.providers(w).valid &&
           (scPred =/= taken || !sumAboveThreshold) &&
           tableSum >= 0.S,
-        p"scUpdate: bank(${w}), scPred(${scPred}), tagePred(${tagePred}), " +
+        p"scClosed: ${scClosed}, scUpdate: bank(${w}), scPred(${scPred}), tagePred(${tagePred}), " +
           p"scSum(+${tableSum.abs}), mispred: sc(${scPred =/= taken}), tage(${updateMisPreds(w)})\n"
       )
       XSDebug(
         updateValids(w) && updateTageMeta.providers(w).valid &&
           (scPred =/= taken || !sumAboveThreshold),
-        p"bank(${w}), update: sc: ${updateSCMeta}\n"
+        p"scClosed: ${scClosed}, bank(${w}), update: sc: ${updateSCMeta}\n"
       )
     }
 
     val realWens = scUpdateMask.transpose.map(v => v.reduce(_ | _))
     for (b <- 0 until TageBanks) {
       for (i <- 0 until SCNTables) {
-        val realWen = realWens(i)
+        val realWen = if (DynCloseSC) { realWens(i) && !s0_sc_closed }
+                      else { realWens(i) }
         scTables(i).io.update.mask(b)      := RegNext(scUpdateMask(b)(i))
         scTables(i).io.update.tagePreds(b) := RegEnable(scUpdateTagePreds(b), realWen)
         scTables(i).io.update.takens(b)    := RegEnable(scUpdateTakens(b), realWen)
@@ -452,6 +497,37 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         scTables(i).io.update.pc           := RegEnable(update_pc, realWen)
         scTables(i).io.update.ghist        := RegEnable(update.ghist, realWen)
       }
+    }
+
+    if (DynCloseSC) {
+      val satUpdateMask = WireInit(0.U.asTypeOf(Vec(TageBanks, Bool())))
+      val deltaType     = WireInit(0.U.asTypeOf(Vec(TageBanks, UInt(3.W))))
+      for (w <- 0 until TageBanks) {
+        val updateTageMeta = updateMeta
+        val updateValid    = updateValids(w) && updateTageMeta.providers(w).valid
+
+        val scClosed_d1    = RegEnable(updateSCMeta.scClosed, updateValid)
+        val scPred_d1      = RegEnable(updateSCMeta.scPreds(w), updateValid)
+        val tagePred_d1    = RegEnable(updateTageMeta.takens(w), updateValid)
+        val taken_d1       = RegEnable(update.br_taken_mask(w), updateValid)
+        val update_conf_d1 = RegEnable(update_conf(w), updateValid)
+
+        satUpdateMask(w) := RegNext(updateValid)
+        deltaType(w) := Mux(
+          !scClosed_d1 && update_conf_d1,
+          Mux(
+            scPred_d1 === tagePred_d1,
+            Mux(tagePred_d1 === taken_d1, 0.U, 1.U),
+            Mux(tagePred_d1 === taken_d1, 2.U, 3.U)
+          ),
+          Mux(tagePred_d1 === taken_d1, 4.U, 5.U)
+        )
+      }
+      scCloseConfCounter := RegEnable(
+        signedSatUpdate(satUpdateMask, scCloseConfCounter, scCloseConfCounterWidth, deltaType),
+        0.S,
+        satUpdateMask.reduce(_ || _)
+      )
     }
 
     tage_perf("sc_conf", PopCount(s2_conf), PopCount(update_conf))
@@ -463,6 +539,8 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
     XSPerfAccumulate("sc_update_on_unconf", PopCount(update_on_unconf))
     XSPerfAccumulate("sc_mispred_but_tage_correct", PopCount(sc_misp_tage_corr))
     XSPerfAccumulate("sc_correct_and_tage_wrong", PopCount(sc_corr_tage_misp))
+
+    XSPerfAccumulate("sc_close_cycle", PopCount(s0_sc_closed))
 
   }
 


### PR DESCRIPTION
* SC is open by default and can be dynamically closed by setting `DynCloseSC` to true.
* SC closure is controlled by the value of `scCloseConfCounter`. 
When `scCloseConfCounter >= 0`, SC is closed. When it is less than 0, SC is enabled.
* To avoid affecting timing, the update of the scCloseConfCounter is placed on the next 
clock cycle after SC update
* The counter is adjusted based on the list for Agree and Disagree scenarios.

* Agree Scenarios  ( When SC opened ):
- When TAGE and SC pred both taken (√) and the actual condition is also taken (√), 
SC performs "Negative action No.3" and scCloseConf will be increased by 
+x1(`SCCloseConfIncWhenSCAgreeAndCorrect`).
- When TAGE and SC pred both taken (√) but the actual condition is not taken (×), 
SC performs  "Negative action No.2" and scCloseConf will be increased by 
+x2(`SCCloseConfIncWhenSCAgreeButWrong`).
- When neither TAGE nor SC pred taken (×) but the actual condition is taken (√), 
SC performs "Negative action No.2" and scCloseConf will be increased by 
+x2(`SCCloseConfIncWhenSCAgreeButWrong`).
- When neither TAGE nor SC pred taken (×) and the actual condition is not taken (×), 
SC  performs "Negative action No.3" and scCloseConf will be increased by 
+x1(`SCCloseConfIncWhenSCAgreeAndCorrect`).
* Disagree Scenarios ( When SC opened ):
- When TAGE pred taken (√) and SC is not taken (×), but the actual condition is taken (√), 
SC  performs  "Negative action No.1" and scCloseConf will be increased by
 +x3(`SCCloseConfIncWhenSCDisagreeButTAGECorrect`).
- When TAGE pred taken (√) and SC is not taken (×), and the actual condition is not taken (×), 
SC performs  "Positive action No.1" and scCloseConf will be decreased by 
-y(`SCCloseConfDecWhenSCDisagreeAndSCCorrect`).
- When TAGE pred not taken (×) but SC is taken (√), and the actual condition is taken (√),
SC performs "Positive action No.1" and scCloseConf will be decreased by 
-y(`SCCloseConfDecWhenSCDisagreeAndSCCorrect`).
- When TAGE pred not taken (×) but SC is taken (√), and the actual condition is not taken (×),
 SC performs "Negative action No.1" and scCloseConf will be increased by 
+x3(`SCCloseConfIncWhenSCDisagreeButTAGECorrect`).

* When SC Closed:
- If TAGE pred wrong, SC should be opened, so scCloseConf will be
 increased by `SCCloseConfIncWhenSCClosedAndTAGEWrong`
- If TAGE pred correct, SC can be closed, so scCloseConf will be
 decreased by `SCCloseConfDecWhenSCClosedAndTAGEWrong`

<img width="408" alt="{1F2C68E6-C46A-4C0B-B747-ED8F3C697702}" src="https://github.com/user-attachments/assets/2790b82a-342e-4464-a0e5-f70e6294121a" />

<img width="353" alt="1737004278808" src="https://github.com/user-attachments/assets/615269ec-bf53-4b92-8ca3-5b5fc634c5f2" />


