### PR TITLE
fix(BusyTable): remove dontTouch to make Verilog cleaner

### DIFF
--- a/src/main/scala/xiangshan/backend/issue/FuBusyTableWrite.scala
+++ b/src/main/scala/xiangshan/backend/issue/FuBusyTableWrite.scala
@@ -54,14 +54,6 @@ class FuBusyTableWrite(fuLatencyMap: Map[FuType.OHType, Int]) (implicit p: Param
   private val og0RespClearShift = Mux(og0RespFail, og0RespMatchVec.asUInt >> 2, Utils.NZeros(tableSize))
   private val og1RespClearShift = Mux(og1RespFail, og1RespMatchVec.asUInt >> 3, Utils.NZeros(tableSize))
 
-  // Just for more readable verilog
-  if(backendParams.debugEn) {
-    dontTouch(fuBusyTableShift)
-    dontTouch(deqRespSetShift)
-    dontTouch(og0RespClearShift)
-    dontTouch(og1RespClearShift)
-  }
-
   fuBusyTableNext := fuBusyTableShift & (~og0RespClearShift).asUInt & (~og1RespClearShift).asUInt | deqRespSetShift.asUInt
 
   io.out.fuBusyTable := fuBusyTable


### PR DESCRIPTION
Some instances of this module may have io.out not connected. Under normal circumstances, Chisel would not generate these modules, but due to dontTouch here, these modules without io connections are still generated. We do not yet understand the specific reason for this.

<img width="741" height="506" alt="6670ffad58bcb52684899f47e5ce13f7" src="https://github.com/user-attachments/assets/1c96c5b8-1ac5-4efb-a9e5-d708f55c7e7d" />

However, such Verilog cannot be synthesized on some FPGA platforms, so in order to ensure the uniformity of RTL, we need to remove this code.
