### PR TITLE
fix(PTW): Fix X-prop caused by using un-initialized stage1Hit in Mux()

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -254,9 +254,9 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   val resp_pte = Mux(pte_valid, pte, fake_pte)
   ptw_resp.apply(resp_pf, resp_af, resp_level, resp_pte, vpn, satp.asid, hgatp.vmid, vpn(sectortlbwidth - 1, 0), not_super = false, not_merge = false, bitmap_checkfailed.asBool)
 
-  val normal_resp = idle === false.B && mem_addr_update && !need_last_s2xlate && (guestFault || (w_mem_resp && find_pte) || (s_pmp_check && accessFault) || onlyS2xlate )
-  val stageHit_resp = idle === false.B && hptw_resp_stage2
-  io.resp.valid := Mux(stage1Hit, stageHit_resp, normal_resp)
+  val normal_resp = mem_addr_update && !need_last_s2xlate && (guestFault || (w_mem_resp && find_pte) || (s_pmp_check && accessFault) || onlyS2xlate )
+  val stageHit_resp = hptw_resp_stage2
+  io.resp.valid := !idle && Mux(stage1Hit, stageHit_resp, normal_resp)
   io.resp.bits.source := source
   io.resp.bits.resp := Mux(stage1Hit || (l3Hit || l2Hit) && guestFault && !pte_valid, stage1, ptw_resp)
   io.resp.bits.h_resp := Mux(gvpn_gpf, fake_h_resp, hptw_resp)


### PR DESCRIPTION
When use `-xprop=xmerge` policy, the un-initialized `stage1Hit` in Mux() will cause the X-state propagate to output port `io.resp.valid`. Fix it by moving `idle` check out of Mux(), which means the `io.resp.valid` only valid when `!idle`.

The generated RTL will changed from:

```
  wire             io_resp_valid_0 =
    stage1Hit
      ? ~idle & hptw_resp_stage2
      : ~idle & mem_addr_update & ~need_last_s2xlate
        & (guestFault | w_mem_resp & find_pte | s_pmp_check & accessFault | onlyS2xlate);
```

to:

```
  wire             io_resp_valid_0 =
    ~idle
    & (stage1Hit
         ? hptw_resp_stage2
         : mem_addr_update & ~need_last_s2xlate
           & (guestFault | w_mem_resp & find_pte | s_pmp_check & accessFault
              | onlyS2xlate));
```