### PR TITLE
feat(pydrofoil): (WIP) add new reference model with pydrofoil

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,7 @@
 [submodule "ChiselAIA"]
 	path = ChiselAIA
 	url = https://github.com/OpenXiangShan/ChiselAIA.git
+[submodule "pydrofoil"]
+	path = pydrofoil
+	url = https://github.com/definfo/pydrofoil.git
+	branch = difftest-ref


### PR DESCRIPTION
NOTE: 🚧🚧🚧 This PR is under development and may not be usable right now. 🚧🚧🚧

# Background

[Pydrofoil](https://github.com/pydrofoil/pydrofoil) is an experimental emulator for various instruction set architectures, which contains a RISC-V emulator based on the [Sail RISC-V ISA model](https://github.com/riscv/sail-riscv).

The RISC-V emulator of Pydrofoil (pydrofoil-riscv) is drastically faster than the C emulator provided by Sail RISC-V model, and almost comparable with Spike. Thus we consider experimenting it on real-world RISC-V emulation purposes.

Details of Pydrofoil's design and implementation: https://arxiv.org/abs/2503.04389

# Goal

I am working to create a reference model for XiangShan emulation difftest with pydrofoil-riscv, according to the Spike's version `riscv64-spike-so`.

# Challenges

1. [Pydrofoil's scripting API](https://github.com/pydrofoil/pydrofoil/blob/main/docs/scripting-api.md) is not guaranteed to be stable. Thus I would be working on a pinned fork for a while.
2. I am currently investigating the API convention between Xiangshan emulation process (`./build/emu`) and the reference model (`riscv64-*-so`), which is not well documented. I would be grateful if anyone could help this.