### PR TITLE
fix(L2TlbPrefetch): fix flush condition of L2 TLB Prefetch

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/L2TlbPrefetch.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TlbPrefetch.scala
@@ -41,7 +41,7 @@ class L2TlbPrefetch(implicit p: Parameters) extends XSModule with HasPtwConst {
     Cat(old_reqs.zip(old_v).map{ case (o,v) => dup(o,vpn) && v}).orR
   }
 
-  val flush = io.sfence.valid || (io.csr.priv.virt && io.csr.vsatp.changed)
+  val flush = io.sfence.valid || io.csr.satp.changed || io.csr.vsatp.changed || io.csr.hgatp.changed
   val next_line = get_next_line(io.in.bits.vpn)
   val next_req = RegEnable(next_line, io.in.valid)
   val input_valid = io.in.valid && !flush && !already_have(next_line)


### PR DESCRIPTION
All components within the L2 TLB should use the same flush condition to avoid potential issues.