### PR TITLE
feat(pdb): add asm and dasm commands for XSPdb

### DIFF
--- a/scripts/xspdb/xscmd/__init__.py
+++ b/scripts/xspdb/xscmd/__init__.py
@@ -15,5 +15,5 @@
 #***************************************************************************************
 
 
-from xspdb.xscmd.util import message, error, warn, info, GREEN, RESET
-from xspdb.xscmd.util import get_completions, find_executable_in_dirs
+from xspdb.xscmd.util import message, error, warn, info, GREEN, RESET, YELLOW
+from xspdb.xscmd.util import get_completions, find_executable_in_dirs, dasm_bytes

--- a/scripts/xspdb/xscmd/cmd_asm.py
+++ b/scripts/xspdb/xscmd/cmd_asm.py
@@ -1,0 +1,188 @@
+#***************************************************************************************
+# Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+# Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# XiangShan is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************
+
+
+import os
+import subprocess
+import tempfile
+import fnmatch
+from . import info, error, message, warn, find_executable_in_dirs, YELLOW, RESET
+
+
+class CmdASM:
+    """Assembly command class for disassembling data"""
+
+    def api_asm_str(self, asm_str, entry_address=0x80000000, debug=True, target_secs=[], search_dirs=["./ready-to-run"]):
+        """Assemble RISC-V assembly code and return a dict mapping section start addresses to bytes (little-endian).
+        Uses riscv64-unknown-elf-gcc and objcopy.
+
+        Args:
+            asm (str): RISC-V assembly code (can contain multiple .section/.text/.data).
+            entry_addr (int): Entry address for the first section (default 0x80000000).
+            debug (bool): Whether to enable debug info (default False).
+
+        Returns:
+            Dict[int, bytes]: {address: bytes} for each section.
+        """
+        cmd_gcc = ""
+        cmd_objdump = ""
+        cmd_objcopy = ""
+        # Check if gcc and objdump are available
+        cmd_prefix = ["riscv64-unknown-elf-", "riscv64-linux-gnu-"]
+        for prefix in cmd_prefix:
+            if not cmd_gcc:
+                cmd_gcc = find_executable_in_dirs(prefix+"gcc", search_dirs = search_dirs)
+            if not cmd_objdump:
+                cmd_objdump = find_executable_in_dirs(prefix+"objdump", search_dirs = search_dirs)
+            if not cmd_objcopy:
+                cmd_objcopy = find_executable_in_dirs(prefix+"objcopy", search_dirs = search_dirs)
+        if not cmd_gcc:
+            error(f"gcc with prefix[{'or'.join(cmd_prefix)}] not found, please install it")
+            return None
+        if not cmd_objdump:
+            error(f"objdump with prefix[{'or'.join(cmd_prefix)}] not found, please install it")
+            return None
+        if not cmd_objcopy:
+            error(f"objcopy with prefix[{'or'.join(cmd_prefix)}] not found, please install it")
+            return None
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asm_file = os.path.join(tmpdir, "input.S")
+            elf_file = os.path.join(tmpdir, "output.elf")
+            map_file = os.path.join(tmpdir, "output.map")
+            # Write asm to file
+            with open(asm_file, "w") as f:
+                raw_asm = asm_str.replace("\\t", "\t").replace(";$", "\n").replace(";", "\n\t")
+                if "__start" not in raw_asm:
+                    raw_asm = ".global _start\n_start:\n\t" + raw_asm
+                if debug:
+                    info("User Input ASM:\n"+raw_asm)
+                f.write(raw_asm)
+            # Assemble to ELF
+            gcc_cmd = [
+                cmd_gcc,
+                "-nostdlib", "-Ttext", hex(entry_address),
+                "-Wl,-Map=" + map_file,
+                asm_file, "-o", elf_file
+            ]
+            subprocess.check_call(gcc_cmd)
+            if debug:
+                objdump_dis_cmd = [
+                    cmd_objdump,
+                    "-d",
+                    elf_file
+                ]
+                objdump_dis_out = subprocess.check_output(objdump_dis_cmd, encoding="utf-8")
+                info("Final Decompiled ASM:\n"+objdump_dis_out)
+            # Get section info using objdump
+            objdump_cmd = [cmd_objdump, "-h", elf_file]
+            objdump_out = subprocess.check_output(objdump_cmd, encoding="utf-8")
+            # Parse section addresses and sizes
+            section_info = {}
+            for line in objdump_out.splitlines():
+                parts = line.split()
+                if len(parts) >= 6 and parts[1].startswith('.'):
+                    name = parts[1]
+                    size = int(parts[2], 16)
+                    addr = int(parts[3], 16)
+                    if size > 0:
+                        section_info[name] = (addr, size)
+            # Extract each section as binary
+            if debug:
+                info(f"Sections in ELF:\n{objdump_out}\n")
+            result = {}
+            for sec, (addr, size) in section_info.items():
+                sec_bin = os.path.join(tmpdir, f"{sec[1:]}.bin")
+                objcopy_cmd = [
+                    cmd_objcopy,
+                    f"-j{sec}",
+                    "-O", "binary",
+                    elf_file, sec_bin
+                ]
+                subprocess.check_call(objcopy_cmd)
+                with open(sec_bin, "rb") as f:
+                    data = f.read()
+                if len(target_secs) > 0:
+                    if not any(fnmatch.fnmatch(sec, pattern) for pattern in target_secs):
+                        if debug:
+                            info(f"Section {sec} not matched, skip")
+                        continue
+                result[sec] = (addr, data)
+            if debug:
+                message = ""
+                for name, (addr, data) in result.items():
+                    message += f"Section[{name}] at {hex(addr)}: {data}\n"
+                info(f"Sections Parsed:\n{message}" + (f"Find {len(result)} sections." if message else f"{YELLOW}No sections found{RESET}"))
+            return result
+
+    def do_xasm(self, arg, debug=True):
+        """Assemble RISC-V assembly code and return a dict mapping section start addresses to bytes (little-endian).
+        Uses riscv64-unknown-elf-gcc and objcopy.
+
+        Args:
+            entry_addr (int): Entry address for the first section (default self.mem_base (0x80000000)). eg <0x80000000>
+            target_secs (list): List of section names to extract (default empty, all sections). eg [.text*, .data*], support wildcards.
+            asm_data (str): RISC-V assembly code (can contain multiple .section/.text/.data).
+        Returns:
+            Dict: {name: (address,bytes)} for each section.
+
+        Examples:
+            xasm <0x80000000> [.text*,.data] addi a0, a0, 1
+            xasm <0x80000000> addi a0, a0, 1
+            xasm [.text*] addi a0, a0, 1
+        """
+        if not arg:
+            message("usage: xasm [<entry_address>] [[sections,...]] <asm_data>")
+            return
+        target_secs = []
+        arg = arg.strip()
+        entry_address = self.mem_base
+        try:
+            if arg.startswith("<"):
+                cmds = arg.split(">", 1)
+                entry_address = int(cmds[0].replace("<", ""), 0)
+                arg = cmds[1].strip()
+            if arg.startswith("["):
+                cmds = arg.split("]", 1)
+                target_secs = [s.strip() for s in cmds[0].replace("[", "").split(",")]
+                arg = cmds[1].strip()
+            asm_str = arg
+            if not asm_str:
+                message("usage: xasm [<entry_address>] <asm_data>")
+                return
+            return self.api_asm_str(asm_str, entry_address=entry_address, debug=debug, target_secs=target_secs)
+        except Exception as e:
+            error(f"asm {arg} fail: {str(e)}")
+            return
+
+    def do_xasm_insert(self, arg):
+        """Assemble RISC-V assembly code and insert it into the target address (with no debug message).
+
+        Args: same as xasm
+        """
+        sections = self.do_xasm(arg, debug=False)
+        if not sections:
+            warn("No sections found, ignore insert")
+            return
+        bytes_count = 0
+        for sec, (addr, data) in sections.items():
+            if len(data) == 0:
+                warn(f"Empty section: {sec}, skip")
+                continue
+            info(f"Insert Section[{sec}] at {hex(addr)}: with {len(data)} bytes")
+            if not self.api_write_bytes(addr, data):
+                break
+            bytes_count += len(data)
+        info(f"Total {bytes_count} bytes inserted")

