### PR TITLE
fix(XSNoCTop): gate clock by hard reset Not i_cpu_sw_rst_n

### DIFF
--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -273,7 +273,7 @@ class XSNoCTop()(implicit p: Parameters) extends BaseXSSoc with HasSoCParameter
 
     /* during power down sequence, SoC reset will gate clock */
     val pwrdownGateClock = withClockAndReset(clock, cpuReset_sync.asAsyncReset) {RegInit(false.B)}
-    pwrdownGateClock := !soc_rst_n && lpState === sPOFFREQ
+    pwrdownGateClock := cpuReset && lpState === sPOFFREQ
     /*
      physical power off handshake:
      i_cpu_pwrdown_req_n


### PR DESCRIPTION
This fix change  clock gate enable by hard reset since i_cpu_sw_rst_n is not used.