### PR TITLE
fix(Bitmap): fix some bugs related to memory isolation

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/BitmapCheck.scala
+++ b/src/main/scala/xiangshan/cache/mmu/BitmapCheck.scala
@@ -33,6 +33,8 @@ class bitmapReqBundle(implicit p: Parameters) extends XSBundle with HasPtwConst 
     val level = UInt(log2Up(Level).W)
     val way_info = UInt(l2tlbParams.l0nWays.W)
     val hptw_bypassed = Bool()
+    val s2xlate = UInt(2.W)
+    val n = Bool() // Napot
 }
 
 class bitmapRespBundle(implicit p: Parameters) extends XSBundle with HasPtwConst {
@@ -41,9 +43,19 @@ class bitmapRespBundle(implicit p: Parameters) extends XSBundle with HasPtwConst
     val id = UInt(log2Up(l2tlbParams.llptwsize+2).W)
 }
 
+class BitmapWakeup(implicit p: Parameters) extends PtwBundle {
+  val setIndex = Input(UInt(PtwL0SetIdxLen.W))
+  val tag = Input(UInt(SPTagLen.W))
+  val way_info = UInt(l2tlbParams.l0nWays.W)
+  val pte_index = UInt(sectortlbwidth.W)
+  val check_success = Bool()
+  val s2xlate = UInt(2.W)
+}
+
 class bitmapEntry(implicit p: Parameters) extends XSBundle with HasPtwConst {
   val ppn = UInt(ppnLen.W)
   val vpn = UInt(vpnLen.W)
+  val s2xlate = UInt(2.W)
   val id = UInt(bMemID.W)
   val wait_id = UInt(log2Up(l2tlbParams.llptwsize+2).W)
   // bitmap check faild? : 0 success, 1 faild
@@ -53,6 +65,7 @@ class bitmapEntry(implicit p: Parameters) extends XSBundle with HasPtwConst {
   val level = UInt(log2Up(Level).W)
   val way_info = UInt(l2tlbParams.l0nWays.W)
   val hptw_bypassed = Bool()
+  val n = Bool() // Napot
   val data = UInt(XLEN.W)
 }
 
@@ -73,14 +86,7 @@ class bitmapIO(implicit p: Parameters) extends MMUIOBaseBundle with HasPtwConst 
     val resp = Flipped(new PMPRespBundle())
   }
 
