### PR TITLE
fix(csr, perf): skip CSR read xtopei

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -934,9 +934,9 @@ class NewCSR(implicit val p: Parameters) extends Module
     (addr >= CSRs.cycle.U) && (addr <= CSRs.hpmcounter31.U)
   ) || 
   ren && (
-    (addr === CSRs.vstopi.U) ||
-    (addr === CSRs.stopi.U) || 
-    (addr === CSRs.mtopi.U)
+    (addr === CSRs.vstopi.U) || (addr === CSRs.vstopei.U) ||
+    (addr === CSRs.stopi.U) || (addr === CSRs.stopei.U) ||
+    (addr === CSRs.mtopi.U) || (addr === CSRs.mtopei.U)
   )
 
   val resetSatp = WireInit(false.B)


### PR DESCRIPTION
* Related to [fix(csr, perf): skip CSR read xtopi](https://github.com/OpenXiangShan/XiangShan/pull/4742), skip for now.

* Currently, there is a situation where xtopei is updated, and then a CSR reads `xtopi` instruction. Since the CSR reads `xtopi` instruction is skipped, `old_xtopei` in NEMU is not updated. Then a CSR reads `xtopei` instruction, causing an error in XiangShan and NEMU diff.