### PR TITLE
refactor(XSNoCTop): Inherit XSNoCDiffTop from XSNoCTop instead composite

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           python3 ./difftest/scripts/st_tools/interface.py ./difftest/build/rtl/GatewayEndpoint.sv
-          python3 ./difftest/scripts/st_tools/interface.py ./build/rtl/XSDiffTop.sv --core --filelist ./build/rtl/filelist.f --simtop ./difftest/build/rtl/SimTop.sv
+          python3 ./difftest/scripts/st_tools/interface.py ./build/rtl/XSTop.sv --core --filelist ./build/rtl/filelist.f --simtop ./difftest/build/rtl/SimTop.sv
           cp -r -v ./difftest/build/* ./build/
           verilator --lint-only -Wno-fatal --top-module XSDiffTopChecker build/XSDiffTopChecker.sv build/rtl/*sv build/rtl/*v -Ibuild/generated-src/ -LDFLAGS -"lreadline"
 

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -500,7 +500,8 @@ object TopMain extends App {
   ChiselDB.init(enableChiselDB && !envInFPGA)
 
   if (config(SoCParamsKey).UseXSNoCDiffTop) {
-    Generator.execute(firrtlOpts, DisableMonitors(p => new XSNoCDiffTop()(p))(config), firtoolOpts)
+    val soc = DisableMonitors(p => LazyModule(new XSNoCDiffTop()(p)))(config)
+    Generator.execute(firrtlOpts, soc.module, firtoolOpts)
   } else if (config(SoCParamsKey).UseXSTileDiffTop) {
     Generator.execute(firrtlOpts, DisableMonitors(p => new XSTileDiffTop()(p))(config), firtoolOpts)
   } else {


### PR DESCRIPTION
Use inherit instead of composite to reduce redundant IO port definitions
and connections. At the same time, we are able to keep the original module
name `XSTop` unchanged.