### PR TITLE
fix(topdown): when instr fused, take it as NoStall

### DIFF
--- a/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
@@ -871,6 +871,12 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
   Mux(vioReplay, TopDownCounters.LoadVioReplayStall.id.U,
   TopDownCounters.LoadL1Stall.id.U))))))))
 
+  val fusedVec = (0 until RenameWidth).map{ case i =>
+    if (i == 0) false.B
+    else (io.fromRename(i-1).fire && !io.fromRename(i).valid &&
+         CommitType.isFused(io.fromRename(i-1).bits.commitType))
+  }
+
   val decodeReason = RegNextN(io.stallReason.reason, 2)
   val renameReason = RegNext(io.stallReason.reason)
 
@@ -878,7 +884,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
   val firedVec = fromRename.map(_.fire)
   io.stallReason.backReason.valid := !canAccept
   io.stallReason.backReason.bits := TopDownCounters.OtherCoreStall.id.U
-  stallReason.zip(io.stallReason.reason).zip(firedVec).zipWithIndex.map { case (((update, in), fire), idx) =>
+  stallReason.zip(io.stallReason.reason).zip(firedVec).zipWithIndex.zip(fusedVec).map { case ((((update, in), fire), idx), fused) =>
     val headIsInt = FuType.isInt(io.robHead.getDebugFuType)  && io.robHeadNotReady
     val headIsFp  = FuType.isFArith(io.robHead.getDebugFuType)   && io.robHeadNotReady
     val headIsDiv = FuType.isDivSqrt(io.robHead.getDebugFuType) && io.robHeadNotReady
@@ -891,7 +897,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     import TopDownCounters._
     update := MuxCase(OtherCoreStall.id.U, Seq(
       // fire
-      (fire                                              ) -> NoStall.id.U          ,
+      (fire || fused                                     ) -> NoStall.id.U          ,
       // dispatch not stall / core stall from decode or rename
       (in =/= OtherCoreStall.id.U && in =/= NoStall.id.U ) -> in                    ,
       // rob stall


### PR DESCRIPTION
When instruction is fused, the fromRename.valid is false. It is taken as an invalid uop which not fire in Dispatch's TopDown logic.
However, the fused instruction is attached to the previous instruction. So the fused instrduction's topdown should be same with the previous one.

Statistic example:
XS' master branch runs SPEC CPU2017's cactuBSSN_128179 checkpoint, 20M for warmup and 20M for sampiling. 
The sampling phase's TopDown's "NoStall":
1. before-fix: 17892923, less than commitInstr
2. after-fix: 20020602, more than commitInstr
