### PR TITLE
fix(StoreUnit): optimize the code by StoreUnit Code Review

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -529,7 +529,6 @@ class UncacheWordReq(implicit p: Parameters) extends DCacheBundle
   val mask = UInt((XLEN/8).W)
   val id   = UInt(uncacheIdxBits.W)
   val instrtype = UInt(sourceTypeWidth.W)
-  val atomic = Bool()
   val nc = Bool()
   val memBackTypeMM = Bool()
   val isFirstIssue = Bool()

--- a/src/main/scala/xiangshan/cache/dcache/Uncache.scala
+++ b/src/main/scala/xiangshan/cache/dcache/Uncache.scala
@@ -61,7 +61,6 @@ class UncacheEntry(implicit p: Parameters) extends UncacheBundle {
   val data = UInt(XLEN.W)
   val mask = UInt(DataBytes.W)
   val nc = Bool()
-  val atomic = Bool()
   val memBackTypeMM = Bool()
 
   val resp_nderr = Bool()
@@ -78,7 +77,6 @@ class UncacheEntry(implicit p: Parameters) extends UncacheBundle {
     mask := x.mask
     nc := x.nc
     memBackTypeMM := x.memBackTypeMM
-    atomic := x.atomic
     resp_nderr := false.B
     // fwd_data := 0.U
     // fwd_mask := 0.U
@@ -282,7 +280,7 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
     // vaddr same, properties same
     getBlockAddr(x.vaddr) === getBlockAddr(e.vaddr) &&
       x.cmd === e.cmd && x.nc && e.nc &&
-      x.memBackTypeMM === e.memBackTypeMM && !x.atomic && !e.atomic &&
+      x.memBackTypeMM === e.memBackTypeMM &&
       continueAndAlign(x.mask | e.mask) &&
     // not receiving uncache response, not waitReturn -> no wake-up signal in these cases
       !(mem_grant.fire && mem_grant.bits.source === eid || states(eid).isWaitReturn())
@@ -482,7 +480,6 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
   /******************************************************************
    * Buffer Flush
    * 1. when io.flush.valid is true: drain store queue and ubuffer
-   * 2. when io.lsq.req.bits.atomic is true: not support temporarily
    ******************************************************************/
   empty := !VecInit(states.map(_.isValid())).asUInt.orR
   io.flush.empty := empty

--- a/src/main/scala/xiangshan/mem/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/Bundles.scala
@@ -56,7 +56,6 @@ object Bundles {
     val nc = Bool()
     val mmio = Bool()
     val memBackTypeMM = Bool() // 1: main memory, 0: IO
-    val atomic = Bool()
     val hasException = Bool()
     val isHyper = Bool()
     val isForVSnonLeafPTE = Bool()

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -175,7 +175,6 @@ class UncacheEntry(entryIndex: Int)(implicit p: Parameters) extends XSModule
   io.uncache.req.bits.id   := entryIndex.U
   io.uncache.req.bits.instrtype := DontCare
   io.uncache.req.bits.replayCarry := DontCare
-  io.uncache.req.bits.atomic := req.atomic
   io.uncache.req.bits.nc := req.nc
   io.uncache.req.bits.memBackTypeMM := req.memBackTypeMM
 

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -262,7 +262,6 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   val pending = RegInit(VecInit(List.fill(StoreQueueSize)(false.B))) // mmio pending: inst is an mmio inst, it will not be executed until it reachs the end of rob
   val nc = RegInit(VecInit(List.fill(StoreQueueSize)(false.B))) // nc: inst is a nc inst
   val mmio = RegInit(VecInit(List.fill(StoreQueueSize)(false.B))) // mmio: inst is an mmio inst
-  val atomic = RegInit(VecInit(List.fill(StoreQueueSize)(false.B)))
   val memBackTypeMM = RegInit(VecInit(List.fill(StoreQueueSize)(false.B)))
   val prefetch = RegInit(VecInit(List.fill(StoreQueueSize)(false.B))) // need prefetch when committing this store to sbuffer?
   val isVec = RegInit(VecInit(List.fill(StoreQueueSize)(false.B))) // vector store instruction
@@ -541,7 +540,6 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     when (storeAddrInFireReg) {
       pending(stWbIndexReg) := io.storeAddrInRe(i).mmio
       mmio(stWbIndexReg) := io.storeAddrInRe(i).mmio
-      atomic(stWbIndexReg) := io.storeAddrInRe(i).atomic
       memBackTypeMM(stWbIndexReg) := io.storeAddrInRe(i).memBackTypeMM
       hasException(stWbIndexReg) := io.storeAddrInRe(i).hasException
       waitStoreS2(stWbIndexReg) := false.B
@@ -859,7 +857,6 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   mmioReq.bits.vaddr:= vaddrModule.io.rdata(0)
   mmioReq.bits.data := shiftDataToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).data)
   mmioReq.bits.mask := shiftMaskToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).mask)
-  mmioReq.bits.atomic := atomic(GatedRegNext(rdataPtrExtNext(0)).value)
   mmioReq.bits.memBackTypeMM := memBackTypeMM(GatedRegNext(rdataPtrExtNext(0)).value)
   mmioReq.bits.nc := false.B
   mmioReq.bits.id := rdataPtrExt(0).value
@@ -908,7 +905,6 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   ncReq.bits.vaddr:= vaddrModule.io.rdata(0)
   ncReq.bits.data := shiftDataToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).data)
   ncReq.bits.mask := shiftMaskToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).mask)
