### PR TITLE
Minor fix to docker build and test-jar dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,9 +216,10 @@ version:
 jar:
 	mill -i xiangshan.assembly
 
-$(JAR):
+$(JAR): FORCE
+	mill -i xiangshan.test.assembly
 	@mkdir -p $(@D); \
-	JAR_REF=$(shell mill -i show xiangshan.test.assembly); \
+	JAR_REF=$(shell mill -i show xiangshan.test.assembly 2> /dev/null); \
 	[ ! -z $${JAR_REF} ] && echo $${JAR_REF} | sed 's/"//g' | awk -F: '{print $$4}' \
 		| xargs -I{} cp {} $@
 test-jar: $(call docker-deps,$(JAR))
@@ -325,4 +326,4 @@ include Makefile.test
 
 include src/main/scala/device/standalone/standalone_device.mk
 
-.PHONY: verilog sim-verilog emu clean help init bump bsp $(REF_SO)
+.PHONY: FORCE verilog sim-verilog emu clean help init bump bsp $(REF_SO)

--- a/scripts/Makefile.docker
+++ b/scripts/Makefile.docker
@@ -25,12 +25,18 @@ NO_XSDEV_IMAGE := $(if $(HAVE_XSDEV_IMAGE),,1)
 # check if fd0 refers to tty
 HAVE_TTY = $(shell [ -t 0 ] && echo y)
 
+# helper to escape MAKEOVERRIDES
+space_escape := _-_SPACE_-_
+define escape_overrides
+$(subst $(space_escape),\ ,$(addprefix -e ,$(subst \ ,$(space_escape),$(MAKEOVERRIDES))))
+endef
+
 # command for docker run
 MILL_WORK_DIR := /work
 MILL_OUTPUT_DIR := .docker-mill-out
 DOCKER_RUN = docker run --init --rm -i $(if $(HAVE_TTY),-t) -e IN_XSDEV_DOCKER=y \
 			-e NOOP_HOME=$(MILL_WORK_DIR) \
-			$(addprefix -e ,$(MAKEOVERRIDES)) \
+			$(escape_overrides) \
 			-v .:$(MILL_WORK_DIR):ro \
 			-v ./$(MILL_OUTPUT_DIR):$(MILL_WORK_DIR)/out:rw \
 			-v $(BUILD_DIR):$(MILL_WORK_DIR)/$(BUILD_DIR):rw \


### PR DESCRIPTION
 - fix(docker): Fix docker "-e" param when `MAKEOVERRIDES` contains space
 - fix(build): Always re-generated test-jar target by mill