### PR TITLE
refactor(Frontend): refactor meta io

### DIFF
--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -786,7 +786,6 @@ class BranchPredictionResp(implicit p: Parameters) extends XSBundle with HasBPUC
   val s1_uftbHasIndirect = Bool()
   val s1_ftbCloseReq     = Bool()
 
-  val last_stage_meta      = UInt(MaxMetaLength.W)
   val last_stage_spec_info = new Ftq_Redirect_SRAMEntry
   val last_stage_ftb_entry = new FTBEntry
 
@@ -826,7 +825,7 @@ class BranchPredictionUpdate(implicit p: Parameters) extends XSBundle with HasBP
   val false_hit         = Bool()
   val new_br_insert_pos = Vec(numBr, Bool())
   val old_entry         = Bool()
-  val meta              = UInt(MaxMetaLength.W)
+  val meta              = new PredictorMeta
   val full_target       = PrunedAddr(VAddrBits)
   val from_stage        = UInt(2.W)
   val ghist             = UInt(HistoryLength.W)

--- a/src/main/scala/xiangshan/frontend/ITTAGE.scala
+++ b/src/main/scala/xiangshan/frontend/ITTAGE.scala
@@ -419,7 +419,6 @@ class FakeITTage(implicit p: Parameters) extends BaseITTage {
 }
 
 class ITTage(implicit p: Parameters) extends BaseITTage {
-  override val meta_size = 0.U.asTypeOf(new ITTageMeta).getWidth
 
   val tables = ITTageTableInfos.zipWithIndex.map {
     case ((nRows, histLen, tagLen), i) =>
@@ -470,7 +469,7 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
 
   val resp_meta = WireInit(0.U.asTypeOf(new ITTageMeta))
 
-  io.out.last_stage_meta := resp_meta.asUInt
+  io.meta.ittageMeta := resp_meta
 
   // Update logic
   val u_valid = RegNext(io.update.valid, init = false.B)
@@ -478,9 +477,8 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
   val update = Wire(new BranchPredictionUpdate)
   update := RegEnable(io.update.bits, io.update.valid)
 
-  // meta is splited by composer
   val updateMeta = Wire(new ITTageMeta)
-  update.meta := updateMeta.asUInt
+  update.meta.ittageMeta := updateMeta
 
   // The pc register has been moved outside of predictor
   // pc field of update bundle and other update data are not in the same stage
@@ -488,7 +486,7 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
   val update_pc = io.update.bits.pc
 
   // To improve Clock Gating Efficiency
-  val u_meta = io.update.bits.meta.asTypeOf(new ITTageMeta)
+  val u_meta = io.update.bits.meta.ittageMeta
   updateMeta := RegEnable(u_meta, io.update.valid)
   updateMeta.provider.bits := RegEnable(
     u_meta.provider.bits,

--- a/src/main/scala/xiangshan/frontend/Ras.scala
+++ b/src/main/scala/xiangshan/frontend/Ras.scala
@@ -95,7 +95,6 @@ class RasDebug(implicit p: Parameters) extends XSBundle {
 }
 
 class Ras(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtrHelper {
-  override val meta_size = WireInit(0.U.asTypeOf(new RasMeta)).getWidth
 
   object RasEntry {
     def apply(retAddr: PrunedAddr, ctr: UInt): RasEntry = {
@@ -575,7 +574,7 @@ class Ras(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
   io.out.last_stage_spec_info.TOSR    := s3_meta.TOSR
   io.out.last_stage_spec_info.NOS     := s3_meta.NOS
   io.out.last_stage_spec_info.topAddr := s3_top
-  io.out.last_stage_meta              := last_stage_meta.asUInt
+  io.meta.rasMeta                     := last_stage_meta
 
   val redirect   = RegNextWithEnable(io.redirect)
   val doRecover  = redirect.valid
@@ -610,7 +609,7 @@ class Ras(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
   // 'val updateMeta = RegEnable(io.update.bits.meta.asTypeOf(new RASMeta), io.update.valid && (io.update.bits.is_call || io.update.bits.is_ret))',
   // but the fault-tolerance mechanism of the return stack needs to be updated in time. Using an unexpected old value on reset will cause errors.
   // Only 9 registers have clock gate efficiency affected, so we relaxed the control signals.
-  val updateMeta = RegEnable(io.update.bits.meta.asTypeOf(new RasMeta), io.update.valid)
+  val updateMeta = RegEnable(io.update.bits.meta.rasMeta, io.update.valid)
 
   stack.commit.valid     := updateValid
   stack.commit.pushValid := updateValid && update.is_call_taken

--- a/src/main/scala/xiangshan/frontend/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/Tage.scala
@@ -616,8 +616,7 @@ class FakeTage(implicit p: Parameters) extends BaseTage {
 
 class Tage(implicit p: Parameters) extends BaseTage {
 
-  val resp_meta          = Wire(new TageMeta)
-  override val meta_size = resp_meta.getWidth
+  val resp_meta = Wire(new TageMeta)
   val tables = TageTableInfos.zipWithIndex.map {
     case ((nRows, histLen, tagLen), i) => {
       val t = Module(new TageTable(nRows, histLen, tagLen, i))
@@ -674,8 +673,8 @@ class Tage(implicit p: Parameters) extends BaseTage {
   val s2_basecnts       = RegEnable(s1_basecnts, io.s1_fire(1))
   val s2_useAltOnNa     = RegEnable(s1_useAltOnNa, io.s1_fire(1))
 
-  io.out                 := io.in.bits.resp_in(0)
-  io.out.last_stage_meta := resp_meta.asUInt
+  io.out           := io.in.bits.resp_in(0)
+  io.meta.tageMeta := resp_meta
 
   val resp_s2 = io.out.s2
 
@@ -693,10 +692,9 @@ class Tage(implicit p: Parameters) extends BaseTage {
     VecInit((0 until TageBanks).map(w =>
       io.update.bits.ftb_entry.brValids(w) && io.update.valid
     )) // io.update.bits.ftb_entry.always_taken has timing issues(FTQEntryGen)
-  val u_meta     = io.update.bits.meta.asTypeOf(new TageMeta)
+  val u_meta     = io.update.bits.meta.tageMeta
   val updateMeta = Wire(new TageMeta)
-  update.meta := updateMeta.asUInt
-  updateMeta  := RegEnable(u_meta, io.update.valid)
+  updateMeta := RegEnable(u_meta, io.update.valid)
   for (i <- 0 until numBr) {
     updateMeta.providers(i).bits := RegEnable(
       u_meta.providers(i).bits,


### PR DESCRIPTION
To make it easier to manage the predictors' meta, we restructured it as a `Bundle` rather than a `UInt`.