### PR TITLE
fix(DCache): fix clock gating enable for s3_error in MainPipe

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -569,19 +569,19 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val miss_new_coh = ClientMetadata(missCohGen(s3_req.cmd, s3_miss_param, s3_miss_dirty))
 
   // report ecc error
-  val s3_tag_error = RegEnable(s2_tag_error, false.B, s2_fire)
+  val s3_tag_error = RegEnable(s2_tag_error, false.B, s2_fire_to_s3)
   // data_error will be reported by data array 1 cycle after data read resp
   val s3_data_error = Wire(Bool())
   s3_data_error := Mux(GatedValidRegNextN(s1_fire, 2), // ecc check result is generated 2 cycle after read req
     io.readline_error_delayed && RegNext(s2_may_report_data_error),
     RegNext(s3_data_error) // do not update s3_data_error if !s1_fire
   )
-  val s3_l2_error = RegEnable(s2_l2_error, false.B, s2_fire)
-  val s3_flag_error = RegEnable(s2_flag_error, false.B, s2_fire)
+  val s3_l2_error = RegEnable(s2_l2_error, false.B, s2_fire_to_s3)
+  val s3_flag_error = RegEnable(s2_flag_error, false.B, s2_fire_to_s3)
   // error signal for amo inst
   // s3_error = s3_flag_error || s3_tag_error || s3_l2_error || s3_data_error
-  val s3_error = RegEnable(s2_error, 0.U.asTypeOf(s2_error), s2_fire) || s3_data_error
-  val s3_error_paddr = get_block_addr(RegEnable(Cat(s2_tag, get_untag(s2_req.vaddr)), s2_fire))
+  val s3_error = RegEnable(s2_error, 0.U.asTypeOf(s2_error), s2_fire_to_s3) || s3_data_error
+  val s3_error_paddr = get_block_addr(RegEnable(Cat(s2_tag, get_untag(s2_req.vaddr)), s2_fire_to_s3))
 
   // LR, SC and AMO
   val debug_sc_fail_addr = RegInit(0.U)


### PR DESCRIPTION
Clock gating for `s3_error` in MainPipe should be enabled by `s2_fire_to_s3`, now fix it. 