### PR TITLE
chore: add the version info to the simulation print output

### DIFF
--- a/.github/workflows/check_verilog.py
+++ b/.github/workflows/check_verilog.py
@@ -31,7 +31,8 @@ if __name__ == "__main__":
             line_number = 1
             for line in f:
                 if "$fatal" in line or "$fwrite" in line:
-                    err(file, line, line_number, "'fatal' or 'fwrite' statement was found!")
+                    if "Commit SHA" not in line:
+                        err(file, line, line_number, "'fatal' or 'fwrite' statement was found!")
                 if "module Decode" in line:
                     in_decode = True
                 elif "module Dispatch" in line:

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CommitIDModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CommitIDModule.scala
@@ -1,11 +1,39 @@
 package xiangshan.backend.fu.NewCSR
 
 import chisel3._
+import chisel3.util.HasBlackBoxInline
 
 import java.util.Properties
 
-class CommitIDModule(shaWidth: Int) extends Module {
+class PrintCommitIDModule(shaWidth: Int, hartIdlen: Int) extends BlackBox with HasBlackBoxInline {
+  val io = IO(new Bundle{
+    val hartID = Input(UInt(hartIdlen.W))
+    val commitID = Input(UInt(shaWidth.W))
+    val dirty = Input(Bool())
+  })
+
+  setInline("PrintCommitIDModule.v",
+    s"""
+      |module PrintCommitIDModule(
+      |  input [${hartIdlen-1}:0] hartID,
+      |  input [${shaWidth-1}:0] commitID,
+      |  input dirty
+      |);
+      |
+      |`ifndef SYNTHESIS
+      |  initial begin
+      |    $$fwrite(32'h80000001, "Core %d's Commit SHA is: %h, dirty: %d\\n", hartID, commitID, dirty);
+      |  end
+      |`endif
+      |
+      |endmodule
+      |""".stripMargin
+  )
+}
+
+class CommitIDModule(shaWidth: Int, hartIdlen: Int) extends Module {
   val io = IO(new Bundle {
+    val hartId = Input(UInt(hartIdlen.W))
     val commitID = Output(UInt(shaWidth.W))
     val dirty    = Output(Bool())
   })
@@ -21,4 +49,9 @@ class CommitIDModule(shaWidth: Int) extends Module {
 
   io.commitID := BigInt(sha, 16).U(shaWidth.W)
   io.dirty := dirty.U
+
+  val printCommitIDMod = Module(new PrintCommitIDModule(shaWidth, hartIdlen))
+  printCommitIDMod.io.hartID := io.hartId
+  printCommitIDMod.io.commitID := io.commitID
+  printCommitIDMod.io.dirty := io.dirty
 }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -291,8 +291,9 @@ class NewCSR(implicit val p: Parameters) extends Module
 
   val permitMod = Module(new CSRPermitModule)
   val sstcIRGen = Module(new SstcInterruptGen)
-  val commidIdMod = Module(new CommitIDModule(40))
+  val commidIdMod = Module(new CommitIDModule(40, hartIdLen))
 
+  commidIdMod.io.hartId := io.fromTop.hartId
   val gitCommitSHA = WireInit(commidIdMod.io.commitID)
   val gitDirty     = WireInit(commidIdMod.io.dirty)
   dontTouch(gitCommitSHA)


### PR DESCRIPTION
This allows the Git commit SHA and dirty status to be known directly from the simulation output.

It helps in scenarios such as responding to issues in the XiangShan repository, where the version used can be identified directly from the provided log file.