### PR TITLE
fix(LoadUnit): no longer allow tlb missing misaligned load to enter misalignbuffer

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1211,8 +1211,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   // soft prefetch will not trigger any exception (but ecc error interrupt may
   // be triggered)
-  val s2_tlb_unrelated_exceps = s2_in.uop.exceptionVec(loadAddrMisaligned) ||
-                                s2_in.uop.exceptionVec(breakPoint)
+  val s2_tlb_unrelated_exceps = s2_in.uop.exceptionVec(breakPoint)
   when (!s2_in.delayedLoadError && (s2_prf || s2_in.tlbMiss && !s2_tlb_unrelated_exceps)) {
     s2_exception_vec := 0.U.asTypeOf(s2_exception_vec.cloneType)
     s2_isMisalign := false.B


### PR DESCRIPTION
Misaligned load that cause TLB miss are no longer allowed to enter the loadmisalignbuffer.
This is because it would cause subsequent exception addresses to be incorrect :

The original address of the misaligned load is 0x07, while the first request address after splitting is 0x00. 
Thus, when a page fault exception occurs, 0x00 would be considered the exception address instead of the original 0x07.

---

Store have always been handled this way and do not require modification.