### PR TITLE
fix(VLSU): modifying vector misalign elemidx generation

### DIFF
--- a/src/main/scala/xiangshan/mem/vector/VecCommon.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecCommon.scala
@@ -610,7 +610,7 @@ object GenElemIdx extends VLSUConstants {
       eewUopFlowsLog2
     )
     LookupTree(uopFlowsLog2, List(
-      0.U -> uopIdx,
+      0.U -> uopIdx ## flowIdx(0), // for hardware misalign
       1.U -> uopIdx ## flowIdx(0),
       2.U -> uopIdx ## flowIdx(1, 0),
       3.U -> uopIdx ## flowIdx(2, 0),


### PR DESCRIPTION

For "unit-stride access with element granularity misaligned and emul<0", it could be the case that: 
has only once valid elements, but splits into two flows(misaligned), which would result in the `elemidx` being the same, making it impossible for the exception handling logic in the `mergebuffer` to recognise the correct order.

Instead of adding a new variable, we have chosen to reuse `elemidx` as a marker.
But this does pollute the original semantics of `elemidx`.


