### PR TITLE
fix(StoreQueue): fix misalign forward fail stall

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -467,9 +467,9 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   dataReadyPtrExt := nextDataReadyPtr
 
   // move unalign ptr
-  val unalignedMoveVec = deqPtrExt.zipWithIndex.map { case (deqPtr, i) =>
-    val ptr = dataReadyPtrExt + i.U
-    allocated(ptr.value) && unalign(ptr.value) && ptr === deqPtr && sqDeqCnt > i.U
+  val unalignedMoveVec = deqPtrExt.zipWithIndex.map { case (ptr, i) =>
+    val dataPtr = dataReadyPtrExt + i.U
+    allocated(dataPtr.value) && unalign(dataPtr.value) && dataPtr === ptr && sqDeqCnt > i.U
   }
   when (unalignedMoveVec) {
     val step = sqDeqCnt - PriorityEncoder(VecInit(unalignedMoveVec))

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -473,7 +473,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   })
   val unalignedCanMove = deqGroupHasUnalign && dataPtrInDeqGroupRangeVec.asUInt.orR
   when (unalignedCanMove) {
-    val step = EnsbufferWidth.U - PriorityEncoder(dataPtrInDeqGroupRangeVec)
+    val step = sqDeqCnt - PriorityEncoder(dataPtrInDeqGroupRangeVec)
     dataReadyPtrExt := dataReadyPtrExt + step
   }
 

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -468,8 +468,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
   // move unalign ptr
   val unalignedMoveVec = deqPtrExt.zipWithIndex.map { case (ptr, i) =>
-    val dataPtr = dataReadyPtrExt + i.U
-    allocated(dataPtr.value) && unaligned(dataPtr.value) && dataPtr === ptr && sqDeqCnt > i.U
+    allocated(ptr.value) && unaligned(ptr.value) && dataReadyPtrExt === ptr && sqDeqCnt > i.U
   }
   val unalignedCanMove = unalignedMoveVec.reduce(_ || _)
   when (unalignedCanMove) {

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -482,7 +482,8 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
   val stDataReadyVecReg = Wire(Vec(StoreQueueSize, Bool()))
   (0 until StoreQueueSize).map(i => {
-    stDataReadyVecReg(i) := allocated(i) && (mmio(i) || datavalid(i) || (isVec(i) && vecMbCommit(i))) && !unaligned(i)
+    stDataReadyVecReg(i) := allocated(i) &&
+      (addrvalid(i) && (mmio(i) || datavalid(i)) || (isVec(i) && vecMbCommit(i))) && !unaligned(i)
   })
   io.stDataReadyVec := GatedValidRegNext(stDataReadyVecReg)
 

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -469,9 +469,10 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   // move unalign ptr
   val unalignedMoveVec = deqPtrExt.zipWithIndex.map { case (ptr, i) =>
     val dataPtr = dataReadyPtrExt + i.U
-    allocated(dataPtr.value) && unalign(dataPtr.value) && dataPtr === ptr && sqDeqCnt > i.U
+    allocated(dataPtr.value) && unaligned(dataPtr.value) && dataPtr === ptr && sqDeqCnt > i.U
   }
-  when (unalignedMoveVec) {
+  val unalignedCanMove = unalignedMoveVec.reduce(_ || _)
+  when (unalignedCanMove) {
     val step = sqDeqCnt - PriorityEncoder(VecInit(unalignedMoveVec))
     dataReadyPtrExt := dataReadyPtrExt + step
   }


### PR DESCRIPTION
Bugs descriptions:
* Here is the instructions sequence:
     * Ld0 PA1
     * St0 PA2
     * Ld1 PA2
* Ld0 need replay by `tlb miss`, Ld1 need St0's data, but it's not ready, hence, Ld1 need replay by `forward fail`
* Ld0 ready to replay, Ld1 ready to replay, but LoadQueueReplay always choose Ld1 (Ld0 and Ld1 in the same bank)
* Ld0 will not committed, St0 will also not committed, finally Ld1 will not committed.

How to fix:
* `stDataReadyVec`: it will not set if it's misalign store
* `dataReadyPtrExt`: it will not move if it's misalign store data ready, until the oldest misalign store committed, `dataReadyPtrExt` plus 1.