### PR TITLE
fix(StoreQueue): fix misalign's Databuffer enq logic

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -1130,35 +1130,22 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     // Vector instructions that prevent triggered exceptions from being written to the 'databuffer'.
     val vecHasExceptionFlagValid = vecExceptionFlag.valid && isVec(ptr) && vecExceptionFlag.bits.robIdx === uop(ptr).robIdx
 
+    val misalignToDataBufferValid = allocated(rdataPtrExt(0).value) && committed(rdataPtrExt(0).value) &&
+                                    (!isVec(rdataPtrExt(0).value) && allvalid(rdataPtrExt(0).value) || vecMbCommit(rdataPtrExt(0).value)) &&
+                                    canDeqMisaligned && (!isCross4KPage || isCross4KPageCanDeq || hasException(rdataPtrExt(0).value))
     // Only the first interface can write unaligned directives.
     // Simplified design, even if the two ports have exceptions, but still only one unaligned dequeue.
     val assert_flag = WireInit(false.B)
     when(firstWithMisalign && firstWithCross16Byte) {
-      dataBuffer.io.enq(0).valid := canDeqMisaligned && allocated(rdataPtrExt(0).value) && committed(rdataPtrExt(0).value) &&
-        ((!isVec(rdataPtrExt(0).value) && allvalid(rdataPtrExt(0).value) || vecMbCommit(rdataPtrExt(0).value)) &&
-        (!isCross4KPage || isCross4KPageCanDeq) || hasException(rdataPtrExt(0).value)) && !ncStall
-
-      dataBuffer.io.enq(1).valid := canDeqMisaligned && allocated(rdataPtrExt(0).value) && committed(rdataPtrExt(0).value) &&
-        (!isVec(rdataPtrExt(0).value) && allvalid(rdataPtrExt(0).value) || vecMbCommit(rdataPtrExt(0).value)) &&
-        (!isCross4KPage || isCross4KPageCanDeq) && !hasException(rdataPtrExt(0).value) && !ncStall
+      dataBuffer.io.enq(i).valid := misalignToDataBufferValid
       assert_flag := dataBuffer.io.enq(1).valid
     }.otherwise {
-      if (i == 0) {
-        dataBuffer.io.enq(i).valid := (
-          allocated(ptr) && committed(ptr)
-            && ((!isVec(ptr) && (allvalid(ptr) || hasException(ptr))) || vecMbCommit(ptr))
-            && !mmioStall && !ncStall
-            && (!unaligned(ptr) || !cross16Byte(ptr) && (allvalid(ptr) || hasException(ptr)))
-          )
-      }
-      else {
-        dataBuffer.io.enq(i).valid := (
-          allocated(ptr) && committed(ptr)
-            && ((!isVec(ptr) && (allvalid(ptr) || hasException(ptr))) || vecMbCommit(ptr))
-            && !mmioStall && !ncStall
-            && (!unaligned(ptr) || !cross16Byte(ptr) && (allvalid(ptr) || hasException(ptr)))
-          )
-      }
+      dataBuffer.io.enq(i).valid := (
+        allocated(ptr) && committed(ptr)
+          && ((!isVec(ptr) && (allvalid(ptr) || hasException(ptr))) || vecMbCommit(ptr))
+          && !mmioStall && !ncStall
+          && (!unaligned(ptr) || !cross16Byte(ptr) && (allvalid(ptr) || hasException(ptr)))
+        )
     }
 
     val misalignAddrLow = vaddrModule.io.rdata(0)(2, 0)


### PR DESCRIPTION

**Please wait for the results of the verification feedback.**

---

Adjusted a problem caused by expanding loops within for loops.

The expected condition for `ncstall` is:
` val ncStall = if(i == 0) nc(rdataPtrExt(0).value) else (nc(rdataPtrExt(i).value) || nc(rdataPtrExt(i-1).value)) `.

Since expanding the assignment in the loop: 
```
      dataBuffer.io.enq(0).valid := canDeqMisaligned && allocated(rdataPtrExt(0).value) && committed(rdataPtrExt(0).value) &&
        ((!isVec(rdataPtrExt(0).value) && allvalid(rdataPtrExt(0).value) || vecMbCommit(rdataPtrExt(0).value)) &&
        (!isCross4KPage || isCross4KPageCanDeq) || hasException(rdataPtrExt(0).value)) && !ncStall

      dataBuffer.io.enq(1).valid := canDeqMisaligned && allocated(rdataPtrExt(0).value) && committed(rdataPtrExt(0).value) &&
        (!isVec(rdataPtrExt(0).value) && allvalid(rdataPtrExt(0).value) || vecMbCommit(rdataPtrExt(0).value)) &&
        (!isCross4KPage || isCross4KPageCanDeq) && !hasException(rdataPtrExt(0).value) && !ncStall
```
This causes ncstall to always use the result of the last loop: 
`(nc(rdataPtrExt(i).value) || nc(rdataPtrExt(i-1).value))`.
which can lead to jams, and `!ncstall` is now no longer needed for the `enq.valid` condition for misaligned accesses. 
for misaligned accesses to `nc space`, because misaligned accesses to `nc space` are supposed to throw an exception.

---

Some `enq.valid` conditions for `DataBuffer` have been briefly organised.