### PR TITLE
fix(LoadQueueRAR): fix `paddrModule` not match by replay

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1019,6 +1019,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
       loadUnits(i).io.misalign_ldin.bits := DontCare
     }
 
+    loadUnits(i).io.release := dcache.io.lsu.release
+
     // alter writeback exception info
     io.mem_to_ooo.s3_delayed_load_error(i) := loadUnits(i).io.s3_dly_ld_err
 

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1680,7 +1680,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.feedback_slow.bits.dataInvalidSqIdx := DontCare
 
   // TODO: vector wakeup?
-  io.ldCancel.ld2Cancel := s3_valid && !s3_safe_wakeup && !s3_isvec
+  io.ldCancel.ld2Cancel := s3_valid && (!s3_safe_wakeup || s3_release_match) && !s3_isvec
 
   val s3_ld_wb_meta = Mux(s3_valid, s3_out.bits, s3_mmio_req.bits)
 


### PR DESCRIPTION
Related: https://github.com/OpenXiangShan/XiangShan/pull/4803

How to fix:
* when release come at the first write cycle, load will at s3, hence, if PA is match, load will replay with `RAR_NACK`