### PR TITLE
fix(LLPTW): first_s2xlate_fault should be true when check_g_perm_fail

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -972,7 +972,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
           state(i) := state_mem_out
           entries(i).hptw_resp := io.hptw.resp.bits.h_resp
           entries(i).hptw_resp.gpf := io.hptw.resp.bits.h_resp.gpf || check_g_perm_fail
-          entries(i).first_s2xlate_fault := io.hptw.resp.bits.h_resp.gaf || io.hptw.resp.bits.h_resp.gpf
+          entries(i).first_s2xlate_fault := io.hptw.resp.bits.h_resp.gaf || io.hptw.resp.bits.h_resp.gpf || check_g_perm_fail
         }.otherwise{ // change the entry that is waiting hptw resp
           val need_to_waiting_vec = state.indices.map(i => state(i) === state_mem_waiting &&
             dup(entries(i).req_info.vpn, entries(io.hptw.resp.bits.id).req_info.vpn) &&


### PR DESCRIPTION
`first_s2xlate_fault` means G-stage translate triggers gpf or gaf. `check_g_perm_fail` also means gpf, however previous design forgot to consider this situation. This PR fixes the bug.