### PR TITLE
feat(utils): add Duplicate

### DIFF
--- a/src/main/scala/utils/Duplicate.scala
+++ b/src/main/scala/utils/Duplicate.scala
@@ -1,0 +1,228 @@
+// Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package utils
+
+import chisel3._
+
+/** Utility class to create a duplicated signal. Used to control fan-out.
+ *
+ * @example {{{
+ * class GCD extends Module {
+ *   val io = IO(new Bundle {
+ *     val value1        = Input(UInt(16.W))
+ *     val value2        = Input(UInt(16.W))
+ *     val loadingValues = Input(Bool())
+ *     val outputGCD     = Output(Duplicate(2, UInt(16.W)))
+ *     val outputValid   = Output(Bool())
+ *   })
+ *
+ *   // create a duplicated register, 1 duplicate for inner logic, 2 duplicates for output
+ *   val x  = Reg(Duplicate(Map("inner" -> 1, "output" -> 2), UInt(16.W)))
+ *   val y  = Reg(UInt())
+ *
+ *   when(x.head > y) {
+ *     x := x.head - y // use overloaded `:=` to broadcast result to all duplicates
+ *   }.otherwise {
+ *     y := y - x.head
+ *   }
+ *   // here, x.head is equivalent to:
+ *   // - x(0)
+ *   // - x.get("inner_0")
+ *
+ *   when(io.loadingValues) {
+ *     x := io.value1
+ *     y := io.value2
+ *   }
+ *
+ *   io.outputGCD := x.group("output")
+ *   // here, x.group("output") is equivalent to:
+ *   // - x(1, 2)
+ *   // - x.get("output_0", "output_1")
+ *   // - x.tail
+ *   io.outputValid := y === 0.U
+ * }
+ * /** verilog
+ *  * module GCD(
+ *  *   input         clock,
+ *  *                 reset,
+ *  *   input  [15:0] io_value1,
+ *  *                 io_value2,
+ *  *   input         io_loadingValues,
+ *  *   output [15:0] io_outputGCD_dup_0,
+ *  *                 io_outputGCD_dup_1,
+ *  *   output        io_outputValid
+ *  * );
+ *  *
+ *  *   reg [15:0] x_dup_0;
+ *  *   reg [15:0] x_dup_1;
+ *  *   reg [15:0] x_dup_2;
+ *  *   reg [15:0] y;
+ *  *   always @(posedge clock) begin
+ *  *     if (io_loadingValues) begin
+ *  *       x_dup_0 <= io_value1;
+ *  *       x_dup_1 <= io_value1;
+ *  *       x_dup_2 <= io_value1;
+ *  *       y <= io_value2;
+ *  *     end
+ *  *     else if (x_dup_0 > y) begin
+ *  *       automatic logic [15:0] _GEN = x_dup_0 - y;
+ *  *       x_dup_0 <= _GEN;
+ *  *       x_dup_1 <= _GEN;
+ *  *       x_dup_2 <= _GEN;
+ *  *     end
+ *  *     else
+ *  *       y <= y - x_dup_0;
+ *  *   end // always @(posedge)
+ *  *   assign io_outputGCD_dup_0 = x_dup_1;
+ *  *   assign io_outputGCD_dup_1 = x_dup_2;
+ *  *   assign io_outputValid = y == 16'h0;
+ *  * endmodule
+ *  */
+ * }}}
+ */
+class Duplicate[T <: Data](
+    names: Seq[String],
+    gen:   T
+) extends Bundle {
+  private val n = names.length
+  require(n > 0, "Duplicate should not be empty")
+
+  val dup: Vec[T] = Vec(n, gen)
+
+  private var next: Int = 0
+
+  def apply(index: Int): T = this.dup(index)
+
+  def apply(indexes: Int*): Duplicate[T] = {
+    val dups  = indexes.map(i => this.dup(i))
+    val names = indexes.map(i => this.names(i))
+    DuplicateInit(names, dups)
+  }
+
+  def get(name: String): T = {
+    val index = this.names.indexOf(name)
+    require(index >= 0, s"Name $name not found in names: ${this.names.mkString(", ")}")
+    apply(index)
+  }
+
+  def get(names: String*): Duplicate[T] = {
+    val dups = names.map(get) // call get(name: String)
+    DuplicateInit(names, dups)
+  }
+
+  def getNext: T = {
+    val ret = dup(next)
+    next = (next + 1) % n
+    ret
+  }
+
+  def group(name: String): Duplicate[T] = {
+    val selected = (this.dup zip this.names).map { case (d, n) =>
+      if (n.startsWith(name)) (d, n) else null
+    }.filter(_ != null)
+    val dups  = selected.map(_._1)
+    val names = selected.map(_._2)
+    require(names.nonEmpty, s"Group $name not found in names: ${this.names.mkString(", ")}")
+    DuplicateInit(names, dups)
+  }
+
+  def head: T = dup.head
+
+  def tail: Duplicate[T] = DuplicateInit(names.tail, this.dup.tail)
+
+  def init: Duplicate[T] = DuplicateInit(names.init, this.dup.init)
+
+  def last: T = dup.last
+
+  def :=(source: T): Unit = dup.foreach(_ := source)
+}
+
+object Duplicate {
+  def apply[T <: Data](
+      n:    Int,
+      data: T
+  ): Duplicate[T] = {
+    val names = (0 until n).map(i => s"dup$i")
+    new Duplicate[T](names, data)
+  }
+
+  def apply[T <: Data](
+      names: Seq[String],
+      data:  T
+  ): Duplicate[T] =
+    new Duplicate[T](names, data)
+
+  def apply[T <: Data](
+      groups: Map[String, Int],
+      data:   T
+  ): Duplicate[T] = {
+    val names = groups.keys.flatMap { name =>
+      val n = groups(name)
+      (0 until n).map(i => s"${name}_${i}")
+    }.toSeq
+    new Duplicate[T](names, data)
+  }
+}
+
+object DuplicateInit {
+  def apply[T <: Data](
+      n:    Int,
+      data: T
+  ): Duplicate[T] = {
+    val dup = Wire(Duplicate[T](n, data.cloneType))
+    dup := data
+    dup
+  }
+
+  def apply[T <: Data](
+      names: Seq[String],
+      data:  T
+  ): Duplicate[T] = {
+    val dup = Wire(Duplicate[T](names, data.cloneType))
+    dup := data
+    dup
+  }
+
+  def apply[T <: Data](
+      groups: Map[String, Int],
+      data:   T
+  ): Duplicate[T] = {
+    val dup = Wire(Duplicate[T](groups, data.cloneType))
+    dup := data
+    dup
+  }
+
+  def apply[T <: Data](
+      datas: Seq[T]
+  ): Duplicate[T] = {
+    val dup = Wire(Duplicate[T](datas.length, datas.head.cloneType))
+    (dup.dup zip datas).foreach { case (dup, source) =>
+      dup := source
+    }
+    dup
+  }
+
+  def apply[T <: Data](
+      names: Seq[String],
+      datas: Seq[T]
+  ): Duplicate[T] = {
+    require(names.length == datas.length, "names and datas should have the same length")
+    val dup = Wire(Duplicate[T](names, datas.head.cloneType))
+    (dup.dup zip datas).foreach { case (dup, source) =>
+      dup := source
+    }
+    dup
+  }
+}

