### PR TITLE
fix(ifu): fix IBuffer enqueue check for nc instructions.

### DIFF
--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -673,7 +673,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val f3_mmio_sent_to_ibuffer     = RegInit(false.B)
   val f3_mmio_can_sent_to_ibuffer = f3_mmio_to_commit && !f3_mmio_sent_to_ibuffer
 
-  when(f3_fire || f3_flush) {
+  when(f3_mmio_req_commit || f3_flush) {
     f3_mmio_sent_to_ibuffer := false.B
   }.elsewhen(io.toIbuffer.fire) {
     f3_mmio_sent_to_ibuffer := true.B

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -692,7 +692,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
 
   when(!f3_req_is_mmio) {
     f3_mmio_sent_to_ibuffer := false.B
-  }.elsewhen(f3_mmio_req_commit || (mmioF3Flush && !f3_need_not_flush)) {
+  }.elsewhen(f3_mmio_req_commit || (mmioF3Flush && !f3_need_not_flush) || f3_ftq_flush_self || f3_ftq_flush_by_older) {
     f3_mmio_sent_to_ibuffer := false.B
   }.elsewhen(io.toIbuffer.fire) {
     f3_mmio_sent_to_ibuffer := true.B


### PR DESCRIPTION
The nc (non-cacheable) attribute instructions go through the MMIO channel. Unlike standard MMIO instructions, nc instructions can be executed speculatively. For MMIO instructions, there's no need to check whether the IBuffer is full when enqueuing. However, nc instructions must check for IBuffer fullness.
This PR primarily fixes the issue where nc instructions were incorrectly allowed to enqueue into the IBuffer even when it was full.