### PR TITLE
fix(Bpu): wait Sram reset to avoid x-state

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
@@ -39,6 +39,8 @@ abstract class BasePredictorIO(implicit p: Parameters) extends BpuBundle {
   val startVAddr: PrunedAddr = Input(PrunedAddr(VAddrBits))
   // train
   val train: Valid[BpuTrain] = Input(Valid(new BpuTrain))
+
+  val resetDone: Bool = Output(Bool())
 }
 
 // The abstract class is used to abstract the setIdx and tag from write requests for updating write buffer entries

--- a/src/main/scala/xiangshan/frontend/bpu/FallThroughPredictor.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/FallThroughPredictor.scala
@@ -29,6 +29,8 @@ class FallThroughPredictor(implicit p: Parameters) extends BasePredictor
 
   val io: FallThroughPredictorIO = IO(new FallThroughPredictorIO)
 
+  io.resetDone := true.B
+
   /* *** predict stage 0 *** */
   private val s0_fire       = io.stageCtrl.s0_fire
   private val s0_startVAddr = io.startVAddr

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
@@ -44,6 +44,12 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers with B
   private val banks     = Seq.fill(NumBanks)(Module(new AheadBtbBank))
   private val replacers = Seq.fill(NumBanks)(Module(new AheadBtbReplacer))
 
+  private val resetDone = RegInit(false.B)
+  when(banks.map(_.io.readReq.ready).reduce(_ && _)) {
+    resetDone := true.B
+  }
+  io.resetDone := resetDone
+
   private val takenCounter = Reg(Vec(NumBanks, Vec(NumSets, Vec(NumWays, new SaturateCounter(TakenCounterWidth)))))
 
   // TODO: write ctr bypass to read
@@ -63,7 +69,7 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers with B
   private val redirectValid   = io.redirectValid
   private val overrideValid   = io.overrideValid
 
-  s0_fire := predictReqValid && banks.map(_.io.readReq.ready).reduce(_ && _)
+  s0_fire := predictReqValid
   s1_fire := s1_valid && s2_ready && predictReqValid
   s2_fire := s2_valid
 

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
@@ -62,6 +62,8 @@ class Ittage(implicit p: Parameters) extends XSModule with HasIttageParameters w
 
   val io: IttageIO = IO(new IttageIO)
 
+  io.resetDone := true.B // FIXME: sram read ready
+
   private val s0_pc   = io.startVAddr
   private val s0_fire = io.stageCtrl.s0_fire
   private val s1_fire = io.stageCtrl.s1_fire

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -57,6 +57,12 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
     Module(new WriteBuffer(new MainBtbSramWriteReq, WriteBufferSize, NumWay, pipe = true))
   }
 
+  private val resetDone = RegInit(false.B)
+  when(sramBanks.flatMap(_.flatMap(_.map(_.io.r.req.ready))).reduce(_ && _)) {
+    resetDone := true.B
+  }
+  io.resetDone := resetDone
+
   sramBanks.map(_.map(_.map { m =>
     m.io.r.req.valid       := false.B
     m.io.r.req.bits.setIdx := 0.U

--- a/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
@@ -50,6 +50,8 @@ class Ras(implicit p: Parameters) extends BasePredictor with HasRasParameters wi
 
   val io: RasIO = IO(new RasIO)
 
+  io.resetDone := true.B
+
   def alignMask: UInt = ((~0.U(VAddrBits.W)) << FetchBlockAlignWidth).asUInt
 
   private val stack = Module(new RasStack(StackSize, SpecQueueSize)).io

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
@@ -55,6 +55,12 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
       ).suggestName(s"tage_base_table_sram_align${alignIdx}_bank${bankIdx}")
     }
 
+  private val resetDone = RegInit(false.B)
+  when(baseTableSramBanks.flatMap(_.map(_.io.r.req.ready)).reduce(_ && _)) {
+    resetDone := true.B
+  }
+  io.resetDone := resetDone
+
   private val baseTableWriteBuffers =
     Seq.tabulate(BaseTableNumAlignBanks, BaseTableInternalBanks) { (_, _) =>
       Module(new WriteBuffer(new BaseTableSramWriteReq, WriteBufferSize, numPorts = 1, pipe = true, hasTag = false))

--- a/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
@@ -32,6 +32,8 @@ class MicroBtb(implicit p: Parameters) extends BasePredictor with HasMicroBtbPar
 
   val io: MicroBtbIO = IO(new MicroBtbIO)
 
+  io.resetDone := true.B
+
   /* *** submodules *** */
   private val entries = RegInit(VecInit(Seq.fill(NumEntries)(0.U.asTypeOf(new MicroBtbEntry))))
 


### PR DESCRIPTION
Fix #4962 simv failure.

#4962 seems to have other problem, so instead merging this to it, I'd suggest merging this to kunminghu-v3 first and rebase #4962 later.

The root cause of that failure is we send read requests to mbtb/tage before their sram ready. #4946/kunminghu-v3 can pass CI because we don't have Bpu.io.train before #4962, chisel can opt-out train-related code, including the failure assertion.

From SRAMTemplate:
```scala
  private val singleHold = if(singlePort) io.w.req.valid else false.B
  private val resetHold = if(shouldReset) resetState else false.B
  io.r.req.ready := !resetHold && !singleHold && !conflictStallRead
```

We cannot connect `io.r.req.ready` directly to `s0_fire`, that forms a combinational loop in tage. So we use a resetDone register to block requests until Sram reset is done (`!resetHold`)