### PR TITLE
fix(LoadPipe): fix `prefetch_w` btot stall

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1023,6 +1023,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   missQueue.io.debugTopDown <> io.debugTopDown
   missQueue.io.l2_hint <> RegNext(io.l2_hint)
   missQueue.io.mainpipe_info := mainPipe.io.mainpipe_info
+  missQueue.io.occupy_set.zip(ldu.map(_.io.occupy_set)).foreach { case (l, r) => l <> r }
+  missQueue.io.occupy_fail.zip(ldu.map(_.io.occupy_fail)).foreach { case (l, r) => l <> r }
   mainPipe.io.refill_info := missQueue.io.refill_info
   mainPipe.io.replace_block := missQueue.io.replace_block
   mainPipe.io.sms_agt_evict_req <> io.sms_agt_evict_req


### PR DESCRIPTION
Bug descritpions:
* When there is a cacheline with `B` permission in DCache, and the `LoadPipe` execute `prefetch_w` requires BtoT, if there are 3 `BtoT`s in `MissQueue` at this time, this miss will still enter `MissQueue`.

How to fix:
* When a `BtoT` request appears in `LoadPipe`, it is necessary to confirm with `MissQueue` that the number of `BtoT` requests in the same set is less than `nWays - 1(3)`.