-  val wakeup = ValidIO(new Bundle {
-    val setIndex = UInt(PtwL0SetIdxLen.W)
-    val tag = UInt(SPTagLen.W)
-    val isSp = Bool()
-    val way_info = UInt(l2tlbParams.l0nWays.W)
-    val pte_index = UInt(sectortlbwidth.W)
-    val check_success = Bool()
-  })
+  val wakeup = DecoupledIO(new BitmapWakeup())
 
   // bitmap cache req/resp and refill port
   val cache = new Bundle {
@@ -94,8 +100,18 @@ class bitmapIO(implicit p: Parameters) extends MMUIOBaseBundle with HasPtwConst 
 }
 
 class Bitmap(implicit p: Parameters) extends XSModule with HasPtwConst {
-  def getBitmapAddr(ppn: UInt): UInt = {
-    val effective_ppn = ppn(ppnLen-KeyIDBits-1, 0)
+  def getRealPPN(ppn: UInt, vpn: UInt, level: UInt, n: Bool): UInt = {
+    val nokeyid_ppn = Cat(0.U(KeyIDBits.W), ppn(ppnLen-KeyIDBits-1, 0))
+    val effective_ppn = MuxLookup(level, 0.U)(Seq(
+      3.U -> Cat(nokeyid_ppn(nokeyid_ppn.getWidth - 1, vpnnLen * 3), vpn(vpnnLen * 3 - 1, 0)),
+      2.U -> Cat(nokeyid_ppn(nokeyid_ppn.getWidth - 1, vpnnLen * 2), vpn(vpnnLen * 2 - 1, 0)),
+      1.U -> Cat(nokeyid_ppn(nokeyid_ppn.getWidth - 1, vpnnLen), vpn(vpnnLen - 1, 0)),
+      0.U -> Mux(n === 0.U, nokeyid_ppn(nokeyid_ppn.getWidth - 1, 0), Cat(nokeyid_ppn(nokeyid_ppn.getWidth - 1, pteNapotBits), vpn(pteNapotBits - 1, 0)))
+    ))
+    effective_ppn
+  }
+
+  def getBitmapAddr(effective_ppn: UInt): UInt = {
     bitmap_base + (effective_ppn >> log2Ceil(XLEN) << log2Ceil(8))
   }
 
@@ -106,7 +122,7 @@ class Bitmap(implicit p: Parameters) extends XSModule with HasPtwConst {
   val flush = sfence.valid || csr.satp.changed || csr.vsatp.changed || csr.hgatp.changed || csr.priv.virt_changed
   val bitmap_base = csr.mbmc.BMA << 6
 
-  val entries = Reg(Vec(l2tlbParams.llptwsize+2, new bitmapEntry()))
+  val entries = RegInit(VecInit(Seq.fill(l2tlbParams.llptwsize+2)(0.U.asTypeOf(new bitmapEntry()))))
   // add pmp check
   val state_idle :: state_addr_check :: state_cache_req :: state_cache_resp  ::state_mem_req :: state_mem_waiting :: state_mem_out :: Nil = Enum(7)
   val state = RegInit(VecInit(Seq.fill(l2tlbParams.llptwsize+2)(state_idle)))
@@ -146,10 +162,12 @@ class Bitmap(implicit p: Parameters) extends XSModule with HasPtwConst {
     cache_req_arb.io.in(i).bits.order := i.U;
   }
 
+  val req_real_ppn = getRealPPN(io.req.bits.bmppn, io.req.bits.vpn, io.req.bits.level, io.req.bits.n)
+
   val dup_vec = state.indices.map(i =>
-    dupBitmapPPN(io.req.bits.bmppn, entries(i).ppn)
+    dupBitmapPPN(req_real_ppn, entries(i).ppn)
   )
-  val dup_req_fire = mem_arb.io.out.fire && dupBitmapPPN(io.req.bits.bmppn, mem_arb.io.out.bits.ppn)
+  val dup_req_fire = mem_arb.io.out.fire && dupBitmapPPN(req_real_ppn, mem_arb.io.out.bits.ppn)
   val dup_vec_wait = dup_vec.zip(is_waiting).map{case (d, w) => d && w}
   val dup_wait_resp = io.mem.resp.fire && VecInit(dup_vec_wait)(io.mem.resp.bits.id - (l2tlbParams.llptwsize + 2).U)
   val wait_id = Mux(dup_req_fire, mem_arb.io.chosen, ParallelMux(dup_vec_wait zip entries.map(_.wait_id)))
@@ -167,14 +185,14 @@ class Bitmap(implicit p: Parameters) extends XSModule with HasPtwConst {
   val need_addr_check = RegNext(enq_state === state_addr_check && io.req.fire && !flush)
 
   io.pmp.req.valid := need_addr_check
-  io.pmp.req.bits.addr := RegEnable(getBitmapAddr(io.req.bits.bmppn),io.req.fire)
+  io.pmp.req.bits.addr := RegEnable(getBitmapAddr(req_real_ppn),io.req.fire)
   io.pmp.req.bits.cmd := TlbCmd.read
   io.pmp.req.bits.size := 3.U
   val pmp_resp_valid = io.pmp.req.valid
 
   when (io.req.fire) {
     state(enq_ptr) := enq_state
-    entries(enq_ptr).ppn := io.req.bits.bmppn
+    entries(enq_ptr).ppn := req_real_ppn
     entries(enq_ptr).vpn := io.req.bits.vpn
     entries(enq_ptr).id := io.req.bits.id
     entries(enq_ptr).wait_id := Mux(to_wait, wait_id, enq_ptr)
@@ -182,10 +200,21 @@ class Bitmap(implicit p: Parameters) extends XSModule with HasPtwConst {
     for (i <- 0 until tlbcontiguous) {
       entries(enq_ptr).cfs(i) := false.B
     }
-    entries(enq_ptr).hit := to_wait
+    when (to_mem_out) {
+      val index = getBitmapAddr(req_real_ppn)(log2Up(l2tlbParams.blockBytes)-1, log2Up(XLEN/8))
+      entries(enq_ptr).cf := bitmapdata(index)(req_real_ppn(log2Up(XLEN)-1, 0))
+      val ppnPart = req_real_ppn(log2Up(XLEN)-1, log2Up(8))
+      val selectedBits = bitmapdata(index).asTypeOf(Vec(XLEN/8, UInt(8.W)))(ppnPart)
+      for (j <- 0 until tlbcontiguous) {
+        entries(enq_ptr).cfs(j) := selectedBits(j)
+      }
+    }
+    entries(enq_ptr).hit := to_wait || to_mem_out
     entries(enq_ptr).level := io.req.bits.level
     entries(enq_ptr).way_info := io.req.bits.way_info
     entries(enq_ptr).hptw_bypassed := io.req.bits.hptw_bypassed
+    entries(enq_ptr).n := io.req.bits.n
+    entries(enq_ptr).s2xlate := io.req.bits.s2xlate
   }
 
   // when pmp check failed, use cf bit represent
@@ -236,14 +265,23 @@ class Bitmap(implicit p: Parameters) extends XSModule with HasPtwConst {
       when (state(i) === state_cache_resp && io.cache.resp.bits.order === i.U) {
           hit := io.cache.resp.bits.hit
           when (hit) {
-            entries(i).cf := io.cache.resp.bits.cfs(entries(i).ppn(5,0))
+            entries(i).cf := io.cache.resp.bits.cfs(entries(i).ppn(2,0))
             entries(i).hit := true.B
             entries(i).cfs := io.cache.resp.bits.cfs
             state(i) := state_mem_out
           } .otherwise {
             state(i) := cm_next_state_normal
             entries(i).wait_id := Mux(cm_to_wait, cm_wait_id, entries(i).wait_id)
-            entries(i).hit := cm_to_wait
+            entries(i).hit := cm_to_wait || cm_to_mem_out
+            when (cm_to_mem_out) {
+              val index = getBitmapAddr(entries(i).ppn)(log2Up(l2tlbParams.blockBytes)-1, log2Up(XLEN/8))
+              entries(i).cf := bitmapdata(index)(entries(i).ppn(log2Up(XLEN)-1,0))
+              val ppnPart = entries(i).ppn(log2Up(XLEN)-1, log2Up(8))
+              val selectedBits = bitmapdata(index).asTypeOf(Vec(XLEN/8, UInt(8.W)))(ppnPart)
+              for (j <- 0 until tlbcontiguous) {
+                entries(i).cfs(j) := selectedBits(j)
+              }
+            }
           }
       }
     }
@@ -264,12 +302,9 @@ class Bitmap(implicit p: Parameters) extends XSModule with HasPtwConst {
         state(i) := state_mem_out
         val index = getBitmapAddr(entries(i).ppn)(log2Up(l2tlbParams.blockBytes)-1, log2Up(XLEN/8))
         entries(i).data := bitmapdata(index)
-        entries(i).cf := bitmapdata(index)(entries(i).ppn(5,0))
-        val ppnPart = entries(i).ppn(5,3)
-        val start = (ppnPart << 3.U)
-        val end = start + 7.U
-        val mask = (1.U << 8) - 1.U
-        val selectedBits = (bitmapdata(index) >> start) & mask
+        entries(i).cf := bitmapdata(index)(entries(i).ppn(log2Up(XLEN)-1, 0))
+        val ppnPart = entries(i).ppn(log2Up(XLEN)-1, log2Up(8))
+        val selectedBits = bitmapdata(index).asTypeOf(Vec(XLEN/8, UInt(8.W)))(ppnPart)
         for (j <- 0 until tlbcontiguous) {
           entries(i).cfs(j) := selectedBits(j)
         }
@@ -287,7 +322,17 @@ class Bitmap(implicit p: Parameters) extends XSModule with HasPtwConst {
 
   io.req.ready := !full
 
-  io.resp.valid := ParallelOR(is_having).asBool
+  // io.resp.ready always ture
+  val wakeup_valid_1cycle = io.resp.valid && !entries(mem_ptr).hptw_bypassed && entries(mem_ptr).level =/= 0.U && entries(mem_ptr).n === 0.U
+  // when wakeup is stall, block resp valid too
+  val wakeup_stall = {
+    val valid = RegInit(false.B)
+    when (wakeup_valid_1cycle) { valid := true.B }
+    when (io.wakeup.fire) { valid := false.B }
+    valid
+  }
+
+  io.resp.valid := ParallelOR(is_having).asBool && !wakeup_stall
   // if cache hit, resp the cache's resp
   io.resp.bits.cf := entries(mem_ptr).cf
   io.resp.bits.cfs := entries(mem_ptr).cfs
@@ -302,13 +347,13 @@ class Bitmap(implicit p: Parameters) extends XSModule with HasPtwConst {
 
   io.mem.req.bits.hptw_bypassed := false.B
 
-  io.wakeup.valid := io.resp.valid && !entries(mem_ptr).hptw_bypassed
-  io.wakeup.bits.setIndex := genPtwL0SetIdx(entries(mem_ptr).vpn)
-  io.wakeup.bits.tag := entries(mem_ptr).vpn(vpnLen - 1, vpnLen - SPTagLen)
-  io.wakeup.bits.isSp := entries(mem_ptr).level =/= 0.U
-  io.wakeup.bits.way_info := entries(mem_ptr).way_info
-  io.wakeup.bits.pte_index := entries(mem_ptr).vpn(sectortlbwidth - 1, 0)
-  io.wakeup.bits.check_success := !entries(mem_ptr).cf
+  io.wakeup.valid := ValidHoldBypass(wakeup_valid_1cycle, io.wakeup.ready)
+  io.wakeup.bits.setIndex := DataHoldBypass(genPtwL0SetIdx(entries(mem_ptr).vpn), wakeup_valid_1cycle)
+  io.wakeup.bits.tag := DataHoldBypass(entries(mem_ptr).vpn(vpnLen - 1, vpnLen - SPTagLen), wakeup_valid_1cycle)
+  io.wakeup.bits.way_info := DataHoldBypass(entries(mem_ptr).way_info, wakeup_valid_1cycle)
+  io.wakeup.bits.pte_index := DataHoldBypass(entries(mem_ptr).vpn(sectortlbwidth - 1, 0), wakeup_valid_1cycle)
+  io.wakeup.bits.check_success := DataHoldBypass(!entries(mem_ptr).cf, wakeup_valid_1cycle)
+  io.wakeup.bits.s2xlate := DataHoldBypass(entries(mem_ptr).s2xlate, wakeup_valid_1cycle)
 
   // when don't hit, refill the data to bitmap cache
   io.refill.valid := io.resp.valid && !entries(mem_ptr).hit
@@ -364,8 +409,12 @@ class BitmapCache(implicit p: Parameters) extends XSModule with HasPtwConst {
   val flush = sfence.valid || csr.satp.changed || csr.vsatp.changed || csr.hgatp.changed || csr.priv.virt_changed
   val bitmap_cache_clear = csr.mbmc.BCLEAR
 
-  val bitmapCachesize = 16
-  val bitmapcache = Reg(Vec(bitmapCachesize,new bitmapCacheEntry()))
+  val bitmapCachesize = 128
+  val init_entry = Wire(new bitmapCacheEntry)
+  init_entry.valid := false.B
+  init_entry.tag := DontCare
+  init_entry.data := DontCare
+  val bitmapcache = RegInit(VecInit.fill(bitmapCachesize) { init_entry })
   val bitmapReplace = ReplacementPolicy.fromString(l2tlbParams.l3Replacer, bitmapCachesize)
 
   // -----
@@ -383,10 +432,7 @@ class BitmapCache(implicit p: Parameters) extends XSModule with HasPtwConst {
   val CacheData = RegEnable(ParallelPriorityMux(hitVecT zip bitmapcache.map(_.data)), io.req.fire)
   val cfs = Wire(Vec(tlbcontiguous, Bool()))
 
-  val start = (index(5, 3) << 3.U)
-  val end = start + 7.U
-  val mask = (1.U << 8) - 1.U
-  val cfsdata = (CacheData >> start) & mask
+  val cfsdata = CacheData.asTypeOf(Vec(XLEN/8, UInt(8.W)))(index(log2Up(XLEN)-1, log2Up(8)))
   for (i <- 0 until tlbcontiguous) {
     cfs(i) := cfsdata(i)
   }

--- a/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUConst.scala
@@ -282,7 +282,7 @@ trait HasPtwConst extends HasTlbConst with MemoryOpConstants{
   }
 
   def dupBitmapPPN(ppn1: UInt, ppn2: UInt) : Bool = {
-    ppn1(ppnLen-1, ppnLen-log2Up(XLEN)) === ppn2(ppnLen-1, ppnLen-log2Up(XLEN))
+    ppn1(ppnLen-1, log2Up(XLEN)-1) === ppn2(ppnLen-1, log2Up(XLEN)-1)
   }
 
   def genPtwL1Idx(vpn: UInt) = {

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -198,14 +198,7 @@ class PtwCacheIO()(implicit p: Parameters) extends MMUIOBaseBundle with HasPtwCo
   val l0_way_info = Option.when(HasBitmapCheck)(Output(UInt(l2tlbParams.l0nWays.W)))
   val sfence_dup = Vec(4, Input(new SfenceBundle()))
   val csr_dup = Vec(3, Input(new TlbCsrBundle()))
-  val bitmap_wakeup = Option.when(HasBitmapCheck)(Flipped(ValidIO(new Bundle {
-    val setIndex = Input(UInt(PtwL0SetIdxLen.W))
-    val tag = Input(UInt(SPTagLen.W))
-    val isSp = Input(Bool())
-    val way_info = UInt(l2tlbParams.l0nWays.W)
-    val pte_index = UInt(sectortlbwidth.W)
-    val check_success = Bool()
-  })))
+  val bitmap_wakeup = Option.when(HasBitmapCheck)(Flipped(DecoupledIO(new BitmapWakeup())))
 }
 
 class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPerfEvents {
@@ -217,7 +210,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   // use two additional regs to record corresponding cache entry whether via bitmap check
   // 32（l0nSets）* 8 (l0nWays) * 8 (tlbcontiguous)
   val l0BitmapReg = RegInit(VecInit(Seq.fill(l2tlbParams.l0nSets)(VecInit(Seq.fill(l2tlbParams.l0nWays)(VecInit(Seq.fill(tlbcontiguous)(0.U(1.W))))))))
-  val spBitmapReg = RegInit(VecInit(Seq.fill(l2tlbParams.spSize)(0.U(1.W))))
 
   val bitmapEnable = io.csr_dup(0).mbmc.BME === 1.U && io.csr_dup(0).mbmc.CMODE === 0.U
   // TODO: four caches make the codes dirty, think about how to deal with it
@@ -231,6 +223,8 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
 
   // when refill, refuce to accept new req
   val rwHarzad = if (sramSinglePort) io.refill.valid else false.B
+  // when bitmap_wakeup, refuce to accept new req
+  val wakeupHarzad = if (HasBitmapCheck) io.bitmap_wakeup.get.fire else false.B
 
   // handle hand signal and req_info
   // TODO: replace with FlushableQueue
@@ -245,7 +239,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   stageResp_valid_1cycle_dup.map(_ := OneCycleValid(stageCheck(1).fire, flush))  // ecc flush
 
   stageReq <> io.req
-  PipelineConnect(stageReq, stageDelay(0), stageDelay(1).ready, flush, rwHarzad)
+  PipelineConnect(stageReq, stageDelay(0), stageDelay(1).ready, flush, rwHarzad || wakeupHarzad)
   InsideStageConnect(stageDelay(0), stageDelay(1), stageDelay_valid_1cycle)
   PipelineConnect(stageDelay(1), stageCheck(0), stageCheck(1).ready, flush)
   InsideStageConnect(stageCheck(0), stageCheck(1), stageCheck_valid_1cycle)
@@ -347,24 +341,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   val spasids = sp.map(_.asid)
   val spvmids = sp.map(_.vmid)
   val sph = Reg(Vec(l2tlbParams.spSize, UInt(2.W)))
-
-  if (HasBitmapCheck) {
-    // wakeup corresponding entry
-    when (io.bitmap_wakeup.get.valid) {
-      when (io.bitmap_wakeup.get.bits.isSp) {
-        for (i <- 0 until l2tlbParams.spSize) {
-          when (sp(i).tag === io.bitmap_wakeup.get.bits.tag && spv(i) === 1.U) {
-            spBitmapReg(i) := io.bitmap_wakeup.get.bits.check_success
-          }
-        }
-      } .otherwise {
-        val wakeup_setindex = io.bitmap_wakeup.get.bits.setIndex
-        l0BitmapReg(wakeup_setindex)(OHToUInt(io.bitmap_wakeup.get.bits.way_info))(io.bitmap_wakeup.get.bits.pte_index) := io.bitmap_wakeup.get.bits.check_success
-        assert(l0v(wakeup_setindex * l2tlbParams.l0nWays.U + OHToUInt(io.bitmap_wakeup.get.bits.way_info)) === 1.U,
-          "Wakeuped entry must be valid!")
-      }
-    }
-  }
 
   // Access Perf
   val l3AccessPerf = if(EnableSv48) Some(Wire(Vec(l2tlbParams.l3Size, Bool()))) else None
@@ -537,7 +513,11 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     (hit, hitWayData.ppns(genPtwL1SectorIdx(check_vpn)), hitWayData.pbmts(genPtwL1SectorIdx(check_vpn)), hitWayData.prefetch, eccError)
   }
   val te = ClockGate.genTeSink
-  val l0_masked_clock = ClockGate(te.cgen, stageReq.fire | (!flush_dup(0) && refill.levelOH.l0) | mbistPlL0.map(_.mbist.req).getOrElse(false.B), clock)
+  val l0_masked_clock = if (HasBitmapCheck) {
+    ClockGate(te.cgen, io.bitmap_wakeup.get.fire | stageReq.fire | (!flush_dup(0) && refill.levelOH.l0) | mbistPlL0.map(_.mbist.req).getOrElse(false.B), clock) 
+  } else {
+    ClockGate(te.cgen, stageReq.fire | (!flush_dup(0) && refill.levelOH.l0) | mbistPlL0.map(_.mbist.req).getOrElse(false.B), clock)
+  }
   val l1_masked_clock = ClockGate(te.cgen, stageReq.fire | (!flush_dup(1) && refill.levelOH.l1) | mbistPlL1.map(_.mbist.req).getOrElse(false.B), clock)
   l0.clock := l0_masked_clock
   l1.clock := l1_masked_clock
@@ -623,8 +603,40 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   val l0cfs = WireInit(VecInit(Seq.fill(tlbcontiguous)(false.B))) // L0 lavel Bitmap Check Failed Vector
   if (HasBitmapCheck) {
     for (i <- 0 until tlbcontiguous) {
-      l0Ptes(i) := Cat(l0HitData.pbmts(i).asUInt,l0HitPPN(i), 0.U(2.W),l0HitPerm(i).asUInt,l0HitValid(i).asUInt)
+      // in l0 "n" is always false
+      l0Ptes(i) := Cat(0.U(pteNLen.W), l0HitData.pbmts(i).asUInt, 0.U(pteResLen.W), 0.U((ppnHignLen+ppnLen-gvpnLen).W), l0HitPPN(i), 0.U(pteRswLen.W),l0HitPerm(i).asUInt,l0HitValid(i).asUInt)
       l0cfs(i) := !l0BitmapCheckResult(i)
+    }
+
+    val wakeup_vpn_search = io.bitmap_wakeup.get.bits.tag
+
+    val wakeup_req_delay_valid = OneCycleValid(io.bitmap_wakeup.get.fire, flush)
+    val wakeup_req_delay = RegEnable(io.bitmap_wakeup.get.bits, io.bitmap_wakeup.get.fire)
+
+    io.bitmap_wakeup.get.ready := !(io.bitmap_wakeup.get.valid && io.refill.valid)
+
+    val wakeup_ridx = genPtwL0SetIdx(wakeup_vpn_search)
+    when (io.bitmap_wakeup.get.fire) {
+      l0.io.r.req.valid := true.B
+      l0.io.r.req.bits.apply(setIdx = wakeup_ridx)
+    }
+    val wakeup_vVec_req = getl0vSet(wakeup_vpn_search)
+    val wakeup_hVec_req = getl0hSet(wakeup_vpn_search)
+
+    // delay one cycle after sram read
+    val wakeup_delay_vpn = wakeup_req_delay.tag
+    val wakeup_delay_h = Mux(wakeup_req_delay.s2xlate === allStage, onlyStage1, wakeup_req_delay.s2xlate)
+    val wakeup_data_resp = DataHoldBypass(l0.io.r.resp.data, wakeup_req_delay_valid)
+    val wakeup_vVec_delay = RegEnable(wakeup_vVec_req, io.bitmap_wakeup.get.fire)
+    val wakeup_hVec_delay = RegEnable(wakeup_hVec_req, io.bitmap_wakeup.get.fire)
+    val wakeup_hitVec_delay = VecInit(wakeup_data_resp.zip(wakeup_vVec_delay.asBools).zip(wakeup_hVec_delay).map { case ((wayData, v), h) =>
+      wayData.entries.hit(wakeup_delay_vpn, io.csr_dup(0).satp.asid, io.csr_dup(0).vsatp.asid, io.csr_dup(0).hgatp.vmid, s2xlate = wakeup_delay_h) && v && (wakeup_delay_h === h)})
+
+    val wakeup_setindex_delay = wakeup_req_delay.setIndex
+    val wakeup_way_info_delay = wakeup_req_delay.way_info
+
+    when (wakeup_req_delay_valid && wakeup_hitVec_delay(OHToUInt(wakeup_way_info_delay))) {
+      l0BitmapReg(wakeup_setindex_delay)(OHToUInt(wakeup_way_info_delay))(wakeup_req_delay.pte_index) := wakeup_req_delay.check_success
     }
   }
 
@@ -639,8 +651,8 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     val jmp_bitmap_check  = WireInit(false.B)
     val hit = WireInit(false.B)
     if (HasBitmapCheck) {
-      hit := Mux(bitmapEnable && (s2x_info =/= allStage || ishptw), ParallelOR(hitVec) && spBitmapReg(OHToUInt(hitVec)) === 1.U, ParallelOR(hitVec))
-      when (bitmapEnable && (s2x_info =/= allStage || ishptw) && ParallelOR(hitVec) && spBitmapReg(OHToUInt(hitVec)) === 0.U) {
+      hit := Mux(bitmapEnable && (s2x_info =/= allStage || ishptw), false.B, ParallelOR(hitVec))
+      when (bitmapEnable && (s2x_info =/= allStage || ishptw) && ParallelOR(hitVec)) {
         jmp_bitmap_check := true.B
       }
     } else {
@@ -666,7 +678,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   }
   val spHitPerm = spHitData.perm.getOrElse(0.U.asTypeOf(new PtePermBundle))
   val spHitLevel = spHitData.level.getOrElse(0.U)
-  val spPte = Cat(spHitData.pbmt.asUInt,spHitData.ppn, 0.U(2.W), spHitPerm.asUInt,spHitData.v.asUInt) // Super-page Page Table Entry
+  val spPte = Cat(spHitData.n.getOrElse(0.U), spHitData.pbmt.asUInt, 0.U(pteResLen.W), 0.U((ppnHignLen+ppnLen-gvpnLen).W) ,spHitData.ppn, 0.U(pteRswLen.W), spHitPerm.asUInt,spHitData.v.asUInt) // Super-page Page Table Entry
 
   val check_res = Wire(new PageCacheRespBundle)
   check_res.l3.map(_.apply(l3Hit.get, l3Pre.get, l3HitPPN.get, l3HitPbmt.get))
@@ -717,10 +729,10 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     io.resp.bits.toFsm.bitmapCheck.get.jmp_bitmap_check := resp_res.l0.bitmapCheck.get.jmp_bitmap_check || resp_res.sp.bitmapCheck.get.jmp_bitmap_check
     io.resp.bits.toFsm.bitmapCheck.get.toLLPTW := resp_res.l0.bitmapCheck.get.jmp_bitmap_check && (stageResp.bits.req_info.s2xlate === noS2xlate || stageResp.bits.req_info.s2xlate === onlyStage1)
     io.resp.bits.toFsm.bitmapCheck.get.hitway := resp_res.l0.bitmapCheck.get.hitway
-    io.resp.bits.toFsm.bitmapCheck.get.pte := resp_res.sp.bitmapCheck.get.pte
-    io.resp.bits.toFsm.bitmapCheck.get.ptes := resp_res.l0.bitmapCheck.get.ptes
+    io.resp.bits.toFsm.bitmapCheck.get.pte := Mux(resp_res.sp.bitmapCheck.get.jmp_bitmap_check, resp_res.sp.bitmapCheck.get.pte, resp_res.l0.bitmapCheck.get.ptes(idx))
+    io.resp.bits.toFsm.bitmapCheck.get.ptes := Mux(resp_res.sp.bitmapCheck.get.jmp_bitmap_check, VecInit(Seq.fill(tlbcontiguous)(resp_res.sp.bitmapCheck.get.pte)), resp_res.l0.bitmapCheck.get.ptes)
     io.resp.bits.toFsm.bitmapCheck.get.cfs := resp_res.l0.bitmapCheck.get.cfs
-    io.resp.bits.toFsm.bitmapCheck.get.SPlevel := resp_res.sp.level
+    io.resp.bits.toFsm.bitmapCheck.get.SPlevel :=  Mux(resp_res.sp.bitmapCheck.get.jmp_bitmap_check, resp_res.sp.level, 0.U)
   }
 
   io.resp.bits.isHptwReq := stageResp.bits.isHptwReq
@@ -753,7 +765,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     io.resp.bits.toHptw.bitmapCheck.get.ptes := resp_res.l0.bitmapCheck.get.ptes
     io.resp.bits.toHptw.bitmapCheck.get.cfs := resp_res.l0.bitmapCheck.get.cfs
     io.resp.bits.toHptw.bitmapCheck.get.fromSP := resp_res.sp.bitmapCheck.get.jmp_bitmap_check
-    io.resp.bits.toHptw.bitmapCheck.get.SPlevel := resp_res.sp.level
+    io.resp.bits.toHptw.bitmapCheck.get.SPlevel := Mux(resp_res.sp.bitmapCheck.get.jmp_bitmap_check, resp_res.sp.level, 0.U)
   }
 
   io.resp.bits.stage1.entry.map(_.tag := stageResp.bits.req_info.vpn(vpnLen - 1, 3))
@@ -809,7 +821,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     io.resp.bits.stage1.entry(i).perm.map(_ := Mux(resp_res.l0.hit, resp_res.l0.perm(i),  Mux(resp_res.sp.hit, resp_res.sp.perm, 0.U.asTypeOf(new PtePermBundle))))
     io.resp.bits.stage1.entry(i).pf := !io.resp.bits.stage1.entry(i).v
     io.resp.bits.stage1.entry(i).af := false.B
-    io.resp.bits.stage1.entry(i).cf := l0cfs(i) // L0 lavel Bitmap Check Failed Vector
+    io.resp.bits.stage1.entry(i).cf := Mux(resp_res.l0.hit, l0cfs(i), false.B) // L0 lavel Bitmap Check Failed Vector
   }
   io.resp.bits.stage1.pteidx := UIntToOH(idx).asBools
   io.resp.bits.stage1.not_super := Mux(resp_res.l0.hit, true.B, false.B)
@@ -867,11 +879,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
       vec(i) := flushMask(i)
     }
     vec
-  }
-  def updateSpBitmapReg(spBitmapReg: Vec[UInt], vec : Vec[UInt]) = {
-    for (i <- 0 until l2tlbParams.spSize) {
-      spBitmapReg(i) := spBitmapReg(i) & vec(i)
-    }
   }
 
   // TODO: handle sfenceLatch outsize
@@ -1055,7 +1062,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
     spv := spv | spRfOH
     spg := spg & ~spRfOH | Mux(memPte(0).perm.g && refill.req_info_dup(0).s2xlate =/= onlyStage2, spRfOH, 0.U)
     sph(spRefillIdx) := refill_h(0)
-    if (HasBitmapCheck) {updateSpBitmapReg(spBitmapReg, TranVec(~spRfOH))}
 
     for (i <- 0 until l2tlbParams.spSize) {
       spRefillPerf(i) := i.U === spRefillIdx

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -288,6 +288,8 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     io.bitmap.get.req.bits.level := Mux(jmp_bitmap_check_r, cache_level, level)
     io.bitmap.get.req.bits.way_info := DontCare
     io.bitmap.get.req.bits.hptw_bypassed := false.B
+    io.bitmap.get.req.bits.n := pte.n
+    io.bitmap.get.req.bits.s2xlate := req_s2xlate
     io.bitmap.get.resp.ready := !w_bitmap_resp
   }
   mem.req.valid := s_mem_req === false.B && !mem.mask && !accessFault && s_pmp_check
@@ -513,7 +515,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
 
   if (HasBitmapCheck) {
     when (whether_need_bitmap_check) {
-      when (bitmap_enable && (!enableS2xlate || onlyS1xlate) && pte.isLeaf()) {
+      when (bitmap_enable && (!enableS2xlate || onlyS1xlate) && pte.isLeaf() && !pageFault) {
         s_bitmap_check := false.B
         whether_need_bitmap_check := false.B
       } .otherwise {
@@ -566,6 +568,9 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
         mem_addr_update := false.B
         accessFault := false.B
         first_gvpn_check_fail := false.B
+        if (HasBitmapCheck) {
+          bitmap_checkfailed := false.B
+        }
       }
       finish := true.B
     }
@@ -699,6 +704,7 @@ class LLPTWEntry(implicit p: Parameters) extends XSBundle with HasPtwConst {
   val from_l0 = Bool()
   val way_info = UInt(l2tlbParams.l0nWays.W)
   val jmp_bitmap_check = Bool()
+  val n = Bool()
   val ptes = Vec(tlbcontiguous, UInt(XLEN.W))
   val cfs = Vec(tlbcontiguous, Bool())
 }
@@ -755,7 +761,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   }
 
 
-  val bitmap_arb = Option.when(HasBitmapCheck)(Module(new RRArbiter(new bitmapReqBundle(), l2tlbParams.llptwsize)))
+  val bitmap_arb = Option.when(HasBitmapCheck)(Module(new RRArbiterInit(new bitmapReqBundle(), l2tlbParams.llptwsize)))
   val way_info = Option.when(HasBitmapCheck)(Wire(Vec(l2tlbParams.llptwsize, UInt(l2tlbParams.l0nWays.W))))
   if (HasBitmapCheck) {
     for (i <- 0 until l2tlbParams.llptwsize) {
@@ -766,6 +772,8 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
       bitmap_arb.get.io.in(i).bits.level := 0.U // last level
       bitmap_arb.get.io.in(i).bits.way_info := Mux(entries(i).from_l0, entries(i).way_info, way_info.get(i))
       bitmap_arb.get.io.in(i).bits.hptw_bypassed := false.B
+      bitmap_arb.get.io.in(i).bits.n := entries(i).n
+      bitmap_arb.get.io.in(i).bits.s2xlate := entries(i).req_info.s2xlate
     }
   }
 
@@ -799,8 +807,8 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   // noS2xlate || onlyStage1 || allStage but exception; do not need Stage2 translate
   val noStage2 = ((entries(io.mem.resp.bits.id).req_info.s2xlate === noS2xlate) || (entries(io.mem.resp.bits.id).req_info.s2xlate === onlyStage1)) ||
     (entries(io.mem.resp.bits.id).req_info.s2xlate === allStage && (last_hptw_vsStagePf || last_hptw_gStagePf))
-  val to_mem_out = dup_wait_resp && noStage2 && !bitmap_enable
-  val to_bitmap_req = (if (HasBitmapCheck) true.B else false.B) && dup_wait_resp && noStage2 && bitmap_enable
+  val to_mem_out = dup_wait_resp && noStage2 && (!bitmap_enable || last_hptw_vsStagePf || last_hptw_gStagePf)
+  val to_bitmap_req = (if (HasBitmapCheck) true.B else false.B) && dup_wait_resp && noStage2 && bitmap_enable && !(last_hptw_vsStagePf || last_hptw_gStagePf)
   val to_cache = if (HasBitmapCheck) Cat(dup_vec_bitmap).orR || Cat(dup_vec_having).orR || Cat(dup_vec_last_hptw).orR
                  else Cat(dup_vec_having).orR || Cat(dup_vec_last_hptw).orR
   val to_hptw_req = io.in.bits.req_info.s2xlate === allStage
@@ -826,7 +834,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     // so 2 + FilterSize is enough to avoid dead-lock
     state(enq_ptr) := enq_state
     entries(enq_ptr).req_info := io.in.bits.req_info
-    entries(enq_ptr).ppn := Mux(to_last_hptw_req || last_hptw_excp, last_hptw_req_ppn, io.in.bits.ppn)
+    entries(enq_ptr).ppn := Mux(to_bitmap_req || to_last_hptw_req || last_hptw_excp, last_hptw_req_ppn, io.in.bits.ppn)
     entries(enq_ptr).wait_id := Mux(to_wait, wait_id, enq_ptr)
     entries(enq_ptr).af := false.B
     if (HasBitmapCheck) {
@@ -838,6 +846,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
         entries(enq_ptr).ptes(i) := 0.U
       }
       entries(enq_ptr).cfs := io.in.bits.bitmapCheck.get.cfs
+      entries(enq_ptr).n := last_hptw_req_pte.n
     }
     entries(enq_ptr).hptw_resp := Mux(to_last_hptw_req, entries(last_hptw_req_id).hptw_resp, Mux(to_wait, entries(wait_id).hptw_resp, entries(enq_ptr).hptw_resp))
     entries(enq_ptr).hptw_resp.gpf := Mux(last_hptw_excp, last_hptw_gStagePf, false.B)
@@ -856,6 +865,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
       entries(enq_ptr).from_l0 := true.B
       entries(enq_ptr).way_info := io.in.bits.bitmapCheck.get.hitway
       entries(enq_ptr).jmp_bitmap_check := io.in.bits.bitmapCheck.get.jmp_bitmap_check
+      entries(enq_ptr).n := io.in.bits.bitmapCheck.get.ptes(io.in.bits.req_info.vpn(sectortlbwidth - 1, 0)).asTypeOf(new PteBundle().cloneType).n
       entries(enq_ptr).ptes := io.in.bits.bitmapCheck.get.ptes
       entries(enq_ptr).cfs := io.in.bits.bitmapCheck.get.cfs
       mem_resp_hit(enq_ptr) := false.B
@@ -924,11 +934,14 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
         val gStagePf = ptes(index).isStage1Gpf(io.csr.hgatp.mode) && !vsStagePf
         state(i) := Mux(entries(i).req_info.s2xlate === allStage && !(vsStagePf || gStagePf),
                         state_last_hptw_req,
-                        Mux(bitmap_enable, state_bitmap_check, state_mem_out))
+                        Mux(bitmap_enable && !(vsStagePf || gStagePf), state_bitmap_check, state_mem_out))
         mem_resp_hit(i) := true.B
         entries(i).ppn := Mux(ptes(index).n === 0.U, ptes(index).getPPN(), Cat(ptes(index).getPPN()(ptePPNLen - 1, pteNapotBits), entries(i).req_info.vpn(pteNapotBits - 1, 0))) // for last stage 2 translation
         // af will be judged in L2 TLB `contiguous_pte_to_merge_ptwResp`
         entries(i).hptw_resp.gpf := Mux(entries(i).req_info.s2xlate === allStage, gStagePf, false.B)
+        if (HasBitmapCheck) {
+          entries(i).n := ptes(index).n
+        }
       }
     }
   }
@@ -1085,6 +1098,8 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     io.bitmap.get.req.bits.level := 0.U
     io.bitmap.get.req.bits.way_info := bitmap_arb.get.io.out.bits.way_info
     io.bitmap.get.req.bits.hptw_bypassed := bitmap_arb.get.io.out.bits.hptw_bypassed
+    io.bitmap.get.req.bits.s2xlate := bitmap_arb.get.io.out.bits.s2xlate
+    io.bitmap.get.req.bits.n := bitmap_arb.get.io.out.bits.n
     bitmap_arb.get.io.out.ready := io.bitmap.get.req.ready
     io.bitmap.get.resp.ready := has_bitmap_resp
   }
@@ -1275,6 +1290,8 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
     io.bitmap.get.req.bits.level := Mux(jmp_bitmap_check, Mux(fromSP,cache_level,0.U), level)
     io.bitmap.get.req.bits.way_info := Mux(jmp_bitmap_check, cache_hitway, way_info)
     io.bitmap.get.req.bits.hptw_bypassed := bypassed
+    io.bitmap.get.req.bits.n := pte.n
+    io.bitmap.get.req.bits.s2xlate := onlyStage2
     io.bitmap.get.resp.ready := !w_bitmap_resp
   }
 
