### PR TITLE
fix(LoadUnit): `tlb.req.kill` is only valid when `s1_valid`

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -946,7 +946,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
     s1_out.uop.debugInfo.tlbRespTime := GTimer()
   }
 
-  io.tlb.req_kill   := s1_kill || s1_dly_err
+  io.tlb.req_kill   := s1_valid && (s1_kill || s1_dly_err)
   io.tlb.req.bits.pmp_addr := s1_in.paddr
   io.tlb.resp.ready := true.B
 


### PR DESCRIPTION
Since this code in the LoadUnit uses RegEnable, these registers will remain enabled indefinitely if no new requests enter the LoadUnit to update them. 
Consequently, `tlb.req.kill` signals will continuously be sent to the TLB.
When executing the vec segment instruction, no new instructions enter the LoadUnit. This causes the TLB to persistently kill requests originating from the segment unit.


I have another repair method: completely preempting TLB requests within MemBlock:
https://github.com/OpenXiangShan/XiangShan/blob/4b099d7611868975a4778e9b0201dc57e5bd3bd6/src/main/scala/xiangshan/mem/MemBlock.scala#L927-L936

be modified ->
```
      dtlb_reqs.take(LduCnt)(i).req.bits  := Mux(vSegmentFlag,
        RegEnable(vSegmentUnit.io.dtlb.req.bits, vsegmentDtlbReqValid),
        loadUnits(i).io.tlb.req.bits
      )
```
Perhaps our esteemed senior sister colleague can determine which approach to use.
