### PR TITLE
fix(TLB): fix a bug in handle_block where s2_ppn is generated

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -572,10 +572,12 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       val s2xlate = io.ptw.resp.bits.s2xlate
       resp(idx).valid := true.B
       resp(idx).bits.miss := false.B
-      val s1_ppn = stage1.genPPN(get_pn(req_out(idx).vaddr))(ppnLen - 1, 0)
-      val s2_ppn = stage2.genPPNS2(get_pn(req_out(idx).vaddr))(ppnLen - 1, 0)
-      val s1_paddr = Cat(s1_ppn, get_off(req_out(idx).vaddr))
-      val s2_paddr = Cat(s2_ppn, get_off(req_out(idx).vaddr))
+      val vpn = get_pn(req_out(idx).vaddr)
+      val s1_ppn = stage1.genPPN(vpn)(ppnLen - 1, 0)
+      val s2_gvpn = Mux(s2xlate === onlyStage2, vpn, s1_ppn)
+      val s2_ppn = stage2.genPPNS2(s2_gvpn)(ppnLen - 1, 0)
+      val s1_paddr = Cat(s1_ppn, get_off(vpn))
+      val s2_paddr = Cat(s2_ppn, get_off(vpn))
       for (d <- 0 until nRespDups) {
         resp(idx).bits.paddr(d) := Mux(s2xlate === onlyStage2 || s2xlate === allStage, s2_paddr, s1_paddr)
         resp(idx).bits.gpaddr(d) := s1_paddr


### PR DESCRIPTION
Consider the following two-stage address translation process:

In the vs-stage, a 2MB large page is found during the lookup, which means the lower 9 bits of the resulting ppn are zeros. When generating the gvpn for the g-stage, it is formed as `gvpn = {s1_ppn, s1_vpn(9 bits)}`.

Then, in the g-stage translation, a 1GB large page is found, so the lower 9 * 2 = 18 bits of the resulting ppn are zeros. The final physical page number is constructed as ppn = `{s2_ppn, s2_gvpn(18 bits)}` = `{s2_ppn, s1_ppn(9 bits), s1_vpn(9 bits)}`.

In other words, if the g-stage page is larger than the vs-stage page, the final ppn should be composed of three parts: s2_ppn, s1_ppn, and s1_vpn.

However, in `handle_block`, the original implementation incorrectly concatenated the lower 18 bits of the ppn solely from s1_vpn, i.e., `{s2_ppn, s1_vpn(18 bits)}`, instead of the correct `{s2_ppn, s1_ppn(9 bits), s1_vpn(9 bits)}`. This commit fixes that bug.