--- a/src/main/scala/utils/Duplicate.scala
+++ b/src/main/scala/utils/Duplicate.scala
@@ -199,7 +199,7 @@ object DuplicateInit {
       n:    Int,
       data: T
   ): Duplicate[T] = {
-    val dup = Wire(Duplicate[T](n, data.cloneType))
+    val dup = Wire(Duplicate[T](n, chiselTypeOf(data)))
     dup := data
     dup
   }
@@ -208,7 +208,7 @@ object DuplicateInit {
       names: Seq[String],
       data:  T
   ): Duplicate[T] = {
-    val dup = Wire(Duplicate[T](names, data.cloneType))
+    val dup = Wire(Duplicate[T](names, chiselTypeOf(data)))
     dup := data
     dup
   }
@@ -217,7 +217,7 @@ object DuplicateInit {
       groups: Map[String, Int],
       data:   T
   ): Duplicate[T] = {
-    val dup = Wire(Duplicate[T](groups, data.cloneType))
+    val dup = Wire(Duplicate[T](groups, chiselTypeOf(data)))
     dup := data
     dup
   }
@@ -225,7 +225,7 @@ object DuplicateInit {
   def apply[T <: Data](
       datas: Seq[T]
   ): Duplicate[T] = {
-    val dup = Wire(Duplicate[T](datas.length, datas.head.cloneType))
+    val dup = Wire(Duplicate[T](datas.length, chiselTypeOf(datas.head)))
     (dup.dup zip datas).foreach { case (dup, source) =>
       dup := source
     }
@@ -237,7 +237,7 @@ object DuplicateInit {
       datas: Seq[T]
   ): Duplicate[T] = {
     require(names.length == datas.length, "Duplicate names and datas should have the same length")
-    val dup = Wire(Duplicate[T](names, datas.head.cloneType))
+    val dup = Wire(Duplicate[T](names, chiselTypeOf(datas.head)))
     (dup.dup zip datas).foreach { case (dup, source) =>
       dup := source
     }

--- a/src/main/scala/utils/Duplicate.scala
+++ b/src/main/scala/utils/Duplicate.scala
@@ -130,7 +130,14 @@ class Duplicate[T <: Data](
 
   def group(name: String): Duplicate[T] = {
     val selected = (this.dup zip this.names).map { case (d, n) =>
-      if (n.startsWith(name)) (d, n) else null
+      val uScoreIdx = n.lastIndexOf("_")
+      if (
+        uScoreIdx < 0 && n == name ||                       // no underscore, do full match
+        uScoreIdx >= 0 && n.substring(0, uScoreIdx) == name // substring before last underscore matches
+      )
+        (d, n)
+      else
+        null
     }.filter(_ != null)
     val dups  = selected.map(_._1)
     val names = selected.map(_._2)

--- a/src/main/scala/utils/Duplicate.scala
+++ b/src/main/scala/utils/Duplicate.scala
@@ -107,8 +107,8 @@ class Duplicate[T <: Data](
 
   sealed trait IndexType[A]
   object IndexType {
-    implicit def intIndex:    IndexType[Int]    = new IndexType[Int] {}
-    implicit def stringIndex: IndexType[String] = new IndexType[String] {}
+    implicit val intIndex:    IndexType[Int]    = new IndexType[Int] {}
+    implicit val stringIndex: IndexType[String] = new IndexType[String] {}
   }
 
   def apply[A: IndexType](index: A): T = index match {

--- a/src/main/scala/utils/Duplicate.scala
+++ b/src/main/scala/utils/Duplicate.scala
@@ -140,16 +140,11 @@ class Duplicate[T <: Data](
   }
 
   def group(name: String): Duplicate[T] = {
-    val selected = (this.dup zip this.names).map { case (d, n) =>
+    val selected = (this.dup zip this.names).filter { case (d, n) =>
       val uScoreIdx = n.lastIndexOf("_")
-      if (
-        uScoreIdx < 0 && n == name ||                       // no underscore, do full match
-        uScoreIdx >= 0 && n.substring(0, uScoreIdx) == name // substring before last underscore matches
-      )
-        (d, n)
-      else
-        null
-    }.filter(_ != null)
+      uScoreIdx < 0 && n == name ||                       // no underscore, do full match
+      uScoreIdx >= 0 && n.substring(0, uScoreIdx) == name // substring before last underscore matches
+    }
     val dups  = selected.map(_._1)
     val names = selected.map(_._2)
     require(names.nonEmpty, s"Duplicate group $name not found in names: ${this.names.mkString(", ")}")


### PR DESCRIPTION
We sometimes manually duplicate some signals to control fanout, like:
```scala
val io = IO(new Bundle{
  val toModuleA = UInt(width.W)
  val toModuleB = Vec(2, UInt(width.W))
  val toModuleC = UInt(width.W)
}

val source = Wire(UInt(width.W))
val xxxDup = Vec(4, UInt(width.W))

xxxDup.foreach(x => x := source)

io.toModuleA.xxx := xxxDup.head
io.toModuleB.xxxDup := VecInit(xxxDup.slice(1, 2))
io.toModuleC.xxx := xxxDup.last
```

This can be confusing sometimes, in BPU for example:
https://github.com/OpenXiangShan/XiangShan/blob/6bd705ec99d7e5781230da449bc54f333b6fcddc/src/main/scala/xiangshan/frontend/BPU.scala#L155-L161
https://github.com/OpenXiangShan/XiangShan/blob/6bd705ec99d7e5781230da449bc54f333b6fcddc/src/main/scala/xiangshan/frontend/ITTAGE.scala#L444-L446

Just, why there is a `(3)` after `io.sx_fire`???

This util class encapsulates some common usage, making it more readable, result:
```scala
val io = IO(new Bundle{
  val toModuleA = UInt(width.W)
  val toModuleB = Duplicate(2, UInt(width.W))
  val toModuleC = UInt(width.W)
}

val source = Wire(UInt(width.W))

// 1. we can use Duplicate like Vec, but in this case we're not able to use xxxDup(name) or xxxDup.group(groupName)
val xxxDup = Duplicate(4, UInt(width.W))

// 2. or, we can name each dup, so we can use xxxDup(name), we can also use xxxDup.group(groupName)
val xxxDup = Duplicate(
  Seq("toModuleA", "toModuleB_0", "toModuleB_1", "toModuleC"),
  UInt(width.W)
)

// 3. or, we can name groups and set duplicate number in each group, so we can use xxxDup(groupName_i), we can also use xxxDup.group(groupname)
val xxxDup = Duplicate(Map(
    "toModuleA" -> 1,
    "toModuleB" -> 2,
    "toModuleC" -> 1,
  ),
  UInt(width.W)
)

xxxDup := source  // this is xxxDup.dup.foreach(x => x:= source)

// 4. also, we can use DuplicateInit to simplify initial wiring
val xxxDup = DuplicateInit(4, source)

// assuming we're using definition 3. above, the wiring can be:
io.toModuleA.xxx := xxxDup.head // or xxxDup("toModuleA_0") or xxxDup(0)
io.toModuleB.xxxDup := xxxDup.group("toModuleB") // or xxxDup("toModuleB_0", "toModuleB_1") or xxxDup(1, 2)
io.toModuleC.xxx := xxxDup.last // or xxxDup("toModuleC_0") or xxxDup(3)
```

Also, the generated verilog will be more readable (if we do not name xxxDup in chisel, like the BPU example above):
```verilog
// val s3_fire = Vec(4, Bool())
wire s3_fire_0;
...
// val s3_fire = Duplicate(4, Bool())
wire s3_fire_dup_0;
...
```