### PR TITLE
feat(Bpu): fast train for s1 predictor

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
@@ -28,6 +28,8 @@ abstract class BpuModule(implicit p: Parameters) extends XSModule with HasBpuPar
 
 abstract class BasePredictor(implicit p: Parameters) extends BpuModule {
   val io: BasePredictorIO
+
+  def EnableFastTrain: Boolean
 }
 
 abstract class BasePredictorIO(implicit p: Parameters) extends BpuBundle {

--- a/src/main/scala/xiangshan/frontend/bpu/FallThroughPredictor.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/FallThroughPredictor.scala
@@ -27,6 +27,9 @@ class FallThroughPredictor(implicit p: Parameters) extends BasePredictor
     val prediction: Prediction = Output(new Prediction)
   }
 
+  // fall-through cannot be fast-trained (actually cannot be trained), this is required by abstract class BasePredictor
+  def EnableFastTrain: Boolean = false
+
   val io: FallThroughPredictorIO = IO(new FallThroughPredictorIO)
 
   io.resetDone := true.B

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/Parameters.scala
@@ -47,4 +47,7 @@ trait HasAheadBtbParameters extends HasBpuParameters {
   def TakenCounterWidth:    Int = abtbParameters.TakenCounterWidth
 
   def EnableTargetFix: Boolean = abtbParameters.EnableTargetFix
+
+  // abtb can only be fast-trained, we don't have continous predict block on resolve
+  def EnableFastTrain: Boolean = true
 }

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Parameters.scala
@@ -70,4 +70,7 @@ trait HasIttageParameters extends HasBpuParameters {
 
   /* *** testing *** */
   def debug: Boolean = !env.FPGAPlatform && env.EnablePerfDebug
+
+  // ittage cannot be fast-trained, this is required by abstract class BasePredictor
+  def EnableFastTrain: Boolean = false
 }

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/Parameters.scala
@@ -53,4 +53,6 @@ trait HasMainBtbParameters extends HasBpuParameters {
   // Used in any aligned-addr-indexed predictor, indicates the position relative to the aligned start addr
   def CfiAlignedPositionWidth: Int = CfiPositionWidth - log2Ceil(NumAlignBanks)
 
+  // mbtb cannot be fast-trained, this is required by abstract class BasePredictor
+  def EnableFastTrain: Boolean = false
 }

--- a/src/main/scala/xiangshan/frontend/bpu/ras/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/Parameters.scala
@@ -33,4 +33,7 @@ trait HasRasParameters extends HasBpuParameters {
   def SpecQueueSize:     Int = rasParameters.SpecSize
   def StackCounterWidth: Int = rasParameters.StackCounterWidth
   def StackCounterMax:   Int = (1 << StackCounterWidth) - 1
+
+  // ras cannot be fast-trained, this is required by abstract class BasePredictor
+  def EnableFastTrain: Boolean = false
 }

--- a/src/main/scala/xiangshan/frontend/bpu/sc/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/sc/Parameters.scala
@@ -25,4 +25,7 @@ case class ScParameters(
 trait HasScParameters extends HasBpuParameters {
   def scParameters: ScParameters = bpuParameters.scParameters
   // TODO
+
+  // sc cannot be fast-trained, this is required by abstract class BasePredictor
+  def EnableFastTrain: Boolean = false
 }

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Parameters.scala
@@ -66,4 +66,7 @@ trait HasTageParameters extends HasBpuParameters {
   def NumTables:  Int                = TableInfos.length
 
   def TageEntryWidth: Int = (new TageEntry).getWidth
+
+  // tage cannot be fast-trained, this is required by abstract class BasePredictor
+  def EnableFastTrain: Boolean = false
 }

--- a/src/main/scala/xiangshan/frontend/bpu/ubtb/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ubtb/Parameters.scala
@@ -25,6 +25,8 @@ case class MicroBtbParameters(
     UsefulCntWidth: Int = 2,
     TakenCntWidth:  Int = 2,
     Replacer:       String = "plru",
+    // use s3 prediction to train ubtb
+    EnableFastTrain: Boolean = false,
     // enable carry and borrow fix for target, so jumps around 2^(TargetWidth+1) boundary will not cause misprediction
     // mainBtb should handle this case, so performance affect should be slight, and, bad for timing
     EnableTargetFix: Boolean = false
@@ -40,5 +42,6 @@ trait HasMicroBtbParameters extends HasBpuParameters {
   def TakenCntWidth:  Int    = ubtbParameters.TakenCntWidth
   def Replacer:       String = ubtbParameters.Replacer
 
+  def EnableFastTrain: Boolean = ubtbParameters.EnableFastTrain
   def EnableTargetFix: Boolean = ubtbParameters.EnableTargetFix
 }


### PR DESCRIPTION
- Add a `EnableFastTrain` parameter to `BasePredictor`
  - ubtb can switch between fast train and resolve train
  - abtb can only be fast-trained currently, we don't have continuous predict block on resolve, so we don't have `previousPc` used to index SRAM
  - S3 predictors cannot be fast-trained, as fast training data is generated by them
- Currently we don't have S3 predictors available, so:
  - ubtb has `EnableFastTrain = false` by default
  - abtb is disabled completely
  - We'll change these in a future PR