### PR TITLE
fix(WritebackQueue): fix `probe` merge with `release` with same PA

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/WritebackQueue.scala
@@ -195,7 +195,6 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
   io.block_addr.bits   := req.addr
 
   s_data_override := true.B // data_override takes only 1 cycle
-  s_no_merge_stall := true.B
   //s_data_merge := true.B // data_merge takes only 1 cycle
 
   XSDebug(state =/= s_invalid, "WritebackEntry: %d state: %d block_addr: %x\n", io.id, state, io.block_addr.bits)
@@ -209,6 +208,7 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
     assert (remain === 0.U)
     req := io.req.bits
     s_data_override := false.B
+    s_no_merge_stall := false.B
     // only update paddr when allocate a new missqueue entry
     paddr_dup_0 := io.req.bits.addr
     paddr_dup_1 := io.req.bits.addr
@@ -216,8 +216,8 @@ class WritebackEntry(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModu
 
     remain_set := Mux(io.req.bits.hasData, ~0.U(refillCycles.W), 1.U(refillCycles.W))
     when (!probe_merge_with_release) {
+      s_no_merge_stall := true.B
       // when probe merge with release, state will not change
-      s_no_merge_stall := false.B
       state      := s_release_req
       state_dup_0 := s_release_req
       state_dup_1 := s_release_req


### PR DESCRIPTION
Bugs descriptions:
There are four requests: 
1. Probe1 PA1
2. Probe2 PA2
3. Grant1 PA2
4. ReleaseData1/ReleaseACK1 PA1
![probe_stall drawio](https://github.com/user-attachments/assets/d5bc6a81-2679-4141-af8b-e2b085d73d94)

* In a) block scheme, `WritebackQueue` send `ReleaseData1` to L2, then L2 send `Probe1` to L1, find a entry (the entry send `ReleaseData1`) with same PA, it will be blocked, hence `Probe2`, `Grant1`, `ReleaseACK1` will be block too. Finally, the core halt.

How to fix:
* In b) merge scheme, L2 send `Probe1` to L1, find a entry (the entry will `ReleaseData1`) with same PA, if the entry have send `ReleaseData1` already,  `Probe1` will merge with release, otherwise, `Probe1` will be block until `ReleaseData1` send, then merge with release.