-  ncReq.bits.atomic := atomic(GatedRegNext(rdataPtrExtNext(0)).value)
   ncReq.bits.memBackTypeMM := memBackTypeMM(GatedRegNext(rdataPtrExtNext(0)).value)
   ncReq.bits.nc := true.B
   ncReq.bits.id := rptr0

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -878,11 +878,6 @@ class HybridUnit(implicit p: Parameters) extends XSModule
                          !s2_exception &&
                          !s2_in.tlbMiss &&
                          !s2_ld_flow
-  val s2_st_atomic     = !s2_prf &&
-                          (RegNext(s1_mmio) || s2_pmp.atomic) &&
-                         !s2_exception &&
-                         !s2_in.tlbMiss &&
-                         !s2_ld_flow
   val s2_full_fwd      = Wire(Bool())
   val s2_mem_amb       = s2_in.uop.storeSetHit &&
                          io.ldu_io.lsq.forward.addrInvalid
@@ -1005,7 +1000,6 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   s2_out.data             := 0.U // data will be generated in load s3
   s2_out.uop.fpWen        := s2_in.uop.fpWen && !s2_exception && s2_ld_flow
   s2_out.mmio             := s2_ld_mmio || s2_st_mmio
-  s2_out.atomic           := s2_st_atomic
   s2_out.uop.flushPipe    := false.B
   s2_out.uop.exceptionVec := s2_exception_vec
   s2_out.forwardMask      := s2_fwd_mask
@@ -1068,7 +1062,6 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   s2_vec_feedback.bits.sourceType := RSFeedbackType.tlbMiss
   s2_vec_feedback.bits.paddr := s2_paddr
   s2_vec_feedback.bits.mmio := s2_st_mmio
-  s2_vec_feedback.bits.atomic := s2_st_mmio
   s2_vec_feedback.bits.exceptionVec := s2_exception_vec
 
   io.stu_io.lsq_replenish := s2_out

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -373,7 +373,6 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   s1_out.nc        := Pbmt.isNC(s1_pbmt)
   s1_out.mmio      := Pbmt.isIO(s1_pbmt)
   s1_out.tlbMiss   := s1_tlb_miss
-  s1_out.atomic    := Pbmt.isIO(s1_pbmt)
   s1_out.isForVSnonLeafPTE := s1_isForVSnonLeafPTE
   when (RegNext(io.tlb.req.bits.checkfullva) &&
     (s1_out.uop.exceptionVec(storePageFault) ||
@@ -438,6 +437,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s2_frm_mab_vec  = RegEnable(s1_frm_mab_vec, true.B, s1_fire)
   val s2_pbmt   = RegEnable(s1_pbmt, s1_fire)
   val s2_trigger_debug_mode = RegEnable(s1_trigger_debug_mode, false.B, s1_fire)
+  val s2_tlb_hit = RegEnable(s1_tlb_hit, s1_fire)
 
   s2_ready := !s2_valid || s2_kill || s3_ready
   when (s1_fire) { s2_valid := true.B }
@@ -470,7 +470,6 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   s2_out        := s2_in
   s2_out.af     := s2_out.uop.exceptionVec(storeAccessFault)
   s2_out.mmio   := s2_mmio && !s2_exception
-  s2_out.atomic := s2_in.atomic || Pbmt.isPMA(s2_pbmt) && s2_pmp.atomic
   s2_out.memBackTypeMM := s2_memBackTypeMM
   s2_out.uop.exceptionVec(storeAccessFault) := (s2_in.uop.exceptionVec(storeAccessFault) ||
                                                 s2_pmp.st ||

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -296,7 +296,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s1_isForVSnonLeafPTE   = io.tlb.resp.bits.isForVSnonLeafPTE
   val s1_tlb_miss  = io.tlb.resp.bits.miss && io.tlb.resp.valid && s1_valid
   val s1_tlb_hit   = !io.tlb.resp.bits.miss && io.tlb.resp.valid && s1_valid
-  val s1_pbmt      = Mux(!s1_tlb_hit, io.tlb.resp.bits.pbmt.head, 0.U(Pbmt.width.W))
+  val s1_pbmt      = Mux(s1_tlb_hit, io.tlb.resp.bits.pbmt.head, 0.U(Pbmt.width.W))
   val s1_exception = ExceptionNO.selectByFu(s1_out.uop.exceptionVec, StaCfg).asUInt.orR
   val s1_isvec     = RegEnable(s0_out.isvec, false.B, s0_fire)
   //We don't want `StoreUnit` to have an additional effect on the Store of vector from a `misalignBuffer,`
@@ -461,7 +461,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
     s2_in.uop.exceptionVec(storeGuestPageFault)
   )
   // This real physical address is located in uncache space.
-  val s2_actually_uncache = !s2_in.tlbMiss && !s2_un_access_exception && (Pbmt.isPMA(s2_pbmt) && s2_pmp.mmio || s2_in.nc || s2_in.mmio) && RegNext(s1_feedback.bits.hit)
+  val s2_actually_uncache = s2_tlb_hit && !s2_un_access_exception && (Pbmt.isPMA(s2_pbmt) && s2_pmp.mmio || s2_in.nc || s2_in.mmio) && RegNext(s1_feedback.bits.hit)
   val s2_isCbo  = RegEnable(s1_isCbo, s1_fire) // all cbo instr
   val s2_isCbo_noZero = LSUOpType.isCbo(s2_in.uop.fuOpType)
 


### PR DESCRIPTION
1. Update pbmt when tlb hit.
2. Kill dcache request when there is nc.
3. Remove the useless `atomic` signal in `LsPipelineBundle`.