### PR TITLE
feat(ifu,ibuffer): new ifu for kunminghu-v3 part2

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -718,7 +718,8 @@ trait HasXSParameter {
   def IBufSize = coreParams.IBufSize
   def IBufEnqWidth = coreParams.IBufEnqWidth
   def IBufWriteBank = coreParams.IBufWriteBank
-  def IBufNBank = coreParams.IBufNBank
+  def IBufReadBank = coreParams.IBufReadBank
+  def IBufNRank = coreParams.IBufNBank
   def backendParams: BackendParams = coreParams.backendParams
   def DecodeWidth = coreParams.DecodeWidth
   def RenameWidth = coreParams.RenameWidth

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -128,7 +128,6 @@ case class XSCoreParameters
   ICacheForceMetaECCError: Boolean = false,
   ICacheForceDataECCError: Boolean = false,
   IBufSize: Int = 48,
-  IBufEnqWidth: Int = 16,
   IBufNBank: Int = 8, // IBuffer bank amount, should divide IBufSize
   DecodeWidth: Int = 8,
   RenameWidth: Int = 8,
@@ -716,7 +715,7 @@ trait HasXSParameter {
   def ICacheForceMetaECCError = coreParams.ICacheForceMetaECCError
   def ICacheForceDataECCError = coreParams.ICacheForceDataECCError
   def IBufSize = coreParams.IBufSize
-  def IBufEnqWidth = coreParams.IBufEnqWidth
+  def IBufEnqWidth = coreParams.IBufWriteBank + PredictWidth
   def IBufWriteBank = coreParams.IBufWriteBank
   def IBufReadBank = coreParams.IBufReadBank
   def IBufNRank = coreParams.IBufNBank

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -79,6 +79,7 @@ case class XSCoreParameters
   HasVPU: Boolean = true,
   HasCustomCSRCacheOp: Boolean = true,
   FetchWidth: Int = 8,
+  FetchPorts: Int = 2,
   AsidLength: Int = 16,
   VmidLength: Int = 14,
   EnableBPU: Boolean = true,
@@ -131,6 +132,8 @@ case class XSCoreParameters
   IBufNBank: Int = 8, // IBuffer bank amount, should divide IBufSize
   DecodeWidth: Int = 8,
   RenameWidth: Int = 8,
+  IBufWriteBank: Int = 4, 
+  IBufReadBank: Int = 8,
   CommitWidth: Int = 8,
   RobCommitWidth: Int = 8,
   RabCommitWidth: Int = 8,
@@ -648,6 +651,7 @@ trait HasXSParameter {
   def HasCustomCSRCacheOp = coreParams.HasCustomCSRCacheOp
   def FetchWidth = coreParams.FetchWidth
   def PredictWidth = FetchWidth * (if (HasCExtension) 2 else 1)
+  def FetchPorts = coreParams.FetchPorts
   def EnableBPU = coreParams.EnableBPU
   def EnableBPD = coreParams.EnableBPD // enable backing predictor(like Tage) in BPUStage3
   def EnableRAS = coreParams.EnableRAS
@@ -713,6 +717,7 @@ trait HasXSParameter {
   def ICacheForceDataECCError = coreParams.ICacheForceDataECCError
   def IBufSize = coreParams.IBufSize
   def IBufEnqWidth = coreParams.IBufEnqWidth
+  def IBufWriteBank = coreParams.IBufWriteBank
   def IBufNBank = coreParams.IBufNBank
   def backendParams: BackendParams = coreParams.backendParams
   def DecodeWidth = coreParams.DecodeWidth

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -140,8 +140,8 @@ class FtqToIfuIO(implicit p: Parameters) extends XSBundle {
 }
 
 class IfuToFtqIO(implicit p: Parameters) extends XSBundle {
-  val mmioCommitRead: MmioCommitRead                        = new MmioCommitRead
-  val pdWb:           Vec[Valid[PredecodeWritebackBundle]]  = Vec(FetchPorts, Valid(new PredecodeWritebackBundle))
+  val mmioCommitRead: MmioCommitRead                       = new MmioCommitRead
+  val pdWb:           Vec[Valid[PredecodeWritebackBundle]] = Vec(FetchPorts, Valid(new PredecodeWritebackBundle))
 }
 
 class PredecodeWritebackBundle(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -271,22 +271,22 @@ class FtqPcOffset(implicit p: Parameters) extends XSBundle {
 }
 
 class FetchToIBuffer(implicit p: Parameters) extends XSBundle {
-  val instrs           = Vec(PredictWidth, UInt(32.W))
-  val valid            = UInt(PredictWidth.W)
-  val enqEnable        = UInt(PredictWidth.W)
-  val pd               = Vec(PredictWidth, new PreDecodeInfo)
-  val foldpc           = Vec(PredictWidth, UInt(MemPredPCWidth.W))
-  val ftqPcOffset      = Vec(PredictWidth, ValidUndirectioned(new FtqPcOffset))
-  val backendException = Vec(PredictWidth, Bool())
-  val exceptionType    = Vec(PredictWidth, new ExceptionType)
-  val crossPageIPFFix  = Vec(PredictWidth, Bool())
-  val illegalInstr     = Vec(PredictWidth, Bool())
-  val triggered        = Vec(PredictWidth, TriggerAction())
-  val isLastInFtqEntry = Vec(PredictWidth, Bool())
+  val instrs           = Vec(IBufEnqWidth, UInt(32.W))
+  val valid            = UInt(IBufEnqWidth.W)
+  val enqEnable        = UInt(IBufEnqWidth.W)
+  val pd               = Vec(IBufEnqWidth, new PreDecodeInfo)
+  val foldpc           = Vec(IBufEnqWidth, UInt(MemPredPCWidth.W))
+  val ftqPcOffset      = Vec(IBufEnqWidth, ValidUndirectioned(new FtqPcOffset))
+  val backendException = Vec(IBufEnqWidth, Bool())
+  val exceptionType    = Vec(IBufEnqWidth, new ExceptionType)
+  val crossPageIPFFix  = Vec(IBufEnqWidth, Bool())
+  val illegalInstr     = Vec(IBufEnqWidth, Bool())
+  val triggered        = Vec(IBufEnqWidth, TriggerAction())
+  val isLastInFtqEntry = Vec(IBufEnqWidth, Bool())
 
-  val pc             = Vec(PredictWidth, PrunedAddr(VAddrBits))
+  val pc             = Vec(IBufEnqWidth, PrunedAddr(VAddrBits))
   val prevIBufEnqPtr = new IBufPtr
-  val debug_seqNum   = Vec(PredictWidth, InstSeqNum())
+  val debug_seqNum   = Vec(IBufEnqWidth, InstSeqNum())
   val ftqPtr         = new FtqPtr
   val topdown_info   = new FrontendTopDownBundle
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -234,9 +234,9 @@ class Ftq(implicit p: Parameters) extends FtqModule
   }
   io.toICache.fetchReq.bits.isBackendException := backendException.hasException && backendExceptionPtr === ifuPtr(0)
 
-  io.toIfu.req.valid           := bpuPtr(0) > ifuPtr(0) && !redirect.valid
-  io.toIfu.req.bits.fetch(0).valid          := bpuPtr(0) > ifuPtr(0) && !redirect.valid
-  io.toIfu.req.bits.fetch(0).startVAddr     := entryQueue(ifuPtr(0).value)
+  io.toIfu.req.valid                    := bpuPtr(0) > ifuPtr(0) && !redirect.valid
+  io.toIfu.req.bits.fetch(0).valid      := bpuPtr(0) > ifuPtr(0) && !redirect.valid
+  io.toIfu.req.bits.fetch(0).startVAddr := entryQueue(ifuPtr(0).value)
   io.toIfu.req.bits.fetch(0).nextStartVAddr := MuxCase(
     entryQueue(ifuPtr(1).value),
     Seq(
@@ -248,7 +248,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
   io.toIfu.req.bits.fetch(0).ftqIdx             := ifuPtr(0)
   io.toIfu.req.bits.fetch(0).ftqOffset          := cfiQueue(ifuPtr(0).value)
 
-  io.toIfu.req.bits.fetch(1)  := 0.U.asTypeOf(new FetchRequestBundle)
+  io.toIfu.req.bits.fetch(1) := 0.U.asTypeOf(new FetchRequestBundle)
   // --------------------------------------------------------------------------------
   // Interaction with backend
   // --------------------------------------------------------------------------------

--- a/src/main/scala/xiangshan/frontend/ftq/IfuRedirectReceiver.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/IfuRedirectReceiver.scala
@@ -33,7 +33,7 @@ trait IfuRedirectReceiver extends HasFtqParameters {
     redirect.bits.level     := RedirectLevel.flushAfter
 
     val cfiUpdate = redirect.bits.cfiUpdate
-    cfiUpdate.pc        := pdWb.bits.pc(pdWb.bits.misOffset.bits).toUInt
+    cfiUpdate.pc        := pdWb.bits.pc.toUInt
     cfiUpdate.pd        := pdWb.bits.pd(pdWb.bits.misOffset.bits)
     cfiUpdate.target    := pdWb.bits.target.toUInt
     cfiUpdate.taken     := pdWb.bits.cfiOffset.valid

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -86,8 +86,8 @@ class ICacheInfo(implicit p: Parameters) extends IfuBundle {
 
 class FinalPredCheckResult(implicit p: Parameters) extends IfuBundle {
   val target     = PrunedAddr(VAddrBits)
-  val misOffset  = Valid(UInt(log2Ceil(PredictWidth).W))
-  val cfiOffset  = Valid(UInt(log2Ceil(PredictWidth).W))
+  val misIdx     = Valid(UInt(log2Ceil(IBufferInPortNum).W))
+  val cfiIdx     = Valid(UInt(log2Ceil(IBufferInPortNum).W))
   val instrRange = UInt(PredictWidth.W)
 }
 

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -20,6 +20,8 @@ import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utils.EnumUInt
 import xiangshan.ValidUndirectioned
+import xiangshan.cache.mmu.Pbmt
+import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.IBufPtr
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.ftq.FtqPtr
@@ -58,35 +60,55 @@ class InstrIndexEntry(implicit p: Parameters) extends IfuBundle with HasIfuParam
 }
 
 class FetchBlockInfo(implicit p: Parameters) extends IfuBundle {
-  val ftqIdx:           FtqPtr                   = new FtqPtr
-  val predTakenIdx:     ValidUndirectioned[UInt] = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
-  val invalidTaken:     Bool                     = Bool()
-  val target:           PrunedAddr               = PrunedAddr(VAddrBits)
-  val instrRange:       UInt                     = UInt(PredictWidth.W)
-  val bubbleInstrValid: UInt                     = UInt(PredictWidth.W)
-  val pcHigh:           UInt                     = UInt((VAddrBits - PcCutPoint).W)
-  val pcHighPlus1:      UInt                     = UInt((VAddrBits - PcCutPoint).W)
-  val fetchSize:        UInt                     = UInt(log2Ceil(PredictWidth + 1).W)
+  val ftqIdx:        FtqPtr                   = new FtqPtr
+  val doubline:      Bool                     = Bool()
+  val predTakenIdx:  ValidUndirectioned[UInt] = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
+  val ftqOffset:     ValidUndirectioned[UInt] = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
+  val invalidTaken:  Bool                     = Bool()
+  val startAddr:     PrunedAddr               = PrunedAddr(VAddrBits)
+  val target:        PrunedAddr               = PrunedAddr(VAddrBits)
+  val instrRange:    UInt                     = UInt(PredictWidth.W)
+  val rawInstrValid: UInt                     = UInt(PredictWidth.W)
+  val pcHigh:        UInt                     = UInt((VAddrBits - PcCutPoint).W)
+  val pcHighPlus1:   UInt                     = UInt((VAddrBits - PcCutPoint).W)
+  val fetchSize:     UInt                     = UInt(log2Ceil(PredictWidth + 1).W)
+}
+
+class ICacheInfo(implicit p: Parameters) extends IfuBundle {
+  val exception:          Vec[ExceptionType] = Vec(PortNumber, new ExceptionType)
+  val pmpMmio:            Bool               = Bool()
+  val itlbPbmt:           UInt               = UInt(Pbmt.width.W)
+  val isBackendException: Bool               = Bool()
+  val isForVSnonLeafPTE:  Bool               = Bool()
+  val gpAddr:             PrunedAddr         = PrunedAddr(PAddrBitsMax)
+  val pAddr:              Vec[PrunedAddr]    = Vec(PortNumber, PrunedAddr(PAddrBits))
+}
+
+class FinalPredCheckResult(implicit p: Parameters) extends IfuBundle {
+  val target     = PrunedAddr(VAddrBits)
+  val misOffset  = Valid(UInt(log2Ceil(PredictWidth).W))
+  val cfiOffset  = Valid(UInt(log2Ceil(PredictWidth).W))
+  val instrRange = UInt(PredictWidth.W)
 }
 
 /* ***** DB ***** */
 class FetchToIBufferDB(implicit p: Parameters) extends IfuBundle {
-  val startAddr:  UInt = UInt(VAddrBits.W) // do not use PrunedAddr for DB
-  val instrCount: UInt = UInt(32.W)        // magic number: just uint32_t field
-  val exception:  Bool = Bool()
-  val isCacheHit: Bool = Bool()
+  val startAddr:  Vec[UInt] = Vec(FetchPorts, UInt(VAddrBits.W)) // do not use PrunedAddr for DB
+  val instrCount: UInt      = UInt(32.W)                         // magic number: just uint32_t field
+  val exception:  Bool      = Bool()
+  val isCacheHit: Bool      = Bool()
 }
 
 class IfuWbToFtqDB(implicit p: Parameters) extends IfuBundle {
-  val startAddr:         UInt = UInt(VAddrBits.W) // do not use PrunedAddr for DB
-  val isMissPred:        Bool = Bool()
-  val missPredOffset:    UInt = UInt(log2Ceil(PredictWidth).W)
-  val checkJalFault:     Bool = Bool()
-  val checkJalrFault:    Bool = Bool()
-  val checkRetFault:     Bool = Bool()
-  val checkTargetFault:  Bool = Bool()
-  val checkNotCFIFault:  Bool = Bool()
-  val checkInvalidTaken: Bool = Bool()
+  val startAddr:         Vec[UInt] = Vec(FetchPorts, UInt(VAddrBits.W)) // do not use PrunedAddr for DB
+  val isMissPred:        Vec[Bool] = Vec(FetchPorts, Bool())
+  val missPredOffset:    Vec[UInt] = Vec(FetchPorts, UInt(log2Ceil(PredictWidth).W))
+  val checkJalFault:     Bool      = Bool()
+  val checkJalrFault:    Bool      = Bool()
+  val checkRetFault:     Bool      = Bool()
+  val checkTargetFault:  Bool      = Bool()
+  val checkNotCFIFault:  Bool      = Bool()
+  val checkInvalidTaken: Bool      = Bool()
 }
 
 class IfuRedirectInternal(implicit p: Parameters) extends IfuBundle {

--- a/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
@@ -71,6 +71,19 @@ trait FetchBlockHelper extends HasXSParameter with HasICacheParameters {
 }
 
 trait IfuHelper extends HasXSParameter with HasIfuParameters {
+  private object ShiftType {
+    val NoShift   = 0.U(2.W)
+    val ShiftRight1 = 1.U(2.W)
+    val ShiftRight2 = 2.U(2.W)
+    val ShiftRight3 = 3.U(2.W)
+  }
+  def bitMask(index: UInt, blockSize: Int, numBlocks: Int): UInt = {
+    val selectOH  = UIntToOH(index)
+    val blocks = VecInit((0 until numBlocks).map { i =>
+      Mux(selectOH(i), Fill(blockSize, 1.U(1.W)), 0.U(blockSize.W))
+    })
+    Cat(blocks.reverse)
+  }
   def catPC(low: UInt, high: UInt, high1: UInt): PrunedAddr =
     PrunedAddrInit(Mux(
       low(PcCutPoint),
@@ -101,18 +114,13 @@ trait IfuHelper extends HasXSParameter with HasIfuParameters {
     val out = WireDefault(VecInit.fill(IBufEnqWidth)(0.U.asTypeOf(default)))
     for (i <- 0 until IBufEnqWidth) {
       out(i) := MuxLookup(shiftNum, 0.U.asTypeOf(default))(Seq(
-        0.U -> Mux(prevIsHalf, if (i == IBufEnqWidth - 1) 0.U.asTypeOf(default) else dataVec(i + 1), dataVec(i)),
-        1.U -> Mux(prevIsHalf, dataVec(i), if (i == 0) 0.U.asTypeOf(default) else dataVec(i - 1)),
-        2.U -> Mux(
-          prevIsHalf,
-          if (i < 1) 0.U.asTypeOf(default) else dataVec(i - 1),
-          if (i < 2) 0.U.asTypeOf(default) else dataVec(i - 2)
-        ),
-        3.U -> Mux(
-          prevIsHalf,
-          if (i < 2) 0.U.asTypeOf(default) else dataVec(i - 2),
-          if (i < 3) 0.U.asTypeOf(default) else dataVec(i - 3)
-        )
+        ShiftType.NoShift     -> Mux(prevIsHalf, if (i == IBufEnqWidth - 1) 0.U.asTypeOf(default) else dataVec(i + 1),
+         dataVec(i)),
+        ShiftType.ShiftRight1 -> Mux(prevIsHalf, dataVec(i), if (i == 0) 0.U.asTypeOf(default) else dataVec(i - 1)),
+        ShiftType.ShiftRight2 -> Mux(prevIsHalf, if (i < 1) 0.U.asTypeOf(default) else dataVec(i - 1),
+         if (i < 2) 0.U.asTypeOf(default) else dataVec(i - 2)),
+        ShiftType.ShiftRight3 -> Mux(prevIsHalf, if (i < 2) 0.U.asTypeOf(default) else dataVec(i - 2),
+         if (i < 3) 0.U.asTypeOf(default) else dataVec(i - 3))
       ))
     }
     out

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -61,7 +61,6 @@ import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
 import xiangshan.frontend.icache.HasICacheParameters
 import xiangshan.frontend.icache.PmpCheckBundle
-import scala.collection.View
 
 class Ifu(implicit p: Parameters) extends IfuModule
     with HasICacheParameters
@@ -245,12 +244,12 @@ class Ifu(implicit p: Parameters) extends IfuModule
    * - calculate pc/half_pc/cut_ptr for every instruction
    * ***************************************************************************** */
 
-  private val s1_valid       = ValidHold(s0_fire && !s0_flush, s1_fire, s1_flush)
-  private val s1_firstValid  = ValidHold(s0_fire && !s0_flush && s0_ftqFetch(0).valid, s1_fire, s1_flush)
+  private val s1_valid      = ValidHold(s0_fire && !s0_flush, s1_fire, s1_flush)
+  private val s1_firstValid = ValidHold(s0_fire && !s0_flush && s0_ftqFetch(0).valid, s1_fire, s1_flush)
   private val s1_secondValid =
-     ValidHold(s0_fire && !s0_flush && s0_ftqFetch(1).valid && !s0_flushFromBpu(1), s1_fire, s1_flush)
-  private val s1_ftqFetch    = RegEnable(s0_ftqFetch, s0_fire)
-  private val s1_doubleline  = RegEnable(s0_doubleline, s0_fire)
+    ValidHold(s0_fire && !s0_flush && s0_ftqFetch(1).valid && !s0_flushFromBpu(1), s1_fire, s1_flush)
+  private val s1_ftqFetch   = RegEnable(s0_ftqFetch, s0_fire)
+  private val s1_doubleline = RegEnable(s0_doubleline, s0_fire)
 
   s1_fire  := s1_valid && s2_ready
   s1_ready := s1_fire || !s1_valid
@@ -259,7 +258,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
   assert(!(fromFtq.flushFromBpu.shouldFlushByStage3(s1_ftqFetch(1).ftqIdx) && s1_secondValid))
 
   private val s1_fetchSize = VecInit.tabulate(FetchPorts) { i =>
-    Mux(s1_ftqFetch(i).ftqOffset.valid,
+    Mux(
+      s1_ftqFetch(i).ftqOffset.valid,
       s1_ftqFetch(i).ftqOffset.bits + 1.U(log2Ceil(PredictWidth + 1).W),
       (s1_ftqFetch(i).nextStartVAddr - s1_ftqFetch(i).startVAddr)(log2Ceil(PredictWidth + 1) + 1, 1)
     )
@@ -307,9 +307,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s2_firstEndPos       = RegEnable(s1_firstEndPos, s1_fire)
   private val s2_totalEndPos       = RegEnable(s1_totalEndPos, s1_fire)
 
-  private val s2_instrPcLowerResult  = WireDefault(VecInit.fill(PredictWidth)(0.U((PcCutPoint + 1).W)))
-  private val s2_instrIsRvc          = WireDefault(VecInit.fill(PredictWidth)(false.B))
-  private val s2_instrOffset         = WireDefault(VecInit.fill(PredictWidth)(0.U(log2Ceil(PredictWidth).W)))
+  private val s2_instrPcLowerResult = WireDefault(VecInit.fill(PredictWidth)(0.U((PcCutPoint + 1).W)))
+  private val s2_instrIsRvc         = WireDefault(VecInit.fill(PredictWidth)(false.B))
+  private val s2_instrOffset        = WireDefault(VecInit.fill(PredictWidth)(0.U(log2Ceil(PredictWidth).W)))
 
   s2_fire  := s2_valid && s3_ready && icacheRespAllValid
   s2_ready := s2_fire || !s2_valid
@@ -318,7 +318,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s2_iCacheAllRespWire =
     fromICache.valid &&
       fromICache.bits.vAddr(0) === s2_ftqFetch(0).startVAddr &&
-      (fromICache.bits.doubleline && fromICache.bits.vAddr(1) === s2_ftqFetch(0).nextCachelineVAddr || !s2_doubleline(0))
+      (fromICache.bits.doubleline && fromICache.bits.vAddr(1) === s2_ftqFetch(0).nextCachelineVAddr || !s2_doubleline(
+        0
+      ))
   private val s2_iCacheAllRespReg = ValidHold(s2_valid && s2_iCacheAllRespWire && !s3_ready, s2_fire, s2_flush)
 
   icacheRespAllValid := s2_iCacheAllRespReg || s2_iCacheAllRespWire
@@ -358,8 +360,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   private val s2_rawData  = fromICache.bits.data
   private val s2_perfInfo = io.fromICache.perf
-  preDecodeBounder.io.req.valid           := fromICache.valid
-  preDecodeBounder.io.req.bits.instrRange := s2_totalInstrRange.asTypeOf(Vec(PredictWidth, Bool()))
+  preDecodeBounder.io.req.valid                  := fromICache.valid
+  preDecodeBounder.io.req.bits.instrRange        := s2_totalInstrRange.asTypeOf(Vec(PredictWidth, Bool()))
   preDecodeBounder.io.req.bits.firstEndPos       := s2_firstEndPos
   preDecodeBounder.io.req.bits.endPos            := s2_totalEndPos
   preDecodeBounder.io.req.bits.prevLastIsHalfRvi := s2_prevLastIsHalfRvi
@@ -474,31 +476,32 @@ class Ifu(implicit p: Parameters) extends IfuModule
       }
   }
 
-  val s2_fetchTakenIdx = Wire(Vec(FetchPorts, ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
-  for (i <- 0 until FetchPorts) {
-    s2_fetchTakenIdx(i).valid := s2_ftqFetch(i).ftqOffset.valid
-    s2_fetchTakenIdx(i).bits  := PopCount(rawInstrValid.asUInt & s2_instrRange(i)) - 1.U
-  }
-
+  private val s2_fetchTakenIdx = VecInit((0 until FetchPorts).map { i =>
+    val b = Wire(new Valid(UInt(log2Ceil(PredictWidth).W)))
+    b.valid := s2_ftqFetch(i).ftqOffset.valid
+    b.bits  := PopCount(rawInstrValid.asUInt & s2_instrRange(i)) - 1.U
+    b
+  })
   s2_fetchTakenIdx(0).valid := s2_ftqFetch(0).ftqOffset.valid && s2_firstValid
   s2_fetchTakenIdx(1).valid := s2_ftqFetch(1).ftqOffset.valid && s2_secondValid
 
-  private val s2_fetchBlock = WireDefault(0.U.asTypeOf(Vec(FetchPorts, new FetchBlockInfo)))
-  for (i <- 0 until FetchPorts) {
-    s2_fetchBlock(i).ftqIdx          := s2_ftqFetch(i).ftqIdx
-    s2_fetchBlock(i).doubline        := s2_doubleline(i)
-    s2_fetchBlock(i).predTakenIdx    := s2_fetchTakenIdx(i)
-    s2_fetchBlock(i).invalidTaken    := !rawInstrValid(s2_ftqFetch(i).ftqOffset.bits) && s2_ftqFetch(i).ftqOffset.valid
-    s2_fetchBlock(i).ftqOffset.valid := s2_ftqFetch(i).ftqOffset.valid
-    s2_fetchBlock(i).ftqOffset.bits  := s2_ftqFetch(i).ftqOffset.bits
-    s2_fetchBlock(i).instrRange      := s2_instrRange(i)
-    s2_fetchBlock(i).pcHigh          := s2_ftqFetch(i).startVAddr(VAddrBits - 1, PcCutPoint)
-    s2_fetchBlock(i).pcHighPlus1     := s2_ftqFetch(i).startVAddr(VAddrBits - 1, PcCutPoint) + 1.U
-    s2_fetchBlock(i).startAddr       := s2_ftqFetch(i).startVAddr
-    s2_fetchBlock(i).target          := s2_ftqFetch(i).nextStartVAddr
-    s2_fetchBlock(i).fetchSize       := s2_fetchSize(i)
-    s2_fetchBlock(i).rawInstrValid   := rawInstrValid.asUInt & s2_instrRange(i)
-  }
+  private val s2_fetchBlock = VecInit((0 until FetchPorts).map { i =>
+    val b = Wire(new FetchBlockInfo)
+    b.ftqIdx          := s2_ftqFetch(i).ftqIdx
+    b.doubline        := s2_doubleline(i)
+    b.predTakenIdx    := s2_fetchTakenIdx(i)
+    b.invalidTaken    := !rawInstrValid(s2_ftqFetch(i).ftqOffset.bits) && s2_ftqFetch(i).ftqOffset.valid
+    b.ftqOffset.valid := s2_ftqFetch(i).ftqOffset.valid
+    b.ftqOffset.bits  := s2_ftqFetch(i).ftqOffset.bits
+    b.instrRange      := s2_instrRange(i)
+    b.pcHigh          := s2_ftqFetch(i).startVAddr(VAddrBits - 1, PcCutPoint)
+    b.pcHighPlus1     := s2_ftqFetch(i).startVAddr(VAddrBits - 1, PcCutPoint) + 1.U
+    b.startAddr       := s2_ftqFetch(i).startVAddr
+    b.target          := s2_ftqFetch(i).nextStartVAddr
+    b.fetchSize       := s2_fetchSize(i)
+    b.rawInstrValid   := rawInstrValid.asUInt & s2_instrRange(i)
+    b
+  })
   s2_fetchBlock(0).ftqOffset.valid := s2_ftqFetch(0).ftqOffset.valid && s2_firstValid
   s2_fetchBlock(1).ftqOffset.valid := s2_ftqFetch(1).ftqOffset.valid && s2_secondValid
 
@@ -506,8 +509,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // valid signals at the end and beginning need to be updated.
   s2_fetchBlock(0).rawInstrValid := (rawInstrValid.asUInt & s2_instrRange(0))
   s2_fetchBlock(1).rawInstrValid := (rawInstrValid.asUInt >> s2_fetchSize(0)) & s2_instrRange(1)
-  private val s2_rawFirstData       = s2_rawData
-  private val s2_rawSecondData      = 0.U((ICacheLineBytes * 8).W)
+  private val s2_rawFirstData         = s2_rawData
+  private val s2_rawSecondData        = 0.U((ICacheLineBytes * 8).W)
   private val s2_rawFirstDataDupWire  = VecInit(Seq.fill(FetchPorts)(s2_rawFirstData))
   private val s2_rawSecondDataDupWire = VecInit(Seq.fill(FetchPorts)(s2_rawSecondData))
   private val s2_firstEndIdx          = s2_fetchTakenIdx(0).bits
@@ -525,7 +528,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s3_fetchBlock     = RegEnable(s2_fetchBlock, s2_fire)
   private val s3_prevIBufEnqPtr = RegInit(0.U.asTypeOf(new IBufPtr))
 
-  private val s3_prevShiftSelect   = UIntToMask(s3_prevIBufEnqPtr.value(1, 0), IfuAlignWidth)
+  private val s3_prevShiftSelect = UIntToMask(s3_prevIBufEnqPtr.value(1, 0), IfuAlignWidth)
 
   s3_fire  := s3_valid && s4_ready
   s3_ready := s3_fire || !s3_valid
@@ -587,44 +590,44 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s3_secondLowICacheData  = cutICacheData(s3_rawSecondDataDup(0))
   private val s3_secondHighICacheData = cutICacheData(s3_rawSecondDataDup(1))
 
-  private val s3_isPredTaken  = VecInit.tabulate(PredictWidth)(i =>
+  private val s3_isPredTaken = VecInit.tabulate(PredictWidth)(i =>
     ((s3_fetchBlock(0).predTakenIdx.bits === i.U && s3_fetchBlock(0).predTakenIdx.valid) &&
       !s3_selectFetchBlock(i) && s3_firstValid) ||
       ((s3_fetchBlock(1).predTakenIdx.bits === i.U && s3_fetchBlock(1).predTakenIdx.valid) &&
-       s3_selectFetchBlock(i))
+        s3_selectFetchBlock(i))
   )
 
   private val s3_invalidTaken = WireDefault(VecInit.fill(PredictWidth)(false.B))
   s3_invalidTaken(s3_fetchBlock(0).predTakenIdx.bits) := s3_fetchBlock(0).invalidTaken && s3_firstValid
   s3_invalidTaken(s3_fetchBlock(1).predTakenIdx.bits) := s3_fetchBlock(1).invalidTaken && s3_secondValid
 
-  private val s3_alignShiftNum       = s3_prevIBufEnqPtr.value(1,0)
-  // Maybe it's better to move the calculation of enqBlockStartPos to the previous pipeline stage 
+  private val s3_alignShiftNum = s3_prevIBufEnqPtr.value(1, 0)
+  // Maybe it's better to move the calculation of enqBlockStartPos to the previous pipeline stage
   // — at least from a timing perspective. But it would require modifying IBufferPrevPtr.
-  private val s3_alignBlockStartPos  = WireDefault(VecInit.fill(IBufferInPortNum)(false.B))
+  private val s3_alignBlockStartPos = WireDefault(VecInit.fill(IBufferInPortNum)(false.B))
   s3_alignBlockStartPos(s3_alignShiftNum) := true.B
-  private val s3_alignInstrPcLower  =
-     alignData(s3_instrPcLowerResult, s3_alignShiftNum, s3_prevLastIsHalfRvi, 0.U((PcCutPoint + 1).W))
-  private val s3_alignInstrData     = WireDefault(VecInit.fill(IBufferInPortNum)(0.U(32.W)))
-  private val s3_alignInstrIndex    =
-     alignData(s3_instrIndex, s3_alignShiftNum, s3_prevLastIsHalfRvi, 0.U.asTypeOf(new InstrIndexEntry))
-  private val s3_alignInstrIsRvc    = alignData(s3_instrIsRvc, s3_alignShiftNum, s3_prevLastIsHalfRvi, false.B)
-  private val s3_alignInstrValid    =
-     alignData(s3_instrValid.asTypeOf(Vec(PredictWidth, Bool())), s3_alignShiftNum, s3_prevLastIsHalfRvi, false.B)
-  private val s3_alignInvalidTaken  = alignData(s3_invalidTaken, s3_alignShiftNum, s3_prevLastIsHalfRvi, false.B)
-  private val s3_alignIsPredTaken   = alignData(s3_isPredTaken, s3_alignShiftNum, s3_prevLastIsHalfRvi, false.B)
-  private val s3_alignSelectBlock   = alignData(s3_selectFetchBlock, s3_alignShiftNum, s3_prevLastIsHalfRvi, false.B)
-  private val s3_alignInstrOffset   =
+  private val s3_alignInstrPcLower =
+    alignData(s3_instrPcLowerResult, s3_alignShiftNum, s3_prevLastIsHalfRvi, 0.U((PcCutPoint + 1).W))
+  private val s3_alignInstrData = WireDefault(VecInit.fill(IBufferInPortNum)(0.U(32.W)))
+  private val s3_alignInstrIndex =
+    alignData(s3_instrIndex, s3_alignShiftNum, s3_prevLastIsHalfRvi, 0.U.asTypeOf(new InstrIndexEntry))
+  private val s3_alignInstrIsRvc = alignData(s3_instrIsRvc, s3_alignShiftNum, s3_prevLastIsHalfRvi, false.B)
+  private val s3_alignInstrValid =
+    alignData(s3_instrValid.asTypeOf(Vec(PredictWidth, Bool())), s3_alignShiftNum, s3_prevLastIsHalfRvi, false.B)
+  private val s3_alignInvalidTaken = alignData(s3_invalidTaken, s3_alignShiftNum, s3_prevLastIsHalfRvi, false.B)
+  private val s3_alignIsPredTaken  = alignData(s3_isPredTaken, s3_alignShiftNum, s3_prevLastIsHalfRvi, false.B)
+  private val s3_alignSelectBlock  = alignData(s3_selectFetchBlock, s3_alignShiftNum, s3_prevLastIsHalfRvi, false.B)
+  private val s3_alignInstrOffset =
     alignData(s3_instrOffset, s3_alignShiftNum, s3_prevLastIsHalfRvi, 0.U(log2Ceil(PredictWidth).W))
-  private val s3_alignPc  = VecInit.tabulate(IBufferInPortNum)(i =>
+  private val s3_alignPc = VecInit.tabulate(IBufferInPortNum)(i =>
     catPC(
       s3_alignInstrPcLower(i),
       Mux(s3_alignSelectBlock(i), s3_fetchBlock(1).pcHigh, s3_fetchBlock(0).pcHigh),
       Mux(s3_alignSelectBlock(i), s3_fetchBlock(1).pcHighPlus1, s3_fetchBlock(0).pcHighPlus1)
     )
   )
-  private val s3_alignFoldPc        = VecInit(s3_alignPc.map(i => XORFold(i(VAddrBits - 1, 1), MemPredPCWidth)))
-  private val s3_alignExceptionVec  = VecInit((0 until IBufferInPortNum).map(i =>
+  private val s3_alignFoldPc = VecInit(s3_alignPc.map(i => XORFold(i(VAddrBits - 1, 1), MemPredPCWidth)))
+  private val s3_alignExceptionVec = VecInit((0 until IBufferInPortNum).map(i =>
     MuxCase(
       ExceptionType.None,
       Seq(
@@ -635,13 +638,13 @@ class Ifu(implicit p: Parameters) extends IfuModule
   ))
 
   for (i <- 0 until IBufferInPortNum / 2) {
-    val lowIdx    = s3_alignInstrIndex(i).value
-    val highIdx   = s3_alignInstrIndex(i + IBufferInPortNum / 2).value
-    val j         = i + IBufferInPortNum / 2
-    val lowSelect   = s3_alignSelectBlock(i)
-    val highSelect  = s3_alignSelectBlock(j)
-    s3_alignInstrData(i)  := Mux(!lowSelect, s3_firstLowICacheData(lowIdx), s3_secondLowICacheData(lowIdx))
-    s3_alignInstrData(j)  := Mux(!highSelect, s3_firstHighICacheData(highIdx), s3_secondHighICacheData(highIdx))
+    val lowIdx     = s3_alignInstrIndex(i).value
+    val highIdx    = s3_alignInstrIndex(i + IBufferInPortNum / 2).value
+    val j          = i + IBufferInPortNum / 2
+    val lowSelect  = s3_alignSelectBlock(i)
+    val highSelect = s3_alignSelectBlock(j)
+    s3_alignInstrData(i) := Mux(!lowSelect, s3_firstLowICacheData(lowIdx), s3_secondLowICacheData(lowIdx))
+    s3_alignInstrData(j) := Mux(!highSelect, s3_firstHighICacheData(highIdx), s3_secondHighICacheData(highIdx))
   }
   private val s3_realAlignInstrData = WireDefault(VecInit.fill(IBufferInPortNum)(0.U(32.W)))
 
@@ -651,7 +654,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
     // val adjustedBlockHeadInst =
     //   Mux(s3_prevLastIsHalfRvi, Cat(s3_alignInstrData(i)(15, 0), s3_prevLastHalfData), s3_alignInstrData(i))
     // s3_realAlignInstrData(i)  := Mux(s3_alignBlockStartPos(i), adjustedBlockHeadInst, s3_alignInstrData(i))
-    s3_realAlignInstrData(i)  := s3_alignInstrData(i)
+    // The commented-out version is actually the final one; the current version is used for handling instructions
+    // crossing prediction blocks in the still-undeleted v2 version.
+    s3_realAlignInstrData(i) := s3_alignInstrData(i)
   }
 
   when(s3_fire && !s3_flush) {
@@ -671,10 +676,10 @@ class Ifu(implicit p: Parameters) extends IfuModule
   }
 
   // PreDecode: delimitation, does not expand RVC
-  preDecoderIn.valid            := s3_valid
-  preDecoderIn.bits.data        := s3_realAlignInstrData
-  preDecoderIn.bits.isRvc       := s3_alignInstrIsRvc
-  preDecoderIn.bits.instrValid  := s3_alignInstrValid // s3_instrValid.asTypeOf(Vec(PredictWidth, Bool()))
+  preDecoderIn.valid           := s3_valid
+  preDecoderIn.bits.data       := s3_realAlignInstrData
+  preDecoderIn.bits.isRvc      := s3_alignInstrIsRvc
+  preDecoderIn.bits.instrValid := s3_alignInstrValid // s3_instrValid.asTypeOf(Vec(PredictWidth, Bool()))
 
   private val s3_alignPd         = preDecoderOut.pd
   private val s3_alignJumpOffset = preDecoderOut.jumpOffset
@@ -682,7 +687,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // No longer applicable for prediction blocks crossing page boundaries; awaiting modification.
   private val s3_alignCrossPageExceptionVec = VecInit((0 until IBufferInPortNum).map { i =>
     val isCrossPage = isLastInLine(s3_alignPc(i)) && !s3_alignPd(i).isRVC &&
-                      s3_doubleline(0) && s3_icacheInfo(0).exception(0).isNone
+      s3_doubleline(0) && s3_icacheInfo(0).exception(0).isNone
     Mux(isCrossPage, s3_icacheInfo(0).exception(1), ExceptionType.None)
   })
 
@@ -690,9 +695,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   private val s3_firstIsMmio = s3_valid && (s3_icacheInfo(0).pmpMmio || Pbmt.isUncache(s3_icacheInfo(0).itlbPbmt)) &&
     s3_icacheInfo(0).exception.map(_.isNone).reduce(_ && _)
-  private val s3_secondIsMmio     = false.B
-  private val s3_mmioResendVAddr  = s3_firstResendVAddr
-  private val s3_mmioFtqIdx       = s3_fetchBlock(0).ftqIdx
+  private val s3_secondIsMmio    = false.B
+  private val s3_mmioResendVAddr = s3_firstResendVAddr
+  private val s3_mmioFtqIdx      = s3_fetchBlock(0).ftqIdx
 
   assert(!s3_secondIsMmio, "MMIO and non-MMIO instructions cannot be processed in the same cycle")
 
@@ -709,25 +714,25 @@ class Ifu(implicit p: Parameters) extends IfuModule
    * ***************************************************************************** */
 
   // assign later
-  private val s4_valid          = WireInit(false.B)
-  private val s4_firstValid     = ValidHold(s3_fire && !s3_flush && s3_firstValid, s4_fire, s4_flush)
-  private val s4_secondValid    = ValidHold(s3_fire && !s3_flush && s3_secondValid, s4_fire, s4_flush)
-  private val s4_fetchBlock     = RegEnable(s3_fetchBlock, s3_fire)
-  private val s4_doubleline     = RegEnable(s3_doubleline, s3_fire)
-  private val s4_prevIBufEnqPtr = RegEnable(s3_prevIBufEnqPtr, s3_fire)
-  private val s4_rawIndex       = RegEnable(s3_rawIndex, s3_fire)
-  private val s4_prevShiftSelect  = RegEnable(s3_prevShiftSelect, s3_fire)
+  private val s4_valid           = WireInit(false.B)
+  private val s4_firstValid      = ValidHold(s3_fire && !s3_flush && s3_firstValid, s4_fire, s4_flush)
+  private val s4_secondValid     = ValidHold(s3_fire && !s3_flush && s3_secondValid, s4_fire, s4_flush)
+  private val s4_fetchBlock      = RegEnable(s3_fetchBlock, s3_fire)
+  private val s4_doubleline      = RegEnable(s3_doubleline, s3_fire)
+  private val s4_prevIBufEnqPtr  = RegEnable(s3_prevIBufEnqPtr, s3_fire)
+  private val s4_rawIndex        = RegEnable(s3_rawIndex, s3_fire)
+  private val s4_prevShiftSelect = RegEnable(s3_prevShiftSelect, s3_fire)
   s4_fire := io.toIBuffer.fire
 
-  private val s4_alignInvalidTaken  = RegEnable(s3_alignInvalidTaken, s3_fire)
-  private val s4_alignIsPredTaken   = RegEnable(s3_alignIsPredTaken, s3_fire)
-  private val s4_alignSelectBlock   = RegEnable(s3_alignSelectBlock, s3_fire)
-  private val s4_alignInstrData     = RegEnable(s3_realAlignInstrData, s3_fire)
-  private val s4_alignInstrValid    = RegEnable(s3_alignInstrValid, s3_fire)
-  private val s4_firstIsMmio        = RegEnable(s3_firstIsMmio, s3_fire)
+  private val s4_alignInvalidTaken = RegEnable(s3_alignInvalidTaken, s3_fire)
+  private val s4_alignIsPredTaken  = RegEnable(s3_alignIsPredTaken, s3_fire)
+  private val s4_alignSelectBlock  = RegEnable(s3_alignSelectBlock, s3_fire)
+  private val s4_alignInstrData    = RegEnable(s3_realAlignInstrData, s3_fire)
+  private val s4_alignInstrValid   = RegEnable(s3_alignInstrValid, s3_fire)
+  private val s4_firstIsMmio       = RegEnable(s3_firstIsMmio, s3_fire)
 
-  private val s4_mmioResendVAddr  = RegEnable(s3_mmioResendVAddr, s3_fire)
-  private val s4_mmioFtqIdx       = RegEnable(s3_mmioFtqIdx, s3_fire)
+  private val s4_mmioResendVAddr = RegEnable(s3_mmioResendVAddr, s3_fire)
+  private val s4_mmioFtqIdx      = RegEnable(s3_mmioFtqIdx, s3_fire)
 
   private val s4_alignExceptionVec          = RegEnable(s3_alignExceptionVec, s3_fire)
   private val s4_alignCrossPageExceptionVec = RegEnable(s3_alignCrossPageExceptionVec, s3_fire)
@@ -745,14 +750,14 @@ class Ifu(implicit p: Parameters) extends IfuModule
   })
   private val s4_alignIll = VecInit(rvcExpanders.map(_.io.ill))
 
-  private val s4_alignPdWire              = RegEnable(s3_alignPd, s3_fire)
-  private val s4_alignPds                 = WireInit(s4_alignPdWire)
-  private val s4_alignJumpOffset          = RegEnable(s3_alignJumpOffset, s3_fire)
-  private val s4_alignInstrPcLower        = RegEnable(s3_alignInstrPcLower, s3_fire)
-  private val s4_alignInstrOffset         = RegEnable(s3_alignInstrOffset, s3_fire)
-  private val s4_rawPcLowerResult         = RegEnable(s3_rawPcLowerResult, s3_fire)
+  private val s4_alignPdWire       = RegEnable(s3_alignPd, s3_fire)
+  private val s4_alignPds          = WireInit(s4_alignPdWire)
+  private val s4_alignJumpOffset   = RegEnable(s3_alignJumpOffset, s3_fire)
+  private val s4_alignInstrPcLower = RegEnable(s3_alignInstrPcLower, s3_fire)
+  private val s4_alignInstrOffset  = RegEnable(s3_alignInstrOffset, s3_fire)
+  private val s4_rawPcLowerResult  = RegEnable(s3_rawPcLowerResult, s3_fire)
 
-  private val s4_alignPc  = VecInit.tabulate(IBufferInPortNum)(i =>
+  private val s4_alignPc = VecInit.tabulate(IBufferInPortNum)(i =>
     catPC(
       s4_alignInstrPcLower(i),
       Mux(s4_alignSelectBlock(i), s4_fetchBlock(1).pcHigh, s4_fetchBlock(0).pcHigh),
@@ -765,7 +770,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s4_prevLastIsHalfRvi  = RegEnable(s3_prevLastIsHalfRvi, s3_fire)
   private val s4_mmioLowerPc        = RegEnable(s3_alignInstrPcLower(s3_alignShiftNum), s3_fire)
   private val s4_alignBlockStartPos = RegEnable(s3_alignBlockStartPos, s3_fire)
-  private val s4_mmioPc   = catPC(s4_mmioLowerPc, s4_fetchBlock(0).pcHigh, s4_fetchBlock(0).pcHighPlus1)
+  private val s4_mmioPc             = catPC(s4_mmioLowerPc, s4_fetchBlock(0).pcHigh, s4_fetchBlock(0).pcHighPlus1)
 
   // Exapnd 1 bit to prevent overflow when assert
   private val s4_fetchStartAddr = VecInit.tabulate(FetchPorts)(i =>
@@ -875,7 +880,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   private val s4_mmioUseSnpc = ValidHold(RegNext(s3_fire && !s3_flush) && s4_reqIsMmio, redirectMmioReq)
 
-  s4_ready  := (io.toIBuffer.ready && (s4_mmioReqCommit || !s4_reqIsMmio)) || !s4_valid
+  s4_ready := (io.toIBuffer.ready && (s4_mmioReqCommit || !s4_reqIsMmio)) || !s4_valid
 
   // mmio state machine
   switch(mmioState) {
@@ -1015,38 +1020,31 @@ class Ifu(implicit p: Parameters) extends IfuModule
   io.pmp.req.bits.size := 3.U
   io.pmp.req.bits.cmd  := TlbCmd.exec
 
-  private val s4_mmioRange            = VecInit((0 until PredictWidth).map(i => if (i == 0) true.B else false.B))
+  private val s4_mmioRange = VecInit((0 until PredictWidth).map(i => if (i == 0) true.B else false.B))
   // private val s4_alignRealInstrValid  = Wire(Vec(IBufferInPortNum, Bool()))
-  private val ignore                  = s4_prevShiftSelect
-  // WireDefault(VecInit.fill(IBufWriteBank)(false.B))
-  // ignore(0) := s4_prevLastIsHalfRvi
-  // ignore  :=  s4_prevShiftSelect.asBools
+  private val s4_ignore = s4_prevShiftSelect
 
   /* ** prediction result check ** */
-  checkerIn.valid                 := s4_valid
-  checkerIn.bits.instrJumpOffset  := s4_alignJumpOffset
-  checkerIn.bits.instrValid       := s4_alignInstrValid.asTypeOf(Vec(IBufferInPortNum, Bool()))
-  checkerIn.bits.instrPds         := s4_alignPds
-  checkerIn.bits.instrPc          := s4_alignPc
-  checkerIn.bits.isPredTaken      := s4_alignIsPredTaken
-  checkerIn.bits.ignore           := ignore.asBools
-  checkerIn.bits.shiftNum         := s4_prevIBufEnqPtr.value(1, 0)
+  checkerIn.valid                := s4_valid
+  checkerIn.bits.instrJumpOffset := s4_alignJumpOffset
+  checkerIn.bits.instrValid      := s4_alignInstrValid.asTypeOf(Vec(IBufferInPortNum, Bool()))
+  checkerIn.bits.instrPds        := s4_alignPds
+  checkerIn.bits.instrPc         := s4_alignPc
+  checkerIn.bits.isPredTaken     := s4_alignIsPredTaken
+  checkerIn.bits.ignore          := s4_ignore.asBools
+  checkerIn.bits.shiftNum        := s4_prevIBufEnqPtr.value(1, 0)
 
-  checkerIn.bits.firstPredTakenIdx.valid  := s4_fetchBlock(0).predTakenIdx.valid
-  checkerIn.bits.firstPredTakenIdx.bits   := Cat(0.U(1.W), s4_fetchBlock(0).predTakenIdx.bits) + s4_prevIBufEnqPtr.value(1, 0)
+  checkerIn.bits.firstPredTakenIdx.valid := s4_fetchBlock(0).predTakenIdx.valid
+  checkerIn.bits.firstPredTakenIdx.bits :=
+    Cat(0.U(1.W), s4_fetchBlock(0).predTakenIdx.bits) + s4_prevIBufEnqPtr.value(1, 0)
   checkerIn.bits.secondPredTakenIdx.valid := s4_fetchBlock(1).predTakenIdx.valid
-  checkerIn.bits.secondPredTakenIdx.bits  := Cat(0.U(1.W), s4_fetchBlock(1).predTakenIdx.bits) + s4_prevIBufEnqPtr.value(1, 0)
-  checkerIn.bits.firstTarget        := s4_fetchBlock(0).target
-  checkerIn.bits.secondTarget       := s4_fetchBlock(1).target
-  checkerIn.bits.selectFetchBlock   := s4_alignSelectBlock
-  checkerIn.bits.invalidTaken       := s4_alignInvalidTaken
-  checkerIn.bits.instrOffset        := s4_alignInstrOffset
-
-  // s4_alignRealInstrValid.zipWithIndex.map {
-  //   case (valid, i) =>
-  //     valid := s4_alignInstrValid(i) & checkerOutStage1.fixedTwoFetchRange(i)
-  // }
-  // s4_alignRealInstrValid(0) := s4_alignInstrValid(0) & checkerOutStage1.fixedTwoFetchRange(0) && !s4_prevLastIsHalfRvi
+  checkerIn.bits.secondPredTakenIdx.bits :=
+    Cat(0.U(1.W), s4_fetchBlock(1).predTakenIdx.bits) + s4_prevIBufEnqPtr.value(1, 0)
+  checkerIn.bits.firstTarget      := s4_fetchBlock(0).target
+  checkerIn.bits.secondTarget     := s4_fetchBlock(1).target
+  checkerIn.bits.selectFetchBlock := s4_alignSelectBlock
+  checkerIn.bits.invalidTaken     := s4_alignInvalidTaken
+  checkerIn.bits.instrOffset      := s4_alignInstrOffset
 
   /* ** frontend Trigger  ** */
   frontendTrigger.io.pds             := s4_alignPds
@@ -1058,15 +1056,15 @@ class Ifu(implicit p: Parameters) extends IfuModule
   /* ** send to IBuffer ** */
   private val s4_toIBufferValid = s4_valid && (!s4_reqIsMmio || s4_mmioCanGo) && !s4_flush
 
-  private val ignoreRange = Cat(Fill(IBufferInPortNum - IfuAlignWidth, 1.U(1.W)), ~ignore)
-  io.toIBuffer.valid            := s4_toIBufferValid
-  io.toIBuffer.bits.instrs      := s4_alignExpdInstr
-  io.toIBuffer.bits.valid       := s4_alignInstrValid.asUInt & ignoreRange
-  io.toIBuffer.bits.enqEnable   := checkerOutStage1.fixedTwoFetchRange.asUInt & s4_alignInstrValid.asUInt & ignoreRange
-  io.toIBuffer.bits.pd          := s4_alignPds
-  io.toIBuffer.bits.ftqPtr      := s4_fetchBlock(0).ftqIdx
-  io.toIBuffer.bits.pc          := s4_alignPc
-  io.toIBuffer.bits.prevIBufEnqPtr  := s4_prevIBufEnqPtr
+  private val ignoreRange = Cat(Fill(IBufferInPortNum - IfuAlignWidth, 1.U(1.W)), ~s4_ignore)
+  io.toIBuffer.valid          := s4_toIBufferValid
+  io.toIBuffer.bits.instrs    := s4_alignExpdInstr
+  io.toIBuffer.bits.valid     := s4_alignInstrValid.asUInt & ignoreRange
+  io.toIBuffer.bits.enqEnable := checkerOutStage1.fixedTwoFetchRange.asUInt & s4_alignInstrValid.asUInt & ignoreRange
+  io.toIBuffer.bits.pd        := s4_alignPds
+  io.toIBuffer.bits.ftqPtr    := s4_fetchBlock(0).ftqIdx
+  io.toIBuffer.bits.pc        := s4_alignPc
+  io.toIBuffer.bits.prevIBufEnqPtr := s4_prevIBufEnqPtr
   // Find last using PriorityMux
   io.toIBuffer.bits.isLastInFtqEntry := Reverse(PriorityEncoderOH(Reverse(io.toIBuffer.bits.enqEnable))).asBools
   io.toIBuffer.bits.ftqPcOffset.zipWithIndex.foreach { case (a, i) =>
@@ -1074,19 +1072,19 @@ class Ifu(implicit p: Parameters) extends IfuModule
     a.bits.offset := s4_alignInstrOffset(i)
     a.valid       := checkerOutStage1.fixedTwoFetchTaken(i) && !s4_reqIsMmio
   }
-  io.toIBuffer.bits.foldpc  := s4_alignFoldPc
+  io.toIBuffer.bits.foldpc := s4_alignFoldPc
   io.toIBuffer.bits.exceptionType := VecInit((s4_alignExceptionVec zip s4_alignCrossPageExceptionVec).map {
-    case (e, ce)  => e || ce // merge, cross page fix has lower priority
+    case (e, ce) => e || ce // merge, cross page fix has lower priority
   })
   // backendException only needs to be set for the first instruction.
   // Other instructions in the same block may have pf or af set,
   // which is a side effect of the first instruction and actually not necessary.
-  io.toIBuffer.bits.backendException  := (0 until IBufferInPortNum).map {
+  io.toIBuffer.bits.backendException := (0 until IBufferInPortNum).map {
     case i => Mux(i.U === s4_prevIBufEnqPtr.value(1, 0), s4_icacheInfo(0).isBackendException, false.B)
   }
-  io.toIBuffer.bits.crossPageIPFFix   := s4_alignCrossPageExceptionVec.map(_.hasException)
-  io.toIBuffer.bits.illegalInstr      := s4_alignIll
-  io.toIBuffer.bits.triggered         := s4_alignTriggered
+  io.toIBuffer.bits.crossPageIPFFix := s4_alignCrossPageExceptionVec.map(_.hasException)
+  io.toIBuffer.bits.illegalInstr    := s4_alignIll
+  io.toIBuffer.bits.triggered       := s4_alignTriggered
 
   when(io.toIBuffer.valid && io.toIBuffer.ready) {
     val enqVec = io.toIBuffer.bits.enqEnable
@@ -1169,7 +1167,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
     io.toIBuffer.bits.crossPageIPFFix(s4_shiftNum) := mmioHasResend && mmioException.hasException
     io.toIBuffer.bits.illegalInstr(s4_shiftNum)    := mmioRvcExpander.io.ill
 
-    io.toIBuffer.bits.enqEnable   := s4_alignBlockStartPos.asUInt //s4_mmioRange.asUInt
+    io.toIBuffer.bits.enqEnable := s4_alignBlockStartPos.asUInt // s4_mmioRange.asUInt
 
     mmioFlushWb.bits.pd(s4_shiftNum).valid  := true.B
     mmioFlushWb.bits.pd(s4_shiftNum).isRVC  := mmioIsRvc
@@ -1194,12 +1192,15 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   // According to the discussed version, IFU will no longer need to send predecode information to FTQ in the future.
   // Therefore, this part of the logic will not be optimized further and will be removed later.
-  val firstRawPds   = WireDefault(VecInit.fill(PredictWidth)(0.U.asTypeOf(new PreDecodeInfo)))
-  val secondRawPds  = WireDefault(VecInit.fill(PredictWidth)(0.U.asTypeOf(new PreDecodeInfo)))
+  val firstRawPds  = WireDefault(VecInit.fill(PredictWidth)(0.U.asTypeOf(new PreDecodeInfo)))
+  val secondRawPds = WireDefault(VecInit.fill(PredictWidth)(0.U.asTypeOf(new PreDecodeInfo)))
   firstRawPds.zipWithIndex.map {
     case (rawPd, i) =>
-      rawPd := Mux(s4_rawInstrValid(i), s4_alignPds(s4_rawIndex(i) + s4_prevIBufEnqPtr.value(1, 0)),
-       0.U.asTypeOf(new PreDecodeInfo))
+      rawPd := Mux(
+        s4_rawInstrValid(i),
+        s4_alignPds(s4_rawIndex(i) + s4_prevIBufEnqPtr.value(1, 0)),
+        0.U.asTypeOf(new PreDecodeInfo)
+      )
   }
   secondRawPds.zipWithIndex.map {
     case (rawPd, i) =>
@@ -1210,16 +1211,16 @@ class Ifu(implicit p: Parameters) extends IfuModule
       )
   }
 
-  private val wbEnable        = RegNext(s3_fire && !s3_flush) && !s4_reqIsMmio && !s4_flush
-  private val wbValid         = RegNext(wbEnable, init = false.B)
-  private val wbFirstValid    = RegEnable(s4_firstValid, wbEnable)
-  private val wbSecondValid   = RegEnable(s4_secondValid, wbEnable)
-  private val wbFetchBlock    = RegEnable(s4_fetchBlock, wbEnable)
-  private val wbPreIBufEnqPtr = RegEnable(s4_prevIBufEnqPtr, wbEnable)
-  private val wbInstrCount    = RegEnable(PopCount(io.toIBuffer.bits.enqEnable), wbEnable)
-  private val wbAlignInstrOffset  = RegEnable(s4_alignInstrOffset, wbEnable)
-  private val wbFirstRawPds       = RegEnable(firstRawPds, wbEnable)
-  private val wbSecondRawPds      = RegEnable(secondRawPds, wbEnable)
+  private val wbEnable           = RegNext(s3_fire && !s3_flush) && !s4_reqIsMmio && !s4_flush
+  private val wbValid            = RegNext(wbEnable, init = false.B)
+  private val wbFirstValid       = RegEnable(s4_firstValid, wbEnable)
+  private val wbSecondValid      = RegEnable(s4_secondValid, wbEnable)
+  private val wbFetchBlock       = RegEnable(s4_fetchBlock, wbEnable)
+  private val wbPreIBufEnqPtr    = RegEnable(s4_prevIBufEnqPtr, wbEnable)
+  private val wbInstrCount       = RegEnable(PopCount(io.toIBuffer.bits.enqEnable), wbEnable)
+  private val wbAlignInstrOffset = RegEnable(s4_alignInstrOffset, wbEnable)
+  private val wbFirstRawPds      = RegEnable(firstRawPds, wbEnable)
+  private val wbSecondRawPds     = RegEnable(secondRawPds, wbEnable)
 
   wbRedirect.instrCount     := wbInstrCount
   wbRedirect.prevIBufEnqPtr := wbPreIBufEnqPtr
@@ -1232,25 +1233,29 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val wbStage2SecondCheck = checkerOutStage2.fixedSecond
 
   private val wbAlignInstrPcLower = RegEnable(s4_alignInstrPcLower, wbEnable)
-  private val checkFlushWb        = Wire(Vec(FetchPorts, Valid(new PredecodeWritebackBundle)))
 
   private val wbInstrRange = wbStage2Check.zipWithIndex.map { case (check, i) =>
     check.instrRange & RegEnable(s4_fetchBlock(i).instrRange, wbEnable)
   }
 
-  for (i <- 0 until FetchPorts) {
+  private val checkFlushWb = VecInit((0 until FetchPorts).map { i =>
+    val b       = Wire(Valid(new PredecodeWritebackBundle))
     val missIdx = wbStage2Check(i).misIdx.bits
-    checkFlushWb(i).bits.pc := catPC(wbAlignInstrPcLower(missIdx), wbFetchBlock(i).pcHigh, wbFetchBlock(i).pcHighPlus1)
-    checkFlushWb(i).bits.ftqIdx          := wbFetchBlock(i).ftqIdx
-    checkFlushWb(i).bits.ftqOffset       := wbFetchBlock(i).ftqOffset.bits
-    checkFlushWb(i).bits.misOffset.valid := wbStage2Check(i).misIdx.valid
-    checkFlushWb(i).bits.misOffset.bits  := wbAlignInstrOffset(wbStage2Check(i).misIdx.bits)
-    checkFlushWb(i).bits.cfiOffset.valid := wbStage2Check(i).cfiIdx.valid
-    checkFlushWb(i).bits.cfiOffset.bits  := wbAlignInstrOffset(wbStage2Check(i).cfiIdx.bits)
-    checkFlushWb(i).bits.target          := wbStage2Check(i).target
-    checkFlushWb(i).bits.jalTarget       := wbStage2Check(i).target
-    checkFlushWb(i).bits.instrRange      := wbInstrRange(i).asTypeOf(Vec(PredictWidth, Bool()))
-  }
+    b.valid                := wbValid && wbFirstValid // Primarily used as a placeholder; the value will be overwritten.
+    b.bits.pd              := wbFirstRawPds           // Primarily used as a placeholder; the value will be overwritten.
+    b.bits.pc              := catPC(wbAlignInstrPcLower(missIdx), wbFetchBlock(i).pcHigh, wbFetchBlock(i).pcHighPlus1)
+    b.bits.ftqIdx          := wbFetchBlock(i).ftqIdx
+    b.bits.ftqOffset       := wbFetchBlock(i).ftqOffset.bits
+    b.bits.misOffset.valid := wbStage2Check(i).misIdx.valid
+    b.bits.misOffset.bits  := wbAlignInstrOffset(wbStage2Check(i).misIdx.bits)
+    b.bits.cfiOffset.valid := wbStage2Check(i).cfiIdx.valid
+    b.bits.cfiOffset.bits  := wbAlignInstrOffset(wbStage2Check(i).cfiIdx.bits)
+    b.bits.target          := wbStage2Check(i).target
+    b.bits.jalTarget       := wbStage2Check(i).target
+    b.bits.instrRange      := wbInstrRange(i).asTypeOf(Vec(PredictWidth, Bool()))
+    b
+  })
+
   checkFlushWb(0).valid   := wbValid && wbFirstValid
   checkFlushWb(1).valid   := wbValid && wbSecondValid
   checkFlushWb(0).bits.pd := wbFirstRawPds
@@ -1259,7 +1264,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   toFtq.pdWb(0) := Mux(wbValid, checkFlushWb(0), mmioFlushWb)
   toFtq.pdWb(1) := checkFlushWb(1)
 
-  wbRedirect.valid  := (checkFlushWb(0).bits.misOffset.valid && checkFlushWb(0).valid) ||
+  wbRedirect.valid := (checkFlushWb(0).bits.misOffset.valid && checkFlushWb(0).valid) ||
     (checkFlushWb(1).bits.misOffset.valid && checkFlushWb(1).valid)
 
   /* write back flush type */
@@ -1359,7 +1364,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   fetchIBufferDumpData.exception    := io.toIBuffer.fire && s4_perfInfo.except
   fetchIBufferDumpData.isCacheHit   := io.toIBuffer.fire && s4_perfInfo.hit
 
-  private val ifuWbToFtqDumpData  = Wire(new IfuWbToFtqDB)
+  private val ifuWbToFtqDumpData = Wire(new IfuWbToFtqDB)
   for (i <- 0 until FetchPorts) {
     ifuWbToFtqDumpData.startAddr(i)      := wbFetchBlock(i).startAddr.toUInt
     ifuWbToFtqDumpData.isMissPred(i)     := checkFlushWb(i).bits.misOffset.valid

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -196,15 +196,19 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   /* *****************************************************************************
    * IFU Stage 0
-   * - send cacheline fetch request to ICacheMainPipe
-   * ***************************************************************************** */
+   *
+   * - Sends cacheline fetch requests to ICacheMainPipe.
+   *
+   * **************************************************************************** */
+  private val s0_ftqFetch   = fromFtq.req.bits.fetch
+  private val s0_doubleline = VecInit(fromFtq.req.bits.fetch.map(_.crossCacheline))
 
-  private val s0_ftqReq     = fromFtq.req.bits
-  private val s0_doubleline = fromFtq.req.bits.crossCacheline
   s0_fire := fromFtq.req.fire
 
-  private val s0_flushFromBpu = fromFtq.flushFromBpu.shouldFlushByStage2(s0_ftqReq.ftqIdx) ||
-    fromFtq.flushFromBpu.shouldFlushByStage3(s0_ftqReq.ftqIdx)
+  private val s0_flushFromBpu = VecInit.tabulate(FetchPorts)(i =>
+    fromFtq.flushFromBpu.shouldFlushByStage2(s0_ftqFetch(i).ftqIdx) ||
+      fromFtq.flushFromBpu.shouldFlushByStage3(s0_ftqFetch(i).ftqIdx)
+  )
 
   private val backendRedirect          = WireInit(false.B)
   private val wbRedirect, mmioRedirect = WireInit(0.U.asTypeOf(new IfuRedirectInternal))
@@ -216,7 +220,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   s3_flush        := backendRedirect || mmioRedirect.valid || wbRedirect.valid
   s2_flush        := s3_flush
   s1_flush        := s2_flush
-  s0_flush        := s1_flush || s0_flushFromBpu
+  s0_flush        := s1_flush || s0_flushFromBpu(0)
 
   fromFtq.req.ready := s1_ready && io.fromICache.fetchReady
 
@@ -233,42 +237,52 @@ class Ifu(implicit p: Parameters) extends IfuModule
   XSPerfAccumulate("fetch_bubble_ftq_not_valid", !fromFtq.req.valid && fromFtq.req.ready)
   XSPerfAccumulate("fetch_flush_backend_redirect", backendRedirect)
   XSPerfAccumulate("fetch_flush_wb_redirect", wbRedirect.valid)
-  XSPerfAccumulate("fetch_flush_s0_flush_from_bpu", s0_flushFromBpu)
+  XSPerfAccumulate("fetch_flush_s0_flush_from_bpu", s0_flushFromBpu(0) | s0_flushFromBpu(1))
 
   /* *****************************************************************************
    * IFU Stage 1
    * - calculate pc/half_pc/cut_ptr for every instruction
    * ***************************************************************************** */
 
-  private val s1_valid      = ValidHold(s0_fire && !s0_flush, s1_fire, s1_flush)
-  private val s1_ftqReq     = RegEnable(s0_ftqReq, s0_fire)
-  private val s1_doubleline = RegEnable(s0_doubleline, s0_fire)
+  private val s1_valid       = ValidHold(s0_fire && !s0_flush, s1_fire, s1_flush)
+  private val s1_firstValid  = ValidHold(s0_fire && !s0_flush && s0_ftqFetch(0).valid, s1_fire, s1_flush)
+  private val s1_secondValid = ValidHold(s0_fire && !s0_flush && s0_ftqFetch(1).valid, s1_fire, s1_flush)
+  private val s1_ftqFetch    = RegEnable(s0_ftqFetch, s0_fire)
+  private val s1_doubleline  = RegEnable(s0_doubleline, s0_fire)
 
   s1_fire  := s1_valid && s2_ready
   s1_ready := s1_fire || !s1_valid
 
-  assert(!(fromFtq.flushFromBpu.shouldFlushByStage3(s1_ftqReq.ftqIdx) && s1_valid))
+  assert(!(fromFtq.flushFromBpu.shouldFlushByStage3(s1_ftqFetch(0).ftqIdx) && s1_firstValid))
+  assert(!(fromFtq.flushFromBpu.shouldFlushByStage3(s1_ftqFetch(1).ftqIdx) && s1_secondValid))
 
-  private val s1_firstFetchSize = Mux(
-    s1_ftqReq.ftqOffset.valid,
-    s1_ftqReq.ftqOffset.bits + 1.U(log2Ceil(PredictWidth + 1).W),
-    (s1_ftqReq.nextStartVAddr - s1_ftqReq.startVAddr)(log2Ceil(PredictWidth + 1) + 1, 1)
-  )
-  private val s1_totalFetchSize = s1_firstFetchSize
-  private val s1_firstEndPos    = s1_firstFetchSize - 1.U
-  private val s1_totalEndPos    = s1_totalFetchSize - 1.U
-  private val s1_firstJumpRange =
-    Fill(PredictWidth, !s1_ftqReq.ftqOffset.valid) | Fill(PredictWidth, 1.U(1.W)) >> ~s1_ftqReq.ftqOffset.bits
-  require(
-    isPow2(PredictWidth),
-    "If PredictWidth is not power of 2," +
-      "expression: Fill(PredictWidth, 1.U(1.W)) >> ~s0_ftqReq.ftqOffset.bits is not right !!"
-  )
-  private val s1_firstFtrRange =
-    Fill(PredictWidth, s1_ftqReq.ftqOffset.valid) | Fill(PredictWidth, 1.U(1.W)) >> ~getBasicBlockIdx(
-      s1_ftqReq.nextStartVAddr,
-      s1_ftqReq.startVAddr
+  private val s1_fetchSize = VecInit.tabulate(FetchPorts) { i =>
+    Mux(s1_ftqFetch(i).ftqOffset.valid,
+      s1_ftqFetch(i).ftqOffset.bits + 1.U(log2Ceil(PredictWidth + 1).W),
+      (s1_ftqFetch(i).nextStartVAddr - s1_ftqFetch(i).startVAddr)(log2Ceil(PredictWidth + 1) + 1, 1)
     )
+  }
+
+  private val s1_jumpRange = VecInit.tabulate(FetchPorts)(i =>
+    Fill(PredictWidth, !s1_ftqFetch(i).ftqOffset.valid) |
+      Fill(PredictWidth, 1.U(1.W)) >> ~s1_ftqFetch(i).ftqOffset.bits
+  )
+  private val s1_ftrRange = VecInit.tabulate(FetchPorts)(i =>
+    Fill(PredictWidth, s1_ftqFetch(i).ftqOffset.valid) | Fill(PredictWidth, 1.U(1.W)) >> ~getBasicBlockIdx(
+      s1_ftqFetch(i).nextStartVAddr,
+      s1_ftqFetch(i).startVAddr
+    )
+  )
+  private val s1_instrRange = VecInit.tabulate(FetchPorts)(i =>
+    s1_jumpRange(i) & s1_ftrRange(i)
+  )
+
+  private val s1_totalEndPos =
+    Mux(s1_firstValid && s1_secondValid, s1_fetchSize(0) + s1_fetchSize(1) - 1.U, s1_fetchSize(0) - 1.U)
+
+  private val s1_firstEndPos = s1_fetchSize(0) - 1.U
+  private val s1_toatalInstrRange =
+    Mux(!s1_secondValid, s1_instrRange(0), (s1_instrRange(1) << s1_fetchSize(0)) | s1_instrRange(0))
   /* *****************************************************************************
    * IFU Stage 2
    * - icache response data (latched for pipeline stop)
@@ -280,19 +294,16 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val icacheRespAllValid = WireInit(false.B)
 
   private val s2_valid             = ValidHold(s1_fire && !s1_flush, s2_fire, s2_flush)
-  private val s2_ftqReq            = RegEnable(s1_ftqReq, s1_fire)
+  private val s2_firstValid        = ValidHold(s1_fire && !s1_flush, s2_fire, s2_flush)
+  private val s2_secondValid       = ValidHold(s1_fire && !s1_flush && s1_secondValid, s2_fire, s2_flush)
+  private val s2_ftqFetch          = RegEnable(s1_ftqFetch, s1_fire)
   private val s2_doubleline        = RegEnable(s1_doubleline, s1_fire)
   private val s2_prevLastIsHalfRvi = RegInit(false.B)
-  private val s2_firstFetchSize    = RegEnable(s1_firstFetchSize, s1_fire)
-  private val s2_totalFetchSize    = RegEnable(s1_totalFetchSize, s1_fire)
+  private val s2_fetchSize         = RegEnable(s1_fetchSize, s1_fire)
+  private val s2_instrRange        = RegEnable(s1_instrRange, s1_fire)
+  private val s2_totalInstrRange   = RegEnable(s1_toatalInstrRange, s1_fire)
   private val s2_firstEndPos       = RegEnable(s1_firstEndPos, s1_fire)
   private val s2_totalEndPos       = RegEnable(s1_totalEndPos, s1_fire)
-  private val s2_firstJumpRange    = RegEnable(s1_firstJumpRange, s1_fire)
-  private val s2_firstFtrRange     = RegEnable(s1_firstFtrRange, s1_fire)
-  // Temporary compromise for V2 compatibility; actually uses RegEnable(s1_firstJumpRange & s1_firstFtrRange, s1_fire)
-  private val s2_firstInstrRange  = RegEnable(s1_firstJumpRange & s1_firstFtrRange, s1_fire)
-  private val s2_secondInstrRange = 0.U(PredictWidth.W)
-  private val s2_totalInstrRange  = (s2_secondInstrRange << s2_firstFetchSize) | s2_firstInstrRange
 
   private val s2_instrPcLowerResult  = WireDefault(VecInit.fill(PredictWidth)(0.U((PcCutPoint + 1).W)))
   private val s2_bubblePcLowerResult = WireDefault(VecInit.fill(PredictWidth)(0.U((PcCutPoint + 1).W)))
@@ -305,20 +316,15 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // TODO: addr compare may be timing critical
   private val s2_iCacheAllRespWire =
     fromICache.valid &&
-      fromICache.bits.vAddr(0) === s2_ftqReq.startVAddr &&
-      (fromICache.bits.doubleline && fromICache.bits.vAddr(1) === s2_ftqReq.nextCachelineVAddr || !s2_doubleline)
+      fromICache.bits.vAddr(0) === s2_ftqFetch(0).startVAddr &&
+      (fromICache.bits.doubleline && fromICache.bits.vAddr(1) === s2_ftqFetch(0).nextCachelineVAddr || !s2_doubleline(0))
   private val s2_iCacheAllRespReg = ValidHold(s2_valid && s2_iCacheAllRespWire && !s3_ready, s2_fire, s2_flush)
 
   icacheRespAllValid := s2_iCacheAllRespReg || s2_iCacheAllRespWire
 
   io.toICache.stall := !s3_ready
 
-  private val s2_exceptionIn        = fromICache.bits.exception
-  private val s2_isBackendException = fromICache.bits.isBackendException
-  // paddr and gpAddr of [startAddr, nextLineAddr]
-  private val s2_pAddr             = fromICache.bits.pAddr
-  private val s2_gpAddr            = fromICache.bits.gpAddr
-  private val s2_isForVSnonLeafPTE = fromICache.bits.isForVSnonLeafPTE
+  private val s2_exceptionIn = fromICache.bits.exception
 
   // FIXME: raise af if one fetch block crosses the cacheable/un-cacheable boundary, might not correct
   private val s2_mmioMismatchException = VecInit(Seq(
@@ -336,82 +342,95 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // merge exceptions
   private val s2_exception = VecInit((s2_exceptionIn zip s2_mmioMismatchException).map { case (in, m) => in || m })
 
+  private val s2_icacheInfo = WireDefault(0.U.asTypeOf(Vec(FetchPorts, new ICacheInfo)))
+  s2_icacheInfo(0).exception          := s2_exception
+  s2_icacheInfo(0).pmpMmio            := fromICache.bits.pmpMmio(0)
+  s2_icacheInfo(0).itlbPbmt           := fromICache.bits.itlbPbmt(0)
+  s2_icacheInfo(0).isBackendException := fromICache.bits.isBackendException
+  s2_icacheInfo(0).pAddr              := fromICache.bits.pAddr
+  s2_icacheInfo(0).gpAddr             := fromICache.bits.gpAddr
+  s2_icacheInfo(0).isForVSnonLeafPTE  := fromICache.bits.isForVSnonLeafPTE
+
   // we need only the first port, as the second is asked to be the same
   private val s2_pmpMmio  = fromICache.bits.pmpMmio(0)
   private val s2_itlbPbmt = fromICache.bits.itlbPbmt(0)
 
   private val s2_rawData  = fromICache.bits.data
   private val s2_perfInfo = io.fromICache.perf
-  preDecodeBounder.io.req.valid            := fromICache.valid
-  preDecodeBounder.io.req.bits.instrRange  := s2_totalInstrRange.asTypeOf(Vec(PredictWidth, Bool()))
-  preDecodeBounder.io.req.bits.cacheData   := Cat(s2_rawData, s2_rawData) >> Cat(s2_ftqReq.startVAddr(5, 0), 0.U(3.W))
-  preDecodeBounder.io.req.bits.endPosition := s2_totalEndPos
+  preDecodeBounder.io.req.valid           := fromICache.valid
+  preDecodeBounder.io.req.bits.instrRange := s2_totalInstrRange.asTypeOf(Vec(PredictWidth, Bool()))
+  preDecodeBounder.io.req.bits.cacheData  :=
+    Cat(s2_rawData, s2_rawData) >> Cat(s2_ftqFetch(0).startVAddr(5, 0), 0.U(3.W))
+  preDecodeBounder.io.req.bits.firstEndPos       := s2_firstEndPos
+  preDecodeBounder.io.req.bits.endPos            := s2_totalEndPos
   preDecodeBounder.io.req.bits.prevLastIsHalfRvi := s2_prevLastIsHalfRvi
 
-  val s2_fetchEndIsHalf = preDecodeBounder.io.resp.bits.isLastHalfRvi
+  val s2_firstFetchEndIsHalf = preDecodeBounder.io.resp.bits.isFirstLastHalfRvi
+  val s2_fetchEndIsHalf      = preDecodeBounder.io.resp.bits.isLastHalfRvi
   when(s2_fire && !s2_flush) {
-    s2_prevLastIsHalfRvi := preDecodeBounder.io.resp.bits.isLastHalfRvi && !s2_ftqReq.ftqOffset.valid
+    s2_prevLastIsHalfRvi := preDecodeBounder.io.resp.bits.isLastHalfRvi && !s2_ftqFetch(0).ftqOffset.valid
   }.elsewhen(s2_flush) {
     s2_prevLastIsHalfRvi := false.B
   }
 
-  private val bubbleInstrValid = preDecodeBounder.io.resp.bits.instrValid
-  private val isRvc            = preDecodeBounder.io.resp.bits.isRvc
-  private val firstFtqOffset   = s2_ftqReq.ftqOffset
+  private val rawInstrValid = preDecodeBounder.io.resp.bits.instrValid
+  private val isRvc         = preDecodeBounder.io.resp.bits.isRvc
 
   /* *****************************************************************************
-   * instrCountBeforeCurrent(i), not include bubbleInstrValid(i)
+   * instrCountBeforeCurrent(i), not include rawInstrValid(i)
    * ***************************************************************************** */
   val instrCountBeforeCurrent = WireDefault(VecInit.fill(PredictWidth + 1)(0.U(log2Ceil(PredictWidth + 1).W)))
   for (i <- 0 until PredictWidth) {
-    instrCountBeforeCurrent(i) := PopCount(bubbleInstrValid.take(i))
+    instrCountBeforeCurrent(i) := PopCount(rawInstrValid.take(i))
   }
-  instrCountBeforeCurrent(PredictWidth) := PopCount(bubbleInstrValid)
+  instrCountBeforeCurrent(PredictWidth) := PopCount(rawInstrValid)
 
   val instrIndexEntry = Wire(Vec(PredictWidth, new InstrIndexEntry))
   val fetchBlockSelect =
     VecInit.tabulate(PredictWidth)(i =>
-      Mux(s2_firstFetchSize > i.U, false.B, false.B)
+      Mux(s2_fetchSize(0) > i.U, false.B, true.B)
     )
 
-  private val s2_firstFetchBlockPcLowerResult = VecInit((0 until PredictWidth).map(i =>
-    Cat(0.U(1.W), s2_ftqReq.startVAddr(PcCutPoint - 1, 0)) + (i * 2).U
-  )) // cat with overflow bit
+  private val s2_fetchPcLowerResult = VecInit.tabulate(FetchPorts)(i =>
+    VecInit((0 until PredictWidth).map(j =>
+      Cat(0.U(1.W), s2_ftqFetch(i).startVAddr(PcCutPoint - 1, 0)) + (j * 2).U
+    ))
+  ) // cat with overflow bit
 
-  private val firstFetchBlockIndex =
-    VecInit.tabulate(PredictWidth)(i => s2_firstFetchBlockPcLowerResult(i)(log2Ceil(ICacheLineBytes) - 1, 1))
-
-  private val fetchBlockIndex = VecInit.tabulate(PredictWidth)(i =>
-    Mux(s2_firstFetchSize > i.U, firstFetchBlockIndex(i), firstFetchBlockIndex(i))
+  private val s2_fetchBlockIndex = VecInit.tabulate(FetchPorts)(i =>
+    VecInit.tabulate(PredictWidth)(j =>
+      s2_fetchPcLowerResult(i)(j)(log2Ceil(ICacheLineBytes) - 1, 1)
+    )
   )
 
-  private val fetchBlockPcLowerResult = VecInit.tabulate(PredictWidth)(i =>
-    Mux(
-      s2_firstFetchSize > i.U,
-      s2_firstFetchBlockPcLowerResult(i),
-      s2_firstFetchBlockPcLowerResult(i)
-    ) // Mux(firstFetchBlockSize > i.U, s1_firstFetchBlockPcLowerResult(i), s1_secondFetchBlockPcLowerResult(i))
+  private val twoFetchBlockIndex = VecInit.tabulate(PredictWidth)(i =>
+    Mux(s2_fetchSize(0) > i.U, s2_fetchBlockIndex(0)(i), s2_fetchBlockIndex(1)(i))
   )
 
-  s2_bubblePcLowerResult := fetchBlockPcLowerResult
+  private val twoFetchPcLowerResult = VecInit.tabulate(PredictWidth)(i =>
+    Mux(s2_fetchSize(0) > i.U, s2_fetchPcLowerResult(0)(i), s2_fetchPcLowerResult(1)(i))
+  )
+
+  private val s2_rawPcLowerResult = twoFetchPcLowerResult
 
   private val instrSelectLowIndex   = WireDefault(VecInit.fill(PredictWidth)(true.B))
   private val instrSelectFetchBlock = WireDefault(VecInit.fill(PredictWidth)(false.B))
 
+  // Fetch PC and index info for valid instructions based on their positions.
   instrIndexEntry.zipWithIndex.foreach {
     case (index, idx) =>
       if (idx < PredictWidth / 2) {
         val validOH = Range(idx, 2 * idx + 2).map {
-          i => bubbleInstrValid(i) & (instrCountBeforeCurrent(i) === idx.U)
+          i => rawInstrValid(i) & (instrCountBeforeCurrent(i) === idx.U)
         }
         val computeIndex = Range(idx, 2 * idx + 2).map {
-          i => fetchBlockIndex(i)
+          i => twoFetchBlockIndex(i)
         }
         val computeSelect = Range(idx, 2 * idx + 2).map {
           i => fetchBlockSelect(i)
         }
         val computePcLowerResult = Range(idx, 2 * idx + 2).map {
-          i => fetchBlockPcLowerResult(i)
+          i => twoFetchPcLowerResult(i)
         }
         val computIsRvc = Range(idx, 2 * idx + 2).map {
           i => isRvc(i)
@@ -428,16 +447,16 @@ class Ifu(implicit p: Parameters) extends IfuModule
         s2_instrOffset(idx)        := Mux1H(validOH, computeInstrOffset)
       } else {
         val validOH = Range(idx, PredictWidth).map {
-          i => bubbleInstrValid(i) && (instrCountBeforeCurrent(i) === idx.U)
+          i => rawInstrValid(i) && (instrCountBeforeCurrent(i) === idx.U)
         }
         val computeIndex = Range(idx, PredictWidth).map {
-          i => fetchBlockIndex(i)
+          i => twoFetchBlockIndex(i)
         }
         val computeSelect = Range(idx, PredictWidth).map {
           i => fetchBlockSelect(i)
         }
         val computePcLowerResult = Range(idx, PredictWidth).map {
-          i => fetchBlockPcLowerResult(i)
+          i => twoFetchPcLowerResult(i)
         }
         val computIsRvc = Range(idx, PredictWidth).map {
           i => isRvc(i)
@@ -454,37 +473,60 @@ class Ifu(implicit p: Parameters) extends IfuModule
       }
   }
 
-  val s2_firstTakenIdx = WireDefault(0.U.asTypeOf(ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
-  s2_firstTakenIdx.valid := firstFtqOffset.valid
-  s2_firstTakenIdx.bits := Mux(
-    firstFtqOffset.valid,
-    instrCountBeforeCurrent(firstFtqOffset.bits + 1.U(5.W)) - 1.U,
-    PopCount(bubbleInstrValid.asUInt & s2_firstInstrRange) - 1.U
-  )
+  val s2_fetchTakenIdx = Wire(Vec(FetchPorts, ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
+  for (i <- 0 until FetchPorts) {
+    s2_fetchTakenIdx(i).valid := s2_ftqFetch(i).ftqOffset.valid
+    s2_fetchTakenIdx(i).bits  := PopCount(rawInstrValid.asUInt & s2_instrRange(i)) - 1.U
+  }
 
-  private val s2_firstBlock  = WireDefault(0.U.asTypeOf(new FetchBlockInfo))
-  private val s2_secondBlock = WireDefault(0.U.asTypeOf(new FetchBlockInfo))
-  s2_firstBlock.ftqIdx       := s2_ftqReq.ftqIdx
-  s2_firstBlock.predTakenIdx := s2_firstTakenIdx
-  s2_firstBlock.invalidTaken := !bubbleInstrValid(firstFtqOffset.bits) && firstFtqOffset.valid
+  s2_fetchTakenIdx(0).valid := s2_ftqFetch(0).ftqOffset.valid && s2_firstValid
+  s2_fetchTakenIdx(1).valid := s2_ftqFetch(1).ftqOffset.valid && s2_secondValid
 
-  s2_firstBlock.instrRange := s2_firstInstrRange // Temporary compromise for V2 compatibility; actually uses s1_firstJumpRange & s1_firstFtrRange
-  s2_firstBlock.pcHigh           := s2_ftqReq.startVAddr(VAddrBits - 1, PcCutPoint)
-  s2_firstBlock.pcHighPlus1      := s2_ftqReq.startVAddr(VAddrBits - 1, PcCutPoint) + 1.U
-  s2_firstBlock.target           := s2_ftqReq.nextStartVAddr
-  s2_firstBlock.fetchSize        := s2_firstFetchSize
-  s2_firstBlock.bubbleInstrValid := bubbleInstrValid.asUInt & s2_firstInstrRange
+  private val s2_fetchBlock = WireDefault(0.U.asTypeOf(Vec(FetchPorts, new FetchBlockInfo)))
+  for (i <- 0 until FetchPorts) {
+    s2_fetchBlock(i).ftqIdx          := s2_ftqFetch(i).ftqIdx
+    s2_fetchBlock(i).doubline        := s2_doubleline(i)
+    s2_fetchBlock(i).predTakenIdx    := s2_fetchTakenIdx(i)
+    s2_fetchBlock(i).invalidTaken    := !rawInstrValid(s2_ftqFetch(i).ftqOffset.bits) && s2_ftqFetch(i).ftqOffset.valid
+    s2_fetchBlock(i).ftqOffset.valid := s2_ftqFetch(i).ftqOffset.valid
+    s2_fetchBlock(i).ftqOffset.bits  := s2_ftqFetch(i).ftqOffset.bits
+    s2_fetchBlock(i).instrRange      := s2_instrRange(i)
+    s2_fetchBlock(i).pcHigh          := s2_ftqFetch(i).startVAddr(VAddrBits - 1, PcCutPoint)
+    s2_fetchBlock(i).pcHighPlus1     := s2_ftqFetch(i).startVAddr(VAddrBits - 1, PcCutPoint) + 1.U
+    s2_fetchBlock(i).startAddr       := s2_ftqFetch(i).startVAddr
+    s2_fetchBlock(i).target          := s2_ftqFetch(i).nextStartVAddr
+    s2_fetchBlock(i).fetchSize       := s2_fetchSize(i)
+    s2_fetchBlock(i).rawInstrValid   := rawInstrValid.asUInt & s2_instrRange(i)
+  }
+  s2_fetchBlock(0).ftqOffset.valid := s2_ftqFetch(0).ftqOffset.valid && s2_firstValid
+  s2_fetchBlock(1).ftqOffset.valid := s2_ftqFetch(1).ftqOffset.valid && s2_secondValid
 
-  s2_secondBlock.bubbleInstrValid := (bubbleInstrValid.asUInt >> s2_firstFetchSize) & s2_secondInstrRange
-  private val s2_rawDataDupWire = VecInit(Seq.fill(2)(s2_rawData))
+  s2_fetchBlock(0).rawInstrValid := rawInstrValid.asUInt & s2_instrRange(0)
+  s2_fetchBlock(1).rawInstrValid := (rawInstrValid.asUInt >> s2_fetchSize(0)) & s2_instrRange(1)
+  private val s2_rawFirstDataDupWire  = VecInit(Seq.fill(2)(s2_rawData))
+  private val s2_rawSecondDataDupWire = VecInit.fill(FetchPorts)(0.U((ICacheLineBytes * 8).W))
+  private val s2_firstEndIdx          = s2_fetchTakenIdx(0).bits
+
+  // When fetching two predicted blocks, if the first ends with a half instruction,
+  // the cross-block instruction may be misinterpreted under the current index calculation.
+  // Correction is needed to ensure accurate decoding at block boundaries.
+  private val recoverDataVec = WireDefault(0.U.asTypeOf(Vec(ICacheLineBytes / 2, UInt(16.W))))
+  private val needRecover    = s2_firstFetchEndIsHalf && s2_firstValid && s2_secondValid
+  private val recoverData    = recoverDataVec(s2_fetchBlock(1).startAddr(log2Ceil(ICacheLineBytes) - 1, 1))
+  private val selectRecover  = WireDefault(0.U.asTypeOf(Vec(PredictWidth, Bool())))
+  selectRecover(s2_firstEndIdx) := needRecover
+
+  // Special case for MMIO:
+  // If two fetches occur and the first is non-MMIO while the second is MMIO,
+  // delay the second fetch by one cycle to split into a one-fetch.
 
   /* *****************************************************************************
    * IFU Stage 3
-   *
    * ***************************************************************************** */
   private val s3_valid          = ValidHold(s2_fire && !s2_flush, s3_fire, s3_flush)
-  private val s3_ftqReq         = RegEnable(s2_ftqReq, s2_fire)
-  private val s3_doubleline     = RegEnable(s2_doubleline, s2_fire)
+  private val s3_firstValid     = ValidHold(s2_fire && !s2_flush && s2_firstValid, s3_fire, s3_flush)
+  private val s3_secondValid    = ValidHold(s2_fire && !s2_flush && s2_secondValid, s3_fire, s3_flush)
+  private val s3_fetchBlock     = RegEnable(s2_fetchBlock, s2_fire)
   private val s3_prevIBufEnqPtr = RegInit(0.U.asTypeOf(new IBufPtr))
 
   s3_fire  := s3_valid && s4_ready
@@ -493,45 +535,50 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s3_instrIndex       = RegEnable(instrIndexEntry, s2_fire)
   private val s3_selectFetchBlock = RegEnable(instrSelectFetchBlock, s2_fire)
   private val s3_instrIsRvc       = RegEnable(s2_instrIsRvc, s2_fire)
-  private val s3_instrCount       = RegEnable(PopCount(bubbleInstrValid), s2_fire)
-  private val s3_instrValid       = RegEnable(UIntToMask(PopCount(bubbleInstrValid), PredictWidth), s2_fire)
+  private val s3_instrCount       = RegEnable(PopCount(rawInstrValid), s2_fire)
+  private val s3_instrValid       = RegEnable(UIntToMask(PopCount(rawInstrValid), PredictWidth), s2_fire)
 
-  private val s3_firstBlock        = RegEnable(s2_firstBlock, s2_fire)
-  private val s3_secondBlock       = RegEnable(s2_secondBlock, s2_fire)
-  private val s3_bubbleIndex       = RegEnable(instrCountBeforeCurrent, s2_fire)
-  private val s3_bubbleInstrValid  = RegEnable(bubbleInstrValid, s2_fire)
+  private val s3_rawIndex          = RegEnable(instrCountBeforeCurrent, s2_fire)
+  private val s3_rawInstrValid     = RegEnable(rawInstrValid, s2_fire)
   private val s3_prevLastIsHalfRvi = RegEnable(s2_prevLastIsHalfRvi, s2_fire)
   private val s3_prevLastHalfData  = RegInit(0.U(16.W))
+  private val s3_perfInfo          = RegEnable(s2_perfInfo, s2_fire)
 
-  private val s3_rawDataDup         = RegEnable(s2_rawDataDupWire, s2_fire)
-  private val s3_exception          = RegEnable(s2_exception, s2_fire)
-  private val s3_isBackendException = RegEnable(s2_isBackendException, s2_fire)
-  private val s3_pAddr              = RegEnable(s2_pAddr, s2_fire)
-  private val s3_gpAddr             = RegEnable(s2_gpAddr, s2_fire)
-  private val s3_isForVSnonLeafPTE  = RegEnable(s2_isForVSnonLeafPTE, s2_fire)
-  private val s3_perfInfo           = RegEnable(s2_perfInfo, s2_fire)
-  private val s3_pmpMmio            = RegEnable(s2_pmpMmio, s2_fire)
-  private val s3_itlbPbmt           = RegEnable(s2_itlbPbmt, s2_fire)
-  private val s3_instrOffset        = RegEnable(s2_instrOffset, s2_fire)
-  private val s3_resendVAddr        = RegEnable(s2_ftqReq.startVAddr + 2.U, s2_fire)
+  private val s3_selectRecover = RegEnable(selectRecover, s2_fire)
+  private val s3_needRecover   = RegEnable(needRecover, s2_fire)
+  private val s3_recoverData   = RegEnable(recoverData, s2_fire)
 
-  private val s3_instrPcLowerResult  = RegEnable(s2_instrPcLowerResult, s2_fire)
-  private val s3_bubblePcLowerResult = RegEnable(s2_bubblePcLowerResult, s2_fire)
+  // Temporarily written this way. In practice, the way ICache passes parameters may need significant changes,
+  // especially if the number of TLBs is reduced.
+  private val s3_rawFirstDataDup  = RegEnable(s2_rawFirstDataDupWire, s2_fire)
+  private val s3_rawSecondDataDup = RegEnable(s2_rawSecondDataDupWire, s2_fire)
+
+  private val s3_doubleline       = RegEnable(s2_doubleline, s2_fire)
+  private val s3_icacheInfo       = RegEnable(s2_icacheInfo, s2_fire)
+  private val s3_instrOffset      = RegEnable(s2_instrOffset, s2_fire)
+  private val s3_firstResendVAddr = RegEnable(s2_fetchBlock(0).startAddr + 2.U, s2_fire)
+
+  private val s3_instrPcLowerResult = RegEnable(s2_instrPcLowerResult, s2_fire)
+  private val s3_rawPcLowerResult   = RegEnable(s2_rawPcLowerResult, s2_fire)
+
+  // Offset logic to ensure the IBuffer enqueue interface is properly aligned.
+
   private val s3_pc = VecInit.tabulate(PredictWidth)(i =>
     catPC(
       s3_instrPcLowerResult(i),
-      Mux(s3_selectFetchBlock(i), s3_secondBlock.pcHigh, s3_firstBlock.pcHigh),
-      Mux(s3_selectFetchBlock(i), s3_secondBlock.pcHighPlus1, s3_firstBlock.pcHighPlus1)
+      Mux(s3_selectFetchBlock(i), s3_fetchBlock(1).pcHigh, s3_fetchBlock(0).pcHigh),
+      Mux(s3_selectFetchBlock(i), s3_fetchBlock(1).pcHighPlus1, s3_fetchBlock(0).pcHighPlus1)
     )
   )
+
   private val s3_foldPc = VecInit(s3_pc.map(i => XORFold(i(VAddrBits - 1, 1), MemPredPCWidth)))
 
-  private val s3_exceptionVec = VecInit((0 until PredictWidth).map(i =>
+  private val s3_firstExceptionVec = VecInit((0 until PredictWidth).map(i =>
     MuxCase(
       ExceptionType.None,
       Seq(
-        !isNextLine(s3_pc(i), s3_ftqReq.startVAddr)                   -> s3_exception(0),
-        (isNextLine(s3_pc(i), s3_ftqReq.startVAddr) && s3_doubleline) -> s3_exception(1)
+        !isNextLine(s3_pc(i), s3_fetchBlock(0).startAddr)                      -> s3_icacheInfo(0).exception(0),
+        (isNextLine(s3_pc(i), s3_fetchBlock(0).startAddr) && s3_doubleline(0)) -> s3_icacheInfo(0).exception(1)
       )
     )
   ))
@@ -564,24 +611,39 @@ class Ifu(implicit p: Parameters) extends IfuModule
    * - ICache respond to IFU:
    * https://github.com/OpenXiangShan/XiangShan/blob/d4078d6edbfb4611ba58c8b0d1d8236c9115dbfc/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala#L473
    */
+  // Placeholder logic for now; subject to change later
+  private val s3_firstLowICacheData   = cutICacheData(s3_rawFirstDataDup(0))
+  private val s3_firstHighICacheData  = cutICacheData(s3_rawFirstDataDup(1))
+  private val s3_secondLowICacheData  = cutICacheData(s3_rawSecondDataDup(0))
+  private val s3_secondHighICacheData = cutICacheData(s3_rawSecondDataDup(1))
 
-  private val s3_lowICacheData  = cutICacheData(s3_rawDataDup(0))
-  private val s3_highICacheData = cutICacheData(s3_rawDataDup(1))
-
+  // Valid instructions are densely packed from the front
   private val noBubbleInstrData = WireDefault(VecInit.fill(PredictWidth)(0.U(32.W)))
   for (i <- 0 until PredictWidth / 2) {
-    noBubbleInstrData(i)                    := s3_lowICacheData(s3_instrIndex(i).value)
-    noBubbleInstrData(i + PredictWidth / 2) := s3_highICacheData(s3_instrIndex(i + PredictWidth / 2).value)
+    val lowIdx     = s3_instrIndex(i).value
+    val highIdx    = s3_instrIndex(i + PredictWidth / 2).value
+    val j          = i + PredictWidth / 2
+    val lowSelect  = s3_selectFetchBlock(i)
+    val highSelect = s3_selectFetchBlock(j)
+    noBubbleInstrData(i) := Mux(!lowSelect, s3_firstLowICacheData(lowIdx), s3_secondLowICacheData(lowIdx))
+    noBubbleInstrData(j) := Mux(!highSelect, s3_firstHighICacheData(highIdx), s3_secondHighICacheData(highIdx))
   }
   private val s3_realInstrData = WireDefault(VecInit.fill(PredictWidth)(0.U(32.W)))
-  for (i <- 0 until PredictWidth) {
-    s3_realInstrData(i) := noBubbleInstrData(i)
-  }
+
   s3_realInstrData(0) := Mux(
     s3_prevLastIsHalfRvi,
     Cat(noBubbleInstrData(0)(15, 0), s3_prevLastHalfData),
     noBubbleInstrData(0)
   )
+
+  for (i <- 1 until PredictWidth) {
+    s3_realInstrData(i) := Mux(
+      s3_selectRecover(i),
+      Cat(s3_recoverData, noBubbleInstrData(0)(15, 0)),
+      noBubbleInstrData(i)
+    )
+  }
+
   when(s3_fire && !s3_flush) {
     s3_prevLastHalfData := s3_realInstrData(s3_instrCount - 1.U)(15, 0)
   }.elsewhen(s4_flush) {
@@ -608,17 +670,34 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s3_pd         = preDecoderOut.pd
   private val s3_jumpOffset = preDecoderOut.jumpOffset
 
-  /* if there is a cross-page RVI instruction, and the former page has no exception,
-   * whether it has exception is actually depends on the latter page
-   */
-  private val s3_crossPageExceptionVec = VecInit((0 until PredictWidth).map { i =>
+  // No longer applicable for prediction blocks crossing page boundaries; awaiting modification.
+  private val s3_firstCrossPageExceptionVec = VecInit((0 until PredictWidth).map { i =>
     Mux(
-      isLastInLine(s3_pc(i)) && !s3_pd(i).isRVC && s3_doubleline && s2_exception(0).isNone,
-      s3_exception(1),
+      isLastInLine(s3_pc(i)) && !s3_pd(i).isRVC && s3_doubleline(0) && s3_icacheInfo(0).exception(0).isNone,
+      s3_icacheInfo(0).exception(1),
       ExceptionType.None
     )
   })
   XSPerfAccumulate("fetch_bubble_icache_not_resp", s3_valid && !icacheRespAllValid)
+
+  private val s3_isPredTaken = VecInit.tabulate(PredictWidth)(i =>
+    ((s3_fetchBlock(0).predTakenIdx.bits === i.U && s3_fetchBlock(0).predTakenIdx.valid) &&
+      !s3_selectFetchBlock(i) && s3_firstValid) ||
+      ((s3_fetchBlock(1).predTakenIdx.bits === i.U && s3_fetchBlock(1).predTakenIdx.valid) &&
+        s3_selectFetchBlock(i) && s3_secondValid)
+  )
+
+  private val s3_invalidTaken = WireDefault(VecInit.fill(PredictWidth)(false.B))
+  s3_invalidTaken(s3_fetchBlock(0).predTakenIdx.bits) := s3_fetchBlock(0).invalidTaken && s3_firstValid
+  s3_invalidTaken(s3_fetchBlock(1).predTakenIdx.bits) := s3_fetchBlock(1).invalidTaken && s3_secondValid
+
+  private val s3_firstIsMmio = s3_valid && (s3_icacheInfo(0).pmpMmio || Pbmt.isUncache(s3_icacheInfo(0).itlbPbmt)) &&
+    s3_icacheInfo(0).exception.map(_.isNone).reduce(_ && _)
+  private val s3_secondIsMmio    = false.B
+  private val s3_mmioResendVAddr = s3_firstResendVAddr
+  private val s3_mmioFtqIdx      = s3_fetchBlock(0).ftqIdx
+
+  assert(!s3_secondIsMmio, "MMIO and non-MMIO instructions cannot be processed in the same cycle")
 
   /* *****************************************************************************
    * IFU Stage 4
@@ -633,29 +712,28 @@ class Ifu(implicit p: Parameters) extends IfuModule
    * ***************************************************************************** */
 
   // assign later
-  private val s4_valid = WireInit(false.B)
-
-  private val s4_ftqReq         = RegEnable(s3_ftqReq, s3_fire)
+  private val s4_valid          = WireInit(false.B)
+  private val s4_firstValid     = ValidHold(s3_fire && !s3_flush && s3_firstValid, s4_fire, s4_flush)
+  private val s4_secondValid    = ValidHold(s3_fire && !s3_flush && s3_secondValid, s4_fire, s4_flush)
+  private val s4_fetchBlock     = RegEnable(s3_fetchBlock, s3_fire)
   private val s4_doubleline     = RegEnable(s3_doubleline, s3_fire)
   private val s4_prevIBufEnqPtr = RegEnable(s3_prevIBufEnqPtr, s3_fire)
   s4_fire := io.toIBuffer.fire
 
-  private val invalidTaken = WireDefault(VecInit.fill(PredictWidth)(false.B))
-  invalidTaken(s3_firstBlock.predTakenIdx.bits)  := s3_firstBlock.invalidTaken
-  invalidTaken(s3_secondBlock.predTakenIdx.bits) := s3_secondBlock.invalidTaken
-
-  private val s4_firstBlock       = RegEnable(s3_firstBlock, s3_fire)
-  private val s4_secondBlock      = RegEnable(s3_secondBlock, s3_fire)
-  private val s4_invalidTaken     = RegEnable(invalidTaken, s3_fire)
+  private val s4_invalidTaken     = RegEnable(s3_invalidTaken, s3_fire)
   private val s4_selectFetchBlock = RegEnable(s3_selectFetchBlock, s3_fire)
   private val s4_instrData        = RegEnable(s3_realInstrData, s3_fire)
-  private val s4_bubbleIndex      = RegEnable(s3_bubbleIndex, s3_fire)
+  private val s4_rawIndex         = RegEnable(s3_rawIndex, s3_fire)
   private val s4_instrValid       = RegEnable(s3_instrValid, s3_fire)
+  private val s4_firstIsMmio      = RegEnable(s3_firstIsMmio, s3_fire)
 
-  private val s4_exception          = RegEnable(s3_exception, s3_fire)
-  private val s4_pmpMmio            = RegEnable(s3_pmpMmio, s3_fire)
-  private val s4_itlbPbmt           = RegEnable(s3_itlbPbmt, s3_fire)
-  private val s4_isBackendException = RegEnable(s3_isBackendException, s3_fire)
+  private val s4_mmioResendVAddr = RegEnable(s3_mmioResendVAddr, s3_fire)
+  private val s4_mmioFtqIdx      = RegEnable(s3_mmioFtqIdx, s3_fire)
+
+  private val s4_firstExceptionVec          = RegEnable(s3_firstExceptionVec, s3_fire)
+  private val s4_firstCrossPageExceptionVec = RegEnable(s3_firstCrossPageExceptionVec, s3_fire)
+
+  private val s4_icacheInfo = RegEnable(s3_icacheInfo, s3_fire)
 
   rvcExpanders.zipWithIndex.foreach { case (expander, i) =>
     expander.io.in      := s4_instrData(i)
@@ -668,40 +746,40 @@ class Ifu(implicit p: Parameters) extends IfuModule
   })
   private val s4_ill = VecInit(rvcExpanders.map(_.io.ill))
 
-  private val s4_pdWire                = RegEnable(s3_pd, s3_fire)
-  private val s4_pd                    = WireInit(s4_pdWire)
-  private val s4_jumpOffset            = RegEnable(s3_jumpOffset, s3_fire)
-  private val s4_exceptionVec          = RegEnable(s3_exceptionVec, s3_fire)
-  private val s4_crossPageExceptionVec = RegEnable(s3_crossPageExceptionVec, s3_fire)
-  private val s4_instrPcLowerResult    = RegEnable(s3_instrPcLowerResult, s3_fire)
-  private val s4_bubblePcLowerResult   = RegEnable(s3_bubblePcLowerResult, s3_fire)
+  private val s4_pdWire             = RegEnable(s3_pd, s3_fire)
+  private val s4_pd                 = WireInit(s4_pdWire)
+  private val s4_jumpOffset         = RegEnable(s3_jumpOffset, s3_fire)
+  private val s4_instrPcLowerResult = RegEnable(s3_instrPcLowerResult, s3_fire)
+  private val s4_rawPcLowerResult   = RegEnable(s3_rawPcLowerResult, s3_fire)
 
   private val s4_pc = VecInit.tabulate(PredictWidth)(i =>
     catPC(
       s4_instrPcLowerResult(i),
-      Mux(s4_selectFetchBlock(i), s4_secondBlock.pcHigh, s4_firstBlock.pcHigh),
-      Mux(s4_selectFetchBlock(i), s4_secondBlock.pcHighPlus1, s4_firstBlock.pcHighPlus1)
+      Mux(s4_selectFetchBlock(i), s4_fetchBlock(1).pcHigh, s4_fetchBlock(0).pcHigh),
+      Mux(s4_selectFetchBlock(i), s4_fetchBlock(1).pcHighPlus1, s4_fetchBlock(0).pcHighPlus1)
     )
   )
 
   private val s4_foldPc            = RegEnable(s3_foldPc, s3_fire)
-  private val s4_pAddr             = RegEnable(s3_pAddr, s3_fire)
-  private val s4_gpAddr            = RegEnable(s3_gpAddr, s3_fire)
-  private val s4_isForVSnonLeafPTE = RegEnable(s3_isForVSnonLeafPTE, s3_fire)
-  private val s4_resendVAddr       = RegEnable(s3_resendVAddr, s3_fire)
-  private val s4_bubbleInstrValid  = RegEnable(s3_bubbleInstrValid, s3_fire)
+  private val s4_rawInstrValid     = RegEnable(s3_rawInstrValid, s3_fire)
   private val s4_prevLastIsHalfRvi = RegEnable(s3_prevLastIsHalfRvi, s3_fire)
   private val s4_instrOffset       = RegEnable(s3_instrOffset, s3_fire)
+  private val s4_isPredTaken       = RegEnable(s3_isPredTaken, s3_fire)
 
   // Expand 1 bit to prevent overflow when assert
-  private val s4_ftqReqStartAddr     = PrunedAddrInit(Cat(0.U(1.W), s4_ftqReq.startVAddr.toUInt))
-  private val s4_ftqReqNextStartAddr = PrunedAddrInit(Cat(0.U(1.W), s4_ftqReq.nextStartVAddr.toUInt))
-
-  when(s4_valid && !s4_ftqReq.ftqOffset.valid) {
-    assert(
-      s4_ftqReqStartAddr + (2 * PredictWidth).U >= s4_ftqReqNextStartAddr,
-      s"More than ${2 * PredictWidth} Bytes fetch is not allowed!"
-    )
+  private val s4_fetchStartAddr = VecInit.tabulate(FetchPorts)(i =>
+    PrunedAddrInit(Cat(0.U(1.W), s4_fetchBlock(i).startAddr.toUInt))
+  )
+  private val s4_fetchNextStartAddr = VecInit.tabulate(FetchPorts)(i =>
+    PrunedAddrInit(Cat(0.U(1.W), s4_fetchBlock(i).target.toUInt))
+  )
+  for (i <- 0 until FetchPorts) {
+    when(s4_valid && !s4_fetchBlock(i).ftqOffset.valid) {
+      assert(
+        s4_fetchStartAddr(i) + (2 * PredictWidth).U >= s4_fetchNextStartAddr(i),
+        s"More than ${2 * PredictWidth} Bytes fetch is not allowed!"
+      )
+    }
   }
 
   /* *** mmio *** */
@@ -744,15 +822,12 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   // last instruction finish
   private val isFirstInstr = RegInit(true.B)
+  private val s4_reqIsMmio = s4_firstIsMmio && s4_valid
 
   /* Determine whether the MMIO instruction is executable based on the previous prediction block */
-  io.toFtq.mmioCommitRead.mmioFtqPtr := RegNext(s4_ftqReq.ftqIdx - 1.U)
-
-  // do mmio fetch only when pmp/pbmt shows it is a un-cacheable address and no exception occurs
-  private val s4_reqIsMmio =
-    s4_valid && (s4_pmpMmio || Pbmt.isUncache(s4_itlbPbmt)) && s3_exception.map(_.isNone).reduce(_ && _)
+  io.toFtq.mmioCommitRead.mmioFtqPtr := RegNext(s4_mmioFtqIdx - 1.U)
   private val mmioCommit = VecInit(io.robCommits.map { commit =>
-    commit.valid && commit.bits.ftqIdx === s4_ftqReq.ftqIdx && commit.bits.ftqOffset === 0.U
+    commit.valid && commit.bits.ftqIdx === s4_mmioFtqIdx && commit.bits.ftqOffset === 0.U
   }).asUInt.orR
   private val s4_mmioReqCommit = s4_reqIsMmio && mmioState === MmioFsmState.Commited
 
@@ -770,7 +845,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val mmioF4Flush     = RegNext(s4_flush, init = false.B)
   private val s4_ftqFlushSelf = fromFtqRedirectReg.valid && RedirectLevel.flushItself(fromFtqRedirectReg.bits.level)
   private val s4_ftqFlushByOlder =
-    fromFtqRedirectReg.valid && isBefore(fromFtqRedirectReg.bits.ftqIdx, s4_ftqReq.ftqIdx)
+    fromFtqRedirectReg.valid && isBefore(fromFtqRedirectReg.bits.ftqIdx, s4_mmioFtqIdx)
 
   private val s4_needNotFlush = s4_reqIsMmio && fromFtqRedirectReg.valid && !s4_ftqFlushSelf && !s4_ftqFlushByOlder
 
@@ -795,7 +870,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val (redirectFtqIdx, redirectFtqOffset) =
     (fromFtqRedirectReg.bits.ftqIdx, fromFtqRedirectReg.bits.ftqOffset)
   private val redirectMmioReq =
-    fromFtqRedirectReg.valid && redirectFtqIdx === s4_ftqReq.ftqIdx && redirectFtqOffset === 0.U
+    fromFtqRedirectReg.valid && redirectFtqIdx === s4_mmioFtqIdx && redirectFtqOffset === 0.U
 
   private val s4_mmioUseSnpc = ValidHold(RegNext(s3_fire && !s3_flush) && s4_reqIsMmio, redirectMmioReq)
 
@@ -806,7 +881,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
     is(MmioFsmState.Idle) {
       when(s4_reqIsMmio) {
         // in idempotent spaces, we can send request directly (i.e. can do speculative fetch)
-        mmioState := Mux(s4_itlbPbmt === Pbmt.nc, MmioFsmState.SendReq, MmioFsmState.WaitLastCommit)
+        mmioState := Mux(s4_icacheInfo(0).itlbPbmt === Pbmt.nc, MmioFsmState.SendReq, MmioFsmState.WaitLastCommit)
       }
     }
 
@@ -827,7 +902,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
         val respIsRVC = isRVC(fromUncache.bits.data(1, 0))
         val exception = ExceptionType(hasAf = fromUncache.bits.corrupt)
         // when response is not RVC, and lower bits of pAddr is 6 => request crosses 8B boundary, need resend
-        val needResend = !respIsRVC && s4_pAddr(0)(2, 1) === 3.U && exception.isNone
+        val needResend = !respIsRVC && s4_icacheInfo(0).pAddr(0)(2, 1) === 3.U && exception.isNone
         mmioState     := Mux(needResend, MmioFsmState.SendTlb, MmioFsmState.WaitCommit)
         mmioException := exception
         mmioIsRvc     := respIsRVC
@@ -847,7 +922,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
         assert(!io.itlb.resp.bits.miss, "blocked mode iTLB miss when resp.fire")
         val itlbException = ExceptionType.fromTlbResp(io.itlb.resp.bits)
         // if itlb re-check respond pbmt mismatch with previous check, must be access fault
-        val pbmtMismatchException = ExceptionType(hasAf = io.itlb.resp.bits.pbmt(0) =/= s3_itlbPbmt)
+        val pbmtMismatchException = ExceptionType(hasAf = io.itlb.resp.bits.pbmt(0) =/= s4_icacheInfo(0).itlbPbmt)
         // merge, itlbException has higher priority
         val exception = itlbException || pbmtMismatchException
         // if tlb has exception, abort checking pmp, just send instr & exception to iBuffer and wait for commit
@@ -863,7 +938,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
     is(MmioFsmState.SendPmp) {
       val pmpException = ExceptionType.fromPmpResp(io.pmp.resp)
       // if pmp re-check respond mismatch with previous check, must be access fault
-      val mmioMismatchException = ExceptionType(hasAf = io.pmp.resp.mmio =/= s3_pmpMmio)
+      val mmioMismatchException = ExceptionType(hasAf = io.pmp.resp.mmio =/= s4_icacheInfo(0).pmpMmio)
       // merge, pmpException has higher priority
       val exception = pmpException || mmioMismatchException
       // if pmp has exception, abort sending request, just send instr & exception to iBuffer and wait for commit
@@ -887,7 +962,11 @@ class Ifu(implicit p: Parameters) extends IfuModule
     is(MmioFsmState.WaitCommit) {
       // in idempotent spaces, we can skip waiting for commit (i.e. can do speculative fetch)
       // but we do not skip MmioFsmState.WaitCommit state, as other signals (e.g. s3_mmioCanGo relies on this)
-      mmioState := Mux(mmioCommit || s4_itlbPbmt === Pbmt.nc, MmioFsmState.Commited, MmioFsmState.WaitCommit)
+      mmioState := Mux(
+        mmioCommit || s4_icacheInfo(0).itlbPbmt === Pbmt.nc,
+        MmioFsmState.Commited,
+        MmioFsmState.WaitCommit
+      )
     }
 
     // normal mmio instruction
@@ -902,15 +981,17 @@ class Ifu(implicit p: Parameters) extends IfuModule
     mmioReset()
   }
 
-  toUncache.valid := ((mmioState === MmioFsmState.SendReq) || (mmioState === MmioFsmState.ResendReq)) && s4_reqIsMmio
-  toUncache.bits.addr := Mux(mmioState === MmioFsmState.ResendReq, mmioResendAddr, s4_pAddr(0))
+  toUncache.valid := ((mmioState === MmioFsmState.SendReq) || (mmioState === MmioFsmState.ResendReq)) &&
+    s4_reqIsMmio && s4_valid
+
+  toUncache.bits.addr := Mux(mmioState === MmioFsmState.ResendReq, mmioResendAddr, s4_icacheInfo(0).pAddr(0))
   fromUncache.ready   := true.B
 
   // send itlb request in MmioFsmState.SendTlb state
   io.itlb.req.valid                   := (mmioState === MmioFsmState.SendTlb) && s4_reqIsMmio
   io.itlb.req.bits.size               := 3.U
-  io.itlb.req.bits.vaddr              := s4_resendVAddr.toUInt
-  io.itlb.req.bits.debug.pc           := s4_resendVAddr.toUInt
+  io.itlb.req.bits.vaddr              := s4_mmioResendVAddr.toUInt
+  io.itlb.req.bits.debug.pc           := s4_mmioResendVAddr.toUInt
   io.itlb.req.bits.cmd                := TlbCmd.exec
   io.itlb.req.bits.isPrefetch         := false.B
   io.itlb.req.bits.kill               := false.B // IFU use itlb for mmio, doesn't need sync, set it to false
@@ -935,23 +1016,26 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   private val s4_mmioRange      = VecInit((0 until PredictWidth).map(i => if (i == 0) true.B else false.B))
   private val s4_realInstrValid = Wire(Vec(PredictWidth, Bool()))
+  private val ignore            = WireDefault(VecInit.fill(IBufWriteBank)(false.B))
+  ignore(0) := s4_prevLastIsHalfRvi
 
   /* ** prediction result check ** */
-  checkerIn.valid                      := s4_valid
-  checkerIn.bits.instrJumpOffset       := s4_jumpOffset
-  checkerIn.bits.instrValid            := s4_instrValid.asTypeOf(Vec(PredictWidth, Bool()))
-  checkerIn.bits.instrPds              := s4_pd
-  checkerIn.bits.instrPc               := s4_pc
-  checkerIn.valid                      := RegNext(s3_fire, init = false.B)
-  checkerIn.bits.tempPrevLastIsHalfRvi := s4_prevLastIsHalfRvi
+  checkerIn.valid                := s4_valid
+  checkerIn.bits.instrJumpOffset := s4_jumpOffset
+  checkerIn.bits.instrValid      := s4_instrValid.asTypeOf(Vec(PredictWidth, Bool()))
+  checkerIn.bits.instrPds        := s4_pd
+  checkerIn.bits.instrPc         := s4_pc
+  checkerIn.bits.isPredTaken     := s4_isPredTaken
+  checkerIn.bits.ignore          := ignore
+  checkerIn.bits.shiftNum        := s4_prevIBufEnqPtr.value(1, 0)
 
-  checkerIn.bits.firstFtqPredTakenIdx  := s4_firstBlock.predTakenIdx
-  checkerIn.bits.secondFtqPredTakenIdx := s4_secondBlock.predTakenIdx
-  checkerIn.bits.firstTarget           := s4_firstBlock.target
-  checkerIn.bits.secondTarget          := s4_secondBlock.target
-  checkerIn.bits.selectFetchBlock      := s4_selectFetchBlock
-  checkerIn.bits.invalidTaken          := s4_invalidTaken
-  checkerIn.bits.instrOffset           := s4_instrOffset
+  checkerIn.bits.firstPredTakenIdx  := s4_fetchBlock(0).predTakenIdx
+  checkerIn.bits.secondPredTakenIdx := s4_fetchBlock(1).predTakenIdx
+  checkerIn.bits.firstTarget        := s4_fetchBlock(0).target
+  checkerIn.bits.secondTarget       := s4_fetchBlock(1).target
+  checkerIn.bits.selectFetchBlock   := s4_selectFetchBlock
+  checkerIn.bits.invalidTaken       := s4_invalidTaken
+  checkerIn.bits.instrOffset        := s4_instrOffset
 
   s4_realInstrValid.zipWithIndex.map {
     case (valid, i) =>
@@ -962,7 +1046,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   /* ** frontend Trigger  ** */
   frontendTrigger.io.pds             := s4_pd
   frontendTrigger.io.pc              := s4_pc
-  frontendTrigger.io.data            := 0.U.asTypeOf(Vec(IBufEnqWidth + 1, UInt(16.W))) // s4_noBubbleInstrData
+  frontendTrigger.io.data            := 0.U.asTypeOf(Vec(IBufferInPortNum + 1, UInt(16.W))) // s4_noBubbleInstrData
   frontendTrigger.io.frontendTrigger := io.frontendTrigger
   private val s4_triggered = frontendTrigger.io.triggered
 
@@ -974,7 +1058,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   io.toIBuffer.bits.valid          := s4_realInstrValid.asUInt
   io.toIBuffer.bits.enqEnable      := checkerOutStage1.fixedTwoFetchRange.asUInt & s4_realInstrValid.asUInt
   io.toIBuffer.bits.pd             := s4_pd
-  io.toIBuffer.bits.ftqPtr         := s4_ftqReq.ftqIdx
+  io.toIBuffer.bits.ftqPtr         := s4_fetchBlock(0).ftqIdx
   io.toIBuffer.bits.pc             := s4_pc
   io.toIBuffer.bits.prevIBufEnqPtr := s4_prevIBufEnqPtr
   // Find last using PriorityMux
@@ -985,23 +1069,23 @@ class Ifu(implicit p: Parameters) extends IfuModule
     a.valid       := checkerOutStage1.fixedTwoFetchTaken(i) && !s4_reqIsMmio
   }
   io.toIBuffer.bits.foldpc := s4_foldPc
-  io.toIBuffer.bits.exceptionType := VecInit((s4_exceptionVec zip s4_crossPageExceptionVec).map { case (e, ce) =>
-    e || ce // merge, cross page fix has lower priority
+  io.toIBuffer.bits.exceptionType := VecInit((s4_firstExceptionVec zip s4_firstCrossPageExceptionVec).map {
+    case (e, ce) => e || ce // merge, cross page fix has lower priority
   })
   // backendException only needs to be set for the first instruction.
   // Other instructions in the same block may have pf or af set,
   // which is a side effect of the first instruction and actually not necessary.
-  io.toIBuffer.bits.backendException := (0 until IBufEnqWidth).map {
-    case 0 => s4_isBackendException
+  io.toIBuffer.bits.backendException := (0 until IBufferInPortNum).map {
+    case 0 => s4_icacheInfo(0).isBackendException
     case _ => false.B
   }
-  io.toIBuffer.bits.crossPageIPFFix := s4_crossPageExceptionVec.map(_.hasException)
+  io.toIBuffer.bits.crossPageIPFFix := s4_firstCrossPageExceptionVec.map(_.hasException)
   io.toIBuffer.bits.illegalInstr    := s4_ill
   io.toIBuffer.bits.triggered       := s4_triggered
 
   when(io.toIBuffer.valid && io.toIBuffer.ready) {
     val enqVec = io.toIBuffer.bits.enqEnable
-    val allocateSeqNum = VecInit((0 until IBufEnqWidth).map { i =>
+    val allocateSeqNum = VecInit((0 until IBufferInPortNum).map { i =>
       val idx  = PopCount(enqVec.take(i + 1))
       val pc   = s4_pc(i).toUInt
       val code = io.toIBuffer.bits.instrs(i)
@@ -1021,14 +1105,14 @@ class Ifu(implicit p: Parameters) extends IfuModule
   io.toBackend.gpaddrMem_wen := s4_toIBufferValid && Mux(
     s4_reqIsMmio,
     mmioException.isGpf,
-    s4_exception.map(_.isGpf).reduce(_ || _)
+    s4_icacheInfo(0).exception.map(_.isGpf).reduce(_ || _)
   )
-  io.toBackend.gpaddrMem_waddr        := s4_ftqReq.ftqIdx.value
-  io.toBackend.gpaddrMem_wdata.gpaddr := Mux(s4_reqIsMmio, mmioResendGpAddr.toUInt, s4_gpAddr.toUInt)
+  io.toBackend.gpaddrMem_waddr        := s4_fetchBlock(0).ftqIdx.value
+  io.toBackend.gpaddrMem_wdata.gpaddr := Mux(s4_reqIsMmio, mmioResendGpAddr.toUInt, s4_icacheInfo(0).gpAddr.toUInt)
   io.toBackend.gpaddrMem_wdata.isForVSnonLeafPTE := Mux(
     s4_reqIsMmio,
     mmioResendIsForVSnonLeafPTE,
-    s4_isForVSnonLeafPTE
+    s4_icacheInfo(0).isForVSnonLeafPTE
   )
 
   // Write back to Ftq
@@ -1042,14 +1126,14 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // In this case, mask .valid to avoid overriding backend redirect
   mmioFlushWb.valid := (s4_reqIsMmio && mmioState === MmioFsmState.WaitCommit && RegNext(fromUncache.fire) &&
     s4_mmioUseSnpc && !s4_ftqFlushSelf && !s4_ftqFlushByOlder)
-  mmioFlushWb.bits.pc := s4_pc
+  mmioFlushWb.bits.pc := s4_pc(0)
   mmioFlushWb.bits.pd := s4_pd
   mmioFlushWb.bits.pd.zipWithIndex.foreach { case (instr, i) => instr.valid := s4_mmioRange(i) }
-  mmioFlushWb.bits.ftqIdx     := s4_ftqReq.ftqIdx
-  mmioFlushWb.bits.ftqOffset  := s4_ftqReq.ftqOffset.bits
+  mmioFlushWb.bits.ftqIdx     := s4_fetchBlock(0).ftqIdx
+  mmioFlushWb.bits.ftqOffset  := s4_fetchBlock(0).ftqOffset.bits
   mmioFlushWb.bits.misOffset  := s4_mmioMissOffset
   mmioFlushWb.bits.cfiOffset  := DontCare
-  mmioFlushWb.bits.target     := Mux(mmioIsRvc, s4_ftqReq.startVAddr + 2.U, s4_ftqReq.startVAddr + 4.U)
+  mmioFlushWb.bits.target     := Mux(mmioIsRvc, s4_fetchBlock(0).startAddr + 2.U, s4_fetchBlock(0).startAddr + 4.U)
   mmioFlushWb.bits.jalTarget  := DontCare
   mmioFlushWb.bits.instrRange := s4_mmioRange
 
@@ -1088,9 +1172,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
     mmioFlushWb.bits.pd(0).isRet  := isRet
   }
 
-  mmioRedirect.valid := s4_reqIsMmio && mmioState === MmioFsmState.WaitCommit && RegNext(
-    fromUncache.fire
-  ) && s4_mmioUseSnpc
+  mmioRedirect.valid := s4_reqIsMmio && mmioState === MmioFsmState.WaitCommit &&
+    RegNext(fromUncache.fire) && s4_mmioUseSnpc
+
   mmioRedirect.instrCount     := 1.U
   mmioRedirect.prevIBufEnqPtr := s4_prevIBufEnqPtr
   XSPerfAccumulate("fetch_bubble_ibuffer_not_ready", io.toIBuffer.valid && !io.toIBuffer.ready)
@@ -1101,89 +1185,117 @@ class Ifu(implicit p: Parameters) extends IfuModule
    * - redirect if found fault prediction
    * - redirect if false hit last half (last PC is not start + 32 Bytes, but in the middle of an notCFI RVI instruction)
    * ***************************************************************************** */
-  val bubblePds = WireDefault(VecInit.fill(PredictWidth)(0.U.asTypeOf(new PreDecodeInfo)))
-  bubblePds.zipWithIndex.map {
-    case (bubblePd, i) =>
-      bubblePd := Mux(s4_bubbleInstrValid(i), s4_pd(s4_bubbleIndex(i)), 0.U.asTypeOf(new PreDecodeInfo))
+  val rawPds = WireDefault(VecInit.fill(PredictWidth)(0.U.asTypeOf(new PreDecodeInfo)))
+  rawPds.zipWithIndex.map {
+    case (rawPd, i) =>
+      rawPd := Mux(s4_rawInstrValid(i), s4_pd(s4_rawIndex(i)), 0.U.asTypeOf(new PreDecodeInfo))
   }
+  val firstRawPds  = WireDefault(VecInit.fill(PredictWidth)(0.U.asTypeOf(new PreDecodeInfo)))
+  val secondRawPds = WireDefault(VecInit.fill(PredictWidth)(0.U.asTypeOf(new PreDecodeInfo)))
+  firstRawPds.zipWithIndex.map {
+    case (rawPd, i) =>
+      rawPd := Mux(s4_rawInstrValid(i), s4_pd(s4_rawIndex(i)), 0.U.asTypeOf(new PreDecodeInfo))
+  }
+  secondRawPds.zipWithIndex.map {
+    case (rawPd, i) =>
+      rawPd := Mux(
+        s4_rawInstrValid(i.U + s4_fetchBlock(0).fetchSize),
+        s4_pd(s4_rawIndex(i.U + s4_fetchBlock(1).fetchSize)),
+        0.U.asTypeOf(new PreDecodeInfo)
+      )
+  }
+
   private val wbEnable        = RegNext(s3_fire && !s3_flush) && !s4_reqIsMmio && !s4_flush
   private val wbValid         = RegNext(wbEnable, init = false.B)
-  private val wbFtqReq        = RegEnable(s4_ftqReq, wbEnable)
+  private val wbFirstValid    = RegEnable(s4_firstValid, wbEnable)
+  private val wbSecondValid   = RegEnable(s4_secondValid, wbEnable)
+  private val wbFetchBlock    = RegEnable(s4_fetchBlock, wbEnable)
   private val wbPreIBufEnqPtr = RegEnable(s4_prevIBufEnqPtr, wbEnable)
   private val wbInstrCount    = RegEnable(PopCount(io.toIBuffer.bits.enqEnable), wbEnable)
+  private val wbInstrOffset   = RegEnable(s4_instrOffset, wbEnable)
+  private val wbFirstRawPds   = RegEnable(firstRawPds, wbEnable)
+  private val wbSecondRawPds  = RegEnable(secondRawPds, wbEnable)
+
   wbRedirect.instrCount     := wbInstrCount
   wbRedirect.prevIBufEnqPtr := wbPreIBufEnqPtr
 
-  private val wbCheckResultStage1 = RegEnable(checkerOutStage1, wbEnable)
-  private val wbCheckResultStage2 = checkerOutStage2
-  private val wbFirstInstrRange =
-    wbCheckResultStage2.fixedFirstBubbleInstrRange & RegEnable(s4_firstBlock.instrRange, wbEnable)
+  s4_wbNotFlush := wbFetchBlock(0).ftqIdx === s4_fetchBlock(0).ftqIdx && s4_valid && wbValid
+  private val wbStage2Check = Wire(Vec(FetchPorts, new FinalPredCheckResult))
+  wbStage2Check(0) := checkerOutStage2.fixedFirst
+  wbStage2Check(1) := checkerOutStage2.fixedSecond
+  private val wbStage2FirstCheck  = checkerOutStage2.fixedFirst
+  private val wbStage2SecondCheck = checkerOutStage2.fixedSecond
 
-  private val wbBubblePcLowerResult   = RegEnable(s4_bubblePcLowerResult, wbEnable)
-  private val wbFirstPcHigh           = RegEnable(s4_firstBlock.pcHigh, wbEnable)
-  private val wbFirstPcHighPlus1      = RegEnable(s4_firstBlock.pcHighPlus1, wbEnable)
-  private val wbFirstBubblePc         = catPC(wbBubblePcLowerResult, wbFirstPcHigh, wbFirstPcHighPlus1)
-  private val wbBubblePd              = RegEnable(bubblePds, wbEnable)
-  private val wbFirstBubbleInstrValid = RegEnable(VecInit(s4_firstBlock.bubbleInstrValid.asBools), wbEnable)
-  private val wbPd                    = RegEnable(s4_pd, wbEnable)
-  private val wbInstrValid            = RegEnable(s4_instrValid.asTypeOf(Vec(PredictWidth, Bool())), wbEnable)
-  private val wbInstrOffset           = RegEnable(s4_instrOffset, wbEnable)
+  private val wbRawPcLowerResult = RegEnable(s4_rawPcLowerResult, wbEnable)
+  private val checkFlushWb       = Wire(Vec(FetchPorts, Valid(new PredecodeWritebackBundle)))
 
-  s4_wbNotFlush := wbFtqReq.ftqIdx === s4_ftqReq.ftqIdx && s4_valid && wbValid
+  private val wbInstrRange = wbStage2Check.zipWithIndex.map { case (check, i) =>
+    check.instrRange & RegEnable(s4_fetchBlock(i).instrRange, wbEnable)
+  }
 
-  private val checkFlushWb = Wire(Valid(new PredecodeWritebackBundle))
-  private val checkFlushWbJalTargetIdx = ParallelPriorityEncoder(VecInit(wbPd.zip(wbInstrValid).map {
-    case (pd, v) =>
-      v && pd.isJal
-  }))
-  private val checkFlushWbTargetIdx = wbCheckResultStage2.fixedFirstMispredIdx.bits
-  checkFlushWb.valid   := wbValid
-  checkFlushWb.bits.pc := wbFirstBubblePc
-  checkFlushWb.bits.pd := wbBubblePd
-  checkFlushWb.bits.pd.zipWithIndex.foreach { case (instr, i) => instr.valid := wbFirstBubbleInstrValid(i) }
-  checkFlushWb.bits.ftqIdx    := wbFtqReq.ftqIdx
-  checkFlushWb.bits.ftqOffset := wbFtqReq.ftqOffset.bits
-  checkFlushWb.bits.misOffset.valid := wbCheckResultStage2.fixedFirstMispredIdx.valid // ParallelOR(wbCheckResultStage2.fixedMissPred)
-  checkFlushWb.bits.misOffset.bits := wbInstrOffset(
-    wbCheckResultStage2.fixedFirstMispredIdx.bits
-  ) // ParallelPriorityEncoder(wbCheckResultStage2.fixedMissPred)
-  checkFlushWb.bits.cfiOffset.valid := wbCheckResultStage2.fixedFirstTakenIdx.valid // ParallelOR(wbCheckResultStage1.fixedTaken)
-  checkFlushWb.bits.cfiOffset.bits := wbInstrOffset(
-    wbCheckResultStage2.fixedFirstTakenIdx.bits
-  ) // ParallelPriorityEncoder(wbCheckResultStage1.fixedTaken)
-  checkFlushWb.bits.target     := wbCheckResultStage2.fixedTwoFetchTarget(checkFlushWbTargetIdx)
-  checkFlushWb.bits.jalTarget  := wbCheckResultStage2.twoFetchJalTarget(checkFlushWbJalTargetIdx)
-  checkFlushWb.bits.instrRange := wbFirstInstrRange.asTypeOf(Vec(PredictWidth, Bool()))
+  for (i <- 0 until FetchPorts) {
+    val missIdx = wbStage2Check(i).misOffset.bits
+    checkFlushWb(i).bits.pc := catPC(wbRawPcLowerResult(missIdx), wbFetchBlock(i).pcHigh, wbFetchBlock(i).pcHighPlus1)
+    checkFlushWb(i).bits.ftqIdx          := wbFetchBlock(i).ftqIdx
+    checkFlushWb(i).bits.ftqOffset       := wbFetchBlock(i).ftqOffset.bits
+    checkFlushWb(i).bits.misOffset.valid := wbStage2Check(i).misOffset.valid
+    checkFlushWb(i).bits.misOffset.bits  := wbInstrOffset(wbStage2Check(i).misOffset.bits)
+    checkFlushWb(i).bits.cfiOffset.valid := wbStage2Check(i).cfiOffset.valid
+    checkFlushWb(i).bits.cfiOffset.bits  := wbInstrOffset(wbStage2Check(i).cfiOffset.bits)
+    checkFlushWb(i).bits.target          := wbStage2Check(i).target
+    checkFlushWb(i).bits.jalTarget       := wbStage2Check(i).target
+    checkFlushWb(i).bits.instrRange      := wbInstrRange(i).asTypeOf(Vec(PredictWidth, Bool()))
+  }
+  checkFlushWb(0).valid   := wbValid && wbFirstValid
+  checkFlushWb(1).valid   := wbValid && wbSecondValid
+  checkFlushWb(0).bits.pd := wbFirstRawPds
+  checkFlushWb(1).bits.pd := wbSecondRawPds
 
-  toFtq.pdWb := Mux(wbValid, checkFlushWb, mmioFlushWb)
+  toFtq.pdWb(0) := Mux(wbValid, checkFlushWb(0), mmioFlushWb)
+  toFtq.pdWb(1) := checkFlushWb(1)
 
-  wbRedirect.valid := checkFlushWb.bits.misOffset.valid && wbValid
+  wbRedirect.valid := (checkFlushWb(0).bits.misOffset.valid && checkFlushWb(0).valid) ||
+    (checkFlushWb(1).bits.misOffset.valid && checkFlushWb(1).valid)
 
   /* write back flush type */
-  private val checkFaultType    = wbCheckResultStage2.twoFetchFaultType
-  private val checkJalFault     = wbValid && checkFaultType.map(_ === PreDecodeFaultType.JalFault).reduce(_ || _)
-  private val checkJalrFault    = wbValid && checkFaultType.map(_ === PreDecodeFaultType.JalrFault).reduce(_ || _)
-  private val checkRetFault     = wbValid && checkFaultType.map(_ === PreDecodeFaultType.RetFault).reduce(_ || _)
-  private val checkTargetFault  = wbValid && checkFaultType.map(_ === PreDecodeFaultType.TargetFault).reduce(_ || _)
-  private val checkNotCFIFault  = wbValid && checkFaultType.map(_ === PreDecodeFaultType.NotCfiFault).reduce(_ || _)
-  private val checkInvalidTaken = wbValid && checkFaultType.map(_ === PreDecodeFaultType.InvalidTaken).reduce(_ || _)
+  private val checkFaultType    = checkerOutStage2.perfFaultType
+  private val checkJalFault     = WireDefault(VecInit.fill(FetchPorts)(false.B))
+  private val checkJalrFault    = WireDefault(VecInit.fill(FetchPorts)(false.B))
+  private val checkRetFault     = WireDefault(VecInit.fill(FetchPorts)(false.B))
+  private val checkTargetFault  = WireDefault(VecInit.fill(FetchPorts)(false.B))
+  private val checkNotCFIFault  = WireDefault(VecInit.fill(FetchPorts)(false.B))
+  private val checkInvalidTaken = WireDefault(VecInit.fill(FetchPorts)(false.B))
+  private val checkFetchValid   = WireDefault(VecInit.fill(FetchPorts)(false.B))
+  checkFetchValid(0) := wbFirstValid
+  checkFetchValid(1) := wbSecondValid
 
-  XSPerfAccumulate("predecode_flush_jalFault", checkJalFault)
-  XSPerfAccumulate("predecode_flush_jalrFault", checkJalrFault)
-  XSPerfAccumulate("predecode_flush_retFault", checkRetFault)
-  XSPerfAccumulate("predecode_flush_targetFault", checkTargetFault)
-  XSPerfAccumulate("predecode_flush_notCFIFault", checkNotCFIFault)
-  XSPerfAccumulate("predecode_flush_invalidTakenFault", checkInvalidTaken)
+  for (i <- 0 until FetchPorts) {
+    val validFetch = wbValid && checkFetchValid(i)
+    checkJalFault(i)     := validFetch && (checkFaultType(i) === PreDecodeFaultType.JalFault)
+    checkJalrFault(i)    := validFetch && (checkFaultType(i) === PreDecodeFaultType.JalrFault)
+    checkRetFault(i)     := validFetch && (checkFaultType(i) === PreDecodeFaultType.RetFault)
+    checkNotCFIFault(i)  := validFetch && (checkFaultType(i) === PreDecodeFaultType.NotCfiFault)
+    checkInvalidTaken(i) := validFetch && (checkFaultType(i) === PreDecodeFaultType.InvalidTaken)
+  }
 
-  XSDebug(
-    checkRetFault,
-    "startAddr:%x  nextStartAddr:%x  taken:%d    takenIdx:%d\n",
-    wbFtqReq.startVAddr.toUInt,
-    wbFtqReq.nextStartVAddr.toUInt,
-    wbFtqReq.ftqOffset.valid,
-    wbFtqReq.ftqOffset.bits
-  )
+  for (i <- 0 until FetchPorts) {
+    XSPerfAccumulate(f"fetch${i}_predecode_flush_jalFault", checkJalFault(i))
+    XSPerfAccumulate(f"fetch${i}_predecode_flush_jalrFault", checkJalrFault(i))
+    XSPerfAccumulate(f"fetch${i}_predecode_flush_retFault", checkRetFault(i))
+    XSPerfAccumulate(f"fetch${i}_predecode_flush_targetFault", checkTargetFault(i))
+    XSPerfAccumulate(f"fetch${i}_predecode_flush_notCFIFault", checkNotCFIFault(i))
+    XSPerfAccumulate(f"fetch${i}_predecode_flush_invalidTakenFault", checkInvalidTaken(i))
 
+    XSDebug(
+      checkRetFault(i),
+      "fetch:%x  startAddr:%x  nextStartAddr:%x  taken:%d    takenIdx:%d\n",
+      i.U,
+      wbFetchBlock(i).startAddr.toUInt,
+      wbFetchBlock(i).target.toUInt,
+      wbFetchBlock(i).ftqOffset.valid,
+      wbFetchBlock(i).ftqOffset.bits
+    )
+  }
   /* *** Perf *** */
   private val s4_perfInfo = RegEnable(s3_perfInfo, s3_fire)
   val perfEvents: Seq[(String, Bool)] = Seq(
@@ -1236,21 +1348,24 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val ifuWbToFtqTable            = ChiselDB.createTable(s"IfuWbToFtq$hartId", new IfuWbToFtqDB)
 
   private val fetchIBufferDumpData = Wire(new FetchToIBufferDB)
-  fetchIBufferDumpData.startAddr  := s4_ftqReq.startVAddr.toUInt
-  fetchIBufferDumpData.instrCount := PopCount(io.toIBuffer.bits.enqEnable)
-  fetchIBufferDumpData.exception  := io.toIBuffer.fire && s4_perfInfo.except
-  fetchIBufferDumpData.isCacheHit := io.toIBuffer.fire && s4_perfInfo.hit
+  fetchIBufferDumpData.startAddr(0) := s4_fetchBlock(0).startAddr.toUInt
+  fetchIBufferDumpData.startAddr(1) := s4_fetchBlock(1).startAddr.toUInt
+  fetchIBufferDumpData.instrCount   := PopCount(io.toIBuffer.bits.enqEnable)
+  fetchIBufferDumpData.exception    := io.toIBuffer.fire && s4_perfInfo.except
+  fetchIBufferDumpData.isCacheHit   := io.toIBuffer.fire && s4_perfInfo.hit
 
   private val ifuWbToFtqDumpData = Wire(new IfuWbToFtqDB)
-  ifuWbToFtqDumpData.startAddr         := wbFtqReq.startVAddr.toUInt
-  ifuWbToFtqDumpData.isMissPred        := checkFlushWb.bits.misOffset.valid
-  ifuWbToFtqDumpData.missPredOffset    := checkFlushWb.bits.misOffset.bits
-  ifuWbToFtqDumpData.checkJalFault     := checkJalFault
-  ifuWbToFtqDumpData.checkJalrFault    := checkJalrFault
-  ifuWbToFtqDumpData.checkRetFault     := checkRetFault
-  ifuWbToFtqDumpData.checkTargetFault  := checkTargetFault
-  ifuWbToFtqDumpData.checkNotCFIFault  := checkNotCFIFault
-  ifuWbToFtqDumpData.checkInvalidTaken := checkInvalidTaken
+  for (i <- 0 until FetchPorts) {
+    ifuWbToFtqDumpData.startAddr(i)      := wbFetchBlock(i).startAddr.toUInt
+    ifuWbToFtqDumpData.isMissPred(i)     := checkFlushWb(i).bits.misOffset.valid
+    ifuWbToFtqDumpData.missPredOffset(i) := checkFlushWb(i).bits.misOffset.bits
+  }
+  ifuWbToFtqDumpData.checkJalFault     := checkJalFault(0) | checkJalFault(1)
+  ifuWbToFtqDumpData.checkJalrFault    := checkJalrFault(0) | checkJalrFault(1)
+  ifuWbToFtqDumpData.checkRetFault     := checkRetFault(0) | checkRetFault(1)
+  ifuWbToFtqDumpData.checkNotCFIFault  := checkNotCFIFault(0) | checkNotCFIFault(1)
+  ifuWbToFtqDumpData.checkInvalidTaken := checkInvalidTaken(0) | checkInvalidTaken(1)
+  ifuWbToFtqDumpData.checkTargetFault  := false.B
 
   fetchToIBufferTable.log(
     data = fetchIBufferDumpData,
@@ -1261,7 +1376,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   )
   ifuWbToFtqTable.log(
     data = ifuWbToFtqDumpData,
-    en = isWriteIfuWbToFtqTable.orR && checkFlushWb.valid,
+    en = isWriteIfuWbToFtqTable.orR && wbValid,
     site = "IFU" + p(XSCoreParamsKey).HartId.toString,
     clock = clock,
     reset = reset

--- a/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
@@ -20,8 +20,8 @@ import xiangshan.HasXSParameter
 import xiangshan.frontend.icache.HasICacheParameters
 
 trait HasIfuParameters extends HasICacheParameters {
-  def FetchPorts:      Int = 2
   def ICacheLineBytes: Int = 64
   // equal lower_result overflow bit
-  def PcCutPoint: Int = (VAddrBits / 4) - 1
+  def PcCutPoint:       Int = (VAddrBits / 4) - 1
+  def IBufferInPortNum: Int = PredictWidth
 }

--- a/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
@@ -23,5 +23,6 @@ trait HasIfuParameters extends HasICacheParameters {
   def ICacheLineBytes: Int = 64
   // equal lower_result overflow bit
   def PcCutPoint:       Int = (VAddrBits / 4) - 1
-  def IBufferInPortNum: Int = PredictWidth
+  def IBufferInPortNum: Int = PredictWidth + IBufWriteBank
+  def IfuAlignWidth:    Int = IBufWriteBank
 }

--- a/src/main/scala/xiangshan/frontend/ifu/PreDecodeBoundary.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PreDecodeBoundary.scala
@@ -29,12 +29,14 @@ class PreDecodeBoundary(implicit p: Parameters) extends IfuModule with PreDecode
       val instrRange:        Vec[Bool] = Vec(PredictWidth, Bool())
       val cacheData:         UInt      = UInt(512.W)
       val prevLastIsHalfRvi: Bool      = Bool()
-      val endPosition:       UInt      = UInt(log2Ceil(PredictWidth).W)
+      val firstEndPos:       UInt      = UInt(log2Ceil(PredictWidth).W)
+      val endPos:            UInt      = UInt(log2Ceil(PredictWidth).W)
     }
     class PreDecodeBoundResp(implicit p: Parameters) extends IfuBundle {
-      val instrValid:    Vec[Bool] = Vec(PredictWidth, Bool())
-      val isRvc:         Vec[Bool] = Vec(PredictWidth, Bool())
-      val isLastHalfRvi: Bool      = Bool()
+      val instrValid:         Vec[Bool] = Vec(PredictWidth, Bool())
+      val isRvc:              Vec[Bool] = Vec(PredictWidth, Bool())
+      val isFirstLastHalfRvi: Bool      = Bool()
+      val isLastHalfRvi:      Bool      = Bool()
     }
 
     val req:  Valid[PreDecodeBoundReq]  = Flipped(ValidIO(new PreDecodeBoundReq))
@@ -142,6 +144,8 @@ class PreDecodeBoundary(implicit p: Parameters) extends IfuModule with PreDecode
   io.resp.bits.isRvc := VecInit(io.resp.bits.instrValid.zip(currentIsRvc).map { case (valid, rvc) =>
     valid & rvc
   })
-  io.resp.bits.isLastHalfRvi := io.resp.bits.instrValid(io.req.bits.endPosition) &&
-    !currentIsRvc(io.req.bits.endPosition)
+  io.resp.bits.isFirstLastHalfRvi := io.resp.bits.instrValid(io.req.bits.firstEndPos) &&
+    !currentIsRvc(io.req.bits.firstEndPos)
+  io.resp.bits.isLastHalfRvi := io.resp.bits.instrValid(io.req.bits.endPos) &&
+    !currentIsRvc(io.req.bits.endPos)
 }

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -29,46 +29,40 @@ import xiangshan.frontend.PrunedAddr
 class PredChecker(implicit p: Parameters) extends IfuModule {
   class PredCheckerIO extends IfuBundle {
     class PredCheckerReq(implicit p: Parameters) extends IfuBundle {
-      val instrJumpOffset:       Vec[PrunedAddr]    = Vec(PredictWidth, PrunedAddr(VAddrBits))
-      val instrValid:            Vec[Bool]          = Vec(PredictWidth, Bool())
-      val instrPds:              Vec[PreDecodeInfo] = Vec(PredictWidth, new PreDecodeInfo)
-      val instrPc:               Vec[PrunedAddr]    = Vec(PredictWidth, PrunedAddr(VAddrBits))
-      val tempPrevLastIsHalfRvi: Bool               = Bool()
+      // Input data is offset-adjusted for IBuffer enqueue.
+      val instrJumpOffset: Vec[PrunedAddr]    = Vec(IBufferInPortNum, PrunedAddr(VAddrBits))
+      val instrValid:      Vec[Bool]          = Vec(IBufferInPortNum, Bool())
+      val instrPds:        Vec[PreDecodeInfo] = Vec(IBufferInPortNum, new PreDecodeInfo)
+      val instrPc:         Vec[PrunedAddr]    = Vec(IBufferInPortNum, PrunedAddr(VAddrBits))
+      val isPredTaken:     Vec[Bool]          = Vec(IBufferInPortNum, Bool())
+      val ignore:          Vec[Bool]          = Vec(IBufWriteBank, Bool())
+      val shiftNum:        UInt               = UInt(log2Ceil(IBufWriteBank).W)
 
-      val firstFtqPredTakenIdx:  Valid[UInt] = Valid(UInt(log2Ceil(PredictWidth).W))
-      val secondFtqPredTakenIdx: Valid[UInt] = Valid(UInt(log2Ceil(PredictWidth).W))
+      val firstPredTakenIdx:  Valid[UInt] = Valid(UInt(log2Ceil(IBufferInPortNum).W))
+      val secondPredTakenIdx: Valid[UInt] = Valid(UInt(log2Ceil(IBufferInPortNum).W))
 
       val firstTarget:      PrunedAddr = PrunedAddr(VAddrBits)
       val secondTarget:     PrunedAddr = PrunedAddr(VAddrBits)
-      val selectFetchBlock: Vec[Bool]  = Vec(PredictWidth, Bool())
-      val invalidTaken:     Vec[Bool]  = Vec(PredictWidth, Bool())
-      val instrOffset:      Vec[UInt]  = Vec(PredictWidth, UInt(log2Ceil(PredictWidth).W))
+      val selectFetchBlock: Vec[Bool]  = Vec(IBufferInPortNum, Bool())
+      val invalidTaken:     Vec[Bool]  = Vec(IBufferInPortNum, Bool())
+      val instrOffset:      Vec[UInt]  = Vec(IBufferInPortNum, UInt(log2Ceil(PredictWidth).W))
     }
 
     class PredCheckerResp(implicit p: Parameters) extends IfuBundle {
-      // to Ibuffer write port  (stage 1)
+      // to Ibuffer write port  (stage 1) ---- Output data is offset-adjusted for IBuffer enqueue.
       class S1Out(implicit p: Parameters) extends IfuBundle {
-        val fixedTwoFetchRange: Vec[Bool] = Vec(PredictWidth, Bool())
-        val fixedTwoFetchTaken: Vec[Bool] = Vec(PredictWidth, Bool())
+        val fixedTwoFetchRange: Vec[Bool] = Vec(IBufferInPortNum, Bool())
+        val fixedTwoFetchTaken: Vec[Bool] = Vec(IBufferInPortNum, Bool())
       }
-      // to Ftq write back port (stage 2)
+      // to Ftq write back port (stage 2) ---- Output data with offset removed for FTQ write-back
       class S2Out(implicit p: Parameters) extends IfuBundle {
-        val fixedTwoFetchTarget: Vec[PrunedAddr] = Vec(PredictWidth, PrunedAddr(VAddrBits))
-        val twoFetchJalTarget:   Vec[PrunedAddr] = Vec(PredictWidth, PrunedAddr(VAddrBits))
-        val twoFetchFaultType:   Vec[UInt]       = Vec(PredictWidth, PreDecodeFaultType())
-
-        val fixedFirstMispredIdx:        Valid[UInt] = Valid(UInt(log2Ceil(PredictWidth).W))
-        val fixedSecondMispredIdx:       Valid[UInt] = Valid(UInt(log2Ceil(PredictWidth).W))
-        val fixedFirstBubbleInstrRange:  UInt        = UInt(PredictWidth.W)
-        val fixedSecondBubbleInstrRange: UInt        = UInt(PredictWidth.W)
-
-        val fixedFirstTakenIdx:  Valid[UInt] = Valid(UInt(log2Ceil(PredictWidth).W))
-        val fixedSecondTakenIdx: Valid[UInt] = Valid(UInt(log2Ceil(PredictWidth).W))
+        val fixedFirst:    FinalPredCheckResult = new FinalPredCheckResult
+        val fixedSecond:   FinalPredCheckResult = new FinalPredCheckResult
+        val perfFaultType: Vec[UInt]            = Vec(FetchPorts, PreDecodeFaultType())
       }
       val stage1Out: S1Out = new S1Out
       val stage2Out: S2Out = new S2Out
     }
-
     val req:  Valid[PredCheckerReq] = Flipped(ValidIO(new PredCheckerReq))
     val resp: PredCheckerResp       = Output(new PredCheckerResp)
   }
@@ -76,203 +70,200 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   val io: PredCheckerIO = IO(new PredCheckerIO)
 
   private val (firstTakenIdx, firstPredTaken) =
-    (io.req.bits.firstFtqPredTakenIdx.bits, io.req.bits.firstFtqPredTakenIdx.valid)
+    (io.req.bits.firstPredTakenIdx.bits, io.req.bits.firstPredTakenIdx.valid)
   private val (secondTakenIdx, secondPredTaken) =
-    (io.req.bits.secondFtqPredTakenIdx.bits, io.req.bits.secondFtqPredTakenIdx.valid)
+    (io.req.bits.secondPredTakenIdx.bits, io.req.bits.secondPredTakenIdx.valid)
+
   private val firstPredTarget  = io.req.bits.firstTarget
   private val secondPredTarget = io.req.bits.secondTarget
   private val selectFetchBlock = io.req.bits.selectFetchBlock
   private val invalidTaken     = io.req.bits.invalidTaken
   private val instrOffset      = io.req.bits.instrOffset
+  private val isPredTaken      = io.req.bits.isPredTaken
 
-  private val tempIgnore = WireDefault(VecInit.fill(PredictWidth)(false.B))
-  tempIgnore(0) := io.req.bits.tempPrevLastIsHalfRvi
+  // Entries made invalid by offset are marked with 'ignore'
+  private val ignore = WireDefault(VecInit.fill(IBufferInPortNum)(false.B))
+  for (i <- 0 until IBufWriteBank) {
+    ignore(i) := io.req.bits.ignore(i)
+  }
 
   private val instrValid            = io.req.bits.instrValid
   private val valid                 = io.req.valid
+  private val shiftNum              = io.req.bits.shiftNum
   private val (pds, pc, jumpOffset) = (io.req.bits.instrPds, io.req.bits.instrPc, io.req.bits.instrJumpOffset)
 
-  private val jalFaultVec, jalrFaultVec, retFaultVec, targetFault, notCfiTaken =
-    Wire(Vec(PredictWidth, Bool()))
+  private val jalFaultVec, jalrFaultVec, retFaultVec, notCfiTaken = Wire(Vec(IBufferInPortNum, Bool()))
 
   /** remask fault may appear together with other faults, but other faults are exclusive
-   * so other f ault mast use fixed mask to keep only one fault would be found and redirect to Ftq
-   * we first detecct remask fault and then use fixedRange to do second check
+   * so other fault mast use fixed mask to keep only one fault would be found and redirect to Ftq
+   * we first detect remask fault and then use fixedRange to do second check
    **/
 
   // Stage 1: detect remask fault
   /** first check: remask Fault */
   jalFaultVec := VecInit(pds.zipWithIndex.map { case (pd, i) =>
-    pd.isJal && instrValid(i) && (
-      ((firstTakenIdx > i.U && firstPredTaken || !firstPredTaken) && !selectFetchBlock(i)) ||
-        ((secondTakenIdx > i.U && secondPredTaken || !secondPredTaken) && selectFetchBlock(i))
-    ) && !tempIgnore(i)
+    pd.isJal && instrValid(i) && !isPredTaken(i) && !ignore(i)
   })
   jalrFaultVec := VecInit(pds.zipWithIndex.map { case (pd, i) =>
-    pd.isJalr && !pd.isRet && instrValid(i) && (
-      ((firstTakenIdx > i.U && firstPredTaken || !firstPredTaken) && !selectFetchBlock(i)) ||
-        ((secondTakenIdx > i.U && secondPredTaken || !secondPredTaken) && selectFetchBlock(i))
-    ) && !tempIgnore(i)
+    pd.isJalr && !pd.isRet && instrValid(i) && !isPredTaken(i) && !ignore(i)
   })
   retFaultVec := VecInit(pds.zipWithIndex.map { case (pd, i) =>
-    pd.isRet && instrValid(i) && (
-      ((firstTakenIdx > i.U && firstPredTaken || !firstPredTaken) && !selectFetchBlock(i)) ||
-        ((secondTakenIdx > i.U && secondPredTaken || !secondPredTaken) && selectFetchBlock(i))
-    ) && !tempIgnore(i)
+    pd.isRet && instrValid(i) && !isPredTaken(i) && !ignore(i)
   })
   private val remaskFault =
-    VecInit((0 until PredictWidth).map(i => jalFaultVec(i) || jalrFaultVec(i) || retFaultVec(i) || invalidTaken(i)))
+    VecInit((0 until IBufferInPortNum).map(i => jalFaultVec(i) || jalrFaultVec(i) || retFaultVec(i) || invalidTaken(i)))
   private val remaskIdx  = ParallelPriorityEncoder(remaskFault.asUInt)
   private val needRemask = ParallelOR(remaskFault)
   private val fixedRange =
-    instrValid.asUInt & (Fill(PredictWidth, !needRemask) | Fill(PredictWidth, 1.U(1.W)) >> ~remaskIdx)
+    instrValid.asUInt & (Fill(IBufferInPortNum, !needRemask) | Fill(IBufferInPortNum, 1.U(1.W)) >> ~remaskIdx)
 
+  // Adjust this if one IBuffer input entry is later removed
   require(
-    isPow2(PredictWidth),
-    "If PredictWidth does not satisfy the power of 2," +
-      "expression: Fill(PredictWidth, 1.U(1.W)) >> ~remaskIdx is not right !!"
+    isPow2(IBufferInPortNum),
+    "If IBufferInPortNum does not satisfy the power of 2," +
+      "expression: Fill(IBufferInPortNum, 1.U(1.W)) >> ~remaskIdx is not right !!"
   )
 
-  io.resp.stage1Out.fixedTwoFetchRange := fixedRange.asTypeOf(Vec(PredictWidth, Bool()))
+  io.resp.stage1Out.fixedTwoFetchRange := fixedRange.asTypeOf(Vec(IBufferInPortNum, Bool()))
 
-  val fixedFirstTaken = VecInit(pds.zipWithIndex.map { case (pd, i) =>
+  val fixedTwoFetchFirstTaken = VecInit(pds.zipWithIndex.map { case (pd, i) =>
     instrValid(i) && fixedRange(i) && (
       pd.isRet || pd.isJal || pd.isJalr ||
-        (firstTakenIdx === i.U && firstPredTaken && !pd.notCFI)
-    ) && !selectFetchBlock(i) && !tempIgnore(i)
+        (isPredTaken(i) && !selectFetchBlock(i) && !pd.notCFI)
+    ) && !ignore(i)
   })
-  val fixedSecondTaken = VecInit(pds.zipWithIndex.map { case (pd, i) =>
+
+  val fixedTwoFetchSecondTaken = VecInit(pds.zipWithIndex.map { case (pd, i) =>
     instrValid(i) && fixedRange(i) && (
       pd.isRet || pd.isJal || pd.isJalr ||
-        (secondTakenIdx === i.U && secondPredTaken && !pd.notCFI)
-    ) && selectFetchBlock(i) && !tempIgnore(i)
+        (isPredTaken(i) && selectFetchBlock(i) && !pd.notCFI)
+    ) && !ignore(i)
   })
-  io.resp.stage1Out.fixedTwoFetchTaken := VecInit(fixedFirstTaken.zip(fixedSecondTaken).map {
+  io.resp.stage1Out.fixedTwoFetchTaken := VecInit(fixedTwoFetchFirstTaken.zip(fixedTwoFetchSecondTaken).map {
     case (firstTaken, secondTaken) =>
       firstTaken || secondTaken
   })
 
-  private val fixedFirstTakenInstrIdx  = WireDefault(0.U.asTypeOf(ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
-  private val fixedSecondTakenInstrIdx = WireDefault(0.U.asTypeOf(ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
-  fixedFirstTakenInstrIdx.valid := ParallelOR(fixedFirstTaken)
-  fixedFirstTakenInstrIdx.bits  := ParallelPriorityEncoder(fixedFirstTaken)
-
-  fixedSecondTakenInstrIdx.valid := ParallelOR(fixedSecondTaken)
-  fixedSecondTakenInstrIdx.bits  := ParallelPriorityEncoder(fixedSecondTaken)
-
   /** second check: faulse prediction fault and target fault */
   notCfiTaken := VecInit(pds.zipWithIndex.map { case (pd, i) =>
-    fixedRange(i) && instrValid(i) && pd.notCFI && (
-      (i.U === firstTakenIdx && firstPredTaken && !selectFetchBlock(i)) ||
-        (i.U === secondTakenIdx && secondPredTaken && selectFetchBlock(i))
-    ) && !tempIgnore(i)
+    fixedRange(i) && instrValid(i) && pd.notCFI && isPredTaken(i) && !ignore(i)
   })
 
-  XSError(
-    valid && instrValid(0) && (remaskFault(0) || (firstPredTaken && (firstTakenIdx === 0.U))) && tempIgnore(0),
-    "Half instruction cases exceeded expectations"
+  private val fixedFirstTakenInstrIdx  = WireDefault(0.U.asTypeOf(ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
+  private val fixedSecondTakenInstrIdx = WireDefault(0.U.asTypeOf(ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
+  fixedFirstTakenInstrIdx.valid := ParallelOR(fixedTwoFetchFirstTaken)
+  fixedFirstTakenInstrIdx.bits  := ParallelPriorityEncoder(fixedTwoFetchFirstTaken)
+
+  fixedSecondTakenInstrIdx.valid := ParallelOR(fixedTwoFetchSecondTaken)
+  fixedSecondTakenInstrIdx.bits  := ParallelPriorityEncoder(fixedTwoFetchSecondTaken)
+
+  private val mispredInstrIdx = WireDefault(0.U.asTypeOf(ValidUndirectioned(UInt(log2Ceil(IBufferInPortNum).W))))
+  private val stage1Fault = VecInit.tabulate(IBufferInPortNum)(i =>
+    jalFaultVec(i) || jalrFaultVec(i) || retFaultVec(i) || notCfiTaken(i) || invalidTaken(i)
   )
+  mispredInstrIdx.valid := ParallelOR(stage1Fault)
+  mispredInstrIdx.bits  := ParallelPosteriorityEncoder(stage1Fault)
 
   private val jumpTargets = VecInit(pds.zipWithIndex.map { case (pd, i) =>
     (pc(i) + jumpOffset(i)).asTypeOf(PrunedAddr(VAddrBits))
   })
   private val seqTargets =
-    VecInit((0 until PredictWidth).map(i => pc(i) + Mux(pds(i).isRVC, 2.U, 4.U)))
+    VecInit((0 until IBufferInPortNum).map(i => pc(i) + Mux(pds(i).isRVC, 2.U, 4.U)))
 
-  // Stage 2: detect target fault
-  /** target calculation: in the next stage  */
-  private val fixedRangeNext       = RegEnable(fixedRange, io.req.valid)
-  private val instrValidNext       = RegEnable(instrValid, io.req.valid)
-  private val firstPredTakenNext   = RegEnable(firstPredTaken, io.req.valid)
-  private val secondPredTakenNext  = RegEnable(secondPredTaken, io.req.valid)
-  private val firstTakenIdxNext    = RegEnable(firstTakenIdx, io.req.valid)
-  private val secondTakenIdxNext   = RegEnable(secondTakenIdx, io.req.valid)
-  private val firstPredTargetNext  = RegEnable(firstPredTarget, io.req.valid)
-  private val secondPredTargetNext = RegEnable(secondPredTarget, io.req.valid)
+  private val mispredIsJump = instrValid(mispredInstrIdx.bits) &&
+    (pds(mispredInstrIdx.bits).isJal || pds(mispredInstrIdx.bits).isBr) && mispredInstrIdx.valid
 
-  private val jumpTargetsNext  = RegEnable(jumpTargets, io.req.valid)
-  private val seqTargetsNext   = RegEnable(seqTargets, io.req.valid)
-  private val pdsNext          = RegEnable(pds, io.req.valid)
+  /* *****************************************************************************
+   * PredChecker Stage 2
+   * ***************************************************************************** */
+  private val mispredIdxNext          = RegEnable(mispredInstrIdx, io.req.valid)
+  private val mispredIsFirstBlockNext = RegEnable(!selectFetchBlock(mispredInstrIdx.bits), io.req.valid)
+  private val mispredInstrOffsetNext  = RegEnable(instrOffset(mispredInstrIdx.bits), io.req.valid)
+  private val mispredIsJumpNext       = RegEnable(mispredIsJump, io.req.valid)
+
+  private val fixedFirstTakenInstrIdxNext  = RegEnable(fixedFirstTakenInstrIdx, io.req.valid)
+  private val fixedSecondTakenInstrIdxNext = RegEnable(fixedSecondTakenInstrIdx, io.req.valid)
+  private val instrOffsetNext              = RegEnable(instrOffset, io.req.valid)
+  private val firstTakenIdxNext            = RegEnable(firstTakenIdx, io.req.valid)
+  private val secondTakenIdxNext           = RegEnable(secondTakenIdx, io.req.valid)
+  private val firstPredTargetNext          = RegEnable(firstPredTarget, io.req.valid)
+  private val secondPredTargetNext         = RegEnable(secondPredTarget, io.req.valid)
+
+  private val jumpTargetsNext = RegEnable(jumpTargets, io.req.valid)
+  private val seqTargetsNext  = RegEnable(seqTargets, io.req.valid)
+
+  private val firstPredTakenNext = RegEnable(firstPredTaken, io.req.valid)
+  private val pdsNext            = RegEnable(pds, io.req.valid)
+  private val fixedRangeNext     = RegEnable(fixedRange, io.req.valid)
+  // --------- These registers are only for performance debugging purposes ---------------------/
   private val jalFaultVecNext  = RegEnable(jalFaultVec, io.req.valid)
   private val jalrFaultVecNext = RegEnable(jalrFaultVec, io.req.valid)
   private val retFaultVecNext  = RegEnable(retFaultVec, io.req.valid)
   private val notCFITakenNext  = RegEnable(notCfiTaken, io.req.valid)
   private val invalidTakenNext = RegEnable(invalidTaken, io.req.valid)
-  private val instrOffsetNext  = RegEnable(instrOffset, io.req.valid)
-  //  private val firstBubbleRangeNext      = RegEnable(firstBubbleRange, io.req.valid)
-  //  private val secondBubbleRangeNext     = RegEnable(secondBubbleRange, io.req.valid)
-  private val fixedFirstTakenInstrIdxNext  = RegEnable(fixedFirstTakenInstrIdx, io.req.valid)
-  private val fixedSecondTakenInstrIdxNext = RegEnable(fixedSecondTakenInstrIdx, io.req.valid)
 
-  targetFault := VecInit(pdsNext.zipWithIndex.map { case (pd, i) =>
-    fixedRangeNext(i) && instrValidNext(i) && (pd.isJal || pd.isBr) && (
-      (firstTakenIdxNext === i.U && firstPredTakenNext && (firstPredTargetNext =/= jumpTargetsNext(i))) ||
-        (secondTakenIdxNext === i.U && secondPredTakenNext && (secondPredTargetNext =/= jumpTargetsNext(i)))
+  private val fixFirstMispred  = mispredIdxNext.valid && mispredIsFirstBlockNext
+  private val fixSecondMispred = mispredIdxNext.valid && !mispredIsFirstBlockNext
+  private val fixedFirstRawInstrRange =
+    Fill(PredictWidth, !fixFirstMispred) |
+      (Fill(PredictWidth, 1.U(1.W)) >> ~mispredInstrOffsetNext(log2Ceil(PredictWidth) - 1, 0))
+
+  private val fixedSecondRawInstrRange =
+    Fill(PredictWidth, !fixSecondMispred) |
+      (Fill(PredictWidth, 1.U(1.W)) >> ~mispredInstrOffsetNext(log2Ceil(PredictWidth) - 1, 0))
+
+  private val mispredTarget =
+    Mux(mispredIsJumpNext, jumpTargetsNext(mispredIdxNext.bits), seqTargetsNext(mispredIdxNext.bits))
+
+  io.resp.stage2Out.fixedFirst.target          := Mux(fixFirstMispred, mispredTarget, firstPredTargetNext)
+  io.resp.stage2Out.fixedFirst.misOffset.valid := fixFirstMispred
+  io.resp.stage2Out.fixedFirst.misOffset.bits :=
+    Mux(fixFirstMispred, instrOffsetNext(mispredIdxNext.bits), instrOffsetNext(firstTakenIdxNext))
+
+  io.resp.stage2Out.fixedFirst.cfiOffset.valid := fixedFirstTakenInstrIdxNext.valid
+  io.resp.stage2Out.fixedFirst.cfiOffset.bits  := instrOffsetNext(fixedFirstTakenInstrIdxNext.bits)
+  io.resp.stage2Out.fixedFirst.instrRange      := fixedFirstRawInstrRange
+
+  io.resp.stage2Out.fixedSecond.target          := Mux(fixSecondMispred, mispredTarget, secondPredTargetNext)
+  io.resp.stage2Out.fixedSecond.misOffset.valid := fixSecondMispred
+  io.resp.stage2Out.fixedSecond.misOffset.bits :=
+    Mux(fixSecondMispred, instrOffsetNext(mispredIdxNext.bits), instrOffsetNext(secondTakenIdxNext))
+  io.resp.stage2Out.fixedSecond.cfiOffset.valid := fixedSecondTakenInstrIdxNext.valid
+  io.resp.stage2Out.fixedSecond.cfiOffset.bits  := instrOffsetNext(fixedSecondTakenInstrIdxNext.bits)
+  io.resp.stage2Out.fixedSecond.instrRange      := fixedSecondRawInstrRange
+
+  private val faultType = MuxCase(
+    PreDecodeFaultType.NoFault,
+    Seq(
+      jalFaultVecNext(mispredIdxNext.bits)  -> PreDecodeFaultType.JalFault,
+      jalrFaultVecNext(mispredIdxNext.bits) -> PreDecodeFaultType.JalrFault,
+      retFaultVecNext(mispredIdxNext.bits)  -> PreDecodeFaultType.RetFault,
+      notCFITakenNext(mispredIdxNext.bits)  -> PreDecodeFaultType.NotCfiFault,
+      invalidTakenNext(mispredIdxNext.bits) -> PreDecodeFaultType.InvalidTaken
     )
-  })
-
-  // private val mispredOffset  = WireDefault(0.U.asTypeOf(ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
-  private val mispredInstrIdx = WireDefault(0.U.asTypeOf(ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
-  private val stage1Fault = VecInit.tabulate(PredictWidth)(i =>
-    jalFaultVec(i) || jalrFaultVec(i) || retFaultVec(i) || notCfiTaken(i) || invalidTaken(i)
-  )
-  mispredInstrIdx.valid := ParallelOR(stage1Fault)
-  mispredInstrIdx.bits  := ParallelPriorityEncoder(stage1Fault)
-
-  private val mispredIdxNext          = RegEnable(mispredInstrIdx, io.req.valid)
-  private val mispredIsFirstBlockNext = RegEnable(!selectFetchBlock(mispredInstrIdx.bits), io.req.valid)
-  private val mispredInstrOffset      = RegEnable(instrOffset(mispredInstrIdx.bits), io.req.valid)
-
-  io.resp.stage2Out.twoFetchFaultType.zipWithIndex.foreach { case (faultType, i) =>
-    faultType := MuxCase(
-      PreDecodeFaultType.NoFault,
-      Seq(
-        jalFaultVecNext(i)  -> PreDecodeFaultType.JalFault,
-        jalrFaultVecNext(i) -> PreDecodeFaultType.JalrFault,
-        retFaultVecNext(i)  -> PreDecodeFaultType.RetFault,
-        targetFault(i)      -> PreDecodeFaultType.TargetFault,
-        notCFITakenNext(i)  -> PreDecodeFaultType.NotCfiFault,
-        invalidTakenNext(i) -> PreDecodeFaultType.InvalidTaken
-      )
-    )
-  }
-
-  io.resp.stage2Out.fixedTwoFetchTarget.zipWithIndex.foreach { case (target, i) =>
-    target := Mux(jalFaultVecNext(i) || targetFault(i), jumpTargetsNext(i), seqTargetsNext(i))
-  }
-  io.resp.stage2Out.twoFetchJalTarget.zipWithIndex.foreach { case (target, i) => target := jumpTargetsNext(i) }
-
-  val fixedFirstMispredIdx  = WireDefault(0.U.asTypeOf(ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
-  val fixedSecondMispredIdx = WireDefault(0.U.asTypeOf(ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))))
-  fixedFirstMispredIdx.valid := (mispredIdxNext.valid && mispredIsFirstBlockNext) || targetFault(firstTakenIdxNext)
-  fixedFirstMispredIdx.bits := Mux(
-    mispredIdxNext.valid && mispredIsFirstBlockNext,
-    mispredIdxNext.bits,
-    firstTakenIdxNext
   )
 
-  fixedSecondMispredIdx.valid := (mispredIdxNext.valid && !mispredIsFirstBlockNext) || targetFault(secondTakenIdxNext)
-  fixedSecondMispredIdx.bits := Mux(
-    mispredIdxNext.valid && !mispredIsFirstBlockNext,
-    mispredIdxNext.bits,
-    firstTakenIdxNext
+  io.resp.stage2Out.perfFaultType(0) := Mux(fixFirstMispred, faultType, PreDecodeFaultType.NoFault)
+  io.resp.stage2Out.perfFaultType(1) := Mux(fixSecondMispred, faultType, PreDecodeFaultType.NoFault)
+
+  // Temporary address check for one-fetch case with dirty data,
+  // used to prevent backend errors due to unhandled conditions
+  private val firstTargetFault = jumpTargetsNext(firstTakenIdxNext) =/= firstPredTargetNext && firstPredTakenNext &&
+    fixedRangeNext(firstTakenIdxNext) && !fixFirstMispred && (pdsNext(firstTakenIdxNext).isBr || pdsNext(
+      firstTakenIdxNext
+    ).isJal)
+
+  io.resp.stage2Out.fixedFirst.target := Mux(
+    firstTargetFault,
+    jumpTargetsNext(firstTakenIdxNext),
+    Mux(fixFirstMispred, mispredTarget, firstPredTargetNext)
   )
 
-  io.resp.stage2Out.fixedFirstMispredIdx  := fixedFirstMispredIdx
-  io.resp.stage2Out.fixedSecondMispredIdx := fixedSecondMispredIdx
-
-  // io.resp.stage2Out.fixedFirstBubbleRange   := fixedFirstBubbleRange
-  // io.resp.stage2Out.fixedSecondBubbleRange  := fixedSecondBubbleRange
-
-  io.resp.stage2Out.fixedFirstTakenIdx  := fixedFirstTakenInstrIdxNext
-  io.resp.stage2Out.fixedSecondTakenIdx := fixedSecondTakenInstrIdxNext
-
-  io.resp.stage2Out.fixedFirstBubbleInstrRange := Fill(
-    PredictWidth,
-    !(mispredIdxNext.valid && mispredIsFirstBlockNext)
-  ) | Fill(PredictWidth, 1.U(1.W)) >> ~mispredInstrOffset(log2Ceil(PredictWidth) - 1, 0)
-  io.resp.stage2Out.fixedSecondBubbleInstrRange := Fill(
-    PredictWidth,
-    !(mispredIdxNext.valid && !mispredIsFirstBlockNext)
-  ) | Fill(PredictWidth, 1.U(1.W)) >> ~mispredInstrOffset(log2Ceil(PredictWidth) - 1, 0)
+  io.resp.stage2Out.fixedFirst.misOffset.valid := fixFirstMispred || firstTargetFault
+  io.resp.stage2Out.fixedFirst.misOffset.bits := Mux(
+    firstTargetFault,
+    instrOffsetNext(firstTakenIdxNext),
+    Mux(fixFirstMispred, instrOffsetNext(mispredIdxNext.bits), instrOffsetNext(firstTakenIdxNext))
+  )
+  // private val firstTargetFault  = fixedFirstTakenInstrIdxNext.valid && jumpTargetsNext(mispredIdxNext.bits) =/= firstPredTargetNext
 }


### PR DESCRIPTION
Supersede https://github.com/OpenXiangShan/XiangShan/pull/4885

Refactor IFU for two-fetch support and IBuffer write bank partitioning：

- Partially removed "first"/"second" naming in two-fetch logic. Some are retained where interface behavior differs significantly to avoid confusion.
- Removed destination address check from preChecker. Based on prior discussions, such checks offer limited benefit and may introduce selective IBuffer flush behavior in two-fetch mode.
- Optimized preChecker timing logic, especially conditions like:  pd.isJal && instrValid(i) && !isPredTaken(i) && !ignore(i). This improves timing of the IBuffer enqEnable signal.
- Initial support for two-fetch added in IFU; still under refinement.
-  Align IFU output data to IBuffer write ports.
- Support IBuffer write banking.


