### PR TITLE
fix(ICache): bpu s3 flush waylookup & mainPipe s1

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -248,6 +248,10 @@ class WayLookupBundle(implicit p: Parameters) extends ICacheBundle {
   def isForVSnonLeafPTE: Bool          = gpf.isForVSnonLeafPTE
 }
 
+class WayLookupWriteBundle(implicit p: Parameters) extends WayLookupBundle {
+  val ftqIdx: FtqPtr = new FtqPtr
+}
+
 /* ***** Miss ***** */
 // ICacheMainPipe / ICachePrefetchPipe -> MissUnit
 class MissReqBundle(implicit p: Parameters) extends ICacheBundle {

--- a/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
@@ -173,15 +173,17 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   missUnit.io.memGrant.bits  := DontCare
   missUnit.io.memGrant <> bus.d
 
-  mainPipe.io.flush     := io.fromFtq.redirectFlush
-  mainPipe.io.respStall := io.fromIfu.stall
-  mainPipe.io.eccEnable := eccEnable
-  mainPipe.io.hartId    := io.hartId
-  mainPipe.io.missResp  := missUnit.io.resp
+  mainPipe.io.flush        := io.fromFtq.redirectFlush
+  mainPipe.io.flushFromBpu := io.fromFtq.flushFromBpu
+  mainPipe.io.respStall    := io.fromIfu.stall
+  mainPipe.io.eccEnable    := eccEnable
+  mainPipe.io.hartId       := io.hartId
+  mainPipe.io.missResp     := missUnit.io.resp
   mainPipe.io.req <> io.fromFtq.fetchReq
   mainPipe.io.wayLookupRead <> wayLookup.io.read
 
-  wayLookup.io.flush := io.fromFtq.redirectFlush
+  wayLookup.io.flush        := io.fromFtq.redirectFlush
+  wayLookup.io.flushFromBpu := io.fromFtq.flushFromBpu
   wayLookup.io.write <> prefetcher.io.wayLookupWrite
   wayLookup.io.update := missUnit.io.resp
 

--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -21,16 +21,19 @@ import org.chipsalliance.cde.config.Parameters
 import utility.CircularQueuePtr
 import utility.HasCircularQueuePtrHelper
 import utility.XSPerfHistogram
+import xiangshan.frontend.ftq.BpuFlushInfo
+import xiangshan.frontend.ftq.FtqPtr
 
 class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     with ICacheMissUpdateHelper
     with HasCircularQueuePtrHelper {
 
   class ICacheWayLookupIO(implicit p: Parameters) extends ICacheBundle {
-    val flush:  Bool                         = Input(Bool())
-    val read:   DecoupledIO[WayLookupBundle] = DecoupledIO(new WayLookupBundle)
-    val write:  DecoupledIO[WayLookupBundle] = Flipped(DecoupledIO(new WayLookupBundle))
-    val update: Valid[MissRespBundle]        = Flipped(ValidIO(new MissRespBundle))
+    val flush:        Bool                              = Input(Bool())
+    val flushFromBpu: BpuFlushInfo                      = Input(new BpuFlushInfo)
+    val read:         DecoupledIO[WayLookupBundle]      = DecoupledIO(new WayLookupBundle)
+    val write:        DecoupledIO[WayLookupWriteBundle] = Flipped(DecoupledIO(new WayLookupWriteBundle))
+    val update:       Valid[MissRespBundle]             = Flipped(ValidIO(new MissRespBundle))
 
     val perf: WayLookupPerfInfo = Output(new WayLookupPerfInfo)
   }
@@ -51,12 +54,23 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
   private val readPtr  = RegInit(ICacheWayLookupPtr(false.B, 0.U))
   private val writePtr = RegInit(ICacheWayLookupPtr(false.B, 0.U))
 
+  private val tailFtqIdx = RegInit(0.U.asTypeOf(new FtqPtr))
+
   private val empty = readPtr === writePtr
   private val full  = (readPtr.value === writePtr.value) && (readPtr.flag ^ writePtr.flag)
+
+  // NOTE: May be unportable, we have bp3 == pf2 now, and WayLookup is written in pf1,
+  // so the tailing 0 (already bypassed to if1) or 1 (if1 stall, stored here) entries might be flushed by bp3,
+  // therefore, when shouldFlushByStage3, we need to move back writePtr by 0 (empty) or 1.
+  // If in future we have bp4 (or even more) flush, this might not be enough.
+  private val bpuS3FlushValid = !empty && io.flushFromBpu.shouldFlushByStage3(tailFtqIdx)
+  private val bpuS3FlushPtr   = writePtr - 1.U
 
   when(io.flush) {
     writePtr.value := 0.U
     writePtr.flag  := false.B
+  }.elsewhen(bpuS3FlushValid) {
+    writePtr := bpuS3FlushPtr
   }.elsewhen(io.write.fire) {
     writePtr := writePtr + 1.U
   }
@@ -68,11 +82,19 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     readPtr := readPtr + 1.U
   }
 
+  when(io.flush) {
+    tailFtqIdx.value := 0.U
+    tailFtqIdx.flag  := false.B
+  }.elsewhen(io.write.fire) {
+    tailFtqIdx := io.write.bits.ftqIdx
+  }
+
   private val gpfEntry = RegInit(0.U.asTypeOf(Valid(new WayLookupGpfEntry)))
   private val gpfPtr   = RegInit(ICacheWayLookupPtr(false.B, 0.U))
   private val gpfHit   = gpfPtr === readPtr && gpfEntry.valid
 
-  when(io.flush) {
+  when(io.flush || bpuS3FlushValid && gpfPtr === bpuS3FlushPtr) {
+    // When flushed by bp3
     // we don't need to reset gpfPtr, since the valid is actually gpf_entries.excp_tlb_gpf
     gpfEntry.valid := false.B
     gpfEntry.bits  := 0.U.asTypeOf(new WayLookupGpfEntry)


### PR DESCRIPTION
In v3 Ftq, we have `redirect` to Bpu and `redirectNext` to prefetch, therefore bp1=pf0. In this case, when an s1 prediction is overridden by s3, it can reach at most pf2/if1 (i.e. in prefetchPipe `s2` stage reg, wayLookup `entries(writePtr - 1)`, or mainPipe `s1` stage reg). In old design, we only flush pf1, that could be wrong.

Though, we don't have to flush prefetchPipe s2, anyway it's prefetch and has no impact on control flow. (If we don't flush it, it can be seen as some sort of wrong-path prefetch).

So, in this PR we implement wayLookup & mainPipe s1 flush from Bpu s3 override.

NOTE: To reduce implementation cost, wayLookup assumes that we can flush at most 1 entry at tail, this could be wrong if we have Bpu s4/5/even more flush in the future. See comments there.