@@ -1366,7 +1383,7 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
 
   if (HasBitmapCheck) {
     when (whether_need_bitmap_check) {
-      when (bitmap_enable && pte.isLeaf()) {
+      when (bitmap_enable && pte.isLeaf() && !pageFault) {
         s_bitmap_check := false.B
         whether_need_bitmap_check := false.B
       } .otherwise {
@@ -1396,6 +1413,9 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
         idle := true.B
         mem_addr_update := false.B
         accessFault := false.B
+        if (HasBitmapCheck) {
+          bitmap_checkfailed := false.B
+        }
       }
       finish := true.B
     }


### PR DESCRIPTION
* add bitmap wakeup the page table cache check hit state;
* modify the calculation of Bitmap permission data address, all of which are accurate to 4K pages, and only return ITLB/DTLB page tables with 4K granularity when permission check is enabled.
* fixed the issue that two requests in Bitmap check were merged and missed the update permission;
* modify the permission query results of Super Page that are no longer cached in PageTableCache;
* fixed the issue of l0Pets splicing format of PageTableCache output;
* fixed the issue that bitmap_checkfailed registers in PTW and HPTW were not reset;
* fixed the issue that bitmapCacheEntry was not initialized;
* fixed the issue of Napot entry jmp_bitmap_check process;
* In BitmapCheck use parameters to selsct cf bits;