### PR TITLE
fix(StoreUnit): cbo violation check should check cacheline

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -114,7 +114,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s0_rob_idx      = Mux(s0_use_non_prf_flow, s0_uop.robIdx, 0.U.asTypeOf(s0_uop.robIdx))
   val s0_pc           = Mux(s0_use_non_prf_flow, s0_uop.pc, 0.U)
   val s0_instr_type   = Mux(s0_use_non_prf_flow, STORE_SOURCE.U, DCACHE_PREFETCH_SOURCE.U)
-  val s0_wlineflag    = Mux(s0_use_flow_rs, s0_uop.fuOpType === LSUOpType.cbo_zero, false.B)
+  val s0_wlineflag    = Mux(s0_use_flow_rs, LSUOpType.isCboAll(s0_uop.fuOpType), false.B)
   val s0_out          = Wire(new LsPipelineBundle)
   val s0_kill         = s0_uop.robIdx.needFlush(io.redirect)
   val s0_can_go       = s1_ready


### PR DESCRIPTION
The cbo instruction should check for violations at the granularity of cacheline.

Theoretically modifying the condition of this variable would allow checking at cacheline granularity in RAW and should not introduce any other side effects.

See:
https://github.com/OpenXiangShan/XiangShan/blob/57a8ca5e38b9245f78623b83e7b009df606585fb/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala#L293