### PR TITLE
fix(TLB): vaddr should be extended to PAddrBitsMax

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -306,7 +306,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     hit.suggestName(s"hit_read_${i}")
     miss.suggestName(s"miss_read_${i}")
 
-    val vaddr = SignExt(req_out(i).vaddr, PAddrBits)
+    val vaddr = SignExt(req_out(i).vaddr, PAddrBitsMax)
     resp(i).bits.miss := miss
     resp(i).bits.ptwBack := ptw.resp.fire
     resp(i).bits.memidx := RegEnable(req_in(i).bits.memidx, req_in(i).valid)


### PR DESCRIPTION
In the previous design, vaddr was sign-extended to PAddrBits to prevent cases where the physical address width exceeds the virtual address width. However, in the SV48x4 mode, the actual width of vaddr is 50 bits, which ended up being truncated to 48 bits.

In the onlyStage2 case, the generated guest physical address (gpaddr) should match vaddr. But due to the truncation, gpaddr was also limited to 48 bits, and the upper 2 bits were lost (set to zero).

To fix this bug, and to better support future extensions—vaddr is now extended to the maximum physical address width (PAddrBitsMax) as defined by the RISC-V specification.