### PR TITLE
fix(DCache): fix DCache replacement when replace a `BtoT` ways

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -394,7 +394,7 @@ class DCacheLineReq(implicit p: Parameters) extends DCacheBundle
   val data   = UInt((cfg.blockBytes * 8).W)
   val mask   = UInt(cfg.blockBytes.W)
   val id     = UInt(reqIdWidth.W)
-  val grow_perm_fail = Bool()
+  val miss_fail_cause_evict_btot = Bool()
   def dump(cond: Bool) = {
     XSDebug(cond, "DCacheLineReq: cmd: %x addr: %x data: %x mask: %x id: %d\n",
       cmd, addr, data, mask, id)
@@ -485,7 +485,6 @@ class DCacheLineResp(implicit p: Parameters) extends DCacheBundle
   // cache req nacked, replay it later
   val replay = Bool()
   val id     = UInt(reqIdWidth.W)
-  val grow_perm_fail = Bool()
   def dump(cond: Bool) = {
     XSDebug(cond, "DCacheLineResp: data: %x id: %d miss: %b replay: %b\n",
       data, id, miss, replay)
@@ -591,7 +590,6 @@ class MainPipeResp(implicit p: Parameters) extends DCacheBundle {
   val ack_miss_queue = Bool()
 
   val id     = UInt(reqIdWidth.W)
-  val grow_perm_fail = Bool()
 
   def isAMO: Bool = source === AMO_SOURCE.U
   def isStore: Bool = source === STORE_SOURCE.U

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1519,8 +1519,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   bus.e <> missQueue.io.mem_finish
   missQueue.io.probe_addr := bus.b.bits.address
   missQueue.io.replace_addr := mainPipe.io.replace_addr
-  missQueue.io.grow_perm_addr := mainPipe.io.grow_perm_addr
-  missQueue.io.BtoT_ways_for_set <> mainPipe.io.BtoT_ways_for_set
+  missQueue.io.evict_set := mainPipe.io.evict_set
+  missQueue.io.btot_ways_for_set <> mainPipe.io.btot_ways_for_set
 
   missQueue.io.main_pipe_resp.valid := RegNext(mainPipe.io.atomic_resp.valid)
   missQueue.io.main_pipe_resp.bits := RegEnable(mainPipe.io.atomic_resp.bits, mainPipe.io.atomic_resp.valid)

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -394,7 +394,6 @@ class DCacheLineReq(implicit p: Parameters) extends DCacheBundle
   val data   = UInt((cfg.blockBytes * 8).W)
   val mask   = UInt(cfg.blockBytes.W)
   val id     = UInt(reqIdWidth.W)
-  val miss_fail_cause_evict_btot = Bool()
   def dump(cond: Bool) = {
     XSDebug(cond, "DCacheLineReq: cmd: %x addr: %x data: %x mask: %x id: %d\n",
       cmd, addr, data, mask, id)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -112,7 +112,7 @@ class MainPipeInfoToMQ(implicit p:Parameters) extends DCacheBundle {
   val s2_miss_id = UInt(log2Up(cfg.nMissEntries).W) // For refill data selection
   val s2_replay_to_mq = Bool()
   val s2_evict_BtoT_way = Bool()
-  val s2_next_evict_way = Bool()
+  val s2_next_evict_way = UInt(nWays.W)
   val s3_valid = Bool()
   val s3_miss_id = UInt(log2Up(cfg.nMissEntries).W) // For mshr release
   val s3_refill_resp = Bool()

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -387,11 +387,9 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s1_need_replacement = s1_req.miss && !s1_tag_match
   val s1_need_eviction = s1_req.miss && !s1_tag_match && s1_repl_coh.state =/= ClientStates.Nothing
 
-  val s1_way_en = Mux(
-    RegEnable(io.pseudo_error.valid, false.B, s0_fire),
-    Mux(ParallelORR(s1_real_tag_match_way), s1_real_tag_match_way, s1_repl_way_en),
-    Mux(s1_need_replacement, s1_repl_way_en, s1_real_tag_match_way)
-  )
+  val s1_no_error_way_en = Mux(s1_need_replacement, s1_repl_way_en, s1_real_tag_match_way)
+  val s1_error_way_en = Mux(ParallelORR(s1_real_tag_match_way), s1_real_tag_match_way, s1_repl_way_en)
+  val s1_way_en = Mux(io.pseudo_error.valid, s1_error_way_en, s1_no_error_way_en)
   assert(!RegNext(s1_fire && PopCount(s1_way_en) > 1.U))
 
   val s1_tag = s1_hit_tag

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -1021,7 +1021,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.mainpipe_info.s3_valid := s3_valid
   io.mainpipe_info.s3_miss_id := s3_req.miss_id
   io.mainpipe_info.s3_refill_resp := RegNext(s2_valid && s2_req.miss && s2_fire_to_s3)
-  XSError(s2_way_en.andR, "s2_way_en should not be all 1")
+  XSError(s3_valid && s2_way_en.andR, "s2_way_en should not be all 1")
 
   // report error to beu and csr, 1 cycle after read data resp
   io.error := 0.U.asTypeOf(ValidIO(new L1CacheErrorInfo))

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -441,8 +441,10 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
 
   val s2_hit = s2_tag_match && s2_has_permission
   val s2_sc = s2_req.cmd === M_XSC
+  val s2_lr = s2_req.cmd === M_XLR
   val s2_amo_hit = s2_hit && !s2_req.probe && !s2_req.miss && s2_req.isAMO
   val s2_store_hit = s2_hit && !s2_req.probe && !s2_req.miss && s2_req.isStore
+  val s2_should_not_report_ecc_error = !s2_req.miss && (s2_req.isAMO && !s2_lr || s2_req.isStore)
 
   if(EnableTagEcc) {
     s2_tag_error := s2_tag_errors.orR && s2_need_tag
@@ -1009,7 +1011,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     s.s1.bits.way_en := s1_way_en
     s.s2.valid := s2_valid && !RegEnable(s1_req.replace, s1_fire)
     s.s2.bits.set := RegEnable(get_idx(s1_req.vaddr), s1_fire)
-    s.s2.bits.way_en := RegEnable(s1_way_en, s1_fire)
+    s.s2.bits.way_en := s2_way_en
     s.s3.valid := s3_valid && !RegEnable(s2_req.replace, s2_fire_to_s3)
     s.s3.bits.set := RegEnable(get_idx(s2_req.vaddr), s2_fire_to_s3)
     s.s3.bits.way_en := RegEnable(s2_way_en, s2_fire_to_s3)
@@ -1027,7 +1029,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   // report error to beu and csr, 1 cycle after read data resp
   io.error := 0.U.asTypeOf(ValidIO(new L1CacheErrorInfo))
   // report error, update error csr
-  io.error.valid := s3_error && GatedValidRegNext(s2_fire && !(s2_req.isAMO || s2_req.isStore))
+  io.error.valid := s3_error && GatedValidRegNext(s2_fire && !s2_should_not_report_ecc_error)
   // only tag_error and data_error will be reported to beu
   // l2_error should not be reported (l2 will report that)
   io.error.bits.report_to_beu := (s3_tag_error || s3_data_error) && RegNext(s2_fire)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -449,7 +449,6 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
 
   // Grow permission fail
   // Only in case BtoT will both cache and missqueue be occupied
-  val s2_evict_BtoT_way = (io.btot_ways_for_set & s2_way_en).orR
   val s2_has_more_then_3_ways_BtoT = PopCount(io.btot_ways_for_set) > (nWays-2).U
   val s2_grow_perm_fail = s2_has_more_then_3_ways_BtoT && s2_grow_perm
   XSError(s2_valid && s2_grow_perm && io.btot_ways_for_set.andR,

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -1021,7 +1021,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.mainpipe_info.s3_valid := s3_valid
   io.mainpipe_info.s3_miss_id := s3_req.miss_id
   io.mainpipe_info.s3_refill_resp := RegNext(s2_valid && s2_req.miss && s2_fire_to_s3)
-  XSError(s3_valid && s2_way_en.andR, "s2_way_en should not be all 1")
+  XSError(s2_valid && s2_way_en.andR, "s2_way_en should not be all 1")
 
   // report error to beu and csr, 1 cycle after read data resp
   io.error := 0.U.asTypeOf(ValidIO(new L1CacheErrorInfo))

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -97,7 +97,7 @@ class MainPipeReq(implicit p: Parameters) extends DCacheBundle {
     req.replace := false.B
     req.error := false.B
     req.id := store.id
-    req.miss_fail_cause_evict_btot := store.miss_fail_cause_evict_btot
+    req.miss_fail_cause_evict_btot := false.B
     req
   }
 }
@@ -420,7 +420,6 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s2_need_data = RegEnable(s1_need_data, s1_fire)
   val s2_need_tag = RegEnable(s1_need_tag, s1_fire)
   val s2_idx = get_idx(s2_req.vaddr)
-
 
   val s2_way_en = RegEnable(s1_way_en, s1_fire)
   val s2_tag = Mux(s2_need_replacement, s2_repl_tag, RegEnable(s1_tag, s1_fire))

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -74,7 +74,7 @@ class MissReqWoStoreData(implicit p: Parameters) extends DCacheBundle {
   /**
     * The way isBtoT requests to occupy
     */
-  val occupy_way = UInt(log2Up(nWays).W)
+  val occupy_way = UInt(nWays.W)
 
   // For now, miss queue entry req is actually valid when req.valid && !cancel
   // * req.valid is fast to generate

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1200,8 +1200,9 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.replace_block := io.replace_addr.valid && Cat(entries.map(e => e.io.req_addr.valid && e.io.req_addr.bits === io.replace_addr.bits) ++ Seq(miss_req_pipe_reg.block_match(io.replace_addr.bits))).orR
   val btot_evict_set_hit = entries.map(e => e.io.req_isBtoT && e.io.req_vaddr.valid && addr_to_dcache_set(e.io.req_vaddr.bits) === io.evict_set) ++
     Seq(miss_req_pipe_reg.evict_set_match(io.evict_set))
-  io.btot_ways_for_set := btot_evict_set_hit.zip(entries).map {
-    case (hit, e) => Fill(nWays, hit) & e.io.occupy_way
+  val btot_occupy_ways = entries.map(e => e.io.occupy_way) ++ Seq(miss_req_pipe_reg.req.occupy_way)
+  io.btot_ways_for_set := btot_evict_set_hit.zip(btot_occupy_ways).map {
+    case (hit, way) => Fill(nWays, hit) & way
   }.reduce(_|_)
 
   io.full := ~Cat(entries.map(_.io.primary_ready)).andR

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -388,7 +388,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val main_pipe_req = DecoupledIO(new MainPipeReq)
     val main_pipe_resp = Input(Bool())
     val main_pipe_refill_resp = Input(Bool())
-    val main_pipe_replay_to_mq = Input(Bool())
+    val main_pipe_replay = Input(Bool())
     val main_pipe_grow_perm_fail = Input(Bool())
 
     // for main pipe s2
@@ -661,7 +661,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     mainpipe_req_fired := true.B
   }
 
-  when (io.main_pipe_replay_to_mq || io.main_pipe_grow_perm_fail) {
+  when (io.main_pipe_replay || io.main_pipe_grow_perm_fail) {
     s_mainpipe_req := false.B
     grow_perm_fail := io.main_pipe_grow_perm_fail
   }
@@ -862,7 +862,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   XSPerfAccumulate("miss_refill_mainpipe_req", io.main_pipe_req.fire)
   XSPerfAccumulate("miss_refill_without_hint", io.main_pipe_req.fire && !mainpipe_req_fired && !w_l2hint)
-  XSPerfAccumulate("miss_refill_replay", io.main_pipe_replay_to_mq)
+  XSPerfAccumulate("miss_refill_replay", io.main_pipe_replay)
 
   val w_grantfirst_forward_info = Mux(isKeyword, w_grantlast, w_grantfirst)
   val w_grantlast_forward_info = Mux(isKeyword, w_grantfirst, w_grantlast)
@@ -1129,7 +1129,7 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       e.io.acquire_fired_by_pipe_reg := acquire_from_pipereg.fire
 
       e.io.main_pipe_resp := io.main_pipe_resp.valid && io.main_pipe_resp.bits.ack_miss_queue && io.main_pipe_resp.bits.miss_id === i.U
-      e.io.main_pipe_replay_to_mq := io.mainpipe_info.s2_valid && io.mainpipe_info.s2_replay_to_mq && io.mainpipe_info.s2_miss_id === i.U
+      e.io.main_pipe_replay := io.mainpipe_info.s2_valid && io.mainpipe_info.s2_replay_to_mq && io.mainpipe_info.s2_miss_id === i.U
       e.io.main_pipe_grow_perm_fail := io.mainpipe_info.s2_valid && io.mainpipe_info.s2_grow_perm_fail && io.mainpipe_info.s2_miss_id === i.U
       e.io.main_pipe_refill_resp := io.mainpipe_info.s3_valid && io.mainpipe_info.s3_refill_resp && io.mainpipe_info.s3_miss_id === i.U
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -971,7 +971,7 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val replace_block = Output(Bool())
 
     // block all way for set to BtoT
-    val evict_set = Flipped(UInt())
+    val evict_set = Input(UInt())
     val btot_ways_for_set = Output(UInt(nWays.W))
 
     // req blocked by wbq

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -664,13 +664,15 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     mainpipe_req_fired := true.B
   }
 
+  val btot_evict_assert = WireInit(false.B)
   when (io.main_pipe_replay || io.main_pipe_evict_BtoT_way) {
     s_mainpipe_req := false.B
-    when (io.main_pipe_evict_BtoT_way) {
-      req.occupy_way := io.main_pipe_next_evict_way
-      XSError(req.isBtoT, "BtoT request will never evict a way")
-    }
   }
+  when (io.main_pipe_evict_BtoT_way) {
+    req.occupy_way := io.main_pipe_next_evict_way
+    btot_evict_assert := true.B
+  }
+  XSError(btot_evict_assert, "BtoT request will never evict a way")
 
   when (io.main_pipe_resp) {
     w_mainpipe_resp := true.B

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -65,6 +65,17 @@ class MissReqWoStoreData(implicit p: Parameters) extends DCacheBundle {
   val req_coh = new ClientMetadata
   val id = UInt(reqIdWidth.W)
 
+  /**
+    * isBtoT is used to mark whether the current request requires BtoT permission.
+    * If so, other requests for BtoT in the same set are blocked. Otherwise,
+    * they are not blocked.
+    */
+  val isBtoT = Bool()
+  /**
+    * The way isBtoT requests to occupy
+    */
+  val occupy_way = UInt(log2Up(nWays).W)
+
   // For now, miss queue entry req is actually valid when req.valid && !cancel
   // * req.valid is fast to generate
   // * cancel is slow to generate, it will not be used until the last moment
@@ -271,6 +282,10 @@ class MissReqPipeRegBundle(edge: TLEdgeOut)(implicit p: Parameters) extends DCac
   def block_match(release_addr: UInt): Bool = {
     reg_valid() && get_block(req.addr) === get_block(release_addr)
   }
+
+  def grow_perm_set_match(grow_perm_addr: UInt): Bool = {
+    reg_valid() && get_idx(req.addr) === get_idx(grow_perm_addr)
+  }
 }
 
 class CMOUnit(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule {
@@ -373,12 +388,14 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val main_pipe_req = DecoupledIO(new MainPipeReq)
     val main_pipe_resp = Input(Bool())
     val main_pipe_refill_resp = Input(Bool())
-    val main_pipe_replay = Input(Bool())
+    val main_pipe_replay_to_mq = Input(Bool())
+    val main_pipe_grow_perm_fail = Input(Bool())
 
     // for main pipe s2
     val refill_info = ValidIO(new MissQueueRefillInfo)
 
     val block_addr = ValidIO(UInt(PAddrBits.W))
+    val occupy_way = Output(UInt(nWays.W))
 
     val req_addr = ValidIO(UInt(PAddrBits.W))
 
@@ -428,6 +445,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   val req_store_mask = Reg(UInt(cfg.blockBytes.W))
   val req_valid = RegInit(false.B)
   val set = addr_to_dcache_set(req.vaddr)
+  val grow_perm_fail = RegInit(false.B)
   // initial keyword
   val isKeyword = RegInit(false.B)
 
@@ -501,8 +519,11 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     req_valid := true.B
 
     req := miss_req_pipe_reg_bits.toMissReqWoStoreData()
-    req_primary_fire := miss_req_pipe_reg_bits.toMissReqWoStoreData()
+    req.isBtoT := DontCare
+    req.occupy_way := Mux(miss_req_pipe_reg_bits.isBtoT, miss_req_pipe_reg_bits.occupy_way, 0.U)
     req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
+    req_primary_fire := miss_req_pipe_reg_bits.toMissReqWoStoreData()
+    grow_perm_fail := false.B
     //only  load miss need keyword
     isKeyword := Mux(miss_req_pipe_reg_bits.isFromLoad, miss_req_pipe_reg_bits.vaddr(5).asBool,false.B)
 
@@ -553,6 +574,9 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
     when (miss_req_pipe_reg_bits.isFromStore) {
       req := miss_req_pipe_reg_bits
+      req.isBtoT := DontCare
+      req.occupy_way := Mux(miss_req_pipe_reg_bits.isBtoT, miss_req_pipe_reg_bits.occupy_way, 0.U)
+      grow_perm_fail := false.B
       req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
       req_store_mask := miss_req_pipe_reg_bits.store_mask
       for (i <- 0 until blockRows) {
@@ -637,8 +661,9 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     mainpipe_req_fired := true.B
   }
 
-  when (io.main_pipe_replay) {
+  when (io.main_pipe_replay_to_mq || io.main_pipe_grow_perm_fail) {
     s_mainpipe_req := false.B
+    grow_perm_fail := io.main_pipe_grow_perm_fail
   }
 
   when (io.main_pipe_resp) {
@@ -818,12 +843,15 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.main_pipe_req.bits.id := req.id
   io.main_pipe_req.bits.pf_source := req.pf_source
   io.main_pipe_req.bits.access := access
+  io.main_pipe_req.bits.grow_perm_fail := grow_perm_fail
 
   io.block_addr.valid := req_valid && w_grantlast
   io.block_addr.bits := req.addr
 
   io.req_addr.valid := req_valid
   io.req_addr.bits := req.addr
+
+  io.occupy_way := req.occupy_way
 
   io.refill_info.valid := req_valid && w_grantlast
   io.refill_info.bits.store_data := refill_and_store_data.asUInt
@@ -834,7 +862,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   XSPerfAccumulate("miss_refill_mainpipe_req", io.main_pipe_req.fire)
   XSPerfAccumulate("miss_refill_without_hint", io.main_pipe_req.fire && !mainpipe_req_fired && !w_l2hint)
-  XSPerfAccumulate("miss_refill_replay", io.main_pipe_replay)
+  XSPerfAccumulate("miss_refill_replay", io.main_pipe_replay_to_mq)
 
   val w_grantfirst_forward_info = Mux(isKeyword, w_grantlast, w_grantfirst)
   val w_grantlast_forward_info = Mux(isKeyword, w_grantfirst, w_grantlast)
@@ -927,6 +955,10 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     // block replace when release an addr valid in mshr
     val replace_addr = Flipped(ValidIO(UInt(PAddrBits.W)))
     val replace_block = Output(Bool())
+
+    // block all way for set to BtoT
+    val grow_perm_addr = Flipped(UInt(PAddrBits.W))
+    val BtoT_ways_for_set = Output(UInt(nWays.W))
 
     // req blocked by wbq
     val wbq_block_miss_req = Input(Bool())
@@ -1097,7 +1129,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       e.io.acquire_fired_by_pipe_reg := acquire_from_pipereg.fire
 
       e.io.main_pipe_resp := io.main_pipe_resp.valid && io.main_pipe_resp.bits.ack_miss_queue && io.main_pipe_resp.bits.miss_id === i.U
-      e.io.main_pipe_replay := io.mainpipe_info.s2_valid && io.mainpipe_info.s2_replay_to_mq && io.mainpipe_info.s2_miss_id === i.U
+      e.io.main_pipe_replay_to_mq := io.mainpipe_info.s2_valid && io.mainpipe_info.s2_replay_to_mq && io.mainpipe_info.s2_miss_id === i.U
+      e.io.main_pipe_grow_perm_fail := io.mainpipe_info.s2_valid && io.mainpipe_info.s2_grow_perm_fail && io.mainpipe_info.s2_miss_id === i.U
       e.io.main_pipe_refill_resp := io.mainpipe_info.s3_valid && io.mainpipe_info.s3_refill_resp && io.mainpipe_info.s3_miss_id === i.U
 
       e.io.memSetPattenDetected := memSetPattenDetected
@@ -1150,6 +1183,11 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.probe_block := Cat(probe_block_vec).orR
 
   io.replace_block := io.replace_addr.valid && Cat(entries.map(e => e.io.req_addr.valid && e.io.req_addr.bits === io.replace_addr.bits) ++ Seq(miss_req_pipe_reg.block_match(io.replace_addr.bits))).orR
+  val grow_perm_set_hit = entries.map(e => e.io.req_addr.valid && get_idx(e.io.req_addr.bits) === get_idx(io.grow_perm_addr)) ++
+    Seq(miss_req_pipe_reg.grow_perm_set_match(io.grow_perm_addr))
+  io.BtoT_ways_for_set := grow_perm_set_hit.zip(entries).map {
+    case (hit, e) => Fill(nWays, hit) & e.io.occupy_way
+  }.reduce(_|_)
 
   io.full := ~Cat(entries.map(_.io.primary_ready)).andR
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
@@ -105,7 +105,7 @@ class ProbeEntry(implicit p: Parameters) extends DCacheModule {
     pipe_req.probe_need_data := req.needData
     pipe_req.error := false.B
     pipe_req.id := io.id
-    pipe_req.grow_perm_fail := false.B
+    pipe_req.miss_fail_cause_evict_btot := false.B
 
     when (io.pipe_req.fire) {
       state := s_wait_resp

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
@@ -105,6 +105,7 @@ class ProbeEntry(implicit p: Parameters) extends DCacheModule {
     pipe_req.probe_need_data := req.needData
     pipe_req.error := false.B
     pipe_req.id := io.id
+    pipe_req.grow_perm_fail := false.B
 
     when (io.pipe_req.fire) {
       state := s_wait_resp

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -80,7 +80,6 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
   // `pdest2` is used to record the pdest of the second uop
   val pdest1, pdest2 = Reg(UInt(PhyRegIdxWidth.W))
   val pdest1Valid, pdest2Valid = RegInit(false.B)
-  val grow_perm_fail = RegInit(false.B)
   /**
     * The # of std uops that an atomic instruction require:
     * (1) For AMOs (except AMOCAS) and LR/SC, 1 std uop is wanted: X(rs2) with uopIdx = 0
@@ -141,7 +140,6 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
       rs1 := io.in.bits.src_rs1
       state := s_tlb_and_flush_sbuffer_req
       have_sent_first_tlb_req := false.B
-      grow_perm_fail := false.B
     }
   }
 
@@ -360,9 +358,6 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
       when (io.dcache.resp.bits.miss) {
         when (io.dcache.resp.bits.replay) {
           state := s_cache_req
-          grow_perm_fail := true.B
-        } .otherwise {
-          grow_perm_fail := false.B
         }
       }.otherwise {
         dcache_resp_data := io.dcache.resp.bits.data

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -536,6 +536,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
   pipe_req.amo_data := genWdataAMO(rs2, uop.fuOpType)
   pipe_req.amo_mask := genWmaskAMO(paddr, uop.fuOpType)
   pipe_req.amo_cmp  := genWdataAMO(rd, uop.fuOpType)
+  pipe_req.miss_fail_cause_evict_btot := false.B
 
   if (env.EnableDifftest) {
     val difftest = DifftestModule(new DiffAtomicEvent)

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -691,7 +691,7 @@ class Sbuffer(implicit p: Parameters)
   io.dcache.req.bits.data  := data(sbuffer_out_s1_evictionIdx).asUInt
   io.dcache.req.bits.mask  := mask(sbuffer_out_s1_evictionIdx).asUInt
   io.dcache.req.bits.id := sbuffer_out_s1_evictionIdx
-  io.dcache.req.bits.grow_perm_fail := false.B
+  io.dcache.req.bits.miss_fail_cause_evict_btot := false.B
 
   XSDebug(sbuffer_out_s1_fire,
     p"send buf [$sbuffer_out_s1_evictionIdx] to Dcache, req fire\n"

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -220,7 +220,6 @@ class Sbuffer(implicit p: Parameters)
   val stateVec = RegInit(VecInit(Seq.fill(StoreBufferSize)(0.U.asTypeOf(new SbufferEntryState))))
   val cohCount = RegInit(VecInit(Seq.fill(StoreBufferSize)(0.U(EvictCountBits.W))))
   val missqReplayCount = RegInit(VecInit(Seq.fill(StoreBufferSize)(0.U(MissqReplayCountBits.W))))
-  val grow_perm_fail = RegInit(VecInit(Seq.fill(StoreBufferSize)(false.B)))
 
   val sbuffer_out_s0_fire = Wire(Bool())
 
@@ -438,7 +437,6 @@ class Sbuffer(implicit p: Parameters)
         // missqReplayCount(insertIdx) := 0.U
         ptag(entryIdx) := reqptag
         vtag(entryIdx) := reqvtag // update vtag if a new sbuffer line is allocated
-        grow_perm_fail(entryIdx) := false.B
       }
     })
   }
@@ -693,7 +691,7 @@ class Sbuffer(implicit p: Parameters)
   io.dcache.req.bits.data  := data(sbuffer_out_s1_evictionIdx).asUInt
   io.dcache.req.bits.mask  := mask(sbuffer_out_s1_evictionIdx).asUInt
   io.dcache.req.bits.id := sbuffer_out_s1_evictionIdx
-  io.dcache.req.bits.grow_perm_fail := grow_perm_fail(sbuffer_out_s1_evictionIdx)
+  io.dcache.req.bits.grow_perm_fail := false.B
 
   XSDebug(sbuffer_out_s1_fire,
     p"send buf [$sbuffer_out_s1_evictionIdx] to Dcache, req fire\n"
@@ -744,7 +742,6 @@ class Sbuffer(implicit p: Parameters)
   when (io.dcache.replay_resp.fire) {
     missqReplayCount(replay_resp_id) := 0.U
     stateVec(replay_resp_id).w_timeout := true.B
-    grow_perm_fail(replay_resp_id) := io.dcache.replay_resp.bits.grow_perm_fail
     // waiting for timeout
     assert(io.dcache.replay_resp.bits.replay)
     assert(stateVec(replay_resp_id).state_inflight === true.B)

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -691,7 +691,6 @@ class Sbuffer(implicit p: Parameters)
   io.dcache.req.bits.data  := data(sbuffer_out_s1_evictionIdx).asUInt
   io.dcache.req.bits.mask  := mask(sbuffer_out_s1_evictionIdx).asUInt
   io.dcache.req.bits.id := sbuffer_out_s1_evictionIdx
-  io.dcache.req.bits.miss_fail_cause_evict_btot := false.B
 
   XSDebug(sbuffer_out_s1_fire,
     p"send buf [$sbuffer_out_s1_evictionIdx] to Dcache, req fire\n"


### PR DESCRIPTION
* t0: dcache has a tag (e.g. `0x90054`), but cacheline sbuffer without write permission has a write request with the tag.
* t1: sbuffer writes dcache, which will cause dcache miss because there is no write request, thus sending a miss request with the tag.
* t2: when other miss request refill to mainpipe, it needs to be replaced, and the algorithm replacement always chooses the way with tag=`0x90054`, At the same time, mainpipe will compare tag=`0x90054` with missqueue. there is a request with tag=`0x90054` in missqueue, causing missqueue refill failure and resend.
* t3: In BtoT's sbuffer write request, L2 did not send grantData, resulting in the refill not being completed, which led to tag=`0x90064` request will not refill to dcache, and probe `0x90064` will be blocked.
* L2 receives a `BtoT` request from Core with addr=`0x90054`, enters `RequestBuf` and waits to be selected for transmission.
* L2 receives a `SnpUniqueFwd` request from rxrsp with addr=`0x90064`, enters the pipeline, allocates `MSHR(1)`, queries meta and finds that there is the latest data on Core, and sends Probe to LSU (no response).
* L2 receives another `SnpUnique` request from rxrsp with addr=`0x90054`, allocates `MSHR(14)`, and after entering the pipeline, this request is blocked behind `MSHR(1)` because it also needs probe, and at the same time blocks the `BtoT` request in `RequestBuffer` from entering the pipeline.
* Because the `BtoT` cannot be completed, the LSU prevents the first Probe (addr=`0x90064`) of L2 from being completed, causing a deadlock.

How to fix:
 * When a request need to grow permssion `BtoT`, if the request in the missqueue has the same set and is `BtoT`, and all the ways within this set is greater than 3, mainpipe will set `grow_perm_fail` to source (e.g sbuffer, atomic) to replay. For example, there are 4 `BtoT` requests within the same set: `R0`(located way 0), `R1` (located way 1), `R2` (located way 2), `R3` (send by Sbuffer). And `R0`, `R1`, `R2` allocated Missqueue first, then sbuffer send `store_req` request to mainpipe, it will query missqueue, and find there are 3 `BtoT` ways, hence `store_req` will not allocate missqueue and replay from sbuffer later.
* A refill request will query missqueue with eivct set, if eivct a BtoT way,  refill request will replay with pre-select way (`PriorityEncodeOH(~BtoT_Way)`, `BtoT_Way` is query from Missqueue which `BtoT` requests occupied), other than PLRU replace way. At s1, only evict fail refill request can use` miss_fail_cause_eivct_btot_way` to select pre-select way. For example, a refill request, `R0`, find miss and select way 0 to evict, but way 0 is a `BtoT` cacheline, so evict will fail, and then refill way will be 2 (PirorityEncodeOH(~0001)) to replay.