### PR TITLE
fix(StoreQueue): fix timeout of vecExceptionFlag when redirect

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -1418,7 +1418,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   // misprediction recovery / exception redirect
   // invalidate sq term using robIdx
   for (i <- 0 until StoreQueueSize) {
-    needCancel(i) := uop(i).robIdx.needFlush(io.brqRedirect) && allocated(i) && !committed(i)
+    needCancel(i) := (uop(i).robIdx.needFlush(io.brqRedirect) & !isVec(i) || isAfter(uop(i).robIdx, io.brqRedirect.bits.robIdx) && io.brqRedirect.valid && isVec(i)) && allocated(i) && !committed(i)
     when (needCancel(i)) {
       allocated(i) := false.B
       completed(i) := false.B


### PR DESCRIPTION
When the vector store that raised the exception is written back to the backend, the StoreQueue is too late to set the corresponding entries to `committed`, resulting in the `redirect` flush them, which results in the `vecExceptionFlag` being asserted due to the timeout not being cleared.
