### PR TITLE
refactor(InstrUncache): follow new style guide

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 src/main/scala/xiangshan/frontend/ @Gao-Zeyu
 src/main/scala/xiangshan/frontend/icache @ngc7331
-src/main/scala/xiangshan/frontend/InstrUncache.scala @ngc7331
+src/main/scala/xiangshan/frontend/instruncache @ngc7331
 src/main/scala/xiangshan/frontend/ifu @ngc7331 @my-mayfly
 src/main/scala/xiangshan/frontend/BPU.scala @eastonman
 src/main/scala/xiangshan/frontend/Composer.scala @eastonman

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -415,9 +415,10 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
   io.backend.cfVec <> ibuffer.io.out
   io.backend.stallReason <> ibuffer.io.stallReason
 
-  instrUncache.io.req <> ifu.io.toUncache
-  ifu.io.fromUncache <> instrUncache.io.resp
+  instrUncache.io.fromIfu <> ifu.io.toUncache
+  ifu.io.fromUncache <> instrUncache.io.toIfu
   instrUncache.io.flush := false.B
+
   io.error <> RegNext(RegNext(icache.io.error))
 
   icache.io.hartId := io.hartId

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -48,6 +48,7 @@ import xiangshan.backend.fu.PMPReqBundle
 import xiangshan.cache.mmu._
 import xiangshan.frontend.icache._
 import xiangshan.frontend.ifu._
