### PR TITLE
fix(sstateenx): generate sstateen[1|2|3]Module to verilog

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/StateEnBundle.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/StateEnBundle.scala
@@ -39,7 +39,7 @@ class Mstateen0Bundle extends Hstateen0Bundle {
 
 class SstateenNonZeroBundle extends CSRBundle {  // for sstateen[1|2|3]
   override val len = 32
-  val ALL = RO(31, 0).withReset(0.U)
+  val ALL = RO(31, 0)
 }
 
 class HstateenNonZeroBundle extends CSRBundle {  // for hstateen[1|2|3]


### PR DESCRIPTION
The final result of both approaches is read-only 0, but in the former case, ssstateen[1|2|3] will be optimized away during Verilog generation, while in the latter case, it is preserved in the form shown in the diagram below. This has no impact on the actual circuit.
![image](https://github.com/user-attachments/assets/bab97a7b-d3eb-4ba3-9542-cb3be05f9800)
