### PR TITLE
fix(vleff): fix vleff writeback `vl` and `vta`

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1712,8 +1712,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
       vsMergeBuffer(i).io.uopWriteback.head.ready := io.mem_to_ooo.writebackVldu(i).ready && !vlMergeBuffer.io.uopWriteback(i).valid
     }
 
-    vfofBuffer.io.mergeUopWriteback(i).valid := vlMergeBuffer.io.uopWriteback(i).valid
-    vfofBuffer.io.mergeUopWriteback(i).bits  := vlMergeBuffer.io.uopWriteback(i).bits
+    vfofBuffer.io.mergeUopWriteback(i).valid := vlMergeBuffer.io.toLsq(i).valid
+    vfofBuffer.io.mergeUopWriteback(i).bits  := vlMergeBuffer.io.toLsq(i).bits
   }
 
 

--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -47,6 +47,7 @@ class MBufferBundle(implicit p: Parameters) extends VLSUBundle{
   // for exception
   val vstart           = UInt(elemIdxBits.W)
   val vl               = UInt(elemIdxBits.W)
+  val originVl         = UInt(elemIdxBits.W) // for backend merge data
   val vaNeedExt        = Bool()
   val vaddr            = UInt(XLEN.W)
   val gpaddr           = UInt(GPAddrBits.W)
@@ -84,6 +85,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     sink.fof          := source.fof
     sink.vlmax        := source.vlmax
     sink.vl           := source.uop.vpu.vl
+    sink.originVl     := source.uop.vpu.vl
     sink.vaddr        := source.vaddr
     sink.vstart       := 0.U
   }
@@ -98,7 +100,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     sink.vdIdxInField.get := source.vdIdx // Mgu needs to use this.
     sink.vdIdx.get        := source.vdIdx
     sink.uop.vpu.vstart   := source.vstart
-    sink.uop.vpu.vl       := source.vl
+    sink.uop.vpu.vl       := source.originVl
     sink
   }
   def ToLsqConnect(source: MBufferBundle): FeedbackToLsqIO = {
@@ -288,7 +290,6 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
         entry.gpaddr       := selPort(0).gpaddr
         entry.isForVSnonLeafPTE := selPort(0).isForVSnonLeafPTE
       }.otherwise{
-        entry.uop.vpu.vta  := VType.tu
         entry.vl           := Mux(entry.vl < vstart, entry.vl, vstart)
       }
     }

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -904,8 +904,6 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
     writebackOut.uop.vpu.vstart         := Mux(instMicroOp.uop.exceptionVec.asUInt.orR || TriggerAction.isDmode(instMicroOp.uop.trigger), instMicroOp.exceptionVstart, instMicroOp.vstart)
     writebackOut.uop.vpu.vmask          := maskUsed
     writebackOut.uop.vpu.vuopIdx        := uopq(deqPtr.value).uop.vpu.vuopIdx
-    // when exception updates vl, should use vtu strategy.
-    writebackOut.uop.vpu.vta            := Mux(instMicroOp.exceptionVl.valid, VType.tu, instMicroOp.uop.vpu.vta)
     writebackOut.debug                  := DontCare
     writebackOut.vdIdxInField.get       := vdIdxInField
     writebackOut.uop.robIdx             := instMicroOp.uop.robIdx

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -282,7 +282,7 @@ class VSegmentUnitIO(implicit p: Parameters) extends VLSUBundle{
 class VfofDataBuffIO(implicit p: Parameters) extends VLSUBundle{
   val redirect            = Flipped(ValidIO(new Redirect))
   val in                  = Vec(VecLoadPipelineWidth, Flipped(Decoupled(new MemExuInput(isVector=true))))
-  val mergeUopWriteback   = Vec(VLUopWritebackWidth, Flipped(DecoupledIO(new MemExuOutput(isVector=true))))
+  val mergeUopWriteback   = Vec(VLUopWritebackWidth, Flipped(DecoupledIO(new FeedbackToLsqIO)))
 
   val uopWriteback        = DecoupledIO(new MemExuOutput(isVector = true))
 }


### PR DESCRIPTION
In commit `785e3bf`, when vleff instructions have exception but not raise, we will set tail undisturbed in uop which will change vl. But backend would not raise exception, and don't consider have trap, We retire as if it were a normal instruction. Such treatment is consistent with the spec, but in order to align with `REF`, we revert commit  `785e3bf`.

This PR modify:
assignment of vfofBuffer's  `io.mergeUopWriteback` , MergeBuffer.io.uopWriteback --> MergeBuffer.io.toLsq; 
writeback origin vl, modified vl --> origin vl.
