### PR TITLE
fix(AXI4Memory): fix write request enqueue DRAMSim logic for AXI4Memory

### DIFF
--- a/src/main/scala/device/AXI4Memory.scala
+++ b/src/main/scala/device/AXI4Memory.scala
@@ -177,10 +177,18 @@ class AXI4MemoryImp[T <: Data](outer: AXI4Memory) extends AXI4SlaveModuleImp(out
   val pending_write_req_data  = RegEnable(in.w.bits, in.w.fire)
   val pending_write_req_ready = Wire(Bool())
   val pending_write_need_req = pending_write_req_valid.last && !pending_write_req_ready
-  val write_req_valid = pending_write_req_valid.head && (pending_write_need_req || in.w.valid && in.w.bits.last)
-  pending_write_req_ready := writeRequest(write_req_valid, pending_write_req_bits.addr, pending_write_req_bits.id)
+  val aw_and_w_last_arrive_at_same_time = in.aw.fire && in.w.fire && in.w.bits.last
+  val w_last_arrive_before_aw = in.aw.fire && pending_write_need_req
+  val aw_arrive_before_w_last = pending_write_req_valid.head && in.w.fire && in.w.bits.last
+  val aw_arrive_before_w = pending_write_req_valid.head && pending_write_need_req
+  val write_req_enq_pending = aw_arrive_before_w || aw_arrive_before_w_last
+  val write_req_enq_no_pending = aw_and_w_last_arrive_at_same_time || w_last_arrive_before_aw
+  val write_req_valid = write_req_enq_pending || write_req_enq_no_pending
+  val write_req_addr = Mux(write_req_enq_pending, pending_write_req_bits.addr, in.aw.bits.addr)
+  val write_req_id = Mux(write_req_enq_pending, pending_write_req_bits.id, in.aw.bits.id)
+  pending_write_req_ready := writeRequest(write_req_valid, write_req_addr, write_req_id)
 
-  when (in.aw.fire) {
+  when (in.aw.fire && !write_req_enq_no_pending) {
     pending_write_req_valid.head := true.B
   }.elsewhen (pending_write_req_ready) {
     pending_write_req_valid.head := false.B

--- a/src/main/scala/device/AXI4Memory.scala
+++ b/src/main/scala/device/AXI4Memory.scala
@@ -184,9 +184,9 @@ class AXI4MemoryImp[T <: Data](outer: AXI4Memory) extends AXI4SlaveModuleImp(out
   val write_req_enq_pending = aw_arrive_before_w || aw_arrive_before_w_last
   val write_req_enq_no_pending = aw_and_w_last_arrive_at_same_time || w_last_arrive_before_aw
   val write_req_valid = write_req_enq_pending || write_req_enq_no_pending
-  val write_req_addr = Mux(write_req_enq_pending, pending_write_req_bits.addr, in.aw.bits.addr)
-  val write_req_id = Mux(write_req_enq_pending, pending_write_req_bits.id, in.aw.bits.id)
-  pending_write_req_ready := writeRequest(write_req_valid, write_req_addr, write_req_id)
+  val write_req_enq_addr = Mux(write_req_enq_pending, pending_write_req_bits.addr, in.aw.bits.addr)
+  val write_req_enq_id = Mux(write_req_enq_pending, pending_write_req_bits.id, in.aw.bits.id)
+  pending_write_req_ready := writeRequest(write_req_valid, write_req_enq_addr, write_req_enq_id)
 
   when (in.aw.fire && !write_req_enq_no_pending) {
     pending_write_req_valid.head := true.B


### PR DESCRIPTION
![axi4mem](https://github.com/user-attachments/assets/31700f73-253d-4383-9569-d4bca52bbfd4)

Bug descriptions:
* At `t0`, `w0 with lenght = 1` arrive,
* At `t1`, `w` buffer's `valid=1`, then `aw0 with id = 0` arrive
* At `t2`, `aw` buffer's `valid = 1, id = 0`, then write to WriteRequestQueue with `id = 0`
* At `t3`, `aw1 with id = 1` and `w1 with length=1` arrive at same time, then write to WriteRequestQueue with `id = 0`. In other words, the ID is used incorrectly.

How to fix:
* When writing, determine whether it can be written immediately. If it is written immediately, use the ID of the current, otherwise use the pending ID.
