### PR TITLE
fix(StoreMisalignBuffer): fix misalign store enq but revoke logic

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -137,8 +137,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   //  - s_resp:  Responds to a split store access request
   //  - s_wb:    writeback yo rob/vecMergeBuffer
   //  - s_block: Wait for this instr to reach the head of Rob.
-  //  - s_recovery: Recovery from a cross page replacement revoke.
-  val s_idle :: s_split :: s_req :: s_resp :: s_wb :: s_block :: s_recovery :: Nil = Enum(7)
+  val s_idle :: s_split :: s_req :: s_resp :: s_wb :: s_block :: Nil = Enum(6)
   val bufferState    = RegInit(s_idle)
 
   // enqueue
@@ -247,10 +246,6 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
           isCrossPage := false.B
         }
       }
-      when (needRecovery) {
-        bufferState := s_recovery
-        isCrossPage := false.B // make sure the state update synchronization.
-      }
     }
 
     is (s_split) {
@@ -347,14 +342,6 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
         globalMMIO := false.B
         globalNC   := false.B
       }
-    }
-    is (s_recovery) {
-      // Recovery the previous request
-      req := recovery_req
-      needFlushPipe := false.B
-
-      // Restart state machine
-      bufferState := s_idle
     }
   }
 

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -125,7 +125,6 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   }
   val req_valid = RegInit(false.B)
   val req = Reg(new StoreMisalignBufferEntry)
-  val recovery_req = Reg(new StoreMisalignBufferEntry)
 
   val cross4KBPageBoundary = Wire(Bool())
   val needFlushPipe = RegInit(false.B)
@@ -169,7 +168,6 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
     req_valid := true.B
   }
   val cross4KBPageEnq = WireInit(false.B)
-  val needRecovery = WireInit(false.B)
   when (cross4KBPageBoundary && !reqRedirect) {
     when(
       reqSelValid &&
@@ -180,11 +178,6 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
       req.portIndex := reqSelPort
       cross4KBPageEnq := true.B
       needFlushPipe   := true.B
-
-      // if the current enq request is a cross page request and it'll be revoked,
-      // we need to recovery the previous request
-      recovery_req := req
-      needRecovery := s2_needRevoke
     } .otherwise {
       req := req
       cross4KBPageEnq := false.B


### PR DESCRIPTION
Bug descriptions:
* a younger misalign store enq at `s1`, and revoke at `s2`, but `req_valid`  not set to false. As a result, it is not freed, and the later older misalign store cannot enter the buffer and cannot be completed, resulting in a stuck state.


How to fix:
* when a misalign store enq at `s1`, but revoke at `s2`, `req_valid` will be set `false` at `s2`
* ~~when a cross page enq replacement occur, but previous request will bt revoked, then previous request will be recovered.~~