### PR TITLE
fix(StoreQueue): cbozero flag is set using `wline` flag

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -965,7 +965,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
   // RegNext(io.sbuffer(i).fire) is used to alignment timing
   val isCboZeroToSbVec = (0 until EnsbufferWidth).map{ i =>
-    RegNext(io.sbuffer(i).fire && io.sbuffer(i).bits.vecValid) && uop(deqPtrExt(i).value).fuOpType === LSUOpType.cbo_zero && allocated(deqPtrExt(i).value)
+    RegNext(io.sbuffer(i).fire && io.sbuffer(i).bits.vecValid && io.sbuffer(i).bits.wline) && allocated(deqPtrExt(i).value)
   }
   val cboZeroToSb        = isCboZeroToSbVec.reduce(_ || _)
   val cboZeroFlushSb     = GatedRegNext(cboZeroToSb)


### PR DESCRIPTION
We no longer use deqptr to index fuoptype for cbozero determination, as this can lead to errors when a misaligned store is adjacent to cbozero:  
An misaligned store is split into two sbuffer requests. 
Assuming deqptr(0) is an unaligned store and deqptr(1) is cbozero, after the non-aligned split, both sbuffer(0) and sbuffer(1) are requests for the misaligned store. 
Using deqptr for indexing would incorrectly identify sbuffer(1) as cbozero.

Therefore, we use the wline flag for determination. Currently, the wline flag is only set by cboinstructions, and cboinstructions other than cbozerodo not enter the sbuffer, so this only applies to cbozero.