### PR TITLE
feat(ifu,ibuffer,backend): adjust instrEndOffset calculation and cross-predict-block handling

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -256,7 +256,6 @@ class Redirect(implicit p: Parameters) extends XSBundle {
   val backendIAF: Bool = Bool() // instruction access fault
 
   def hasBackendFault: Bool = backendIGPF || backendIPF || backendIAF
-  def flushItself(): Bool = RedirectLevel.flushItself(level)
 
   // for backend and memory
   val robIdx = new RobPtr

--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -268,9 +268,24 @@ class Redirect(implicit p: Parameters) extends XSBundle {
   val stFtqIdx = new FtqPtr // for load violation predict
   val stFtqOffset: UInt = UInt(log2Up(PredictWidth).W)
 
-  val debug_runahead_checkpoint_id: UInt = UInt(64.W)
-  val debugIsCtrl: Bool = Bool()
-  val debugIsMemVio: Bool = Bool()
+  val debug_runahead_checkpoint_id = UInt(64.W)
+  val debugIsCtrl = Bool()
+  val debugIsMemVio = Bool()
+
+  def flushItself() = RedirectLevel.flushItself(level)
+
+  def getPcOffset() = {
+    val ftqOffset = (this.ftqOffset << instOffsetBits).asUInt
+    val rvcOffset = Mux(this.isRVC, 0.U, 2.U)
+    val thisPcOffset = SignExt(ftqOffset -& rvcOffset, VAddrBits)
+    thisPcOffset
+  }
+
+  def getNextPcOffset() = {
+    val ftqOffset = (this.ftqOffset << instOffsetBits).asUInt
+    val nextPcOffset = ftqOffset +& 2.U
+    nextPcOffset
+  }
 }
 
 object Redirect extends HasCircularQueuePtrHelper {

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -121,7 +121,7 @@ case class XSCoreParameters
   StoreQueueNWriteBanks: Int = 8, // NOTE: make sure that StoreQueueSize is divided by StoreQueueNWriteBanks
   StoreQueueForwardWithMask: Boolean = true,
   VlsQueueSize: Int = 8,
-  RobSize: Int = 160,
+  RobSize: Int = 224,
   RabSize: Int = 256,
   VTypeBufferSize: Int = 64, // used to reorder vtype
   IssueQueueSize: Int = 20,

--- a/src/main/scala/xiangshan/backend/BackendParams.scala
+++ b/src/main/scala/xiangshan/backend/BackendParams.scala
@@ -41,7 +41,7 @@ case class BackendParams(
 
   def debugEn(implicit p: Parameters): Boolean = p(DebugOptionsKey).EnableDifftest
 
-  def robCompressEn: Boolean = true
+  def robCompressEn: Boolean = false
 
   def basicDebugEn(implicit p: Parameters): Boolean = p(DebugOptionsKey).AlwaysBasicDiff || debugEn
 

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -340,13 +340,13 @@ class CtrlBlockImp(
   }
   val loadRedirectStartPcRead = pcMem.io.rdata(pcMemRdIndexes("redirect").head).toUInt
   val load_target = loadRedirectStartPcRead + loadRedirectTargetOffset
-  redirectGen.io.loadReplay.bits.cfiUpdate.target := load_target
+  redirectGen.io.loadReplay.bits.target := load_target
   // TODO loadRedirectPcOffset is useful?
   val loadRedirectPcOffset = Reg(UInt(VAddrBits.W))
   when(memViolation.valid) {
     loadRedirectPcOffset := memViolation.bits.getPcOffset()
   }
-  redirectGen.io.loadReplay.bits.cfiUpdate.pc := loadRedirectStartPcRead + loadRedirectPcOffset
+  redirectGen.io.loadReplay.bits.pc := loadRedirectStartPcRead + loadRedirectPcOffset
 
   redirectGen.io.robFlush := s1_robFlushRedirect
 

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -57,7 +57,7 @@ class FuncUnitDataInput(cfg: FuConfig)(implicit p: Parameters) extends XSBundle 
   val src       = MixedVec(cfg.genSrcDataVec)
   val imm       = UInt(cfg.destDataBits.W)
   val pc        = OptionWrapper(cfg.needPc, UInt(VAddrData().dataWidth.W))
-  val nextPcOffset = OptionWrapper(cfg.needPc, UInt((log2Up(PredictWidth) + 1).W))
+  val nextPcOffset = OptionWrapper(cfg.needPc, UInt((log2Up(PredictWidth) + 2).W))
 
   def getSrcVConfig : UInt = src(cfg.vconfigIdx)
   def getSrcMask    : UInt = src(cfg.maskSrcIdx)

--- a/src/main/scala/xiangshan/backend/fu/Jump.scala
+++ b/src/main/scala/xiangshan/backend/fu/Jump.scala
@@ -36,7 +36,7 @@ class JumpDataModule(implicit p: Parameters) extends XSModule {
     val src = Input(UInt(XLEN.W))
     val pc = Input(UInt(XLEN.W)) // sign-ext to XLEN
     val imm = Input(UInt(33.W)) // imm-U need 32 bits, highest bit is sign bit
-    val nextPcOffset = Input(UInt((log2Up(PredictWidth) + 1).W))
+    val nextPcOffset = Input(UInt((log2Up(PredictWidth) + 2).W))
     val func = Input(FuOpType())
     val isRVC = Input(Bool())
     val result, target = Output(UInt(XLEN.W))
@@ -48,7 +48,7 @@ class JumpDataModule(implicit p: Parameters) extends XSModule {
   val isAuipc = JumpOpType.jumpOpisAuipc(func)
   val offset = SignExt(imm, XLEN)
 
-  val snpc = pc + (io.nextPcOffset << instOffsetBits).asUInt
+  val snpc = pc + io.nextPcOffset
   val target = Mux(JumpOpType.jumpOpisJalr(func), src1 + offset, pc + offset) // NOTE: src1 is (pc/rf(rs1)), src2 is (offset)
 
   // RISC-V spec for JALR:

--- a/src/main/scala/xiangshan/backend/fu/wrapper/BranchUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/BranchUnit.scala
@@ -16,13 +16,13 @@ class AddrAddModule(implicit p: Parameters) extends XSModule {
     val isRVC = Input(Bool())
     val imm = Input(UInt(32.W)) // branch inst only support 12 bits immediate num
     val target = Output(UInt(XLEN.W))
-    val nextPcOffset = Input(UInt((log2Up(PredictWidth) + 1).W))
+    val nextPcOffset = Input(UInt((log2Up(PredictWidth) + 2).W))
   })
   val immMinWidth = FuConfig.BrhCfg.immType.map(x => SelImm.getImmUnion(x).len).max
   print(s"[Branch]: immMinWidth = $immMinWidth\n")
   io.target := SignExt(Mux(io.taken,
     io.pcExtend + SignExt(io.imm(immMinWidth + 2, 0), VAddrBits + 1),
-    io.pcExtend + (io.nextPcOffset << instOffsetBits).asUInt
+    io.pcExtend + io.nextPcOffset
   ), XLEN)
 }
 

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -141,15 +141,15 @@ class IfuToFtqIO(implicit p: Parameters) extends XSBundle {
 }
 
 class PredecodeWritebackBundle(implicit p: Parameters) extends XSBundle {
-  val pd         = Vec(PredictWidth, new PreDecodeInfo) // TODO: redefine Predecode
-  val pc         = PrunedAddr(VAddrBits)
-  val ftqIdx     = new FtqPtr
-  val ftqOffset  = UInt(log2Ceil(PredictWidth).W)
-  val misOffset  = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
-  val cfiOffset  = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
-  val target     = PrunedAddr(VAddrBits)
-  val jalTarget  = PrunedAddr(VAddrBits)
-  val instrRange = Vec(PredictWidth, Bool())
+  val pd           = Vec(PredictWidth, new PreDecodeInfo) // TODO: redefine Predecode
+  val pc           = PrunedAddr(VAddrBits)
+  val ftqIdx       = new FtqPtr
+  val ftqEndOffset = UInt(log2Ceil(PredictWidth).W)
+  val misEndOffset = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
+  val cfiEndOffset = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
+  val target       = PrunedAddr(VAddrBits)
+  val jalTarget    = PrunedAddr(VAddrBits)
+  val instrRange   = Vec(PredictWidth, Bool())
 }
 
 class MmioCommitRead(implicit p: Parameters) extends XSBundle {
@@ -266,13 +266,19 @@ class FtqPcOffset(implicit p: Parameters) extends XSBundle {
   val offset = UInt(log2Ceil(PredictWidth).W)
 }
 
+class InstrEndOffset(implicit p: Parameters) extends XSBundle {
+  val taken  = Bool()
+  val offset = UInt(log2Ceil(PredictWidth).W)
+}
+
 class FetchToIBuffer(implicit p: Parameters) extends XSBundle {
-  val instrs           = Vec(IBufEnqWidth, UInt(32.W))
-  val valid            = UInt(IBufEnqWidth.W)
-  val enqEnable        = UInt(IBufEnqWidth.W)
-  val pd               = Vec(IBufEnqWidth, new PreDecodeInfo)
-  val foldpc           = Vec(IBufEnqWidth, UInt(MemPredPCWidth.W))
-  val ftqPcOffset      = Vec(IBufEnqWidth, ValidUndirectioned(new FtqPcOffset))
+  val instrs         = Vec(IBufEnqWidth, UInt(32.W))
+  val valid          = UInt(IBufEnqWidth.W)
+  val enqEnable      = UInt(IBufEnqWidth.W)
+  val pd             = Vec(IBufEnqWidth, new PreDecodeInfo)
+  val foldpc         = Vec(IBufEnqWidth, UInt(MemPredPCWidth.W))
+  val instrEndOffset = Vec(IBufEnqWidth, new InstrEndOffset)
+  // val ftqPcOffset      = Vec(IBufEnqWidth, ValidUndirectioned(new FtqPcOffset))
   val backendException = Vec(IBufEnqWidth, Bool())
   val exceptionType    = Vec(IBufEnqWidth, new ExceptionType)
   val crossPageIPFFix  = Vec(IBufEnqWidth, Bool())

--- a/src/main/scala/xiangshan/frontend/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/IBuffer.scala
@@ -91,7 +91,7 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
   val pd               = new PreDecodeInfo
   val predTaken        = Bool()
   val ftqPtr           = new FtqPtr
-  val ftqPcOffset      = new FtqPcOffset
+  val instrEndOffset   = UInt(log2Ceil(PredictWidth).W)
   val exceptionType    = IBufferExceptionType()
   val backendException = Bool()
   val triggered        = TriggerAction()
@@ -99,13 +99,13 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
   val debug_seqNum     = InstSeqNum()
 
   def fromFetch(fetch: FetchToIBuffer, i: Int): IBufEntry = {
-    inst        := fetch.instrs(i)
-    pc          := fetch.pc(i)
-    foldpc      := fetch.foldpc(i)
-    pd          := fetch.pd(i)
-    predTaken   := fetch.ftqPcOffset(i).valid
-    ftqPtr      := fetch.ftqPtr
-    ftqPcOffset := fetch.ftqPcOffset(i).bits
+    inst           := fetch.instrs(i)
+    pc             := fetch.pc(i)
+    foldpc         := fetch.foldpc(i)
+    pd             := fetch.pd(i)
+    predTaken      := fetch.instrEndOffset(i).taken
+    ftqPtr         := fetch.ftqPtr
+    instrEndOffset := fetch.instrEndOffset(i).offset
     exceptionType := IBufferExceptionType.cvtFromFetchExcpAndCrossPageAndRVCII(
       fetch.exceptionType(i),
       fetch.crossPageIPFFix(i),
@@ -131,25 +131,27 @@ class IBufEntry(implicit p: Parameters) extends XSBundle {
     result.triggered        := triggered
     result.isLastInFtqEntry := isLastInFtqEntry
     result.debug_seqNum     := debug_seqNum
-    result.ftqInstrEndOffset :=
-      Mux(pd.isRVC || ftqPcOffset.borrow, ftqPcOffset.offset, ftqPcOffset.offset + 1.U)
+    result.instrEndOffset   := instrEndOffset
     result
   }
 }
 
+// The definition of IBufOutEntry is currently retained.
+// In the future, the backend will perform certain computations
+// in the IBuffer, which will be differentiated from IBufEntry.
 class IBufOutEntry(implicit p: Parameters) extends XSBundle {
-  val inst              = UInt(32.W)
-  val pc                = PrunedAddr(VAddrBits)
-  val foldpc            = UInt(MemPredPCWidth.W)
-  val pd                = new PreDecodeInfo
-  val predTaken         = Bool()
-  val ftqPtr            = new FtqPtr
-  val exceptionType     = IBufferExceptionType()
-  val backendException  = Bool()
-  val triggered         = TriggerAction()
-  val isLastInFtqEntry  = Bool()
-  val debug_seqNum      = InstSeqNum()
-  val ftqInstrEndOffset = UInt(log2Ceil(PredictWidth).W)
+  val inst             = UInt(32.W)
+  val pc               = PrunedAddr(VAddrBits)
+  val foldpc           = UInt(MemPredPCWidth.W)
+  val pd               = new PreDecodeInfo
+  val predTaken        = Bool()
+  val ftqPtr           = new FtqPtr
+  val exceptionType    = IBufferExceptionType()
+  val backendException = Bool()
+  val triggered        = TriggerAction()
+  val isLastInFtqEntry = Bool()
+  val debug_seqNum     = InstSeqNum()
+  val instrEndOffset   = UInt(log2Ceil(PredictWidth).W)
 
   def toCtrlFlow: CtrlFlow = {
     val cf = Wire(new CtrlFlow)
@@ -172,7 +174,7 @@ class IBufOutEntry(implicit p: Parameters) extends XSBundle {
     cf.loadWaitStrict                    := DontCare
     cf.ssid                              := DontCare
     cf.ftqPtr                            := ftqPtr
-    cf.ftqOffset                         := ftqInstrEndOffset
+    cf.ftqOffset                         := instrEndOffset
     cf.isLastInFtqEntry                  := isLastInFtqEntry
     cf.debug_seqNum                      := debug_seqNum
     cf

--- a/src/main/scala/xiangshan/frontend/ftq/IfuRedirectReceiver.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/IfuRedirectReceiver.scala
@@ -27,14 +27,13 @@ trait IfuRedirectReceiver extends HasFtqParameters {
   ): Valid[Redirect] = {
     val redirect = WireInit(0.U.asTypeOf(Valid(new Redirect)))
 
-    redirect.valid          := pdWb.valid && pdWb.bits.misOffset.valid
+    redirect.valid          := pdWb.valid && pdWb.bits.misEndOffset.valid
     redirect.bits.ftqIdx    := pdWb.bits.ftqIdx
-    redirect.bits.ftqOffset := pdWb.bits.ftqOffset
+    redirect.bits.ftqOffset := pdWb.bits.ftqEndOffset
     redirect.bits.level     := RedirectLevel.flushAfter
     redirect.bits.pc        := pdWb.bits.pc.toUInt
     redirect.bits.target    := pdWb.bits.target.toUInt
-    redirect.bits.taken     := pdWb.bits.cfiOffset.valid
-
+    redirect.bits.taken     := pdWb.bits.cfiEndOffset.valid
     redirect
   }
 }

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -63,9 +63,9 @@ class FetchBlockInfo(implicit p: Parameters) extends IfuBundle {
   val ftqIdx:        FtqPtr                   = new FtqPtr
   val doubline:      Bool                     = Bool()
   val predTakenIdx:  ValidUndirectioned[UInt] = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
-  val ftqOffset:     ValidUndirectioned[UInt] = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
+  val ftqEndOffset:  ValidUndirectioned[UInt] = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
   val invalidTaken:  Bool                     = Bool()
-  val startAddr:     PrunedAddr               = PrunedAddr(VAddrBits)
+  val startVAddr:    PrunedAddr               = PrunedAddr(VAddrBits)
   val target:        PrunedAddr               = PrunedAddr(VAddrBits)
   val instrRange:    UInt                     = UInt(PredictWidth.W)
   val rawInstrValid: UInt                     = UInt(PredictWidth.W)

--- a/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
@@ -104,35 +104,19 @@ trait IfuHelper extends HasXSParameter with HasIfuParameters {
     result
   }
 
-  def alignData[T <: Data](indataVec: Vec[T], shiftNum: UInt, prevIsHalf: Bool, default: T): Vec[T] = {
+  def alignData[T <: Data](indataVec: Vec[T], shiftNum: UInt, default: T): Vec[T] = {
     require(shiftNum.getWidth == 2)
     val dataVec = VecInit((0 until IBufEnqWidth).map(i =>
       if (i < indataVec.length) indataVec(i) else 0.U.asTypeOf(default)
     ))
     VecInit((0 until IBufEnqWidth).map { i =>
       MuxLookup(shiftNum, 0.U.asTypeOf(default))(Seq(
-        ShiftType.NoShift -> Mux(
-          prevIsHalf,
-          if (i == IBufEnqWidth - 1) 0.U.asTypeOf(default) else dataVec(i + 1),
-          dataVec(i)
-        ),
-        ShiftType.ShiftRight1 -> Mux(
-          prevIsHalf,
-          dataVec(i),
-          if (i == 0) 0.U.asTypeOf(default) else dataVec(i - 1)
-        ),
-        ShiftType.ShiftRight2 -> Mux(
-          prevIsHalf,
-          if (i < 1) 0.U.asTypeOf(default) else dataVec(i - 1),
-          if (i < 2) 0.U.asTypeOf(default) else dataVec(i - 2)
-        ),
-        ShiftType.ShiftRight3 -> Mux(
-          prevIsHalf,
-          if (i < 2) 0.U.asTypeOf(default) else dataVec(i - 2),
-          if (i < 3) 0.U.asTypeOf(default) else dataVec(i - 3)
-        )
+        ShiftType.NoShift     -> dataVec(i),
+        ShiftType.ShiftRight1 -> (if (i == 0) 0.U.asTypeOf(default) else dataVec(i - 1)),
+        ShiftType.ShiftRight2 -> (if (i < 2) 0.U.asTypeOf(default) else dataVec(i - 2)),
+        ShiftType.ShiftRight3 -> (if (i < 3) 0.U.asTypeOf(default) else dataVec(i - 3))
       ))
     })
-  }
 
+  }
 }

--- a/src/main/scala/xiangshan/frontend/ifu/PreDecodeBoundary.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PreDecodeBoundary.scala
@@ -144,6 +144,7 @@ class PreDecodeBoundary(implicit p: Parameters) extends IfuModule with PreDecode
   io.resp.bits.isRvc := VecInit(io.resp.bits.instrValid.zip(currentIsRvc).map { case (valid, rvc) =>
     valid & rvc
   })
+  io.resp.bits.isRvc(0) := Mux(io.req.bits.prevLastIsHalfRvi, false.B, io.resp.bits.instrValid(0) && currentIsRvc(0))
   io.resp.bits.isFirstLastHalfRvi := io.resp.bits.instrValid(io.req.bits.firstEndPos) &&
     !currentIsRvc(io.req.bits.firstEndPos)
   io.resp.bits.isLastHalfRvi := io.resp.bits.instrValid(io.req.bits.endPos) &&

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -45,7 +45,7 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
       val secondTarget:     PrunedAddr = PrunedAddr(VAddrBits)
       val selectFetchBlock: Vec[Bool]  = Vec(IBufferInPortNum, Bool())
       val invalidTaken:     Vec[Bool]  = Vec(IBufferInPortNum, Bool())
-      val instrOffset:      Vec[UInt]  = Vec(IBufferInPortNum, UInt(log2Ceil(PredictWidth).W))
+      val instrEndOffset:   Vec[UInt]  = Vec(IBufferInPortNum, UInt(log2Ceil(PredictWidth).W))
     }
 
     class PredCheckerResp(implicit p: Parameters) extends IfuBundle {
@@ -78,7 +78,7 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   private val secondPredTarget = io.req.bits.secondTarget
   private val selectFetchBlock = io.req.bits.selectFetchBlock
   private val invalidTaken     = io.req.bits.invalidTaken
-  private val instrOffset      = io.req.bits.instrOffset
+  private val instrEndOffset   = io.req.bits.instrEndOffset
   private val isPredTaken      = io.req.bits.isPredTaken
 
   // Entries made invalid by offset are marked with 'ignore'
@@ -170,7 +170,7 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
     (pc(i) + jumpOffset(i)).asTypeOf(PrunedAddr(VAddrBits))
   })
   private val seqTargets =
-    VecInit((0 until IBufferInPortNum).map(i => pc(i) + Mux(pds(i).isRVC, 2.U, 4.U)))
+    VecInit((0 until IBufferInPortNum).map(i => pc(i) + Mux(pds(i).isRVC || invalidTaken(i), 2.U, 4.U)))
 
   private val mispredIsJump =
     instrValid(mispredInstrIdx.bits) &&
@@ -180,14 +180,14 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   /* *****************************************************************************
    * PredChecker Stage 2
    * ***************************************************************************** */
-  private val mispredIdxNext          = RegEnable(mispredInstrIdx, io.req.valid)
-  private val mispredIsFirstBlockNext = RegEnable(!selectFetchBlock(mispredInstrIdx.bits), io.req.valid)
-  private val mispredInstrOffsetNext  = RegEnable(instrOffset(mispredInstrIdx.bits), io.req.valid)
-  private val mispredIsJumpNext       = RegEnable(mispredIsJump, io.req.valid)
+  private val mispredIdxNext            = RegEnable(mispredInstrIdx, io.req.valid)
+  private val mispredIsFirstBlockNext   = RegEnable(!selectFetchBlock(mispredInstrIdx.bits), io.req.valid)
+  private val mispredInstrEndOffsetNext = RegEnable(instrEndOffset(mispredInstrIdx.bits), io.req.valid)
+  private val mispredIsJumpNext         = RegEnable(mispredIsJump, io.req.valid)
 
   private val fixedFirstTakenInstrIdxNext  = RegEnable(fixedFirstTakenInstrIdx, io.req.valid)
   private val fixedSecondTakenInstrIdxNext = RegEnable(fixedSecondTakenInstrIdx, io.req.valid)
-  private val instrOffsetNext              = RegEnable(instrOffset, io.req.valid)
+  private val instrEndOffsetNext           = RegEnable(instrEndOffset, io.req.valid)
   private val firstTakenIdxNext            = RegEnable(firstTakenIdx, io.req.valid)
   private val secondTakenIdxNext           = RegEnable(secondTakenIdx, io.req.valid)
   private val firstPredTargetNext          = RegEnable(firstPredTarget, io.req.valid)
@@ -210,11 +210,11 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   private val fixSecondMispred = mispredIdxNext.valid && !mispredIsFirstBlockNext
   private val fixedFirstRawInstrRange =
     Fill(PredictWidth, !fixFirstMispred) |
-      (Fill(PredictWidth, 1.U(1.W)) >> ~mispredInstrOffsetNext(log2Ceil(PredictWidth) - 1, 0))
+      (Fill(PredictWidth, 1.U(1.W)) >> ~mispredInstrEndOffsetNext(log2Ceil(PredictWidth) - 1, 0))
 
   private val fixedSecondRawInstrRange =
     Fill(PredictWidth, !fixSecondMispred) |
-      (Fill(PredictWidth, 1.U(1.W)) >> ~mispredInstrOffsetNext(log2Ceil(PredictWidth) - 1, 0))
+      (Fill(PredictWidth, 1.U(1.W)) >> ~mispredInstrEndOffsetNext(log2Ceil(PredictWidth) - 1, 0))
 
   private val mispredTarget =
     Mux(mispredIsJumpNext, jumpTargetsNext(mispredIdxNext.bits), seqTargetsNext(mispredIdxNext.bits))
@@ -265,8 +265,8 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   io.resp.stage2Out.fixedFirst.misIdx.valid := fixFirstMispred || firstTargetFault
   io.resp.stage2Out.fixedFirst.misIdx.bits := Mux(
     firstTargetFault,
-    instrOffsetNext(firstTakenIdxNext),
-    Mux(fixFirstMispred, instrOffsetNext(mispredIdxNext.bits), instrOffsetNext(firstTakenIdxNext))
+    instrEndOffsetNext(firstTakenIdxNext),
+    Mux(fixFirstMispred, instrEndOffsetNext(mispredIdxNext.bits), instrEndOffsetNext(firstTakenIdxNext))
   )
   // private val firstTargetFault  = fixedFirstTakenInstrIdxNext.valid && jumpTargetsNext(mispredIdxNext.bits) =/= firstPredTargetNext
 }


### PR DESCRIPTION
- feat(ifu): Switch cross-predict-block instructions from read to wait for concatenation.
- feat(backend): read pc support new ftqOffset from frontend.
- feat(ibuffer): instrOffset to backend now points to instruction end instead of start.

This PR does not handle the case where an MMIO instruction crosses a page boundary. When a single MMIO instruction spans across pages, it may generate a prediction block that contains no valid instructions. Due to the blocked speculative execution policy, this can lead to a deadlock. Since the MMIO fetch strategy will undergo significant changes, we will not add temporary workaround code here. The issue is expected to be fixed together with the MMIO strategy update in a subsequent PR.