### PR TITLE
fix(Ifu,InstrUncache): flush mmio fsm

### DIFF
--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -421,7 +421,6 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
 
   instrUncache.io.req <> ifu.io.uncacheInter.toUncache
   ifu.io.uncacheInter.fromUncache <> instrUncache.io.resp
-  instrUncache.io.flush := false.B
   io.error <> RegNext(RegNext(icache.io.error))
 
   icache.io.hartId := io.hartId


### PR DESCRIPTION
This should not happen on a normal MMIO req (mmio is sent only when last instruction is commited, so no redirect will happen).

But on a pbmt=nc area, we can do speculative fetch: #3944, so it can be cancelled by backend/ifu redirects, we should reset MMIO fsm and cancel (or flush) requests from InstrUncache.