### PR TITLE
fix: use a more sensible entry priority of uncacheBuffer

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -31,7 +31,7 @@ import utility._
 import utils._
 import xiangshan._
 import xiangshan.backend.Bundles.DynInst
-import xiangshan.backend.rob.RobDebugRollingIO
+import xiangshan.backend.rob.{RobDebugRollingIO, RobPtr}
 import xiangshan.cache.wpu._
 import xiangshan.mem.{AddPipelineReg, HasL1PrefetchSourceParameter}
 import xiangshan.mem.prefetch._
@@ -522,6 +522,7 @@ class DCacheWordIO(implicit p: Parameters) extends DCacheBundle
 
 class UncacheWordReq(implicit p: Parameters) extends DCacheBundle
 {
+  val robIdx = new RobPtr
   val cmd  = UInt(M_SZ.W)
   val addr = UInt(PAddrBits.W)
   val vaddr = UInt(VAddrBits.W) // for uncache buffer forwarding

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -175,6 +175,7 @@ class UncacheEntry(entryIndex: Int)(implicit p: Parameters) extends XSModule
   io.uncache.req.bits.id   := entryIndex.U
   io.uncache.req.bits.instrtype := DontCare
   io.uncache.req.bits.replayCarry := DontCare
+  io.uncache.req.bits.robIdx := req.uop.robIdx
   io.uncache.req.bits.nc := req.nc
   io.uncache.req.bits.memBackTypeMM := req.memBackTypeMM
 

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -857,6 +857,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   mmioReq.bits.vaddr:= vaddrModule.io.rdata(0)
   mmioReq.bits.data := shiftDataToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).data)
   mmioReq.bits.mask := shiftMaskToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).mask)
+  mmioReq.bits.robIdx := uop(GatedRegNext(rdataPtrExtNext(0)).value).robIdx
   mmioReq.bits.memBackTypeMM := memBackTypeMM(GatedRegNext(rdataPtrExtNext(0)).value)
   mmioReq.bits.nc := false.B
   mmioReq.bits.id := rdataPtrExt(0).value
@@ -913,6 +914,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   ncReq.bits.vaddr:= vaddrModule.io.rdata(0)
   ncReq.bits.data := shiftDataToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).data)
   ncReq.bits.mask := shiftMaskToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).mask)
+  ncReq.bits.robIdx := uop(GatedRegNext(rdataPtrExtNext(0)).value).robIdx
   ncReq.bits.memBackTypeMM := memBackTypeMM(GatedRegNext(rdataPtrExtNext(0)).value)
   ncReq.bits.nc := true.B
   ncReq.bits.id := rptr0


### PR DESCRIPTION
The priority of entering the uncacheBuffer has been changed from load priority to robIdx old priority