### PR TITLE
fix(ITLB): if sfence occurs while waiting for ptw response, reset ready to allow new req

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -79,7 +79,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       req_out(i).fullva := EffectiveVa(i)
     }
   }
-  val req_out_v = (0 until Width).map(i => ValidHold(req_in(i).fire && !req_in(i).bits.kill, resp(i).fire, flush_pipe(i)))
+  val req_out_v = (0 until Width).map(i => ValidHold(req_in(i).fire && !req_in(i).bits.kill, resp(i).fire, flush_pipe(i) || flush_mmu))
 
   val isHyperInst = (0 until Width).map(i => req_out_v(i) && req_out(i).hyperinst)
 


### PR DESCRIPTION
In the ITLB, the request port from the IFU is blocking: once a request is issued, it keeps ready low until a response arrives or a flush occurs, preventing new requests from entering. If an sfence or csr_changed event occurs before the ITLB receives a PTW response, the ITLB will never get that response. In this case, the flush signal is supposed to reset the IFU request port by driving ready high again to allow new requests. However, the existing logic failed to use the correct flush signal to reset the port’s ready. As a result, the IFU request port could remain permanently blocked, causing a deadlock in the request path.