### PR TITLE
fix(AtomicsUnit): flush sbuffer until sbuffer is empty

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -464,7 +464,11 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
   io.out.bits.uop.debugInfo.tlbFirstReqTime := GTimer() // FIXME lyq: it will be always assigned
 
   // send req to sbuffer to flush it if it is not empty
-  io.flush_sbuffer.valid := !sbuffer_empty && state === s_tlb_and_flush_sbuffer_req
+  io.flush_sbuffer.valid := !sbuffer_empty && (
+    state === s_tlb_and_flush_sbuffer_req ||
+    state === s_pm ||
+    state === s_wait_flush_sbuffer_resp
+  )
 
   // When is sta issue port ready:
   // (1) AtomicsUnit is idle, or


### PR DESCRIPTION
In the previous design, AtomicsUnit sends out sbuffer flush request only under `s_tlb_and_flush_sbuffer_req` state. The request sets sbuffer under `x_drain_all` state. Sbuffer returns to `x_idle` state when it is empty. However StoreQueue may not be fully cleared at this point because there could be committed stores that haven't yet entered sbuffer. After these stores eventually enter sbuffer, sbuffer remains in `x_idle` state and will not flush them into DCache. This results in sbuffer being unable to drain completely, therefore the atomic instruction gets into deadlock.

This commit fixes this bug by continuously request sbuffer flush until sbuffer is fully drained.