### PR TITLE
fix(Vsplit): fix Vec Store split stuck when misaligned

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1593,8 +1593,10 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     )
     vsSplit(i).io.vstd.get := DontCare // Todo: Discuss how to pass vector store data
 
-    vsSplit(i).io.vstdMisalign.get.storeMisalignBufferEmpty := !storeMisalignBuffer.io.full
-    vsSplit(i).io.vstdMisalign.get.storePipeEmpty := !storeUnits(i).io.s0_s1_valid
+    vsSplit(i).io.vstdMisalign.get.storeMisalignBufferEmpty  := storeMisalignBuffer.io.toVecSplit.empty
+    vsSplit(i).io.vstdMisalign.get.storeMisalignBufferRobIdx := storeMisalignBuffer.io.toVecSplit.robIdx
+    vsSplit(i).io.vstdMisalign.get.storeMisalignBufferUopIdx := storeMisalignBuffer.io.toVecSplit.uopIdx
+    vsSplit(i).io.vstdMisalign.get.storePipeEmpty := !storeUnits(i).io.s0_s1_s2_valid
 
   }
   (0 until VlduCnt).foreach{i =>

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -71,7 +71,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
     // trigger
     val fromCsrTrigger = Input(new CsrTriggerBundle)
 
-    val s0_s1_valid = Output(Bool())
+    val s0_s1_s2_valid = Output(Bool())
   })
 
   PerfCCT.updateInstPos(io.stin.bits.uop.debug_seqNum, PerfCCT.InstPos.AtFU.id.U, io.stin.valid, clock, reset)
@@ -343,9 +343,6 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s1_trigger_debug_mode = TriggerAction.isDmode(s1_trigger_action)
   val s1_trigger_breakpoint = TriggerAction.isExp(s1_trigger_action)
 
-  // for misalign in vsMergeBuffer
-  io.s0_s1_valid := s0_valid || s1_valid
-
   // Send TLB feedback to store issue queue
   // Store feedback is generated in store_s1, sent to RS in store_s2
   val s1_feedback = Wire(Valid(new RSFeedback))
@@ -555,6 +552,9 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.prefetch_train.bits.misalignNeedWakeUp := false.B
   io.prefetch_train.bits.updateAddrValid := false.B
   io.prefetch_train.bits.hasException := false.B
+
+  // for misalign in vsMergeBuffer
+  io.s0_s1_s2_valid := s0_valid || s1_valid || s2_valid
 
   // Pipeline
   // --------------------------------------------------------------------------------

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -451,7 +451,11 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
 }
 
 class VSSplitBufferImp(implicit p: Parameters) extends VSplitBuffer(isVStore = true){
-  override lazy val misalignedCanGo = io.vstdMisalign.get.storePipeEmpty && io.vstdMisalign.get.storeMisalignBufferEmpty
+  override lazy val misalignedCanGo = io.vstdMisalign.get.storePipeEmpty &&
+    (io.vstdMisalign.get.storeMisalignBufferEmpty ||
+      io.vstdMisalign.get.storeMisalignBufferRobIdx > io.out.bits.uop.robIdx ||
+      io.vstdMisalign.get.storeMisalignBufferRobIdx === io.out.bits.uop.robIdx &&
+        io.vstdMisalign.get.storeMisalignBufferUopIdx > io.out.bits.uop.uopIdx)
 
   // split data
   val splitData = genVSData(

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -221,8 +221,10 @@ class FeedbackToLsqIO(implicit p: Parameters) extends VLSUBundle{
 }
 
 class storeMisaignIO(implicit p: Parameters) extends Bundle{
-  val storePipeEmpty           = Input(Bool())
-  val storeMisalignBufferEmpty = Input(Bool())
+  val storePipeEmpty            = Input(Bool())
+  val storeMisalignBufferEmpty  = Input(Bool())
+  val storeMisalignBufferRobIdx = Input(new RobPtr)
+  val storeMisalignBufferUopIdx = Input(UopIdx())
 }
 
 class VSplitIO(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle{


### PR DESCRIPTION
When `younger` misaligned store enters `StoreMisalignedBuffer`, the `older` misaligned vector store will stop to split, which lead to stuck.