### PR TITLE
fix(ICache,Perf): correct topdown.itlbMissBubble

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -290,6 +290,7 @@ class PmpCheckBundle(implicit p: Parameters) extends ICacheBundle {
 }
 
 /* ***** Perf ***** */
+// to Ifu
 class ICachePerfInfo(implicit p: Parameters) extends ICacheBundle {
   val hits:         Vec[Bool]          = Vec(PortNumber, Bool())
   val isDoubleLine: Bool               = Bool()
@@ -316,12 +317,24 @@ class ICachePerfInfo(implicit p: Parameters) extends ICacheBundle {
   def except: Bool = exception(0).hasException || (isDoubleLine && exception(1).hasException)
 }
 
+// to Ifu -> IBuffer -> Backend
 class ICacheTopdownInfo(implicit p: Parameters) extends ICacheBundle {
   val iCacheMissBubble: Bool = Output(Bool())
   val itlbMissBubble:   Bool = Output(Bool())
 }
 
-class ICachePerfEventsInfo(implicit p: Parameters) extends ICacheBundle {
-  val miss:       Bool = Output(Bool())
-  val missBubble: Bool = Output(Bool())
+// inner MainPipe -> top
+class MainPipePerfInfo(implicit p: Parameters) extends ICacheBundle {
+  val rawHits:     Vec[Bool] = Vec(PortNumber, Bool())
+  val pendingMiss: Bool      = Bool() // currently handling a miss
+}
+
+// inner PrefetchPipe -> top
+class PrefetchPipePerfInfo(implicit p: Parameters) extends ICacheBundle {
+  val pendingItlbMiss: Bool = Bool()
+}
+
+// inner WayLookup -> top
+class WayLookupPerfInfo(implicit p: Parameters) extends ICacheBundle {
+  val empty: Bool = Bool()
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -498,8 +498,9 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   // tell ICache top when handling miss
   io.perf.pendingMiss := s2_valid && !s2_fetchFinish
 
-  XSPerfAccumulate("icache_bubble_s2_miss", s2_valid && !s2_fetchFinish)
-  XSPerfAccumulate("icache_bubble_s0_wayLookup", s0_valid && !fromWayLookup.valid)
+  XSPerfAccumulate("missUnitStall", toMiss.valid && !toMiss.ready)
+  XSPerfAccumulate("missBubble", s2_valid && !s2_fetchFinish)
+  XSPerfAccumulate("wayLookupBubble", s0_valid && !fromWayLookup.valid)
 
   // class ICacheTouchDB(implicit p: Parameters) extends ICacheBundle{
   //   val blkPAddr  = UInt((PAddrBits - blockOffBits).W)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -61,10 +61,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     // backend/Beu
     val errors: Vec[Valid[L1CacheErrorInfo]] = Output(Vec(PortNumber, ValidIO(new L1CacheErrorInfo)))
 
-    /* *** Perf *** */
-    val perf:       ICachePerfInfo       = Output(new ICachePerfInfo)
-    val topdown:    ICacheTopdownInfo    = Output(new ICacheTopdownInfo)
-    val perfEvents: ICachePerfEventsInfo = Output(new ICachePerfEventsInfo)
+    val perf: MainPipePerfInfo = Output(new MainPipePerfInfo)
   }
 
   val io: ICacheMainPipeIO = IO(new ICacheMainPipeIO)
@@ -494,25 +491,15 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   /* *****************************************************************************
    * perf
    * ***************************************************************************** */
-  // when fired, tell ifu hit state of each cache line
+  // when fired, tell ifu raw hit state of each cache line
   // NOTE: we cannot use s2_hits, it will be reset when refilled from L2
   private val s2_rawHits = RegEnable(s1_hits, 0.U.asTypeOf(s1_hits), s1_fire)
-  io.perf.hits         := s2_rawHits
-  io.perf.isDoubleLine := s2_doubleline
-  io.perf.exception    := s2_exceptionOut
+  io.perf.rawHits := s2_rawHits
+  // tell ICache top when handling miss
+  io.perf.pendingMiss := s2_valid && !s2_fetchFinish
 
-  // tell topdown when waiting for icache refill or itlb refill
-  io.topdown.iCacheMissBubble := s2_valid && !s2_fetchFinish
-  io.topdown.itlbMissBubble   := s0_valid && !fromWayLookup.ready
-
-  // tell icache top when waiting for refill
-  io.perfEvents.missBubble := s2_valid && !s2_fetchFinish
-  // and when fired, tell icache top if it is a miss
-  io.perfEvents.miss := s2_fire && (!s2_rawHits(0) || !s2_rawHits(1) && s2_doubleline)
-
-  // count fetch bubble, same as topdown, but an inner perf counter
   XSPerfAccumulate("icache_bubble_s2_miss", s2_valid && !s2_fetchFinish)
-  XSPerfAccumulate("icache_bubble_s0_wayLookup", s0_valid && !fromWayLookup.ready)
+  XSPerfAccumulate("icache_bubble_s0_wayLookup", s0_valid && !fromWayLookup.valid)
 
   // class ICacheTouchDB(implicit p: Parameters) extends ICacheBundle{
   //   val blkPAddr  = UInt((PAddrBits - blockOffBits).W)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMetaArray.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMetaArray.scala
@@ -133,8 +133,6 @@ class ICacheMetaArray(implicit p: Parameters) extends ICacheModule with ICacheEc
     validArray(writeWayNum) := validArray(writeWayNum).bitSet(io.write.req.bits.vSetIdx, true.B)
   }
 
-  XSPerfAccumulate("meta_refill_num", io.write.req.valid)
-
   io.read.resp.metas <> DontCare
   io.read.resp.codes <> DontCare
   private val readMetaEntries = tagArrays.map(port => port.io.r.resp.asTypeOf(Vec(nWays, new ICacheMetaEntry())))
@@ -186,7 +184,10 @@ class ICacheMetaArray(implicit p: Parameters) extends ICacheModule with ICacheEc
     (0 until nWays).foreach(w => validArray(w) := 0.U)
   }
 
