### PR TITLE
perf(L1StreamPf): double the L2 prefetch distance

### DIFF
--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -31,7 +31,7 @@ trait HasStreamPrefetchHelper extends HasL1PrefetchHelper {
   val WIDTH_BYTES = 128
   val WIDTH_CACHE_BLOCKS = WIDTH_BYTES / dcacheParameters.blockBytes
 
-  val L2_DEPTH_RATIO = 2
+  val L2_DEPTH_RATIO = 3
   val L2_WIDTH_BYTES = WIDTH_BYTES * 2
   val L2_WIDTH_CACHE_BLOCKS = L2_WIDTH_BYTES / dcacheParameters.blockBytes
 


### PR DESCRIPTION
This PR change stream prefetcher L2 distance from 128 to 256 blocks.

Since the latency from L2 to DDR is much higher in NoC scenarios, it is necessary to increase the L2 prefetch distance of  stream prefetcher to ensure timeliness.