### PR TITLE
refactor(Config): refactor `DFT` option passing method

### DIFF
--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -19,7 +19,7 @@ package top
 
 import org.chipsalliance.cde.config.{Config, Parameters}
 import system.SoCParamsKey
-import xiangshan.{DebugOptionsKey, XSTileKey}
+import xiangshan.{DebugOptionsKey, DFTOptionsKey, XSTileKey}
 import freechips.rocketchip.tile.MaxHartIdBits
 import difftest.DifftestModule
 
@@ -196,11 +196,11 @@ object ArgParser {
           }), tail)
         case "--dfx" :: value :: tail =>
           nextOption(config.alter((site, here, up) => {
-            case XSTileKey => up(XSTileKey).map(_.copy(hasMbist = value.toBoolean))
+            case DFTOptionsKey => up(DFTOptionsKey).copy(EnableMbist = value.toBoolean)
           }), tail)
         case "--sram-with-ctl" :: tail =>
           nextOption(config.alter((site, here, up) => {
-            case XSTileKey => up(XSTileKey).map(_.copy(hasSramCtl = true))
+            case DFTOptionsKey => up(DFTOptionsKey).copy(EnableSramCtl = true)
           }), tail)
         case "--seperate-tl-bus" :: tail =>
           nextOption(config.alter((site, here, up) => {

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -37,13 +37,13 @@ import huancun._
 import coupledL2._
 import coupledL2.prefetch._
 
-class BaseConfig(n: Int, hasMbist: Boolean = false) extends Config((site, here, up) => {
+class BaseConfig(n: Int) extends Config((site, here, up) => {
   case XLen => 64
   case DebugOptionsKey => DebugOptions()
   case SoCParamsKey => SoCParameters()
   case CVMParamskey => CVMParameters()
   case PMParameKey => PMParameters()
-  case XSTileKey => Seq.tabulate(n){ i => XSCoreParameters(HartId = i, hasMbist = hasMbist) }
+  case XSTileKey => Seq.tabulate(n){ i => XSCoreParameters(HartId = i) }
   case ExportDebug => DebugAttachParams(protocols = Set(JTAG))
   case DebugModuleKey => Some(DebugModuleParams(
     nAbstractDataWords = (if (site(XLen) == 32) 1 else if (site(XLen) == 64) 2 else 4),
@@ -57,6 +57,7 @@ class BaseConfig(n: Int, hasMbist: Boolean = false) extends Config((site, here, 
   case JtagDTMKey => JtagDTMKey
   case MaxHartIdBits => log2Up(n) max 6
   case EnableJtag => true.B
+  case DFTOptionsKey => DFTOptions()
 })
 
 // Synthesizable minimal XiangShan
@@ -323,8 +324,8 @@ case class L2CacheConfig
         enableRollingDB = site(DebugOptionsKey).EnableRollingDB,
         enableMonitor = site(DebugOptionsKey).AlwaysBasicDB,
         elaboratedTopDown = !site(DebugOptionsKey).FPGAPlatform,
-        hasMbist = p.hasMbist,
-        hasSramCtl = p.hasSramCtl,
+        hasMbist = site(DFTOptionsKey).EnableMbist,
+        hasSramCtl = site(DFTOptionsKey).EnableSramCtl,
       )),
       L2NBanks = banks
     ))
@@ -461,7 +462,7 @@ class DefaultConfig(n: Int = 1) extends Config(
   L3CacheConfig("16MB", inclusive = false, banks = 4, ways = 16)
     ++ L2CacheConfig("1MB", inclusive = true, banks = 4)
     ++ WithNKBL1D(64, ways = 4)
-    ++ new BaseConfig(n, true)
+    ++ new BaseConfig(n)
 )
 
 class CVMConfig(n: Int = 1) extends Config(

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -145,8 +145,8 @@ class XSNoCTop()(implicit p: Parameters) extends BaseXSSoc with HasSoCParameter
     val noc_reset = EnableCHIAsyncBridge.map(_ => IO(Input(AsyncReset())))
     val soc_clock = IO(Input(Clock()))
     val soc_reset = IO(Input(AsyncReset()))
-    private val hasMbist = tiles.head.hasMbist
-    private val hasSramCtl = tiles.head.hasSramCtl
+    private val hasMbist = p(DFTOptionsKey).EnableMbist
+    private val hasSramCtl = p(DFTOptionsKey).EnableSramCtl
     private val hasDFT = hasMbist || hasSramCtl
     val io = IO(new Bundle {
       val hartId = Input(UInt(p(MaxHartIdBits).W))

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -23,7 +23,7 @@ import aia.IMSICParams
 import org.chipsalliance.cde.config.Parameters
 import system.SoCParamsKey
 import xiangshan.backend.fu.{MemoryRange, PMAConfigEntry}
-import xiangshan.XSTileKey
+import xiangshan.{DFTOptionsKey, XSTileKey}
 import freechips.rocketchip.devices.debug.{DebugAttachParams, ExportDebug}
 import freechips.rocketchip.devices.debug.{DMI, JTAG, CJTAG, APB}
 import freechips.rocketchip.devices.debug.{DebugModuleKey, DebugModuleParams}
@@ -173,12 +173,12 @@ object YamlParser {
     }
     yamlConfig.EnableDFX.foreach { enable =>
       newConfig = newConfig.alter((site, here, up) => {
-        case XSTileKey => up(XSTileKey).map(_.copy(hasMbist = enable))
+        case DFTOptionsKey => up(DFTOptionsKey).copy(EnableMbist = enable)
       })
     }
     yamlConfig.EnableSramCtl.foreach { enable =>
       newConfig = newConfig.alter((site, here, up) => {
-        case XSTileKey => up(XSTileKey).map(_.copy(hasSramCtl = enable))
+        case DFTOptionsKey => up(DFTOptionsKey).copy(EnableSramCtl = enable)
       })
     }
     yamlConfig.EnableCHINS.foreach { enable =>

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -353,9 +353,7 @@ case class XSCoreParameters
   softTLB: Boolean = false, // dpi-c l1tlb debug only
   softPTW: Boolean = false, // dpi-c l2tlb debug only
   softPTWDelay: Int = 1,
-  hasMbist: Boolean = false,
   wfiResume: Boolean = true,
-  hasSramCtl: Boolean = false,
 ){
   def ISABase = "rv64i"
   def ISAExtensions = Seq(
@@ -565,6 +563,14 @@ case class DebugOptions
   EnableChiselDB: Boolean = false,
   AlwaysBasicDB: Boolean = true,
   EnableRollingDB: Boolean = false
+)
+
+case object DFTOptionsKey extends Field[DFTOptions]
+
+case class DFTOptions
+(
+  EnableMbist: Boolean = true, // enable mbist default
+  EnableSramCtl: Boolean = false,
 )
 
 trait HasXSParameter {
@@ -907,9 +913,8 @@ trait HasXSParameter {
   def IretireWidthCompressed = log2Up(RenameWidth * CommitWidth * 2 + 1)
   def IlastsizeWidth         = coreParams.traceParams.IlastsizeWidth
 
-  def hasMbist               = coreParams.hasMbist
-
   def wfiResume              = coreParams.wfiResume
-  def hasSramCtl             = coreParams.hasSramCtl
-  def hasDFT            = hasMbist || hasSramCtl
+  def hasMbist               = p(DFTOptionsKey).EnableMbist
+  def hasSramCtl             = p(DFTOptionsKey).EnableSramCtl
+  def hasDFT                 = hasMbist || hasSramCtl
 }


### PR DESCRIPTION
* Refactor `DFT` option passing method by `DFTOptionsKey`
* `DFX` and `DFTOptionsKey.EnableMbist` are related. e.g. `DFX=1` equal to `DFTOptionsKey.EnableMbist=true`
* `SRAM_WITH_CTL` and `DFTOptionsKey.EnableSramCtl` are related. e.g. `SRAM_WITH_CTL=1` equal to `DFTOptionsKey.EnableSramCtl=1`
* `DFTOptionsKey.EnableMbist=true` by default

**!!!Attention!!!**
* `EnableMbist=true` and `EnableSramCtl=true`: support
* `EnableMbist=true` and `EnableSramCtl=false`:  support
* `EnableMbist=false` and `EnableSramCtl=true`: it needs bump latest `Utility` for submodules, which references `Utility`
* `EnableMbist=false` and `EnableSramCtl=false`: support