### PR TITLE
fix(MetaArray): enable write bypass for read

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/meta/AsynchronousMetaArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/meta/AsynchronousMetaArray.scala
@@ -48,7 +48,7 @@ class FlagMetaWriteReq(implicit p: Parameters) extends MetaReadReq {
   val flag = Bool()
 }
 
-class L1CohMetaArray(readPorts: Int, writePorts: Int, bypassRead: Boolean = false)(implicit p: Parameters) extends DCacheModule {
+class L1CohMetaArray(readPorts: Int, writePorts: Int, bypassRead: Boolean = true)(implicit p: Parameters) extends DCacheModule {
   val io = IO(new Bundle() {
     val read = Vec(readPorts, Flipped(DecoupledIO(new MetaReadReq)))
     val resp = Output(Vec(readPorts, Vec(nWays, new Meta)))


### PR DESCRIPTION
Enable bypass to allow reads to obtain write data when reads and writes occur simultaneously.

---

load s0 reads meta.
load s1 obtains the read meta result.
load s2 requests entry into rarqueue.

If a write meta probe is generated simultaneously with load s0, without enabling bypass, this read meta will obtain old data.
This will result in a dcache hit.
However, the rarqueue release occurs on the next cycle after the probe write meta, which is when load s1 is generated. At this point, the load has not yet entered the rarqueue, so it is not marked as released in the rarqueue.