### PR TITLE
fix(csr): set xstatus.VS dirty when a vector memory access instr has exception

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
@@ -539,7 +539,7 @@ class MstatusModule(implicit override val p: Parameters) extends CSRModule("MSta
     reg.FS := ContextStatus.Dirty
   }
 
-  when (robCommit.vsDirty || writeVCSR) {
+  when (robCommit.vsDirty || writeVCSR || robCommit.vstart.valid && robCommit.vstart.bits =/= 0.U) {
     assert(reg.VS =/= ContextStatus.Off, "The [m|s]status.VS should not be Off when set dirty, please check decode")
     reg.VS := ContextStatus.Dirty
   }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/VirtualSupervisorLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/VirtualSupervisorLevel.scala
@@ -33,7 +33,7 @@ trait VirtualSupervisorLevel { self: NewCSR with SupervisorLevel with Hypervisor
         reg.FS := ContextStatus.Dirty
       }
 
-      when ((robCommit.vsDirty || writeVCSR) && isVirtMode) {
+      when ((robCommit.vsDirty || writeVCSR || robCommit.vstart.valid && robCommit.vstart.bits =/= 0.U) && isVirtMode) {
         assert(reg.VS =/= ContextStatus.Off, "The vsstatus.VS should not be Off when set dirty, please check decode")
         reg.VS := ContextStatus.Dirty
       }


### PR DESCRIPTION
* When the vstart of a vector memory access instruction is not 0, the xstatus.VS field is set to dirty.