### PR TITLE
refactor(Frontend): remove all dups

### DIFF
--- a/src/main/scala/xiangshan/frontend/BPU.scala
+++ b/src/main/scala/xiangshan/frontend/BPU.scala
@@ -130,10 +130,10 @@ class PredictorMeta(implicit p: Parameters) extends XSBundle {
 class BasePredictorInput(implicit p: Parameters) extends XSBundle with HasBPUConst {
   def nInputs = 1
 
-  val s0_pc = Vec(numDup, PrunedAddr(VAddrBits))
+  val s0_pc = PrunedAddr(VAddrBits)
 
-  val folded_hist    = Vec(numDup, new AllFoldedHistories(foldedGHistInfos))
-  val s1_folded_hist = Vec(numDup, new AllFoldedHistories(foldedGHistInfos))
+  val folded_hist    = new AllFoldedHistories(foldedGHistInfos)
+  val s1_folded_hist = new AllFoldedHistories(foldedGHistInfos)
   val ghist          = UInt(HistoryLength.W)
 
   val resp_in = Vec(nInputs, new BranchPredictionResp)
@@ -160,13 +160,10 @@ class BasePredictorIO(implicit p: Parameters) extends XSBundle with HasBPUConst 
 
   val ctrl = Input(new BPUCtrl)
 
-  val s0_fire = Input(Vec(numDup, Bool()))
-  val s1_fire = Input(Vec(numDup, Bool()))
-  val s2_fire = Input(Vec(numDup, Bool()))
-  val s3_fire = Input(Vec(numDup, Bool()))
-
-  val s2_redirect = Input(Vec(numDup, Bool()))
-  val s3_redirect = Input(Vec(numDup, Bool()))
+  val s0_fire = Input(Bool())
+  val s1_fire = Input(Bool())
+  val s2_fire = Input(Bool())
+  val s3_fire = Input(Bool())
 
   val s1_ready = Output(Bool())
   val s2_ready = Output(Bool())
@@ -197,26 +194,31 @@ abstract class BasePredictor(implicit p: Parameters) extends XSModule
   io.s2_ready := true.B
   io.s3_ready := true.B
 
-  val s0_pc_dup = WireInit(io.in.bits.s0_pc) // fetchIdx(io.f0_pc)
-  val s1_pc_dup = s0_pc_dup.zip(io.s0_fire).map { case (s0_pc, s0_fire) => RegEnable(s0_pc, s0_fire) }
-//  FIXME: Potential problems here. Ideally, we should modify SegmentedAddrNext to support PrunedAddr.
-//   However, we are not doing this now because SegmentedAddrNext is in submodule.
-//   This should be fixed after PrunedAddr is merged to master.
-// TODO: Check the generated Verilog whether this works or not
-  val s2_pc_dup = s1_pc_dup.zip(io.s1_fire).map { case (s1_pc, s1_fire) =>
-    PrunedAddrInit(SegmentedAddrNext(s1_pc.toUInt, pcSegments, s1_fire, Some("s2_pc")).getAddr())
-  }
-  val s3_pc_dup = s2_pc_dup.zip(io.s2_fire).map { case (s2_pc, s2_fire) =>
-    PrunedAddrInit(SegmentedAddrNext(s2_pc.toUInt, pcSegments, s2_fire, Some("s3_pc")).getAddr())
-  }
+//  val s0_pc_dup = WireInit(io.in.bits.s0_pc) // fetchIdx(io.f0_pc)
+//  val s1_pc_dup = s0_pc_dup.zip(io.s0_fire).map { case (s0_pc, s0_fire) => RegEnable(s0_pc, s0_fire) }
+////  FIXME: Potential problems here. Ideally, we should modify SegmentedAddrNext to support PrunedAddr.
+////   However, we are not doing this now because SegmentedAddrNext is in submodule.
+////   This should be fixed after PrunedAddr is merged to master.
+//// TODO: Check the generated Verilog whether this works or not
+//  val s2_pc_dup = s1_pc_dup.zip(io.s1_fire).map { case (s1_pc, s1_fire) =>
+//    PrunedAddrInit(SegmentedAddrNext(s1_pc.toUInt, pcSegments, s1_fire, Some("s2_pc")).getAddr())
+//  }
+//  val s3_pc_dup = s2_pc_dup.zip(io.s2_fire).map { case (s2_pc, s2_fire) =>
+//    PrunedAddrInit(SegmentedAddrNext(s2_pc.toUInt, pcSegments, s2_fire, Some("s3_pc")).getAddr())
+//  }
+
+  val s0_pc = io.in.bits.s0_pc
+  val s1_pc = RegEnable(s0_pc, io.s0_fire)
+  val s2_pc = RegEnable(s1_pc, io.s1_fire)
+  val s3_pc = RegEnable(s2_pc, io.s2_fire)
 
   when(RegNext(RegNext(reset.asBool) && !reset.asBool)) {
-    s1_pc_dup.map { case s1_pc => s1_pc := io.reset_vector }
+    s1_pc := io.reset_vector
   }
 
-  io.out.s1.pc := s1_pc_dup
-  io.out.s2.pc := s2_pc_dup
-  io.out.s3.pc := s3_pc_dup
+  io.out.s1.pc := s1_pc
+  io.out.s2.pc := s2_pc
+  io.out.s3.pc := s3_pc
 
   val perfEvents: Seq[(String, UInt)] = Seq()
 
@@ -247,6 +249,9 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
 
   val ctrl       = DelayN(io.ctrl, 1)
   val predictors = Module(if (useBPD) new Composer else new FakePredictor)
+
+  val totalMetaSize = (new PredictorMeta).getWidth
+  println(s"total meta size: $totalMetaSize\n")
 
   def numOfStage = 3
   require(numOfStage > 1, "BPU numOfStage must be greater than 1")
@@ -286,53 +291,56 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
   predictors.io.ctrl         := ctrl
   predictors.io.reset_vector := io.reset_vector
 
-  val s0_stall_dup = dup_wire(Bool()) // For some reason s0 stalled, usually FTQ Full
-  val s0_fire_dup, s1_fire_dup, s2_fire_dup, s3_fire_dup                        = dup_wire(Bool())
-  val s1_valid_dup, s2_valid_dup, s3_valid_dup                                  = dup_seq(RegInit(false.B))
-  val s1_ready_dup, s2_ready_dup, s3_ready_dup                                  = dup_wire(Bool())
-  val s1_components_ready_dup, s2_components_ready_dup, s3_components_ready_dup = dup_wire(Bool())
+  val s0_stall = Wire(Bool()) // For some reason s0 stalled, usually FTQ Full
 
-  val s0_pc_dup     = dup(WireInit(0.U.asTypeOf(PrunedAddr(VAddrBits))))
-  val s0_pc_reg_dup = s0_pc_dup.zip(s0_stall_dup).map { case (s0_pc, s0_stall) => RegEnable(s0_pc, !s0_stall) }
+  val s0_fire, s1_fire, s2_fire, s3_fire = Wire(Bool())
+
+  val s1_valid, s2_valid, s3_valid = RegInit(false.B)
+
+  val s1_ready, s2_ready, s3_ready = Wire(Bool())
+
+  val s1_components_ready, s2_components_ready, s3_components_ready = Wire(Bool())
+
+  val s1_flush, s2_flush, s3_flush = Wire(Bool())
+
+  val s2_redirect, s3_redirect = Wire(Bool())
+
+  val s0_pc     = WireInit(0.U.asTypeOf(PrunedAddr(VAddrBits)))
+  val s0_pc_reg = RegEnable(s0_pc, !s0_stall)
   when(RegNext(RegNext(reset.asBool) && !reset.asBool)) {
-    s0_pc_reg_dup.map { case s0_pc => s0_pc := io.reset_vector }
+    s0_pc_reg := io.reset_vector
   }
-  val s1_pc = RegEnable(s0_pc_dup(0), s0_fire_dup(0))
-  val s2_pc = RegEnable(s1_pc, s1_fire_dup(0))
-  val s3_pc = RegEnable(s2_pc, s2_fire_dup(0))
 
-  val s0_folded_gh_dup = dup_wire(new AllFoldedHistories(foldedGHistInfos))
-  val s0_folded_gh_reg_dup = s0_folded_gh_dup.zip(s0_stall_dup).map {
-    case (x, s0_stall) => RegEnable(x, 0.U.asTypeOf(s0_folded_gh_dup(0)), !s0_stall)
-  }
-  val s1_folded_gh_dup = RegEnable(s0_folded_gh_dup, 0.U.asTypeOf(s0_folded_gh_dup), s0_fire_dup(1))
-  val s2_folded_gh_dup = RegEnable(s1_folded_gh_dup, 0.U.asTypeOf(s0_folded_gh_dup), s1_fire_dup(1))
-  val s3_folded_gh_dup = RegEnable(s2_folded_gh_dup, 0.U.asTypeOf(s0_folded_gh_dup), s2_fire_dup(1))
+  val s1_pc = RegEnable(s0_pc, s0_fire)
+  val s2_pc = RegEnable(s1_pc, s1_fire)
+  val s3_pc = RegEnable(s2_pc, s2_fire)
 
-  val s0_last_br_num_oh_dup = dup_wire(UInt((numBr + 1).W))
-  val s0_last_br_num_oh_reg_dup = s0_last_br_num_oh_dup.zip(s0_stall_dup).map {
-    case (x, s0_stall) => RegEnable(x, 0.U, !s0_stall)
-  }
-  val s1_last_br_num_oh_dup = RegEnable(s0_last_br_num_oh_dup, 0.U.asTypeOf(s0_last_br_num_oh_dup), s0_fire_dup(1))
-  val s2_last_br_num_oh_dup = RegEnable(s1_last_br_num_oh_dup, 0.U.asTypeOf(s0_last_br_num_oh_dup), s1_fire_dup(1))
-  val s3_last_br_num_oh_dup = RegEnable(s2_last_br_num_oh_dup, 0.U.asTypeOf(s0_last_br_num_oh_dup), s2_fire_dup(1))
+  val s0_folded_gh     = Wire(new AllFoldedHistories(foldedGHistInfos))
+  val s0_folded_gh_reg = RegEnable(s0_folded_gh, 0.U.asTypeOf(s0_folded_gh), !s0_stall)
 
-  val s0_ahead_fh_oldest_bits_dup = dup_wire(new AllAheadFoldedHistoryOldestBits(foldedGHistInfos))
-  val s0_ahead_fh_oldest_bits_reg_dup = s0_ahead_fh_oldest_bits_dup.zip(s0_stall_dup).map {
-    case (x, s0_stall) => RegEnable(x, 0.U.asTypeOf(s0_ahead_fh_oldest_bits_dup(0)), !s0_stall)
-  }
-  val s1_ahead_fh_oldest_bits_dup =
-    RegEnable(s0_ahead_fh_oldest_bits_dup, 0.U.asTypeOf(s0_ahead_fh_oldest_bits_dup), s0_fire_dup(1))
-  val s2_ahead_fh_oldest_bits_dup =
-    RegEnable(s1_ahead_fh_oldest_bits_dup, 0.U.asTypeOf(s0_ahead_fh_oldest_bits_dup), s1_fire_dup(1))
-  val s3_ahead_fh_oldest_bits_dup =
-    RegEnable(s2_ahead_fh_oldest_bits_dup, 0.U.asTypeOf(s0_ahead_fh_oldest_bits_dup), s2_fire_dup(1))
+  val s1_folded_gh = RegEnable(s0_folded_gh, 0.U.asTypeOf(s0_folded_gh), s0_fire)
+  val s2_folded_gh = RegEnable(s1_folded_gh, 0.U.asTypeOf(s0_folded_gh), s1_fire)
+  val s3_folded_gh = RegEnable(s2_folded_gh, 0.U.asTypeOf(s0_folded_gh), s2_fire)
 
-  val npcGen_dup         = Seq.tabulate(numDup)(n => new PhyPriorityMuxGenerator[PrunedAddr])
-  val foldedGhGen_dup    = Seq.tabulate(numDup)(n => new PhyPriorityMuxGenerator[AllFoldedHistories])
-  val ghistPtrGen_dup    = Seq.tabulate(numDup)(n => new PhyPriorityMuxGenerator[CGHPtr])
-  val lastBrNumOHGen_dup = Seq.tabulate(numDup)(n => new PhyPriorityMuxGenerator[UInt])
-  val aheadFhObGen_dup   = Seq.tabulate(numDup)(n => new PhyPriorityMuxGenerator[AllAheadFoldedHistoryOldestBits])
+  val s0_last_br_num_oh     = Wire(UInt((numBr + 1).W))
+  val s0_last_br_num_oh_reg = RegEnable(s0_last_br_num_oh, 0.U, !s0_stall)
+
+  val s1_last_br_num_oh = RegEnable(s0_last_br_num_oh, 0.U.asTypeOf(s0_last_br_num_oh), s0_fire)
+  val s2_last_br_num_oh = RegEnable(s1_last_br_num_oh, 0.U.asTypeOf(s0_last_br_num_oh), s1_fire)
+  val s3_last_br_num_oh = RegEnable(s2_last_br_num_oh, 0.U.asTypeOf(s0_last_br_num_oh), s2_fire)
+
+  val s0_ahead_fh_oldest_bits     = Wire(new AllAheadFoldedHistoryOldestBits(foldedGHistInfos))
+  val s0_ahead_fh_oldest_bits_reg = RegEnable(s0_ahead_fh_oldest_bits, 0.U.asTypeOf(s0_ahead_fh_oldest_bits), !s0_stall)
+
+  val s1_ahead_fh_oldest_bits = RegEnable(s0_ahead_fh_oldest_bits, 0.U.asTypeOf(s0_ahead_fh_oldest_bits), s0_fire)
+  val s2_ahead_fh_oldest_bits = RegEnable(s1_ahead_fh_oldest_bits, 0.U.asTypeOf(s0_ahead_fh_oldest_bits), s1_fire)
+  val s3_ahead_fh_oldest_bits = RegEnable(s2_ahead_fh_oldest_bits, 0.U.asTypeOf(s0_ahead_fh_oldest_bits), s2_fire)
+
+  val npcGen         = new PhyPriorityMuxGenerator[PrunedAddr]
+  val foldedGhGen    = new PhyPriorityMuxGenerator[AllFoldedHistories]
+  val ghistPtrGen    = new PhyPriorityMuxGenerator[CGHPtr]
+  val lastBrNumOHGen = new PhyPriorityMuxGenerator[UInt]
+  val aheadFhObGen   = new PhyPriorityMuxGenerator[AllAheadFoldedHistoryOldestBits]
 
   val ghvBitWriteGens = Seq.tabulate(HistoryLength)(n => new PhyPriorityMuxGenerator[Bool])
   // val ghistGen = new PhyPriorityMuxGenerator[UInt]
@@ -346,449 +354,309 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
   val ghv_write_datas = Wire(Vec(HistoryLength, Bool()))
   val ghv_wens        = Wire(Vec(HistoryLength, Bool()))
 
-  val s0_ghist_ptr_dup = dup_wire(new CGHPtr)
-  val s0_ghist_ptr_reg_dup = s0_ghist_ptr_dup.zip(s0_stall_dup).map {
-    case (x, s0_stall) => RegEnable(x, 0.U.asTypeOf(new CGHPtr), !s0_stall)
-  }
-  val s1_ghist_ptr_dup = RegEnable(s0_ghist_ptr_dup, 0.U.asTypeOf(s0_ghist_ptr_dup), s0_fire_dup(1))
-  val s2_ghist_ptr_dup = RegEnable(s1_ghist_ptr_dup, 0.U.asTypeOf(s0_ghist_ptr_dup), s1_fire_dup(1))
-  val s3_ghist_ptr_dup = RegEnable(s2_ghist_ptr_dup, 0.U.asTypeOf(s0_ghist_ptr_dup), s2_fire_dup(1))
+  val s0_ghist_ptr     = Wire(new CGHPtr)
+  val s0_ghist_ptr_reg = RegEnable(s0_ghist_ptr, 0.U.asTypeOf(new CGHPtr), !s0_stall)
+
+  val s1_ghist_ptr = RegEnable(s0_ghist_ptr, 0.U.asTypeOf(s0_ghist_ptr), s0_fire)
+  val s2_ghist_ptr = RegEnable(s1_ghist_ptr, 0.U.asTypeOf(s0_ghist_ptr), s1_fire)
+  val s3_ghist_ptr = RegEnable(s2_ghist_ptr, 0.U.asTypeOf(s0_ghist_ptr), s2_fire)
 
   def getHist(ptr: CGHPtr): UInt = (Cat(ghv_wire.asUInt, ghv_wire.asUInt) >> (ptr.value + 1.U))(HistoryLength - 1, 0)
-  s0_ghist := getHist(s0_ghist_ptr_dup(0))
+  s0_ghist := getHist(s0_ghist_ptr)
 
   val resp = predictors.io.out
 
-  val toFtq_fire = io.bpu_to_ftq.resp.valid && io.bpu_to_ftq.resp.ready
-
-  val s1_flush_dup, s2_flush_dup, s3_flush_dup = dup_wire(Bool())
-  val s2_redirect_dup, s3_redirect_dup         = dup_wire(Bool())
-
-  // predictors.io := DontCare
-  predictors.io.in.valid               := s0_fire_dup(0)
-  predictors.io.in.bits.s0_pc          := s0_pc_dup
+  predictors.io.in.valid               := s0_fire
+  predictors.io.in.bits.s0_pc          := s0_pc
   predictors.io.in.bits.ghist          := s0_ghist
-  predictors.io.in.bits.folded_hist    := s0_folded_gh_dup
-  predictors.io.in.bits.s1_folded_hist := s1_folded_gh_dup
+  predictors.io.in.bits.folded_hist    := s0_folded_gh
+  predictors.io.in.bits.s1_folded_hist := s1_folded_gh
   predictors.io.in.bits.resp_in(0)     := 0.U.asTypeOf(new BranchPredictionResp)
   predictors.io.fauftb_entry_in        := 0.U.asTypeOf(new FTBEntry)
   predictors.io.fauftb_entry_hit_in    := false.B
   predictors.io.redirectFromIFU        := RegNext(io.ftq_to_bpu.redirctFromIFU, init = false.B)
-  // predictors.io.in.bits.resp_in(0).s1.pc := s0_pc
-  // predictors.io.in.bits.toFtq_fire := toFtq_fire
 
-  // predictors.io.out.ready := io.bpu_to_ftq.resp.ready
-
-  val redirect_req    = io.ftq_to_bpu.redirect
-  val do_redirect_dup = dup_seq(RegNextWithEnable(redirect_req))
+  val redirect_req = io.ftq_to_bpu.redirect
+  val do_redirect  = RegNextWithEnable(redirect_req)
 
   // Pipeline logic
-  s2_redirect_dup.map(_ := false.B)
-  s3_redirect_dup.map(_ := false.B)
+  s2_redirect := false.B
+  s3_redirect := false.B
 
-  s3_flush_dup.map(_ := redirect_req.valid) // flush when redirect comes
-  for (((s2_flush, s3_flush), s3_redirect) <- s2_flush_dup zip s3_flush_dup zip s3_redirect_dup)
-    s2_flush := s3_flush || s3_redirect
-  for (((s1_flush, s2_flush), s2_redirect) <- s1_flush_dup zip s2_flush_dup zip s2_redirect_dup)
-    s1_flush := s2_flush || s2_redirect
+  s3_flush := redirect_req.valid // flush when redirect comes
+  s2_flush := s3_flush || s3_redirect
+  s1_flush := s2_flush || s2_redirect
 
-  s1_components_ready_dup.map(_ := predictors.io.s1_ready)
-  for (((s1_ready, s1_fire), s1_valid) <- s1_ready_dup zip s1_fire_dup zip s1_valid_dup)
-    s1_ready := s1_fire || !s1_valid
-  for (((s0_fire, s1_components_ready), s1_ready) <- s0_fire_dup zip s1_components_ready_dup zip s1_ready_dup)
-    s0_fire             := s1_components_ready && s1_ready
-  predictors.io.s0_fire := s0_fire_dup
+  s1_components_ready := predictors.io.s1_ready
+  s2_components_ready := predictors.io.s2_ready
+  s3_components_ready := predictors.io.s3_ready
 
-  s2_components_ready_dup.map(_ := predictors.io.s2_ready)
-  for (((s2_ready, s2_fire), s2_valid) <- s2_ready_dup zip s2_fire_dup zip s2_valid_dup)
-    s2_ready := s2_fire || !s2_valid
-  for (
-    (((s1_fire, s2_components_ready), s2_ready), s1_valid) <-
-      s1_fire_dup zip s2_components_ready_dup zip s2_ready_dup zip s1_valid_dup
-  )
-    s1_fire := s1_valid && s2_components_ready && s2_ready && io.bpu_to_ftq.resp.ready
+  s1_ready := s1_fire || !s1_valid
+  s2_ready := s2_fire || !s2_valid
+  s3_ready := s3_fire || !s3_valid
 
-  s3_components_ready_dup.map(_ := predictors.io.s3_ready)
-  for (((s3_ready, s3_fire), s3_valid) <- s3_ready_dup zip s3_fire_dup zip s3_valid_dup)
-    s3_ready := s3_fire || !s3_valid
-  for (
-    (((s2_fire, s3_components_ready), s3_ready), s2_valid) <-
-      s2_fire_dup zip s3_components_ready_dup zip s3_ready_dup zip s2_valid_dup
-  )
-    s2_fire := s2_valid && s3_components_ready && s3_ready
+  s0_fire := s1_components_ready && s1_ready
+  s1_fire := s1_valid && s2_components_ready && s2_ready && io.bpu_to_ftq.resp.ready
+  s2_fire := s2_valid && s3_components_ready && s3_ready
+  s3_fire := s3_valid
 
-  for ((((s0_fire, s1_flush), s1_fire), s1_valid) <- s0_fire_dup zip s1_flush_dup zip s1_fire_dup zip s1_valid_dup) {
-    when(redirect_req.valid)(s1_valid := false.B)
-      .elsewhen(s0_fire)(s1_valid := true.B)
-      .elsewhen(s1_flush)(s1_valid := false.B)
-      .elsewhen(s1_fire)(s1_valid := false.B)
-  }
-  predictors.io.s1_fire := s1_fire_dup
+  predictors.io.s0_fire := s0_fire
+  predictors.io.s1_fire := s1_fire
+  predictors.io.s2_fire := s2_fire
+  predictors.io.s3_fire := s3_fire
 
-  for (
-    ((((s1_fire, s2_flush), s2_fire), s2_valid), s1_flush) <-
-      s1_fire_dup zip s2_flush_dup zip s2_fire_dup zip s2_valid_dup zip s1_flush_dup
-  ) {
+  when(redirect_req.valid)(s1_valid := false.B)
+    .elsewhen(s0_fire)(s1_valid := true.B)
+    .elsewhen(s1_flush)(s1_valid := false.B)
+    .elsewhen(s1_fire)(s1_valid := false.B)
 
-    when(s2_flush)(s2_valid := false.B)
-      .elsewhen(s1_fire)(s2_valid := !s1_flush)
-      .elsewhen(s2_fire)(s2_valid := false.B)
-  }
+  when(s2_flush)(s2_valid := false.B)
+    .elsewhen(s1_fire)(s2_valid := !s1_flush)
+    .elsewhen(s2_fire)(s2_valid := false.B)
 
-  predictors.io.s2_fire     := s2_fire_dup
-  predictors.io.s2_redirect := s2_redirect_dup
+  when(s3_flush)(s3_valid := false.B)
+    .elsewhen(s2_fire)(s3_valid := !s2_flush)
+    .elsewhen(s3_fire)(s3_valid := false.B)
 
-  s3_fire_dup := s3_valid_dup
-
-  for (
-    ((((s2_fire, s3_flush), s3_fire), s3_valid), s2_flush) <-
-      s2_fire_dup zip s3_flush_dup zip s3_fire_dup zip s3_valid_dup zip s2_flush_dup
-  ) {
-
-    when(s3_flush)(s3_valid := false.B)
-      .elsewhen(s2_fire)(s3_valid := !s2_flush)
-      .elsewhen(s3_fire)(s3_valid := false.B)
-  }
-
-  predictors.io.s3_fire     := s3_fire_dup
-  predictors.io.s3_redirect := s3_redirect_dup
-
-  io.bpu_to_ftq.resp.valid :=
-    s1_valid_dup(2) && s2_components_ready_dup(2) && s2_ready_dup(2) ||
-      s2_fire_dup(2) && s2_redirect_dup(2) ||
-      s3_fire_dup(2) && s3_redirect_dup(2)
+  io.bpu_to_ftq.resp.valid := s1_valid && s2_components_ready && s2_ready ||
+    s2_fire && s2_redirect ||
+    s3_fire && s3_redirect
   io.bpu_to_ftq.resp.bits                              := predictors.io.out
-  io.bpu_to_ftq.resp.bits.last_stage_spec_info.histPtr := s3_ghist_ptr_dup(2)
-
-  io.bpu_to_ftq.meta := predictors.io.meta
-
-  val full_pred_diff        = WireInit(false.B)
-  val full_pred_diff_stage  = WireInit(0.U)
-  val full_pred_diff_offset = WireInit(0.U)
-  for (i <- 0 until numDup - 1) {
-    when(io.bpu_to_ftq.resp.valid &&
-      ((io.bpu_to_ftq.resp.bits.s1.full_pred(i).asTypeOf(UInt()) =/= io.bpu_to_ftq.resp.bits.s1.full_pred(
-        i + 1
-      ).asTypeOf(UInt()) && io.bpu_to_ftq.resp.bits.s1.full_pred(i).hit) ||
-        (io.bpu_to_ftq.resp.bits.s2.full_pred(i).asTypeOf(UInt()) =/= io.bpu_to_ftq.resp.bits.s2.full_pred(
-          i + 1
-        ).asTypeOf(UInt()) && io.bpu_to_ftq.resp.bits.s2.full_pred(i).hit) ||
-        (io.bpu_to_ftq.resp.bits.s3.full_pred(i).asTypeOf(UInt()) =/= io.bpu_to_ftq.resp.bits.s3.full_pred(
-          i + 1
-        ).asTypeOf(UInt()) && io.bpu_to_ftq.resp.bits.s3.full_pred(i).hit))) {
-      full_pred_diff        := true.B
-      full_pred_diff_offset := i.U
-      when(io.bpu_to_ftq.resp.bits.s1.full_pred(i).asTypeOf(UInt()) =/= io.bpu_to_ftq.resp.bits.s1.full_pred(
-        i + 1
-      ).asTypeOf(UInt())) {
-        full_pred_diff_stage := 1.U
-      }.elsewhen(io.bpu_to_ftq.resp.bits.s2.full_pred(i).asTypeOf(UInt()) =/= io.bpu_to_ftq.resp.bits.s2.full_pred(
-        i + 1
-      ).asTypeOf(UInt())) {
-        full_pred_diff_stage := 2.U
-      }.otherwise {
-        full_pred_diff_stage := 3.U
-      }
-    }
-  }
-  XSError(full_pred_diff, "Full prediction difference detected!")
+  io.bpu_to_ftq.resp.bits.last_stage_spec_info.histPtr := s3_ghist_ptr
+  io.bpu_to_ftq.meta                                   := predictors.io.meta
 
   // s0_stall should be exclusive with any other PC source
-  s0_stall_dup.zip(s1_valid_dup).zip(s2_redirect_dup).zip(s3_redirect_dup).zip(do_redirect_dup).foreach {
-    case ((((s0_stall, s1_valid), s2_redirect), s3_redirect), do_redirect) => {
-      s0_stall := !(s1_valid || s2_redirect || s3_redirect || do_redirect.valid)
-    }
-  }
+  s0_stall := !(s1_valid || s2_redirect || s3_redirect || do_redirect.valid)
+
   // Power-on reset
   val powerOnResetState = RegInit(true.B)
-  when(s0_fire_dup(0)) {
+  when(s0_fire) {
     // When BPU pipeline first time fire, we consider power-on reset is done
     powerOnResetState := false.B
   }
   XSError(
-    !powerOnResetState && s0_stall_dup(0) && s0_pc_dup(0) =/= s0_pc_reg_dup(0),
+    !powerOnResetState && s0_stall && s0_pc =/= s0_pc_reg,
     "s0_stall but s0_pc is differenct from s0_pc_reg"
   )
 
-  npcGen_dup.zip(s0_pc_reg_dup).map { case (gen, reg) =>
-    gen.register(true.B, reg, Some("stallPC"), 0)
-  }
-  foldedGhGen_dup.zip(s0_folded_gh_reg_dup).map { case (gen, reg) =>
-    gen.register(true.B, reg, Some("stallFGH"), 0)
-  }
-  ghistPtrGen_dup.zip(s0_ghist_ptr_reg_dup).map { case (gen, reg) =>
-    gen.register(true.B, reg, Some("stallGHPtr"), 0)
-  }
-  lastBrNumOHGen_dup.zip(s0_last_br_num_oh_reg_dup).map { case (gen, reg) =>
-    gen.register(true.B, reg, Some("stallBrNumOH"), 0)
-  }
-  aheadFhObGen_dup.zip(s0_ahead_fh_oldest_bits_reg_dup).map { case (gen, reg) =>
-    gen.register(true.B, reg, Some("stallAFHOB"), 0)
-  }
+  npcGen.register(true.B, s0_pc_reg, Some("stallPC"), 0)
+  foldedGhGen.register(true.B, s0_folded_gh_reg, Some("stallFGH"), 0)
+  ghistPtrGen.register(true.B, s0_ghist_ptr_reg, Some("stallGHPtr"), 0)
+  lastBrNumOHGen.register(true.B, s0_last_br_num_oh_reg, Some("stallBrNumOH"), 0)
+  aheadFhObGen.register(true.B, s0_ahead_fh_oldest_bits_reg, Some("stallAFHOB"), 0)
 
   // assign pred cycle for profiling
-  io.bpu_to_ftq.resp.bits.s1.full_pred.map(_.predCycle.map(_ := GTimer()))
-  io.bpu_to_ftq.resp.bits.s2.full_pred.map(_.predCycle.map(_ := GTimer()))
-  io.bpu_to_ftq.resp.bits.s3.full_pred.map(_.predCycle.map(_ := GTimer()))
+  io.bpu_to_ftq.resp.bits.s1.full_pred.predCycle.map(_ := GTimer())
+  io.bpu_to_ftq.resp.bits.s2.full_pred.predCycle.map(_ := GTimer())
+  io.bpu_to_ftq.resp.bits.s3.full_pred.predCycle.map(_ := GTimer())
 
   // History manage
   // s1
-  val s1_possible_predicted_ghist_ptrs_dup = s1_ghist_ptr_dup.map(ptr => (0 to numBr).map(ptr - _.U))
-  val s1_predicted_ghist_ptr_dup = s1_possible_predicted_ghist_ptrs_dup.zip(resp.s1.lastBrPosOH).map { case (ptr, oh) =>
-    Mux1H(oh, ptr)
-  }
-  val s1_possible_predicted_fhs_dup =
-    for (
-      ((((fgh, afh), br_num_oh), t), br_pos_oh) <-
-        s1_folded_gh_dup zip s1_ahead_fh_oldest_bits_dup zip s1_last_br_num_oh_dup zip resp.s1.brTaken zip resp.s1.lastBrPosOH
-    )
-      yield (0 to numBr).map(i =>
-        fgh.update(afh, br_num_oh, i, t & br_pos_oh(i))
-      )
-  val s1_predicted_fh_dup = resp.s1.lastBrPosOH.zip(s1_possible_predicted_fhs_dup).map { case (oh, fh) =>
-    Mux1H(oh, fh)
-  }
+  val s1_possible_predicted_ghist_ptrs = (0 to numBr).map(s1_ghist_ptr - _.U)
 
-  val s1_ahead_fh_ob_src_dup = dup_wire(new AllAheadFoldedHistoryOldestBits(foldedGHistInfos))
-  s1_ahead_fh_ob_src_dup.zip(s1_ghist_ptr_dup).map { case (src, ptr) => src.read(ghv, ptr) }
+  val s1_predicted_ghist_ptr = Mux1H(resp.s1.lastBrPosOH, s1_possible_predicted_ghist_ptrs)
+
+  val s1_possible_predicted_fhs = (0 to numBr).map(i =>
+    s1_folded_gh.update(s1_ahead_fh_oldest_bits, s1_last_br_num_oh, i, resp.s1.brTaken & resp.s1.lastBrPosOH(i))
+  )
+
+  val s1_predicted_fh = Mux1H(resp.s1.lastBrPosOH, s1_possible_predicted_fhs)
+
+  val s1_ahead_fh_ob_src = Wire(new AllAheadFoldedHistoryOldestBits(foldedGHistInfos))
+  s1_ahead_fh_ob_src.read(ghv, s1_ghist_ptr)
 
   if (EnableGHistDiff) {
-    val s1_predicted_ghist = WireInit(getHist(s1_predicted_ghist_ptr_dup(0)).asTypeOf(Vec(HistoryLength, Bool())))
+    val s1_predicted_ghist = WireInit(getHist(s1_predicted_ghist_ptr).asTypeOf(Vec(HistoryLength, Bool())))
     for (i <- 0 until numBr) {
-      when(resp.s1.shouldShiftVec(0)(i)) {
-        s1_predicted_ghist(i) := resp.s1.brTaken(0) && (i == 0).B
+      when(resp.s1.shouldShiftVec(i)) {
+        s1_predicted_ghist(i) := resp.s1.brTaken && (i == 0).B
       }
     }
-    when(s1_valid_dup(0)) {
+    when(s1_valid) {
       s0_ghist := s1_predicted_ghist.asUInt
     }
   }
 
   val s1_ghv_wens = (0 until HistoryLength).map(n =>
     (0 until numBr).map(b =>
-      s1_ghist_ptr_dup(0).value === (CGHPtr(false.B, n.U) + b.U).value &&
-        resp.s1.shouldShiftVec(0)(b) && s1_valid_dup(0)
+      s1_ghist_ptr.value === (CGHPtr(false.B, n.U) + b.U).value &&
+        resp.s1.shouldShiftVec(b) && s1_valid
     )
   )
   val s1_ghv_wdatas = (0 until HistoryLength).map(n =>
     Mux1H(
       (0 until numBr).map(b =>
         (
-          s1_ghist_ptr_dup(0).value === (CGHPtr(false.B, n.U) + b.U).value && resp.s1.shouldShiftVec(0)(b),
-          resp.s1.brTaken(0) && resp.s1.lastBrPosOH(0)(b + 1)
+          s1_ghist_ptr.value === (CGHPtr(false.B, n.U) + b.U).value && resp.s1.shouldShiftVec(b),
+          resp.s1.brTaken && resp.s1.lastBrPosOH(b + 1)
         )
       )
     )
   )
 
-  for (((npcGen, s1_valid), s1_target) <- npcGen_dup zip s1_valid_dup zip resp.s1.getTarget)
-    npcGen.register(s1_valid, s1_target, Some("s1_target"), 4)
-  for (((foldedGhGen, s1_valid), s1_predicted_fh) <- foldedGhGen_dup zip s1_valid_dup zip s1_predicted_fh_dup)
-    foldedGhGen.register(s1_valid, s1_predicted_fh, Some("s1_FGH"), 4)
-  for (
-    ((ghistPtrGen, s1_valid), s1_predicted_ghist_ptr) <- ghistPtrGen_dup zip s1_valid_dup zip s1_predicted_ghist_ptr_dup
-  )
-    ghistPtrGen.register(s1_valid, s1_predicted_ghist_ptr, Some("s1_GHPtr"), 4)
-  for (
-    ((lastBrNumOHGen, s1_valid), s1_brPosOH) <-
-      lastBrNumOHGen_dup zip s1_valid_dup zip resp.s1.lastBrPosOH.map(_.asUInt)
-  )
-    lastBrNumOHGen.register(s1_valid, s1_brPosOH, Some("s1_BrNumOH"), 4)
-  for (((aheadFhObGen, s1_valid), s1_ahead_fh_ob_src) <- aheadFhObGen_dup zip s1_valid_dup zip s1_ahead_fh_ob_src_dup)
-    aheadFhObGen.register(s1_valid, s1_ahead_fh_ob_src, Some("s1_AFHOB"), 4)
+  npcGen.register(s1_valid, resp.s1.getTarget, Some("s1_target"), 4)
+  foldedGhGen.register(s1_valid, s1_predicted_fh, Some("s1_FGH"), 4)
+  ghistPtrGen.register(s1_valid, s1_predicted_ghist_ptr, Some("s1_GHPtr"), 4)
+  lastBrNumOHGen.register(s1_valid, resp.s1.lastBrPosOH.asUInt, Some("s1_BrNumOH"), 4)
+  aheadFhObGen.register(s1_valid, s1_ahead_fh_ob_src, Some("s1_AFHOB"), 4)
+
   ghvBitWriteGens.zip(s1_ghv_wens).zipWithIndex.map { case ((b, w), i) =>
     b.register(w.reduce(_ || _), s1_ghv_wdatas(i), Some(s"s1_new_bit_$i"), 4)
   }
 
   class PreviousPredInfo extends Bundle {
-    val hit         = Vec(numDup, Bool())
-    val target      = Vec(numDup, PrunedAddr(VAddrBits))
-    val lastBrPosOH = Vec(numDup, Vec(numBr + 1, Bool()))
-    val taken       = Vec(numDup, Bool())
-    val takenMask   = Vec(numDup, Vec(numBr, Bool()))
-    val cfiIndex    = Vec(numDup, UInt(log2Ceil(PredictWidth).W))
+    val hit         = Bool()
+    val target      = PrunedAddr(VAddrBits)
+    val lastBrPosOH = Vec(numBr + 1, Bool())
+    val taken       = Bool()
+    val takenMask   = Vec(numBr, Bool())
+    val cfiIndex    = UInt(log2Ceil(PredictWidth).W)
   }
 
-  def preds_needs_redirect_vec_dup(x: PreviousPredInfo, y: BranchPredictionBundle) = {
+  def preds_needs_redirect_vec(x: PreviousPredInfo, y: BranchPredictionBundle) = {
     // Timing optimization
     // We first compare all target with previous stage target,
     // then select the difference by taken & hit
     // Usually target is generated quicker than taken, so do target compare before select can help timing
-    val targetDiffVec: IndexedSeq[Vec[Bool]] =
-      x.target.zip(y.getAllTargets).map {
-        case (xTarget, yAllTarget) => VecInit(yAllTarget.map(_ =/= xTarget))
-      } // [numDup][all Target comparison]
-    val targetDiff: IndexedSeq[Bool] =
-      targetDiffVec.zip(x.hit).zip(x.takenMask).map {
-        case ((diff, hit), takenMask) => selectByTaken(takenMask, hit, diff)
-      } // [numDup]
+    val targetDiffVec: Vec[Bool] = VecInit(y.getAllTargets.map(_ =/= x.target))
 
-    val lastBrPosOHDiff: IndexedSeq[Bool] = x.lastBrPosOH.zip(y.lastBrPosOH).map { case (oh1, oh2) =>
-      oh1.asUInt =/= oh2.asUInt
-    }
-    val takenDiff: IndexedSeq[Bool] = x.taken.zip(y.taken).map { case (t1, t2) => t1 =/= t2 }
-    val takenOffsetDiff: IndexedSeq[Bool] = x.cfiIndex.zip(y.cfiIndex).zip(x.taken).zip(y.taken).map {
-      case (((i1, i2), xt), yt) => xt && yt && i1 =/= i2.bits
-    }
-    VecInit(
-      for (
-        (((tgtd, lbpohd), tkd), tod) <-
-          targetDiff zip lastBrPosOHDiff zip takenDiff zip takenOffsetDiff
-      )
-        yield VecInit(tgtd, lbpohd, tkd, tod)
-      // x.shouldShiftVec.asUInt =/= y.shouldShiftVec.asUInt,
-      // x.brTaken =/= y.brTaken
-    )
+    val targetDiff: Bool = selectByTaken(x.takenMask, x.hit, targetDiffVec)
+
+    val lastBrPosOHDiff: Bool = x.lastBrPosOH.asUInt =/= y.lastBrPosOH.asUInt
+
+    val takenDiff: Bool = x.taken =/= y.taken
+
+    val takenOffsetDiff: Bool = x.taken && y.taken && x.cfiIndex =/= y.cfiIndex.bits
+
+    VecInit(targetDiff, lastBrPosOHDiff, takenDiff, takenOffsetDiff)
+    // x.shouldShiftVec.asUInt =/= y.shouldShiftVec.asUInt,
+    // x.brTaken =/= y.brTaken
   }
 
   // s2
-  val s2_possible_predicted_ghist_ptrs_dup = s2_ghist_ptr_dup.map(ptr => (0 to numBr).map(ptr - _.U))
-  val s2_predicted_ghist_ptr_dup = s2_possible_predicted_ghist_ptrs_dup.zip(resp.s2.lastBrPosOH).map { case (ptr, oh) =>
-    Mux1H(oh, ptr)
-  }
+  val s2_possible_predicted_ghist_ptrs = (0 to numBr).map(s2_ghist_ptr - _.U)
+  val s2_predicted_ghist_ptr           = Mux1H(resp.s2.lastBrPosOH, s2_possible_predicted_ghist_ptrs)
 
-  val s2_possible_predicted_fhs_dup =
-    for (
-      (((fgh, afh), br_num_oh), full_pred) <-
-        s2_folded_gh_dup zip s2_ahead_fh_oldest_bits_dup zip s2_last_br_num_oh_dup zip resp.s2.full_pred
+  val s2_possible_predicted_fhs = (0 to numBr).map(i =>
+    s2_folded_gh.update(
+      s2_ahead_fh_oldest_bits,
+      s2_last_br_num_oh,
+      i,
+      if (i > 0) resp.s2.full_pred.br_taken_mask(i - 1) else false.B
     )
-      yield (0 to numBr).map(i =>
-        fgh.update(afh, br_num_oh, i, if (i > 0) full_pred.br_taken_mask(i - 1) else false.B)
-      )
-  val s2_predicted_fh_dup = resp.s2.lastBrPosOH.zip(s2_possible_predicted_fhs_dup).map { case (oh, fh) =>
-    Mux1H(oh, fh)
-  }
+  )
 
-  val s2_ahead_fh_ob_src_dup = dup_wire(new AllAheadFoldedHistoryOldestBits(foldedGHistInfos))
-  s2_ahead_fh_ob_src_dup.zip(s2_ghist_ptr_dup).map { case (src, ptr) => src.read(ghv, ptr) }
+  val s2_predicted_fh = Mux1H(resp.s2.lastBrPosOH, s2_possible_predicted_fhs)
+
+  val s2_ahead_fh_ob_src = Wire(new AllAheadFoldedHistoryOldestBits(foldedGHistInfos))
+  s2_ahead_fh_ob_src.read(ghv, s2_ghist_ptr)
 
   if (EnableGHistDiff) {
-    val s2_predicted_ghist = WireInit(getHist(s2_predicted_ghist_ptr_dup(0)).asTypeOf(Vec(HistoryLength, Bool())))
+    val s2_predicted_ghist = WireInit(getHist(s2_predicted_ghist_ptr).asTypeOf(Vec(HistoryLength, Bool())))
     for (i <- 0 until numBr) {
-      when(resp.s2.shouldShiftVec(0)(i)) {
-        s2_predicted_ghist(i) := resp.s2.brTaken(0) && (i == 0).B
+      when(resp.s2.shouldShiftVec(i)) {
+        s2_predicted_ghist(i) := resp.s2.brTaken && (i == 0).B
       }
     }
-    when(s2_redirect_dup(0)) {
+    when(s2_redirect) {
       s0_ghist := s2_predicted_ghist.asUInt
     }
   }
 
   val s2_ghv_wens = (0 until HistoryLength).map(n =>
     (0 until numBr).map(b =>
-      s2_ghist_ptr_dup(0).value === (CGHPtr(false.B, n.U) + b.U).value &&
-        resp.s2.shouldShiftVec(0)(b) && s2_redirect_dup(0)
+      s2_ghist_ptr.value === (CGHPtr(false.B, n.U) + b.U).value &&
+        resp.s2.shouldShiftVec(b) && s2_redirect
     )
   )
   val s2_ghv_wdatas = (0 until HistoryLength).map(n =>
     Mux1H(
       (0 until numBr).map(b =>
         (
-          s2_ghist_ptr_dup(0).value === (CGHPtr(false.B, n.U) + b.U).value && resp.s2.shouldShiftVec(0)(b),
-          resp.s2.full_pred(0).real_br_taken_mask()(b)
+          s2_ghist_ptr.value === (CGHPtr(false.B, n.U) + b.U).value && resp.s2.shouldShiftVec(b),
+          resp.s2.full_pred.real_br_taken_mask()(b)
         )
       )
     )
   )
 
   val s1_pred_info = Wire(new PreviousPredInfo)
-  s1_pred_info.hit         := resp.s1.full_pred.map(_.hit)
+  s1_pred_info.hit         := resp.s1.full_pred.hit
   s1_pred_info.target      := resp.s1.getTarget
   s1_pred_info.lastBrPosOH := resp.s1.lastBrPosOH
   s1_pred_info.taken       := resp.s1.taken
-  s1_pred_info.takenMask   := resp.s1.full_pred.map(_.taken_mask_on_slot)
-  s1_pred_info.cfiIndex    := resp.s1.cfiIndex.map { case x => x.bits }
+  s1_pred_info.takenMask   := resp.s1.full_pred.taken_mask_on_slot
+  s1_pred_info.cfiIndex    := resp.s1.cfiIndex.bits
 
-  val previous_s1_pred_info = RegEnable(s1_pred_info, 0.U.asTypeOf(new PreviousPredInfo), s1_fire_dup(0))
+  val previous_s1_pred_info = RegEnable(s1_pred_info, 0.U.asTypeOf(new PreviousPredInfo), s1_fire)
 
-  val s2_redirect_s1_last_pred_vec_dup = preds_needs_redirect_vec_dup(previous_s1_pred_info, resp.s2)
+  val s2_redirect_s1_last_pred_vec = preds_needs_redirect_vec(previous_s1_pred_info, resp.s2)
 
-  for (
-    ((s2_redirect, s2_fire), s2_redirect_s1_last_pred_vec) <-
-      s2_redirect_dup zip s2_fire_dup zip s2_redirect_s1_last_pred_vec_dup
-  )
-    s2_redirect := s2_fire && s2_redirect_s1_last_pred_vec.reduce(_ || _)
+  s2_redirect := s2_fire && s2_redirect_s1_last_pred_vec.reduce(_ || _)
 
-  for (((npcGen, s2_redirect), s2_target) <- npcGen_dup zip s2_redirect_dup zip resp.s2.getTarget)
-    npcGen.register(s2_redirect, s2_target, Some("s2_target"), 5)
-  for (((foldedGhGen, s2_redirect), s2_predicted_fh) <- foldedGhGen_dup zip s2_redirect_dup zip s2_predicted_fh_dup)
-    foldedGhGen.register(s2_redirect, s2_predicted_fh, Some("s2_FGH"), 5)
-  for (
-    ((ghistPtrGen, s2_redirect), s2_predicted_ghist_ptr) <-
-      ghistPtrGen_dup zip s2_redirect_dup zip s2_predicted_ghist_ptr_dup
-  )
-    ghistPtrGen.register(s2_redirect, s2_predicted_ghist_ptr, Some("s2_GHPtr"), 5)
-  for (
-    ((lastBrNumOHGen, s2_redirect), s2_brPosOH) <-
-      lastBrNumOHGen_dup zip s2_redirect_dup zip resp.s2.lastBrPosOH.map(_.asUInt)
-  )
-    lastBrNumOHGen.register(s2_redirect, s2_brPosOH, Some("s2_BrNumOH"), 5)
-  for (
-    ((aheadFhObGen, s2_redirect), s2_ahead_fh_ob_src) <- aheadFhObGen_dup zip s2_redirect_dup zip s2_ahead_fh_ob_src_dup
-  )
-    aheadFhObGen.register(s2_redirect, s2_ahead_fh_ob_src, Some("s2_AFHOB"), 5)
+  npcGen.register(s2_redirect, resp.s2.getTarget, Some("s2_target"), 5)
+  foldedGhGen.register(s2_redirect, s2_predicted_fh, Some("s2_FGH"), 5)
+  ghistPtrGen.register(s2_redirect, s2_predicted_ghist_ptr, Some("s2_GHPtr"), 5)
+  lastBrNumOHGen.register(s2_redirect, resp.s2.lastBrPosOH.asUInt, Some("s2_BrNumOH"), 5)
+  aheadFhObGen.register(s2_redirect, s2_ahead_fh_ob_src, Some("s2_AFHOB"), 5)
+
   ghvBitWriteGens.zip(s2_ghv_wens).zipWithIndex.map { case ((b, w), i) =>
     b.register(w.reduce(_ || _), s2_ghv_wdatas(i), Some(s"s2_new_bit_$i"), 5)
   }
 
-  XSPerfAccumulate("s2_redirect_because_target_diff", s2_fire_dup(0) && s2_redirect_s1_last_pred_vec_dup(0)(0))
-  XSPerfAccumulate("s2_redirect_because_branch_num_diff", s2_fire_dup(0) && s2_redirect_s1_last_pred_vec_dup(0)(1))
-  XSPerfAccumulate("s2_redirect_because_direction_diff", s2_fire_dup(0) && s2_redirect_s1_last_pred_vec_dup(0)(2))
-  XSPerfAccumulate("s2_redirect_because_cfi_idx_diff", s2_fire_dup(0) && s2_redirect_s1_last_pred_vec_dup(0)(3))
+  XSPerfAccumulate("s2_redirect_because_target_diff", s2_fire && s2_redirect_s1_last_pred_vec(0))
+  XSPerfAccumulate("s2_redirect_because_branch_num_diff", s2_fire && s2_redirect_s1_last_pred_vec(1))
+  XSPerfAccumulate("s2_redirect_because_direction_diff", s2_fire && s2_redirect_s1_last_pred_vec(2))
+  XSPerfAccumulate("s2_redirect_because_cfi_idx_diff", s2_fire && s2_redirect_s1_last_pred_vec(3))
   // XSPerfAccumulate("s2_redirect_because_shouldShiftVec_diff", s2_fire && s2_redirect_s1_last_pred_vec(4))
   // XSPerfAccumulate("s2_redirect_because_brTaken_diff", s2_fire && s2_redirect_s1_last_pred_vec(5))
-  XSPerfAccumulate("s2_redirect_because_fallThroughError", s2_fire_dup(0) && resp.s2.fallThruError(0))
+  XSPerfAccumulate("s2_redirect_because_fallThroughError", s2_fire && resp.s2.fallThruError)
 
-  XSPerfAccumulate("s2_redirect_when_taken", s2_redirect_dup(0) && resp.s2.taken(0) && resp.s2.full_pred(0).hit)
-  XSPerfAccumulate("s2_redirect_when_not_taken", s2_redirect_dup(0) && !resp.s2.taken(0) && resp.s2.full_pred(0).hit)
-  XSPerfAccumulate("s2_redirect_when_not_hit", s2_redirect_dup(0) && !resp.s2.full_pred(0).hit)
+  XSPerfAccumulate("s2_redirect_when_taken", s2_redirect && resp.s2.taken && resp.s2.full_pred.hit)
+  XSPerfAccumulate("s2_redirect_when_not_taken", s2_redirect && !resp.s2.taken && resp.s2.full_pred.hit)
+  XSPerfAccumulate("s2_redirect_when_not_hit", s2_redirect && !resp.s2.full_pred.hit)
 
   // s3
-  val s3_possible_predicted_ghist_ptrs_dup = s3_ghist_ptr_dup.map(ptr => (0 to numBr).map(ptr - _.U))
-  val s3_predicted_ghist_ptr_dup = s3_possible_predicted_ghist_ptrs_dup.zip(resp.s3.lastBrPosOH).map { case (ptr, oh) =>
-    Mux1H(oh, ptr)
-  }
+  val s3_possible_predicted_ghist_ptrs = (0 to numBr).map(s3_ghist_ptr - _.U)
+  val s3_predicted_ghist_ptr           = Mux1H(resp.s3.lastBrPosOH, s3_possible_predicted_ghist_ptrs)
 
-  val s3_possible_predicted_fhs_dup =
-    for (
-      (((fgh, afh), br_num_oh), full_pred) <-
-        s3_folded_gh_dup zip s3_ahead_fh_oldest_bits_dup zip s3_last_br_num_oh_dup zip resp.s3.full_pred
+  val s3_possible_predicted_fhs = (0 to numBr).map(i =>
+    s3_folded_gh.update(
+      s3_ahead_fh_oldest_bits,
+      s3_last_br_num_oh,
+      i,
+      if (i > 0) resp.s3.full_pred.br_taken_mask(i - 1) else false.B
     )
-      yield (0 to numBr).map(i =>
-        fgh.update(afh, br_num_oh, i, if (i > 0) full_pred.br_taken_mask(i - 1) else false.B)
-      )
-  val s3_predicted_fh_dup = resp.s3.lastBrPosOH.zip(s3_possible_predicted_fhs_dup).map { case (oh, fh) =>
-    Mux1H(oh, fh)
-  }
+  )
 
-  val s3_ahead_fh_ob_src_dup = dup_wire(new AllAheadFoldedHistoryOldestBits(foldedGHistInfos))
-  s3_ahead_fh_ob_src_dup.zip(s3_ghist_ptr_dup).map { case (src, ptr) => src.read(ghv, ptr) }
+  val s3_predicted_fh = Mux1H(resp.s3.lastBrPosOH, s3_possible_predicted_fhs)
+
+  val s3_ahead_fh_ob_src = Wire(new AllAheadFoldedHistoryOldestBits(foldedGHistInfos))
+  s3_ahead_fh_ob_src.read(ghv, s3_ghist_ptr)
 
   if (EnableGHistDiff) {
-    val s3_predicted_ghist = WireInit(getHist(s3_predicted_ghist_ptr_dup(0)).asTypeOf(Vec(HistoryLength, Bool())))
+    val s3_predicted_ghist = WireInit(getHist(s3_predicted_ghist_ptr).asTypeOf(Vec(HistoryLength, Bool())))
     for (i <- 0 until numBr) {
-      when(resp.s3.shouldShiftVec(0)(i)) {
-        s3_predicted_ghist(i) := resp.s3.brTaken(0) && (i == 0).B
+      when(resp.s3.shouldShiftVec(i)) {
+        s3_predicted_ghist(i) := resp.s3.brTaken && (i == 0).B
       }
     }
-    when(s3_redirect_dup(0)) {
+    when(s3_redirect) {
       s0_ghist := s3_predicted_ghist.asUInt
     }
   }
 
   val s3_ghv_wens = (0 until HistoryLength).map(n =>
     (0 until numBr).map(b =>
-      s3_ghist_ptr_dup(0).value === (CGHPtr(false.B, n.U) + b.U).value && resp.s3.shouldShiftVec(0)(
-        b
-      ) && s3_redirect_dup(0)
+      s3_ghist_ptr.value === (CGHPtr(false.B, n.U) + b.U).value && resp.s3.shouldShiftVec(b) && s3_redirect
     )
   )
   val s3_ghv_wdatas = (0 until HistoryLength).map(n =>
     Mux1H(
       (0 until numBr).map(b =>
         (
-          s3_ghist_ptr_dup(0).value === (CGHPtr(false.B, n.U) + b.U).value && resp.s3.shouldShiftVec(0)(b),
-          resp.s3.full_pred(0).real_br_taken_mask()(b)
+          s3_ghist_ptr.value === (CGHPtr(false.B, n.U) + b.U).value && resp.s3.shouldShiftVec(b),
+          resp.s3.full_pred.real_br_taken_mask()(b)
         )
       )
     )
@@ -796,117 +664,93 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
 
   // To optimize Clock Gating Efficiency of previous_s2_*
   val previous_s2_pred = Wire(new BranchPredictionBundle(isNotS3 = true))
-  previous_s2_pred.pc := RegEnable(resp.s2.pc, 0.U.asTypeOf(resp.s2.pc), s2_fire_dup(0)).suggestName(
+  previous_s2_pred.pc := RegEnable(resp.s2.pc, 0.U.asTypeOf(resp.s2.pc), s2_fire).suggestName(
     s"previous_s2_pred_pc"
   )
-  previous_s2_pred.valid := RegEnable(resp.s2.valid, 0.U.asTypeOf(resp.s2.valid), s2_fire_dup(0)).suggestName(
+  previous_s2_pred.valid := RegEnable(resp.s2.valid, 0.U.asTypeOf(resp.s2.valid), s2_fire).suggestName(
     s"previous_s2_pred_valid"
   )
   previous_s2_pred.hasRedirect := RegEnable(
     resp.s2.hasRedirect,
     0.U.asTypeOf(resp.s2.hasRedirect),
-    s2_fire_dup(0)
+    s2_fire
   ).suggestName(s"previous_s2_pred_hasRedirect")
-  previous_s2_pred.ftq_idx := RegEnable(resp.s2.ftq_idx, 0.U.asTypeOf(resp.s2.ftq_idx), s2_fire_dup(0)).suggestName(
+  previous_s2_pred.ftq_idx := RegEnable(resp.s2.ftq_idx, 0.U.asTypeOf(resp.s2.ftq_idx), s2_fire).suggestName(
     s"previous_s2_pred_ftq_idx"
   )
   previous_s2_pred.full_pred := RegEnable(
     resp.s2.full_pred,
     0.U.asTypeOf(resp.s2.full_pred),
-    s2_fire_dup(0)
+    s2_fire
   ).suggestName(s"previous_s2_pred_full_pred")
-  previous_s2_pred.full_pred.zip(resp.s2.full_pred.zipWithIndex).map { case (prev_fp, (new_fp, dupIdx)) =>
-    prev_fp.targets.zip(new_fp.taken_mask_on_slot.zipWithIndex).map { case (target, (taken_mask, slotIdx)) =>
+
+  previous_s2_pred.full_pred.targets.zip(resp.s2.full_pred.taken_mask_on_slot.zipWithIndex).map {
+    case (target, (taken_mask, slotIdx)) =>
       // This enable signal can better improve CGE, but it may lead to timing violations:
       //    s2_fire_dup(0) && !new_fp.taken_mask_on_slot.take(slotIdx).fold(false.B)(_||_) && taken_mask && new_fp.hit
-      target := RegEnable(new_fp.targets(slotIdx), 0.U.asTypeOf(new_fp.targets(slotIdx)), s2_fire_dup(0) && taken_mask)
-    }
-    // This enable signal can better improve CGE, but it may lead to timing violations:
-    //    s2_fire_dup(0) && new_fp.hit && !new_fp.taken_mask_on_slot.reduce(_||_)
-    prev_fp.fallThroughAddr := RegEnable(
-      new_fp.fallThroughAddr,
-      0.U.asTypeOf(new_fp.fallThroughAddr),
-      s2_fire_dup(0) && resp.s2.full_pred(0).hit && !resp.s2.full_pred(0).taken_mask_on_slot(0)
-    )
+      target := RegEnable(
+        resp.s2.full_pred.targets(slotIdx),
+        0.U.asTypeOf(resp.s2.full_pred.targets(slotIdx)),
+        s2_fire && taken_mask
+      )
   }
+  // This enable signal can better improve CGE, but it may lead to timing violations:
+  //    s2_fire_dup(0) && new_fp.hit && !new_fp.taken_mask_on_slot.reduce(_||_)
+  previous_s2_pred.full_pred.fallThroughAddr := RegEnable(
+    resp.s2.full_pred.fallThroughAddr,
+    0.U.asTypeOf(resp.s2.full_pred.fallThroughAddr),
+    s2_fire && resp.s2.full_pred.hit && !resp.s2.full_pred.taken_mask_on_slot(0)
+  )
 
-  val s3_redirect_on_br_taken_dup = resp.s3.full_pred.zip(previous_s2_pred.full_pred).map { case (fp1, fp2) =>
-    fp1.real_br_taken_mask().asUInt =/= fp2.real_br_taken_mask().asUInt
-  }
-  val s3_both_first_taken_dup = resp.s3.full_pred.zip(previous_s2_pred.full_pred).map { case (fp1, fp2) =>
-    fp1.real_br_taken_mask()(0) && fp2.real_br_taken_mask()(0)
-  }
-  val s3_redirect_on_target_dup = resp.s3.getTarget.zip(previous_s2_pred.getTarget).map { case (t1, t2) => t1 =/= t2 }
-  val s3_redirect_on_jalr_target_dup = resp.s3.full_pred.zip(previous_s2_pred.full_pred).map { case (fp1, fp2) =>
-    fp1.hit_taken_on_jalr && fp1.jalr_target =/= fp2.jalr_target
-  }
-  val s3_redirect_on_fall_thru_error_dup = resp.s3.fallThruError
-  val s3_redirect_on_ftb_multi_hit_dup   = resp.s3.ftbMultiHit
+  val s3_redirect_on_br_taken =
+    resp.s3.full_pred.real_br_taken_mask().asUInt =/= previous_s2_pred.full_pred.real_br_taken_mask().asUInt
 
-  for (
-    (
-      (
-        ((((s3_redirect, s3_fire), s3_redirect_on_br_taken), s3_redirect_on_target), s3_redirect_on_fall_thru_error),
-        s3_redirect_on_ftb_multi_hit
-      ),
-      s3_both_first_taken
-    ) <-
-      s3_redirect_dup zip s3_fire_dup zip s3_redirect_on_br_taken_dup zip s3_redirect_on_target_dup zip s3_redirect_on_fall_thru_error_dup zip s3_redirect_on_ftb_multi_hit_dup zip s3_both_first_taken_dup
-  ) {
+  val s3_both_first_taken =
+    resp.s3.full_pred.real_br_taken_mask()(0) && previous_s2_pred.full_pred.real_br_taken_mask()(0)
+  val s3_redirect_on_target = resp.s3.getTarget =/= previous_s2_pred.getTarget
+  val s3_redirect_on_jalr_target =
+    resp.s3.full_pred.hit_taken_on_jalr && resp.s3.full_pred.jalr_target =/= previous_s2_pred.full_pred.jalr_target
 
-    s3_redirect := s3_fire && (
-      (s3_redirect_on_br_taken && !s3_both_first_taken) || s3_redirect_on_target || s3_redirect_on_fall_thru_error || s3_redirect_on_ftb_multi_hit
-    )
-  }
+  val s3_redirect_on_fall_thru_error = resp.s3.fallThruError
+  val s3_redirect_on_ftb_multi_hit   = resp.s3.ftbMultiHit
 
-  XSPerfAccumulate(f"s3_redirect_on_br_taken", s3_fire_dup(0) && s3_redirect_on_br_taken_dup(0))
-  XSPerfAccumulate(f"s3_redirect_on_jalr_target", s3_fire_dup(0) && s3_redirect_on_jalr_target_dup(0))
+  s3_redirect := s3_fire && (
+    (s3_redirect_on_br_taken && !s3_both_first_taken) ||
+      s3_redirect_on_target || s3_redirect_on_fall_thru_error || s3_redirect_on_ftb_multi_hit
+  )
+
+  XSPerfAccumulate(f"s3_redirect_on_br_taken", s3_fire && s3_redirect_on_br_taken)
+  XSPerfAccumulate(f"s3_redirect_on_jalr_target", s3_fire && s3_redirect_on_jalr_target)
   XSPerfAccumulate(
     f"s3_redirect_on_others",
-    s3_redirect_dup(0) && !(s3_redirect_on_br_taken_dup(0) || s3_redirect_on_jalr_target_dup(0))
+    s3_redirect && !(s3_redirect_on_br_taken || s3_redirect_on_jalr_target)
   )
 
-  for (((npcGen, s3_redirect), s3_target) <- npcGen_dup zip s3_redirect_dup zip resp.s3.getTarget)
-    npcGen.register(s3_redirect, s3_target, Some("s3_target"), 3)
-  for (((foldedGhGen, s3_redirect), s3_predicted_fh) <- foldedGhGen_dup zip s3_redirect_dup zip s3_predicted_fh_dup)
-    foldedGhGen.register(s3_redirect, s3_predicted_fh, Some("s3_FGH"), 3)
-  for (
-    ((ghistPtrGen, s3_redirect), s3_predicted_ghist_ptr) <-
-      ghistPtrGen_dup zip s3_redirect_dup zip s3_predicted_ghist_ptr_dup
-  )
-    ghistPtrGen.register(s3_redirect, s3_predicted_ghist_ptr, Some("s3_GHPtr"), 3)
-  for (
-    ((lastBrNumOHGen, s3_redirect), s3_brPosOH) <-
-      lastBrNumOHGen_dup zip s3_redirect_dup zip resp.s3.lastBrPosOH.map(_.asUInt)
-  )
-    lastBrNumOHGen.register(s3_redirect, s3_brPosOH, Some("s3_BrNumOH"), 3)
-  for (
-    ((aheadFhObGen, s3_redirect), s3_ahead_fh_ob_src) <- aheadFhObGen_dup zip s3_redirect_dup zip s3_ahead_fh_ob_src_dup
-  )
-    aheadFhObGen.register(s3_redirect, s3_ahead_fh_ob_src, Some("s3_AFHOB"), 3)
+  npcGen.register(s3_redirect, resp.s3.getTarget, Some("s3_target"), 3)
+  foldedGhGen.register(s3_redirect, s3_predicted_fh, Some("s3_FGH"), 3)
+  ghistPtrGen.register(s3_redirect, s3_predicted_ghist_ptr, Some("s3_GHPtr"), 3)
+  lastBrNumOHGen.register(s3_redirect, resp.s3.lastBrPosOH.asUInt, Some("s3_BrNumOH"), 3)
+  aheadFhObGen.register(s3_redirect, s3_ahead_fh_ob_src, Some("s3_AFHOB"), 3)
+
   ghvBitWriteGens.zip(s3_ghv_wens).zipWithIndex.map { case ((b, w), i) =>
     b.register(w.reduce(_ || _), s3_ghv_wdatas(i), Some(s"s3_new_bit_$i"), 3)
   }
 
   // Send signal tell Ftq override
-  val s2_ftq_idx = RegEnable(io.ftq_to_bpu.enq_ptr, s1_fire_dup(0))
-  val s3_ftq_idx = RegEnable(s2_ftq_idx, s2_fire_dup(0))
+  val s2_ftq_idx = RegEnable(io.ftq_to_bpu.enq_ptr, s1_fire)
+  val s3_ftq_idx = RegEnable(s2_ftq_idx, s2_fire)
 
-  for (((to_ftq_s1_valid, s1_fire), s1_flush) <- io.bpu_to_ftq.resp.bits.s1.valid zip s1_fire_dup zip s1_flush_dup) {
-    to_ftq_s1_valid := s1_fire && !s1_flush
-  }
-  io.bpu_to_ftq.resp.bits.s1.hasRedirect.map(_ := false.B)
-  io.bpu_to_ftq.resp.bits.s1.ftq_idx := DontCare
-  for (((to_ftq_s2_valid, s2_fire), s2_flush) <- io.bpu_to_ftq.resp.bits.s2.valid zip s2_fire_dup zip s2_flush_dup) {
-    to_ftq_s2_valid := s2_fire && !s2_flush
-  }
-  io.bpu_to_ftq.resp.bits.s2.hasRedirect.zip(s2_redirect_dup).map { case (hr, r) => hr := r }
-  io.bpu_to_ftq.resp.bits.s2.ftq_idx := s2_ftq_idx
-  for (((to_ftq_s3_valid, s3_fire), s3_flush) <- io.bpu_to_ftq.resp.bits.s3.valid zip s3_fire_dup zip s3_flush_dup) {
-    to_ftq_s3_valid := s3_fire && !s3_flush
-  }
-  io.bpu_to_ftq.resp.bits.s3.hasRedirect.zip(s3_redirect_dup).map { case (hr, r) => hr := r }
-  io.bpu_to_ftq.resp.bits.s3.ftq_idx := s3_ftq_idx
+  io.bpu_to_ftq.resp.bits.s1.valid       := s1_fire && !s1_flush
+  io.bpu_to_ftq.resp.bits.s1.hasRedirect := false.B
+  io.bpu_to_ftq.resp.bits.s1.ftq_idx     := DontCare
+
+  io.bpu_to_ftq.resp.bits.s2.valid       := s2_fire && !s2_flush
+  io.bpu_to_ftq.resp.bits.s2.hasRedirect := s2_redirect
+  io.bpu_to_ftq.resp.bits.s2.ftq_idx     := s2_ftq_idx
+
+  io.bpu_to_ftq.resp.bits.s3.valid       := s3_fire && !s3_flush
+  io.bpu_to_ftq.resp.bits.s3.hasRedirect := s3_redirect
+  io.bpu_to_ftq.resp.bits.s3.ftq_idx     := s3_ftq_idx
 
   predictors.io.update            := io.ftq_to_bpu.update
   predictors.io.update.bits.ghist := getHist(io.ftq_to_bpu.update.bits.spec_info.histPtr)
@@ -918,32 +762,27 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
     Some("predictors_io_update_pc")
   ).getAddr())
 
-  val redirect_dup = do_redirect_dup.map(_.bits)
-  predictors.io.redirect := do_redirect_dup(0)
+  val redirectBits = do_redirect.bits
+  predictors.io.redirect := do_redirect
 
   // Redirect logic
-  val shift_dup       = redirect_dup.map(_.cfiUpdate.shift)
-  val addIntoHist_dup = redirect_dup.map(_.cfiUpdate.addIntoHist)
+  val shift       = redirectBits.cfiUpdate.shift
+  val addIntoHist = redirectBits.cfiUpdate.addIntoHist
   // TODO: remove these below
-  val shouldShiftVec_dup = shift_dup.map(shift =>
+  val shouldShiftVec =
     Mux(
       shift === 0.U,
       VecInit(0.U((1 << (log2Ceil(numBr) + 1)).W).asBools),
       VecInit(LowerMask(1.U << (shift - 1.U)).asBools)
     )
-  )
+
   // TODO end
-  val afhob_dup       = redirect_dup.map(_.cfiUpdate.afhob)
-  val lastBrNumOH_dup = redirect_dup.map(_.cfiUpdate.lastBrNumOH)
 
-  val isBr_dup  = redirect_dup.map(_.cfiUpdate.pd.isBr)
-  val taken_dup = redirect_dup.map(_.cfiUpdate.taken)
-  val real_br_taken_mask_dup =
-    for (((shift, taken), addIntoHist) <- shift_dup zip taken_dup zip addIntoHist_dup)
-      yield (0 until numBr).map(i => shift === (i + 1).U && taken && addIntoHist)
+  val taken              = redirectBits.cfiUpdate.taken
+  val real_br_taken_mask = (0 until numBr).map(i => shift === (i + 1).U && taken && addIntoHist)
 
-  val oldPtr_dup      = redirect_dup.map(_.cfiUpdate.histPtr)
-  val updated_ptr_dup = oldPtr_dup.zip(shift_dup).map { case (oldPtr, shift) => oldPtr - shift }
+  val oldPtr      = redirectBits.cfiUpdate.histPtr
+  val updated_ptr = oldPtr - shift
   def computeFoldedHist(hist: UInt, compLen: Int)(histLen: Int): UInt =
     if (histLen > 0) {
       val nChunks     = (histLen + compLen - 1) / compLen
@@ -951,42 +790,35 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
       ParallelXOR(hist_chunks)
     } else 0.U
 
-  val oldFh_dup = dup_seq(WireInit(0.U.asTypeOf(new AllFoldedHistories(foldedGHistInfos))))
-  oldFh_dup.zip(oldPtr_dup).map { case (oldFh, oldPtr) =>
-    foldedGHistInfos.foreach { case (histLen, compLen) =>
-      oldFh.getHistWithInfo((histLen, compLen)).folded_hist := computeFoldedHist(getHist(oldPtr), compLen)(histLen)
-    }
+  val oldFh = WireInit(0.U.asTypeOf(new AllFoldedHistories(foldedGHistInfos)))
+  foldedGHistInfos.foreach { case (histLen, compLen) =>
+    oldFh.getHistWithInfo((histLen, compLen)).folded_hist := computeFoldedHist(getHist(oldPtr), compLen)(histLen)
   }
 
-  val updated_fh_dup =
-    for (
-      ((((oldFh, oldPtr), taken), addIntoHist), shift) <-
-        oldFh_dup zip oldPtr_dup zip taken_dup zip addIntoHist_dup zip shift_dup
-    )
-      yield VecInit((0 to numBr).map(i => oldFh.update(ghv, oldPtr, i, taken && addIntoHist)))(shift)
-  val thisBrNumOH_dup   = shift_dup.map(shift => UIntToOH(shift, numBr + 1))
-  val thisAheadFhOb_dup = dup_wire(new AllAheadFoldedHistoryOldestBits(foldedGHistInfos))
-  thisAheadFhOb_dup.zip(oldPtr_dup).map { case (afhob, oldPtr) => afhob.read(ghv, oldPtr) }
+  val updated_fh    = VecInit((0 to numBr).map(i => oldFh.update(ghv, oldPtr, i, taken && addIntoHist)))(shift)
+  val thisBrNumOH   = UIntToOH(shift, numBr + 1)
+  val thisAheadFhOb = Wire(new AllAheadFoldedHistoryOldestBits(foldedGHistInfos))
+  thisAheadFhOb.read(ghv, oldPtr)
   val redirect_ghv_wens = (0 until HistoryLength).map(n =>
     (0 until numBr).map(b =>
-      oldPtr_dup(0).value === (CGHPtr(false.B, n.U) + b.U).value && shouldShiftVec_dup(0)(b) && do_redirect_dup(0).valid
+      oldPtr.value === (CGHPtr(false.B, n.U) + b.U).value && shouldShiftVec(b) && do_redirect.valid
     )
   )
   val redirect_ghv_wdatas = (0 until HistoryLength).map(n =>
     Mux1H(
-      (0 until numBr).map(b => oldPtr_dup(0).value === (CGHPtr(false.B, n.U) + b.U).value && shouldShiftVec_dup(0)(b)),
-      real_br_taken_mask_dup(0)
+      (0 until numBr).map(b => oldPtr.value === (CGHPtr(false.B, n.U) + b.U).value && shouldShiftVec(b)),
+      real_br_taken_mask
     )
   )
 
   if (EnableGHistDiff) {
-    val updated_ghist = WireInit(getHist(updated_ptr_dup(0)).asTypeOf(Vec(HistoryLength, Bool())))
+    val updated_ghist = WireInit(getHist(updated_ptr).asTypeOf(Vec(HistoryLength, Bool())))
     for (i <- 0 until numBr) {
-      when(shift_dup(0) >= (i + 1).U) {
-        updated_ghist(i) := taken_dup(0) && addIntoHist_dup(0) && (i == 0).B
+      when(shift >= (i + 1).U) {
+        updated_ghist(i) := taken && addIntoHist && (i == 0).B
       }
     }
-    when(do_redirect_dup(0).valid) {
+    when(do_redirect.valid) {
       s0_ghist := updated_ghist.asUInt
     }
   }
@@ -1040,17 +872,12 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
     }
   }
 
-  // val updatedGh = oldGh.update(shift, taken && addIntoHist)
-  for ((npcGen, do_redirect) <- npcGen_dup zip do_redirect_dup)
-    npcGen.register(do_redirect.valid, PrunedAddrInit(do_redirect.bits.cfiUpdate.target), Some("redirect_target"), 2)
-  for (((foldedGhGen, do_redirect), updated_fh) <- foldedGhGen_dup zip do_redirect_dup zip updated_fh_dup)
-    foldedGhGen.register(do_redirect.valid, updated_fh, Some("redirect_FGHT"), 2)
-  for (((ghistPtrGen, do_redirect), updated_ptr) <- ghistPtrGen_dup zip do_redirect_dup zip updated_ptr_dup)
-    ghistPtrGen.register(do_redirect.valid, updated_ptr, Some("redirect_GHPtr"), 2)
-  for (((lastBrNumOHGen, do_redirect), thisBrNumOH) <- lastBrNumOHGen_dup zip do_redirect_dup zip thisBrNumOH_dup)
-    lastBrNumOHGen.register(do_redirect.valid, thisBrNumOH, Some("redirect_BrNumOH"), 2)
-  for (((aheadFhObGen, do_redirect), thisAheadFhOb) <- aheadFhObGen_dup zip do_redirect_dup zip thisAheadFhOb_dup)
-    aheadFhObGen.register(do_redirect.valid, thisAheadFhOb, Some("redirect_AFHOB"), 2)
+  npcGen.register(do_redirect.valid, PrunedAddrInit(do_redirect.bits.cfiUpdate.target), Some("redirect_target"), 2)
+  foldedGhGen.register(do_redirect.valid, updated_fh, Some("redirect_FGHT"), 2)
+  ghistPtrGen.register(do_redirect.valid, updated_ptr, Some("redirect_GHPtr"), 2)
+  lastBrNumOHGen.register(do_redirect.valid, thisBrNumOH, Some("redirect_BrNumOH"), 2)
+  aheadFhObGen.register(do_redirect.valid, thisAheadFhOb, Some("redirect_AFHOB"), 2)
+
   ghvBitWriteGens.zip(redirect_ghv_wens).zipWithIndex.map { case ((b, w), i) =>
     b.register(w.reduce(_ || _), redirect_ghv_wdatas(i), Some(s"redirect_new_bit_$i"), 2)
   }
@@ -1063,15 +890,12 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
   // foldedGhGen.register(need_reset, 0.U.asTypeOf(s0_folded_gh), Some("reset_FGH"), 1)
   // ghistPtrGen.register(need_reset, 0.U.asTypeOf(new CGHPtr), Some("reset_GHPtr"), 1)
 
-  s0_pc_dup.zip(npcGen_dup).map { case (s0_pc, npcGen) => s0_pc := npcGen() }
-  s0_folded_gh_dup.zip(foldedGhGen_dup).map { case (s0_folded_gh, foldedGhGen) => s0_folded_gh := foldedGhGen() }
-  s0_ghist_ptr_dup.zip(ghistPtrGen_dup).map { case (s0_ghist_ptr, ghistPtrGen) => s0_ghist_ptr := ghistPtrGen() }
-  s0_ahead_fh_oldest_bits_dup.zip(aheadFhObGen_dup).map { case (s0_ahead_fh_oldest_bits, aheadFhObGen) =>
-    s0_ahead_fh_oldest_bits := aheadFhObGen()
-  }
-  s0_last_br_num_oh_dup.zip(lastBrNumOHGen_dup).map { case (s0_last_br_num_oh, lastBrNumOHGen) =>
-    s0_last_br_num_oh := lastBrNumOHGen()
-  }
+  s0_pc                   := npcGen()
+  s0_folded_gh            := foldedGhGen()
+  s0_ghist_ptr            := ghistPtrGen()
+  s0_ahead_fh_oldest_bits := aheadFhObGen()
+  s0_last_br_num_oh       := lastBrNumOHGen()
+
   (ghv_write_datas zip ghvBitWriteGens).map { case (wd, d) => wd := d() }
   for (i <- 0 until HistoryLength) {
     ghv_wens(i) := Seq(s1_ghv_wens, s2_ghv_wens, s3_ghv_wens, redirect_ghv_wens).map(_(i).reduce(_ || _)).reduce(_ || _)
@@ -1081,21 +905,21 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
   }
 
   // TODO: signals for memVio and other Redirects
-  controlRedirectBubble := do_redirect_dup(0).valid && do_redirect_dup(0).bits.ControlRedirectBubble
-  ControlBTBMissBubble  := do_redirect_dup(0).bits.ControlBTBMissBubble
-  TAGEMissBubble        := do_redirect_dup(0).bits.TAGEMissBubble
-  SCMissBubble          := do_redirect_dup(0).bits.SCMissBubble
-  ITTAGEMissBubble      := do_redirect_dup(0).bits.ITTAGEMissBubble
-  RASMissBubble         := do_redirect_dup(0).bits.RASMissBubble
+  controlRedirectBubble := do_redirect.valid && do_redirect.bits.ControlRedirectBubble
+  ControlBTBMissBubble  := do_redirect.bits.ControlBTBMissBubble
+  TAGEMissBubble        := do_redirect.bits.TAGEMissBubble
+  SCMissBubble          := do_redirect.bits.SCMissBubble
+  ITTAGEMissBubble      := do_redirect.bits.ITTAGEMissBubble
+  RASMissBubble         := do_redirect.bits.RASMissBubble
 
-  memVioRedirectBubble                 := do_redirect_dup(0).valid && do_redirect_dup(0).bits.MemVioRedirectBubble
-  otherRedirectBubble                  := do_redirect_dup(0).valid && do_redirect_dup(0).bits.OtherRedirectBubble
-  btbMissBubble                        := do_redirect_dup(0).valid && do_redirect_dup(0).bits.BTBMissBubble
-  overrideBubble(0)                    := s2_redirect_dup(0)
-  overrideBubble(1)                    := s3_redirect_dup(0)
-  ftqUpdateBubble(0)                   := !s1_components_ready_dup(0)
-  ftqUpdateBubble(1)                   := !s2_components_ready_dup(0)
-  ftqUpdateBubble(2)                   := !s3_components_ready_dup(0)
+  memVioRedirectBubble                 := do_redirect.valid && do_redirect.bits.MemVioRedirectBubble
+  otherRedirectBubble                  := do_redirect.valid && do_redirect.bits.OtherRedirectBubble
+  btbMissBubble                        := do_redirect.valid && do_redirect.bits.BTBMissBubble
+  overrideBubble(0)                    := s2_redirect
+  overrideBubble(1)                    := s3_redirect
+  ftqUpdateBubble(0)                   := !s1_components_ready
+  ftqUpdateBubble(1)                   := !s2_components_ready
+  ftqUpdateBubble(2)                   := !s3_components_ready
   ftqFullStall                         := !io.bpu_to_ftq.resp.ready
   io.bpu_to_ftq.resp.bits.topdown_info := topdown_stages(numOfStage - 1)
 
@@ -1162,70 +986,70 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
   }
 
   XSError(
-    isBefore(redirect_dup(0).cfiUpdate.histPtr, s3_ghist_ptr_dup(0)) && do_redirect_dup(0).valid,
-    p"s3_ghist_ptr ${s3_ghist_ptr_dup(0)} exceeds redirect histPtr ${redirect_dup(0).cfiUpdate.histPtr}\n"
+    isBefore(redirectBits.cfiUpdate.histPtr, s3_ghist_ptr) && do_redirect.valid,
+    p"s3_ghist_ptr ${s3_ghist_ptr} exceeds redirect histPtr ${redirectBits.cfiUpdate.histPtr}\n"
   )
   XSError(
-    isBefore(redirect_dup(0).cfiUpdate.histPtr, s2_ghist_ptr_dup(0)) && do_redirect_dup(0).valid,
-    p"s2_ghist_ptr ${s2_ghist_ptr_dup(0)} exceeds redirect histPtr ${redirect_dup(0).cfiUpdate.histPtr}\n"
+    isBefore(redirectBits.cfiUpdate.histPtr, s2_ghist_ptr) && do_redirect.valid,
+    p"s2_ghist_ptr ${s2_ghist_ptr} exceeds redirect histPtr ${redirectBits.cfiUpdate.histPtr}\n"
   )
   XSError(
-    isBefore(redirect_dup(0).cfiUpdate.histPtr, s1_ghist_ptr_dup(0)) && do_redirect_dup(0).valid,
-    p"s1_ghist_ptr ${s1_ghist_ptr_dup(0)} exceeds redirect histPtr ${redirect_dup(0).cfiUpdate.histPtr}\n"
+    isBefore(redirectBits.cfiUpdate.histPtr, s1_ghist_ptr) && do_redirect.valid,
+    p"s1_ghist_ptr ${s1_ghist_ptr} exceeds redirect histPtr ${redirectBits.cfiUpdate.histPtr}\n"
   )
 
   XSDebug(RegNext(reset.asBool) && !reset.asBool, "Reseting...\n")
   XSDebug(io.ftq_to_bpu.update.valid, p"Update from ftq\n")
   XSDebug(io.ftq_to_bpu.redirect.valid, p"Redirect from ftq\n")
 
-  XSDebug("[BP0]                 fire=%d                      pc=%x\n", s0_fire_dup(0), s0_pc_dup(0).toUInt)
+  XSDebug("[BP0]                 fire=%d                      pc=%x\n", s0_fire, s0_pc.toUInt)
   XSDebug(
     "[BP1] v=%d r=%d cr=%d fire=%d             flush=%d pc=%x\n",
-    s1_valid_dup(0),
-    s1_ready_dup(0),
-    s1_components_ready_dup(0),
-    s1_fire_dup(0),
-    s1_flush_dup(0),
+    s1_valid,
+    s1_ready,
+    s1_components_ready,
+    s1_fire,
+    s1_flush,
     s1_pc.toUInt
   )
   XSDebug(
     "[BP2] v=%d r=%d cr=%d fire=%d redirect=%d flush=%d pc=%x\n",
-    s2_valid_dup(0),
-    s2_ready_dup(0),
-    s2_components_ready_dup(0),
-    s2_fire_dup(0),
-    s2_redirect_dup(0),
-    s2_flush_dup(0),
+    s2_valid,
+    s2_ready,
+    s2_components_ready,
+    s2_fire,
+    s2_redirect,
+    s2_flush,
     s2_pc.toUInt
   )
   XSDebug(
     "[BP3] v=%d r=%d cr=%d fire=%d redirect=%d flush=%d pc=%x\n",
-    s3_valid_dup(0),
-    s3_ready_dup(0),
-    s3_components_ready_dup(0),
-    s3_fire_dup(0),
-    s3_redirect_dup(0),
-    s3_flush_dup(0),
+    s3_valid,
+    s3_ready,
+    s3_components_ready,
+    s3_fire,
+    s3_redirect,
+    s3_flush,
     s3_pc.toUInt
   )
   XSDebug("[FTQ] ready=%d\n", io.bpu_to_ftq.resp.ready)
-  XSDebug("resp.s1.target=%x\n", resp.s1.getTarget(0).toUInt)
-  XSDebug("resp.s2.target=%x\n", resp.s2.getTarget(0).toUInt)
+  XSDebug("resp.s1.target=%x\n", resp.s1.getTarget.toUInt)
+  XSDebug("resp.s2.target=%x\n", resp.s2.getTarget.toUInt)
   // XSDebug("s0_ghist: %b\n", s0_ghist.predHist)
   // XSDebug("s1_ghist: %b\n", s1_ghist.predHist)
   // XSDebug("s2_ghist: %b\n", s2_ghist.predHist)
   // XSDebug("s2_predicted_ghist: %b\n", s2_predicted_ghist.predHist)
-  XSDebug(p"s0_ghist_ptr: ${s0_ghist_ptr_dup(0)}\n")
-  XSDebug(p"s1_ghist_ptr: ${s1_ghist_ptr_dup(0)}\n")
-  XSDebug(p"s2_ghist_ptr: ${s2_ghist_ptr_dup(0)}\n")
-  XSDebug(p"s3_ghist_ptr: ${s3_ghist_ptr_dup(0)}\n")
+  XSDebug(p"s0_ghist_ptr: $s0_ghist_ptr\n")
+  XSDebug(p"s1_ghist_ptr: $s1_ghist_ptr\n")
+  XSDebug(p"s2_ghist_ptr: $s2_ghist_ptr\n")
+  XSDebug(p"s3_ghist_ptr: $s3_ghist_ptr\n")
 
   io.ftq_to_bpu.update.bits.display(io.ftq_to_bpu.update.valid)
   io.ftq_to_bpu.redirect.bits.display(io.ftq_to_bpu.redirect.valid)
 
-  XSPerfAccumulate("s2_redirect", s2_redirect_dup(0))
-  XSPerfAccumulate("s3_redirect", s3_redirect_dup(0))
-  XSPerfAccumulate("s1_not_valid", !s1_valid_dup(0))
+  XSPerfAccumulate("s2_redirect", s2_redirect)
+  XSPerfAccumulate("s3_redirect", s3_redirect)
+  XSPerfAccumulate("s1_not_valid", !s1_valid)
 
   val perfEvents = predictors.asInstanceOf[Composer].getPerfEvents
   generatePerfEvent()

--- a/src/main/scala/xiangshan/frontend/Composer.scala
+++ b/src/main/scala/xiangshan/frontend/Composer.scala
@@ -32,8 +32,6 @@ class Composer(implicit p: Parameters) extends BasePredictor with HasBPUConst wi
     io.out.s1 := fast_pred.io.out.s1
   }
 
-  var metas   = 0.U(1.W)
-  var meta_sz = 0
   for (c <- components) {
     c.io.reset_vector           := io.reset_vector
     c.io.in.valid               := io.in.valid
@@ -46,9 +44,6 @@ class Composer(implicit p: Parameters) extends BasePredictor with HasBPUConst wi
     c.io.s1_fire := io.s1_fire
     c.io.s2_fire := io.s2_fire
     c.io.s3_fire := io.s3_fire
-
-    c.io.s2_redirect := io.s2_redirect
-    c.io.s3_redirect := io.s3_redirect
 
     c.io.redirect        := io.redirect
     c.io.ctrl            := DelayN(io.ctrl, 1)

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -242,9 +242,9 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
       case (nRows, ctrBits, histLen) => {
         val t   = Module(new SCTable(nRows / TageBanks, ctrBits, histLen))
         val req = t.io.req
-        req.valid            := io.s0_fire(3)
-        req.bits.pc          := s0_pc_dup(3)
-        req.bits.folded_hist := io.in.bits.folded_hist(3)
+        req.valid            := io.s0_fire
+        req.bits.pc          := s0_pc
+        req.bits.folded_hist := io.in.bits.folded_hist
         req.bits.ghist       := DontCare
         if (!EnableSC) { t.io.update := DontCare }
         t
@@ -300,25 +300,25 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
           ParallelSingedExpandingAdd(s1_scResps map (r => getCentered(r.ctrs(w)(i)))) // TODO: rewrite with wallace tree
         }
       )
-      val s2_scTableSums         = RegEnable(s1_scTableSums, io.s1_fire(3))
-      val s2_tagePrvdCtrCentered = getPvdrCentered(RegEnable(s1_providerResps(w).ctr, io.s1_fire(3)))
+      val s2_scTableSums         = RegEnable(s1_scTableSums, io.s1_fire)
+      val s2_tagePrvdCtrCentered = getPvdrCentered(RegEnable(s1_providerResps(w).ctr, io.s1_fire))
       val s2_totalSums           = s2_scTableSums.map(_ +& s2_tagePrvdCtrCentered)
       val s2_sumAboveThresholds =
         VecInit((0 to 1).map(i => aboveThreshold(s2_scTableSums(i), s2_tagePrvdCtrCentered, useThresholds(w))))
       val s2_scPreds = VecInit(s2_totalSums.map(_ >= 0.S))
 
-      val s2_scResps   = VecInit(RegEnable(s1_scResps, io.s1_fire(3)).map(_.ctrs(w)))
-      val s2_scCtrs    = VecInit(s2_scResps.map(_(s2_tageTakens_dup(3)(w).asUInt)))
-      val s2_chooseBit = s2_tageTakens_dup(3)(w)
+      val s2_scResps   = VecInit(RegEnable(s1_scResps, io.s1_fire).map(_.ctrs(w)))
+      val s2_scCtrs    = VecInit(s2_scResps.map(_(s2_tageTakens(w).asUInt)))
+      val s2_chooseBit = s2_tageTakens(w)
 
       val s2_pred =
-        Mux(s2_provideds(w) && s2_sumAboveThresholds(s2_chooseBit), s2_scPreds(s2_chooseBit), s2_tageTakens_dup(3)(w))
+        Mux(s2_provideds(w) && s2_sumAboveThresholds(s2_chooseBit), s2_scPreds(s2_chooseBit), s2_tageTakens(w))
 
-      val s3_disagree = RegEnable(s2_disagree, io.s2_fire(3))
+      val s3_disagree = RegEnable(s2_disagree, io.s2_fire)
       io.out.last_stage_spec_info.sc_disagree.map(_ := s3_disagree)
 
-      scMeta.scPreds(w) := RegEnable(s2_scPreds(s2_chooseBit), io.s2_fire(3))
-      scMeta.ctrs(w)    := RegEnable(s2_scCtrs, io.s2_fire(3))
+      scMeta.scPreds(w) := RegEnable(s2_scPreds(s2_chooseBit), io.s2_fire)
+      scMeta.ctrs(w)    := RegEnable(s2_scCtrs, io.s2_fire)
 
       val pred = s2_scPreds(s2_chooseBit)
       // FIXME: This looks strange. Maybe we don't need this anymore.
@@ -329,8 +329,8 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         s2_conf(w)    := s2_sumAboveThresholds(s2_chooseBit)
         // Use prediction from Statistical Corrector
         when(s2_sumAboveThresholds(s2_chooseBit)) {
-          s2_agree(w)    := s2_tageTakens_dup(3)(w) === pred
-          s2_disagree(w) := s2_tageTakens_dup(3)(w) =/= pred
+          s2_agree(w)    := s2_tageTakens(w) === pred
+          s2_disagree(w) := s2_tageTakens(w) =/= pred
           // fit to always-taken condition
           // io.out.s2.full_pred.br_taken_mask(w) := pred
         }
@@ -341,15 +341,9 @@ trait HasSC extends HasSCParameter with HasPerfEvents { this: Tage =>
         p"pc(${Hexadecimal(debug_pc)}) SC(${w.U}) overriden pred to ${pred}\n"
       )
 
-      val s3_pred_dup   = io.s2_fire.map(f => RegEnable(s2_pred, f))
-      val sc_enable_dup = dup(RegNext(io.ctrl.sc_enable))
-      for (
-        sc_enable & fp & s3_pred <-
-          sc_enable_dup zip io.out.s3.full_pred zip s3_pred_dup
-      ) {
-        when(sc_enable) {
-          fp.br_taken_mask(w) := s3_pred
-        }
+      val s3_pred = RegEnable(s2_pred, io.s2_fire)
+      when(RegNext(io.ctrl.sc_enable)) {
+        io.out.s3.full_pred.br_taken_mask(w) := s3_pred
       }
 
       val updateTageMeta    = updateMeta

--- a/src/main/scala/xiangshan/frontend/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/Tage.scala
@@ -620,16 +620,16 @@ class Tage(implicit p: Parameters) extends BaseTage {
   val tables = TageTableInfos.zipWithIndex.map {
     case ((nRows, histLen, tagLen), i) => {
       val t = Module(new TageTable(nRows, histLen, tagLen, i))
-      t.io.req.valid            := io.s0_fire(1)
-      t.io.req.bits.pc          := s0_pc_dup(1)
-      t.io.req.bits.folded_hist := io.in.bits.folded_hist(1)
+      t.io.req.valid            := io.s0_fire
+      t.io.req.bits.pc          := s0_pc
+      t.io.req.bits.folded_hist := io.in.bits.folded_hist
       t.io.req.bits.ghist       := io.in.bits.ghist
       t
     }
   }
   val bt = Module(new TageBTable)
-  bt.io.req.valid := io.s0_fire(1)
-  bt.io.req.bits  := s0_pc_dup(1)
+  bt.io.req.valid := io.s0_fire
+  bt.io.req.bits  := s0_pc
   private val mbistPl           = MbistPipeline.PlaceMbistPipeline(1, "MbistPipeTage", hasMbist)
   val bankTickCtrDistanceToTops = Seq.fill(numBr)(RegInit(((1 << TickWidth) - 1).U(TickWidth.W)))
   val bankTickCtrs              = Seq.fill(numBr)(RegInit(0.U(TickWidth.W)))
@@ -647,9 +647,9 @@ class Tage(implicit p: Parameters) extends BaseTage {
   // val s1_bim = io.in.bits.resp_in(0).s1.full_pred
   // val s2_bim = RegEnable(s1_bim, io.s1_fire)
 
-  val debug_pc_s0 = s0_pc_dup(1)
-  val debug_pc_s1 = RegEnable(s0_pc_dup(1), io.s0_fire(1))
-  val debug_pc_s2 = RegEnable(debug_pc_s1, io.s1_fire(1))
+  val debug_pc_s0 = s0_pc
+  val debug_pc_s1 = RegEnable(debug_pc_s0, io.s0_fire)
+  val debug_pc_s2 = RegEnable(debug_pc_s1, io.s1_fire)
 
   val s1_provideds     = Wire(Vec(numBr, Bool()))
   val s1_providers     = Wire(Vec(numBr, UInt(log2Ceil(TageNTables).W)))
@@ -662,16 +662,16 @@ class Tage(implicit p: Parameters) extends BaseTage {
   val s1_basecnts   = Wire(Vec(numBr, UInt(2.W)))
   val s1_useAltOnNa = Wire(Vec(numBr, Bool()))
 
-  val s2_provideds     = RegEnable(s1_provideds, io.s1_fire(1))
-  val s2_providers     = RegEnable(s1_providers, io.s1_fire(1))
-  val s2_providerResps = RegEnable(s1_providerResps, io.s1_fire(1))
+  val s2_provideds     = RegEnable(s1_provideds, io.s1_fire)
+  val s2_providers     = RegEnable(s1_providers, io.s1_fire)
+  val s2_providerResps = RegEnable(s1_providerResps, io.s1_fire)
   // val s2_altProvideds     = RegEnable(s1_altProvideds, io.s1_fire)
   // val s2_altProviders     = RegEnable(s1_altProviders, io.s1_fire)
   // val s2_altProviderResps = RegEnable(s1_altProviderResps, io.s1_fire)
-  val s2_altUsed        = RegEnable(s1_altUsed, io.s1_fire(1))
-  val s2_tageTakens_dup = io.s1_fire.map(f => RegEnable(s1_tageTakens, f))
-  val s2_basecnts       = RegEnable(s1_basecnts, io.s1_fire(1))
-  val s2_useAltOnNa     = RegEnable(s1_useAltOnNa, io.s1_fire(1))
+  val s2_altUsed    = RegEnable(s1_altUsed, io.s1_fire)
+  val s2_tageTakens = RegEnable(s1_tageTakens, io.s1_fire)
+  val s2_basecnts   = RegEnable(s1_basecnts, io.s1_fire)
+  val s2_useAltOnNa = RegEnable(s1_useAltOnNa, io.s1_fire)
 
   io.out           := io.in.bits.resp_in(0)
   io.meta.tageMeta := resp_meta
@@ -753,7 +753,7 @@ class Tage(implicit p: Parameters) extends BaseTage {
   // access tag tables and output meta info
 
   for (i <- 0 until numBr) {
-    val useAltCtr  = Mux1H(UIntToOH(use_alt_idx(s1_pc_dup(0)), NUM_USE_ALT_ON_NA), useAltOnNaCtrs(i))
+    val useAltCtr  = Mux1H(UIntToOH(use_alt_idx(s1_pc), NUM_USE_ALT_ON_NA), useAltOnNaCtrs(i))
     val useAltOnNa = useAltCtr(USE_ALT_ON_NA_WIDTH - 1) // highest bit
 
     val s1_per_br_resp = VecInit(s1_resps.map(_(i)))
@@ -778,14 +778,14 @@ class Tage(implicit p: Parameters) extends BaseTage {
     // s1_altProviders(i)   := altProviderInfo.tableIdx
     // s1_altProviderResps(i) := altProviderInfo.resp
 
-    resp_meta.providers(i).valid := RegEnable(s2_provideds(i), io.s2_fire(1))
-    resp_meta.providers(i).bits  := RegEnable(s2_providers(i), io.s2_fire(1))
-    resp_meta.providerResps(i)   := RegEnable(s2_providerResps(i), io.s2_fire(1))
+    resp_meta.providers(i).valid := RegEnable(s2_provideds(i), io.s2_fire)
+    resp_meta.providers(i).bits  := RegEnable(s2_providers(i), io.s2_fire)
+    resp_meta.providerResps(i)   := RegEnable(s2_providerResps(i), io.s2_fire)
     // resp_meta.altProviders(i).valid := RegEnable(s2_altProvideds(i), io.s2_fire)
     // resp_meta.altProviders(i).bits  := RegEnable(s2_altProviders(i), io.s2_fire)
     // resp_meta.altProviderResps(i)   := RegEnable(s2_altProviderResps(i), io.s2_fire)
-    resp_meta.pred_cycle.map(_ := RegEnable(GTimer(), io.s2_fire(1)))
-    resp_meta.use_alt_on_na.map(_(i) := RegEnable(s2_useAltOnNa(i), io.s2_fire(1)))
+    resp_meta.pred_cycle.map(_ := RegEnable(GTimer(), io.s2_fire))
+    resp_meta.use_alt_on_na.map(_(i) := RegEnable(s2_useAltOnNa(i), io.s2_fire))
 
     // Create a mask fo tables which did not hit our query, and also contain useless entries
     // and also uses a longer history than the provider
@@ -794,10 +794,10 @@ class Tage(implicit p: Parameters) extends BaseTage {
         VecInit(s1_per_br_resp.map(r => !r.valid && !r.bits.u)).asUInt &
           ~(LowerMask(UIntToOH(s1_providers(i)), TageNTables) &
             Fill(TageNTables, s1_provideds(i).asUInt)),
-        io.s1_fire(1)
+        io.s1_fire
       )
 
-    resp_meta.allocates(i) := RegEnable(allocatableSlots, io.s2_fire(1))
+    resp_meta.allocates(i) := RegEnable(allocatableSlots, io.s2_fire)
 
     val s1_bimCtr = bt.io.s1_cnt(i)
     s1_altUsed(i) := !provided || providerInfo.use_alt_on_unconf
@@ -806,14 +806,11 @@ class Tage(implicit p: Parameters) extends BaseTage {
     s1_basecnts(i)   := s1_bimCtr
     s1_useAltOnNa(i) := providerInfo.use_alt_on_unconf
 
-    resp_meta.altUsed(i)  := RegEnable(s2_altUsed(i), io.s2_fire(1))
-    resp_meta.basecnts(i) := RegEnable(s2_basecnts(i), io.s2_fire(1))
+    resp_meta.altUsed(i)  := RegEnable(s2_altUsed(i), io.s2_fire)
+    resp_meta.basecnts(i) := RegEnable(s2_basecnts(i), io.s2_fire)
 
-    val tage_enable_dup = dup(RegNext(io.ctrl.tage_enable))
-    for (tage_enable & fp & s2_tageTakens <- tage_enable_dup zip resp_s2.full_pred zip s2_tageTakens_dup) {
-      when(tage_enable) {
-        fp.br_taken_mask(i) := s2_tageTakens(i)
-      }
+    when(RegNext(io.ctrl.tage_enable)) {
+      resp_s2.full_pred.br_taken_mask(i) := s2_tageTakens(i)
     }
 
     // ---------------- update logics below ------------------//
@@ -1037,15 +1034,15 @@ class Tage(implicit p: Parameters) extends BaseTage {
       m.allocates(b)
     )
   }
-  val s2_resps = RegEnable(s1_resps, io.s1_fire(1))
-  XSDebug("req: v=%d, pc=0x%x\n", io.s0_fire(1), s0_pc_dup(1).toUInt)
-  XSDebug("s1_fire:%d, resp: pc=%x\n", io.s1_fire(1), debug_pc_s1.toUInt)
+  val s2_resps = RegEnable(s1_resps, io.s1_fire)
+  XSDebug("req: v=%d, pc=0x%x\n", io.s0_fire, s0_pc.toUInt)
+  XSDebug("s1_fire:%d, resp: pc=%x\n", io.s1_fire, debug_pc_s1.toUInt)
   XSDebug(
     "s2_fireOnLastCycle: resp: pc=%x, target=%x, hits=%b, takens=%b\n",
     debug_pc_s2.toUInt,
-    io.out.s2.getTarget(1).toUInt,
+    io.out.s2.getTarget.toUInt,
     s2_provideds.asUInt,
-    s2_tageTakens_dup(0).asUInt
+    s2_tageTakens.asUInt
   )
 
   for (b <- 0 until TageBanks) {


### PR DESCRIPTION
In the previous implementation, we duplicated certain wires to reduce fan-out, but this led to confusing variable naming and reduced code readability. This PR removes all such duplication in the frontend, and we will address fan-out issues in a more readable way in the future.