### PR TITLE
fix(XSNoCTop): synchronize CHI syscoack for cross clock domain protection

### DIFF
--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -17,7 +17,7 @@ PMAConfigs:
 
 EnableCHIAsyncBridge: true
 
-L2CacheConfig: { size: 1 MB, ways: 8, inclusive: true, banks: 4, tp: true, enableFlush: false }
+L2CacheConfig: { size: 1 MB, ways: 8, inclusive: true, banks: 4, tp: false, enableFlush: true }
 
 L3CacheConfig: { size: 16 MB, ways: 16, inclusive: false, banks: 4 }
 
@@ -61,7 +61,7 @@ CHIIssue: E.b
 
 WFIClockGate: false
 
-EnablePowerDown: false
+EnablePowerDown: true 
 
 XSTopPrefix: ""
 

--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -17,7 +17,7 @@ PMAConfigs:
 
 EnableCHIAsyncBridge: true
 
-L2CacheConfig: { size: 1 MB, ways: 8, inclusive: true, banks: 4, tp: false, enableFlush: true }
+L2CacheConfig: { size: 1 MB, ways: 8, inclusive: true, banks: 4, tp: true, enableFlush: false }
 
 L3CacheConfig: { size: 16 MB, ways: 16, inclusive: false, banks: 4 }
 
@@ -61,7 +61,7 @@ CHIIssue: E.b
 
 WFIClockGate: false
 
-EnablePowerDown: true 
+EnablePowerDown: false
 
 XSTopPrefix: ""
 

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -107,6 +107,7 @@ trait HasCoreLowPowerImp[+L <: HasXSTile] { this: BaseXSSocImp with HasXSTileCHI
     val sIDLE :: sL2FLUSH :: sWAITWFI :: sEXITCO :: sWAITQ :: sQREQ :: sPOFFREQ :: Nil = Enum(7)
     val lpState = withClockAndReset(clock, cpuReset_sync) {RegInit(sIDLE)}
     val cpu_no_op = withClockAndReset(clock, cpuReset_sync) {RegInit(false.B)}
+    val sync_chi_syscoack = withClockAndReset(clock, cpuReset_sync) {AsyncResetSynchronizerShiftReg(io_chi.syscoack, 3, 0)}
     val l2_flush_en = withClockAndReset(clock, cpuReset_sync) {
       AsyncResetSynchronizerShiftReg(core.io.l2_flush_en.getOrElse(false.B), 3, 0)
     }
@@ -117,7 +118,7 @@ trait HasCoreLowPowerImp[+L <: HasXSTile] { this: BaseXSSocImp with HasXSTileCHI
       AsyncResetSynchronizerShiftReg(core.io.cpu_halt, 3, 0)
     }
     val exitco = withClockAndReset(clock, cpuReset_sync) {
-      AsyncResetSynchronizerShiftReg((!io_chi.syscoreq & !io_chi.syscoack),3, 0)}
+      AsyncResetSynchronizerShiftReg((!io_chi.syscoreq & !sync_chi_syscoack),3, 0)}
     val QACTIVE = WireInit(false.B)
     val QACCEPTn = WireInit(false.B)
     cpu_no_op := lpState === sPOFFREQ


### PR DESCRIPTION
1. synchronize CHI syscoack for cross clock domain protection
2. remove WFI clock gating related logic when disable this function