### PR TITLE
fix(ICache): stall read when updating

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -118,18 +118,7 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     }.reduce(_ || _)
   })
   // if the entry is being updated, we should not read it (i.e. read.valid should be false)
-  // NOTE: this is not necessary in current design:
-  //       when update is valid, DataArray is refilling at the same cycle, so DataArray.read.req.ready will be false.B
-  //       then, MainPipe will get s0_canGo (= toData.last.ready && fromWayLookup.valid && s1_ready) = false.B
-  //       then, WayLookup.read.ready (= s0_fire = s0_valid && s0_canGo && !s0_flush) will be false.B
-  //       so, even if read.valid is true, read.fire will still be false.B, and no read happens.
-//  private val updateStall = entryUpdate(readPtr.value)
-  //       currently, we use a simple assertion to avoid using extra logic
-  assert(
-    !(!empty && io.read.fire && entryUpdate(readPtr.value)),
-    "WayLookup read should not happen when entry is being updated"
-  )
-  private val updateStall = false.B
+  private val updateStall = entryUpdate(readPtr.value)
 
   /* *** read *** */
   // if the entry is empty, but there is a valid write, we can bypass it to read port (maybe timing critical)


### PR DESCRIPTION
Fix kunminghu-v3 CI failure.

In current design, when fence.i/flush/bus corrupt, the original assumption no longer holds.