--- a/scripts/xspdb/xscmd/cmd_dasm.py
+++ b/scripts/xspdb/xscmd/cmd_dasm.py
@@ -1,0 +1,240 @@
+#***************************************************************************************
+# Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+# Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+#
+# XiangShan is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+#
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+#
+# See the Mulan PSL v2 for more details.
+#***************************************************************************************
+
+
+from . import dasm_bytes, error, info, message
+
+class CmdDASM:
+
+    def api_is_flash_address(self, address):
+        """Check if the address is in Flash range
+    
+        Args:
+            address (int): Target address
+    
+        Returns:
+            bool: True if the address is in Flash range, False otherwise
+        """
+        return self.flash_base <= address < self.flash_ends
+    
+    def api_merge_asm_list_overlap_append(self, a, b):
+        if len(b) == 0:
+            return a
+        if len(a) == 0:
+            return b
+        b_head = b[0][0]
+        a_end_index = -1
+        a_size = len(a)
+        while abs(a_end_index) <= a_size:
+            if a[a_end_index][0] < b_head:
+                if a_end_index == -1:
+                    return a + b
+                else:
+                    return a[:a_end_index + 1] + b
+            a_end_index -= 1
+        return b
+
+    def api_all_data_to_asm(self, address, length):
+        """Convert memory data to assembly instructions
+
+        Args:
+            address (int): Target memory address
+            length (int): Target memory length
+
+        Returns:
+            list((address, hex, mnemonic, str)): Disassembly results
+        """
+        end_address = address + length
+        if self.api_is_flash_address(address) and \
+           not self.api_is_flash_address(end_address):
+            return self.api_merge_asm_list_overlap_append(self.api_flash_data_to_asm(address, self.flash_ends - address),
+                                                          self.api_mem_data_to_asm(self.flash_ends, end_address - self.flash_ends))
+
+        if not self.api_is_flash_address(address) and \
+           self.api_is_flash_address(end_address):
+            return self.api_merge_asm_list_overlap_append(self.api_mem_data_to_asm(address, self.flash_base - address),
+                                                          self.api_flash_data_to_asm(self.flash_base, end_address - self.flash_base))
+
+        if self.api_is_flash_address(address):
+            return self.api_flash_data_to_asm(address, length)
+        else:
+            return self.api_mem_data_to_asm(address, length)
+
+    def api_flash_data_to_asm(self, address, length):
+        """Convert Flash data to assembly instructions
+
+        Args:
+            address (int): Target Flash address
+            length (int): Target Flash length
+
+        Returns:
+            list((address, hex, mnemonic, str)): Disassembly results
+        """
+        def _flash_read(addr):
+            return self.df.FlashRead(max(0, addr - self.flash_base))
+        return self.api_read_data_as_asm(address, length, _flash_read)
+
+    def api_mem_data_to_asm(self, address, length):
+        """Convert memory data to assembly instructions
+
+        Args:
+            address (int): Target memory address
+            length (int): Target memory length
+
+        Returns:
+            list((address, hex, mnemonic, str)): Disassembly results
+        """
+        return self.api_read_data_as_asm(address, length, self.df.pmem_read)
+
+    def api_dasm_from_bytes(self, bytes, start_address=0):
+        """Convert binary data to assembly instructions
+
+        Args:
+            bytes (bytes): Binary data
+            start_address (int): Starting address
+
+        Returns:
+            list((address, hex, mnemonic, str)): Disassembly results
+        """
+        return dasm_bytes(bytes, start_address)
+
+    def api_read_data_as_asm(self, address, length, read_func):
+        """Convert memory data to assembly instructions
+
+        Args:
+            address (int): Target memory address
+            length (int): Target memory length
+            read_func (function): Function to read uint64
+
+        Returns:
+            list((address, hex, mnemonic, str)): Disassembly results
+        """
+        dasm_list = []
+        try:
+            sta_address = address - address % 2                      # Starting memory address must be 2-byte aligned
+            end_address = sta_address + (2 + length//2 + length % 2) # Ending memory address must be 2-byte aligned; read at least 2 bytes
+            assert sta_address >=0 , "address need >=0 and not miss align"
+            assert length >=0, "length need >=0 "
+
+            pmem_sta_address = sta_address - sta_address % 8         # Physical memory reads 8 bytes at a time; must be 8-byte aligned
+            pmem_end_address = end_address - end_address % 8         # Physical memory reads 8 bytes at a time; must be 8-byte aligned
+            count = 1 + pmem_end_address - pmem_sta_address
+            buffer = bytearray()
+            for index in range(count):
+                padd = pmem_sta_address + 8*index
+                buffer += read_func(padd).to_bytes(8, byteorder='little', signed=False)
+            # Calculate offset
+            offset = sta_address - pmem_sta_address
+            for instr in dasm_bytes(buffer[offset:], sta_address):
+                    dasm_list.append(instr)
+        except Exception as e:
+            import traceback
+            error(f"disasm fail: {str(e)} {traceback.print_exc()}")
+        return dasm_list
+
+    def do_xdasm(self, arg):
+        """Disassemble memory data
+
+        Args:
+            arg (string): Memory address and length
+        """
+        if not arg:
+            error("dasm <address> [length]")
+            return
+        args = arg.strip().split()
+        length = 10
+        if len(args) < 2:
+            args.append(str(length))
+        try:
+            address = int(args[0], 0)
+            length = int(args[1])
+            for l in self.api_all_data_to_asm(address, length):
+                message("0x%x: %s\t%s\t%s" % (l[0], l[1], l[2], l[3]))
+        except Exception as e:
+            error(f"convert {args[0]} or {args[1]} to number fail: {str(e)}")
+
+    def do_xdasmflash(self, arg):
+        """Disassemble Flash data
+
+        Args:
+            arg (string): Flash address and length
+        """
+        if not arg:
+            error("dasmflash <address> [length]")
+            return
+        args = arg.strip().split()
+        length = 10
+        if len(args) < 2:
+            args.append(str(length))
+        try:
+            address = int(args[0], 0)
+            length = int(args[1])
+            for l in self.api_flash_data_to_asm(address, length):
+                message("0x%x: %s\t%s\t%s" % (l[0], l[1], l[2], l[3]))
+        except Exception as e:
+            error(f"convert {args[0]} or {args[1]} to number fail: {str(e)}")
+
+    def do_xdasmbytes(self, arg):
+        """Disassemble binary data
+
+        Args:
+            arg (string): Binary data
+        """
+        if not arg:
+            error("dasmbytes <bytes> [address]")
+            return
+        try:
+            params = arg.strip().split()
+            address = 0
+            if len(params) > 1:
+                address = int(params[1], 0)
+            data_bytes = params[0].strip()
+            if not data_bytes.startswith("b'"):
+                new_data_bytes = "b'"
+                for i in range(0, len(data_bytes), 2):
+                    new_data_bytes += "\\x%s" % params[0][i:i+2]
+                data_bytes = new_data_bytes + "'"
+            for i in self.api_dasm_from_bytes(eval(data_bytes), address):
+                message("0x%x: %s\t%s\t%s" % (i[0], i[1], i[2], i[3]))
+        except Exception as e:
+            error(f"convert {arg} to bytes fail: {str(e)}")
+
+    def do_xdasmnumber(self, arg):
+        """Disassemble a number
+
+        Args:
+            arg (string): Number data
+        """
+        if not arg:
+            error("dasmbytes <number> [address]")
+            return
+        try:
+            params = arg.strip().split()
+            address = 0
+            if len(params) > 1:
+                address = int(params[1], 0)
+            for i in self.api_dasm_from_bytes(int(params[0], 0).to_bytes(4, byteorder="little", signed=False), address):
+                message("0x%x: %s\t%s\t%s" % (i[0], i[1], i[2], i[3]))
+        except Exception as e:
+            error(f"convert {arg} to bytes fail: {str(e)}")
+
+    def do_xclear_dasm_cache(self, arg):
+        """Clear disassembly cache
+
+        Args:
+            arg (None): No arguments
+        """
+        self.info_cache_asm.clear()


### PR DESCRIPTION
### 1. Purpose of this Pull Request 

This PR adds two new commands to xspdb to enable RISC-V assembly and disassembly functionality:
- asm command: Assembles RISC-V assembly code.
    1. Assembles the given instructions and displays the machine code.
    2. Assembles the instructions and writes the resulting machine code directly to the specified target address (silently, with no debug messages).
- dasm command: Disassembles machine code into RISC-V assembly instructions.
    1. Disassembles count instructions from a memory address.
    2. Disassembles count instructions from a Flash address.

### 2. Changes Made

- **cmd_asm.py**: Implements the asm command for assembly.
- **cmd_dasm.py**: Implements the dasm command for disassembly.

### 3. Usage 

The new commands can be used by command like this.
1. **start XSPdb**: 
```bash
     make pdb-run NOOP_HOME=$(pwd)
 ```
2.  **Run a asm and dasm commands with the XSPdb**:
```bash
    xasm <0x80000000> addi a0, a0, 1
    xasm_insert <0x80000000> addi a0, a0, 1
    xdasm <0x80000000>
    xdasmflash <0x80000000>
 ```

