### PR TITLE
feat(Bpu): v3 bpu part3

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -34,7 +34,7 @@ import xiangshan.frontend.{AllAheadFoldedHistoryOldestBits, AllFoldedHistories, 
 import xiangshan.frontend.ftq.{FtqPtr, FtqToCtrlIO}
 import xiangshan.frontend.{IfuToBackendIO, PreDecodeInfo}
 import xiangshan.frontend.ftq.FtqRedirectSramEntry
-import xiangshan.frontend.bpu.{HasBPUParameter, BPUCtrl, RasPtr}
+import xiangshan.frontend.bpu.{HasBPUParameter, BpuCtrl, RasPtr}
 import xiangshan.frontend.bpu.phr.PhrPtr
 import xiangshan.cache.HasDCacheParameters
 import utility._
@@ -620,7 +620,7 @@ class CustomCSRCtrlIO(implicit p: Parameters) extends XSBundle {
   val storeset_no_fast_wakeup = Output(Bool())
   val lvpred_timeout = Output(UInt(5.W))
   // Branch predictor
-  val bp_ctrl = Output(new BPUCtrl)
+  val bp_ctrl = Output(new BpuCtrl)
   // Memory Block
   val sbuffer_threshold = Output(UInt(4.W))
   val ldld_vio_check_enable = Output(Bool())

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRBundles.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRBundles.scala
@@ -8,7 +8,7 @@ import xiangshan.backend.fu.NewCSR.CSRDefines.{CSRROField => RO, CSRRWField => R
 import xiangshan.backend.fu.NewCSR.CSRFunc._
 import xiangshan.backend.fu.fpu.Bundles.Fflags
 import xiangshan.backend.fu.vector.Bundles.{Vl, Vstart, Vxsat}
-import xiangshan.frontend.bpu.BPUCtrl
+import xiangshan.frontend.bpu.BpuCtrl
 import xiangshan.mem.prefetch.PrefetchCtrl
 import chisel3.experimental.noPrefix
 
@@ -180,7 +180,7 @@ object CSRBundles {
     val storeset_no_fast_wakeup = Output(Bool())
     val lvpred_timeout = Output(UInt(5.W))
     // Branch predictor
-    val bp_ctrl = Output(new BPUCtrl)
+    val bp_ctrl = Output(new BpuCtrl)
     // Memory Block
     val sbuffer_threshold = Output(UInt(4.W))
     val ldld_vio_check_enable = Output(Bool())

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRCustom.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRCustom.scala
@@ -68,13 +68,13 @@ trait CSRCustom { self: NewCSR =>
 }
 
 class SbpctlBundle extends CSRBundle {
-  val LOOP_ENABLE = RW(6).withReset(true.B)
-  val RAS_ENABLE  = RW(5).withReset(true.B)
-  val SC_ENABLE   = RW(4).withReset(true.B)
-  val TAGE_ENABLE = RW(3).withReset(true.B)
-  val BIM_ENABLE  = RW(2).withReset(true.B)
-  val BTB_ENABLE  = RW(1).withReset(true.B)
-  val UBTB_ENABLE = RW(0).withReset(true.B)
+  val RAS_ENABLE    = RW(6).withReset(true.B)
+  val ITTAGE_ENABLE = RW(5).withReset(true.B)
+  val SC_ENABLE     = RW(4).withReset(true.B)
+  val TAGE_ENABLE   = RW(3).withReset(true.B)
+  val MBTB_ENABLE   = RW(2).withReset(true.B)
+  val ABTB_ENABLE   = RW(1).withReset(true.B)
+  val UBTB_ENABLE   = RW(0).withReset(true.B)
 }
 
 class SpfctlBundle extends CSRBundle {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -1334,13 +1334,13 @@ class NewCSR(implicit val p: Parameters) extends Module
   io.status.custom.storeset_no_fast_wakeup := slvpredctl.regOut.STORESET_NO_FAST_WAKEUP.asBool
   io.status.custom.lvpred_timeout          := slvpredctl.regOut.LVPRED_TIMEOUT.asUInt
 
-  io.status.custom.bp_ctrl.ubtb_enable     := sbpctl.regOut.UBTB_ENABLE .asBool
-  io.status.custom.bp_ctrl.btb_enable      := sbpctl.regOut.BTB_ENABLE  .asBool
-  io.status.custom.bp_ctrl.bim_enable      := sbpctl.regOut.BIM_ENABLE  .asBool
-  io.status.custom.bp_ctrl.tage_enable     := sbpctl.regOut.TAGE_ENABLE .asBool
-  io.status.custom.bp_ctrl.sc_enable       := sbpctl.regOut.SC_ENABLE   .asBool
-  io.status.custom.bp_ctrl.ras_enable      := sbpctl.regOut.RAS_ENABLE  .asBool
-  io.status.custom.bp_ctrl.loop_enable     := sbpctl.regOut.LOOP_ENABLE .asBool
+  io.status.custom.bp_ctrl.ubtbEnable   := sbpctl.regOut.UBTB_ENABLE.asBool
+  io.status.custom.bp_ctrl.abtbEnable   := sbpctl.regOut.ABTB_ENABLE.asBool
+  io.status.custom.bp_ctrl.mbtbEnable   := sbpctl.regOut.MBTB_ENABLE.asBool
+  io.status.custom.bp_ctrl.tageEnable   := sbpctl.regOut.TAGE_ENABLE.asBool
+  io.status.custom.bp_ctrl.scEnable     := sbpctl.regOut.SC_ENABLE.asBool
+  io.status.custom.bp_ctrl.ittageEnable := sbpctl.regOut.ITTAGE_ENABLE.asBool
+  io.status.custom.bp_ctrl.rasEnable    := sbpctl.regOut.RAS_ENABLE.asBool
 
   io.status.custom.sbuffer_threshold                := smblockctl.regOut.SBUFFER_THRESHOLD.asUInt
   io.status.custom.ldld_vio_check_enable            := smblockctl.regOut.LDLD_VIO_CHECK_ENABLE.asBool

--- a/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
@@ -37,11 +37,8 @@ abstract class BasePredictorIO(implicit p: Parameters) extends BpuBundle {
   val stageCtrl: StageCtrl = Input(new StageCtrl)
   // predict request
   val startVAddr: PrunedAddr = Input(PrunedAddr(VAddrBits))
-
-  // other predictor specific io
-  // maybe meta, differs from predictor to predictor
-  // train: differs from predictor to predictor
-  // ...
+  // train
+  val train: Valid[BpuTrain] = Input(Valid(new BpuTrain))
 }
 
 // The abstract class is used to abstract the setIdx and tag from write requests for updating write buffer entries

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -25,6 +25,18 @@ import xiangshan.frontend.bpu.mbtb.MainBtbMeta
 import xiangshan.frontend.bpu.phr.PhrPtr
 import xiangshan.frontend.ftq.FtqPtr
 
+class BpuCtrl extends Bundle {
+  // s1 predictor enable
+  val ubtbEnable: Bool = Bool()
+  val abtbEnable: Bool = Bool()
+  // s3 predictor enable
+  val mbtbEnable:   Bool = Bool()
+  val tageEnable:   Bool = Bool()
+  val scEnable:     Bool = Bool() // depends on tageEnable
+  val ittageEnable: Bool = Bool()
+  val rasEnable:    Bool = Bool()
+}
+
 class BranchAttribute extends Bundle {
   val branchType: UInt = BranchAttribute.BranchType()
   val rasAction:  UInt = BranchAttribute.RasAction()

--- a/src/main/scala/xiangshan/frontend/bpu/DummyBpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/DummyBpu.scala
@@ -35,7 +35,7 @@ import xiangshan.frontend.ftq.FtqToBpuIO
 
 class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   class DummyBpuIO extends Bundle {
-    val ctrl:        BPUCtrl    = Input(new BPUCtrl)
+    val ctrl:        BpuCtrl    = Input(new BpuCtrl)
     val resetVector: PrunedAddr = Input(PrunedAddr(PAddrBits))
     val fromFtq:     FtqToBpuIO = Flipped(new FtqToBpuIO)
     val toFtq:       BpuToFtqIO = new BpuToFtqIO
@@ -66,10 +66,10 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   /* *** CSR ctrl sub-predictor enable *** */
   private val ctrl = DelayN(io.ctrl, 2) // delay 2 cycle for timing
   fallThrough.io.enable := true.B // fallThrough is always enabled
-  ubtb.io.enable        := ctrl.ubtb_enable
-  abtb.io.enable        := true.B // FIXME
-  mbtb.io.enable        := true.B
-  tage.io.enable        := true.B
+  ubtb.io.enable        := ctrl.ubtbEnable
+  abtb.io.enable        := ctrl.abtbEnable
+  mbtb.io.enable        := ctrl.mbtbEnable
+  tage.io.enable        := ctrl.tageEnable
 
   // For some reason s0 stalled, usually FTQ Full
   private val s0_stall = Wire(Bool())

--- a/src/main/scala/xiangshan/frontend/bpu/DummyBpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/DummyBpu.scala
@@ -23,15 +23,14 @@ import utility.XSError
 import utility.XSPerfAccumulate
 import utility.XSPerfHistogram
 import xiangshan.frontend.BpuToFtqIO
+import xiangshan.frontend.FtqToBpuIO
 import xiangshan.frontend.PrunedAddr
-import xiangshan.frontend.PrunedAddrInit
 import xiangshan.frontend.bpu.abtb.AheadBtb
 import xiangshan.frontend.bpu.mbtb.MainBtb
 import xiangshan.frontend.bpu.phr.Phr
 import xiangshan.frontend.bpu.phr.PhrAllFoldedHistories
 import xiangshan.frontend.bpu.tage.Tage
 import xiangshan.frontend.bpu.ubtb.MicroBtb
-import xiangshan.frontend.ftq.FtqToBpuIO
 
 class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   class DummyBpuIO extends Bundle {
@@ -60,7 +59,7 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   )
 
   /* *** aliases *** */
-  private val train    = io.fromFtq.update
+  private val train    = io.fromFtq.train
   private val redirect = io.fromFtq.redirect
 
   /* *** CSR ctrl sub-predictor enable *** */
@@ -108,72 +107,25 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val s3_pc = RegEnable(s2_pc, s2_fire)
 
   /* *** common inputs *** */
+  private val stageCtrl = Wire(new StageCtrl)
+  stageCtrl.s0_fire := s0_fire
+  stageCtrl.s1_fire := s1_fire
+  stageCtrl.s2_fire := s2_fire
+  stageCtrl.s3_fire := s3_fire
+
   predictors.foreach { p =>
     // TODO: duplicate pc and fire to solve high fan-out issue
-    p.io.startVAddr        := s0_pc
-    p.io.stageCtrl.s0_fire := s0_fire
-    p.io.stageCtrl.s1_fire := s1_fire
-    p.io.stageCtrl.s2_fire := s2_fire
-    p.io.stageCtrl.s3_fire := s3_fire
+    p.io.startVAddr := s0_pc
+    p.io.stageCtrl  := stageCtrl
+    p.io.train      := train
   }
 
   /* *** predictor specific inputs *** */
-  // fall-through and ubtb currently doesn't have
+  // FIXME: should use s3_prediction to train ubtb
+
   // abtb
   abtb.io.redirectValid := redirect.valid
   abtb.io.overrideValid := s3_override
-
-  /* *** train *** */
-  private val t0_valid      = train.valid
-  private val t0_startVAddr = train.bits.pc
-  private val t0_taken      = train.bits.ftqOffset.valid
-  private val (t0_cfiPosition, t0_cfiPositionCarry) = getAlignedPosition(
-    train.bits.pc,
-    train.bits.ftqOffset.bits
-  )
-  assert(
-    !(train.valid && train.bits.ftqOffset.valid && t0_cfiPositionCarry),
-    "ftqOffset exceeds 2 * 32B aligned fetch block range, cfiPosition overflow!"
-  )
-  private val t0_target = train.bits.full_target
-  private val t0_attribute = MuxCase(
-    BranchAttribute.Conditional,
-    Seq(
-      (train.bits.is_call && train.bits.is_jal)  -> BranchAttribute.DirectCall,
-      (train.bits.is_call && train.bits.is_jalr) -> BranchAttribute.IndirectCall,
-      train.bits.is_ret                          -> BranchAttribute.Return,
-      train.bits.is_jal                          -> BranchAttribute.OtherDirect,
-      train.bits.is_jalr                         -> BranchAttribute.OtherIndirect
-    )
-  )
-  private val t0_meta = train.bits.meta
-
-  // FIXME: should use s3_prediction to train ubtb
-  // ubtb
-  ubtb.io.train.valid            := t0_valid
-  ubtb.io.train.bits.startVAddr  := t0_startVAddr
-  ubtb.io.train.bits.taken       := t0_taken
-  ubtb.io.train.bits.cfiPosition := t0_cfiPosition
-  ubtb.io.train.bits.target      := t0_target
-  ubtb.io.train.bits.attribute   := t0_attribute
-
-  // abtb
-  abtb.io.train.valid          := t0_valid
-  abtb.io.train.bits.startPc   := t0_startVAddr
-  abtb.io.train.bits.target    := t0_target
-  abtb.io.train.bits.taken     := t0_taken
-  abtb.io.train.bits.position  := t0_cfiPosition
-  abtb.io.train.bits.attribute := t0_attribute
-  abtb.io.train.bits.meta      := t0_meta.abtb
-
-  // mbtb
-  mbtb.io.train.valid            := t0_valid
-  mbtb.io.train.bits.startVAddr  := t0_startVAddr
-  mbtb.io.train.bits.taken       := t0_taken
-  mbtb.io.train.bits.cfiPosition := t0_cfiPosition
-  mbtb.io.train.bits.target      := t0_target
-  mbtb.io.train.bits.attribute   := t0_attribute
-  mbtb.io.train.bits.meta        := t0_meta.mbtb
 
   private val s2_ftqPtr = RegEnable(io.fromFtq.bpuPtr, s1_fire)
   private val s3_ftqPtr = RegEnable(s2_ftqPtr, s2_fire)
@@ -211,7 +163,7 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   // s1 prediction selection:
   // if ubtb or abtb find a taken branch, use the corresponding prediction
   // otherwise, use fall-through prediction
-  private val s1_prediction = Wire(new BranchPrediction)
+  private val s1_prediction = Wire(new Prediction)
   s1_prediction := MuxCase(
     fallThrough.io.prediction,
     Seq(
@@ -221,20 +173,20 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   )
 
   // s3 prediction: TODO
-  private val s3_prediction = Wire(new BranchPrediction)
+  private val s3_prediction = Wire(new Prediction)
   s3_prediction := DontCare
 
+  // to Ftq
   io.toFtq.prediction.valid := s1_valid && s2_ready || s3_fire && s3_override
-
   when(s3_override) {
     io.toFtq.prediction.bits.fromStage(s3_pc, s3_prediction)
   }.otherwise {
     io.toFtq.prediction.bits.fromStage(s1_pc, s1_prediction)
   }
+  io.toFtq.prediction.bits.s3Override := s3_override
 
-  // override
-  io.toFtq.prediction.bits.s3Override.valid       := s3_override
-  io.toFtq.prediction.bits.s3Override.bits.ftqPtr := s3_ftqPtr
+  // tell ftq s3 ftqptr for meta enqueue and s3 override
+  io.toFtq.s3FtqPtr := s3_ftqPtr
 
   // abtb meta delay to s3
   private val s2_abtbMeta = RegEnable(abtb.io.meta, s1_fire)
@@ -243,10 +195,10 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   // mbtb meta
   val s3_mbtbMeta = RegEnable(mbtb.io.meta, s2_fire)
 
-  private val s3_speculativeMeta = Wire(new PredictorSpeculativeMeta)
+  private val s3_speculativeMeta = Wire(new BpuSpeculativeMeta)
   s3_speculativeMeta.phrHistPtr := phr.io.phrPtr
 
-  private val s3_meta = Wire(new PredictorMeta)
+  private val s3_meta = Wire(new BpuMeta)
   s3_meta.abtb := s3_abtbMeta
   s3_meta.mbtb := s3_mbtbMeta
   // TODO: other meta
@@ -260,7 +212,7 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   s0_pc := MuxCase(
     s0_pcReg,
     Seq(
-      redirect.valid -> PrunedAddrInit(redirect.bits.cfiUpdate.target),
+      redirect.valid -> redirect.bits.target,
       s3_override    -> s3_prediction.target,
       s1_valid       -> s1_prediction.target
     )
@@ -272,21 +224,15 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val s1_foldedPhr = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(TageFoldedGHistInfos)))
   private val s2_foldedPhr = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(TageFoldedGHistInfos)))
   private val s3_foldedPhr = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(TageFoldedGHistInfos)))
-  phr.io.train.s0_stall          := s0_stall
-  phr.io.train.stageCtrl.s0_fire := s0_fire
-  phr.io.train.stageCtrl.s1_fire := s1_fire
-  phr.io.train.stageCtrl.s2_fire := s2_fire
-  phr.io.train.stageCtrl.s3_fire := s3_fire
-  phr.io.train.redirectValid     := redirect.valid
-  phr.io.train.redirectPc        := PrunedAddrInit(redirect.bits.cfiUpdate.pc)
-  phr.io.train.redirectTaken     := redirect.bits.cfiUpdate.taken
-  phr.io.train.redirectPhrPtr    := redirect.bits.cfiUpdate.phrHistPtr
-  phr.io.train.s3_override       := s3_override
-  phr.io.train.s3_pc             := s3_pc
-  phr.io.train.s3_taken          := s3_prediction.taken
-  phr.io.train.s1_valid          := s1_valid
-  phr.io.train.s1_pc             := s1_pc
-  phr.io.train.s1_taken          := s1_prediction.taken
+  phr.io.train.s0_stall    := s0_stall
+  phr.io.train.stageCtrl   := stageCtrl
+  phr.io.train.redirect    := redirect
+  phr.io.train.s3_override := s3_override
+  phr.io.train.s3_pc       := s3_pc
+  phr.io.train.s3_taken    := s3_prediction.taken
+  phr.io.train.s1_valid    := s1_valid
+  phr.io.train.s1_pc       := s1_pc
+  phr.io.train.s1_taken    := s1_prediction.taken
 
   s0_foldedPhr := phr.io.s0_foldedPhr
   s1_foldedPhr := phr.io.s1_foldedPhr
@@ -296,7 +242,7 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   private val phrsWireValue = phrsWire.asUInt
   private val redirectPhrValue =
-    (Cat(phrsWire.asUInt, phrsWire.asUInt) >> (redirect.bits.cfiUpdate.phrHistPtr.value + 1.U))(
+    (Cat(phrsWire.asUInt, phrsWire.asUInt) >> (redirect.bits.speculativeMeta.phrHistPtr.value + 1.U))(
       PhrHistoryLength - 1,
       0
     )
@@ -326,7 +272,7 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   /* *** perf pred *** */
   XSPerfAccumulate("toFtqFire", io.toFtq.prediction.fire)
-  XSPerfAccumulate("s3Override", io.toFtq.prediction.fire && io.toFtq.prediction.bits.s3Override.valid)
+  XSPerfAccumulate("s3Override", io.toFtq.prediction.fire && io.toFtq.prediction.bits.s3Override)
   XSPerfHistogram(
     "fetchBlockSize",
     Mux(
@@ -348,5 +294,5 @@ class DummyBpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   XSPerfAccumulate("s1Invalid", !s1_valid)
 
   /* *** perf train *** */
-  XSPerfAccumulate("train", io.fromFtq.update.valid)
+  XSPerfAccumulate("train", io.fromFtq.train.valid)
 }

--- a/src/main/scala/xiangshan/frontend/bpu/FallThroughPredictor.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/FallThroughPredictor.scala
@@ -24,7 +24,7 @@ class FallThroughPredictor(implicit p: Parameters) extends BasePredictor
     with HalfAlignHelper
     with CrossPageHelper {
   class FallThroughPredictorIO extends BasePredictorIO {
-    val prediction: BranchPrediction = Output(new BranchPrediction)
+    val prediction: Prediction = Output(new Prediction)
   }
 
   val io: FallThroughPredictorIO = IO(new FallThroughPredictorIO)

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/Bundles.scala
@@ -19,21 +19,9 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import xiangshan.frontend.PrunedAddr
-import xiangshan.frontend.bpu.BasePredictorIO
 import xiangshan.frontend.bpu.BranchAttribute
-import xiangshan.frontend.bpu.BranchPrediction
 import xiangshan.frontend.bpu.TargetCarry
 import xiangshan.frontend.bpu.WriteReqBundle
-
-class AheadBtbIO(implicit p: Parameters) extends BasePredictorIO {
-  val redirectValid: Bool                 = Input(Bool())
-  val overrideValid: Bool                 = Input(Bool())
-  val train:         Valid[AheadBtbTrain] = Flipped(Valid(new AheadBtbTrain))
-
-  val prediction:       BranchPrediction = Output(new BranchPrediction)
-  val meta:             AheadBtbMeta     = Output(new AheadBtbMeta)
-  val debug_startVaddr: PrunedAddr       = Output(PrunedAddr(VAddrBits))
-}
 
 class BankReadReq(implicit p: Parameters) extends AheadBtbBundle {
   val setIdx: UInt = UInt(SetIdxWidth.W)
@@ -100,13 +88,4 @@ class AheadBtbEntry(implicit p: Parameters) extends AheadBtbBundle {
   val targetLowerBits: UInt            = UInt(TargetLowerBitsWidth.W)
   // target fix, see comment in Parameters.scala
   val targetCarry: Option[TargetCarry] = if (EnableTargetFix) Option(new TargetCarry) else None
-}
-
-class AheadBtbTrain(implicit p: Parameters) extends AheadBtbBundle {
-  val startPc:   PrunedAddr      = PrunedAddr(VAddrBits)
-  val target:    PrunedAddr      = PrunedAddr(VAddrBits)
-  val taken:     Bool            = Bool()
-  val position:  UInt            = UInt(CfiPositionWidth.W)
-  val attribute: BranchAttribute = new BranchAttribute
-  val meta:      AheadBtbMeta    = new AheadBtbMeta
 }

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/Bundles.scala
@@ -58,12 +58,3 @@ class MainBtbMeta(implicit p: Parameters) extends MainBtbBundle {
   val stronglyBiasedMask = Vec(NumAlignBanks * NumWay, Bool())
   val positions          = Vec(NumAlignBanks * NumWay, UInt(CfiPositionWidth.W)) // FIXME: use correct one
 }
-
-class MainBtbTrain(implicit p: Parameters) extends MainBtbBundle {
-  val startVAddr:  PrunedAddr      = Input(PrunedAddr(VAddrBits))
-  val taken:       Bool            = Bool()
-  val cfiPosition: UInt            = UInt(CfiPositionWidth.W)
-  val target:      PrunedAddr      = PrunedAddr(VAddrBits)
-  val attribute:   BranchAttribute = new BranchAttribute
-  val meta:        MainBtbMeta     = new MainBtbMeta
-}

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -23,15 +23,13 @@ import utility.XSPerfHistogram
 import utility.sram.SRAMTemplate
 import xiangshan.frontend.bpu.BasePredictor
 import xiangshan.frontend.bpu.BasePredictorIO
-import xiangshan.frontend.bpu.BranchPrediction
+import xiangshan.frontend.bpu.Prediction
 import xiangshan.frontend.bpu.WriteBuffer
 
 class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParameters with Helpers {
   class MainBtbIO(implicit p: Parameters) extends BasePredictorIO {
-    val prediction: BranchPrediction = Output(new BranchPrediction)
-    val meta:       MainBtbMeta      = Output(new MainBtbMeta)
-    // training specific bundle
-    val train: Valid[MainBtbTrain] = Flipped(Valid(new MainBtbTrain))
+    val prediction: Prediction  = Output(new Prediction)
+    val meta:       MainBtbMeta = Output(new MainBtbMeta)
   }
 
   val io: MainBtbIO = IO(new MainBtbIO)
@@ -173,7 +171,7 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   private val t1_thisSetIdx       = getSetIndex(t1_train.startVAddr)
   private val t1_nextSetIdx       = t1_thisSetIdx + 1.U
   private val t1_alignBankIdx     = getAlignBankIndex(t1_train.startVAddr)
-  private val t1_meta             = t1_train.meta
+  private val t1_meta             = t1_train.meta.mbtb
   private val t1_LFSR             = random.LFSR(16, true.B)
   private val t1_setIdxVec: Vec[UInt] =
     VecInit.tabulate(NumAlignBanks)(bankIdx => Mux(bankIdx.U < t1_alignBankIdx, t1_nextSetIdx, t1_thisSetIdx))

--- a/src/main/scala/xiangshan/frontend/bpu/old/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/old/Bpu.scala
@@ -46,7 +46,7 @@ import xiangshan.frontend.CGHPtr
 import xiangshan.frontend.FrontendTopDownBundle
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
-import xiangshan.frontend.ftq.FtqToBpuIO
+import xiangshan.frontend.ftq.OldFtqToBpuIO
 import xiangshan.frontend.selectByTaken
 
 trait HasBPUConst extends HasXSParameter {
@@ -157,7 +157,7 @@ trait HasPredictorCommonSignals extends HasXSParameter {
 
 class BpuIO(implicit p: Parameters) extends XSBundle {
   val toFtq        = new BpuToFtqIO
-  val fromFtq      = Flipped(new FtqToBpuIO)
+  val fromFtq      = Flipped(new OldFtqToBpuIO)
   val ctrl         = Input(new BpuCtrl)
   val reset_vector = Input(PrunedAddr(PAddrBits))
 }

--- a/src/main/scala/xiangshan/frontend/bpu/old/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/old/Bpu.scala
@@ -88,16 +88,6 @@ trait HasBPUParameter extends HasXSParameter with HasBPUConst {
   val EnableCommit        = false
 }
 
-class BPUCtrl(implicit p: Parameters) extends XSBundle {
-  val ubtb_enable = Bool()
-  val btb_enable  = Bool()
-  val bim_enable  = Bool()
-  val tage_enable = Bool()
-  val sc_enable   = Bool()
-  val ras_enable  = Bool()
-  val loop_enable = Bool()
-}
-
 trait BPUUtils extends HasXSParameter {
   // circular shifting
   def circularShiftLeft(source: UInt, len: Int, shamt: UInt): UInt = {
@@ -161,14 +151,14 @@ trait HasPredictorCommonSignals extends HasXSParameter {
   val s2_fire = Bool()
   val s3_fire = Bool()
 
-  val ctrl   = new BPUCtrl
+  val ctrl   = new BpuCtrl
   val update = Valid(new BranchPredictionUpdate)
 }
 
 class BpuIO(implicit p: Parameters) extends XSBundle {
   val toFtq        = new BpuToFtqIO
   val fromFtq      = Flipped(new FtqToBpuIO)
-  val ctrl         = Input(new BPUCtrl)
+  val ctrl         = Input(new BpuCtrl)
   val reset_vector = Input(PrunedAddr(PAddrBits))
 }
 

--- a/src/main/scala/xiangshan/frontend/bpu/old/Ftb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/old/Ftb.scala
@@ -746,7 +746,7 @@ class Ftb(implicit p: Parameters) extends XSModule with FTBParams with HasPerfEv
 
   // After closing ftb, the hit output from s2 is the hit of FauFTB cached in s1.
   // s1_hit is the ftbBank hit.
-  val s1_hit            = Mux(s1_close_ftb_req, false.B, ftbBank.io.read_hits.valid && io.in.ctrl.btb_enable)
+  val s1_hit            = Mux(s1_close_ftb_req, false.B, ftbBank.io.read_hits.valid)
   val s2_ftb_hit        = RegEnable(s1_hit, 0.B, s1_fire)
   val s2_hit            = Mux(s2_close_ftb_req, s2_fauftb_ftb_entry_hit, s2_ftb_hit)
   val s3_hit            = RegEnable(Mux(s2_multi_hit_enable, s2_multi_hit, s2_hit), 0.B, s2_fire)

--- a/src/main/scala/xiangshan/frontend/bpu/old/MicroFtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/old/MicroFtb.scala
@@ -137,7 +137,7 @@ class MicroFtb(implicit p: Parameters) extends XSModule with FauFTBParams with B
   val s1_hit_full_pred   = Mux1H(s1_hitOH, s1_possible_full_preds)
   val s1_hit_fauftbentry = Mux1H(s1_hitOH, s1_all_entries)
   XSError(PopCount(s1_hitOH) > 1.U, "fauftb has multiple hits!\n")
-  val fauftb_enable = RegNext(io.in.ctrl.ubtb_enable)
+  val fauftb_enable = true.B
   io.out.s1_fullPred            := s1_hit_full_pred
   io.out.s1_fullPred.hit        := s1_hit && fauftb_enable
   io.out.toFtb.fauftb_entry     := s1_hit_fauftbentry

--- a/src/main/scala/xiangshan/frontend/bpu/old/Ras.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/old/Ras.scala
@@ -568,7 +568,7 @@ class Ras(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val s3_isRet = fromFtb.s3_isRet && !fromFtb.s3_fallThroughErr
   val s3_top   = stack.spec.popAddr
 
-  io.out.predictionValid  := io.in.ctrl.ras_enable && s3_isRet
+  io.out.predictionValid  := s3_isRet
   io.out.s3_returnAddress := s3_top
 
   val s3_meta = Wire(new RasInternalMeta)

--- a/src/main/scala/xiangshan/frontend/bpu/old/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/old/Tage.scala
@@ -826,11 +826,7 @@ class Tage(implicit p: Parameters) extends XSModule with TageParams with BPUUtil
     tageMeta.altUsed(i)  := RegEnable(s2_altUsed(i), s2_fire)
     tageMeta.basecnts(i) := RegEnable(s2_basecnts(i), s2_fire)
 
-    when(RegNext(io.in.ctrl.tage_enable)) {
-      io.out.toFtb.s2_branchTakenMask(i) := s2_tageTakens(i)
-    }.otherwise {
-      io.out.toFtb.s2_branchTakenMask(i) := false.B
-    }
+    io.out.toFtb.s2_branchTakenMask(i) := s2_tageTakens(i)
 
     // ---------------- update logics below ------------------//
     val hasUpdate     = updateValids(i)

--- a/src/main/scala/xiangshan/frontend/bpu/phr/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/phr/Bundles.scala
@@ -22,6 +22,7 @@ import utility.CircularQueuePtr
 import utility.XSDebug
 import xiangshan.XSCoreParamsKey
 import xiangshan.frontend.PrunedAddr
+import xiangshan.frontend.bpu.BpuRedirect
 import xiangshan.frontend.bpu.StageCtrl
 
 class PhrPtr(implicit p: Parameters) extends CircularQueuePtr[PhrPtr](p =>
@@ -55,10 +56,7 @@ class PhrTrain(implicit p: Parameters) extends PhrBundle {
   val s0_stall:  Bool      = Bool()
   val stageCtrl: StageCtrl = new StageCtrl
 
-  val redirectValid:  Bool       = Bool()
-  val redirectPc:     PrunedAddr = PrunedAddr(VAddrBits)
-  val redirectTaken:  Bool       = Bool()
-  val redirectPhrPtr: PhrPtr     = new PhrPtr
+  val redirect: Valid[BpuRedirect] = Valid(new BpuRedirect)
 
   val s1_valid: Bool       = Bool()
   val s1_pc:    PrunedAddr = PrunedAddr(VAddrBits)
@@ -67,16 +65,6 @@ class PhrTrain(implicit p: Parameters) extends PhrBundle {
   val s3_override: Bool       = Bool()
   val s3_pc:       PrunedAddr = PrunedAddr(VAddrBits)
   val s3_taken:    Bool       = Bool()
-}
-
-class PhrIO(implicit p: Parameters) extends PhrBundle with HasPhrParameters {
-  val train:        PhrTrain              = Input(new PhrTrain)
-  val s0_foldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(TageFoldedGHistInfos))
-  val s1_foldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(TageFoldedGHistInfos))
-  val s2_foldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(TageFoldedGHistInfos))
-  val s3_foldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(TageFoldedGHistInfos))
-  val phrs:         Vec[Bool]             = Output(Vec(PhrHistoryLength, Bool()))
-  val phrPtr:       PhrPtr                = Output(new PhrPtr)
 }
 
 //NOTE: Folded history maintainance logic reuse kmh-v2 ghr folded history management logic,

--- a/src/main/scala/xiangshan/frontend/bpu/phr/Phr.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/phr/Phr.scala
@@ -21,8 +21,17 @@ import org.chipsalliance.cde.config.Parameters
 import utility.XSPerfAccumulate
 import xiangshan.frontend.PrunedAddr
 
+// PHR: Predicted History Register
 class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with Helpers {
-  // PHR: Predicted History Register
+  class PhrIO(implicit p: Parameters) extends PhrBundle with HasPhrParameters {
+    val s0_foldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(TageFoldedGHistInfos))
+    val s1_foldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(TageFoldedGHistInfos))
+    val s2_foldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(TageFoldedGHistInfos))
+    val s3_foldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(TageFoldedGHistInfos))
+    val phrs:         Vec[Bool]             = Output(Vec(PhrHistoryLength, Bool()))
+    val phrPtr:       PhrPtr                = Output(new PhrPtr)
+    val train:        PhrTrain              = Input(new PhrTrain)
+  }
   val io: PhrIO = IO(new PhrIO)
 
   private val phr = RegInit(0.U.asTypeOf(Vec(PhrHistoryLength, Bool())))
@@ -67,10 +76,10 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
   private val updateOverride  = WireInit(false.B)
   private val redirctPhr      = WireInit(0.U(PhrHistoryLength.W))
 
-  redirectData.valid  := io.train.redirectValid
-  redirectData.taken  := io.train.redirectTaken
-  redirectData.pc     := io.train.redirectPc
-  redirectData.phrPtr := io.train.redirectPhrPtr
+  redirectData.valid  := io.train.redirect.valid
+  redirectData.taken  := io.train.redirect.bits.taken
+  redirectData.pc     := io.train.redirect.bits.startVAddr
+  redirectData.phrPtr := io.train.redirect.bits.speculativeMeta.phrHistPtr
 
   s3_override               := io.train.s3_override
   s3_overrideData.valid     := s3_override

--- a/src/main/scala/xiangshan/frontend/bpu/ubtb/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ubtb/Bundles.scala
@@ -65,15 +65,6 @@ class MicroBtbMeta(implicit p: Parameters) extends MicroBtbBundle {
   // seems no meta is needed now, reserved for future use
 }
 
-class MicroBtbTrain(implicit p: Parameters) extends MicroBtbBundle {
-  val startVAddr:  PrunedAddr      = PrunedAddr(VAddrBits)
-  val taken:       Bool            = Bool()
-  val cfiPosition: UInt            = UInt(CfiPositionWidth.W)
-  val target:      PrunedAddr      = PrunedAddr(VAddrBits)
-  val attribute:   BranchAttribute = new BranchAttribute
-  val meta:        MicroBtbMeta    = new MicroBtbMeta // not used now
-}
-
 class ReplacerPerfInfo(implicit p: Parameters) extends MicroBtbBundle {
   val replaceNotUseful: Bool = Bool() // if not, replacePlru
 }

--- a/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
@@ -21,15 +21,13 @@ import org.chipsalliance.cde.config.Parameters
 import utility.XSPerfAccumulate
 import xiangshan.frontend.bpu.BasePredictor
 import xiangshan.frontend.bpu.BasePredictorIO
-import xiangshan.frontend.bpu.BranchPrediction
+import xiangshan.frontend.bpu.Prediction
 
 // TODO: 2-taken
 class MicroBtb(implicit p: Parameters) extends BasePredictor with HasMicroBtbParameters with Helpers {
   class MicroBtbIO(implicit p: Parameters) extends BasePredictorIO {
     // predict
-    val prediction: BranchPrediction = Output(new BranchPrediction)
-    // train
-    val train: Valid[MicroBtbTrain] = Flipped(Valid(new MicroBtbTrain))
+    val prediction: Prediction = Output(new Prediction)
   }
 
   val io: MicroBtbIO = IO(new MicroBtbIO)

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -24,18 +24,18 @@ import xiangshan.frontend.BranchPredictionUpdate
 import xiangshan.frontend.CGHPtr
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.RasSpeculativeInfo
+import xiangshan.frontend.bpu.BpuMeta
+import xiangshan.frontend.bpu.BpuSpeculativeMeta
 import xiangshan.frontend.bpu.FTBEntry
-import xiangshan.frontend.bpu.PredictorMeta
-import xiangshan.frontend.bpu.PredictorSpeculativeMeta
 
 class FtqRedirectSramEntry(implicit p: Parameters) extends FtqBundle { // TODO: rename this
   val histPtr         = new CGHPtr             // TODO: delete this
   val rasSpecInfo     = new RasSpeculativeInfo // TODO: delete this
-  val speculativeMeta = new PredictorSpeculativeMeta
+  val speculativeMeta = new BpuSpeculativeMeta
 }
 
 class MetaEntry(implicit p: Parameters) extends FtqBundle {
-  val meta       = new PredictorMeta
+  val meta       = new BpuMeta
   val ftb_entry  = new FTBEntry // TODO: delete this
   val paddingBit = if ((meta.getWidth + ftb_entry.getWidth) % 2 != 0) Some(UInt(1.W)) else None
 }
@@ -53,7 +53,8 @@ class FtqRead[T <: Data](private val gen: T)(implicit p: Parameters) extends Ftq
   }
 }
 
-class FtqToBpuIO(implicit p: Parameters) extends FtqBundle {
+// TODO: remove this
+class OldFtqToBpuIO(implicit p: Parameters) extends FtqBundle {
   val redirect:        Valid[BranchPredictionRedirect] = Valid(new BranchPredictionRedirect)
   val update:          Valid[BranchPredictionUpdate]   = Valid(new BranchPredictionUpdate)
   val bpuPtr:          FtqPtr                          = Output(new FtqPtr)


### PR DESCRIPTION
Please use rebase and merge, do NOT squash this PR!

Stage part 3 of new Bpu, including:
- timing & x-state fixes
- renewed ports with backend (CsrCtrl & Redirect & Train)

Rebased & squashed from [feat-v3-bpu](https://github.com/OpenXiangShan/XiangShan/tree/feat-v3-bpu) branch, original commit history:
d1150de9faca063936f39efab47af4e0d9189aa9 refactor(Bpu): re-write BpuRedirect and BpuTrain port
546ff6f1e0ebf0eff264603c3a1cece1cbdaac82 fix(abtb): fix s0_fire condition to solve x-state issue **(dropped as already cherry-picked to dev-new-frontend)**
69b1ef4f55fb98265e99721efa2bc5c4d4195ac6 feat(Bpu,Csr): rewrite Sbpctl
01142a1cea6a111791e2898966f77490b218813c timing(fallThroughPredictor): move calculate logic to s1
