### PR TITLE
feat(build): add `DISABLE_XMR` to use `bore` instead of `tapAndRead`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,11 @@ ifneq ($(HART_ID_BITS),)
 COMMON_EXTRA_ARGS += --hartidbits $(HART_ID_BITS)
 endif
 
+# disable xmr
+ifeq ($(DISABLE_XMR),1)
+COMMON_EXTRA_ARGS += --disable-xmr
+endif
+
 # configuration from yaml file
 ifneq ($(YAML_CONFIG),)
 COMMON_EXTRA_ARGS += --yaml-config $(YAML_CONFIG)

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -218,6 +218,10 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case XSTileKey => up(XSTileKey).map(_.copy(wfiResume = value.toBoolean))
           }), tail)
+        case "--disable-xmr" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(EnableXMR = false)
+          }), tail)
         case "--yaml-config" :: yamlFile :: tail =>
           nextOption(YamlParser.parseYaml(config, yamlFile), tail)
         case option :: tail =>
@@ -229,15 +233,16 @@ object ArgParser {
     val newArgs = DifftestModule.parseArgs(args)
     val config = nextOption(default, newArgs.toList).alter((site, here, up) => {
       case LogUtilsOptionsKey => LogUtilsOptions(
-        here(DebugOptionsKey).EnableDebug,
-        here(DebugOptionsKey).EnablePerfDebug,
-        here(DebugOptionsKey).FPGAPlatform
+        enableDebug = here(DebugOptionsKey).EnableDebug,
+        enablePerf = here(DebugOptionsKey).EnablePerfDebug,
+        fpgaPlatform = here(DebugOptionsKey).FPGAPlatform,
+        enableXMR = here(DebugOptionsKey).EnableXMR
       )
       case PerfCounterOptionsKey => PerfCounterOptions(
-        here(DebugOptionsKey).EnablePerfDebug && !here(DebugOptionsKey).FPGAPlatform,
-        here(DebugOptionsKey).EnableRollingDB && !here(DebugOptionsKey).FPGAPlatform,
-        XSPerfLevel.withName(here(DebugOptionsKey).PerfLevel),
-        0
+        enablePerfPrint = here(DebugOptionsKey).EnablePerfDebug && !here(DebugOptionsKey).FPGAPlatform,
+        enablePerfDB = here(DebugOptionsKey).EnableRollingDB && !here(DebugOptionsKey).FPGAPlatform,
+        perfLevel = XSPerfLevel.withName(here(DebugOptionsKey).PerfLevel),
+        perfDBHartID = 0
       )
     })
     (config, firrtlOpts, firtoolOpts)

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -557,6 +557,7 @@ case class DebugOptions
   EnableDebug: Boolean = false,
   EnablePerfDebug: Boolean = true,
   PerfLevel: String = "VERBOSE",
+  EnableXMR: Boolean = true,
   UseDRAMSim: Boolean = false,
   EnableConstantin: Boolean = false,
   EnableChiselDB: Boolean = false,

--- a/src/test/scala/xiangshan/frontend/FrontTrigger.scala
+++ b/src/test/scala/xiangshan/frontend/FrontTrigger.scala
@@ -16,7 +16,8 @@ class FrontendTriggerTest extends AnyFlatSpec with ChiselScalatestTester with Ma
     case LogUtilsOptionsKey => LogUtilsOptions(
       here(DebugOptionsKey).EnableDebug,
       here(DebugOptionsKey).EnablePerfDebug,
-      here(DebugOptionsKey).FPGAPlatform
+      here(DebugOptionsKey).FPGAPlatform,
+      here(DebugOptionsKey).EnableXMR
     )
   })
 


### PR DESCRIPTION
To prevent non-synthesizable (?) hierarchy XMR.