### PR TITLE
fix(ICache,Ifu): set memBackTypeMM and memPageTypeNC correctly

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMissUnit.scala
@@ -19,6 +19,7 @@ package xiangshan.frontend.icache
 
 import chisel3._
 import chisel3.util._
+import coupledL2.MemBackTypeMM
 import difftest._
 import freechips.rocketchip.tilelink._
 import org.chipsalliance.cde.config.Parameters
@@ -165,6 +166,7 @@ class ICacheMSHR(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Paramet
   )._2
   io.acquire.bits.acquire := getBlock
   io.acquire.bits.acquire.user.lift(ReqSourceKey).foreach(_ := MemReqSource.CPUInst.id.U)
+  io.acquire.bits.acquire.user.lift(MemBackTypeMM).foreach(_ := true.B) // icache is always requesting main memory
   io.acquire.bits.vSetIdx := vSetIdx
 
   // get victim way when acquire fire

--- a/src/main/scala/xiangshan/frontend/icache/InstrUncache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/InstrUncache.scala
@@ -19,6 +19,8 @@ package xiangshan.frontend.icache
 
 import chisel3._
 import chisel3.util._
+import coupledL2.MemBackTypeMM
+import coupledL2.MemPageTypeNC
 import freechips.rocketchip.diplomacy.IdRange
 import freechips.rocketchip.diplomacy.LazyModule
 import freechips.rocketchip.diplomacy.LazyModuleImp
@@ -35,7 +37,9 @@ import xiangshan.WfiReqBundle
 import xiangshan.frontend._
 
 class InsUncacheReq(implicit p: Parameters) extends ICacheBundle {
-  val addr: UInt = UInt(PAddrBits.W)
+  val addr:          UInt = UInt(PAddrBits.W)
+  val memBackTypeMM: Bool = Bool() // !pmp.mmio, pbmt.nc/io on a main memory region
+  val memPageTypeNC: Bool = Bool() // pbmt.nc
   // FIXME: this IO is re-organized in kunminghu-v3, this is a temp solution for v2
   val flush: Bool = Bool()
 }
@@ -106,6 +110,8 @@ class InstrMMIOEntry(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheModu
       toAddress = Cat(address_aligned, 0.U(log2Ceil(mmioBusBytes).W)),
       lgSize = log2Ceil(mmioBusBytes).U
     )._2
+    io.mmio_acquire.bits.user.lift(MemBackTypeMM).foreach(_ := req.memBackTypeMM)
+    io.mmio_acquire.bits.user.lift(MemPageTypeNC).foreach(_ := req.memPageTypeNC)
 
     when(io.mmio_acquire.fire) {
       state := s_refill_resp

--- a/src/main/scala/xiangshan/frontend/icache/InstrUncache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/InstrUncache.scala
@@ -19,7 +19,10 @@ package xiangshan.frontend.icache
 
 import chisel3._
 import chisel3.util._
-import coupledL2.{MemBackTypeMM, MemBackTypeMMField, MemPageTypeNC, MemPageTypeNCField}
+import coupledL2.MemBackTypeMM
+import coupledL2.MemBackTypeMMField
+import coupledL2.MemPageTypeNC
+import coupledL2.MemPageTypeNCField
 import freechips.rocketchip.diplomacy.IdRange
 import freechips.rocketchip.diplomacy.LazyModule
 import freechips.rocketchip.diplomacy.LazyModuleImp

--- a/src/main/scala/xiangshan/frontend/icache/InstrUncache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/InstrUncache.scala
@@ -19,8 +19,7 @@ package xiangshan.frontend.icache
 
 import chisel3._
 import chisel3.util._
-import coupledL2.MemBackTypeMM
-import coupledL2.MemPageTypeNC
+import coupledL2.{MemBackTypeMM, MemBackTypeMMField, MemPageTypeNC, MemPageTypeNCField}
 import freechips.rocketchip.diplomacy.IdRange
 import freechips.rocketchip.diplomacy.LazyModule
 import freechips.rocketchip.diplomacy.LazyModuleImp
@@ -168,7 +167,8 @@ class InstrUncache()(implicit p: Parameters) extends LazyModule with HasICachePa
     clients = Seq(TLMasterParameters.v1(
       "InstrUncache",
       sourceId = IdRange(0, cacheParams.nMMIOs)
-    ))
+    )),
+    requestFields = Seq(MemBackTypeMMField(), MemPageTypeNCField())
   )
   val clientNode: TLClientNode = TLClientNode(Seq(clientParameters))
 


### PR DESCRIPTION
`MemBackTypeMM`: requesting region backed by main memory (`!pmp.mmio`) (don't care pbmt)
`MemPageTypeNC`: requesting `pbmt=nc` region (don't care backtype)

We need to tell L2 Cache about this via Tilelink to make it work.

This PR:
- ICache: Always work on main memory (`!pmp.mmio && pbmt=pmp`)
  - `MemBackTypeMM` is always true
  - `MemPageTypeNC` is always false (keep default value)
- Ifu/InstrUncache: Might be working on main memory, but pbmt=nc/io. Or on real mmio region
  - `MemBackTypeMM = !f3_pmp_mmio`
  - `MemPageTypeNC = f3_itlb_pbmt === Pbmt.nc`