### PR TITLE
fix(MainPipe): add reg enable for mainpipe `ecc_delayed`

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1294,6 +1294,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   bankedDataArray.io.readline_stall := mainPipe.io.data_readline_stall
   bankedDataArray.io.readline_can_resp := mainPipe.io.data_readline_can_resp
   bankedDataArray.io.readline_intend := mainPipe.io.data_read_intend
+  mainPipe.io.readline_error := bankedDataArray.io.readline_error
   mainPipe.io.readline_error_delayed := bankedDataArray.io.readline_error_delayed
   mainPipe.io.data_resp := bankedDataArray.io.readline_resp
 

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -667,6 +667,12 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   val mbistSramPorts = mbistPl.map(pl => Seq.tabulate(DCacheSetDiv, DCacheBanks, DCacheWays) ({ (i, j, k) =>
     pl.toSRAM(i * DCacheBanks * DCacheWays + j * DCacheWays + k)
   }))
+
+  // read result: expose banked read result
+  private val mbist_r_way = OHToUInt(mbistSramPorts.map(_.flatMap(_.map(w => Cat(w.map(_.re).reverse))).reduce(_ | _)).getOrElse(0.U(DCacheWays.W)))
+  private val mbist_r_div = OHToUInt(mbistSramPorts.map(_.map(d => Cat(d.flatMap(w => w.map(_.re))).orR)).getOrElse(Seq.fill(DCacheSetDiv)(false.B)))
+  private val mbist_ack = mbistPl.map(_.mbist.ack).getOrElse(false.B)
+
   data_banks.map(_.map(_.dump()))
 
   val way_en = Wire(Vec(LoadPipelineWidth, io.read(0).bits.way_en.cloneType))
@@ -896,16 +902,9 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     })
   })
 
-  // read result: expose banked read result
-  private val mbist_r_way = OHToUInt(mbistSramPorts.map(_.flatMap(_.map(w => Cat(w.map(_.re).reverse))).reduce(_ | _)).getOrElse(0.U(DCacheWays.W)))
-  private val mbist_r_div = OHToUInt(mbistSramPorts.map(_.map(d => Cat(d.flatMap(w => w.map(_.re))).orR)).getOrElse(Seq.fill(DCacheSetDiv)(false.B)))
-  private val mbist_ack = mbistPl.map(_.mbist.ack).getOrElse(false.B)
-
   val readline_error_delayed = Wire(Vec(DCacheBanks, Bool()))
-  val readline_r_way_addr = RegEnable(Mux(mbist_ack, mbist_r_way, OHToUInt(io.readline.bits.way_en)), io.readline.valid | mbist_ack)
-  val readline_rr_way_addr = RegEnable(readline_r_way_addr, RegNext(io.readline.valid))
-  val readline_r_div_addr = RegEnable(Mux(mbist_ack, mbist_r_div, line_div_addr), io.readline.valid | mbist_ack)
-  val readline_rr_div_addr = RegEnable(readline_r_div_addr, RegNext(io.readline.valid))
+  val readline_r_way_addr = RegEnable(Mux(mbist_ack, mbist_r_way, OHToUInt(io.readline.bits.way_en)), io.readline.fire | mbist_ack)
+  val readline_r_div_addr = RegEnable(Mux(mbist_ack, mbist_r_div, line_div_addr), io.readline.fire | mbist_ack)
   val readline_resp = Wire(io.readline_resp.cloneType)
   (0 until DCacheBanks).foreach(i => {
     mbistSramPorts.foreach(_.foreach(_(i).foreach(_.rdata := Cat(io.readline_resp(i).ecc, io.readline_resp(i).raw_data))))
@@ -914,10 +913,16 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
       bank_result(readline_r_div_addr)(i)(readline_r_way_addr),
       RegEnable(readline_resp(i), io.readline_stall | mbist_ack)
     )
-    readline_error_delayed(i) := bank_result(readline_rr_div_addr)(i)(readline_rr_way_addr).error_delayed
+
+    if (EnableDataEcc) {
+      val ecc_data_delayed = io.readline_resp(i).asECCData()
+      readline_error_delayed(i) := dcacheParameters.dataCode.decode(ecc_data_delayed).error
+    } else {
+      readline_error_delayed(i) := false.B
+    }
   })
   io.readline_resp := RegEnable(readline_resp, io.readline_can_resp | mbist_ack)
-  io.readline_error_delayed := RegNext(RegNext(io.readline.fire)) && readline_error_delayed.asUInt.orR
+  io.readline_error_delayed := readline_error_delayed.asUInt.orR
 
   // write data_banks & ecc_banks
   for (div_index <- 0 until DCacheSetDiv) {


### PR DESCRIPTION
Bug descriptions:
`MainPipe`  has two requests, `req0 (probe)`, `req1 (sbuffer)`

`t0`: `req0` arrives first and to `s3`.  At this time, `WritebackQueue` cannot accept the request, thus blocking `req0`, and `s3_data_error=1`
`t1`: `req1` arrives at `s0`,
`t2`: `req1` arrives at `s1`, and `s1_fire=1`,
`t3`: `req1` arrives at `s2`, at this time `s2_may_report_data_error = 0`
`t4`: `req1` returns to sbuffer
`t5`: `WritebackQueue` can accept the request, but at this time, `GatedValidRegNextN(s1_fire, 2) = 1`, at this time `s3_data_error` will be updated to the result of `req1`, and then latched.

How to fix:
* `s3_data_error` use `s2_can_fire_to_s3` instead of `s2_fire`