### PR TITLE
fix(StoreQueue): redirect logic for vector exception

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -1459,7 +1459,11 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   // misprediction recovery / exception redirect
   // invalidate sq term using robIdx
   for (i <- 0 until StoreQueueSize) {
-    needCancel(i) := (uop(i).robIdx.needFlush(io.brqRedirect) & !isVec(i) || isAfter(uop(i).robIdx, io.brqRedirect.bits.robIdx) && io.brqRedirect.valid && isVec(i)) && allocated(i) && !committed(i)
+    needCancel(i) := allocated(i) && !committed(i) && Mux(
+        vecExceptionFlag.valid,
+        isAfter(uop(i).robIdx, io.brqRedirect.bits.robIdx) && io.brqRedirect.valid,
+        uop(i).robIdx.needFlush(io.brqRedirect)
+      )
     when (needCancel(i)) {
       allocated(i) := false.B
       completed(i) := false.B


### PR DESCRIPTION
In this pr(https://github.com/OpenXiangShan/XiangShan/pull/4660), we introduce additional logic for redirect on vector exceptions.

Previously, it was because, when `vecExceptionFlag` was high, we would need to wait for `lastflow` deq, in order to clear `vecExceptionFlag`, so we might need to prevent this one instruction from being flushed.

---

However, with the previous modification, when a vector store has not yet deq, but needs to redirect itself, it will fail to cancel due to the use of `isAfter`. 
This leads to ptr exceptions in the storequeue, which can lead to stuckness.

---

The solution, which has always been simple, is to prevent canceling itself only when the exception's directive deqs, i.e., when `vecExceptionFlag` is set.
