### PR TITLE
fix(XSNoCTop): fix wfi wakeup by snoop

### DIFF
--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -246,11 +246,12 @@ class XSNoCTop()(implicit p: Parameters) extends BaseXSSoc with HasSoCParameter
      2. when Core is in wfi state, core+l2 clock is gated
      3. only reset/interrupt/snoop could recover core+l2 clock
     */
-    val sNORMAL :: sGCLOCK :: sAWAKE :: Nil = Enum(3)
+    val sNORMAL :: sGCLOCK :: sAWAKE :: sFLITWAKE :: Nil = Enum(4)
     val wfiState = withClockAndReset(clock, cpuReset.asAsyncReset) {RegInit(sNORMAL)}
     val isNormal = lpState === sIDLE
     val wfiGateClock = withClockAndReset(clock, cpuReset.asAsyncReset) {RegInit(false.B)}
-    wfiState := WfiStateNext(wfiState, isWFI, isNormal, io.chi.rx.snp.flitpend, intSrc)
+    val flitpend = io.chi.rx.snp.flitpend | io.chi.rx.rsp.flitpend | io.chi.rx.dat.flitpend
+    wfiState := WfiStateNext(wfiState, isWFI, isNormal, flitpend, intSrc)
 
     if (WFIClockGate) {
       wfiGateClock := (wfiState === sGCLOCK)

--- a/src/main/scala/utils/LowPowerState.scala
+++ b/src/main/scala/utils/LowPowerState.scala
@@ -21,13 +21,14 @@ import chisel3.util._
 
 /* WFI state Update */
 object WfiStateNext {
-  val sNORMAL :: sGCLOCK :: sAWAKE :: Nil = Enum(3)
+  val sNORMAL :: sGCLOCK :: sAWAKE :: sFLITWAKE :: Nil = Enum(4)
 
   def apply(wfiState: UInt, isWFI: Bool, isNormal: Bool, flitpend: Bool, intSrc: UInt): UInt = {
     val nextState = MuxCase(wfiState, Array(
       (wfiState === sNORMAL && isWFI && isNormal && !intSrc.orR) -> sGCLOCK,
       (wfiState === sGCLOCK && intSrc.orR) -> sAWAKE,
-      (wfiState === sGCLOCK && flitpend)   -> sNORMAL,
+      (wfiState === sGCLOCK && flitpend)   -> sFLITWAKE,
+      (wfiState === sFLITWAKE && ~isWFI)   -> sNORMAL,
       (wfiState === sAWAKE && !intSrc.orR) -> sNORMAL
     ).toIndexedSeq)
 


### PR DESCRIPTION
* add flitpend wakeup with all rx channel instead of rx.snp
* After clock is restored by flitpend, wait for Core to enter wfi again before gating the clock