### PR TITLE
fix(LoadUnit): misaligned exception addr should use split addr

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -996,7 +996,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   s1_out                   := s1_in
   s1_out.vaddr             := s1_vaddr
-  s1_out.fullva            := io.tlb.resp.bits.fullva
+  s1_out.fullva            := Mux(s1_in.isFrmMisAlignBuf, s1_in.vaddr, io.tlb.resp.bits.fullva)
   s1_out.vaNeedExt         := io.tlb.resp.bits.excp(0).vaNeedExt
   s1_out.isHyper           := io.tlb.resp.bits.excp(0).isHyper
   s1_out.paddr             := s1_paddr_dup_lsu


### PR DESCRIPTION
In this PR(https://github.com/OpenXiangShan/XiangShan/pull/4701), I originally planned to modify the `fullva` related parts of both `ldu` and `stu`.
However, for some reason, only the `stu` part was modified in this PR.  
This may be my own foolish disappointment, as the name of this PR (‘fix(LSU)’) was intended to modify both `ldu` and `stu`.
If only `stu` were modified, I would have named it (‘fix(StoreUnit)’).  

Therefore, I believe this is my own foolish mistake. Please forgive me. :pig_nose:

