### PR TITLE
fix(ramctl): remove RegNext in Frontend and MemBlock

### DIFF
--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -493,7 +493,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
         sig.cgen         := dft.cgen
       }
       if (hasSramCtl) {
-        sig.ram_ctl := RegNext(dft.ram_ctl)
+        sig.ram_ctl := dft.ram_ctl
       }
   }
 }

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -2178,7 +2178,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
         sig.cgen := dft.cgen
       }
       if (hasSramCtl) {
-        sig.ram_ctl := RegNext(dft.ram_ctl)
+        sig.ram_ctl := dft.ram_ctl
       }
   }
   io.dft_frnt.zip(sigFromSrams).foreach({ case (a, b) => a := b })


### PR DESCRIPTION
`ram_ctl` signals are considered static signals since power-on and never change. If we have `RegNext` in our design, it requires two extra cycles for SRAM to get `ram_ctl` from outside correctly, which may cause unexpected behavior.