### PR TITLE
Revert "fix(TLB): should always send onlyS1 req when req_need_gpa (#4…

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -495,9 +495,9 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     val req_s2xlate = Wire(UInt(2.W))
     req_s2xlate := MuxCase(noS2xlate, Seq(
       (!(virt_out(idx) || req_out(idx).hyperinst)) -> noS2xlate,
-      (csr.vsatp.mode =/= 0.U && csr.hgatp.mode =/= 0.U && !req_need_gpa) -> allStage,
-      (csr.vsatp.mode === 0.U && !req_need_gpa) -> onlyStage2,
-      (csr.hgatp.mode === 0.U || req_need_gpa) -> onlyStage1
+      (csr.vsatp.mode =/= 0.U && csr.hgatp.mode =/= 0.U) -> allStage,
+      (csr.vsatp.mode === 0.U) -> onlyStage2,
+      (csr.hgatp.mode === 0.U) -> onlyStage1
     ))
 
     val ptw_just_back = ptw.resp.fire && req_s2xlate === ptw.resp.bits.s2xlate && ptw.resp.bits.hit(get_pn(req_out(idx).vaddr), csr.satp.asid, csr.vsatp.asid, csr.hgatp.vmid, true, false)
@@ -545,9 +545,9 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     val miss_req_s2xlate = Wire(UInt(2.W))
     miss_req_s2xlate := MuxCase(noS2xlate, Seq(
       (!(virt_out(idx) || req_out(idx).hyperinst)) -> noS2xlate,
-      (csr.vsatp.mode =/= 0.U && csr.hgatp.mode =/= 0.U && !req_need_gpa) -> allStage,
-      (csr.vsatp.mode === 0.U && !req_need_gpa) -> onlyStage2,
-      (csr.hgatp.mode === 0.U || req_need_gpa) -> onlyStage1
+      (csr.vsatp.mode =/= 0.U && csr.hgatp.mode =/= 0.U) -> allStage,
+      (csr.vsatp.mode === 0.U) -> onlyStage2,
+      (csr.hgatp.mode === 0.U) -> onlyStage1
     ))
     val miss_req_s2xlate_reg = RegEnable(miss_req_s2xlate, io.ptw.req(idx).fire)
     val hasS2xlate = miss_req_s2xlate_reg =/= noS2xlate
@@ -700,7 +700,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
         (!RegNext(virt_in || req_in(i).bits.hyperinst)) -> noS2xlate,
         (csr.vsatp.mode =/= 0.U && csr.hgatp.mode =/= 0.U) -> allStage,
         (csr.vsatp.mode === 0.U) -> onlyStage2,
-        (csr.hgatp.mode === 0.U || req_need_gpa) -> onlyStage1
+        (csr.hgatp.mode === 0.U) -> onlyStage1
       ))
       difftest.s2xlate := req_s2xlate
     }


### PR DESCRIPTION
…513)"

This reverts commit 6d07e62cded1f9718c229f7c38d297fed2c95cb8.

At the same time, this commit also fixes a bug where a onlyS1 request was issued when `req_need_gpa` was active. In fact, even when `req_need_gpa` is active, it is necessary to determine whether to issue allStage, onlyS1, or onlyS2 based on the values of the vsatp or hgatp registers. The previous approach in https://github.com/OpenXiangShan/XiangShan/pull/4513 was incorrect, and the details are as follows:

The process of two-stage address translation:

vaddr -> VS-L2  -> G-L2 -> G-L1 -> G-L0 (G-Stage for VS-Stage)
      -> VS-L1  -> G-L2 -> G-L1 -> G-L0 (G-Stage for VS-Stage)
      -> VS-L0  -> G-L2 -> G-L1 -> G-L0 (G-Stage for VS-Stage)
      -> gpaddr -> G-L1 -> G-L0 -> paddr (last G-Stage)

When a page fault occurs at "G-Stage for VS-Stage" in the diagram, the corresponding VS-Stage result before the arrow is the gpaddr value to be written to the *tval register.

However, for example, the required gpaddr comes from VS-L0. Although the first G-Stage query result for VS-L0 is not needed, it is clear that two G-Stage requests are required before this, after VS-L2 and VS-L1, in order to obtain the correct VS-L0 memory access address. If the L1 TLB directly issues an onlyS1 request, then any G-Stage requests will be ignored, which is unreasonable.