### PR TITLE
fix(StoreQueue): setting addrvalid on misalign revoke

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -541,6 +541,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
       mmio(stWbIndexReg) := io.storeAddrInRe(i).mmio
       memBackTypeMM(stWbIndexReg) := io.storeAddrInRe(i).memBackTypeMM
       hasException(stWbIndexReg) := io.storeAddrInRe(i).hasException
+      addrvalid(stWbIndexReg) := addrvalid(stWbIndexReg) || io.storeAddrInRe(i).hasException
       waitStoreS2(stWbIndexReg) := false.B
     }
     // dcache miss info (one cycle later than storeIn)


### PR DESCRIPTION
Previously, we set addrvalid to be set only at s1.

For misaligned stores, if it will go into misalignbuffer at s1, it may generate a revoke at s2 due to an exception.
If no revoke is generated, the addrvalid should not be set because the addrvalid will be set by the subsequent split request.
And if a revoke is generated, then an exception is generated and the addrvalid should be set at s2 to make this uop available for enq.