### PR TITLE
fix(PMP): take a beat for `cmd`

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/PMP.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMP.scala
@@ -569,8 +569,9 @@ class PMPChecker
   val res_pmp = pmp_match_res(leaveHitMux, io.req.valid)(req.addr(PMPAddrBits-PMPKeyIDBits-1, 0), req.size, io.check_env.pmp, io.check_env.mode, lgMaxSize)
   val res_pma = pma_match_res(leaveHitMux, io.req.valid)(req.addr(PMPAddrBits-PMPKeyIDBits-1, 0), req.size, io.check_env.pma, io.check_env.mode, lgMaxSize)
 
-  val resp_pmp = pmp_check(req.cmd, res_pmp.cfg)
-  val resp_pma = pma_check(req.cmd, res_pma.cfg)
+  val cmd = if(leaveHitMux) RegEnable(req.cmd, io.req.valid) else req.cmd
+  val resp_pmp = pmp_check(cmd, res_pmp.cfg)
+  val resp_pma = pma_check(cmd, res_pma.cfg)
   
   def keyid_check(leaveHitMux: Boolean = false, valid: Bool = true.B, addr: UInt) = {
     val resp = Wire(new PMPRespBundle)


### PR DESCRIPTION
When leaveHitMux is enabled, pmp will take a beat for the vast majority of io.req.bits. 
However, io.req.bits.cmd didn't take a beat.

Previously, a pipeline would only generate one cmd request, so even if the beat count was not aligned, no bugs would occur.
However, currently, loadunit issues both write and read requests, which causes permission checks to fail.
