### PR TITLE
fix(smstateen): add [m|h|s]stateen[1|2|3] CSRs

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/HypervisorLevel.scala
@@ -167,11 +167,23 @@ trait HypervisorLevel { self: NewCSR =>
   })
     .setAddr(CSRs.hgeip)
 
-  val hstateen0 = Module(new CSRModule("Hstateen", new HstateenBundle0) with HasStateen0Bundle {
+  val hstateen0 = Module(new CSRModule("Hstateen0", new Hstateen0Bundle) with HasStateenBundle {
     // For every bit in an mstateen CSR that is zero (whether read-only zero or set to zero), the same bit
     // appears as read-only zero in the matching hstateen and sstateen CSRs.
     regOut := reg.asUInt & fromMstateen0.asUInt
   }).setAddr(CSRs.hstateen0)
+
+  val hstateen1 = Module(new CSRModule("Hstateen1", new HstateenNonZeroBundle) with HasStateenBundle {
+    regOut := reg.asUInt & fromMstateen1.asUInt
+  }).setAddr(CSRs.hstateen1)
+
+  val hstateen2 = Module(new CSRModule("Hstateen2", new HstateenNonZeroBundle) with HasStateenBundle {
+    regOut := reg.asUInt & fromMstateen2.asUInt
+  }).setAddr(CSRs.hstateen2)
+
+  val hstateen3 = Module(new CSRModule("Hstateen3", new HstateenNonZeroBundle) with HasStateenBundle {
+    regOut := reg.asUInt & fromMstateen3.asUInt
+  }).setAddr(CSRs.hstateen3)
 
   val hypervisorCSRMods: Seq[CSRModule[_]] = Seq(
     hstatus,
@@ -193,6 +205,9 @@ trait HypervisorLevel { self: NewCSR =>
     hgatp,
     hgeip,
     hstateen0,
+    hstateen1,
+    hstateen2,
+    hstateen3,
   )
 
   val hypervisorCSRMap: SeqMap[Int, (CSRAddrWriteBundle[_], UInt)] = SeqMap.from(

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
@@ -381,7 +381,13 @@ trait MachineLevel { self: NewCSR =>
   }))
     .setAddr(CSRs.mconfigptr)
 
-  val mstateen0 = Module(new CSRModule("Mstateen", new MstateenBundle0)).setAddr(CSRs.mstateen0)
+  val mstateen0 = Module(new CSRModule("Mstateen0", new Mstateen0Bundle)).setAddr(CSRs.mstateen0)
+
+  val mstateen1 = Module(new CSRModule("Mstateen1", new MstateenNonZeroBundle)).setAddr(CSRs.mstateen1)
+
+  val mstateen2 = Module(new CSRModule("Mstateen2", new MstateenNonZeroBundle)).setAddr(CSRs.mstateen2)
+
+  val mstateen3 = Module(new CSRModule("Mstateen3", new MstateenNonZeroBundle)).setAddr(CSRs.mstateen3)
 
   // smrnmi extension
   val mnepc = Module(new CSRModule("Mnepc", new Epc) with TrapEntryMNEventSinkBundle {
@@ -432,6 +438,9 @@ trait MachineLevel { self: NewCSR =>
     mhartid,
     mconfigptr,
     mstateen0,
+    mstateen1,
+    mstateen2,
+    mstateen3,
     mnepc,
     mncause,
     mnstatus,

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -492,7 +492,13 @@ class NewCSR(implicit val p: Parameters) extends Module
   permitMod.io.in.xcounteren.scounteren := scounteren.rdata
 
   permitMod.io.in.xstateen.mstateen0 := mstateen0.rdata
+  permitMod.io.in.xstateen.mstateen1 := mstateen1.rdata
+  permitMod.io.in.xstateen.mstateen2 := mstateen2.rdata
+  permitMod.io.in.xstateen.mstateen3 := mstateen3.rdata
   permitMod.io.in.xstateen.hstateen0 := hstateen0.rdata
+  permitMod.io.in.xstateen.hstateen1 := hstateen1.rdata
+  permitMod.io.in.xstateen.hstateen2 := hstateen2.rdata
+  permitMod.io.in.xstateen.hstateen3 := hstateen3.rdata
   permitMod.io.in.xstateen.sstateen0 := sstateen0.rdata
 
   permitMod.io.in.xenvcfg.menvcfg := menvcfg.rdata
@@ -752,8 +758,11 @@ class NewCSR(implicit val p: Parameters) extends Module
       case _ =>
     }
     mod match {
-      case m: HasStateen0Bundle =>
+      case m: HasStateenBundle =>
         m.fromMstateen0 := mstateen0.regOut
+        m.fromMstateen1 := mstateen1.regOut
+        m.fromMstateen2 := mstateen2.regOut
+        m.fromMstateen3 := mstateen3.regOut
         m.fromHstateen0 := hstateen0.regOut
         m.privState     := privState
       case _ =>

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/StateEnBundle.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/StateEnBundle.scala
@@ -5,31 +5,54 @@ import xiangshan.backend.fu.NewCSR.CSRDefines.{CSRROField => RO, CSRRWField => R
 import xiangshan.backend.fu.NewCSR.CSRBundles.PrivState
 
 
-class SstateenBundle0 extends CSRBundle {
+class Sstateen0Bundle extends CSRBundle {
   override val len: Int = 32
   val JVT  = RO(2).withReset(0.U) // jvt CSR in Zcmt extension
   val FCSR = RO(1).withReset(0.U) // fp inst op 'x' register not f in Zfinx, Zdinx; misa.F =1 -> RO 0; misa.F=0 & this=0 -> V/EX_II
-  val C    = RW(0).withReset(0.U) // custom state enable, [m|h|s]stateen is standard, not custom.
+  val C    = RW(0)                // custom state enable, [m|h|s]stateen is standard, not custom.
 }
 
-class HstateenBundle0 extends SstateenBundle0 {
+class Hstateen0Bundle extends Sstateen0Bundle {
   override val len: Int = 64
-  val SE0     = RW(63).withReset(0.U) // m: [h|s]stateen                h: sstateen
-  val ENVCFG  = RW(62).withReset(0.U) // m: [h|s]envcfg                 h: senvcfg
+  val SE0     = RW(63)                // m: [h|s]stateen                h: sstateen
+  val ENVCFG  = RW(62)                // m: [h|s]envcfg                 h: senvcfg
   // Bits in any stateen CSR that are defined to control state that a hart doesn’t implement are read-only
   // zeros for that hart. Smcsrind/Sscsrind is not implemented.
-  val CSRIND  = RW(60).withReset(0.U) // m: [vs|s]iselect, [vs|s]ireg*  h: siselect, sireg*
-  val AIA     = RW(59).withReset(0.U) // all other state added by the AIA and not controlled by bits 60 and 58
-  val IMSIC   = RW(58).withReset(0.U) // m: [vs|s]topei                 h: stopei
+  val CSRIND  = RW(60)                // m: [vs|s]iselect, [vs|s]ireg*  h: siselect, sireg*
+  val AIA     = RW(59)                // all other state added by the AIA and not controlled by bits 60 and 58
+  val IMSIC   = RW(58)                // m: [vs|s]topei                 h: stopei
   val CONTEXT = RO(57).withReset(0.U) // m: [h|s]context in Sdtrig      h: scontext
 }
 
-class MstateenBundle0 extends HstateenBundle0 {
-  val P1P13   = RO(56).withReset(0.U) // hedelegh in Priv Spec V1.13
+class Mstateen0Bundle extends Hstateen0Bundle {
+  override val SE0     = RW(63).withReset(0.U) // m: [h|s]stateen                h: sstateen
+  override val ENVCFG  = RW(62).withReset(0.U) // m: [h|s]envcfg                 h: senvcfg
+  // Bits in any stateen CSR that are defined to control state that a hart doesn’t implement are read-only
+  // zeros for that hart. Smcsrind/Sscsrind is not implemented.
+  override val CSRIND  = RW(60).withReset(0.U) // m: [vs|s]iselect, [vs|s]ireg*  h: siselect, sireg*
+  override val AIA     = RW(59).withReset(0.U) // all other state added by the AIA and not controlled by bits 60 and 58
+  override val IMSIC   = RW(58).withReset(0.U) // m: [vs|s]topei                 h: stopei
+  val P1P13            = RO(56).withReset(0.U) // hedelegh in Priv Spec V1.13
+  override val C       = RW(0).withReset(0.U)  // custom state enable, [m|h|s]stateen is standard, not custom.
 }
 
-trait HasStateen0Bundle { self: CSRModule[_] =>
-  val fromMstateen0 = IO(Input(new MstateenBundle0))
-  val fromHstateen0 = IO(Input(new HstateenBundle0))
+class SstateenNonZeroBundle extends CSRBundle {  // for sstateen[1|2|3]
+  override val len = 32
+  val ALL = RO(31, 0).withReset(0.U)
+}
+
+class HstateenNonZeroBundle extends CSRBundle {  // for hstateen[1|2|3]
+  val SE = RW(63)
+}
+class MstateenNonZeroBundle extends HstateenNonZeroBundle {  // for mstateen[1|2|3]
+  override val SE = RW(63).withReset(0.U)
+}
+
+trait HasStateenBundle { self: CSRModule[_] =>
+  val fromMstateen0 = IO(Input(new Mstateen0Bundle))
+  val fromMstateen1 = IO(Input(new MstateenNonZeroBundle))
+  val fromMstateen2 = IO(Input(new MstateenNonZeroBundle))
+  val fromMstateen3 = IO(Input(new MstateenNonZeroBundle))
+  val fromHstateen0 = IO(Input(new Hstateen0Bundle))
   val privState     = IO(Input(new PrivState))
 }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/SupervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/SupervisorLevel.scala
@@ -161,13 +161,20 @@ trait SupervisorLevel { self: NewCSR with MachineLevel =>
     ))
   }).setAddr(CSRs.scountovf)
 
-  val sstateen0 = Module(new CSRModule("Sstateen", new SstateenBundle0) with HasStateen0Bundle {
+  val sstateen0 = Module(new CSRModule("Sstateen0", new Sstateen0Bundle) with HasStateenBundle {
     // For every bit in an mstateen CSR that is zero (whether read-only zero or set to zero), the same bit
     // appears as read-only zero in the matching hstateen and sstateen CSRs. For every bit in an hstateen
     // CSR that is zero (whether read-only zero or set to zero), the same bit appears as read-only zero in
     // sstateen when accessed in VS-mode.
     regOut := Mux(privState.isVirtual, fromHstateen0.asUInt, fromMstateen0.asUInt) & reg.asUInt
   }).setAddr(CSRs.sstateen0)
+
+  // sstateen[1|2|3] read-only zero
+  val sstateen1 = Module(new CSRModule("Sstateen1", new SstateenNonZeroBundle)).setAddr(CSRs.sstateen1)
+
+  val sstateen2 = Module(new CSRModule("Sstateen2", new SstateenNonZeroBundle)).setAddr(CSRs.sstateen2)
+
+  val sstateen3 = Module(new CSRModule("Sstateen3", new SstateenNonZeroBundle)).setAddr(CSRs.sstateen3)
 
   val supervisorLevelCSRMods: Seq[CSRModule[_]] = Seq(
     sie,
@@ -183,6 +190,9 @@ trait SupervisorLevel { self: NewCSR with MachineLevel =>
     satp,
     scountovf,
     sstateen0,
+    sstateen1,
+    sstateen2,
+    sstateen3,
   )
 
   val supervisorLevelCSRMap: SeqMap[Int, (CSRAddrWriteBundle[_], UInt)] = SeqMap(


### PR DESCRIPTION
 * add [m|h|s]stateen[1|2|3] csr.
 * Bits in any stateen CSR that are defined to control state that a hart doesn’t implement are read-only zeros
for that hart.
 * only reset mstateen[0|1|2|3]
 
 This pr should be rebase and merged. Include two commits:
* fix(smstateen): add [m|h|s]stateen[1|2|3] csr.
* submodule(ready-to-run): bump ready-to-run to fix smstateen
 