### PR TITLE
fix(fpga): fix fpga compile

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CommitIDModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CommitIDModule.scala
@@ -19,7 +19,7 @@ class PrintCommitIDModule(shaWidth: Int, hartIdlen: Int) extends BlackBox with H
       |  input [${shaWidth-1}:0] commitID,
       |  input dirty
       |);
-      |
+      |  wire _dummy_unused = 1'b1;
       |`ifndef SYNTHESIS
       |  initial begin
       |    $$fwrite(32'h80000001, "Core %d's Commit SHA is: %h, dirty: %d\\n", hartID, commitID, dirty);


### PR DESCRIPTION
When implemented in vivado2020.2, an empty module will trigger the error DRC INBB-3, which can be solved by adding a wire to the module. The software will optimize this module without increasing the resource occupation