### PR TITLE
fix(EnumUInt): disallow 0 as one-hot value by default

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -23,4 +23,7 @@ rewrite.trailingCommas.style = never
 
 docstrings.style = keep
 
-project.includePaths = ["glob:**/src/main/scala/xiangshan/frontend/**.scala"]
+project.includePaths = [
+  "glob:**/src/main/scala/xiangshan/frontend/**.scala",
+  "glob:**/src/main/scala/utils/EnumUInt.scala"
+]

--- a/src/main/scala/utils/EnumUInt.scala
+++ b/src/main/scala/utils/EnumUInt.scala
@@ -133,7 +133,7 @@ abstract class EnumUInt(
         s"EnumUInt ${this.getClass.getName} using one-hot has non one-hot value(${litValue}): ${name}."
       )
       assert( // check3.2: one-hot values must not be 0
-        !useOneHot || !allowZeroForOneHot || litValue != 0,
+        !useOneHot || allowZeroForOneHot || litValue != 0,
         s"EnumUInt ${this.getClass.getName} using one-hot has zero value(0): ${name}. " +
           s"Please consider using Vec[Bool] if you want to use 0 as 'None' and other values are one-hot. " +
           s"Or, set allowZeroForOneHot to true if you intentionally want to use 0 as one-hot value for EnumUInt."
@@ -148,7 +148,7 @@ abstract class EnumUInt(
       val methodsNotUpperCamelCase = methodsAll.diff(methods)
       methodsNotUpperCamelCase.foreach { method =>
         println(
-          s"[Warn]: EnumUInt ${this.getClass.getName} seems has constants defination '${method.getName}' " +
+          s"[Warn]: EnumUInt ${this.getClass.getName} seems has constants definition '${method.getName}' " +
             s"that is not UpperCamelCase, Do you mean '${method.getName.capitalize}'?"
         )
       }


### PR DESCRIPTION
The original design allows 0 for enums like `ExceptionVec`, we use 0 for `None` and one-hot values for each exception, but in this case, `Vec[Bool]` may be preferred.

When using `EnumUInt` for fsm states, etc., we found that allowing 0 is confusing, and may generate redundant logic. Thanks @TheKiteRunner24.

Therefore, in this PR we disallow 0 as one-hot value by default, and developers are prompt to use `Vec[Bool]` or explicitly use `allowZeroForOneHot`.

Also:
- enable scalafmt for `EnumUInt`
- fix a typo