### PR TITLE
fix(ras): fix rasPtr width based on wrong stack size

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -131,8 +131,8 @@ class MinimalConfig(n: Int = 1) extends Config(
               TagWidth = 7
             ),
             rasParameters = RasParameters(
-              StackSize = 8,
-              SpecSize = 16
+              CommitStackSize = 8,
+              SpecQueueSize = 16
             ),
           ),
           ftqParameters = FtqParameters(

--- a/src/main/scala/xiangshan/frontend/bpu/ras/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/Bundles.scala
@@ -39,7 +39,7 @@ object RasEntry {
 }
 
 class RasPtr(implicit p: Parameters) extends CircularQueuePtr[RasPtr](p =>
-      p(XSCoreParamsKey).frontendParameters.bpuParameters.rasParameters.StackSize
+      p(XSCoreParamsKey).frontendParameters.bpuParameters.rasParameters.SpecQueueSize
     ) {}
 
 object RasPtr {
@@ -54,7 +54,7 @@ object RasPtr {
 }
 
 class RasInternalMeta(implicit p: Parameters) extends RasBundle {
-  val ssp:  UInt   = UInt(log2Up(StackSize).W)
+  val ssp:  UInt   = UInt(log2Up(CommitStackSize).W)
   val sctr: UInt   = UInt(StackCounterWidth.W)
   val tosw: RasPtr = new RasPtr
   val tosr: RasPtr = new RasPtr
@@ -74,7 +74,7 @@ object RasInternalMeta {
 }
 
 class RasMeta(implicit p: Parameters) extends RasBundle {
-  val ssp:  UInt   = UInt(log2Up(StackSize).W)
+  val ssp:  UInt   = UInt(log2Up(CommitStackSize).W)
   val tosw: RasPtr = new RasPtr
 }
 
@@ -90,7 +90,7 @@ object RasMeta {
 class RasDebug(implicit p: Parameters) extends RasBundle {
   val specQueue:   Vec[RasEntry] = Output(Vec(SpecQueueSize, new RasEntry))
   val specNos:     Vec[RasPtr]   = Output(Vec(SpecQueueSize, new RasPtr))
-  val commitStack: Vec[RasEntry] = Output(Vec(StackSize, new RasEntry))
+  val commitStack: Vec[RasEntry] = Output(Vec(CommitStackSize, new RasEntry))
   val bos:         RasPtr        = Output(new RasPtr)
 }
 

--- a/src/main/scala/xiangshan/frontend/bpu/ras/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/Parameters.scala
@@ -19,18 +19,18 @@ import chisel3.util._
 import xiangshan.frontend.bpu.HasBpuParameters
 
 case class RasParameters(
-    StackSize:         Int = 16, // Size of the RAS stack
-    SpecSize:          Int = 32, // Size of the RAS speculative queue
+    CommitStackSize:   Int = 16, // Size of the RAS stack
+    SpecQueueSize:     Int = 32, // Size of the RAS speculative queue
     StackCounterWidth: Int = 3   // Width of the RAS counter (log2 of number of same calls merged in single stack entry)
 ) {
-  require(isPow2(SpecSize), "SpecSize must be a power of 2")
+  require(isPow2(SpecQueueSize), "SpecSize must be a power of 2")
 }
 
 trait HasRasParameters extends HasBpuParameters {
   def rasParameters: RasParameters = bpuParameters.rasParameters
 
-  def StackSize:         Int = rasParameters.StackSize
-  def SpecQueueSize:     Int = rasParameters.SpecSize
+  def CommitStackSize:   Int = rasParameters.CommitStackSize
+  def SpecQueueSize:     Int = rasParameters.SpecQueueSize
   def StackCounterWidth: Int = rasParameters.StackCounterWidth
   def StackCounterMax:   Int = (1 << StackCounterWidth) - 1
 

--- a/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
@@ -53,7 +53,7 @@ class Ras(implicit p: Parameters) extends BasePredictor with HasRasParameters wi
 
   def alignMask: UInt = ((~0.U(VAddrBits.W)) << FetchBlockAlignWidth).asUInt
 
-  private val stack = Module(new RasStack(StackSize, SpecQueueSize)).io
+  private val stack = Module(new RasStack).io
   // Here is an assertion that the same piece of valid data lasts for only one cycle.
   // io.specIn.valid = s3_fire
   private val stackNearOverflow = stack.specNearOverflow
@@ -124,7 +124,7 @@ class Ras(implicit p: Parameters) extends BasePredictor with HasRasParameters wi
     XSDebug(specFire, "\n")
   }
   XSDebug(specFire, "  index       addr           ctr   (committed part)\n")
-  for (i <- 0 until StackSize) {
+  for (i <- 0 until CommitStackSize) {
     XSDebug(
       specFire,
       "  (%d)   0x%x      %d",


### PR DESCRIPTION
1.Correct rasPtr bit-width calculation — it should be determined by the speculative stack size, not the commit stack size parameter.
2.Clean up confusing naming between stackSize and specSize in the Ras module.