-  // PERF: flush counter
+  /* *** perf *** */
+  // refill
+  XSPerfAccumulate("refill", io.write.req.valid)
+  // flush
   XSPerfAccumulate("flush", io.flush.req.map(_.valid).reduce(_ || _))
-  XSPerfAccumulate("flush_all", io.flushAll)
+  XSPerfAccumulate("flushAll", io.flushAll)
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
@@ -261,19 +261,24 @@ class ICacheMissUnit(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheModu
    * perf
    * ***************************************************************************** */
   // Total requests, duplicate requests will be excluded.
-  XSPerfAccumulate("enq_fetch_req", fetchDemux.io.in.fire)
-  XSPerfAccumulate("enq_prefetch_req", prefetchDemux.io.in.fire)
+  XSPerfAccumulate("enqFetchReq", fetchDemux.io.in.fire)
+  XSPerfAccumulate("enqPrefetchReq", prefetchDemux.io.in.fire)
+
+  // Duplicate requests
+  XSPerfAccumulate("duplicateFetchReq", fetchHit)
+  XSPerfAccumulate("duplicatePrefetchReq", prefetchHit) // includes prefetchHitFetchReq
+  XSPerfAccumulate("prefetchHitFetchReq", prefetchHitFetchReq)
 
   // Mshr occupancy
   XSPerfHistogram(
-    "fetchMshrReadyCnt",
+    "fetchMshrEmptyCnt",
     PopCount(fetchDemux.io.out.map(_.ready)),
     true.B,
     0,
     nFetchMshr
   )
   XSPerfHistogram(
-    "prefetchMshrReadyCnt",
+    "prefetchMshrEmptyCnt",
     PopCount(prefetchDemux.io.out.map(_.ready)),
     true.B,
     0,

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMshr.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMshr.scala
@@ -19,8 +19,10 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.tilelink.TLEdgeOut
 import org.chipsalliance.cde.config.Parameters
+import utility.BoolStopWatch
 import utility.MemReqSource
 import utility.ReqSourceKey
+import utility.XSPerfHistogram
 import xiangshan.WfiReqBundle
 
 class ICacheMshr(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Parameters) extends ICacheModule {
@@ -122,4 +124,13 @@ class ICacheMshr(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Paramet
 
   // we are safe to enter wfi if we have no pending response from L2
   io.wfi.wfiSafe := !(valid && issue)
+
+  XSPerfHistogram(
+    "responseLatency",
+    BoolStopWatch(io.acquire.fire, io.invalid),
+    io.invalid,
+    0,
+    200,
+    10
+  )
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -543,32 +543,16 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   io.perf.pendingItlbMiss := s1_valid && !tlbFinish
 
   // the number of bpu flush
-  XSPerfAccumulate("bpu_s0_flush", fromBpuS0Flush)
-  XSPerfAccumulate("bpu_s1_flush", fromBpuS1Flush)
+  XSPerfAccumulate("bpuS0Flush", fromBpuS0Flush)
+  XSPerfAccumulate("bpuS1Flush", fromBpuS1Flush)
   // the number of prefetch request received from ftq or backend (software prefetch)
-//  XSPerfAccumulate("prefetch_req_receive", io.req.fire)
-  XSPerfAccumulate("prefetch_req_receive_hw", io.req.fire && !io.req.bits.isSoftPrefetch)
-  XSPerfAccumulate("prefetch_req_receive_sw", io.req.fire && io.req.bits.isSoftPrefetch)
+  XSPerfAccumulate("hwReq", io.req.fire && !io.req.bits.isSoftPrefetch)
+  XSPerfAccumulate("swReq", io.req.fire && io.req.bits.isSoftPrefetch)
   // the number of prefetch request sent to missUnit
-//  XSPerfAccumulate("prefetch_req_send", toMiss.fire)
-  XSPerfAccumulate("prefetch_req_send_hw", toMiss.fire && !s2_isSoftPrefetch)
-  XSPerfAccumulate("prefetch_req_send_sw", toMiss.fire && s2_isSoftPrefetch)
-  XSPerfAccumulate("to_missUnit_stall", toMiss.valid && !toMiss.ready)
+  XSPerfAccumulate("hwMiss", toMiss.fire && !s2_isSoftPrefetch)
+  XSPerfAccumulate("swMiss", toMiss.fire && s2_isSoftPrefetch)
+  XSPerfAccumulate("missUnitStall", toMiss.valid && !toMiss.ready)
 
-  /**
-    * Count the number of requests that are filtered for various reasons.
-    * The number of prefetch discard in Performance Accumulator may be
-    * a little larger the number of really discarded. Because there can
-    * be multiple reasons for a canceled request at the same time.
-    */
-  // discard prefetch request by flush
-  // XSPerfAccumulate("fdip_prefetch_discard_by_tlb_except",  p1_discard && p1_tlb_except)
-  // // discard prefetch request by hit icache SRAM
-  // XSPerfAccumulate("fdip_prefetch_discard_by_hit_cache",   p2_discard && p1_meta_hit)
-  // // discard prefetch request by hit write SRAM
-  // XSPerfAccumulate("fdip_prefetch_discard_by_p1_monitor",  p1_discard && p1_monitor_hit)
-  // // discard prefetch request by pmp except or mmio
-  // XSPerfAccumulate("fdip_prefetch_discard_by_pmp",         p2_discard && p2_pmp_except)
-  // // discard prefetch request by hit mainPipe info
-  // // XSPerfAccumulate("fdip_prefetch_discard_by_mainPipe",    p2_discard && p2_mainPipe_hit)
+  // itlb miss bubble
+  XSPerfAccumulate("itlbMissBubble", s1_valid && !tlbFinish)
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -51,6 +51,8 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     val missReq:        DecoupledIO[MissReqBundle]     = DecoupledIO(new MissReqBundle)
     val missResp:       Valid[MissRespBundle]          = Flipped(ValidIO(new MissRespBundle))
     val wayLookupWrite: DecoupledIO[WayLookupBundle]   = DecoupledIO(new WayLookupBundle)
+
+    val perf: PrefetchPipePerfInfo = Output(new PrefetchPipePerfInfo)
   }
 
   val io: ICachePrefetchPipeIO = IO(new ICachePrefetchPipeIO)
@@ -534,7 +536,12 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   s2_ready := s2_finish || !s2_valid
   s2_fire  := s2_valid && s2_finish && !s2_flush
 
-  /** PerfAccumulate */
+  /* *****************************************************************************
+   * perf
+   * ***************************************************************************** */
+  // tell ICache top when handling itlb miss
+  io.perf.pendingItlbMiss := s1_valid && !tlbFinish
+
   // the number of bpu flush
   XSPerfAccumulate("bpu_s0_flush", fromBpuS0Flush)
   XSPerfAccumulate("bpu_s1_flush", fromBpuS1Flush)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -19,9 +19,12 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.CircularQueuePtr
-import xiangshan.frontend.ExceptionType
+import utility.HasCircularQueuePtrHelper
+import utility.XSPerfHistogram
 
-class ICacheWayLookup(implicit p: Parameters) extends ICacheModule with ICacheMissUpdateHelper {
+class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
+    with ICacheMissUpdateHelper
+    with HasCircularQueuePtrHelper {
 
   class ICacheWayLookupIO(implicit p: Parameters) extends ICacheBundle {
     val flush:  Bool                         = Input(Bool())
@@ -137,4 +140,14 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule with ICacheMi
   /* *** perf *** */
   // tell ICache top if queue is empty
   io.perf.empty := empty
+
+  // perf counter
+  // occupancy
+  XSPerfHistogram(
+    "occupiedEntryCnt",
+    distanceBetween(writePtr, readPtr),
+    true.B,
+    0,
+    nWayLookupSize
+  )
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -28,6 +28,8 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule with ICacheMi
     val read:   DecoupledIO[WayLookupBundle] = DecoupledIO(new WayLookupBundle)
     val write:  DecoupledIO[WayLookupBundle] = Flipped(DecoupledIO(new WayLookupBundle))
     val update: Valid[MissRespBundle]        = Flipped(ValidIO(new MissRespBundle))
+
+    val perf: WayLookupPerfInfo = Output(new WayLookupPerfInfo)
   }
 
   val io: ICacheWayLookupIO = IO(new ICacheWayLookupIO)
@@ -131,4 +133,8 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule with ICacheMi
       gpfPtr         := writePtr
     }
   }
+
+  /* *** perf *** */
+  // tell ICache top if queue is empty
+  io.perf.empty := empty
 }


### PR DESCRIPTION
`itlbMissBubble` should be:
- prefetchPipe has a pending itlb miss
- and, wayLookup is empty.

This means mainPipe will have to wait itlb refill and send response to prefetchPipe -> wayLookup -> mainPipe, and therefore, create bubble in fetch pipeline.

Also see discussion in #4798 

Fixes #4798

Also:
- refactor ICache inner interface for perf, reduce redundant ports
- rename `XSPerfAccumulate`s for camelCase & better readability
- add `itlbMissBubble` counter in prefetchPipe
- add `occupiedEntryCnt` histogram in wayLookup
- add dup request counters in missUnit