### PR TITLE
refactor(Bpu): now tage only output condTakenMask

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -248,9 +248,14 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper with Co
       )
     )
 
-  private val s2_taken              = tage.io.takenMask.reduce(_ || _)
-  private val s2_mbtbResult         = mbtb.io.result
-  private val s2_firstTakenBranchOH = getMinimalValueOH(s2_mbtbResult.positions, tage.io.takenMask)
+  private val s2_mbtbResult    = mbtb.io.result
+  private val s2_condTakenMask = tage.io.condTakenMask
+  private val s2_jumpMask = VecInit(s2_mbtbResult.hitMask.zip(s2_mbtbResult.attributes).map {
+    case (hit, attribute) => hit && (attribute.isDirect || attribute.isIndirect)
+  })
+  private val s2_takenMask          = s2_condTakenMask.zip(s2_jumpMask).map { case (a, b) => a || b }
+  private val s2_taken              = s2_takenMask.reduce(_ || _)
+  private val s2_firstTakenBranchOH = getMinimalValueOH(s2_mbtbResult.positions, s2_takenMask)
 
   private val s3_taken                      = RegEnable(s2_taken, s2_fire)
   private val s3_mbtbResult                 = RegEnable(s2_mbtbResult, s2_fire)

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
@@ -36,7 +36,7 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     val mbtbResult:             MainBtbResult         = Input(new MainBtbResult)
     val foldedPathHist:         PhrAllFoldedHistories = Input(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
     val foldedPathHistForTrain: PhrAllFoldedHistories = Input(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
-    val takenMask:              Vec[Bool]             = Output(Vec(NumBtbResultEntries, Bool()))
+    val condTakenMask:          Vec[Bool]             = Output(Vec(NumBtbResultEntries, Bool()))
     val readBankIdx:            UInt                  = Output(UInt(log2Ceil(NumBanks).W)) // to resolveQueue
   }
   val io: TageIO = IO(new TageIO)
@@ -131,13 +131,17 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
   private val s2_mbtbPositions  = io.mbtbResult.positions
   private val s2_mbtbAttributes = io.mbtbResult.attributes
 
-  private val s2_tableResult = s2_mbtbHitMask.zip(s2_mbtbPositions).zip(s2_mbtbAttributes).map {
-    case ((mbtbHit, position), attribute) => // for each btb entry
+  private val s2_mbtbHitCondMask = s2_mbtbHitMask.zip(s2_mbtbAttributes).map {
+    case (hit, attribute) => hit && attribute.isConditional
+  }
+
+  private val s2_tableResult = s2_mbtbHitCondMask.zip(s2_mbtbPositions).map {
+    case (mbtbHit, position) => // for each btb entry
       val result = s2_allTableEntries.zipWithIndex.map {
         case (entries, tableIdx) => // for each table
           val tag        = s2_tempTag(tableIdx) ^ position // use position to distinguish different branches
           val hitWayMask = entries.map(entry => entry.valid && entry.tag === tag)
-          val hit        = mbtbHit && attribute.isConditional && hitWayMask.reduce(_ || _)
+          val hit        = mbtbHit && hitWayMask.reduce(_ || _)
           val takenCtr   = Mux1H(PriorityEncoderOH(hitWayMask), entries.map(_.takenCtr))
           (hit, takenCtr)
       }
@@ -147,22 +151,15 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
       (hasProvider, pred)
   }
 
-  private val s2_takenMask = s2_mbtbHitMask.zip(s2_mbtbPositions).zip(s2_mbtbAttributes).zip(s2_tableResult).map {
-    case (((hit, position), attribute), result) =>
+  private val s2_condTakenMask = s2_mbtbHitCondMask.zip(s2_mbtbPositions).zip(s2_tableResult).map {
+    case ((hit, position), result) =>
       val hasProvider = result._1
       val pred        = result._2
       val altPred     = s2_baseTableCtrs(position).isPositive
-      MuxCase(
-        false.B,
-        Seq(
-          (hit && attribute.isConditional && hasProvider)       -> pred,
-          (hit && attribute.isConditional && !hasProvider)      -> altPred,
-          (hit && (attribute.isDirect || attribute.isIndirect)) -> true.B
-        )
-      )
+      hit && Mux(hasProvider, pred, altPred)
   }
 
-  io.takenMask := s2_takenMask
+  io.condTakenMask := s2_condTakenMask
 
   /* --------------------------------------------------------------------------------------------------------------
      train pipeline stage 0


### PR DESCRIPTION
TAGE should only be responsible for predicting the direction of conditional branches; therefore, it now only outputs condTakenMask instead of the takenMask for all branches.