### PR TITLE
feat(top): Move DTS ResourceBinding flow to BaseXSSoC

### DIFF
--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -50,6 +50,7 @@ import difftest.common.DifftestWiring
 import difftest.util.Profile
 
 abstract class BaseXSSoc()(implicit p: Parameters) extends LazyModule
+  with HasSoCParameter
   with BindingScope
 {
   // val misc = LazyModule(new SoCMisc())
@@ -57,7 +58,7 @@ abstract class BaseXSSoc()(implicit p: Parameters) extends LazyModule
   lazy val json = JSON(bindingTree)
 }
 
-class XSTop()(implicit p: Parameters) extends BaseXSSoc() with HasSoCParameter
+class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 {
   val nocMisc = if (enableCHI) Some(LazyModule(new MemMisc())) else None
   val socMisc = if (!enableCHI) Some(LazyModule(new SoCMisc())) else None

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -41,7 +41,7 @@ import freechips.rocketchip.util.AsyncResetSynchronizerShiftReg
 import difftest.common.DifftestWiring
 import difftest.util.Profile
 
-class XSNoCTop()(implicit p: Parameters) extends BaseXSSoc with HasSoCParameter
+class XSNoCTop()(implicit p: Parameters) extends BaseXSSoc
 {
   override lazy val desiredName: String = "XSTop"
 

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -45,22 +45,6 @@ class XSNoCTop()(implicit p: Parameters) extends BaseXSSoc
 {
   override lazy val desiredName: String = "XSTop"
 
-  ResourceBinding {
-    val width = ResourceInt(2)
-    val model = "freechips,rocketchip-unknown"
-    Resource(ResourceAnchors.root, "model").bind(ResourceString(model))
-    Resource(ResourceAnchors.root, "compat").bind(ResourceString(model + "-dev"))
-    Resource(ResourceAnchors.soc, "compat").bind(ResourceString(model + "-soc"))
-    Resource(ResourceAnchors.root, "width").bind(width)
-    Resource(ResourceAnchors.soc, "width").bind(width)
-    Resource(ResourceAnchors.cpus, "width").bind(ResourceInt(1))
-    def bindManagers(xbar: TLNexusNode) = {
-      ManagerUnification(xbar.edges.in.head.manager.managers).foreach{ manager =>
-        manager.resources.foreach(r => r.bind(manager.toResource))
-      }
-    }
-  }
-
   require(enableCHI)
 
   // xstile
@@ -127,17 +111,15 @@ class XSNoCTop()(implicit p: Parameters) extends BaseXSSoc
   val core_rst_node = BundleBridgeSource(() => Reset())
   core_with_l2.tile.core_reset_sink := core_rst_node
 
-  class XSNoCTopImp(wrapper: XSNoCTop) extends LazyRawModuleImp(wrapper) {
+  class XSNoCTopImp(wrapper: XSNoCTop) extends LazyRawModuleImp(wrapper)
+    with HasDTSImp[XSNoCTop]
+  {
     soc.XSTopPrefix.foreach { prefix =>
       val mod = this.toNamed
       annotate(new ChiselAnnotation {
         def toFirrtl = NestedPrefixModulesAnnotation(mod, prefix, true)
       })
     }
-    FileRegisters.add("dts", dts)
-    FileRegisters.add("graphml", graphML)
-    FileRegisters.add("json", json)
-    FileRegisters.add("plusArgs", freechips.rocketchip.util.PlusArgArtefacts.serialize_cHeader())
 
     val clock = IO(Input(Clock()))
     val reset = IO(Input(AsyncReset()))


### PR DESCRIPTION
There are two independent SoC designs in XiangShan (a.k.a. `XSTop` and `XSNoCTop`),
each containing its own DTS generation logic. This PR merges them into common
base class `BaseXSSoc` and a specialized `HasDTSImp` trait, to prevent modifications
to this part from being missed in different designs.