### PR TITLE
fix(MainPipe): fix probe/replace stall for alias scheme

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1026,7 +1026,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   missQueue.io.occupy_set.zip(ldu.map(_.io.occupy_set)).foreach { case (l, r) => l <> r }
   missQueue.io.occupy_fail.zip(ldu.map(_.io.occupy_fail)).foreach { case (l, r) => l <> r }
   mainPipe.io.refill_info := missQueue.io.refill_info
-  mainPipe.io.replace_block := missQueue.io.replace_block
+  mainPipe.io.replace <> missQueue.io.replace
   mainPipe.io.sms_agt_evict_req <> io.sms_agt_evict_req
   io.memSetPattenDetected := missQueue.io.memSetPattenDetected
   io.wfi <> missQueue.io.wfi
@@ -1518,10 +1518,22 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   // tilelink stuff
   bus.a <> missQueue.io.mem_acquire
   bus.e <> missQueue.io.mem_finish
-  missQueue.io.probe_addr := bus.b.bits.address
-  missQueue.io.replace_addr := mainPipe.io.replace_addr
   missQueue.io.evict_set := mainPipe.io.evict_set
   missQueue.io.btot_ways_for_set <> mainPipe.io.btot_ways_for_set
+  missQueue.io.replace <> mainPipe.io.replace
+  missQueue.io.probe.req.valid := bus.b.valid
+  missQueue.io.probe.req.bits.addr := bus.b.bits.address
+  if(DCacheAboveIndexOffset > DCacheTagOffset) {
+    // have alias problem, extra alias bits needed for index
+    val alias_addr_frag = bus.b.bits.data(2, 1)
+    missQueue.io.probe.req.bits.vaddr := Cat(
+      bus.b.bits.address(PAddrBits - 1, DCacheAboveIndexOffset), // dontcare
+      alias_addr_frag(DCacheAboveIndexOffset - DCacheTagOffset - 1, 0), // index
+      bus.b.bits.address(DCacheTagOffset - 1, 0)                 // index & others
+    )
+  } else { // no alias problem
+    missQueue.io.probe.req.bits.vaddr := bus.b.bits.address
+  }
 
   missQueue.io.main_pipe_resp.valid := RegNext(mainPipe.io.atomic_resp.valid)
   missQueue.io.main_pipe_resp.bits := RegEnable(mainPipe.io.atomic_resp.bits, mainPipe.io.atomic_resp.valid)
@@ -1529,7 +1541,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   //----------------------------------------
   // probe
   // probeQueue.io.mem_probe <> bus.b
-  block_decoupled(bus.b, probeQueue.io.mem_probe, missQueue.io.probe_block)
+  block_decoupled(bus.b, probeQueue.io.mem_probe, missQueue.io.probe.block)
   probeQueue.io.lrsc_locked_block <> mainPipe.io.lrsc_locked_block
   probeQueue.io.update_resv_set <> mainPipe.io.update_resv_set
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -183,8 +183,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     val btot_ways_for_set = Input(UInt(nWays.W))
 
     // writeback addr to be replaced
-    val replace_addr = ValidIO(UInt(PAddrBits.W))
-    val replace_block = Input(Bool())
+    val replace = new MissQueueBlockIO
 
     // sms prefetch
     val sms_agt_evict_req = DecoupledIO(new AGTEvictReq)
@@ -468,7 +467,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   )
 
   // For a store req, it either hits and goes to s3, or miss and enter miss queue immediately
-  val s2_replace_block = io.replace_block && io.replace_addr.valid
+  val s2_replace_block = io.replace.block && io.replace.req.valid
   val s2_req_miss_without_data = Mux(s2_valid, s2_req.miss && !io.refill_info.valid, false.B)
   val s2_can_go_to_mq_no_data = (s2_req_miss_without_data && RegEnable(s2_req_miss_without_data && !io.mainpipe_info.s2_replay_to_mq, false.B, s2_valid)) // miss_req in s2 but refill data is invalid, can block 1 cycle
   val s2_can_go_to_mq_evict_fail = s2_replace_block // dcache and miss queue both occupy the same set, (BtoT scheme)
@@ -938,8 +937,9 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   XSPerfAccumulate("fake_tag_write_intend", io.tag_write_intend && !io.tag_write.valid)
   XSPerfAccumulate("mainpipe_tag_write", io.tag_write.valid)
 
-  io.replace_addr.valid := s2_valid && s2_need_eviction && !s2_refill_tag_eq_way
-  io.replace_addr.bits  := get_block_addr(Cat(s2_tag, get_untag(s2_req.vaddr)))
+  io.replace.req.valid := s2_valid && s2_need_eviction && !s2_refill_tag_eq_way
+  io.replace.req.bits.addr := get_block_addr(Cat(s2_tag, get_untag(s2_req.vaddr)))
+  io.replace.req.bits.vaddr := s2_req.vaddr
 
   io.evict_set := addr_to_dcache_set(s2_req.vaddr) // only use set index
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -291,7 +291,7 @@ class MissReqPipeRegBundle(edge: TLEdgeOut)(implicit p: Parameters) extends DCac
     acquire
   }
 
-  def block_match(releaseReq: MissQueueBlockReqBundle): Bool = {
+  def block_and_alias_match(releaseReq: MissQueueBlockReqBundle): Bool = {
     reg_valid() && get_block(req.addr) === get_block(releaseReq.addr) && is_alias_match(req.vaddr, releaseReq.vaddr)
   }
 
@@ -1252,7 +1252,7 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     case e =>
       e.io.replace.req <> io.replace.req
       e.io.replace.block
-  } :+ miss_req_pipe_reg.block_match(io.replace.req.bits)).orR
+  } :+ miss_req_pipe_reg.block_and_alias_match(io.replace.req.bits)).orR
 
   val btot_evict_set_hit = entries.map(e => e.io.req_isBtoT && e.io.req_vaddr.valid && addr_to_dcache_set(e.io.req_vaddr.bits) === io.evict_set) ++
     Seq(miss_req_pipe_reg.evict_set_match(io.evict_set))


### PR DESCRIPTION
Bug description:
Address `0x15002cf00` has a valid cacheline at setidx`0x3c`, then there is an sbuffer write request, setidx=`0xfc`, it will miss and enters the `MissQueue`, then wait for refill. There is another refill request sent by `MissQueue` with setidx=`0xfc`, it will replace this cacheline, but the tag (`0x15002cf00`) is already in the `MissQueue`, so it will blocks

How to fix:
Add alias bit comparison to the blocking logic of replace and probe