### PR TITLE
fix(VsegmentUnit): fix latch of paddr when element is unalign

### DIFF
--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -493,11 +493,11 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
         instMicroOp.exceptionVaddr    := io.dtlb.resp.bits.fullva
         instMicroOp.exceptionGpaddr   := io.dtlb.resp.bits.gpaddr(0)
         instMicroOp.exceptionIsForVSnonLeafPTE  := io.dtlb.resp.bits.isForVSnonLeafPTE
-        lowPagePaddr  := Mux(isMisalignReg && !notCross16ByteReg && !curPtr, io.dtlb.resp.bits.paddr(0), lowPagePaddr)
-        lowPageGPaddr := Mux(isMisalignReg && !notCross16ByteReg && !curPtr, io.dtlb.resp.bits.gpaddr(0), lowPageGPaddr)
+        lowPagePaddr  := Mux(!curPtr, io.dtlb.resp.bits.paddr(0), lowPagePaddr)
+        lowPageGPaddr := Mux(!curPtr, io.dtlb.resp.bits.gpaddr(0), lowPageGPaddr)
 
-        highPagePaddr  := Mux(isMisalignReg && !notCross16ByteReg && curPtr, io.dtlb.resp.bits.paddr(0), highPagePaddr)
-        highPageGPaddr := Mux(isMisalignReg && !notCross16ByteReg && curPtr, io.dtlb.resp.bits.gpaddr(0), highPageGPaddr)
+        highPagePaddr  := Mux(curPtr, io.dtlb.resp.bits.paddr(0), highPagePaddr)
+        highPageGPaddr := Mux(curPtr, io.dtlb.resp.bits.gpaddr(0), highPageGPaddr)
       }
   }
   // pmp


### PR DESCRIPTION
Previously, lowPagePaddr/lowPageGPaddr will be set when `state == s_wait_tlb_resp && isMisalignReg && !notCross16ByteReg`, but `isMisalignReg` and `notCross16ByteReg` will be set when `state == s_pm`. Currently, the `s_pm` is the next state of the `s_wait_tlb_resp`. Therefore, when unaligned element is first split, the `Paddr` of first split requestor will not to be latched, which lead to send a zero Acquire. 

This PR relaxed the situtation of latch lowPagePaddr/highPagePaddr will now be latched based on `curPtr` (`curPtr` indicates whether it is the first split element).