+import xiangshan.frontend.instruncache.InstrUncache
 
 class Frontend()(implicit p: Parameters) extends LazyModule with HasXSParameter {
   override def shouldBeInlined: Boolean = false

--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -26,6 +26,8 @@ import xiangshan.backend.GPAMemEntry
 import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.cache.mmu.TlbResp
 import xiangshan.frontend.icache._
+import xiangshan.frontend.instruncache.InstrUncacheReq
+import xiangshan.frontend.instruncache.InstrUncacheResp
 
 class FrontendTopDownBundle(implicit p: Parameters) extends XSBundle {
   val reasons    = Vec(TopDownCounters.NumStallReasons.id, Bool())
@@ -107,6 +109,14 @@ class ICacheToIfuIO(implicit p: Parameters) extends XSBundle {
 
 class IfuToICacheIO(implicit p: Parameters) extends XSBundle {
   val stall: Bool = Output(Bool())
+}
+
+class IfuToInstrUncacheIO(implicit p: Parameters) extends XSBundle {
+  val req: DecoupledIO[InstrUncacheReq] = DecoupledIO(new InstrUncacheReq)
+}
+
+class InstrUncacheToIfuIO(implicit p: Parameters) extends XSBundle {
+  val resp: DecoupledIO[InstrUncacheResp] = DecoupledIO(new InstrUncacheResp)
 }
 
 class FtqToIfuIO(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/frontend/icache/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Parameters.scala
@@ -45,7 +45,6 @@ case class ICacheParameters(
     ICacheDataSRAMWidth: Int = 66,
     // TODO: hard code, need delete
     partWayNum:          Int = 4,
-    nMMIOs:              Int = 1,
     blockBytes:          Int = 64,
     cacheCtrlAddressOpt: Option[AddressSet] = None
 ) extends L1CacheParameters {

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -50,13 +50,13 @@ import xiangshan.frontend.ICacheToIfuIO
 import xiangshan.frontend.IfuToBackendIO
 import xiangshan.frontend.IfuToFtqIO
 import xiangshan.frontend.IfuToICacheIO
-import xiangshan.frontend.InsUncacheReq
-import xiangshan.frontend.InsUncacheResp
 import xiangshan.frontend.PredecodeWritebackBundle
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
 import xiangshan.frontend.icache.HasICacheParameters
 import xiangshan.frontend.icache.PmpCheckBundle
+import xiangshan.frontend.instruncache.InsUncacheReq
+import xiangshan.frontend.instruncache.InsUncacheResp
 import xiangshan.frontend.mmioCommitRead
 
 class Ifu(implicit p: Parameters) extends IfuModule

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -50,13 +50,13 @@ import xiangshan.frontend.ICacheToIfuIO
 import xiangshan.frontend.IfuToBackendIO
 import xiangshan.frontend.IfuToFtqIO
 import xiangshan.frontend.IfuToICacheIO
+import xiangshan.frontend.IfuToInstrUncacheIO
+import xiangshan.frontend.InstrUncacheToIfuIO
 import xiangshan.frontend.PredecodeWritebackBundle
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
 import xiangshan.frontend.icache.HasICacheParameters
 import xiangshan.frontend.icache.PmpCheckBundle
-import xiangshan.frontend.instruncache.InsUncacheReq
-import xiangshan.frontend.instruncache.InsUncacheResp
 import xiangshan.frontend.mmioCommitRead
 
 class Ifu(implicit p: Parameters) extends IfuModule
@@ -80,8 +80,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
     val toICache:   IfuToICacheIO = new IfuToICacheIO
 
     // Uncache: mmio request / response
-    val fromUncache: DecoupledIO[InsUncacheResp] = Flipped(DecoupledIO(new InsUncacheResp))
-    val toUncache:   DecoupledIO[InsUncacheReq]  = DecoupledIO(new InsUncacheReq)
+    val toUncache:   IfuToInstrUncacheIO = new IfuToInstrUncacheIO
+    val fromUncache: InstrUncacheToIfuIO = Flipped(new InstrUncacheToIfuIO)
 
     // IBuffer: enqueue
     val toIBuffer: DecoupledIO[FetchToIBuffer] = DecoupledIO(new FetchToIBuffer)
@@ -116,7 +116,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // alias
   private val (toFtq, fromFtq)              = (io.toFtq, io.fromFtq)
   private val fromICache                    = io.fromICache.fetchResp
-  private val (toUncache, fromUncache)      = (io.toUncache, io.fromUncache)
+  private val (toUncache, fromUncache)      = (io.toUncache.req, io.fromUncache.resp)
   private val (preDecoderIn, preDecoderOut) = (preDecoder.io.req, preDecoder.io.resp)
   private val (checkerIn, checkerOutStage1, checkerOutStage2) =
     (predChecker.io.req, predChecker.io.resp.stage1Out, predChecker.io.resp.stage2Out)

--- a/src/main/scala/xiangshan/frontend/instruncache/Abstracts.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/Abstracts.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2020-2021 Peng Cheng Laboratory
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package xiangshan.frontend.instruncache
+
+import org.chipsalliance.cde.config.Parameters
+import xiangshan.XSBundle
+import xiangshan.XSModule
+
+abstract class InstrUncacheBundle(implicit p: Parameters) extends XSBundle with HasInstrUncacheParameters
+
+abstract class InstrUncacheModule(implicit p: Parameters) extends XSModule with HasInstrUncacheParameters

--- a/src/main/scala/xiangshan/frontend/instruncache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/Bundles.scala
@@ -17,14 +17,13 @@ package xiangshan.frontend.instruncache
 
 import chisel3._
 import org.chipsalliance.cde.config.Parameters
-import xiangshan.XSBundle
 import xiangshan.frontend.PrunedAddr
 
-class InstrUncacheReq(implicit p: Parameters) extends XSBundle {
+class InstrUncacheReq(implicit p: Parameters) extends InstrUncacheBundle {
   val addr: PrunedAddr = PrunedAddr(PAddrBits)
 }
 
-class InstrUncacheResp(implicit p: Parameters) extends XSBundle {
+class InstrUncacheResp(implicit p: Parameters) extends InstrUncacheBundle {
   val data:    UInt = UInt(32.W) // TODO: add a const for InstrLen, maybe in XSParameters, and use it all over the repo
   val corrupt: Bool = Bool()
 }

--- a/src/main/scala/xiangshan/frontend/instruncache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/Bundles.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2020-2021 Peng Cheng Laboratory
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package xiangshan.frontend.instruncache
+
+import chisel3._
+import org.chipsalliance.cde.config.Parameters
+import xiangshan.XSBundle
+import xiangshan.frontend.PrunedAddr
+
+class InstrUncacheReq(implicit p: Parameters) extends XSBundle {
+  val addr: PrunedAddr = PrunedAddr(PAddrBits)
+}
+
+class InstrUncacheResp(implicit p: Parameters) extends XSBundle {
+  val data:    UInt = UInt(32.W) // TODO: add a const for InstrLen, maybe in XSParameters, and use it all over the repo
+  val corrupt: Bool = Bool()
+}

--- a/src/main/scala/xiangshan/frontend/instruncache/InstrUncache.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/InstrUncache.scala
@@ -28,7 +28,7 @@ class InstrUncache(implicit p: Parameters) extends LazyModule with HasInstrUncac
   val clientParameters: TLMasterPortParameters = TLMasterPortParameters.v1(
     clients = Seq(TLMasterParameters.v1(
       "InstrUncache",
-      sourceId = IdRange(0, cacheParams.nMMIOs)
+      sourceId = IdRange(0, nMmioEntry)
     ))
   )
   val clientNode: TLClientNode = TLClientNode(Seq(clientParameters))

--- a/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheEntry.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheEntry.scala
@@ -29,8 +29,8 @@ class InstrUncacheEntry(edge: TLEdgeOut)(implicit p: Parameters) extends InstrUn
   class InstrUncacheEntryIO(edge: TLEdgeOut)(implicit p: Parameters) extends InstrUncacheBundle {
     val id: UInt = Input(UInt(log2Up(cacheParams.nMMIOs).W))
     // client requests
-    val req:  DecoupledIO[InsUncacheReq]  = Flipped(DecoupledIO(new InsUncacheReq))
-    val resp: DecoupledIO[InsUncacheResp] = DecoupledIO(new InsUncacheResp)
+    val req:  DecoupledIO[InstrUncacheReq]  = Flipped(DecoupledIO(new InstrUncacheReq))
+    val resp: DecoupledIO[InstrUncacheResp] = DecoupledIO(new InstrUncacheResp)
 
     val mmioAcquire: DecoupledIO[TLBundleA] = DecoupledIO(new TLBundleA(edge.bundle))
     val mmioGrant:   DecoupledIO[TLBundleD] = Flipped(DecoupledIO(new TLBundleD(edge.bundle)))
@@ -50,7 +50,7 @@ class InstrUncacheEntry(edge: TLEdgeOut)(implicit p: Parameters) extends InstrUn
 
   private val state = RegInit(State.Invalid)
 
-  private val req            = Reg(new InsUncacheReq)
+  private val req            = Reg(new InstrUncacheReq)
   private val respDataReg    = RegInit(0.U(MmioBusWidth.W))
   private val respCorruptReg = RegInit(false.B)
 

--- a/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheEntry.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheEntry.scala
@@ -1,0 +1,136 @@
+// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2020-2021 Peng Cheng Laboratory
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package xiangshan.frontend.instruncache
+
+import chisel3._
+import chisel3.util._
+import freechips.rocketchip.tilelink.TLBundleA
+import freechips.rocketchip.tilelink.TLBundleD
+import freechips.rocketchip.tilelink.TLEdgeOut
+import org.chipsalliance.cde.config.Parameters
+import utils.NamedUInt
+import xiangshan.frontend.PrunedAddr
+
+// One miss entry deals with one mmio request
+class InstrUncacheEntry(edge: TLEdgeOut)(implicit p: Parameters) extends InstrUncacheModule {
+  class InstrUncacheEntryIO(edge: TLEdgeOut)(implicit p: Parameters) extends InstrUncacheBundle {
+    val id: UInt = Input(UInt(log2Up(cacheParams.nMMIOs).W))
+    // client requests
+    val req:  DecoupledIO[InsUncacheReq]  = Flipped(DecoupledIO(new InsUncacheReq))
+    val resp: DecoupledIO[InsUncacheResp] = DecoupledIO(new InsUncacheResp)
+
+    val mmioAcquire: DecoupledIO[TLBundleA] = DecoupledIO(new TLBundleA(edge.bundle))
+    val mmioGrant:   DecoupledIO[TLBundleD] = Flipped(DecoupledIO(new TLBundleD(edge.bundle)))
+
+    val flush: Bool = Input(Bool())
+  }
+
+  val io: InstrUncacheEntryIO = IO(new InstrUncacheEntryIO(edge))
+
+  private def nState: Int = 4
+  private object State extends NamedUInt(log2Up(nState)) {
+    def Invalid:    UInt = 0.U(width.W)
+    def RefillReq:  UInt = 1.U(width.W)
+    def RefillResp: UInt = 2.U(width.W)
+    def SendResp:   UInt = 3.U(width.W)
+  }
+
+  private val state = RegInit(State.Invalid)
+
+  private val req            = Reg(new InsUncacheReq)
+  private val respDataReg    = RegInit(0.U(MmioBusWidth.W))
+  private val respCorruptReg = RegInit(false.B)
+
+  // assign default values to output signals
+  io.req.ready  := false.B
+  io.resp.valid := false.B
+  io.resp.bits  := DontCare
+
+  io.mmioAcquire.valid := false.B
+  io.mmioAcquire.bits  := DontCare
+
+  io.mmioGrant.ready := false.B
+
+  private val needFlush = RegInit(false.B)
+
+  when(io.flush && (state =/= State.Invalid) && (state =/= State.SendResp)) {
+    needFlush := true.B
+  }.elsewhen((state === State.SendResp) && needFlush) {
+    needFlush := false.B
+  }
+
+  // --------------------------------------------
+  // State.Invalid: receive requests
+  when(state === State.Invalid) {
+    io.req.ready := true.B
+
+    when(io.req.fire) {
+      req   := io.req.bits
+      state := State.RefillReq
+    }
+  }
+
+  when(state === State.RefillReq) {
+    val alignedAddr = req.addr(req.addr.getWidth - 1, log2Ceil(MmioBusBytes))
+    io.mmioAcquire.valid := true.B
+    io.mmioAcquire.bits := edge.Get(
+      fromSource = io.id,
+      toAddress = Cat(alignedAddr, 0.U(log2Ceil(MmioBusBytes).W)),
+      lgSize = log2Ceil(MmioBusBytes).U
+    )._2
+
+    when(io.mmioAcquire.fire) {
+      state := State.RefillResp
+    }
+  }
+
+  val (_, _, refillDone, _) = edge.addr_inc(io.mmioGrant)
+
+  when(state === State.RefillResp) {
+    io.mmioGrant.ready := true.B
+
+    when(io.mmioGrant.fire) {
+      assert(refillDone)
+      respDataReg    := io.mmioGrant.bits.data
+      respCorruptReg := io.mmioGrant.bits.corrupt // this includes bits.denied, as tilelink spec defines
+      state          := State.SendResp
+    }
+  }
+
+  private def getDataFromBus(pc: PrunedAddr): UInt = {
+    val respData = Wire(UInt(32.W))
+    respData := Mux(
+      pc(2, 1) === "b00".U,
+      respDataReg(31, 0),
+      Mux(
+        pc(2, 1) === "b01".U,
+        respDataReg(47, 16),
+        Mux(pc(2, 1) === "b10".U, respDataReg(63, 32), Cat(0.U, respDataReg(63, 48)))
+      )
+    )
+    respData
+  }
+
+  when(state === State.SendResp) {
+    io.resp.valid        := !needFlush
+    io.resp.bits.data    := getDataFromBus(req.addr)
+    io.resp.bits.corrupt := respCorruptReg
+    // metadata should go with the response
+    when(io.resp.fire || needFlush) {
+      state := State.Invalid
+    }
+  }
+}

--- a/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheEntry.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheEntry.scala
@@ -26,7 +26,7 @@ import utils.NamedUInt
 // One miss entry deals with one mmio request
 class InstrUncacheEntry(edge: TLEdgeOut)(implicit p: Parameters) extends InstrUncacheModule {
   class InstrUncacheEntryIO(edge: TLEdgeOut)(implicit p: Parameters) extends InstrUncacheBundle {
-    val id: UInt = Input(UInt(log2Up(cacheParams.nMMIOs).W))
+    val id: UInt = Input(UInt(log2Up(nMmioEntry).W))
     // client requests
     val req:  DecoupledIO[InstrUncacheReq]  = Flipped(DecoupledIO(new InstrUncacheReq))
     val resp: DecoupledIO[InstrUncacheResp] = DecoupledIO(new InstrUncacheResp)

--- a/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheImp.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheImp.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2020-2021 Peng Cheng Laboratory
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package xiangshan.frontend.instruncache
+
+import chisel3._
+import chisel3.util._
+import freechips.rocketchip.diplomacy.LazyModuleImp
+import freechips.rocketchip.tilelink.TLArbiter
+import org.chipsalliance.cde.config.Parameters
+import utils.HasTLDump
+import xiangshan.frontend.IfuToInstrUncacheIO
+import xiangshan.frontend.InstrUncacheToIfuIO
+
+class InstrUncacheImp(wrapper: InstrUncache) extends LazyModuleImp(wrapper)
+    with HasInstrUncacheParameters
+    with HasTLDump {
+
+  class InstrUncacheIO(implicit p: Parameters) extends InstrUncacheBundle {
+    val fromIfu: IfuToInstrUncacheIO = Flipped(new IfuToInstrUncacheIO)
+    val toIfu:   InstrUncacheToIfuIO = new InstrUncacheToIfuIO
+    val flush:   Bool                = Input(Bool())
+  }
+
+  val io: InstrUncacheIO = IO(new InstrUncacheIO)
+
+  private val (bus, edge) = wrapper.clientNode.out.head
+
+  private val respArbiter = Module(new Arbiter(new InstrUncacheResp, cacheParams.nMMIOs))
+
+  private val req         = io.fromIfu.req
+  private val resp        = io.toIfu.resp
+  private val mmioAcquire = bus.a
+  private val mmioGrant   = bus.d
+
+  private val entryAllocIdx = Wire(UInt())
+  private val reqReady      = WireInit(false.B)
+
+  // assign default values to output signals
+  bus.b.ready := false.B
+  bus.c.valid := false.B
+  bus.c.bits  := DontCare
+  bus.d.ready := false.B
+  bus.e.valid := false.B
+  bus.e.bits  := DontCare
+
+  private val entries = (0 until cacheParams.nMMIOs).map { i =>
+    val entry = Module(new InstrUncacheEntry(edge))
+
+    entry.io.id    := i.U(log2Up(cacheParams.nMMIOs).W)
+    entry.io.flush := io.flush
+
+    // entry req
+    entry.io.req.valid := (i.U === entryAllocIdx) && req.valid
+    entry.io.req.bits  := req.bits
+    when(i.U === entryAllocIdx) {
+      reqReady := entry.io.req.ready
+    }
+
+    // entry resp
+    respArbiter.io.in(i) <> entry.io.resp
+
+    entry.io.mmioGrant.valid := false.B
+    entry.io.mmioGrant.bits  := DontCare
+    when(mmioGrant.bits.source === i.U) {
+      entry.io.mmioGrant <> mmioGrant
+    }
+    entry
+  }
+
+  // override mmioGrant.ready to prevent x-propagation
+  mmioGrant.ready := true.B
+
+  entryAllocIdx := PriorityEncoder(entries.map(m => m.io.req.ready))
+
+  req.ready := reqReady
+  resp <> respArbiter.io.out
+  TLArbiter.lowestFromSeq(edge, mmioAcquire, entries.map(_.io.mmioAcquire))
+}

--- a/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheImp.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheImp.scala
@@ -38,7 +38,7 @@ class InstrUncacheImp(wrapper: InstrUncache) extends LazyModuleImp(wrapper)
 
   private val (bus, edge) = wrapper.clientNode.out.head
 
-  private val respArbiter = Module(new Arbiter(new InstrUncacheResp, cacheParams.nMMIOs))
+  private val respArbiter = Module(new Arbiter(new InstrUncacheResp, nMmioEntry))
 
   private val req         = io.fromIfu.req
   private val resp        = io.toIfu.resp
@@ -56,10 +56,10 @@ class InstrUncacheImp(wrapper: InstrUncache) extends LazyModuleImp(wrapper)
   bus.e.valid := false.B
   bus.e.bits  := DontCare
 
-  private val entries = (0 until cacheParams.nMMIOs).map { i =>
+  private val entries = (0 until nMmioEntry).map { i =>
     val entry = Module(new InstrUncacheEntry(edge))
 
-    entry.io.id    := i.U(log2Up(cacheParams.nMMIOs).W)
+    entry.io.id    := i.U(log2Up(nMmioEntry).W)
     entry.io.flush := io.flush
 
     // entry req

--- a/src/main/scala/xiangshan/frontend/instruncache/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/Parameters.scala
@@ -15,11 +15,14 @@
 
 package xiangshan.frontend.instruncache
 
-import xiangshan.frontend.icache.HasICacheParameters
+import xiangshan.HasXSParameter
 
 trait HasInstrUncacheConst {
   def MmioBusWidth: Int = 64
   def MmioBusBytes: Int = MmioBusWidth / 8
+
+  // we can't do speculative fetch in Mmio region, so more than 1 MmioEntry should be useless?
+  def nMmioEntry: Int = 1
 }
 
-trait HasInstrUncacheParameters extends HasICacheParameters with HasInstrUncacheConst
+trait HasInstrUncacheParameters extends HasXSParameter with HasInstrUncacheConst

--- a/src/main/scala/xiangshan/frontend/instruncache/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/Parameters.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2020-2021 Peng Cheng Laboratory
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package xiangshan.frontend.instruncache
+
+import xiangshan.frontend.icache.HasICacheParameters
+
+trait HasInstrUncacheConst {
+  def MmioBusWidth: Int = 64
+  def MmioBusBytes: Int = MmioBusWidth / 8
+}
+
+trait HasInstrUncacheParameters extends HasICacheParameters with HasInstrUncacheConst

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -32,7 +32,6 @@ import utility.sram.{SramMbistBundle, SramBroadcastBundle, SramHelper}
 import system.SoCParamsKey
 import xiangshan._
 import xiangshan.ExceptionNO._
-import xiangshan.frontend.HasInstrMMIOConst
 import xiangshan.backend.Bundles.{DynInst, MemExuInput, MemExuOutput}
 import xiangshan.backend.ctrlblock.{DebugLSIO, LsTopdownInfo}
 import xiangshan.backend.exu.MemExeUnit
@@ -53,6 +52,7 @@ import xiangshan.cache._
 import xiangshan.cache.mmu._
 import coupledL2.PrefetchRecv
 import system.HasSoCParameter
+import xiangshan.frontend.instruncache.HasInstrUncacheConst
 
 trait HasMemBlockParameters extends HasXSParameter {
   // number of memory units
@@ -198,7 +198,7 @@ class fetch_to_mem(implicit p: Parameters) extends XSBundle{
 }
 
 // triple buffer applied in i-mmio path (two at MemBlock, one at L2Top)
-class InstrUncacheBuffer()(implicit p: Parameters) extends LazyModule with HasInstrMMIOConst {
+class InstrUncacheBuffer()(implicit p: Parameters) extends LazyModule with HasInstrUncacheConst {
   val node = new TLBufferNode(BufferParams.default, BufferParams.default, BufferParams.default, BufferParams.default, BufferParams.default)
   lazy val module = new InstrUncacheBufferImpl
 
@@ -210,9 +210,9 @@ class InstrUncacheBuffer()(implicit p: Parameters) extends LazyModule with HasIn
       // only a.valid, a.ready, a.address can change
       // hoping that the rest would be optimized to keep MemBlock port unchanged after adding buffer
       out.a.bits.data := 0.U
-      out.a.bits.mask := Fill(mmioBusBytes, 1.U(1.W))
+      out.a.bits.mask := Fill(MmioBusBytes, 1.U(1.W))
       out.a.bits.opcode := 4.U // Get
-      out.a.bits.size := log2Ceil(mmioBusBytes).U
+      out.a.bits.size := log2Ceil(MmioBusBytes).U
       out.a.bits.source := 0.U
     }
   }


### PR DESCRIPTION
- each class in a separate file (except Bundles / Utils)
- module IO inside module class
- renames:
  - camel cases
  - unify bundle naming convention
  - re-organize IO
- rewrite `InstrUncacheEntry`
  - use `switch-is` for fsm
  - avoid `DontCare`: we can assign values directly
  - replace `Mux(pc(...), data(...), Mux(pc(...), ..., ...))` tree with `Mux1H(UIntToOH(pc), Seq(data(...), ...))` for better readability (and maybe timing?)
- remove InstrUncache's dependency on `ICacheParameters`