### PR TITLE
fix(NCMM): nc access in main memory should not skip difftest

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -345,12 +345,12 @@ class ResetPregStateReq(implicit p: Parameters) extends XSBundle {
 
 class DebugBundle(implicit p: Parameters) extends XSBundle {
   val isMMIO = Bool()
-  val isNC = Bool()
+  val isNCIO = Bool()
   val isPerfCnt = Bool()
   val paddr = UInt(PAddrBits.W)
   val vaddr = UInt(VAddrBits.W)
 
-  def isSkipDiff: Bool = isMMIO || isNC || isPerfCnt
+  def isSkipDiff: Bool = isMMIO || isNCIO || isPerfCnt
   /* add L/S inst info in EXU */
   // val L1toL2TlbLatency = UInt(XLEN.W)
   // val levelTlbHit = UInt(2.W)

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1492,6 +1492,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
 
   // LSQ to store buffer
   lsq.io.sbuffer        <> sbuffer.io.in
+  lsq.io.generateFromSBuffer <> sbuffer.io.generateToSQ
   sbuffer.io.in(0).valid := lsq.io.sbuffer(0).valid || vSegmentUnit.io.sbuffer.valid
   sbuffer.io.in(0).bits  := Mux1H(Seq(
     vSegmentUnit.io.sbuffer.valid -> vSegmentUnit.io.sbuffer.bits,

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -132,6 +132,8 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
     // top-down
     val debugTopDown = new LoadQueueTopDownIO
     val noUopsIssued = Input(Bool())
+
+    val generateFromSBuffer = Input(new GenerateInfoFromSBuffer)
   })
 
   val loadQueue = Module(new LoadQueue)
@@ -196,6 +198,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   storeQueue.io.cmoOpResp    <> io.cmoOpResp
   storeQueue.io.flushSbuffer <> io.flushSbuffer
   storeQueue.io.maControl    <> io.maControl
+  storeQueue.io.generateFromSBuffer := io.generateFromSBuffer
 
   /* <------- DANGEROUS: Don't change sequence here ! -------> */
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -232,7 +232,7 @@ class UncacheEntry(entryIndex: Int)(implicit p: Parameters) extends XSModule
     io.mmioOut.bits.uop.exceptionVec(hardwareError) := nderr
     io.mmioOut.bits.data := rdataPartialLoad
     io.mmioOut.bits.debug.isMMIO := true.B
-    io.mmioOut.bits.debug.isNC := false.B
+    io.mmioOut.bits.debug.isNCIO := false.B
     io.mmioOut.bits.debug.paddr := req.paddr
     io.mmioOut.bits.debug.vaddr := req.vaddr
     io.mmioRawData.lqData := uncacheData

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -1370,7 +1370,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
     // the event that nc store to main memory
     val ncmmStoreEvent = DifftestModule(new DiffStoreEvent, delay = 2, dontCare = true)
-    val dataMask = Cat((0 until DCacheWordBytes).reverse.map(i => Fill(DCacheWordBytes, ncReq.bits.mask(i))))
+    val dataMask = Cat((0 until DCacheWordBytes).reverse.map(i => Fill(8, ncReq.bits.mask(i))))
     ncmmStoreEvent.coreid := io.hartId
     ncmmStoreEvent.index := 0.U
     ncmmStoreEvent.valid := ncReq.fire && ncReq.bits.memBackTypeMM

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -1196,7 +1196,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   s3_out.bits.uop.replayInst := s3_rep_frm_fetch
   s3_out.bits.data            := s3_in.data
   s3_out.bits.debug.isMMIO    := s3_in.mmio
-  s3_out.bits.debug.isNC      := s3_in.nc
+  s3_out.bits.debug.isNCIO    := s3_in.nc && !s3_in.memBackTypeMM
   s3_out.bits.debug.isPerfCnt := false.B
   s3_out.bits.debug.paddr     := s3_in.paddr
   s3_out.bits.debug.vaddr     := s3_in.vaddr

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1607,7 +1607,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   s3_out.bits.data            := s3_in.data
   s3_out.bits.isFromLoadUnit  := true.B
   s3_out.bits.debug.isMMIO    := s3_in.mmio
-  s3_out.bits.debug.isNC      := s3_in.nc
+  s3_out.bits.debug.isNCIO    := s3_in.nc && !s3_in.memBackTypeMM
   s3_out.bits.debug.isPerfCnt := false.B
   s3_out.bits.debug.paddr     := s3_in.paddr
   s3_out.bits.debug.vaddr     := s3_in.vaddr

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -573,7 +573,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   s3_out.uop             := s3_in.uop
   s3_out.data            := DontCare
   s3_out.debug.isMMIO    := s3_in.mmio
-  s3_out.debug.isNC      := s3_in.nc
+  s3_out.debug.isNCIO    := s3_in.nc && !s3_in.memBackTypeMM
   s3_out.debug.paddr     := s3_in.paddr
   s3_out.debug.vaddr     := s3_in.vaddr
   s3_out.debug.isPerfCnt := false.B

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -882,6 +882,8 @@ class Sbuffer(implicit p: Parameters)
   for (i <- 0 until EnsbufferWidth) {
     io.vecDifftestInfo(i) := DontCare
   }
+
+  io.generateToSQ.diffStoreEventCount := 0.U // initializtion
   if (env.EnableDifftest) {
     val VecMemFLOWMaxNumber = 16
     val WlineMaxNumber = blockWords


### PR DESCRIPTION
**Bug Trigger:** In a self-modifying program, the program modifies its own instructions in a region where PBMT=NC and PMA=MM. If difftest is skipped in this case, NEMU will not execute the corresponding memory access instruction. This causes NEMU and DUT to execute different instructions later on, ultimately leading to an error.

**Solution:** For regions where PBMT=NC and PMA=MM, difftest should not be skipped, since PMA=MM indicates that NEMU can perform normal synchronization. However, for regions with PMA=IO, difftest should still be skipped because NEMU might not be able to access the corresponding devices. Instruction self-modification in PMA=IO regions is generally not a concern, as such regions are typically non-writable. Therefore, synchronization of self-modifying IO instructions is not handled here (as doing so would be overly complex).