### PR TITLE
fix(StoreQueue): prohibit setting exceptionFlag for misaligned split items

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -1325,7 +1325,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     val ptr = rdataPtrExt(i).value
     val mmioStall = if(i == 0) mmio(rdataPtrExt(0).value) else (mmio(rdataPtrExt(i).value) || mmio(rdataPtrExt(i-1).value))
     val ncStall = if(i == 0) nc(rdataPtrExt(0).value) else (nc(rdataPtrExt(i).value) || nc(rdataPtrExt(i-1).value))
-    val exceptionVliad      = isVec(ptr) && hasException(ptr) && dataBuffer.io.enq(i).fire
+    val exceptionVliad      = isVec(ptr) && hasException(ptr) && dataBuffer.io.enq(i).fire && dataBuffer.io.enq(i).bits.sqNeedDeq
     (exceptionVliad, uop(ptr), vecLastFlow(ptr))
   }
 


### PR DESCRIPTION
Due to misalignment, the rdataPtr(0) entry needs to be split into two writes to the databuffer. 
However, when setting vecExceptionFlag, rdataPtr is used for indexing, which incorrectly sets rdataPtr(1)
to vecExceptionFlag, causing a deadlock.