### PR TITLE
feat(ICache,Ftq): drop duplicates of fetch request

### DIFF
--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -94,10 +94,9 @@ class FtqToPrefetchBundle(implicit p: Parameters) extends XSBundle {
   val backendException: ExceptionType = new ExceptionType
 }
 
-class FtqToFetchBundle(implicit p: Parameters) extends XSBundle with HasICacheParameters {
-  val req:                Vec[FtqICacheInfo] = Vec(5, new FtqICacheInfo)
-  val readValid:          Vec[Bool]          = Vec(5, Bool())
-  val isBackendException: Bool               = Bool()
+class FtqToFetchBundle(implicit p: Parameters) extends XSBundle {
+  val req:                FtqICacheInfo = new FtqICacheInfo
+  val isBackendException: Bool          = Bool()
 }
 
 class FtqToICacheIO(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -221,18 +221,12 @@ class Ftq(implicit p: Parameters) extends FtqModule
     ExceptionType.None
   )
 
-  // TODO: we should not need both fetchReq.valid and fetchReq.bits.readValid
   // TODO: consider BPU bypass
-  io.toICache.fetchReq.valid := bpuPtr(0) > ifuPtr(0) && !redirect.valid
-  io.toICache.fetchReq.bits.readValid.foreach(valid =>
-    valid := io.toICache.fetchReq.valid
-  )
-  io.toICache.fetchReq.bits.req.foreach { req =>
-    req.startVAddr         := entryQueue(ifuPtr(0).value)
-    req.nextCachelineVAddr := req.startVAddr + (CacheLineSize / 8).U
-    req.ftqIdx             := ifuPtr(0)
-  }
-  io.toICache.fetchReq.bits.isBackendException := backendException.hasException && backendExceptionPtr === ifuPtr(0)
+  io.toICache.fetchReq.valid                       := bpuPtr(0) > ifuPtr(0) && !redirect.valid
+  io.toICache.fetchReq.bits.req.startVAddr         := entryQueue(ifuPtr(0).value)
+  io.toICache.fetchReq.bits.req.nextCachelineVAddr := entryQueue(ifuPtr(0).value) + (CacheLineSize / 8).U
+  io.toICache.fetchReq.bits.req.ftqIdx             := ifuPtr(0)
+  io.toICache.fetchReq.bits.isBackendException     := backendException.hasException && backendExceptionPtr === ifuPtr(0)
 
   io.toIfu.req.valid                    := bpuPtr(0) > ifuPtr(0) && !redirect.valid
   io.toIfu.req.bits.fetch(0).valid      := bpuPtr(0) > ifuPtr(0) && !redirect.valid

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -132,8 +132,8 @@ class DataReadBundle(implicit p: Parameters) extends ICacheBundle {
     val datas: Vec[UInt] = Vec(DataBanks, UInt(ICacheDataBits.W))
     val codes: Vec[UInt] = Vec(DataBanks, UInt(DataEccBits.W))
   }
-  val req:  Vec[DecoupledIO[DataReadReqBundle]] = Vec(partWayNum, DecoupledIO(new DataReadReqBundle))
-  val resp: DataReadRespBundle                  = Input(new DataReadRespBundle)
+  val req:  DecoupledIO[DataReadReqBundle] = DecoupledIO(new DataReadReqBundle)
+  val resp: DataReadRespBundle             = Input(new DataReadRespBundle)
 }
 
 /* ***** Replacer ***** */

--- a/src/main/scala/xiangshan/frontend/icache/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Parameters.scala
@@ -111,9 +111,6 @@ trait HasICacheParameters extends HasFrontendParameters with HasL1CacheParameter
   // testing
   def ForceMetaEccFail: Boolean = icacheParameters.ForceMetaEccFail
   def ForceDataEccFail: Boolean = icacheParameters.ForceDataEccFail
-
-  // constants
-  def partWayNum: Int = 4 // TODO: hard code, need delete
 }
 
 // For users: these are default ICache parameters set by dev, do not change them here,


### PR DESCRIPTION
These duplicates were used to resolve high-fanout issue, though currently ICache accesses DataArray at s0, so I doubt if it can actually solve the problem.

And, the implementation is ugly.

This PR simply remove duplicates, maybe we'll add it back accroding to physical design report.