### PR TITLE
fix(MMU): fix gvpn generate when PTWCache Stage1Hit a napot entry

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -1270,7 +1270,9 @@ class PtwMergeResp(implicit p: Parameters) extends PtwBundle {
       3.U -> Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, vpnnLen * 3 - sectortlbwidth), tag(vpnnLen * 3 - 1, 0)),
       2.U -> Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, vpnnLen * 2 - sectortlbwidth), tag(vpnnLen * 2 - 1, 0)),
       1.U -> Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, vpnnLen - sectortlbwidth), tag(vpnnLen - 1, 0)),
-      0.U -> Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, 0), entry(idx).ppn_low))
+      0.U -> Mux(entry(idx).n.getOrElse(0.U) === 0.U,
+        Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, 0), entry(idx).ppn_low),
+        Cat(entry(idx).ppn(entry(idx).ppn.getWidth - 1, pteNapotBits - sectortlbwidth), tag(pteNapotBits - 1, 0))))
     )
   }
 }


### PR DESCRIPTION
For allStage case, when there is a PageTableCache Stage1Hit, the GVPN is reconstructed within the PTW. However, this reconstruction process did not account for the napot case. This commit fixes the bug.