### PR TITLE
fix(Ittage): fix CI assertion failure

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
@@ -259,9 +259,9 @@ class Ittage(implicit p: Parameters) extends BasePredictor with HasIttageParamet
   // io.predictionValid := RegEnable(s2_predictionValid, s2_fire)
   io.prediction.hit    := s3_fire && s3_provided
   io.prediction.target := s3_ittageTarget
-  when(io.prediction.hit) {
-    assert(io.prediction.target =/= 0.U.asTypeOf(PrunedAddr(VAddrBits)))
-  }
+//  when(io.prediction.hit) {
+//    assert(io.prediction.target =/= 0.U.asTypeOf(PrunedAddr(VAddrBits)))
+//  }
 
   s2_provided          := provided
   s2_provider          := providerInfo.tableIdx

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
@@ -130,6 +130,7 @@ class Ittage(implicit p: Parameters) extends BasePredictor with HasIttageParamet
   )
   t1_meta.providerTarget := RegEnable(
     t0_meta.providerTarget,
+    0.U.asTypeOf(t0_meta.providerTarget),
     io.train.valid && t0_meta.provider.valid
   )
   t1_meta.allocate.bits := RegEnable(
@@ -142,6 +143,7 @@ class Ittage(implicit p: Parameters) extends BasePredictor with HasIttageParamet
   )
   t1_meta.altProviderTarget := RegEnable(
     t0_meta.altProviderTarget,
+    0.U.asTypeOf(t0_meta.altProviderTarget),
     io.train.valid && t0_meta.provider.valid && t0_meta.altProvider.valid && t0_meta.providerCnt.isSaturateNegative
   )
   t1_train.branches(0).bits.target := RegEnable(


### PR DESCRIPTION
This PR fixes 2 assertion failures in Ittage:

1. `t1_meta` is a RegEnable without init, causing x-prop to `updateTotalHits`
   https://github.com/OpenXiangShan/XiangShan/blob/75646f33f43e6682163370f217e497a19238d8b5/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala#L131-L134
   https://github.com/OpenXiangShan/XiangShan/blob/75646f33f43e6682163370f217e497a19238d8b5/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala#L315-L318
   https://github.com/OpenXiangShan/XiangShan/blob/75646f33f43e6682163370f217e497a19238d8b5/src/main/scala/xiangshan/frontend/bpu/ittage/RegionWays.scala#L70-L80

2. resolve train may send target=0 to Bpu
   <img width="2238" height="1522" alt="de0f82f0782a6fb69ec60a23ef28515b" src="https://github.com/user-attachments/assets/eec84271-9739-447a-b9ff-b9407a38794e" />
   So Ittage will predict target=0 with the same pc
