### PR TITLE
feat(Frontend): increase FetchBlockSize to 64B

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -102,6 +102,7 @@ class MinimalConfig(n: Int = 1) extends Config(
         RobSize = 48,
         RabSize = 96,
         frontendParameters = FrontendParameters(
+          FetchBlockSize = 32, // in bytes
           bpuParameters = BpuParameters(
             // FIXME: these are from V2 Ftb(Size=512, Way=2), may not correct
             mbtbParameters = MainBtbParameters(

--- a/src/main/scala/xiangshan/frontend/FrontendParameters.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendParameters.scala
@@ -25,7 +25,7 @@ import xiangshan.frontend.icache.ICacheParameters
 import xiangshan.frontend.ifu.IfuParameters
 
 case class FrontendParameters(
-    FetchBlockSize: Int = 32, // bytes // FIXME: 64B, waiting for ftq/icache support
+    FetchBlockSize: Int = 64, // bytes
     FetchPorts:     Int = 2,  // 2-fetch
 
     bpuParameters:     BpuParameters = BpuParameters(),


### PR DESCRIPTION
Also:
- Fix unportable code (use of magic number) in PreDecodeBoundary & PredChecker

For MinimalConfig, we still do 32B fetch, it has `IBufferSize = 24`, but we need `IBufferSize >= FetchBlockSize / 2 + IBufferWriteBanks` to make it work. Since we don't care about performance to much with MinimalConfig, I'd rather decreasing FetchBlockSize instead of increasing IBufferSize.

~~Test ci now, should rebase after #4999, also wait for V3 parameter system in Ifu & IBuffer for cleaner parameters:~~
- [x] #4999
- [x] #5013 
- [x] #4975