### PR TITLE
fix(StoreQueue): not do nc store when having exception

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -877,7 +877,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   val rptr0 = rdataPtrExt(0).value
   switch(ncState){
     is(nc_idle) {
-      when(nc(rptr0) && allocated(rptr0) && committed(rptr0) && !mmio(rptr0) && !isVec(rptr0) && !hasException(rptr0)) {
+      when(nc(rptr0) && allocated(rptr0) && committed(rptr0) && !mmio(rptr0) && !isVec(rptr0) && !hasException(rptr0) && !completed(rptr0)) {
         ncState := nc_req
         ncWaitRespPtrReg := rptr0
       }

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -876,7 +876,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   val rptr0 = rdataPtrExt(0).value
   switch(ncState){
     is(nc_idle) {
-      when(nc(rptr0) && allocated(rptr0) && committed(rptr0) && !mmio(rptr0) && !isVec(rptr0)) {
+      when(nc(rptr0) && allocated(rptr0) && committed(rptr0) && !mmio(rptr0) && !isVec(rptr0) && !hasException(rptr0)) {
         ncState := nc_req
         ncWaitRespPtrReg := rptr0
       }


### PR DESCRIPTION
### Bug Description

The NC store does not handle exceptions properly. When an exception occurs during its execution, the store queue (SQ) continues to process it as if it were a normal nc store—this includes committing it and sending it to the uncache—resulting in an invalid memory access.

### Bug Analysis

In the current SQ design, for regular stores, both `rdataPtr` and `deqPtr` advance based on handshakes with `dataBuffer` and `SBuffer`, respectively. Thus, even if an exception occurs, the store is marked as `committed = true` and passed into both buffers. If an exception is detected at the `SBuffer`, the actual write is skipped.

For NC stores, the `committed` logic is reused from regular stores. However, there is no dedicated handling for exceptional cases in the later pipeline stages—such as preventing handshake with the `UBuffer`, or allowing the handshake but skipping the write. This fix adopts the former approach: **NC stores will not perform a handshake with the `UBuffer` when an exception is detected**, in order to preserve a clean and consistent `UBuffer` interface.

### Solution

* NC stores continue to be marked as `committed = true`.
* Only when `!completed(rptr0) && allvalid(rptr0) && !hasException(rptr0)` is satisfied, the NC store is allowed to enter the `UBuffer`.
* If the instruction causes an exception, the backend will flush it and all subsequent instructions.
* When the flushed instruction reaches the NC store entry in the store queue, `completed` is set to `true`.
* For `deqPtr`, since `deqPtr` advances based on the `completed` signal, no additional changes are needed.
* For `rdataPtr`, behavior remains unchanged for regular stores, but for NC stores, advancement is now triggered by `completed` instead of `ncReadNextTrigger`.
