### PR TITLE
feat(utils): Add EnumUInt for defining enum values

### DIFF
--- a/src/main/scala/utils/EnumUInt.scala
+++ b/src/main/scala/utils/EnumUInt.scala
@@ -1,0 +1,126 @@
+package utils
+
+import chisel3._
+import chisel3.util._
+
+/**
+ * Used to define enum values (e.g. finite state machine states)
+ *
+ * @example {{{
+ *   object FsmState extends EnumUInt(3) {
+ *     def Idle: UInt = 0.U(width.W)
+ *     def Work: UInt = 1.U(width.W)
+ *     def Done: UInt = 2.U(width.W)
+ *   }
+ *   FsmState.validate()
+ * }}}
+ *
+ * validate() will check:
+ * 1. all values are unique (unless allowDuplicate is true)
+ *    @example {{{
+ *      object FsmState extends EnumUInt(3) {
+ *        def Idle: UInt = 0.U(width.W)
+ *        def Work: UInt = 1.U(width.W)
+ *        def Done: UInt = 1.U(width.W)
+ *      }
+ *      FsmState.validate() // will fail, as Idle/Work are duplicate
+ *    }}}
+ *    @example {{{
+ *      object FsmState extends EnumUInt(3, allowDuplicate = true) {
+ *        def Idle: UInt = 0.U(width.W)
+ *        def Work: UInt = 1.U(width.W)
+ *        def AliasOfWork: UInt = 1.U(width.W)
+ *        def Done: UInt = 2.U(width.W)
+ *      }
+ *      FsmState.validate() // will pass, we allow duplicate values for alias
+ *      // but please note that we must have n unique values (to satisfy rule 4)
+ *    }}}
+ * 2. all value's width is defined width
+ *    @example {{{
+ *      object FsmState extends EnumUInt(3) {
+ *        def Idle: UInt = 0.U
+ *        def Work: UInt = 1.U
+ *        def Done: UInt = 2.U
+ *      }
+ *      FsmState.validate() // will fail, as Idle/Work are not defined with width, it's default to 1, but 2 expected
+ *    }}}
+ * 3. if useOneHot is true, all values are power of 2
+ *    @example {{{
+ *      object FsmState extends EnumUInt(4, useOneHot = true) {
+ *        def Idle: UInt = 0.U(width.W)
+ *        def Work: UInt = 1.U(width.W)
+ *        def Done: UInt = 2.U(width.W)
+ *        def Error: UInt = 3.U(width.W)
+ *      }
+ *      FsmState.validate() // will fail, as Error = 3.U is not a power of 2, Error = 4.U is expected
+ *    }}}
+ * 4. all possible values are defined
+ *    @example {{{
+ *      object FsmState extends EnumUInt(3) {
+ *        def Idle: UInt = 0.U(width.W)
+ *        def Work: UInt = 1.U(width.W)
+ *      }
+ *      FsmState.validate() // will fail, as only 2 values are defined, but 3 are expected
+ *    }}}
+ * NOTE: all methods used to define constants must be in UpperCamelCase, and return UInt, and take no parameters
+ */
+abstract class EnumUInt(
+    n:              Int,
+    useOneHot:      Boolean = false,
+    allowDuplicate: Boolean = false
+) extends NamedUInt(if (useOneHot) n else log2Up(n)) {
+  def validate(): Unit = {
+    val methodsAll = this.getClass.getDeclaredMethods
+      .filter { method =>
+        method.getReturnType == classOf[UInt] && // return UInt
+        method.getParameterTypes.isEmpty         // no parameters
+      }
+    val methods = methodsAll.filter(_.getName()(0).isUpper) // UpperCamelCase
+    var values  = Seq[BigInt]()
+    methods.foreach { method =>
+      val uint   = method.invoke(this).asInstanceOf[UInt]
+      val value  = uint.litValue
+      val dupIdx = values.indexOf(value)
+      assert( // check1: all values must have a correct width
+        uint.getWidth == width,
+        s"EnumUInt ${this.getClass.getName} has value with width(${uint.getWidth}), expected $width: ${method.getName}."
+      )
+      assert( // check2: all values must be unique, unless allowDuplicate is true
+        allowDuplicate || dupIdx == -1,
+        s"EnumUInt ${this.getClass.getName} has duplicate value($value): ${method.getName} and ${methods(dupIdx).getName}."
+      )
+      assert( // check3: one-hot values must be power of 2
+        !useOneHot || isPow2(value),
+        s"EnumUInt ${this.getClass.getName} has non one-hot value($value): ${method.getName}."
+      )
+      values = values :+ value
+    }
+
+    // check4: if allowDuplicate is true, we can have more than n methods, but we must have n unique values
+    // check4: otherwise, we must have n methods and n unique values
+    if (values.toSet.size != n) {
+      // warn if there are methods seems to be constants but not UpperCamelCase before throw AssertionError
+      val methodsNotUpperCamelCase = methodsAll.diff(methods)
+      methodsNotUpperCamelCase.foreach { method =>
+        println(
+          s"[Warn]: EnumUInt ${this.getClass.getName} seems has constants defination '${method.getName}' " +
+            s"that is not UpperCamelCase, Do you mean '${method.getName.capitalize}'?"
+        )
+      }
+      assert(
+        false,
+        s"EnumUInt ${this.getClass.getName} has ${values.toSet.size} unique values, but expected $n." +
+          (if (methodsNotUpperCamelCase.nonEmpty) " Maybe you miss UpperCamelCase? check warnings above." else "")
+      )
+    }
+
+    // pass!
+    println(
+      s"EnumUInt ${this.getClass.getName} validated:" +
+        s"${(methods.map(_.getName) zip values).sortBy { case (_, i) => i }.mkString("[", ",", "]")}"
+    )
+  }
+
+  // call validate() in the constructor
+  validate()
+}

