### PR TITLE
fix(PrintControl): handle IntModule in onModule method

### DIFF
--- a/src/main/scala/xiangshan/transforms/PrintControl.scala
+++ b/src/main/scala/xiangshan/transforms/PrintControl.scala
@@ -128,6 +128,7 @@ class PrintControl extends firrtl.options.Phase {
 
     def onModule(m: firrtl.ir.DefModule): firrtl.ir.DefModule = m match {
       case _: firrtl.ir.ExtModule => m
+      case _: firrtl.ir.IntModule => m
       case _: firrtl.ir.Module =>
         def inRange(seq: Seq[String]): Boolean = {
           seq.nonEmpty && (seq.contains(m.name) || seq.map(elm => {


### PR DESCRIPTION
This PR fixes the problem that `PrintControl`'s `onModule` does not handle `firrtl.ir.IntModule` cases.

When using the `Chisel.ltl` API, an Intrinsic such as `LTLAndIntrinsic` will be generated via `IntModule`, and an error will be reported at compile time due to the lack of handling of this case in `PrintControl`:

```shell
[709] Exception in thread "main" scala.MatchError: IntModule( @[src/main/scala/chisel3/util/circt/LTLIntrinsics.scala 51:24],LTLAndIntrinsic,List(Port(,lhs,Input,UIntType(IntWidth(1))), Port(,rhs,Input,UIntType(IntWidth(1))), Port(,out,Output,UIntType(IntWidth(1)))),circt_ltl_and,List()) (of class firrtl.ir.IntModule)
[709]   at xiangshan.transforms.PrintControl.onModule$1(PrintControl.scala:129)
[709]   at xiangshan.transforms.PrintControl.$anonfun$transform$10(PrintControl.scala:148)
[709]   at scala.collection.immutable.List.map(List.scala:251)
[709]   at scala.collection.immutable.List.map(List.scala:79)
...
```

btw, here are some of my attempts at `LoadQueueRAR` module's formal verification, if you're interested:

https://github.com/Clo91eaf/XiangShan/commit/df1cd8ffbec11cc574a53e6311ab023cfb199341

https://github.com/Clo91eaf/xs-formal