### PR TITLE
fix(robCompress): enable compression for isLastInFtqEntry insts

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -1195,8 +1195,7 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
     (isCboInval && io.fromCSR.special.cboI2F) -> LSUOpType.cbo_flush,
   ))
 
-  // Don't compress in the same Rob entry when crossing Ftq entry boundary
-  io.deq.decodedInst.canRobCompress := decodedInst.canRobCompress && !io.enq.decodeInUop.isLastInFtqEntry
+  io.deq.decodedInst.canRobCompress := decodedInst.canRobCompress
 
   //-------------------------------------------------------------
   // Debug Info

--- a/src/main/scala/xiangshan/backend/rename/BusyTable.scala
+++ b/src/main/scala/xiangshan/backend/rename/BusyTable.scala
@@ -90,7 +90,8 @@ class BusyTable(numReadPorts: Int, numWritePorts: Int, numPhyPregs: Int, pregWB:
     case FpWB(_, _) => allWakeUp.filter{x => x.bits.params.writeFpRf && !x.bits.params.isIntExeUnit}
     case VfWB(_, _) => allWakeUp.filter(_.bits.params.writeVfRf)
     case V0WB(_, _) => allWakeUp.filter(_.bits.params.writeV0Rf)
-    case VlWB(_, _) => allWakeUp.filter(_.bits.params.writeVlRf)
+    // avoid load fast wakes, since load cancel signal not connected to vlbusytable, may have bug for vsetvli
+    case VlWB(_, _) => allWakeUp.filter(x => false)
     case _ => throw new IllegalArgumentException(s"WbConfig ${pregWB} is not permitted")
   }
   val loadDependency = RegInit(0.U.asTypeOf(Vec(numPhyPregs, Vec(LoadPipelineWidth, UInt(LoadDependencyWidth.W)))))


### PR DESCRIPTION
The ROB compression ratio improved from 1.38 to 1.43 in 0.3 coverage checkpoints.