### PR TITLE
chore(scalastyle): allow ([a-z][0-9]|perf|debug)_ prefix

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -138,7 +138,7 @@
  <check enabled="true" class="org.scalastyle.scalariform.FieldNamesChecker" level="warning">
   <parameters>
    <!-- we allow sx_lowerCamelCase for pipeline signals -->
-   <parameter name="regex">^(s[0-9]_)?[a-z][A-Za-z0-9]*$</parameter>
+   <parameter name="regex">^(([a-z][0-9]|perf|debug)_)?[a-z][A-Za-z0-9]*$</parameter>
    <parameter name="objectFieldRegex">^[A-Z][A-Za-z0-9]*$</parameter>
   </parameters>
  </check>

--- a/scalastyle-test-config.xml
+++ b/scalastyle-test-config.xml
@@ -138,7 +138,7 @@
  <check enabled="true" class="org.scalastyle.scalariform.FieldNamesChecker" level="warning">
   <parameters>
    <!-- we allow sx_lowerCamelCase for pipeline signals -->
-   <parameter name="regex">^(s[0-9]_)?[a-z][A-Za-z0-9]*$</parameter>
+   <parameter name="regex">^(([a-z][0-9]|perf|debug)_)?[a-z][A-Za-z0-9]*$</parameter>
    <parameter name="objectFieldRegex">^[A-Z][A-Za-z0-9]*$</parameter>
   </parameters>
  </check>


### PR DESCRIPTION
In kunminghu v3 bpu, we have prediction & training pipeline in a single module, so only allowing `s[0-9]_` as prefix may not enough. In this PR, we simply allow any single lower-case character as pipeline prefix, so we can have `s[0-9]` for prediction and `t[0-9]` for training.

And, we also allow `perf_` and `debug_` prefix for defining performance counter / debug signals, those signals should be opt-out in the RTL for physical backend. E.g. PerfCCT is using `debug_seqNum` for inst lifetime trace.