### PR TITLE
refactor(ICache): use new frontend parameter system

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -95,7 +95,12 @@ class MinimalConfig(n: Int = 1) extends Config(
         IBufSize = 24,
         IBufNBank = 8,
         frontendParameters = FrontendParameters(
-          ftqParameters = FtqParameters(FtqSize = 8)
+          ftqParameters = FtqParameters(
+            FtqSize = 8,
+          ),
+          icacheParameters = ICacheParameters( // default 64B blockBytes, 4way, 256set (64KB ICache)
+            nSets = 64, // override to 64set in MinimalConfig (16KB ICache)
+          ),
         ),
         StoreBufferSize = 4,
         StoreBufferThreshold = 3,
@@ -110,13 +115,6 @@ class MinimalConfig(n: Int = 1) extends Config(
           numEntries = 160,
           numRead = None,
           numWrite = None,
-        ),
-        icacheParameters = ICacheParameters(
-          nSets = 64, // 16KB ICache
-          tagECC = Some("parity"),
-          dataECC = Some("parity"),
-          replacer = Some("setplru"),
-          cacheCtrlAddressOpt = Some(AddressSet(0x38022080, 0x7f)),
         ),
         dcacheParametersOpt = Some(DCacheParameters(
           nSets = 64, // 32KB DCache

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -86,7 +86,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
 
   val i_mmio_port = TLTempNode()
   val d_mmio_port = TLTempNode()
-  val icachectrl_port_opt = Option.when(icacheParameters.cacheCtrlAddressOpt.nonEmpty)(TLTempNode())
+  val icachectrl_port_opt = Option.when(icacheCtrlEnabled)(TLTempNode())
   val sep_tl_port_opt = Option.when(SeperateTLBus)(TLTempNode())
 
   val misc_l2_pmu = BusPerfMonitor(name = "Misc_L2", enable = !debugOpts.FPGAPlatform) // l1D & l1I & PTW
@@ -147,7 +147,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
   mmio_xbar := TLBuffer.chainNode(2) := i_mmio_port
   mmio_xbar := TLBuffer.chainNode(2) := d_mmio_port
   beu.node := TLBuffer.chainNode(1) := mmio_xbar
-  if (icacheParameters.cacheCtrlAddressOpt.nonEmpty) {
+  if (icacheCtrlEnabled) {
     icachectrl_port_opt.get := TLBuffer.chainNode(1) := mmio_xbar
   }
   if (SeperateTLBus) {
@@ -156,7 +156,9 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
 
   // filter out in-core addresses before sent to mmio_port
   // Option[AddressSet] ++ Option[AddressSet] => List[AddressSet]
-  private def cacheAddressSet: Seq[AddressSet] = (icacheParameters.cacheCtrlAddressOpt ++ dcacheParameters.cacheCtrlAddressOpt).toSeq
+  private def icacheCtrlAddressOpt: Option[AddressSet] = Option.when(icacheCtrlEnabled)(icacheCtrlAddress)
+  private def dcacheCtrlAddressOpt: Option[AddressSet] = dcacheParameters.cacheCtrlAddressOpt
+  private def cacheAddressSet: Seq[AddressSet] = (icacheCtrlAddressOpt ++ dcacheCtrlAddressOpt).toSeq
   private def mmioFilters = if(SeperateTLBus) (SeperateTLBusRanges ++ cacheAddressSet) else cacheAddressSet
   mmio_port :=
     TLFilter(TLFilter.mSubtract(mmioFilters)) :=

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -67,7 +67,6 @@ case class XSCoreParameters
   HasCExtension: Boolean = true,
   HasHExtension: Boolean = true,
   HasDiv: Boolean = true,
-  HasICache: Boolean = true,
   HasDCache: Boolean = true,
   AddrBits: Int = 64,
   PAddrBitsMax: Int = 56,   // The bits of physical address from Sv39/Sv48/Sv57 virtual address translation.
@@ -124,8 +123,6 @@ case class XSCoreParameters
   SCHistLens: Seq[Int] = Seq(0, 4, 10, 16),
   numBr: Int = 2,
   // old bpu deprecate end
-  ICacheForceMetaECCError: Boolean = false,
-  ICacheForceDataECCError: Boolean = false,
   IBufSize: Int = 48,
   IBufEnqWidth: Int = 16,
   IBufNBank: Int = 8, // IBuffer bank amount, should divide IBufSize
@@ -306,12 +303,6 @@ case class XSCoreParameters
   ),
   l2tlbParameters: L2TLBParameters = L2TLBParameters(),
   NumPerfCounters: Int = 16,
-  icacheParameters: ICacheParameters = ICacheParameters(
-    tagECC = Some("parity"),
-    dataECC = Some("parity"),
-    replacer = Some("setplru"),
-    cacheCtrlAddressOpt = Some(AddressSet(0x38022080, 0x7f))
-  ),
   dcacheParametersOpt: Option[DCacheParameters] = Some(DCacheParameters(
     tagECC = Some("secded"),
     dataECC = Some("secded"),
@@ -600,7 +591,6 @@ trait HasXSParameter {
   def HasHExtension = coreParams.HasHExtension
   def EnableSv48 = coreParams.EnableSv48
   def HasDiv = coreParams.HasDiv
-  def HasIcache = coreParams.HasICache
   def HasDcache = coreParams.HasDCache
   def AddrBits = coreParams.AddrBits // AddrBits is used in some cases
   def PAddrBitsMax = coreParams.PAddrBitsMax
@@ -709,8 +699,6 @@ trait HasXSParameter {
   def CacheLineHalfWord = CacheLineSize / 16
   def ExtHistoryLength = HistoryLength + 64
   def FtqSize = coreParams.frontendParameters.ftqParameters.FtqSize
-  def ICacheForceMetaECCError = coreParams.ICacheForceMetaECCError
-  def ICacheForceDataECCError = coreParams.ICacheForceDataECCError
   def IBufSize = coreParams.IBufSize
   def IBufEnqWidth = coreParams.IBufEnqWidth
   def IBufNBank = coreParams.IBufNBank
@@ -849,7 +837,9 @@ trait HasXSParameter {
   def instBytes = if (HasCExtension) 2 else 4
   def instOffsetBits = log2Ceil(instBytes)
 
-  def icacheParameters = coreParams.icacheParameters
+  def icacheCtrlEnabled = coreParams.frontendParameters.icacheParameters.EnableCtrlUnit
+  def icacheCtrlAddress = coreParams.frontendParameters.icacheParameters.ctrlUnitParameters.Address // valid only when icacheCtrlEnabled is true
+
   def dcacheParameters = coreParams.dcacheParametersOpt.getOrElse(DCacheParameters())
 
   // dcache block cacheline when lr for LRSCCycles - LRSCBackOff cycles

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -68,7 +68,7 @@ abstract class XSCoreBase()(implicit p: config.Parameters) extends LazyModule
 
   memBlock.inner.frontendBridge.icache_node := frontend.inner.icache.clientNode
   memBlock.inner.frontendBridge.instr_uncache_node := frontend.inner.instrUncache.clientNode
-  if (icacheParameters.cacheCtrlAddressOpt.nonEmpty) {
+  if (icacheCtrlEnabled) {
     frontend.inner.icache.ctrlUnitOpt.get.node := memBlock.inner.frontendBridge.icachectrl_node
   }
 }

--- a/src/main/scala/xiangshan/XSDts.scala
+++ b/src/main/scala/xiangshan/XSDts.scala
@@ -43,6 +43,7 @@ trait HasXSDts {
         "d-cache-size" -> (dcacheParameters.nSets * dcacheParameters.nWays * dcacheParameters.blockBytes).asProperty
       ) else Map()
 
+      def icacheParameters = coreParams.frontendParameters.icacheParameters
       val icache = Map(
         "i-cache-block-size" -> icacheParameters.blockBytes.asProperty,
         "i-cache-sets" -> icacheParameters.nSets.asProperty,

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -92,7 +92,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
 
   // mmio
   l2top.inner.i_mmio_port := l2top.inner.i_mmio_buffer.node := memBlock.frontendBridge.instr_uncache_node
-  if (icacheParameters.cacheCtrlAddressOpt.nonEmpty) {
+  if (icacheCtrlEnabled) {
     memBlock.frontendBridge.icachectrl_node := l2top.inner.icachectrl_port_opt.get
   }
   l2top.inner.d_mmio_port := memBlock.uncache_port

--- a/src/main/scala/xiangshan/cache/wpu/WPU.scala
+++ b/src/main/scala/xiangshan/cache/wpu/WPU.scala
@@ -64,6 +64,7 @@ class WPUBaseIO(portNum: Int, nWays: Int)(implicit p:Parameters) extends BaseWPU
 }
 
 abstract class BaseWPU(wpuParam: WPUParameters, nPorts: Int)(implicit p:Parameters) extends WPUModule {
+  def icacheParameters = coreParams.frontendParameters.icacheParameters
   val cacheParams: L1CacheParameters = if (wpuParam.isICache) icacheParameters else dcacheParameters
 
   val setSize = nSets

--- a/src/main/scala/xiangshan/frontend/FrontendParameters.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendParameters.scala
@@ -20,12 +20,14 @@ import chisel3.util._
 import xiangshan.HasXSParameter
 import xiangshan.frontend.bpu.BpuParameters
 import xiangshan.frontend.ftq.FtqParameters
+import xiangshan.frontend.icache.ICacheParameters
 
 case class FrontendParameters(
     FetchBlockSize: Int = 32, // bytes // FIXME: 64B, waiting for ftq/icache support
 
-    bpuParameters: BpuParameters = BpuParameters(),
-    ftqParameters: FtqParameters = FtqParameters()
+    bpuParameters:    BpuParameters = BpuParameters(),
+    ftqParameters:    FtqParameters = FtqParameters(),
+    icacheParameters: ICacheParameters = ICacheParameters()
 ) {
   // sanity check
   require(isPow2(FetchBlockSize))

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -116,7 +116,7 @@ class MetaReadBundle(implicit p: Parameters) extends ICacheBundle {
   class MetaReadReqBundle(implicit p: Parameters) extends ArrayReadReqBundle
   class MetaReadRespBundle(implicit p: Parameters) extends ICacheBundle {
     val metas:      Vec[Vec[ICacheMetadata]] = Vec(PortNumber, Vec(nWays, new ICacheMetadata))
-    val codes:      Vec[Vec[UInt]]           = Vec(PortNumber, Vec(nWays, UInt(ICacheMetaCodeBits.W)))
+    val codes:      Vec[Vec[UInt]]           = Vec(PortNumber, Vec(nWays, UInt(MetaEccBits.W)))
     val entryValid: Vec[Vec[Bool]]           = Vec(PortNumber, Vec(nWays, Bool()))
     // for compatibility
     def tags: Vec[Vec[UInt]] = VecInit(metas.map(port => VecInit(port.map(way => way.tag))))
@@ -129,8 +129,8 @@ class MetaReadBundle(implicit p: Parameters) extends ICacheBundle {
 class DataReadBundle(implicit p: Parameters) extends ICacheBundle {
   class DataReadReqBundle(implicit p: Parameters) extends ArrayReadReqBundle
   class DataReadRespBundle(implicit p: Parameters) extends ICacheBundle {
-    val datas: Vec[UInt] = Vec(ICacheDataBanks, UInt(ICacheDataBits.W))
-    val codes: Vec[UInt] = Vec(ICacheDataBanks, UInt(ICacheDataCodeBits.W))
+    val datas: Vec[UInt] = Vec(DataBanks, UInt(ICacheDataBits.W))
+    val codes: Vec[UInt] = Vec(DataBanks, UInt(DataEccBits.W))
   }
   val req:  Vec[DecoupledIO[DataReadReqBundle]] = Vec(partWayNum, DecoupledIO(new DataReadReqBundle))
   val resp: DataReadRespBundle                  = Input(new DataReadRespBundle)
@@ -219,7 +219,7 @@ class WayLookupEntry(implicit p: Parameters) extends ICacheBundle {
   val pTag:          Vec[UInt]          = Vec(PortNumber, UInt(tagBits.W))
   val itlbException: Vec[ExceptionType] = Vec(PortNumber, new ExceptionType)
   val itlbPbmt:      Vec[UInt]          = Vec(PortNumber, UInt(Pbmt.width.W))
-  val metaCodes:     Vec[UInt]          = Vec(PortNumber, UInt(ICacheMetaCodeBits.W))
+  val metaCodes:     Vec[UInt]          = Vec(PortNumber, UInt(MetaEccBits.W))
 }
 
 class WayLookupGpfEntry(implicit p: Parameters) extends ICacheBundle {

--- a/src/main/scala/xiangshan/frontend/icache/ICacheCtrlUnit.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheCtrlUnit.scala
@@ -31,21 +31,22 @@ import utils.EnumUInt
 import xiangshan.frontend.PrunedAddrInit
 
 // currently for ECC control only
-class ICacheCtrlUnit(params: ICacheCtrlUnitParameters)(implicit p: Parameters) extends LazyModule {
+class ICacheCtrlUnit(implicit p: Parameters) extends LazyModule
+    with HasICacheCtrlUnitParameters {
   lazy val module = new ICacheCtrlUnitImp(this)
 
   // register tilelink node
   val device: SimpleDevice = new SimpleDevice("L1ICacheCtrl", Seq("xiangshan,l1icache_ctrl"))
 
   val node: TLRegisterNode = TLRegisterNode(
-    address = Seq(params.address),
+    address = Seq(Address),
     device = device,
-    beatBytes = params.beatBytes,
+    beatBytes = BeatBytes,
     concurrency = 1
   )
 
   class ICacheCtrlUnitImp(wrapper: LazyModule) extends LazyModuleImp(wrapper)
-      with HasICacheParameters
+      with HasICacheCtrlUnitParameters
       with ICacheMetaHelper {
     class ICacheCtrlUnitIO(implicit p: Parameters) extends ICacheBundle {
       // ecc control
@@ -136,8 +137,8 @@ class ICacheCtrlUnit(params: ICacheCtrlUnitParameters)(implicit p: Parameters) e
     private val eccIAddr = RegInit(EccIAddrBundle.default)
 
     // sanity check
-    require(params.regWidth >= eccCtrl.asUInt.getWidth)
-    require(params.regWidth >= eccIAddr.asUInt.getWidth)
+    require(RegWidth >= eccCtrl.asUInt.getWidth)
+    require(RegWidth >= eccIAddr.asUInt.getWidth)
 
     // control signal
     io.eccEnable := eccCtrl.enable
@@ -249,7 +250,7 @@ class ICacheCtrlUnit(params: ICacheCtrlUnitParameters)(implicit p: Parameters) e
 
     private def eccctrlRegField(x: EccCtrlBundle): RegField =
       RegField(
-        params.regWidth,
+        RegWidth,
         RegReadFn { ready =>
           val res = WireInit(x)
           res.inject := false.B // read always 0
@@ -292,11 +293,11 @@ class ICacheCtrlUnit(params: ICacheCtrlUnitParameters)(implicit p: Parameters) e
       )
 
     private def ecciaddrRegField(x: EccIAddrBundle): RegField =
-      RegField(params.regWidth, x.asUInt, ecciaddrRegDesc)
+      RegField(RegWidth, x.asUInt, ecciaddrRegDesc)
 
     node.regmap(
-      params.EccCtrlOffset  -> Seq(eccctrlRegField(eccCtrl)),
-      params.EccIAddrOffset -> Seq(ecciaddrRegField(eccIAddr))
+      EccCtrlOffset  -> Seq(eccctrlRegField(eccCtrl)),
+      EccIAddrOffset -> Seq(ecciaddrRegField(eccIAddr))
     )
   }
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMshr.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMshr.scala
@@ -99,7 +99,7 @@ class ICacheMshr(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Paramet
   private val getBlock = edge.Get(
     fromSource = ID.U,
     toAddress = Cat(blkPAddr, 0.U(blockOffBits.W)),
-    lgSize = log2Up(cacheParams.blockBytes).U
+    lgSize = log2Up(blockBytes).U
   )._2
   io.acquire.bits.acquire := getBlock
   io.acquire.bits.acquire.user.lift(ReqSourceKey).foreach(_ := MemReqSource.CPUInst.id.U)

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -286,7 +286,7 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   private val s1_mshrValid    = fromMiss.valid && !fromMiss.bits.corrupt
   private val s1_waymasks     = WireInit(VecInit(Seq.fill(PortNumber)(0.U(nWays.W))))
   private val s1_waymasksReg  = RegEnable(s1_waymasks, 0.U.asTypeOf(s1_waymasks), s1_sramValid || s1_mshrValid)
-  private val s1_metaCodes    = WireInit(VecInit(Seq.fill(PortNumber)(0.U(ICacheMetaCodeBits.W))))
+  private val s1_metaCodes    = WireInit(VecInit(Seq.fill(PortNumber)(0.U(MetaEccBits.W))))
   private val s1_metaCodesReg = RegEnable(s1_metaCodes, 0.U.asTypeOf(s1_metaCodes), s1_sramValid || s1_mshrValid)
 
   // update waymasks and meta_codes

--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -37,7 +37,7 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
 
   val io: ICacheWayLookupIO = IO(new ICacheWayLookupIO)
 
-  class ICacheWayLookupPtr extends CircularQueuePtr[ICacheWayLookupPtr](nWayLookupSize)
+  class ICacheWayLookupPtr extends CircularQueuePtr[ICacheWayLookupPtr](WayLookupSize)
   private object ICacheWayLookupPtr {
     def apply(f: Bool, v: UInt): ICacheWayLookupPtr = {
       val ptr = Wire(new ICacheWayLookupPtr)
@@ -47,7 +47,7 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     }
   }
 
-  private val entries  = RegInit(VecInit(Seq.fill(nWayLookupSize)(0.U.asTypeOf(new WayLookupEntry))))
+  private val entries  = RegInit(VecInit(Seq.fill(WayLookupSize)(0.U.asTypeOf(new WayLookupEntry))))
   private val readPtr  = RegInit(ICacheWayLookupPtr(false.B, 0.U))
   private val writePtr = RegInit(ICacheWayLookupPtr(false.B, 0.U))
 
@@ -159,6 +159,6 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     distanceBetween(writePtr, readPtr),
     true.B,
     0,
-    nWayLookupSize
+    WayLookupSize
   )
 }


### PR DESCRIPTION
- move icacheParameters into coreParams.frontendParameters
- remove unused params
  - `nTLBEntries` is already replaced by `itlbParameters.NWays`
  - `partWayNum` is actually fixed to `4`, we cannot change it
  - `ICacheDataBanks` is actually `blockBytes * 8 / rowBits`
  - `replacement` is never used
- drop `ICache` prefix