### PR TITLE
feat(ifu): adapt interface to IBuffer for two fetch

### DIFF
--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -308,7 +308,7 @@ class FetchToIBuffer(implicit p: Parameters) extends FrontendBundle {
   val prevIBufEnqPtr: IBufPtr               = new IBufPtr
   val prevInstrCount: UInt                  = UInt(log2Ceil(IBufferEnqueueWidth).W)
   val debug_seqNum:   Vec[UInt]             = Vec(IBufferEnqueueWidth, InstSeqNum())
-  val ftqPtr:         FtqPtr                = new FtqPtr
+  val ftqPtr:         Vec[FtqPtr]           = Vec(IBufferEnqueueWidth, new FtqPtr)
   val topdownInfo:    FrontendTopDownBundle = new FrontendTopDownBundle
 }
 

--- a/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
@@ -106,7 +106,7 @@ class IBufEntry(implicit p: Parameters) extends IBufferBundle {
     pd             := fetch.pd(i)
     predTaken      := fetch.instrEndOffset(i).predTaken
     fixedTaken     := fetch.instrEndOffset(i).fixedTaken
-    ftqPtr         := fetch.ftqPtr
+    ftqPtr         := fetch.ftqPtr(i)
     instrEndOffset := fetch.instrEndOffset(i).offset
     exceptionType := IBufferExceptionType.cvtFromFetchExcpAndCrossPageAndRVCII(
       fetch.exceptionType(i),

--- a/src/main/scala/xiangshan/frontend/ifu/FrontendTrigger.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/FrontendTrigger.scala
@@ -28,6 +28,8 @@ import xiangshan.backend.fu.util.SdtrigExt
 import xiangshan.frontend.PreDecodeInfo
 import xiangshan.frontend.PrunedAddr
 
+// IFU trigger pre-marks instructions that may be executed.
+// Actual triggering is determined by the backend (pre-match stage).
 class FrontendTrigger(implicit p: Parameters) extends IfuModule with SdtrigExt {
   class FrontendTriggerIO(implicit p: Parameters) extends IfuBundle {
     val frontendTrigger: FrontendTdataDistributeIO = Input(new FrontendTdataDistributeIO)


### PR DESCRIPTION
- adapt interface to IBuffer for two fetch, the main modified signals are ftqPtr and isLastInFtqEntry.
- fix the concatenation errors of PcLower and instrOffset in the two-Fetch scenario.
- simplify the calculations of instrRange and fetchSize. 