### PR TITLE
fix(RobCompress): fix isRVC transfer logic for new ftqoffset

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -121,7 +121,7 @@ case class XSCoreParameters
   StoreQueueNWriteBanks: Int = 8, // NOTE: make sure that StoreQueueSize is divided by StoreQueueNWriteBanks
   StoreQueueForwardWithMask: Boolean = true,
   VlsQueueSize: Int = 8,
-  RobSize: Int = 224,
+  RobSize: Int = 160,
   RabSize: Int = 256,
   VTypeBufferSize: Int = 64, // used to reorder vtype
   IssueQueueSize: Int = 20,

--- a/src/main/scala/xiangshan/backend/BackendParams.scala
+++ b/src/main/scala/xiangshan/backend/BackendParams.scala
@@ -41,7 +41,7 @@ case class BackendParams(
 
   def debugEn(implicit p: Parameters): Boolean = p(DebugOptionsKey).EnableDifftest
 
-  def robCompressEn: Boolean = false
+  def robCompressEn: Boolean = true
 
   def basicDebugEn(implicit p: Parameters): Boolean = p(DebugOptionsKey).AlwaysBasicDiff || debugEn
 

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -231,7 +231,8 @@ object Bundles {
     val singleStep = Bool() // debug module
     val numLsElem = NumLsElem()
     val hasException = Bool()
-    val ftqLastOffset = UInt(log2Up(PredictWidth).W) // store ftqoffset before channge in rename
+    val ftqLastOffset = UInt(log2Up(PredictWidth).W) // store ftqoffset before change in rename
+    val lastIsRVC = Bool() // store isrvc before change in rename
     val debug = OptionWrapper(backendParams.debugEn, new RenameOutUopDebug())
     val crossFtqCommit = UInt(2.W) // use to caculate the ftq idx of ftqentry when commit
     val crossFtq = Bool() // use to caculate the ftq idx of brh instructions when pass to exu

--- a/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
@@ -167,6 +167,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
   val fromRenameUpdate = Wire(Vec(RenameWidth, Flipped(ValidIO(new DispatchUpdateUop))))
 
   // Update ftqidx to dispatch: Due to branch instructions/store compression, the required ftqidx should correspond to the ftqidx of the last instruction in the compressed robentry.
+  // update isrvc to dispatch: branch need last isrvc, rob need first isrvc as rob should attach interrupt to first uop
   for (i <- 0 until RenameWidth) {
     fromRenameUpdate(i).valid := fromRename(i).valid
     // srcLoadDependency and srcState
@@ -175,6 +176,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     fromRenameUpdate(i).bits.debug.foreach(connectSamePort(_, fromRename(i).bits.debug.get))
     fromRenameUpdate(i).bits.ftqOffset := fromRename(i).bits.ftqLastOffset
     fromRenameUpdate(i).bits.ftqPtr := fromRename(i).bits.ftqPtr + fromRename(i).bits.crossFtq
+    fromRenameUpdate(i).bits.preDecodeInfo.isRVC := fromRename(i).bits.lastIsRVC
   }
 
   val renameWidth = io.fromRename.size


### PR DESCRIPTION
With the new `ftqoffset` definition, computing the PC now requires `isRVC`. 
When ROB compression is enabled, we previously recorded the `isRVC` of the last instruction, mainly to compute the PC when the last instruction is a jump. 
However, if an interrupt hits the first instruction of a ROB entry, the PC computation cannot obtain the correct `isRVC`, causing the calculation to fail. 
Therefore, we change the policy: 
- use the last instruction’s `isRVC` when dispatching to the execution pipelines
- use the first instruction’s `isRVC` when enqueuing into the ROB.

This pr also open the ROBcompress for branch kunminghu-v3