### PR TITLE
misc(ci): increase swap & decrease JVM_XMX to avoid oom

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -441,83 +441,86 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' }}
     continue-on-error: false
-    timeout-minutes: 40
+    timeout-minutes: 60
     name: Upload Artifacts
     steps:
       - uses: actions/checkout@v4
-      - name: set env
+      - name: Set env
         run: echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-      - name: psutil
-        run: sudo apt install python3-psutil
-      - name: init
-        run: make init
-      - name: mill
+      - name: Install deps
         run: |
+          sudo apt install python3-psutil
           mkdir -p ~/.local/bin
           sh -c "curl -L https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.4/mill-dist-1.0.4-mill.sh -o ~/.local/bin/mill && chmod +x ~/.local/bin/mill"
           export PATH=~/.local/bin:$PATH
-      - name: swapfile
+      - name: make init
+        run: make init
+      - name: Init swapfile
         run: |
-          sudo fallocate -l 10G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-      - name: clean up
+          if [ -f /mnt/swapfile ]; then
+            sudo swapoff /mnt/swapfile || true
+            sudo rm -f /mnt/swapfile
+          fi
+          sudo fallocate -l 32G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+      - name: Clean up
         run: python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
-      - name: generate standalone devices for AXI4
+      - name: Generate standalone devices for AXI4
         run: |
           make StandAloneCLINT DEVICE_BASE_ADDR=0x38000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=CLINT_
           make StandAloneDebugModule DEVICE_BASE_ADDR=0x38020000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=DM_
           make StandAlonePLIC DEVICE_BASE_ADDR=0x3C000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=PLIC_
-      - name: generate CHI Issue B XSNoCTop verilog with difftest and filelist
+      - name: Generate CHI Issue B XSNoCTop verilog with difftest and filelist
         run: |
-          make verilog WITH_CONSTANTIN=0 WITH_CHISELDB=0 CONFIG='XSNoCTopConfig --enable-difftest' ISSUE=B XSTOP_PREFIX=bosc_ JVM_XMX=16g
+          make verilog WITH_CONSTANTIN=0 WITH_CHISELDB=0 CONFIG='XSNoCTopConfig --enable-difftest' ISSUE=B XSTOP_PREFIX=bosc_ JVM_XMX=10g
           rm `find $GITHUB_WORKSPACE/build -name "*.fir"`
           cd $GITHUB_WORKSPACE/build/rtl && find . -name "*.*v" > filelist.f
-      - name: acrhive issue B verilog artifacts
+      - name: Archive issue B verilog artifacts
         uses: actions/upload-artifact@v4
         with:
           name: xs-issue-b-difftest-verilog
           path: build
-      - name: clean up
+      - name: Clean up
         run: python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
-      - name: generate standalone devices for AXI4
+      - name: Generate standalone devices for AXI4
         run: |
           make StandAloneCLINT DEVICE_BASE_ADDR=0x38000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=CLINT_
           make StandAloneDebugModule DEVICE_BASE_ADDR=0x38020000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=DM_
           make StandAlonePLIC DEVICE_BASE_ADDR=0x3C000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=PLIC_
-      - name: generate CHI Issue E.b XSNoCTop verilog with difftest and filelist
+      - name: Generate CHI Issue E.b XSNoCTop verilog with difftest and filelist
         run: |
-          make verilog WITH_CONSTANTIN=0 WITH_CHISELDB=0 CONFIG='XSNoCTopConfig --enable-difftest' ISSUE=E.b XSTOP_PREFIX=bosc_ JVM_XMX=16g
+          make verilog WITH_CONSTANTIN=0 WITH_CHISELDB=0 CONFIG='XSNoCTopConfig --enable-difftest' ISSUE=E.b XSTOP_PREFIX=bosc_ JVM_XMX=10g
           rm `find $GITHUB_WORKSPACE/build -name "*.fir"`
           cd $GITHUB_WORKSPACE/build/rtl && find . -name "*.*v" > filelist.f
-      - name: acrhive issue E.b verilog artifacts
+      - name: Archive issue E.b verilog artifacts
         uses: actions/upload-artifact@v4
         with:
           name: xs-issue-e-b-difftest-verilog
           path: build
-      - name: clean up
+      - name: Clean up
         run: python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
-      - name: generate standalone devices for AXI4
+      - name: Generate standalone devices for AXI4
         run: |
           make StandAloneCLINT DEVICE_BASE_ADDR=0x38000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=CLINT_
           make StandAloneDebugModule DEVICE_BASE_ADDR=0x38020000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=DM_
           make StandAlonePLIC DEVICE_BASE_ADDR=0x3C000000 DEVICE_ADDR_WIDTH=32 DEVICE_DATA_WIDTH=64 DEVICE_TL=0 DEVICE_PREFIX=PLIC_
-      - name: generate CHI Issue E.b lowpower XSNoCTop verilog with difftest and filelist
+      - name: Generate CHI Issue E.b lowpower XSNoCTop verilog with difftest and filelist
         run: |
-          make verilog WITH_CONSTANTIN=0 WITH_CHISELDB=0 CONFIG='XSNoCTopConfig --enable-difftest' ISSUE=E.b XSTOP_PREFIX=bosc_ JVM_XMX=16g YAML_CONFIG=$NOOP_HOME/src/main/resources/config/Poweroff.yml
+          make verilog WITH_CONSTANTIN=0 WITH_CHISELDB=0 CONFIG='XSNoCTopConfig --enable-difftest' ISSUE=E.b XSTOP_PREFIX=bosc_ JVM_XMX=10g YAML_CONFIG=$NOOP_HOME/src/main/resources/config/Poweroff.yml
           rm `find $GITHUB_WORKSPACE/build -name "*.fir"`
           cd $GITHUB_WORKSPACE/build/rtl && find . -name "*.*v" > filelist.f
-      - name: acrhive issue E.b lowpower verilog artifacts
+      - name: Archive issue E.b lowpower verilog artifacts
         uses: actions/upload-artifact@v4
         with:
           name: xs-issue-e-b-lowpower-difftest-verilog
           path: build
-      - name: generate test-jar
+      - name: Generate test-jar
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
           make test-jar
-      - name: acrhive test jar artifacts
+      - name: Archive test jar artifacts
         uses: actions/upload-artifact@v4
         with:
           name: xsgen


### PR DESCRIPTION
Hopefully this will fix CI failure due to Upload Artifact (on GitHub hosted runner, with only 16G mem) OOM:
<img width="858" height="88" alt="image" src="https://github.com/user-attachments/assets/1e78ce7f-49e5-4b1c-8f9d-41d74fdf52a9" />

Local analysis by jvisualvm shows we need 8.8G heap mem at peak (JVM_XMX=16G with default gc strategy), so maybe we can reduce JVM_MAX from 16G to 10G to trigger gc more frequently, and use less mem.

And, we can clean up unused pre-installed tool to reclaim more space for swap (refer to https://github.com/actions/runner-images/issues/709#issuecomment-612569242), though we're utilizing `/mnt` now and it seems the disk space is already enough. Then we can increase swapfile size.

Also: fix typo