### PR TITLE
fix(Svinval): remove assert related to Svinval extension in ROB

### DIFF
--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -173,7 +173,6 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   // special cases
   val hasBlockBackward = RegInit(false.B)
   val hasWaitForward = RegInit(false.B)
-  val doingSvinval = RegInit(false.B)
   val enqPtr = enqPtrVec(0)
   val deqPtr = deqPtrVec(0)
   val walkPtr = walkPtrVec(0)
@@ -428,16 +427,6 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       }
       val enqTriggerActionIsDebugMode = TriggerAction.isDmode(io.enq.req(i).bits.trigger)
       val enqHasException = ExceptionNO.selectFrontend(enqUop.exceptionVec).asUInt.orR
-      // the begin instruction of Svinval enqs so mark doingSvinval as true to indicate this process
-      when(!enqTriggerActionIsDebugMode && !enqHasException && enqUop.isSvinvalBegin(enqUop.flushPipe)) {
-        doingSvinval := true.B
-      }
-      // the end instruction of Svinval enqs so clear doingSvinval
-      when(!enqTriggerActionIsDebugMode && !enqHasException && enqUop.isSvinvalEnd(enqUop.flushPipe)) {
-        doingSvinval := false.B
-      }
-      // when we are in the process of Svinval software code area , only Svinval.vma and end instruction of Svinval can appear
-      assert(!doingSvinval || (enqUop.isSvinval(enqUop.flushPipe) || enqUop.isSvinvalEnd(enqUop.flushPipe) || enqUop.isNotSvinval))
       when(enqUop.isWFI && !enqHasException && !enqTriggerActionIsDebugMode) {
         hasWFI := true.B
       }


### PR DESCRIPTION
The RISC-V manual says that:
> In typical usage, software will invalidate a range of virtual addresses in the addresstranslation caches by executing an SFENCE.W.INVAL instruction, executing a series of SINVAL.VMA, HINVAL.VVMA, or HINVAL.GVMA instructions to the addresses (and optionally ASIDs or VMIDs) in question, and then executing an SFENCE.INVAL.IR instruction.

Some additional information was obtained through https://github.com/riscv/riscv-isa-manual/issues/1936

However, other instructions may still appear between SFENCE.W.INVAL and SFENCE.INVAL.IR.
> Translation of any memory accesses during that sequence are subject to the usual uncertainty as to which translation (among old and new ones) is used.

Moreover, these memory accesses are not entirely unpredictable either.
> Each subsequent memory access will unpredictably use either the old translation or the new translation. Other behaviors can't occur.