### PR TITLE
fix(LCOFI): fix writable of LCOFI bit(13) of mvip/mvien/hvip/hvien

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
@@ -230,6 +230,7 @@ class HvipBundle extends InterruptPendingBundle {
   // VSSIP, VSTIP, VSEIP, localIP is writable
   this.getVS.foreach(_.setRW().withReset(0.U))
   this.getLocal.foreach(_.setRW().withReset(0.U))
+  this.LCOFIP.setRO().withReset(0.U)
 }
 
 class HieBundle extends InterruptEnableBundle {
@@ -249,7 +250,7 @@ class HvienBundle extends InterruptEnableBundle {
   // For interrupt numbers 13–63, implementations may freely choose which bits of hvien are writable
   // and which bits are read-only zero or one.
   this.getLocal.foreach(_.setRW().withReset(0.U))
-
+  this.LCOFIE.setRO().withReset(0.U)
 }
 
 class HgeieBundle(implicit val p: Parameters) extends CSRBundle with HasSoCParameter {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
@@ -640,11 +640,13 @@ class MvienBundle extends InterruptEnableBundle {
   this.SSIE.setRW().withReset(0.U)
   this.SEIE.setRW().withReset(0.U)
   this.getLocal.foreach(_.setRW().withReset(0.U))
+  this.LCOFIE.setRO().withReset(0.U)
 }
 
 class MvipBundle extends InterruptPendingBundle {
   this.getHS.foreach(_.setRW().withReset(0.U))
   this.getLocal.foreach(_.setRW().withReset(0.U))
+  this.LCOFIP.setRO().withReset(0.U)
 }
 
 class Epc extends CSRBundle {


### PR DESCRIPTION
For implementations that support Smcdeleg, Sscofpmf, and Smaia, the local counter overflow interrupt (LCOFI) bit (bit 13) in each of CSRs mvip and mvien is implemented and writable.

For implementations that support Smcdeleg/Ssccfg, Sscofpmf, Smaia/Ssaia, and the H extension, the LCOFI bit (bit 13) in each of hvip and hvien is implemented and writable.