### PR TITLE
fix(LSU): fix exception for misalign access to `nc` space

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
@@ -179,13 +179,17 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
   val needWakeUpWB       = RegInit(false.B)
   val data_select        = RegEnable(genRdataOH(select_req_bit.uop), 0.U(genRdataOH(select_req_bit.uop).getWidth.W), canEnqValid)
 
-  // if there is exception or mmio in split load
+  // if there is exception or uncache in split load
   val globalException = RegInit(false.B)
+  val globalUncache = RegInit(false.B)
+
+  // debug info
   val globalMMIO = RegInit(false.B)
+  val globalNC   = RegInit(false.B)
 
   val hasException = io.splitLoadResp.bits.vecActive &&
     ExceptionNO.selectByFu(io.splitLoadResp.bits.uop.exceptionVec, LduCfg).asUInt.orR || TriggerAction.isDmode(io.splitLoadResp.bits.uop.trigger)
-  val isMMIO = io.splitLoadResp.bits.mmio
+  val isUncache = io.splitLoadResp.bits.mmio || io.splitLoadResp.bits.nc
   needWakeUpReqsWire := false.B
   switch(bufferState) {
     is (s_idle) {
@@ -207,12 +211,14 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
     is (s_resp) {
       when (io.splitLoadResp.valid) {
         val clearOh = UIntToOH(curPtr)
-        when (hasException || isMMIO) {
+        when (hasException || isUncache) {
           // commit directly when exception ocurs
-          // if any split load reaches mmio space, delegate to software loadAddrMisaligned exception
+          // if any split load reaches uncache space, delegate to software loadAddrMisaligned exception
           bufferState := s_wb
           globalException := hasException
-          globalMMIO := isMMIO
+          globalUncache := isUncache
+          globalMMIO := io.splitLoadResp.bits.mmio
+          globalNC   := io.splitLoadResp.bits.nc
         } .elsewhen(io.splitLoadResp.bits.rep_info.need_rep || (unSentLoads & ~clearOh).orR) {
           // need replay or still has unsent requests
           bufferState := s_req
@@ -246,8 +252,11 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
           curPtr := 0.U
           unSentLoads := 0.U
           globalException := false.B
-          globalMMIO := false.B
+          globalUncache := false.B
           needWakeUpWB := false.B
+
+          globalMMIO := false.B
+          globalNC   := false.B
         }
 
       } .otherwise {
@@ -257,8 +266,11 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
           curPtr := 0.U
           unSentLoads := 0.U
           globalException := false.B
-          globalMMIO := false.B
+          globalUncache := false.B
           needWakeUpWB := false.B
+
+          globalMMIO := false.B
+          globalNC   := false.B
         }
       }
 
@@ -498,7 +510,7 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
   when (io.splitLoadResp.valid) {
     val resp = io.splitLoadResp.bits
     splitLoadResp(curPtr) := io.splitLoadResp.bits
-    when (isMMIO) {
+    when (isUncache) {
       unSentLoads := 0.U
       exceptionVec := ExceptionNO.selectByFu(0.U.asTypeOf(exceptionVec.cloneType), LduCfg)
       // delegate to software
@@ -534,19 +546,20 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
 
   }
 
-  io.writeBack.valid := req_valid && (bufferState === s_wb) && (io.splitLoadResp.valid && io.splitLoadResp.bits.misalignNeedWakeUp || globalMMIO || globalException) && !io.loadOutValid && !req.isvec
+  io.writeBack.valid := req_valid && (bufferState === s_wb) && (io.splitLoadResp.valid && io.splitLoadResp.bits.misalignNeedWakeUp || globalUncache || globalException) && !io.loadOutValid && !req.isvec
   io.writeBack.bits.uop := req.uop
   io.writeBack.bits.uop.exceptionVec := DontCare
-  LduCfg.exceptionOut.map(no => io.writeBack.bits.uop.exceptionVec(no) := (globalMMIO || globalException) && exceptionVec(no))
-  io.writeBack.bits.uop.rfWen := !globalException && !globalMMIO && req.uop.rfWen
+  LduCfg.exceptionOut.map(no => io.writeBack.bits.uop.exceptionVec(no) := (globalUncache || globalException) && exceptionVec(no))
+  io.writeBack.bits.uop.rfWen := !globalException && !globalUncache && req.uop.rfWen
   io.writeBack.bits.uop.fuType := FuType.ldu.U
   io.writeBack.bits.uop.flushPipe := false.B
   io.writeBack.bits.uop.replayInst := false.B
   io.writeBack.bits.data := newRdataHelper(data_select, combinedData)
   io.writeBack.bits.isFromLoadUnit := needWakeUpWB
+  // Misaligned accesses to uncache space trigger exceptions, so theoretically these signals won't do anything practical.
+  // But let's get them assigned correctly.
   io.writeBack.bits.debug.isMMIO := globalMMIO
-  // FIXME lyq: temporarily set to false
-  io.writeBack.bits.debug.isNC := false.B
+  io.writeBack.bits.debug.isNC := globalNC
   io.writeBack.bits.debug.isPerfCnt := false.B
   io.writeBack.bits.debug.paddr := req.paddr
   io.writeBack.bits.debug.vaddr := req.vaddr
@@ -575,10 +588,10 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
   io.vecWriteBack.bits.vaNeedExt            := req.vaNeedExt
   io.vecWriteBack.bits.gpaddr               := req.gpaddr
   io.vecWriteBack.bits.isForVSnonLeafPTE    := req.isForVSnonLeafPTE
-  io.vecWriteBack.bits.mmio                 := DontCare
+  io.vecWriteBack.bits.mmio                 := globalMMIO
   io.vecWriteBack.bits.vstart               := req.uop.vpu.vstart
   io.vecWriteBack.bits.vecTriggerMask       := req.vecTriggerMask
-  io.vecWriteBack.bits.nc                   := false.B
+  io.vecWriteBack.bits.nc                   := globalNC
 
 
   val flush = req_valid && req.uop.robIdx.needFlush(io.redirect)
@@ -589,7 +602,10 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
     curPtr := 0.U
     unSentLoads := 0.U
     globalException := false.B
+    globalUncache := false.B
+
     globalMMIO := false.B
+    globalNC   := false.B
   }
 
   // NOTE: spectial case (unaligned load cross page, page fault happens in next page)
@@ -614,8 +630,8 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
   io.overwriteExpBuf.gpaddr := overwriteGpaddr
   io.overwriteExpBuf.isForVSnonLeafPTE := overwriteIsForVSnonLeafPTE
 
-  // when no exception or mmio, flush loadExceptionBuffer at s_wb
-  val flushLdExpBuff = GatedValidRegNext(req_valid && (bufferState === s_wb) && !(globalMMIO || globalException))
+  // when no exception or uncache, flush loadExceptionBuffer at s_wb
+  val flushLdExpBuff = GatedValidRegNext(req_valid && (bufferState === s_wb) && !(globalUncache || globalException))
   io.flushLdExpBuff := flushLdExpBuff
 
   XSPerfAccumulate("alloc",                  RegNext(!req_valid) && req_valid)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -203,11 +203,15 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
 
   // if there is exception or mmio in split store
   val globalException = RegInit(false.B)
+  val globalUncache = RegInit(false.B)
+
+  // debug info
   val globalMMIO = RegInit(false.B)
+  val globalNC   = RegInit(false.B)
 
   val hasException = io.splitStoreResp.bits.vecActive && !io.splitStoreResp.bits.need_rep &&
     ExceptionNO.selectByFu(io.splitStoreResp.bits.uop.exceptionVec, StaCfg).asUInt.orR || TriggerAction.isDmode(io.splitStoreResp.bits.uop.trigger)
-  val isMMIO = io.splitStoreResp.bits.mmio && !io.splitStoreResp.bits.need_rep
+  val isUncache = (io.splitStoreResp.bits.mmio || io.splitStoreResp.bits.nc) && !io.splitStoreResp.bits.need_rep
 
   io.sqControl.toStoreQueue.crossPageWithHit := io.sqControl.toStoreMisalignBuffer.sqPtr === req.uop.sqIdx && isCrossPage
   io.sqControl.toStoreQueue.crossPageCanDeq := !isCrossPage || bufferState === s_block
@@ -245,12 +249,14 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
     is (s_resp) {
       when (io.splitStoreResp.valid) {
         val clearOh = UIntToOH(curPtr)
-        when (hasException || isMMIO) {
+        when (hasException || isUncache) {
           // commit directly when exception ocurs
           // if any split store reaches mmio space, delegate to software storeAddrMisaligned exception
           bufferState := s_wb
           globalException := hasException
-          globalMMIO := isMMIO
+          globalUncache := isUncache
+          globalMMIO := io.splitStoreResp.bits.mmio
+          globalNC   := io.splitStoreResp.bits.nc
         } .elsewhen(io.splitStoreResp.bits.need_rep || (unSentStores & (~clearOh).asUInt).orR) {
           // need replay or still has unsent requests
           bufferState := s_req
@@ -270,22 +276,28 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
           unSentStores := 0.U
           unWriteStores := 0.U
           globalException := false.B
-          globalMMIO := false.B
+          globalUncache := false.B
           isCrossPage := false.B
           needFlushPipe := false.B
+
+          globalMMIO := false.B
+          globalNC   := false.B
         }
 
       }.otherwise {
-        when (io.writeBack.fire && (!isCrossPage || globalMMIO || globalException)) {
+        when (io.writeBack.fire && (!isCrossPage || globalUncache || globalException)) {
           bufferState := s_idle
           req_valid := false.B
           curPtr := 0.U
           unSentStores := 0.U
           unWriteStores := 0.U
           globalException := false.B
-          globalMMIO := false.B
+          globalUncache := false.B
           isCrossPage := false.B
           needFlushPipe := false.B
+
+          globalMMIO := false.B
+          globalNC   := false.B
         } .elsewhen(io.writeBack.fire && isCrossPage) {
           bufferState := s_block
         } .otherwise {
@@ -303,8 +315,12 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
         unSentStores := 0.U
         unWriteStores := 0.U
         globalException := false.B
-        globalMMIO := false.B
+        globalUncache := false.B
         isCrossPage := false.B
+        needFlushPipe := false.B
+
+        globalMMIO := false.B
+        globalNC   := false.B
       }
     }
   }
@@ -525,7 +541,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   when (io.splitStoreResp.valid) {
     val resp = io.splitStoreResp.bits
     splitStoreResp(curPtr) := io.splitStoreResp.bits
-    when (isMMIO) {
+    when (isUncache) {
       unWriteStores := 0.U
       unSentStores := 0.U
       exceptionVec := ExceptionNO.selectByFu(0.U.asTypeOf(exceptionVec.cloneType), StaCfg)
@@ -567,14 +583,13 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   io.writeBack.valid := req_valid && (bufferState === s_wb) && !io.storeOutValid && !req.isvec
   io.writeBack.bits.uop := req.uop
   io.writeBack.bits.uop.exceptionVec := DontCare
-  StaCfg.exceptionOut.map(no => io.writeBack.bits.uop.exceptionVec(no) := (globalMMIO || globalException) && exceptionVec(no))
+  StaCfg.exceptionOut.map(no => io.writeBack.bits.uop.exceptionVec(no) := (globalUncache || globalException) && exceptionVec(no))
   io.writeBack.bits.uop.flushPipe := needFlushPipe
   io.writeBack.bits.uop.replayInst := false.B
   io.writeBack.bits.data := DontCare
   io.writeBack.bits.isFromLoadUnit := DontCare
   io.writeBack.bits.debug.isMMIO := globalMMIO
-  // FIXME lyq: temporarily set to false
-  io.writeBack.bits.debug.isNC := false.B
+  io.writeBack.bits.debug.isNC := globalNC
   io.writeBack.bits.debug.isPerfCnt := false.B
   io.writeBack.bits.debug.paddr := req.paddr
   io.writeBack.bits.debug.vaddr := req.vaddr
@@ -603,7 +618,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
       wb.bits.isForVSnonLeafPTE := req.isForVSnonLeafPTE
       wb.bits.vstart            := req.uop.vpu.vstart
       wb.bits.vecTriggerMask    := 0.U
-      wb.bits.nc                := false.B
+      wb.bits.nc                := globalNC
     }
   }
 
@@ -616,9 +631,12 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
     unSentStores := 0.U
     unWriteStores := 0.U
     globalException := false.B
-    globalMMIO := false.B
+    globalUncache := false.B
     isCrossPage := false.B
     needFlushPipe := false.B
+
+    globalMMIO := false.B
+    globalNC   := false.B
   }
 
   // NOTE: spectial case (unaligned store cross page, page fault happens in next page)

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1203,7 +1203,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     s2_exception_vec(loadAccessFault) := s2_vecActive && (
       s2_in.uop.exceptionVec(loadAccessFault) ||
       s2_pmp.ld ||
-      (s2_isvec || s2_frm_mabuf) && s2_uncache ||
+      s2_isvec && s2_uncache ||
       io.dcache.resp.bits.tag_error && GatedValidRegNext(io.csrCtrl.cache_error_enable)
     )
   }

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -468,7 +468,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   s2_out.memBackTypeMM := s2_memBackTypeMM
   s2_out.uop.exceptionVec(storeAccessFault) := (s2_in.uop.exceptionVec(storeAccessFault) ||
                                                 s2_pmp.st ||
-                                                ((s2_in.isvec || s2_frm_mabuf || s2_isCbo) && s2_actually_uncache && RegNext(s1_feedback.bits.hit))
+                                                ((s2_in.isvec || s2_isCbo) && s2_actually_uncache && RegNext(s1_feedback.bits.hit))
                                                 ) && s2_vecActive
   s2_out.uop.exceptionVec(storeAddrMisaligned) := s2_actually_uncache && s2_in.isMisalign && !s2_un_misalign_exception
   s2_out.uop.vpu.vstart     := s2_in.vecVaddrOffset >> s2_in.uop.vpu.veew


### PR DESCRIPTION
For misaligned accesses, say if the access after the split goes to `nc` space, then a misaligned exception should also be generated.

