### PR TITLE
refactor(Ifu): switch to V3 parameter system

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -111,7 +111,7 @@ class CtrlFlow(implicit p: Parameters) extends XSBundle {
   val loadWaitStrict = Bool()
   val ssid = UInt(SSIDWidth.W)
   val ftqPtr = new FtqPtr
-  val ftqOffset = UInt(log2Up(PredictWidth).W)
+  val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
   val isLastInFtqEntry = Bool()
   val debug_seqNum = InstSeqNum()
 }
@@ -248,7 +248,7 @@ class XSBundleWithMicroOp(implicit p: Parameters) extends XSBundle {
 class Redirect(implicit p: Parameters) extends XSBundle {
   // for frontend
   val ftqIdx = new FtqPtr
-  val ftqOffset: UInt = UInt(log2Up(PredictWidth).W)
+  val ftqOffset: UInt = UInt(FetchBlockInstOffsetWidth.W)
   val target: UInt = UInt(VAddrBits.W)
   val isRVC: Bool = Bool()
   val level: UInt = RedirectLevel()
@@ -268,7 +268,7 @@ class Redirect(implicit p: Parameters) extends XSBundle {
   val fullTarget: UInt = UInt(XLEN.W) // only used for tval storage in backend
 
   val stFtqIdx = new FtqPtr // for load violation predict
-  val stFtqOffset: UInt = UInt(log2Up(PredictWidth).W)
+  val stFtqOffset: UInt = UInt(FetchBlockInstOffsetWidth.W)
 
   val debug_runahead_checkpoint_id = UInt(64.W)
   val debugIsCtrl = Bool()
@@ -305,7 +305,7 @@ object Redirect extends HasCircularQueuePtrHelper {
 
 class Resolve(implicit p: Parameters) extends XSBundle {
   val ftqIdx: FtqPtr = new FtqPtr
-  val ftqOffset: UInt = UInt(log2Up(PredictWidth).W)
+  val ftqOffset: UInt = UInt(FetchBlockInstOffsetWidth.W)
   val pc: PrunedAddr = PrunedAddr(VAddrBits)
   val target: PrunedAddr = PrunedAddr(VAddrBits)
   val taken: Bool = Bool()

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -77,7 +77,6 @@ case class XSCoreParameters
   HasFPU: Boolean = true,
   HasVPU: Boolean = true,
   HasCustomCSRCacheOp: Boolean = true,
-  FetchWidth: Int = 8,
   AsidLength: Int = 16,
   VmidLength: Int = 14,
   EnbaleTlbDebug: Boolean = false,
@@ -596,8 +595,6 @@ trait HasXSParameter {
   def HasFPU = coreParams.HasFPU
   def HasVPU = coreParams.HasVPU
   def HasCustomCSRCacheOp = coreParams.HasCustomCSRCacheOp
-  def FetchWidth = coreParams.FetchWidth
-  def PredictWidth = FetchWidth * (if (HasCExtension) 2 else 1)
   def EnbaleTlbDebug = coreParams.EnbaleTlbDebug
   def EnableCommitGHistDiff = coreParams.EnableCommitGHistDiff
   def EnableClockGate = coreParams.EnableClockGate
@@ -605,8 +602,9 @@ trait HasXSParameter {
   def CacheLineSize = coreParams.CacheLineSize
   def CacheLineHalfWord = CacheLineSize / 16
   def FtqSize = coreParams.frontendParameters.ftqParameters.FtqSize
+  def FetchBlockInstOffsetWidth: Int = log2Ceil(coreParams.frontendParameters.FetchBlockSize / instBytes)
   def IBufSize = coreParams.IBufSize
-  def IBufEnqWidth = coreParams.IBufWriteBank + PredictWidth
+  def IBufEnqWidth = coreParams.IBufWriteBank + coreParams.frontendParameters.FetchBlockSize / instBytes
   def IBufWriteBank = coreParams.IBufWriteBank
   def IBufReadBank = coreParams.IBufReadBank
   def IBufNRank = coreParams.IBufNBank

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -78,7 +78,6 @@ case class XSCoreParameters
   HasVPU: Boolean = true,
   HasCustomCSRCacheOp: Boolean = true,
   FetchWidth: Int = 8,
-  FetchPorts: Int = 2,
   AsidLength: Int = 16,
   VmidLength: Int = 14,
   EnbaleTlbDebug: Boolean = false,
@@ -599,7 +598,6 @@ trait HasXSParameter {
   def HasCustomCSRCacheOp = coreParams.HasCustomCSRCacheOp
   def FetchWidth = coreParams.FetchWidth
   def PredictWidth = FetchWidth * (if (HasCExtension) 2 else 1)
-  def FetchPorts = coreParams.FetchPorts
   def EnbaleTlbDebug = coreParams.EnbaleTlbDebug
   def EnableCommitGHistDiff = coreParams.EnableCommitGHistDiff
   def EnableClockGate = coreParams.EnableClockGate

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -63,7 +63,7 @@ object Bundles {
     val pred_taken = Bool()
     val crossPageIPFFix = Bool()
     val ftqPtr = new FtqPtr
-    val ftqOffset = UInt(log2Up(PredictWidth).W)
+    val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
     val isLastInFtqEntry = Bool()
     val instr = UInt(32.W)
     val debug = OptionWrapper(backendParams.debugEn, new DecodeInUopDebug())
@@ -94,7 +94,7 @@ object Bundles {
     val pred_taken = Bool()
     val crossPageIPFFix = Bool()
     val ftqPtr = new FtqPtr
-    val ftqOffset = UInt(log2Up(PredictWidth).W)
+    val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
     val isLastInFtqEntry = Bool()
     // DecodeOutUop also needs instr because the fusion decoder uses it.
     val instr = UInt(32.W)
@@ -160,7 +160,7 @@ object Bundles {
   class TrapInstInfo(implicit p: Parameters) extends XSBundle {
     val instr = UInt(32.W)
     val ftqPtr = new FtqPtr
-    val ftqOffset = UInt(log2Up(PredictWidth).W)
+    val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
 
     def needFlush(ftqPtr: FtqPtr, ftqOffset: UInt): Bool = {
       val sameFlush = this.ftqPtr === ftqPtr && this.ftqOffset > ftqOffset
@@ -187,7 +187,7 @@ object Bundles {
     val identifiedCfi = Bool()
     val crossPageIPFFix = Bool()
     val ftqPtr = new FtqPtr
-    val ftqOffset = UInt(log2Up(PredictWidth).W)
+    val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
     val commitType = CommitType()
 
     val srcType = Vec(numSrc, SrcType())
@@ -235,7 +235,7 @@ object Bundles {
     val singleStep = Bool() // debug module
     val numLsElem = NumLsElem()
     val hasException = Bool()
-    val ftqLastOffset = UInt(log2Up(PredictWidth).W) // store ftqoffset before change in rename
+    val ftqLastOffset = UInt(FetchBlockInstOffsetWidth.W) // store ftqoffset before change in rename
     val lastIsRVC = Bool() // store isrvc before change in rename
     val debug = OptionWrapper(backendParams.debugEn, new RenameOutUopDebug())
     val crossFtqCommit = UInt(2.W) // use to caculate the ftq idx of ftqentry when commit
@@ -260,7 +260,7 @@ object Bundles {
     val pred_taken = Bool()
     val identifiedCfi = Bool()
     val ftqPtr = new FtqPtr
-    val ftqOffset = UInt(log2Up(PredictWidth).W)
+    val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
     // from decode
     val srcType = Vec(numSrc, SrcType())
     val fuType = FuType()
@@ -324,8 +324,8 @@ object Bundles {
     val pred_taken      = Bool()
     val crossPageIPFFix = Bool()
     val ftqPtr          = new FtqPtr
-    val ftqOffset       = UInt(log2Up(PredictWidth).W)
-    val ftqLastOffset   = UInt(log2Up(PredictWidth).W) // store ftqoffset before channge in rename
+    val ftqOffset       = UInt(FetchBlockInstOffsetWidth.W)
+    val ftqLastOffset   = UInt(FetchBlockInstOffsetWidth.W) // store ftqoffset before channge in rename
     val stdwriteNeed    = Bool()
     // passed from DecodeOutUop
     val srcType         = Vec(numSrc, SrcType())
@@ -776,7 +776,7 @@ object Bundles {
     val src           = Vec(params.numRegSrc, UInt(params.srcDataBitsMax.W))
     val copySrc       = if(hasCopySrc) Some(Vec(params.numCopySrc, Vec(if(params.numRegSrc < 2) 1 else 2, UInt(params.srcDataBitsMax.W)))) else None
     val imm           = UInt(64.W)
-    val nextPcOffset  = OptionWrapper(params.hasBrhFu, UInt((log2Up(PredictWidth) + 2).W))
+    val nextPcOffset  = OptionWrapper(params.hasBrhFu, UInt((FetchBlockInstOffsetWidth + 2).W))
     val robIdx        = new RobPtr
     val iqIdx         = UInt(log2Up(MemIQSizeMax).W)// Only used by store yet
     val isFirstIssue  = Bool()                      // Only used by store yet
@@ -801,7 +801,7 @@ object Bundles {
     val ftqIdx        = if (params.needPc || params.replayInst || params.hasStoreAddrFu || params.hasCSR)
                                                   Some(new FtqPtr)                    else None
     val ftqOffset     = if (params.needPc || params.replayInst || params.hasStoreAddrFu || params.hasCSR)
-                                                  Some(UInt(log2Up(PredictWidth).W))  else None
+                                                  Some(UInt(FetchBlockInstOffsetWidth.W))  else None
     val predictInfo   = if (params.needPdInfo)  Some(new Bundle {
       val target = UInt(VAddrData().dataWidth.W)
       val taken = Bool()

--- a/src/main/scala/xiangshan/backend/GPAMem.scala
+++ b/src/main/scala/xiangshan/backend/GPAMem.scala
@@ -51,7 +51,7 @@ class GPAMemIO(implicit val p: Parameters) extends Bundle with HasXSParameter {
 
   val exceptionReadAddr = Input(ValidIO(new Bundle {
     val ftqPtr = new FtqPtr()
-    val ftqOffset = UInt(log2Up(PredictWidth).W)
+    val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
   }))
   val exceptionReadData = Output(new GPAMemEntry)
 }

--- a/src/main/scala/xiangshan/backend/GPAMem.scala
+++ b/src/main/scala/xiangshan/backend/GPAMem.scala
@@ -20,9 +20,9 @@ class GPAMemImp(override val wrapper: GPAMem)(implicit p: Parameters) extends La
 
   private val mem = Module (new SyncDataModuleTemplate(new GPAMemEntry, FtqSize, numRead = 1, numWrite = 1, hasRen = true))
 
-  mem.io.wen.head := io.fromIFU.gpaddrMem_wen
-  mem.io.waddr.head := io.fromIFU.gpaddrMem_waddr
-  mem.io.wdata.head := io.fromIFU.gpaddrMem_wdata
+  mem.io.wen.head := io.fromIFU.gpAddrMem.wen
+  mem.io.waddr.head := io.fromIFU.gpAddrMem.waddr
+  mem.io.wdata.head := io.fromIFU.gpAddrMem.wdata
 
   mem.io.ren.get.head := io.exceptionReadAddr.valid
   mem.io.raddr.head := io.exceptionReadAddr.bits.ftqPtr.value

--- a/src/main/scala/xiangshan/backend/datapath/PcTargetMem.scala
+++ b/src/main/scala/xiangshan/backend/datapath/PcTargetMem.scala
@@ -66,7 +66,7 @@ class PcToDataPathIO(params: BackendParams)(implicit p: Parameters) extends XSBu
   //Ftq
   val fromDataPathValid = Input(Vec(params.numPcMemReadPort, Bool()))
   val fromDataPathFtqPtr = Input(Vec(params.numPcMemReadPort, new FtqPtr))
-  val fromDataPathFtqOffset = Input(Vec(params.numPcMemReadPort, UInt(log2Up(PredictWidth).W)))
+  val fromDataPathFtqOffset = Input(Vec(params.numPcMemReadPort, UInt(FetchBlockInstOffsetWidth.W)))
   //Target PC
   val toDataPathTargetPC = Output(Vec(params.numTargetReadPort, UInt(VAddrData().dataWidth.W)))
   //PC

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -29,7 +29,7 @@ class FuncUnitCtrlInput(cfg: FuConfig)(implicit p: Parameters) extends XSBundle 
   val flushPipe   = OptionWrapper(cfg.flushPipe,  Bool())
   val preDecode   = OptionWrapper(cfg.hasPredecode, new PreDecodeInfo)
   val ftqIdx      = OptionWrapper(cfg.needPc || cfg.replayInst || cfg.isSta || cfg.isCsr, new FtqPtr)
-  val ftqOffset   = OptionWrapper(cfg.needPc || cfg.replayInst || cfg.isSta || cfg.isCsr, UInt(log2Up(PredictWidth).W))
+  val ftqOffset   = OptionWrapper(cfg.needPc || cfg.replayInst || cfg.isSta || cfg.isCsr, UInt(FetchBlockInstOffsetWidth.W))
   val predictInfo = OptionWrapper(cfg.needPdInfo, new Bundle {
     val target    = UInt(VAddrData().dataWidth.W)
     val taken     = Bool()
@@ -59,7 +59,7 @@ class FuncUnitDataInput(cfg: FuConfig)(implicit p: Parameters) extends XSBundle 
   val src       = MixedVec(cfg.genSrcDataVec)
   val imm       = UInt(cfg.destDataBits.W)
   val pc        = OptionWrapper(cfg.needPc, UInt(VAddrData().dataWidth.W))
-  val nextPcOffset = OptionWrapper(cfg.needPc, UInt((log2Up(PredictWidth) + 2).W))
+  val nextPcOffset = OptionWrapper(cfg.needPc, UInt((FetchBlockInstOffsetWidth + 2).W))
 
   def getSrcVConfig : UInt = src(cfg.vconfigIdx)
   def getSrcMask    : UInt = src(cfg.maskSrcIdx)

--- a/src/main/scala/xiangshan/backend/fu/Jump.scala
+++ b/src/main/scala/xiangshan/backend/fu/Jump.scala
@@ -36,7 +36,7 @@ class JumpDataModule(implicit p: Parameters) extends XSModule {
     val src = Input(UInt(XLEN.W))
     val pc = Input(UInt(XLEN.W)) // sign-ext to XLEN
     val imm = Input(UInt(33.W)) // imm-U need 32 bits, highest bit is sign bit
-    val nextPcOffset = Input(UInt((log2Up(PredictWidth) + 2).W))
+    val nextPcOffset = Input(UInt((FetchBlockInstOffsetWidth + 2).W))
     val func = Input(FuOpType())
     val isRVC = Input(Bool())
     val result, target = Output(UInt(XLEN.W))

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/TrapInstMod.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/TrapInstMod.scala
@@ -12,7 +12,7 @@ import xiangshan.backend.decode.isa.bitfield.OPCODE5Bit
 
 class FtqInfo(implicit p: Parameters) extends XSBundle {
   val ftqPtr = new FtqPtr()
-  val ftqOffset = UInt(log2Up(PredictWidth).W)
+  val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
 }
 
 class TrapInstMod(implicit p: Parameters) extends Module with HasCircularQueuePtrHelper {

--- a/src/main/scala/xiangshan/backend/fu/wrapper/BranchUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/BranchUnit.scala
@@ -17,7 +17,7 @@ class AddrAddModule(implicit p: Parameters) extends XSModule {
     val isRVC = Input(Bool())
     val imm = Input(UInt(32.W)) // branch inst only support 12 bits immediate num
     val target = Output(UInt(XLEN.W))
-    val nextPcOffset = Input(UInt((log2Up(PredictWidth) + 2).W))
+    val nextPcOffset = Input(UInt((FetchBlockInstOffsetWidth + 2).W))
   })
   val immMinWidth = FuConfig.BrhCfg.immType.map(x => SelImm.getImmUnion(x).len).max
   print(s"[Branch]: immMinWidth = $immMinWidth\n")

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -108,7 +108,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     })
     val readGPAMemAddr = ValidIO(new Bundle {
       val ftqPtr = new FtqPtr()
-      val ftqOffset = UInt(log2Up(PredictWidth).W)
+      val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
     })
     val readGPAMemData = Input(new GPAMemEntry)
     val vstartIsZero = Input(Bool())
@@ -498,7 +498,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val vsetvlState = RegInit(vs_idle)
 
   val firstVInstrFtqPtr = RegInit(0.U.asTypeOf(new FtqPtr))
-  val firstVInstrFtqOffset = RegInit(0.U.asTypeOf(UInt(log2Up(PredictWidth).W)))
+  val firstVInstrFtqOffset = RegInit(0.U.asTypeOf(UInt(FetchBlockInstOffsetWidth.W)))
   val firstVInstrRobIdx = RegInit(0.U.asTypeOf(new RobPtr))
 
   val enq0 = io.enq.req(0)

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -56,7 +56,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val dirtyVs = Bool()
     val commitType = CommitType()
     val ftqIdx = new FtqPtr
-    val ftqOffset = UInt(log2Up(PredictWidth).W)
+    val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
     val isRVC = Bool()
     val isVset = Bool()
     val isHls = Bool()
@@ -106,7 +106,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val mmio = Bool()
     val commitType = CommitType()
     val ftqIdx = new FtqPtr
-    val ftqOffset = UInt(log2Up(PredictWidth).W)
+    val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
     val fpWen = Bool()
     val rfWen = Bool()
     val needFlush = Bool()
@@ -275,7 +275,7 @@ class RobExceptionInfo(implicit p: Parameters) extends XSBundle {
   // val valid = Bool()
   val robIdx = new RobPtr
   val ftqPtr = new FtqPtr
-  val ftqOffset = UInt(log2Up(PredictWidth).W)
+  val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
   // set 1 if there is 1 exists in exceptionVec
   val hasException = Bool()
   // This signal is valid iff currentValid is true
@@ -312,6 +312,6 @@ class RobExceptionInfo(implicit p: Parameters) extends XSBundle {
 class RobFlushInfo(implicit p: Parameters) extends XSBundle {
   val ftqIdx = new FtqPtr
   val robIdx = new RobPtr
-  val ftqOffset = UInt(log2Up(PredictWidth).W)
+  val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
   val replayInst = Bool()
 }

--- a/src/main/scala/xiangshan/backend/trace/Interface.scala
+++ b/src/main/scala/xiangshan/backend/trace/Interface.scala
@@ -24,7 +24,7 @@ class TracePipe(iretireWidth: Int)(implicit val p: Parameters) extends Bundle wi
 class TraceBlock(hasIaddr: Boolean, iretireWidth: Int)(implicit val p: Parameters) extends Bundle with HasXSParameter {
   val iaddr     = if (hasIaddr)   Some(UInt(IaddrWidth.W))                else None
   val ftqIdx    = if (!hasIaddr)  Some(new FtqPtr)                        else None
-  val ftqOffset = if (!hasIaddr)  Some(UInt(log2Up(PredictWidth).W))      else None
+  val ftqOffset = if (!hasIaddr)  Some(UInt(FetchBlockInstOffsetWidth.W))      else None
   val tracePipe = new TracePipe(iretireWidth)
 }
 
@@ -50,7 +50,7 @@ class TraceCoreInterface(hasOffset: Boolean = false)(implicit val p: Parameters)
     }
     val groups = Vec(TraceGroupNum, ValidIO(new Bundle{
       val iaddr     = UInt(IaddrWidth.W)
-      val ftqOffset = if (hasOffset)  Some(UInt(log2Up(PredictWidth).W)) else None
+      val ftqOffset = if (hasOffset)  Some(UInt(FetchBlockInstOffsetWidth.W)) else None
       val itype     = UInt(ItypeWidth.W)
       val iretire   = UInt(IretireWidthCompressed.W)
       val ilastsize = UInt(IlastsizeWidth.W)

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -42,7 +42,7 @@ import xiangshan.frontend.instruncache.InstrUncacheResp
 
 class FrontendTopDownBundle(implicit p: Parameters) extends FrontendBundle {
   val reasons:    Vec[Bool] = Vec(TopDownCounters.NumStallReasons.id, Bool())
-  val stallWidth: UInt      = UInt(log2Ceil(PredictWidth).W)
+  val stallWidth: UInt      = UInt(FetchBlockInstOffsetWidth.W)
 }
 
 class BpuToFtqIO(implicit p: Parameters) extends FrontendBundle {
@@ -143,15 +143,15 @@ class IfuToFtqIO(implicit p: Parameters) extends FrontendBundle {
 }
 
 class PredecodeWritebackBundle(implicit p: Parameters) extends FrontendBundle {
-  val pd:             Vec[PreDecodeInfo] = Vec(PredictWidth, new PreDecodeInfo) // TODO: redefine Predecode
+  val pd:             Vec[PreDecodeInfo] = Vec(FetchBlockInstNum, new PreDecodeInfo) // TODO: redefine Predecode
   val pc:             PrunedAddr         = PrunedAddr(VAddrBits)
   val ftqIdx:         FtqPtr             = new FtqPtr
-  val takenCfiOffset: UInt               = UInt(log2Ceil(PredictWidth).W)
-  val misEndOffset:   Valid[UInt]        = Valid(UInt(log2Ceil(PredictWidth).W))
-  val cfiEndOffset:   Valid[UInt]        = Valid(UInt(log2Ceil(PredictWidth).W))
+  val takenCfiOffset: UInt               = UInt(FetchBlockInstOffsetWidth.W)
+  val misEndOffset:   Valid[UInt]        = Valid(UInt(FetchBlockInstOffsetWidth.W))
+  val cfiEndOffset:   Valid[UInt]        = Valid(UInt(FetchBlockInstOffsetWidth.W))
   val target:         PrunedAddr         = PrunedAddr(VAddrBits)
   val jalTarget:      PrunedAddr         = PrunedAddr(VAddrBits)
-  val instrRange:     Vec[Bool]          = Vec(PredictWidth, Bool())
+  val instrRange:     Vec[Bool]          = Vec(FetchBlockInstNum, Bool())
 }
 
 class MmioCommitRead(implicit p: Parameters) extends FrontendBundle {
@@ -265,12 +265,12 @@ class PreDecodeInfo extends Bundle { // 8 bit
 // pc = ftq.startAddr + Cat(offset, 0.U(1.W)) - Cat(borrow, 0.U(1.W))
 class FtqPcOffset(implicit p: Parameters) extends FrontendBundle {
   val borrow: Bool = Bool()
-  val offset: UInt = UInt(log2Ceil(PredictWidth).W)
+  val offset: UInt = UInt(FetchBlockInstOffsetWidth.W)
 }
 
 class InstrEndOffset(implicit p: Parameters) extends FrontendBundle {
   val taken:  Bool = Bool()
-  val offset: UInt = UInt(log2Ceil(PredictWidth).W)
+  val offset: UInt = UInt(FetchBlockInstOffsetWidth.W)
 }
 
 class FetchToIBuffer(implicit p: Parameters) extends FrontendBundle {

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -126,7 +126,7 @@ class InstrUncacheToIfuIO(implicit p: Parameters) extends XSBundle {
 }
 
 class FtqToIfuIO(implicit p: Parameters) extends FrontendBundle {
-  class FtqToIfuReq(implicit p: Parameters) extends Bundle {
+  class FtqToIfuReq extends Bundle {
     val fetch:       Vec[FetchRequestBundle] = Vec(FetchPorts, new FetchRequestBundle)
     val topdownInfo: FrontendTopDownBundle   = new FrontendTopDownBundle
   }
@@ -136,7 +136,7 @@ class FtqToIfuIO(implicit p: Parameters) extends FrontendBundle {
   val flushFromBpu:     BpuFlushInfo             = new BpuFlushInfo
 }
 
-class IfuToFtqIO(implicit p: Parameters) extends XSBundle {
+class IfuToFtqIO(implicit p: Parameters) extends FrontendBundle {
   val mmioCommitRead: MmioCommitRead                       = new MmioCommitRead
   val pdWb:           Vec[Valid[PredecodeWritebackBundle]] = Vec(FetchPorts, Valid(new PredecodeWritebackBundle))
 }

--- a/src/main/scala/xiangshan/frontend/FrontendParameters.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendParameters.scala
@@ -25,6 +25,7 @@ import xiangshan.frontend.ifu.IfuParameters
 
 case class FrontendParameters(
     FetchBlockSize: Int = 32, // bytes // FIXME: 64B, waiting for ftq/icache support
+    FetchPorts:     Int = 2,  // 2-fetch
 
     bpuParameters:    BpuParameters = BpuParameters(),
     ftqParameters:    FtqParameters = FtqParameters(),
@@ -58,6 +59,8 @@ case class FrontendParameters(
 
 trait HasFrontendParameters extends HasXSParameter {
   def frontendParameters: FrontendParameters = coreParams.frontendParameters
+
+  def FetchPorts: Int = frontendParameters.FetchPorts
 
   def FetchBlockSize:    Int = frontendParameters.FetchBlockSize
   def FetchBlockInstNum: Int = FetchBlockSize / instBytes

--- a/src/main/scala/xiangshan/frontend/FrontendParameters.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendParameters.scala
@@ -64,5 +64,6 @@ trait HasFrontendParameters extends HasXSParameter {
 
   def FetchBlockSize:    Int = frontendParameters.FetchBlockSize
   def FetchBlockInstNum: Int = FetchBlockSize / instBytes
-  def CfiPositionWidth:  Int = log2Ceil(FetchBlockInstNum) // 2/4B(inst) aligned
+//  def FetchBlockInstOffsetWidth = log2Ceil(FetchBlockInstNum) inherited from HasXSParameter
+  def CfiPositionWidth: Int = log2Ceil(FetchBlockInstNum) // 2/4B(inst) aligned
 }

--- a/src/main/scala/xiangshan/frontend/FrontendParameters.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendParameters.scala
@@ -21,13 +21,15 @@ import xiangshan.HasXSParameter
 import xiangshan.frontend.bpu.BpuParameters
 import xiangshan.frontend.ftq.FtqParameters
 import xiangshan.frontend.icache.ICacheParameters
+import xiangshan.frontend.ifu.IfuParameters
 
 case class FrontendParameters(
     FetchBlockSize: Int = 32, // bytes // FIXME: 64B, waiting for ftq/icache support
 
     bpuParameters:    BpuParameters = BpuParameters(),
     ftqParameters:    FtqParameters = FtqParameters(),
-    icacheParameters: ICacheParameters = ICacheParameters()
+    icacheParameters: ICacheParameters = ICacheParameters(),
+    ifuParameters:    IfuParameters = IfuParameters()
 ) {
   // according to style guide, this should be in `trait HasBpuParameters` and named `PhrHistoryLength`,
   // but, we need to use this value in `class PhrPtr` definition, so we cannot put it in a trait.

--- a/src/main/scala/xiangshan/frontend/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/IBuffer.scala
@@ -446,7 +446,7 @@ class IBuffer(implicit p: Parameters) extends XSModule with HasCircularQueuePtrH
   // TopDown
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   val topdown_stage = RegInit(0.U.asTypeOf(new FrontendTopDownBundle))
-  topdown_stage := io.in.bits.topdown_info
+  topdown_stage := io.in.bits.topdownInfo
   when(io.flush) {
     when(io.ControlRedirect) {
       when(io.ControlBTBMissBubble) {

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -165,7 +165,7 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
     s2_rawBtbEntries.map(e =>
       getFullTarget(s2_startVAddr, e.targetLowerBits, Some(e.targetCarry))
     ) // FIXME: parameterize target carry
-  private val debug_s2_perBankSignals = Seq.tabulate(PredictWidth) { pos =>
+  private val debug_s2_perBankSignals = Seq.tabulate(FetchBlockInstNum) { pos =>
     val posHitMask = s2_hitMask zip s2_positions map { case (hit, p) =>
       hit && p === pos.U
     }

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
@@ -173,7 +173,7 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
 
   t1_baseTableWriteCtrs := DontCare
   t1_baseTableWriteWaymask.foreach(_.foreach(_ := false.B))
-  for (pos <- 0 until PredictWidth) {
+  for (pos <- 0 until FetchBlockInstNum) {
     // FIXME: won't work when alignment bank is not 2
     when(pos.U < t1_cfiPosition) {
       t1_baseTableWriteCtrs(pos.U.asBools.last + t1_alignBankIdx)(

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -44,7 +44,7 @@ class ResolveEntry(implicit p: Parameters) extends FtqBundle {
 class FtqRead[T <: Data](private val gen: T)(implicit p: Parameters) extends FtqBundle {
   val valid  = Output(Bool())
   val ptr    = Output(new FtqPtr)
-  val offset = Output(UInt(log2Ceil(PredictWidth).W))
+  val offset = Output(UInt(FetchBlockInstOffsetWidth.W))
   val data   = Input(gen)
   def apply(valid: Bool, ptr: FtqPtr, offset: UInt) = {
     this.valid  := valid

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -333,7 +333,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // --------------------------------------------------------------------------------
   io.bpuInfo                    := DontCare
   io.toIfu.req.bits.topdownInfo := DontCare
-  io.toIfu.topdown_redirect     := DontCare
+  io.toIfu.topdownRedirect      := DontCare
   io.ControlBTBMissBubble       := DontCare
   io.TAGEMissBubble             := DontCare
   io.SCMissBubble               := DontCare

--- a/src/main/scala/xiangshan/frontend/ifu/Abstracts.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Abstracts.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 // Copyright (c) 2020-2021 Peng Cheng Laboratory
 //
 // XiangShan is licensed under Mulan PSL v2.
@@ -16,9 +16,9 @@
 package xiangshan.frontend.ifu
 
 import org.chipsalliance.cde.config.Parameters
-import xiangshan.XSBundle
-import xiangshan.XSModule
+import xiangshan.frontend.FrontendBundle
+import xiangshan.frontend.FrontendModule
 
-abstract class IfuBundle(implicit p: Parameters) extends XSBundle with HasIfuParameters
+abstract class IfuBundle(implicit p: Parameters) extends FrontendBundle with HasIfuParameters
 
-abstract class IfuModule(implicit p: Parameters) extends XSModule with HasIfuParameters
+abstract class IfuModule(implicit p: Parameters) extends FrontendModule with HasIfuParameters

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 // Copyright (c) 2020-2021 Peng Cheng Laboratory
 //
 // XiangShan is licensed under Mulan PSL v2.
@@ -55,7 +55,7 @@ class LastHalfEntry(implicit p: Parameters) extends IfuBundle {
   val middlePC: PrunedAddr = PrunedAddr(VAddrBits)
 }
 
-class InstrIndexEntry(implicit p: Parameters) extends IfuBundle with HasIfuParameters {
+class InstrIndexEntry(implicit p: Parameters) extends IfuBundle {
   val valid: Bool = Bool()
   val value: UInt = UInt(log2Ceil(ICacheLineBytes / 2).W)
 }
@@ -76,6 +76,7 @@ class FetchBlockInfo(implicit p: Parameters) extends IfuBundle {
   val identifiedCfi:  Vec[Bool]   = Vec(FetchBlockInstNum, Bool())
 }
 
+// HasICacheParameters is for PortNumber
 class ICacheInfo(implicit p: Parameters) extends IfuBundle with HasICacheParameters {
   val exception:          ExceptionType = new ExceptionType
   val pmpMmio:            Bool          = Bool()

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -19,7 +19,6 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utils.EnumUInt
-import xiangshan.ValidUndirectioned
 import xiangshan.cache.mmu.Pbmt
 import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.IBufPtr
@@ -88,11 +87,11 @@ class ICacheInfo(implicit p: Parameters) extends IfuBundle with HasICacheParamet
 }
 
 class FinalPredCheckResult(implicit p: Parameters) extends IfuBundle {
-  val target       = PrunedAddr(VAddrBits)
-  val misIdx       = Valid(UInt(log2Ceil(IBufferInPortNum).W))
-  val cfiIdx       = Valid(UInt(log2Ceil(IBufferInPortNum).W))
-  val instrRange   = UInt(FetchBlockInstNum.W)
-  val invalidTaken = Bool()
+  val target:       PrunedAddr  = PrunedAddr(VAddrBits)
+  val misIdx:       Valid[UInt] = Valid(UInt(log2Ceil(IBufferInPortNum).W))
+  val cfiIdx:       Valid[UInt] = Valid(UInt(log2Ceil(IBufferInPortNum).W))
+  val instrRange:   UInt        = UInt(FetchBlockInstNum.W)
+  val invalidTaken: Bool        = Bool()
 }
 
 /* ***** DB ***** */

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -63,16 +63,16 @@ class InstrIndexEntry(implicit p: Parameters) extends IfuBundle {
 class FetchBlockInfo(implicit p: Parameters) extends IfuBundle {
   val ftqIdx:         FtqPtr      = new FtqPtr
   val doubleline:     Bool        = Bool()
-  val predTakenIdx:   Valid[UInt] = Valid(UInt(log2Ceil(PredictWidth).W))
-  val takenCfiOffset: Valid[UInt] = Valid(UInt(log2Ceil(PredictWidth).W))
+  val predTakenIdx:   Valid[UInt] = Valid(UInt(FetchBlockInstOffsetWidth.W))
+  val takenCfiOffset: Valid[UInt] = Valid(UInt(FetchBlockInstOffsetWidth.W))
   val invalidTaken:   Bool        = Bool()
   val startVAddr:     PrunedAddr  = PrunedAddr(VAddrBits)
   val target:         PrunedAddr  = PrunedAddr(VAddrBits)
-  val instrRange:     UInt        = UInt(PredictWidth.W)
-  val rawInstrValid:  UInt        = UInt(PredictWidth.W)
+  val instrRange:     UInt        = UInt(FetchBlockInstNum.W)
+  val rawInstrValid:  UInt        = UInt(FetchBlockInstNum.W)
   val pcHigh:         UInt        = UInt((VAddrBits - PcCutPoint).W)
   val pcHighPlus1:    UInt        = UInt((VAddrBits - PcCutPoint).W)
-  val fetchSize:      UInt        = UInt(log2Ceil(PredictWidth + 1).W)
+  val fetchSize:      UInt        = UInt(log2Ceil(FetchBlockInstNum + 1).W)
   val identifiedCfi:  Vec[Bool]   = Vec(FetchBlockInstNum, Bool())
 }
 
@@ -91,7 +91,7 @@ class FinalPredCheckResult(implicit p: Parameters) extends IfuBundle {
   val target       = PrunedAddr(VAddrBits)
   val misIdx       = Valid(UInt(log2Ceil(IBufferInPortNum).W))
   val cfiIdx       = Valid(UInt(log2Ceil(IBufferInPortNum).W))
-  val instrRange   = UInt(PredictWidth.W)
+  val instrRange   = UInt(FetchBlockInstNum.W)
   val invalidTaken = Bool()
 }
 
@@ -106,7 +106,7 @@ class FetchToIBufferDB(implicit p: Parameters) extends IfuBundle {
 class IfuWbToFtqDB(implicit p: Parameters) extends IfuBundle {
   val startAddr:         Vec[UInt] = Vec(FetchPorts, UInt(VAddrBits.W)) // do not use PrunedAddr for DB
   val isMissPred:        Vec[Bool] = Vec(FetchPorts, Bool())
-  val missPredOffset:    Vec[UInt] = Vec(FetchPorts, UInt(log2Ceil(PredictWidth).W))
+  val missPredOffset:    Vec[UInt] = Vec(FetchPorts, UInt(FetchBlockInstOffsetWidth.W))
   val checkJalFault:     Bool      = Bool()
   val checkJalrFault:    Bool      = Bool()
   val checkRetFault:     Bool      = Bool()
@@ -117,7 +117,7 @@ class IfuWbToFtqDB(implicit p: Parameters) extends IfuBundle {
 
 class IfuRedirectInternal(implicit p: Parameters) extends IfuBundle {
   val valid:          Bool    = Bool()
-  val instrCount:     UInt    = UInt(log2Ceil(PredictWidth + 1).W)
+  val instrCount:     UInt    = UInt(log2Ceil(FetchBlockInstNum + 1).W)
   val prevIBufEnqPtr: IBufPtr = new IBufPtr
   // A fallthrough does not always correspond to a half RVI instruction.
   val isHalfInstr: Bool       = Bool()

--- a/src/main/scala/xiangshan/frontend/ifu/F3PreDecode.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/F3PreDecode.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 // Copyright (c) 2020-2021 Peng Cheng Laboratory
 //
 // XiangShan is licensed under Mulan PSL v2.

--- a/src/main/scala/xiangshan/frontend/ifu/F3PreDecode.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/F3PreDecode.scala
@@ -21,8 +21,8 @@ import xiangshan.frontend.PreDecodeInfo
 
 class F3PreDecode(implicit p: Parameters) extends IfuModule with PreDecodeHelper {
   class F3PreDecodeIO(implicit p: Parameters) extends IfuBundle {
-    val instr: Vec[UInt]          = Input(Vec(PredictWidth, UInt(32.W)))
-    val pd:    Vec[PreDecodeInfo] = Output(Vec(PredictWidth, new PreDecodeInfo))
+    val instr: Vec[UInt]          = Input(Vec(FetchBlockInstNum, UInt(32.W)))
+    val pd:    Vec[PreDecodeInfo] = Output(Vec(FetchBlockInstNum, new PreDecodeInfo))
   }
   val io: F3PreDecodeIO = IO(new F3PreDecodeIO)
 

--- a/src/main/scala/xiangshan/frontend/ifu/FrontendTrigger.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/FrontendTrigger.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 // Copyright (c) 2020-2021 Peng Cheng Laboratory
 //
 // XiangShan is licensed under Mulan PSL v2.

--- a/src/main/scala/xiangshan/frontend/ifu/FrontendTrigger.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/FrontendTrigger.scala
@@ -84,7 +84,7 @@ class FrontendTrigger(implicit p: Parameters) extends IfuModule with SdtrigExt {
     io.triggered(i) := triggerAction
     XSDebug(
       triggerCanFireVec.asUInt.orR,
-      p"Debug Mode: Predecode Inst No. ${i} has trigger action vec ${triggerCanFireVec.asUInt.orR}\n"
+      p"Debug Mode: Predecode Inst No. $i has trigger action vec ${triggerCanFireVec.asUInt.orR}\n"
     )
   }
 }

--- a/src/main/scala/xiangshan/frontend/ifu/FrontendTrigger.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/FrontendTrigger.scala
@@ -62,7 +62,7 @@ class FrontendTrigger(implicit p: Parameters) extends IfuModule with SdtrigExt {
 
   private val debugMode            = io.frontendTrigger.debugMode
   private val triggerCanRaiseBpExp = io.frontendTrigger.triggerCanRaiseBpExp
-  // val triggerHitVec = Wire(Vec(PredictWidth, Vec(TriggerNum, Bool())))
+  // val triggerHitVec = Wire(Vec(FetchBlockInstNum, Vec(TriggerNum, Bool())))
   private val triggerHitVec = (0 until TriggerNum).map { j =>
     TriggerCmpConsecutive(
       VecInit(io.pc.map(_.toUInt)),

--- a/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 // Copyright (c) 2020-2021 Peng Cheng Laboratory
 //
 // XiangShan is licensed under Mulan PSL v2.
@@ -18,13 +18,12 @@ package xiangshan.frontend.ifu
 import chisel3._
 import chisel3.util._
 import utility.SignExt
-import xiangshan.HasXSParameter
 import xiangshan.backend.decode.isa.predecode.PreDecodeInst
 import xiangshan.frontend.BrType
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
 
-trait PreDecodeHelper extends HasXSParameter {
+trait PreDecodeHelper extends HasIfuParameters {
   def isRVC(inst: UInt): Bool = inst(1, 0) =/= 3.U
 
   def isLink(reg: UInt): Bool = reg === 1.U || reg === 5.U
@@ -56,14 +55,14 @@ trait PreDecodeHelper extends HasXSParameter {
   }
 }
 
-trait FetchBlockHelper extends HasXSParameter with HasIfuParameters {
+trait FetchBlockHelper extends HasIfuParameters {
   def getBasicBlockIdx(pc: PrunedAddr, start: PrunedAddr): UInt = {
     val byteOffset = (pc - start).toUInt
     (byteOffset - instBytes.U)(log2Ceil(PredictWidth), instOffsetBits)
   }
 }
 
-trait IfuHelper extends HasXSParameter with HasIfuParameters {
+trait IfuHelper extends HasIfuParameters {
   private object ShiftType {
     val NoShift     = 0.U(2.W)
     val ShiftRight1 = 1.U(2.W)

--- a/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
@@ -58,7 +58,7 @@ trait PreDecodeHelper extends HasIfuParameters {
 trait FetchBlockHelper extends HasIfuParameters {
   def getBasicBlockIdx(pc: PrunedAddr, start: PrunedAddr): UInt = {
     val byteOffset = (pc - start).toUInt
-    (byteOffset - instBytes.U)(log2Ceil(PredictWidth), instOffsetBits)
+    (byteOffset - instBytes.U)(FetchBlockInstOffsetWidth, instOffsetBits)
   }
 }
 

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -143,53 +143,53 @@ class Ifu(implicit p: Parameters) extends IfuModule
   when(itlbMissBubble) {
     topdownStages(1).reasons(TopDownCounters.ITLBMissBubble.id) := true.B
   }
-  io.toIBuffer.bits.topdown_info := topdownStages(numOfStage - 1)
-  when(fromFtq.topdown_redirect.valid) {
+  io.toIBuffer.bits.topdownInfo := topdownStages(numOfStage - 1)
+  when(fromFtq.topdownRedirect.valid) {
     // only redirect from backend, IFU redirect itself is handled elsewhere
-    when(fromFtq.topdown_redirect.bits.debugIsCtrl) {
+    when(fromFtq.topdownRedirect.bits.debugIsCtrl) {
       /*
       for (i <- 0 until numOfStage) {
         topdown_stages(i).reasons(TopDownCounters.ControlRedirectBubble.id) := true.B
       }
-      io.toIBuffer.bits.topdown_info.reasons(TopDownCounters.ControlRedirectBubble.id) := true.B
+      io.toIBuffer.bits.topdownInfo.reasons(TopDownCounters.ControlRedirectBubble.id) := true.B
        */
       // FIXME
 //      when(fromFtq.topdown_redirect.bits.ControlBTBMissBubble) {
 //        for (i <- 0 until numOfStage) {
 //          topdownStages(i).reasons(TopDownCounters.BTBMissBubble.id) := true.B
 //        }
-//        io.toIBuffer.bits.topdown_info.reasons(TopDownCounters.BTBMissBubble.id) := true.B
+//        io.toIBuffer.bits.topdownInfo.reasons(TopDownCounters.BTBMissBubble.id) := true.B
 //      }.elsewhen(fromFtq.topdown_redirect.bits.TAGEMissBubble) {
 //        for (i <- 0 until numOfStage) {
 //          topdownStages(i).reasons(TopDownCounters.TAGEMissBubble.id) := true.B
 //        }
-//        io.toIBuffer.bits.topdown_info.reasons(TopDownCounters.TAGEMissBubble.id) := true.B
+//        io.toIBuffer.bits.topdownInfo.reasons(TopDownCounters.TAGEMissBubble.id) := true.B
 //      }.elsewhen(fromFtq.topdown_redirect.bits.SCMissBubble) {
 //        for (i <- 0 until numOfStage) {
 //          topdownStages(i).reasons(TopDownCounters.SCMissBubble.id) := true.B
 //        }
-//        io.toIBuffer.bits.topdown_info.reasons(TopDownCounters.SCMissBubble.id) := true.B
+//        io.toIBuffer.bits.topdownInfo.reasons(TopDownCounters.SCMissBubble.id) := true.B
 //      }.elsewhen(fromFtq.topdown_redirect.bits.ITTAGEMissBubble) {
 //        for (i <- 0 until numOfStage) {
 //          topdownStages(i).reasons(TopDownCounters.ITTAGEMissBubble.id) := true.B
 //        }
-//        io.toIBuffer.bits.topdown_info.reasons(TopDownCounters.ITTAGEMissBubble.id) := true.B
+//        io.toIBuffer.bits.topdownInfo.reasons(TopDownCounters.ITTAGEMissBubble.id) := true.B
 //      }.elsewhen(fromFtq.topdown_redirect.bits.RASMissBubble) {
 //        for (i <- 0 until numOfStage) {
 //          topdownStages(i).reasons(TopDownCounters.RASMissBubble.id) := true.B
 //        }
-//        io.toIBuffer.bits.topdown_info.reasons(TopDownCounters.RASMissBubble.id) := true.B
+//        io.toIBuffer.bits.topdownInfo.reasons(TopDownCounters.RASMissBubble.id) := true.B
 //      }
-    }.elsewhen(fromFtq.topdown_redirect.bits.debugIsMemVio) {
+    }.elsewhen(fromFtq.topdownRedirect.bits.debugIsMemVio) {
       for (i <- 0 until numOfStage) {
         topdownStages(i).reasons(TopDownCounters.MemVioRedirectBubble.id) := true.B
       }
-      io.toIBuffer.bits.topdown_info.reasons(TopDownCounters.MemVioRedirectBubble.id) := true.B
+      io.toIBuffer.bits.topdownInfo.reasons(TopDownCounters.MemVioRedirectBubble.id) := true.B
     }.otherwise {
       for (i <- 0 until numOfStage) {
         topdownStages(i).reasons(TopDownCounters.OtherRedirectBubble.id) := true.B
       }
-      io.toIBuffer.bits.topdown_info.reasons(TopDownCounters.OtherRedirectBubble.id) := true.B
+      io.toIBuffer.bits.topdownInfo.reasons(TopDownCounters.OtherRedirectBubble.id) := true.B
     }
   }
 
@@ -1091,14 +1091,14 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   /** to backend */
   // s4_gpAddr is valid iff gpf is detected
-  io.toBackend.gpaddrMem_wen := s4_toIBufferValid && Mux(
+  io.toBackend.gpAddrMem.wen := s4_toIBufferValid && Mux(
     s4_reqIsMmio,
     mmioException.isGpf,
     s4_icacheInfo(0).exception.isGpf
   )
-  io.toBackend.gpaddrMem_waddr        := s4_fetchBlock(0).ftqIdx.value
-  io.toBackend.gpaddrMem_wdata.gpaddr := Mux(s4_reqIsMmio, mmioResendGpAddr.toUInt, s4_icacheInfo(0).gpAddr.toUInt)
-  io.toBackend.gpaddrMem_wdata.isForVSnonLeafPTE := Mux(
+  io.toBackend.gpAddrMem.waddr        := s4_fetchBlock(0).ftqIdx.value
+  io.toBackend.gpAddrMem.wdata.gpaddr := Mux(s4_reqIsMmio, mmioResendGpAddr.toUInt, s4_icacheInfo(0).gpAddr.toUInt)
+  io.toBackend.gpAddrMem.wdata.isForVSnonLeafPTE := Mux(
     s4_reqIsMmio,
     mmioResendIsForVSnonLeafPTE,
     s4_icacheInfo(0).isForVSnonLeafPTE

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 // Copyright (c) 2020-2021 Peng Cheng Laboratory
 //
 // XiangShan is licensed under Mulan PSL v2.

--- a/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
@@ -15,14 +15,20 @@
 
 package xiangshan.frontend.ifu
 
-import chisel3.util._
-import xiangshan.HasXSParameter
-import xiangshan.frontend.icache.HasICacheParameters
+import xiangshan.frontend.HasFrontendParameters
 
-trait HasIfuParameters extends HasICacheParameters {
-  def ICacheLineBytes: Int = 64
+case class IfuParameters(
+    PcCutPoint: Option[Int] = None // default cut at lower VAddrBits/4
+) {}
+
+trait HasIfuParameters extends HasFrontendParameters {
+  def ifuParameters: IfuParameters = frontendParameters.ifuParameters
+
+  def ICacheLineBytes: Int = frontendParameters.icacheParameters.blockBytes
   // equal lower_result overflow bit
-  def PcCutPoint:       Int = (VAddrBits / 4) - 1
+  def PcCutPoint:       Int = ifuParameters.PcCutPoint.getOrElse((VAddrBits / 4) - 1)
   def IBufferInPortNum: Int = PredictWidth + IBufWriteBank
   def IfuAlignWidth:    Int = IBufWriteBank
+
+  require(PcCutPoint > 0 && PcCutPoint < VAddrBits, s"PcCutPoint($PcCutPoint) must be in range (0, $VAddrBits)")
 }

--- a/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
@@ -27,7 +27,7 @@ trait HasIfuParameters extends HasFrontendParameters {
   def ICacheLineBytes: Int = frontendParameters.icacheParameters.blockBytes
   // equal lower_result overflow bit
   def PcCutPoint:       Int = ifuParameters.PcCutPoint.getOrElse((VAddrBits / 4) - 1)
-  def IBufferInPortNum: Int = PredictWidth + IBufWriteBank
+  def IBufferInPortNum: Int = FetchBlockInstNum + IBufWriteBank
   def IfuAlignWidth:    Int = IBufWriteBank
 
   require(PcCutPoint > 0 && PcCutPoint < VAddrBits, s"PcCutPoint($PcCutPoint) must be in range (0, $VAddrBits)")

--- a/src/main/scala/xiangshan/frontend/ifu/PreDecode.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PreDecode.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 // Copyright (c) 2020-2021 Peng Cheng Laboratory
 //
 // XiangShan is licensed under Mulan PSL v2.
@@ -19,11 +19,10 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.XSDebug
-import utility.XSError
 import xiangshan.frontend.PreDecodeInfo
 import xiangshan.frontend.PrunedAddr
 
-class PreDecode(implicit p: Parameters) extends IfuModule with PreDecodeHelper with HasIfuParameters {
+class PreDecode(implicit p: Parameters) extends IfuModule with PreDecodeHelper {
   class PreDecodeIO(implicit p: Parameters) extends IfuBundle {
     class PreDecodeReq(implicit p: Parameters) extends IfuBundle {
       val data:       Vec[UInt] = Vec(IBufferInPortNum, UInt(32.W))

--- a/src/main/scala/xiangshan/frontend/ifu/PreDecodeBoundary.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PreDecodeBoundary.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 // Copyright (c) 2020-2021 Peng Cheng Laboratory
 //
 // XiangShan is licensed under Mulan PSL v2.
@@ -18,10 +18,7 @@ package xiangshan.frontend.ifu
 import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
-import utility.XSDebug
 import utility.XSError
-import xiangshan.frontend.PreDecodeInfo
-import xiangshan.frontend.PrunedAddr
 
 class PreDecodeBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelper {
   class PreDecodeBoundIO(implicit p: Parameters) extends IfuBundle {

--- a/src/main/scala/xiangshan/frontend/ifu/PreDecodeBoundary.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PreDecodeBoundary.scala
@@ -78,7 +78,6 @@ class PreDecodeBoundary(implicit p: Parameters) extends IfuModule with PreDecode
       bound:        Vec[BoundInfo],
       start:        Int,
       end:          Int,
-      isAlt:        Boolean = false,
       preIsHalfRvi: Bool = false.B
   ): Unit = {
     // when !HasCExtension, data is stepped by 4, and every data is a valid instruction start
@@ -106,12 +105,12 @@ class PreDecodeBoundary(implicit p: Parameters) extends IfuModule with PreDecode
     }
   }
 
-  genBound(bound, 0, FetchBlockInstNum / 2, false, io.req.bits.prevLastIsHalfRvi)
-  genBound(rearBound, FetchBlockInstNum / 2, FetchBlockInstNum, false, false.B)
-  genBound(rearBoundPlus1, FetchBlockInstNum / 2 + 1, FetchBlockInstNum, false, false.B)
+  genBound(bound, 0, FetchBlockInstNum / 2, io.req.bits.prevLastIsHalfRvi)
+  genBound(rearBound, FetchBlockInstNum / 2, FetchBlockInstNum, false.B)
+  genBound(rearBoundPlus1, FetchBlockInstNum / 2 + 1, FetchBlockInstNum, false.B)
 
   // for xxxPlus1, FetchBlockInstNum / 2 must be a valid end, since we assume FetchBlockInstNum / 2 + 1 is a valid start
-  // and, it must not be a valid start, otherwise, FetchBlockInstNum / 2 - 1 is a valid end and rearBound should be selected
+  // and, it must not be a valid start, otherwise, FetchBlockInstNum/2-1 is a valid end and rearBound should be selected
   rearBoundPlus1(FetchBlockInstNum / 2).isStart := false.B
   rearBoundPlus1(FetchBlockInstNum / 2).isEnd   := true.B
 
@@ -126,7 +125,7 @@ class PreDecodeBoundary(implicit p: Parameters) extends IfuModule with PreDecode
   // we also compute the whole block directly for differential testing, this will be optimized out in released code
   private val boundDiff = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(0.U.asTypeOf(new BoundInfo))))
 
-  genBound(boundDiff, 0, FetchBlockInstNum, false, io.req.bits.prevLastIsHalfRvi)
+  genBound(boundDiff, 0, FetchBlockInstNum, io.req.bits.prevLastIsHalfRvi)
 
   private val startMismatch = Wire(Bool())
   private val endMismatch   = Wire(Bool())

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 // Copyright (c) 2020-2021 Peng Cheng Laboratory
 //
 // XiangShan is licensed under Mulan PSL v2.
@@ -19,9 +19,7 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.ParallelOR
-import utility.ParallelPosteriorityEncoder
 import utility.ParallelPriorityEncoder
-import utility.XSError
 import xiangshan.ValidUndirectioned
 import xiangshan.frontend.PreDecodeInfo
 import xiangshan.frontend.PrunedAddr

--- a/src/main/scala/xiangshan/frontend/ifu/RvcExpander.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/RvcExpander.scala
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
-// Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 // Copyright (c) 2020-2021 Peng Cheng Laboratory
 //
 // XiangShan is licensed under Mulan PSL v2.

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
@@ -328,7 +328,7 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
   // Lq rollback seq check is done in s3 (next stage), as getting rollbackLq MicroOp is slow
   val rollbackLqWb = Wire(Vec(StorePipelineWidth, Valid(new DynInst)))
   val stFtqIdx = Wire(Vec(StorePipelineWidth, new FtqPtr))
-  val stFtqOffset = Wire(Vec(StorePipelineWidth, UInt(log2Up(PredictWidth).W)))
+  val stFtqOffset = Wire(Vec(StorePipelineWidth, UInt(FetchBlockInstOffsetWidth.W)))
   for (w <- 0 until StorePipelineWidth) {
     val detectedRollback = detectRollback(w)
     rollbackLqWb(w).valid := detectedRollback._1 && DelayN(storeIn(w).valid && !storeIn(w).bits.miss, TotalSelectCycles)


### PR DESCRIPTION
Also
- remove old `PredictWidth` (now `FetchBlockInstNum` defined by Bpu) and unused `FetchWidth`
- update Ifu license
- fix IDE warning in Ifu

Conflicts need rebasing:
- [x] #4961 
- [x] #4962
- [x] #4909
- [x] #4989
- [x] #5003 