### PR TITLE
fix(Ftq): add ExceptionType.fromBackend & fix write condition in Ftq

### DIFF
--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -226,6 +226,14 @@ object ExceptionType {
   def apply(hasAf: Bool): ExceptionType =
     apply(hasPf = false.B, hasGpf = false.B, hasAf = hasAf)
 
+  // raise pf/gpf/af according to backend redirect request (tlb pre-check)
+  def fromBackend(redirect: Redirect): ExceptionType =
+    apply(
+      hasPf = redirect.backendIPF,
+      hasGpf = redirect.backendIGPF,
+      hasAf = redirect.backendIAF
+    )
+
   // raise pf/gpf/af according to itlb response
   def fromTlbResp(resp: TlbResp, useDup: Int = 0): ExceptionType = {
     require(useDup >= 0 && useDup < resp.excp.length)

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -116,12 +116,9 @@ class Ftq(implicit p: Parameters) extends FtqModule
   private val backendException    = RegInit(ExceptionType.None)
   private val backendExceptionPtr = RegInit(FtqPtr(false.B, 0.U))
   when(backendRedirect.valid) {
-    backendException := ExceptionType(
-      hasPf = backendRedirect.bits.backendIPF,
-      hasGpf = backendRedirect.bits.backendIGPF,
-      hasAf = backendRedirect.bits.backendIAF
-    )
-    when(backendException.hasException) {
+    val exception = ExceptionType.fromBackend(backendRedirect.bits)
+    when(exception.hasException) {
+      backendException    := exception
       backendExceptionPtr := ifuWbPtr(0)
     }
   }.elsewhen(ifuWbPtr(0) =/= backendExceptionPtr) {


### PR DESCRIPTION
`backendException` is a Reg and `backendRedirect` is a RegNext, we have:
1. cycle 0: `backendRedirect.valid && (backendRedirect.bits.backendIPF || backendRedirect.bits.backendIPF || backendRedirect.bits.backendIPF)`
2. cycle 1: `backendException.hasException`, but `!backendRedirect.valid`

So `backendExceptionPtr` is not written unless we have a old backendException