### PR TITLE
feat(ICache): remove pAddr(1)

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -164,7 +164,7 @@ class ICacheRespBundle(implicit p: Parameters) extends ICacheBundle {
   val doubleline:         Bool            = Bool()
   val vAddr:              Vec[PrunedAddr] = Vec(PortNumber, PrunedAddr(VAddrBits))
   val data:               UInt            = UInt(blockBits.W)
-  val pAddr:              Vec[PrunedAddr] = Vec(PortNumber, PrunedAddr(PAddrBits))
+  val pAddr:              PrunedAddr      = PrunedAddr(PAddrBits)
   val exception:          ExceptionType   = new ExceptionType
   val pmpMmio:            Bool            = Bool()
   val itlbPbmt:           UInt            = UInt(Pbmt.width.W)
@@ -216,8 +216,8 @@ class PrefetchReqBundle(implicit p: Parameters) extends ICacheBundle {
 class WayLookupEntry(implicit p: Parameters) extends ICacheBundle {
   val vSetIdx:       Vec[UInt]     = Vec(PortNumber, UInt(idxBits.W))
   val waymask:       Vec[UInt]     = Vec(PortNumber, UInt(nWays.W))
-  val pTag:          Vec[UInt]     = Vec(PortNumber, UInt(tagBits.W))
   val metaCodes:     Vec[UInt]     = Vec(PortNumber, UInt(MetaEccBits.W))
+  val pTag:          UInt          = UInt(tagBits.W)
   val itlbException: ExceptionType = new ExceptionType
   val itlbPbmt:      UInt          = UInt(Pbmt.width.W)
 }
@@ -235,8 +235,8 @@ class WayLookupBundle(implicit p: Parameters) extends ICacheBundle {
   // for compatibility
   def vSetIdx:           Vec[UInt]     = entry.vSetIdx
   def waymask:           Vec[UInt]     = entry.waymask
-  def pTag:              Vec[UInt]     = entry.pTag
   def metaCodes:         Vec[UInt]     = entry.metaCodes
+  def pTag:              UInt          = entry.pTag
   def itlbException:     ExceptionType = entry.itlbException
   def itlbPbmt:          UInt          = entry.itlbPbmt
   def gpAddr:            PrunedAddr    = gpf.gpAddr

--- a/src/main/scala/xiangshan/frontend/icache/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Helpers.scala
@@ -149,8 +149,8 @@ trait ICacheDataHelper extends HasICacheParameters {
 }
 
 trait ICacheAddrHelper extends HasICacheParameters {
-  def getBlkAddr(addr: PrunedAddr): UInt =
-    (addr >> blockOffBits).asUInt
+  def getBlkAddrFromPTag(vAddr: PrunedAddr, pTag: UInt): UInt =
+    Cat(pTag, vAddr(pgUntagBits - 1, blockOffBits))
 
   def getPTagFromBlk(blkAddr: UInt): UInt =
     (blkAddr >> (pgUntagBits - blockOffBits)).asUInt
@@ -160,9 +160,6 @@ trait ICacheAddrHelper extends HasICacheParameters {
 
   def getPAddrFromPTag(vAddr: PrunedAddr, pTag: UInt): PrunedAddr =
     PrunedAddrInit(Cat(pTag, vAddr(pgUntagBits - 1, 0)))
-
-  def getPAddrFromPTag(vAddrVec: Vec[PrunedAddr], pTagVec: Vec[UInt]): Vec[PrunedAddr] =
-    VecInit((vAddrVec zip pTagVec).map { case (vAddr, pTag) => getPAddrFromPTag(vAddr, pTag) })
 }
 
 trait ICacheMissUpdateHelper extends HasICacheParameters with ICacheEccHelper with ICacheAddrHelper {
@@ -214,11 +211,11 @@ trait ICacheMissUpdateHelper extends HasICacheParameters with ICacheEccHelper wi
   def checkMshrHitVec(
       update:       Valid[MissRespBundle],
       vSetIdxVec:   Vec[UInt],
-      pTagVec:      Vec[UInt],
+      pTag:         UInt,
       validVec:     Vec[Bool],
       allowCorrupt: Boolean = false
   ): Vec[Bool] =
-    VecInit((vSetIdxVec zip pTagVec zip validVec).map { case ((vs, pt), v) =>
-      checkMshrHit(update, vs, pt, v, allowCorrupt)
+    VecInit((vSetIdxVec zip validVec).map { case (vs, v) =>
+      checkMshrHit(update, vs, pTag, v, allowCorrupt)
     })
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -85,7 +85,7 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
         io.update,
         entry.waymask(i),
         entry.vSetIdx(i),
-        entry.pTag(i),
+        entry.pTag,
         entry.metaCodes(i)
       )
       when(updated) {

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -25,6 +25,7 @@ import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.IBufPtr
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.ftq.FtqPtr
+import xiangshan.frontend.icache.HasICacheParameters
 
 /* ***
  * Naming:
@@ -74,14 +75,14 @@ class FetchBlockInfo(implicit p: Parameters) extends IfuBundle {
   val fetchSize:     UInt                     = UInt(log2Ceil(PredictWidth + 1).W)
 }
 
-class ICacheInfo(implicit p: Parameters) extends IfuBundle {
-  val exception:          ExceptionType   = new ExceptionType
-  val pmpMmio:            Bool            = Bool()
-  val itlbPbmt:           UInt            = UInt(Pbmt.width.W)
-  val isBackendException: Bool            = Bool()
-  val isForVSnonLeafPTE:  Bool            = Bool()
-  val gpAddr:             PrunedAddr      = PrunedAddr(PAddrBitsMax)
-  val pAddr:              Vec[PrunedAddr] = Vec(PortNumber, PrunedAddr(PAddrBits))
+class ICacheInfo(implicit p: Parameters) extends IfuBundle with HasICacheParameters {
+  val exception:          ExceptionType = new ExceptionType
+  val pmpMmio:            Bool          = Bool()
+  val itlbPbmt:           UInt          = UInt(Pbmt.width.W)
+  val isBackendException: Bool          = Bool()
+  val isForVSnonLeafPTE:  Bool          = Bool()
+  val gpAddr:             PrunedAddr    = PrunedAddr(PAddrBitsMax)
+  val pAddr:              PrunedAddr    = PrunedAddr(PAddrBits)
 }
 
 class FinalPredCheckResult(implicit p: Parameters) extends IfuBundle {

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -891,7 +891,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
         val respIsRVC = isRVC(fromUncache.bits.data(1, 0))
         val exception = ExceptionType(hasAf = fromUncache.bits.corrupt)
         // when response is not RVC, and lower bits of pAddr is 6 => request crosses 8B boundary, need resend
-        val needResend = !respIsRVC && s4_icacheInfo(0).pAddr(0)(2, 1) === 3.U && exception.isNone
+        val needResend = !respIsRVC && s4_icacheInfo(0).pAddr(2, 1) === 3.U && exception.isNone
         mmioState     := Mux(needResend, MmioFsmState.SendTlb, MmioFsmState.WaitCommit)
         mmioException := exception
         mmioIsRvc     := respIsRVC
@@ -973,7 +973,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   toUncache.valid := ((mmioState === MmioFsmState.SendReq) || (mmioState === MmioFsmState.ResendReq)) &&
     s4_reqIsMmio && s4_valid
 
-  toUncache.bits.addr := Mux(mmioState === MmioFsmState.ResendReq, mmioResendAddr, s4_icacheInfo(0).pAddr(0))
+  toUncache.bits.addr := Mux(mmioState === MmioFsmState.ResendReq, mmioResendAddr, s4_icacheInfo(0).pAddr)
   // if !pmp_mmio, then we're actually sending a MMIO request to main memory, it must be pbmt.nc/io
   // we need to tell L2 Cache about this to make it work correctly
   toUncache.bits.memBackTypeMM := !s4_icacheInfo(0).pmpMmio


### PR DESCRIPTION
No cross page is allowed, so physical page number of these two ports are the same, we need only pAddr(0) and we can calculate pAddr(1) from pAddr(0) and vAddr(1)

Follow #4909