### PR TITLE
fix(ICache): do bpuFlush even if wayLookup is empty

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -65,13 +65,13 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
   // so the tailing 0 (already bypassed to if1) or 1 (if1 stall, stored here) entries might be flushed by bp3,
   // therefore, when shouldFlushByStage3, we need to move back writePtr by 0 (empty) or 1.
   // If in future we have bp4 (or even more) flush, this might not be enough.
-  private val bpuS3FlushValid = io.flushFromBpu.shouldFlushByStage3(tailFtqIdx, !empty)
+  private val bpuS3FlushValid = io.flushFromBpu.shouldFlushByStage3(tailFtqIdx, true.B)
   private val bpuS3FlushPtr   = writePtr - 1.U
 
   when(io.flush) {
     writePtr.value := 0.U
     writePtr.flag  := false.B
-  }.elsewhen(bpuS3FlushValid) {
+  }.elsewhen(bpuS3FlushValid && !empty) {
     writePtr := bpuS3FlushPtr
   }.elsewhen(io.write.fire) {
     writePtr := writePtr + 1.U


### PR DESCRIPTION
Fix CI failure at https://github.com/OpenXiangShan/XiangShan/actions/runs/19022725954/job/54320638787

We store exception even if it's bypassed for better timing (and also saving power by stall prefetch), but this will cause core stuck when:
- cycle0: empty & write with exception
- cycle1: bpu s3 override

In this case, `bpuS3FlushValid` will not be set as wayLookup is empty, thus `exceptionEntry.valid` will not be cleared, so wayLookup is stuck waiting for flush.

This PR fixed the problem by setting `bpuS3FlushValid` even if wayLookup is empty, we just do not move r/wPtr if `bpuS3FlushValid && empty`, but we clear `exceptionEntry.valid` regardless of `empty`.