### PR TITLE
fix(ICache,Ifu,InstrUncache): set tilelink user fields correctly

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
@@ -75,6 +75,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   println(s"  DataEccUnit: $DataEccUnit bits")
   println(s"  DataSramWidth(data + ecc + padding): $ICacheDataBits + $DataEccBits + $DataPaddingBits = $DataSramWidth")
   println(s"  Ecc(meta, data): $MetaEcc, $DataEcc")
+  println(s"  AliasTagBits: $AliasTagBits")
   println(s"  CtrlUnit:")
   println(s"    Enabled: $EnableCtrlUnit")
   println(s"    Address: ${icacheParameters.ctrlUnitParameters.Address}")

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMshr.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMshr.scala
@@ -17,6 +17,7 @@ package xiangshan.frontend.icache
 
 import chisel3._
 import chisel3.util._
+import coupledL2.MemBackTypeMM
 import freechips.rocketchip.tilelink.TLEdgeOut
 import org.chipsalliance.cde.config.Parameters
 import utility.BoolStopWatch
@@ -103,6 +104,7 @@ class ICacheMshr(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Paramet
   )._2
   io.acquire.bits.acquire := getBlock
   io.acquire.bits.acquire.user.lift(ReqSourceKey).foreach(_ := MemReqSource.CPUInst.id.U)
+  io.acquire.bits.acquire.user.lift(MemBackTypeMM).foreach(_ := true.B) // icache is always requesting main memory
   io.acquire.bits.vSetIdx := vSetIdx
 
   // get victim way when acquire fire

--- a/src/main/scala/xiangshan/frontend/instruncache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/Bundles.scala
@@ -20,7 +20,9 @@ import org.chipsalliance.cde.config.Parameters
 import xiangshan.frontend.PrunedAddr
 
 class InstrUncacheReq(implicit p: Parameters) extends InstrUncacheBundle {
-  val addr: PrunedAddr = PrunedAddr(PAddrBits)
+  val addr:          PrunedAddr = PrunedAddr(PAddrBits)
+  val memBackTypeMM: Bool       = Bool() // !pmp.mmio, pbmt.nc/io on a main memory region
+  val memPageTypeNC: Bool       = Bool() // pbmt.nc
 }
 
 class InstrUncacheResp(implicit p: Parameters) extends InstrUncacheBundle {

--- a/src/main/scala/xiangshan/frontend/instruncache/InstrUncache.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/InstrUncache.scala
@@ -15,6 +15,8 @@
 
 package xiangshan.frontend.instruncache
 
+import coupledL2.MemBackTypeMMField
+import coupledL2.MemPageTypeNCField
 import freechips.rocketchip.diplomacy.IdRange
 import freechips.rocketchip.diplomacy.LazyModule
 import freechips.rocketchip.tilelink.TLClientNode
@@ -26,10 +28,14 @@ class InstrUncache(implicit p: Parameters) extends LazyModule with HasInstrUncac
   override def shouldBeInlined: Boolean = false
 
   val clientParameters: TLMasterPortParameters = TLMasterPortParameters.v1(
-    clients = Seq(TLMasterParameters.v1(
+    Seq(TLMasterParameters.v1(
       "InstrUncache",
       sourceId = IdRange(0, nMmioEntry)
-    ))
+    )),
+    requestFields = Seq(
+      MemBackTypeMMField(),
+      MemPageTypeNCField()
+    )
   )
   val clientNode: TLClientNode = TLClientNode(Seq(clientParameters))
 

--- a/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheEntry.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheEntry.scala
@@ -17,6 +17,8 @@ package xiangshan.frontend.instruncache
 
 import chisel3._
 import chisel3.util._
+import coupledL2.MemBackTypeMM
+import coupledL2.MemPageTypeNC
 import freechips.rocketchip.tilelink.TLBundleA
 import freechips.rocketchip.tilelink.TLBundleD
 import freechips.rocketchip.tilelink.TLEdgeOut
@@ -71,6 +73,8 @@ class InstrUncacheEntry(edge: TLEdgeOut)(implicit p: Parameters) extends InstrUn
     toAddress = Cat(alignedAddr, 0.U(log2Ceil(MmioBusBytes).W)),
     lgSize = log2Ceil(MmioBusBytes).U
   )._2
+  io.mmioAcquire.bits.user.lift(MemBackTypeMM).foreach(_ := reqReg.memBackTypeMM)
+  io.mmioAcquire.bits.user.lift(MemPageTypeNC).foreach(_ := reqReg.memPageTypeNC)
 
   // receive tilelink response
   io.mmioGrant.ready := state === State.RefillResp


### PR DESCRIPTION
- ICache,Ifu,InstrUncache: pick #4898
- ICache: declare MemBackTypeMMField()
- ICache: drop unused PrefetchField()
- ICache: set AliasField correctly