### PR TITLE
fix(excp): add SWC to exception priorities

### DIFF
--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -839,6 +839,7 @@ package object xiangshan {
     // def singleStep          = 14
     def storePageFault      = 15
     def doubleTrap          = 16
+    def softwareCheck       = 18
     def hardwareError       = 19
     def instrGuestPageFault = 20
     def loadGuestPageFault  = 21
@@ -862,6 +863,7 @@ package object xiangshan {
     def EX_LPF    = loadPageFault
     def EX_SPF    = storePageFault
     def EX_DT     = doubleTrap
+    def EX_SWC    = softwareCheck
     def EX_HWE    = hardwareError
     def EX_IGPF   = instrGuestPageFault
     def EX_LGPF   = loadGuestPageFault
@@ -890,6 +892,7 @@ package object xiangshan {
       instrPageFault,
       instrGuestPageFault,
       instrAccessFault,
+      softwareCheck,
       illegalInstr,
       virtualInstr,
       instrAddrMisaligned,


### PR DESCRIPTION
The software-check exception caused by Zicfilp has higher priority than an illegal-instruction exception but lower priority than instruction access-fault