### PR TITLE
fix(LoadUnit): reaccess the data even if it is a fast replay

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -479,7 +479,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     out.elemIdx       := src.elemIdx
     out.elemIdxInsideVd := src.elemIdxInsideVd
     out.alignedType   := src.alignedType
-    out.isnc          := src.nc
     out.data          := src.data
     out
   }


### PR DESCRIPTION
# Bug Description

In multi-core case that st1 is access the memory between ld1 and ld2.

cpu0:

```
ld1
ld2
```

cpu1:

```
st1
```


If ld2 completes first but triggers a RAW hazard with the store pipeline (s2_nuke), it will issue a fast replay (the only reason for fast replay). During this fast replay, if ld1 enters the load pipeline and writes back normally, the system fails to detect the RAR violation where:
* Ld1 (issued earlier) accesses new data
* Ld2 (issued later) accesses old data

# Root Cause

Fast replay does not re-fetch data, so ordering checks miss the RAR conflict.

# Fix

If fast replay occurs, it must re-access the data.