### PR TITLE
fix(PTW): fix gpf_level generate logic when Sv39

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -337,7 +337,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
       } .otherwise {
         level := Mux(req.l2Hit, 1.U, 2.U)
         af_level := Mux(req.l2Hit, 1.U, 2.U)
-        gpf_level := 0.U
+        gpf_level := Mux(req.l2Hit, 2.U, 0.U)
         ppn := Mux(req.l2Hit, io.req.bits.ppn, satp.ppn)
         l3Hit := false.B
         gvpn_wire := Mux(req.l2Hit, io.req.bits.ppn, satp.ppn)
@@ -345,7 +345,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     } else {
       level := Mux(req.l2Hit, 1.U, 2.U)
       af_level := Mux(req.l2Hit, 1.U, 2.U)
-      gpf_level := 0.U
+      gpf_level := Mux(req.l2Hit, 2.U, 0.U)
       ppn := Mux(req.l2Hit, io.req.bits.ppn, satp.ppn)
       l3Hit := false.B
       gvpn_wire := Mux(req.l2Hit, io.req.bits.ppn, satp.ppn)
@@ -475,7 +475,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   when(mem.resp.fire && w_mem_resp === false.B){
     w_mem_resp := true.B
     af_level := af_level - 1.U
-    gpf_level := Mux(mode === Sv39 && !pte_valid && !(l3Hit || l2Hit), gpf_level - 2.U, gpf_level - 1.U)
+    gpf_level := Mux(mode === Sv39 && !pte_valid && !l2Hit, gpf_level - 2.U, gpf_level - 1.U)
     pte_valid := true.B
     update_full_gvpn_mem_resp := true.B
     if (HasBitmapCheck) {


### PR DESCRIPTION
For historical reasons, `gpf_level` needs to be 1 greater than `af_level`. In the original design, only the Sv48 case was considered, and a similar treatment is needed for the Sv39 case.

As an extra note here, `gpf_level` is a 2-bit register, so when `gpf_level` = 0.U, `gpf_level` - 2.U = `00` - 2 = `10` = 2.U. The PTW module's `gpf_level` computation uses this feature, which is extremely unscalable, and, except for the original author, is completely incomprehensible, and is in dire need of refactoring.