### PR TITLE
fix(TLB): should always send onlyS1 req when req_need_gpa

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -495,8 +495,8 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     val req_s2xlate = Wire(UInt(2.W))
     req_s2xlate := MuxCase(noS2xlate, Seq(
       (!(virt_out(idx) || req_out(idx).hyperinst)) -> noS2xlate,
-      (csr.vsatp.mode =/= 0.U && csr.hgatp.mode =/= 0.U) -> allStage,
-      (csr.vsatp.mode === 0.U) -> onlyStage2,
+      (csr.vsatp.mode =/= 0.U && csr.hgatp.mode =/= 0.U && !req_need_gpa) -> allStage,
+      (csr.vsatp.mode === 0.U && !req_need_gpa) -> onlyStage2,
       (csr.hgatp.mode === 0.U || req_need_gpa) -> onlyStage1
     ))
 
@@ -545,8 +545,8 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     val miss_req_s2xlate = Wire(UInt(2.W))
     miss_req_s2xlate := MuxCase(noS2xlate, Seq(
       (!(virt_out(idx) || req_out(idx).hyperinst)) -> noS2xlate,
-      (csr.vsatp.mode =/= 0.U && csr.hgatp.mode =/= 0.U) -> allStage,
-      (csr.vsatp.mode === 0.U) -> onlyStage2,
+      (csr.vsatp.mode =/= 0.U && csr.hgatp.mode =/= 0.U && !req_need_gpa) -> allStage,
+      (csr.vsatp.mode === 0.U && !req_need_gpa) -> onlyStage2,
       (csr.hgatp.mode === 0.U || req_need_gpa) -> onlyStage1
     ))
     val miss_req_s2xlate_reg = RegEnable(miss_req_s2xlate, io.ptw.req(idx).fire)


### PR DESCRIPTION
`req_need_gpa` indicates that the request needs to access the guest physical address (GPA) where a GPF occurred by querying the L2 TLB. When `req_need_gpa` is valid, it is sufficient to send an onlyStage1 request to obtain the guest physical address.

In the original design, multiple cases in the `MuxCase` could be valid at the same time. For example, when both `csr.vsatp.mode =/= 0.U` and `csr.hgatp.mode =/= 0.U` are valid, an allStage request would be sent directly, without considering the `req_need_gpa` condition. This commit fixes that bug.