### PR TITLE
fix(TrapEntry): hardwareError should be a memory exception

### DIFF
--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -862,6 +862,7 @@ package object xiangshan {
     def EX_LPF    = loadPageFault
     def EX_SPF    = storePageFault
     def EX_DT     = doubleTrap
+    def EX_HWE    = hardwareError
     def EX_IGPF   = instrGuestPageFault
     def EX_LGPF   = loadGuestPageFault
     def EX_VI     = virtualInstr
@@ -879,9 +880,9 @@ package object xiangshan {
 
     def getFetchFault = Seq(EX_IAM, EX_IAF, EX_IPF)
 
-    def getLoadFault = Seq(EX_LAM, EX_LAF, EX_LPF)
+    def getLoadFault = Seq(EX_LAM, EX_LAF, EX_LPF, EX_HWE)
 
-    def getStoreFault = Seq(EX_SAM, EX_SAF, EX_SPF)
+    def getStoreFault = Seq(EX_SAM, EX_SAF, EX_SPF, EX_HWE)
 
     def priorities = Seq(
       doubleTrap,


### PR DESCRIPTION
Currently, the access memory generates hwe exception for bus error and the frontend generates iaf exception for bus error .
We plan to have the frontend also generate hwe exception in kmhV3.

---

HardwareError should belong to memory access exception, and use virtual addresses as the value of xtval when trapping.

Previously, no exception types were added for HardwareError to handle in trapEvent, which resulted in the inability to match and select valid xtval:
https://github.com/OpenXiangShan/XiangShan/blob/8769efd7b4782ab06aed08c14e330f602918c930/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala#L85-L90

---

**In addition**

Since fetch may also produce hardwareError exception in theory, and hardwareError exception produced by fetch should write pc to xtval.
Therefore, I have written a more accurate version(https://github.com/OpenXiangShan/XiangShan/pull/4765). 
Please consider which solution we should adopt.
