### PR TITLE
fix(MMU): SuperPage should not consider valididx

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -1169,7 +1169,6 @@ class PtwSectorResp(implicit p: Parameters) extends PtwBundle {
     val asid_hit = if (ignoreAsid) true.B else (this.entry.asid === asid)
     val vmid_hit = Mux(s2xlate, this.entry.vmid.getOrElse(0.U) === vmid, true.B)
 
-    val addr_low_hit = valididx(vpn(sectortlbwidth - 1, 0))
     val tag_match = Wire(Vec(Level + 1, Bool()))
     tag_match(0) := Mux(entry.n.getOrElse(0.U) === 0.U,
       entry.tag(vpnnLen - sectortlbwidth - 1, 0) === vpn(vpnnLen - 1, sectortlbwidth),
@@ -1185,6 +1184,9 @@ class PtwSectorResp(implicit p: Parameters) extends PtwBundle {
       1.U -> (tag_match(3) && tag_match(2) && tag_match(1)),
       0.U -> (tag_match(3) && tag_match(2) && tag_match(1) && tag_match(0)))
     )
+
+    val isSuperPage = entry.level.getOrElse(0.U) =/= 0.U || entry.n.getOrElse(0.U) =/= 0.U
+    val addr_low_hit = Mux(isSuperPage, true.B, valididx(vpn(sectortlbwidth - 1, 0)))
 
     asid_hit && vmid_hit && level_match && addr_low_hit
   }


### PR DESCRIPTION
The lower bits of valididx(i) indicate whether the i-th entry is valid among a contiguous range of n 4KB pages, and `addr_low_hit` is used to check this. However, for large pages and NAPOT cases, since the covered range exceeds what the TLB compression can represent, `addr_low_hit` should always be true.