--- a/src/main/scala/utils/EnumUInt.scala
+++ b/src/main/scala/utils/EnumUInt.scala
@@ -98,36 +98,44 @@ abstract class EnumUInt(
       }
     ) {
 
-  def validate(): Unit = {
+  private var names     = Seq[String]()
+  private var values    = Seq[UInt]()
+  private var litValues = Seq[BigInt]()
+
+  private def getValuesString: String =
+    (this.names zip this.litValues).sortBy { case (_, i) => i }.mkString("[", ", ", "]")
+
+  private def validate(): Unit = {
     val methodsAll = this.getClass.getDeclaredMethods
       .filter { method =>
         method.getReturnType == classOf[UInt] && // return UInt
         method.getParameterTypes.isEmpty         // no parameters
       }
     val methods = methodsAll.filter(_.getName()(0).isUpper) // UpperCamelCase
-    var values  = Seq[BigInt]()
-    methods.foreach { method =>
-      val uint   = method.invoke(this).asInstanceOf[UInt]
-      val value  = uint.litValue
-      val dupIdx = values.indexOf(value)
+    this.names = methods.map(_.getName).toSeq
+    this.values = methods.map(_.invoke(this).asInstanceOf[UInt]).toSeq
+    this.litValues = this.values.map(_.litValue)
+
+    (this.names zip this.values zip this.litValues).zipWithIndex.foreach { case (((name, value), litValue), i) =>
+      val dupIdx = this.litValues.slice(0, i).indexOf(litValue)
       assert( // check1: all values must have a correct width
-        uint.getWidth == width,
-        s"EnumUInt ${this.getClass.getName} has value with width(${uint.getWidth}), expected $width: ${method.getName}."
+        value.getWidth == this.width,
+        s"EnumUInt ${this.getClass.getName} has value with width(${value.getWidth}), expected $width: ${name}."
       )
       assert( // check2: all values must be unique, unless allowDuplicate is true
         allowDuplicate || dupIdx == -1,
-        s"EnumUInt ${this.getClass.getName} has duplicate value($value): ${method.getName} and ${methods(dupIdx).getName}."
+        s"EnumUInt ${this.getClass.getName} has duplicate value(${litValue}): ${name} and ${this.names(dupIdx)}."
       )
       assert( // check3: one-hot values must be power of 2
-        !useOneHot || isPow2(value),
-        s"EnumUInt ${this.getClass.getName} has non one-hot value($value): ${method.getName}."
+        !useOneHot || isPow2(litValue),
+        s"EnumUInt ${this.getClass.getName} has non one-hot value(${litValue}): ${name}."
       )
-      values = values :+ value
     }
 
     // check4: if allowDuplicate is true, we can have more than n methods, but we must have n unique values
     // check4: otherwise, we must have n methods and n unique values
-    if (values.toSet.size != n) {
+    val uniqueLitValues = this.litValues.toSet.size
+    if (uniqueLitValues != this.n) {
       // warn if there are methods seems to be constants but not UpperCamelCase before throw AssertionError
       val methodsNotUpperCamelCase = methodsAll.diff(methods)
       methodsNotUpperCamelCase.foreach { method =>
@@ -137,17 +145,66 @@ abstract class EnumUInt(
         )
       }
       assert(
-        false,
-        s"EnumUInt ${this.getClass.getName} has ${values.toSet.size} unique values, but expected $n." +
+        cond = false,
+        s"EnumUInt ${this.getClass.getName} has ${uniqueLitValues} unique values, but expected ${this.n}." +
           (if (methodsNotUpperCamelCase.nonEmpty) " Maybe you miss UpperCamelCase? check warnings above." else "")
       )
     }
 
     // pass!
-    println(
-      s"EnumUInt ${this.getClass.getName} validated:" +
-        s"${(methods.map(_.getName) zip values).sortBy { case (_, i) => i }.mkString("[", ",", "]")}"
-    )
+    println(s"EnumUInt ${this.getClass.getName} validated: ${this.getValuesString}")
+  }
+
+  /** Check or generate assertion for unsafe inputs
+   * @example {{{
+   *   class ExceptionType extends Bundle {
+   *     val value: UInt = ExceptionType() // this is inherit from NamedUInt.apply(), i.e. UInt(width.W)
+   *
+   *     def hasException: Bool = value =/= ExceptionType.None
+   *   }
+   *
+   *   object ExceptionType extends EnumUInt(4) {
+   *     def None: UInt = 0.U(width.W)
+   *     def Pf:   UInt = 1.U(width.W)
+   *     def Gpf:  UInt = 2.U(width.W)
+   *     def Af:   UInt = 3.U(width.W)
+   *
+   *     def apply(that: UInt): ExceptionType = {
+   *       assertLegal(that) // do check or generate assertion before do wiring
+   *       val e = Wire(new ExceptionType)
+   *       e.value := that
+   *       e
+   *     }
+   *   }
+   *
+   *   val e1 = ExceptionType(4.U) // will be checked at compile time, and fails as 4.U is not a legal value
+   *
+   *   val unsafeWire = Wire(UInt(2.W))
+   *   val e2 = ExceptionType(unsafeWire) // will be checked at runtime
+   *
+   *   val e3 = 0.U.asTypeOf(new ExceptionType) // this cannot be checked, we should avoid at best effort
+   *   // -> val e3 = ExceptionType(0.U) // this is better
+   * }}}
+   */
+  def assertLegal(that: UInt): Unit = {
+    if (that.isLit) { // if is literal, check value at compile time (if legal, we don't need to care about width)
+      assert(
+        this.litValues.contains(that.litValue),
+        s"EnumUInt ${this.getClass.getName} gets illegal input with value(${that.litValue}), " +
+          s"expected one of ${this.getValuesString}."
+      )
+    } else { // otherwise, check width at compile time, and value at runtime
+      assert(
+        this.width == that.getWidth,
+        s"EnumUInt ${this.getClass.getName} gets illegal input with width(${that.getWidth}), expected $width."
+      )
+      assert(
+        VecInit(this.values.map(_ === that)).asUInt.orR,
+        s"EnumUInt ${this.getClass.getName} gets illegal input with value(%d), " +
+          s"expected one of ${this.getValuesString}.",
+        that // that is a hardware Wire/Reg, we cannot use litValue
+      )
+    }
   }
 
   // call validate() in the constructor


### PR DESCRIPTION
Basically a enhanced `NamedUInt`, refer to comments in `EnumUInt.scala`:
https://github.com/OpenXiangShan/XiangShan/blob/9c0cfc26f18c8bb85af825da6d74612b7108696f/src/main/scala/utils/EnumUInt.scala#L6-L66

It uses [java reflection](https://www.runoob.com/java/java-reflection.html) mechanism to check constant definations (UpperCamelCase, return UInt, and take no parameters), and can help prevent mistakes like:
- [`7ff49a5` (#4461)](https://github.com/OpenXiangShan/XiangShan/pull/4461/commits/7ff49a504062bd585789fcf8bc1bc985ba1f289d)
- #4124 

Migration example:
- `NamedUInt(log2Up(...))` (uses width) -> `EnumUInt` (uses actual number of unique values, or width for one-hot mode)
  ```diff
  - private object S1FsmState extends NamedUInt(log2Up(5)) {
  + private object S1FsmState extends EnumUInt(5) {
      def Idle:       UInt = 0.U(width.W)
      def ItlbResend: UInt = 1.U(width.W)
  ```
  ```diff
  - private object OneHotFsmState extends NamedUInt(3) {
  + private object OneHotFsmState extends EnumUInt(3, useOneHot = true) {
      def Idle: UInt = "b001".U(width.W)
      def Work: UInt = "b010".U(width.W)
      def Done: UInt = "b100".U(width.W)
  ```

- ... also apply UpperCamelCase for constants
  ```diff
  - object ExceptionType extends NamedUInt(2) {
  -   def none: UInt = 0.U(width.W)
  -   def pf:   UInt = 1.U(width.W) // instruction page fault
  -   def gpf:  UInt = 2.U(width.W) // instruction guest page fault
  -   def af:   UInt = 3.U(width.W) // instruction access fault
  + object ExceptionType extends EnumUInt(4) {
  +   def None: UInt = 0.U(width.W)
  +   def Pf:   UInt = 1.U(width.W) // instruction page fault
  +   def Gpf:  UInt = 2.U(width.W) // instruction guest page fault
  +   def Af:   UInt = 3.U(width.W) // instruction access fault
  ```

- ... also add reserved definitions to keep width, or use `fixedWidth`
  ```diff
  + import annotation.unused

  - object EccCtrlInjTarget extends NamedUInt(2) {
  + object EccCtrlInjTarget extends EnumUInt(4) {   // we need 3~4 unique numbers to keep width = 2
      def MetaArray: UInt = 0.U(width.W)
      def DataArray: UInt = 1.U(width.W)
  +   @unused
  +   def Rsvd2: UInt = 2.U(width.W)
  +   @unused
  +   def Rsvd3: UInt = 3.U(width.W)
    }
  ```
  ```diff
  - object EccCtrlInjTarget extends NamedUInt(2) {
  + object EccCtrlInjTarget extends EnumUInt(2, fixedWidth=Some(2)) {
      def MetaArray: UInt = 0.U(width.W)
      def DataArray: UInt = 1.U(width.W)
    }
  ```