### PR TITLE
fix(ifu): fix speculative instruction fetch in MMIO region.

### DIFF
--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -103,6 +103,7 @@ class PredecodeWritebackBundle(implicit p: Parameters) extends XSBundle {
 }
 
 class mmioCommitRead(implicit p: Parameters) extends XSBundle {
+  val valid          = Output(Bool())
   val mmioFtqPtr     = Output(new FtqPtr)
   val mmioLastCommit = Input(Bool())
 }

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -654,9 +654,6 @@ class NewIFU(implicit p: Parameters) extends XSModule
   // last instuction finish
   val is_first_instr = RegInit(true.B)
 
-  /*** Determine whether the MMIO instruction is executable based on the previous prediction block ***/
-  io.mmioCommitRead.mmioFtqPtr := RegNext(f3_ftq_req.ftqIdx - 1.U)
-
   val m_idle :: m_waitLastCmt :: m_sendReq :: m_waitResp :: m_sendTLB :: m_tlbResp :: m_sendPMP :: m_resendReq :: m_waitResendResp :: m_waitCommit :: m_commited :: Nil =
     Enum(11)
   val mmio_state = RegInit(m_idle)
@@ -675,6 +672,10 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f3_mmio_to_commit      = f3_req_is_mmio && mmio_state === m_waitCommit
   val f3_mmio_to_commit_next = RegNext(f3_mmio_to_commit)
   val f3_mmio_can_go         = f3_mmio_to_commit && !f3_mmio_to_commit_next
+
+  /*** Determine whether the MMIO instruction is executable based on the previous prediction block ***/
+  io.mmioCommitRead.valid      := RegNext(f3_req_is_mmio && f3_valid, false.B)
+  io.mmioCommitRead.mmioFtqPtr := RegNext(f3_ftq_req.ftqIdx - 1.U)
 
   val fromFtqRedirectReg = Wire(fromFtq.redirect.cloneType)
   fromFtqRedirectReg.bits := RegEnable(

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -1401,9 +1401,10 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
     * MMIO instruction fetch is allowed only if MMIO is the oldest instruction.
     *************************************************************************************
     */
-  val mmioReadPtr = io.mmioCommitRead.mmioFtqPtr
-  val mmioLastCommit = isAfter(commPtr, mmioReadPtr) ||
-    commPtr === mmioReadPtr && validInstructions.reduce(_ || _) && lastInstructionStatus === c_committed
+  val mmioReadPtr   = io.mmioCommitRead.mmioFtqPtr
+  val mmioReadValid = io.mmioCommitRead.valid
+  val mmioLastCommit = mmioReadValid && (isAfter(commPtr, mmioReadPtr) ||
+    commPtr === mmioReadPtr && validInstructions.reduce(_ || _) && lastInstructionStatus === c_committed)
   io.mmioCommitRead.mmioLastCommit := RegNext(mmioLastCommit)
 
   // commit reads


### PR DESCRIPTION
1.Scenario: A, B are normal blocks, C is MMIO. If B stalls (iTLB/ICache miss) and A commits while C enters waitLastCommit, C may wrongly assume B has committed, sending its request to the bus prematurely.
2.This issue can likely be avoided by using PMP to mark bus-unmapped or side-effecting memory addresses as non-executable.