### PR TITLE
feat(Top): make address spaces of seperate TL port configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,6 @@ ifneq ($(L3_CACHE_SIZE),)
 COMMON_EXTRA_ARGS += --l3-cache-size $(L3_CACHE_SIZE)
 endif
 
-# seperate bus for DebugModule
-ifeq ($(SEPERATE_DM_BUS),1)
-COMMON_EXTRA_ARGS += --seperate-dm-bus
-endif
-
 # configuration from yaml file
 ifneq ($(YAML_CONFIG),)
 COMMON_EXTRA_ARGS += --yaml-config $(YAML_CONFIG)

--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -22,3 +22,10 @@ L2CacheConfig: { size: 1 MB, ways: 8, inclusive: true, banks: 4, tp: true }
 L3CacheConfig: { size: 16 MB, ways: 16, inclusive: false, banks: 4 }
 
 DebugModuleBaseAddr: 0x38020000
+
+SeperateDM: false
+
+SeperateTLBus: false
+
+SeperateTLBusRanges:
+  - { base: 0x38020000, mask: 0xFFF } # Default Debug Module Address

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -197,9 +197,13 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case XSTileKey => up(XSTileKey).map(_.copy(hasSramCtl = true))
           }), tail)
-        case "--seperate-dm-bus" :: tail =>
+        case "--seperate-tl-bus" :: tail =>
           nextOption(config.alter((site, here, up) => {
-            case SoCParamsKey => up(SoCParamsKey).copy(SeperateDMBus = true)
+            case SoCParamsKey => up(SoCParamsKey).copy(SeperateTLBus = true)
+          }), tail)
+        case "--seperate-dm" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case SoCParamsKey => up(SoCParamsKey).copy(SeperateDM = true)
           }), tail)
         case "--yaml-config" :: yamlFile :: tail =>
           nextOption(YamlParser.parseYaml(config, yamlFile), tail)

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -24,6 +24,7 @@ import system.SoCParamsKey
 import xiangshan.backend.fu.{MemoryRange, PMAConfigEntry}
 import freechips.rocketchip.devices.debug.DebugModuleKey
 import freechips.rocketchip.util.AsyncQueueParams
