### PR TITLE
fix(MMU): PMM is disabled if MXR is effective

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -160,6 +160,8 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       pmm := 0.U
     } .elsewhen (premode(i) === ModeM) {
       pmm := csr.pmm.mseccfg
+    } .elsewhen (Mux(virt_in || req_in(i).bits.hyperinst, csr.priv.vmxr || csr.priv.mxr, csr.priv.mxr)) {
+      pmm := 0.U
     } .elsewhen (!(virt_in || req_in(i).bits.hyperinst) && premode(i) === ModeS) {
       pmm := csr.pmm.menvcfg
     } .elsewhen ((virt_in || req_in(i).bits.hyperinst) && premode(i) === ModeS) {


### PR DESCRIPTION
According PMM spec, PMM is not used for instruction fetch, including ifetch, hlvx and MXR. Previous implementation of PMM didn't handle MXR at all.

This patch introduces MXR into PMM handling procedure. Note:
* MXR only works when translation is enabled, i.e. effective mode is less than M. So MXR should be considered after M mode is identified.
* There is 2 MXR: MXR (mstatus/sstatus.MXR) and vMXR (vsstatus.MXR). When V=1, for VS stage, both of then are effective.
* The modification is inspired by spike.