### PR TITLE
submodule(CoupledL2): parameterize NS assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,12 @@ ifeq ($(SRAM_WITH_CTL),1)
 COMMON_EXTRA_ARGS += --sram-with-ctl
 endif
 
+# enable non-secure access or not
+# CHI requests are secure as default by now
+ifeq ($(ENABLE_NS),1)
+COMMON_EXTRA_ARGS += --enable-ns
+endif
+
 # L2 cache size in KB
 ifneq ($(L2_CACHE_SIZE),)
 COMMON_EXTRA_ARGS += --l2-cache-size $(L2_CACHE_SIZE)

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -148,6 +148,10 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case SoCParamsKey => up(SoCParamsKey).copy(IMSICUseTL = true)
           }), tail)
+        case "--enable-ns" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case coupledL2.tl2chi.NonSecureKey => true
+          }), tail)
         case "--firtool-opt" :: option :: tail =>
           firtoolOpts ++= option.split(" ").filter(_.nonEmpty)
           nextOption(config, tail)


### PR DESCRIPTION
This pull request parameterizes the NS (Non-Secure) field in the CHI bus, making it configurable. By default, the NS field is set to 0 (Secure), allowing XiangShan core to function as a secure boot processor in NoC. For systems that already utilize an MCU for secure boot, access of XiangShan core should theoretically be non-secure. In the latter cases, `ENABLE_NS=1` option should be added to the `make` compilation command.