+import freechips.rocketchip.diplomacy.AddressSet
 
 case class YamlConfig(
   PmemRanges: Option[List[MemoryRange]],
@@ -31,7 +32,10 @@ case class YamlConfig(
   EnableCHIAsyncBridge: Option[Boolean],
   L2CacheConfig: Option[L2CacheConfig],
   L3CacheConfig: Option[L3CacheConfig],
-  DebugModuleBaseAddr: Option[BigInt]
+  DebugModuleBaseAddr: Option[BigInt],
+  SeperateDM: Option[Boolean],
+  SeperateTLBus: Option[Boolean],
+  SeperateTLBusRanges: Option[List[AddressSet]]
 )
 
 object YamlParser {
@@ -69,6 +73,21 @@ object YamlParser {
     yamlConfig.DebugModuleBaseAddr.foreach { addr =>
       newConfig = newConfig.alter((site, here, up) => {
         case DebugModuleKey => up(DebugModuleKey).map(_.copy(baseAddress = addr))
+      })
+    }
+    yamlConfig.SeperateDM.foreach { enable =>
+      newConfig = newConfig.alter((site, here, up) => {
+        case SoCParamsKey => up(SoCParamsKey).copy(SeperateDM = enable)
+      })
+    }
+    yamlConfig.SeperateTLBus.foreach { enable =>
+      newConfig = newConfig.alter((site, here, up) => {
+        case SoCParamsKey => up(SoCParamsKey).copy(SeperateTLBus = enable)
+      })
+    }
+    yamlConfig.SeperateTLBusRanges.foreach { ranges =>
+      newConfig = newConfig.alter((site, here, up) => {
+        case SoCParamsKey => up(SoCParamsKey).copy(SeperateTLBusRanges = ranges)
       })
     }
     newConfig

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -86,7 +86,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
   val i_mmio_port = TLTempNode()
   val d_mmio_port = TLTempNode()
   val icachectrl_port_opt = Option.when(icacheParameters.cacheCtrlAddressOpt.nonEmpty)(TLTempNode())
-  val sep_dm_port_opt = Option.when(SeperateDMBus)(TLTempNode())
+  val sep_tl_port_opt = Option.when(SeperateTLBus)(TLTempNode())
 
   val misc_l2_pmu = BusPerfMonitor(name = "Misc_L2", enable = !debugOpts.FPGAPlatform) // l1D & l1I & PTW
   val l2_l3_pmu = BusPerfMonitor(name = "L2_L3", enable = !debugOpts.FPGAPlatform && !enableCHI, stat_latency = true)
@@ -147,14 +147,14 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
   if (icacheParameters.cacheCtrlAddressOpt.nonEmpty) {
     icachectrl_port_opt.get := TLBuffer.chainNode(1) := mmio_xbar
   }
-  if (SeperateDMBus) {
-    sep_dm_port_opt.get := TLBuffer.chainNode(1) := mmio_xbar
+  if (SeperateTLBus) {
+    sep_tl_port_opt.get := TLBuffer.chainNode(1) := mmio_xbar
   }
 
   // filter out in-core addresses before sent to mmio_port
   // Option[AddressSet] ++ Option[AddressSet] => List[AddressSet]
   private def cacheAddressSet: Seq[AddressSet] = (icacheParameters.cacheCtrlAddressOpt ++ dcacheParameters.cacheCtrlAddressOpt).toSeq
-  private def mmioFilters = if(SeperateDMBus) (p(DebugModuleKey).get.address +: cacheAddressSet) else cacheAddressSet
+  private def mmioFilters = if(SeperateTLBus) (SeperateTLBusRanges ++ cacheAddressSet) else cacheAddressSet
   mmio_port :=
     TLFilter(TLFilter.mSubtract(mmioFilters)) :=
     TLBuffer() :=

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -47,7 +47,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
   val core_l3_pf_port = memBlock.l3_pf_sender_opt
   val memory_port = if (enableCHI && enableL2) None else Some(l2top.inner.memory_port.get)
   val tl_uncache = l2top.inner.mmio_port
-  val sep_dm_opt = l2top.inner.sep_dm_port_opt
+  val sep_tl_opt = l2top.inner.sep_tl_port_opt
   val beu_int_source = l2top.inner.beu.intNode
   val core_reset_sink = BundleBridgeSink(Some(() => Reset()))
   val clint_int_node = l2top.inner.clint_int_node

--- a/src/main/scala/xiangshan/XSTileWrap.scala
+++ b/src/main/scala/xiangshan/XSTileWrap.scala
@@ -53,16 +53,15 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
   tile.nmi_int_node := IntBuffer(3, cdc = true) := nmiIntNode
   beuIntNode := IntBuffer() := tile.beu_int_source
 
-  // seperate DebugModule bus
-  val EnableDMAsync = EnableDMAsyncBridge.isDefined
-  println(s"SeperateDMBus = $SeperateDMBus")
-  println(s"EnableDMAsync = $EnableDMAsync")
+  // seperate TL bus
+  println(s"SeperateTLBus = $SeperateTLBus")
+  println(s"EnableSeperateTLAsync = $EnableSeperateTLAsync")
   // asynchronous bridge source node
-  val dmAsyncSourceOpt = Option.when(SeperateDMBus && EnableDMAsync)(LazyModule(new TLAsyncCrossingSource()))
-  dmAsyncSourceOpt.foreach(_.node := tile.sep_dm_opt.get)
+  val tlAsyncSourceOpt = Option.when(SeperateTLBus && EnableSeperateTLAsync)(LazyModule(new TLAsyncCrossingSource()))
+  tlAsyncSourceOpt.foreach(_.node := tile.sep_tl_opt.get)
   // synchronous source node
-  val dmSyncSourceOpt = Option.when(SeperateDMBus && !EnableDMAsync)(TLTempNode())
-  dmSyncSourceOpt.foreach(_ := tile.sep_dm_opt.get)
+  val tlSyncSourceOpt = Option.when(SeperateTLBus && !EnableSeperateTLAsync)(TLTempNode())
+  tlSyncSourceOpt.foreach(_ := tile.sep_tl_opt.get)
 
   class XSTileWrapImp(wrapper: LazyModule) extends LazyRawModuleImp(wrapper) {
     val clock = IO(Input(Clock()))
@@ -156,9 +155,9 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
     }
 
     // Seperate DebugModule TL Async Queue Source
-    if (SeperateDMBus && EnableDMAsync) {
-      dmAsyncSourceOpt.get.module.clock := clock
-      dmAsyncSourceOpt.get.module.reset := soc_reset_sync
+    if (SeperateTLBus && EnableSeperateTLAsync) {
+      tlAsyncSourceOpt.get.module.clock := clock
+      tlAsyncSourceOpt.get.module.reset := soc_reset_sync
     }
 
     withClockAndReset(clock, reset_sync) {


### PR DESCRIPTION
- `SeperateTLBus` and `SeperateTLBusRanges`: Generate a separate TileLink bus with corresponding address ranges
  - with `XSNoCTopConfig`: Multiple ranges can be specified, and `SeperateDM` is ignored
  - without `XSNoCTopConfig`: exactly one address range can be specified, and can only be used to connected with DM by `SeperateDM`