### PR TITLE
chore(scalastyle): disable space-around-operator checks

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -71,38 +71,38 @@
  <!-- always add a space after `//` or `/*` before comments -->
  <check enabled="true" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" level="warning"/>
  <!-- check space around operators, ref: https://github.com/scala-ide/scalariform/blob/master/scalariform/src/main/scala/scalariform/lexer/Tokens.scala -->
- <check enabled="true" class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" level="warning">
   <parameters>
    <!-- (, ~, ! -->
    <parameter name="tokens">LPAREN, TILDE, EXCLAMATION</parameter>
   </parameters>
  </check>
- <check enabled="true" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" level="warning">
   <parameters>
    <!-- :, ,, ) -->
    <parameter name="tokens">COLON, COMMA, RPAREN</parameter>
   </parameters>
  </check>
- <check enabled="true" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" level="warning">
   <parameters>
    <!-- if, match, case, for, while, =>, <-, {, <:, <%:, >:, +, -, *, |, = -->
    <parameter name="tokens">IF, MATCH, CASE, FOR, WHILE, ARROW, LARROW, LBRACE, SUBTYPE, VIEWBOUND, SUPERTYPE, PLUS, MINUS, STAR, PIPE, EQUAL</parameter>
   </parameters>
  </check>
- <check enabled="true" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" level="warning">
   <parameters>
    <!-- =>, <-, }, <:, <%, >:, +, -, *, |, = -->
    <parameter name="tokens">ARROW, LARROW, RBRACE, SUBTYPE, VIEWBOUND, SUPERTYPE, PLUS, MINUS, STAR, PIPE, EQUAL</parameter>
   </parameters>
  </check>
- <check enabled="true" class="org.scalastyle.file.RegexChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.file.RegexChecker" level="warning">
   <parameters>
    <!-- :=, :<=, :>=, :<>=, :#=, <>, ===, =/=, <<, >>, <=, >= -->
    <parameter name="regex"><![CDATA[[^ ](:<?#?>?=|<>|=[=/]=|<<|>>|[<>]=)]]></parameter>
   </parameters>
   <customMessage>No space before operators</customMessage>
  </check>
- <check enabled="true" class="org.scalastyle.file.RegexChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.file.RegexChecker" level="warning">
   <parameters>
    <!-- :=, :<=, :>=, :<>=, :#=, <>, ===, =/=, <<, >>, <=, >= -->
    <parameter name="regex"><![CDATA[(:<?#?>?=|<>|=[=/]=|<<|>>|[<>]=)[^ \n]]]></parameter>

--- a/scalastyle-test-config.xml
+++ b/scalastyle-test-config.xml
@@ -71,43 +71,43 @@
  <!-- always add a space after `//` or `/*` before comments -->
  <check enabled="true" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" level="warning"/>
  <!-- check space around operators, ref: https://github.com/scala-ide/scalariform/blob/master/scalariform/src/main/scala/scalariform/lexer/Tokens.scala -->
- <check enabled="true" class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" level="warning">
   <parameters>
    <!-- (, ~, ! -->
    <parameter name="tokens">LPAREN, TILDE, EXCLAMATION</parameter>
   </parameters>
  </check>
- <check enabled="true" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" level="warning">
   <parameters>
    <!-- :, ,, ) -->
    <parameter name="tokens">COLON, COMMA, RPAREN</parameter>
   </parameters>
  </check>
- <check enabled="true" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" level="warning">
   <parameters>
    <!-- if, match, case, for, while, =>, <-, {, <:, <%:, >:, +, -, *, |, = -->
    <parameter name="tokens">IF, MATCH, CASE, FOR, WHILE, ARROW, LARROW, LBRACE, SUBTYPE, VIEWBOUND, SUPERTYPE, PLUS, MINUS, STAR, PIPE, EQUAL</parameter>
   </parameters>
  </check>
- <check enabled="true" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" level="warning">
   <parameters>
    <!-- =>, <-, }, <:, <%, >:, +, -, *, |, = -->
    <parameter name="tokens">ARROW, LARROW, RBRACE, SUBTYPE, VIEWBOUND, SUPERTYPE, PLUS, MINUS, STAR, PIPE, EQUAL</parameter>
   </parameters>
  </check>
- <check enabled="true" class="org.scalastyle.file.RegexChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.file.RegexChecker" level="warning">
   <parameters>
    <!-- :=, :<=, :>=, :<>=, :#=, <>, ===, =/=, <<, >>, <=, >= -->
    <parameter name="regex"><![CDATA[[^ ](:<?#?>?=|<>|=[=/]=|<<|>>|[<>]=)]]></parameter>
   </parameters>
   <customMessage>No space before operators</customMessage>
  </check>
- <check enabled="true" class="org.scalastyle.file.RegexChecker" level="warning">
+ <check enabled="false" class="org.scalastyle.file.RegexChecker" level="warning">
   <parameters>
    <!-- :=, :<=, :>=, :<>=, :#=, <>, ===, =/=, <<, >>, <=, >= -->
-   <parameter name="regex"><![CDATA[(:<?#?>?=|<>|=[=/]=|<<|>>|[<>]=)[^ ]]]></parameter>
+   <parameter name="regex"><![CDATA[(:<?#?>?=|<>|=[=/]=|<<|>>|[<>]=)[^ \n]]]></parameter>
   </parameters>
-  <customMessage>No space after operators</customMessage>
+  <customMessage>No space or newline after operators</customMessage>
  </check>
 
  <!-- ===== imports ===== -->
@@ -158,7 +158,7 @@
  <!-- pure lower cases for package names -->
  <check enabled="true" class="org.scalastyle.scalariform.PackageNamesChecker" level="warning">
   <parameters>
-   <parameter name="regex">^[a-z]*$</parameter>
+   <parameter name="regex">^[a-z0-9]*$</parameter>
   </parameters>
  </check>
 


### PR DESCRIPTION
... also sync configuration to `scalastyle-test-config.xml`

In recent development I've noticed that `scalastyle`'s analysis is rather simple (it only does lexical analysis), which leads to it not being able to distinguish between different semantics of a token, which in turn generates a lot of false-positive warnings:
```scala
val a = b + c // we want spaces around "add"
def +(that: UInt) = ... // we don't want space after "overload definition"

val d = e * f // we want spaces around "multiply"
def example(args: Int*) // we don't want spaces around "varargs"

if (cond) { // we want space or newline after left braces
  ...
} // and space or newline before right braces
println(s"${something}") // but not in this case
```

On the other hand, `scalafmt` can handle those cases very well and automatically add missing or remove extra spaces. Therefore I'd suggest turning off the related check in `scalastyle` and handing them over to `scalafmt`.