### PR TITLE
feat(ibuffer): relax IBuffer enqueue condition

### DIFF
--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -294,6 +294,7 @@ class FetchToIBuffer(implicit p: Parameters) extends FrontendBundle {
 
   val pc:             Vec[PrunedAddr]       = Vec(IBufferEnqueueWidth, PrunedAddr(VAddrBits))
   val prevIBufEnqPtr: IBufPtr               = new IBufPtr
+  val prevInstrCount: UInt                  = UInt(log2Ceil(IBufferEnqueueWidth).W)
   val debug_seqNum:   Vec[UInt]             = Vec(IBufferEnqueueWidth, InstSeqNum())
   val ftqPtr:         FtqPtr                = new FtqPtr
   val topdownInfo:    FrontendTopDownBundle = new FrontendTopDownBundle

--- a/src/main/scala/xiangshan/frontend/ibuffer/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/ibuffer/IBuffer.scala
@@ -124,10 +124,17 @@ class IBuffer(implicit p: Parameters) extends IBufferModule with HasCircularQueu
   private val numValid = distanceBetween(enqPtr, deqPtr)
   // counter next number of valid
   private val numValidNext = numValid + numEnq - numDeq
-  private val allowEnq     = RegInit(true.B)
   private val numFromFetch = Mux(io.in.valid, PopCount(io.in.bits.enqEnable), 0.U)
 
-  allowEnq := (Size - FetchBlockInstNum).U >= numValidNext // Disable when almost full
+  // TODO: Use ParallelAdder to calculate the sum of Seq(Size.U, -numValid, -numEnq, numDeq)
+  private val numInvalidNext = Size.U - numValidNext
+  private val allowEnq     = RegInit(true.B)
+
+  /* prevInstrCount is equal to next cycle's numFromFetch, ‘prev’ means ifu.s3 stage,
+   * so compare it with next cycle's number of invalid entries (i.e. numInvalidNext),
+   * the answer is next cycle's ready (NOT considering dequeue behavior and predChecker).
+   */
+  allowEnq := io.in.bits.prevInstrCount < numInvalidNext
 
   private val enqOffset = VecInit.tabulate(EnqueueWidth)(i => PopCount(io.in.bits.valid.asBools.take(i)))
   private val enqData   = VecInit.tabulate(EnqueueWidth)(i => Wire(new IBufEntry).fromFetch(io.in.bits, i))

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -1044,6 +1044,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   io.toIBuffer.bits.pd        := s4_alignPds
   io.toIBuffer.bits.ftqPtr    := s4_fetchBlock(0).ftqIdx
   io.toIBuffer.bits.pc        := s4_alignPc
+  io.toIBuffer.bits.prevInstrCount := Mux(s3_fire, s3_instrCount, 0.U)
   io.toIBuffer.bits.prevIBufEnqPtr := s4_prevIBufEnqPtr
   // Find last using PriorityMux
   io.toIBuffer.bits.isLastInFtqEntry := Reverse(PriorityEncoderOH(Reverse(io.toIBuffer.bits.enqEnable))).asBools

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -698,6 +698,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s4_prevLastRvi         = RegEnable(s3_prevLastIsHalfRvi, s3_fire)
   private val s4_currentLastHalfData = RegEnable(s3_alignInstrData(s3_instrCount + s3_alignShiftNum)(15, 0), s3_fire)
   private val s4_currentLastHalfRvi  = RegEnable(s3_currentLastHalfRvi, s3_fire)
+  private val s4_instrCount          = RegEnable(s3_instrCount, s3_fire)
   s4_fire := io.toIBuffer.fire
 
   private val s4_alignInvalidTaken = RegEnable(s3_alignInvalidTaken, s3_fire)
@@ -1044,8 +1045,12 @@ class Ifu(implicit p: Parameters) extends IfuModule
   io.toIBuffer.bits.pd        := s4_alignPds
   io.toIBuffer.bits.ftqPtr    := s4_fetchBlock(0).ftqIdx
   io.toIBuffer.bits.pc        := s4_alignPc
-  io.toIBuffer.bits.prevInstrCount := Mux(s3_fire, s3_instrCount, 0.U)
   io.toIBuffer.bits.prevIBufEnqPtr := s4_prevIBufEnqPtr
+  io.toIBuffer.bits.prevInstrCount := PriorityMux(Seq(
+    s3_fire -> s3_instrCount,
+    (s4_valid && !s4_ready) -> s4_instrCount,  // if s4 stall, prevInstrCount equals to instrCount
+    true.B   -> 0.U
+  ))
   // Find last using PriorityMux
   io.toIBuffer.bits.isLastInFtqEntry := Reverse(PriorityEncoderOH(Reverse(io.toIBuffer.bits.enqEnable))).asBools
   io.toIBuffer.bits.instrEndOffset.zipWithIndex.foreach { case (a, i) =>


### PR DESCRIPTION
- `prevInstrCount` is equal to next cycle's `numFromFetch`, which calculated at ifu.s3,
- compare `prevInstrCount` with next cycle's number of invalid entries (i.e. `numInvalidNext`),
- the answer is next cycle's ready (NOT considering dequeue behavior and predChecker).