### PR TITLE
feat(pdb): add difftest debugging commands for xspdb

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,5 +37,6 @@ huancun/ @linjuanZ @Ivyfeather
 
 src/main/scala/top/ @Tang-Haojin
 
+scripts/Makefile.pdb @yaozhicheng @forever043 @SFangYy @Tang-Haojin
 scripts/pdb-run.py @yaozhicheng @forever043 @SFangYy @Tang-Haojin 
-scripts/xspdb/ @yaozhicheng @forever043 @SFangYy @Tang-Haojin 
+scripts/xspdb/ @yaozhicheng @SFangYy 

--- a/scripts/xspdb/xscmd/cmd_difftest.py
+++ b/scripts/xspdb/xscmd/cmd_difftest.py
@@ -185,14 +185,14 @@ class CmdDiffTest:
 
     def api_istep_update_commit_pc(self):
         old_p = self.condition_instrunct_istep.get("pc_old_list")
-        new_P = self.condition_instrunct_istep.get("pc_lst_list")
-        if not (old_p and new_P):
+        new_p = self.condition_instrunct_istep.get("pc_lst_list")
+        if not (old_p and new_p):
             self.istep_last_commit_pc = []
         else:
             self.istep_last_commit_pc = []
             for i in range(8):
                 old_pc = int.from_bytes(old_p[i].AsBytes(), byteorder='little', signed=False)
-                new_pc = int.from_bytes(new_P[i].AsBytes(), byteorder='little', signed=False)
+                new_pc = int.from_bytes(new_p[i].AsBytes(), byteorder='little', signed=False)
                 if old_pc != new_pc:
                     self.istep_last_commit_pc.append(new_pc)
 
@@ -326,3 +326,154 @@ class CmdDiffTest:
         """
         return self.df.GetDifftest(instance)
 
+    def complete_xdifftest_turn_on(self, text, line, begidx, endidx):
+        return [x for x in ["on", "off"] if x.startswith(text)] if text else ["on", "off"]
+
+    def do_xdifftest_turn_on_with_ref(self, arg):
+        """Turn on the difftest diff with reference so
+        Args:
+            arg (string): ref so path
+        """
+        if self.difftest_ref_is_inited:
+            error("difftest reference already inited")
+            return
+        if not arg.strip():
+            error("difftest ref so path not found\n usage: xdifftest_turn_on_with_ref <path>")
+            return
+        if not self.api_load_ref_so(arg):
+            error(f"load difftest ref so {arg} failed")
+            return
+        self.api_set_difftest_diff(True)
+
+    def complete_xdifftest_turn_on_with_ref(self, text, line, begidx, endidx):
+        return self.api_complite_localfile(text)
+
+    def do_xexpdiffstate(self, var):
+        """Set a variable to difftest_stat
+
+        Args:
+            var (string): Variable name
+        """
+        self.curframe.f_locals[var] = self.difftest_stat
+
+    def do_xwatch_commit_pc(self, arg):
+        """Watch commit PC
+
+        Args:
+            arg (address): PC address
+        """
+        if arg.strip() == "update":
+            checker = self.condition_watch_commit_pc.get("checker")
+            if checker:
+                checker.Reset()
+            return
+        try:
+            address = int(arg, 0)
+        except Exception as e:
+            error(f"convert {arg} to number fail: {str(e)}")
+            return
+
+        if not self.condition_watch_commit_pc.get("checker"):
+            checker = self.xsp.ComUseCondCheck(self.dut.xclock)
+            cmtpccmp = self.xsp.ComUseRangeCheck(6, 8);
+            self.condition_watch_commit_pc["checker"] = checker
+            self.condition_watch_commit_pc["cmtpcmp"] = cmtpccmp
+
+        checker = self.condition_watch_commit_pc["checker"]
+        if "watch_pc_0x%x_0"%address not in checker.ListCondition():
+            cmtpccmp = self.condition_watch_commit_pc["cmtpcmp"]
+            target_pc = self.xsp.ComUseDataArray(8)
+            target_pc.FromBytes(address.to_bytes(8, byteorder='little', signed=False))
+            pc_lst_list = [self.xsp.ComUseDataArray(self.difftest_stat.get_commit(i).get_pc_address(), 8) for i in range(8)]
+            for i, lpc in enumerate(pc_lst_list):
+                checker.SetCondition("watch_pc_0x%x_%d" % (address, i), lpc.BaseAddr(), target_pc.BaseAddr(), self.xsp.ComUseCondCmp_GE, 8,
+                                     0, 0, 1, cmtpccmp.GetArrayCmp(), cmtpccmp.CSelf())
+            checker.SetMaxCbs(1)
+            self.condition_watch_commit_pc["0x%x"%address] = {"pc_lst_list": pc_lst_list, "target_pc": target_pc}
+        else:
+            error(f"watch_commit_pc 0x{address:x} already exists")
+            return
+        cb_key = "watch_commit_pc"
+        self.dut.xclock.RemoveStepRisCbByDesc(cb_key)
+        self.dut.xclock.StepRis(checker.GetCb(), checker.CSelf(), cb_key)
+        message(f"watch commit pc: 0x{address:x}")
+
+    def do_xunwatch_commit_pc(self, arg):
+        """Unwatch commit PC
+
+        Args:
+            arg (address): PC address
+        """
+        try:
+            address = int(arg, 0)
+        except Exception as e:
+            error(f"convert {arg} to number fail: {str(e)}")
+            return
+        checker = self.condition_watch_commit_pc.get("checker")
+        if not checker:
+            error("watch_commit_pc.checker not found")
+            return
+        if "watch_pc_0x%x_0"%address not in checker.ListCondition():
+            error(f"watch_commit_pc 0x{address:x} not found")
+            return
+        key = "0x%x"%address
+        if key in self.condition_watch_commit_pc:
+            # remove cached entry for this watch target if present
+            self.condition_watch_commit_pc.pop(key, None)
+        for i in range(8):
+            checker.RemoveCondition("watch_pc_0x%x_%d" % (address, i))
+        if len(checker.ListCondition()) < 1:
+            self.dut.xclock.RemoveStepRisCbByDesc("watch_commit_pc")
+            assert "watch_commit_pc" not in self.dut.xclock.ListSteRisCbDesc()
+            self.condition_watch_commit_pc.clear()
+            message("No commit pc to watch, remove checker")
+
+    def do_xdifftest_display(self, arg):
+        """Display the difftest status
+
+        Args:
+            arg (number): difftest instance to display, default is 0
+        """
+        instance = 0
+        if arg.strip():
+            try:
+                instance = int(arg)
+            except Exception as e:
+                error(f"convert {arg} to number fail: {str(e)}\n usage: xdifftest_display [instance]")
+                return
+        if not self.difftest_ref_is_inited:
+            error("difftest reference not inited")
+            return
+        x = self.api_difftest_get_instance(instance)
+        if x:
+            x.display()
+        else:
+            error(f"difftest instance {instance} not found")
+
+    def do_xdifftest_pmem_base_first_instr_address(self, arg):
+        """Display or set PMEM_BASE, FIRST_INST_ADDRESS
+
+        Args:
+            PMEM_BASE (int): PMEM_BASE value default None
+            FIRST_INST_ADDRESS (int): FIRST_INST_ADDRESS value default None
+        """
+        a, b = None, None
+        str_usage = "usage xdifftest_pmem_base_first_instr_address [PMEM_BASE FIRST_INST_ADDRESS]"
+        if arg.strip():
+            args = arg.split()
+            if len(args) != 2:
+                error(str_usage)
+                return
+            try:
+                a, b = int(args[0], 0), int(args[1], 0)
+            except Exception as e:
+                error("Error: %s\n%s"%(e, str_usage))
+                return
+        x, y = self.api_update_pmem_base_and_first_inst_addr(a, b)
+        if (a is not None) and (b is not None):
+            message("PMEM_BASE = %s, FIRST_INST_ADDRESS = %s" % (hex(x), hex(y)))
+        elif (a and a != x) or (b and b != y):
+            error("Set PMEM_BASE(%s != %s), FIRST_INST_ADDRESS(%s != %s) fail!" % (a, x, b, y))
+        else:
+            message("PMEM_BASE = %s, FIRST_INST_ADDRESS = %s" % (hex(x), hex(y)))
+            error(str_usage)


### PR DESCRIPTION
## Description

This PR adds comprehensive difftest capabilities to xspdb, enabling developers to perform co-simulation debugging with reference models.

## Features

### Core APIs 
- `api_load_ref_so()`: Load difftest reference shared object
- `api_init_ref()`: Initialize difftest reference
- `api_set_difftest_diff()`: Turn on/off difftest checking
- `api_difftest_reset()`: Reset difftest state

### Debugging Commands
- `xload_difftest_ref_so <path>`: Load reference .so file
- `xdifftest_turn_on_with_ref <path>`: Turn on difftest with reference
- `xdifftest_reset`: Reset difftest state
- `xdifftest_display [instance]`: Display difftest status
- `xistep [count]`: Step through instructions and stop at commit
- `xistep_break <on|off>`: Control instruction breakpoint
- `xpc`: Display current commit PCs and instructions

### PC Watching 
- `xwatch_commit_pc <address>`: Watch a specific commit PC
- `xunwatch_commit_pc <address>`: Remove PC watch

### Configuration 
- `xdifftest_pmem_base_first_instr_address`: Configure memory base and entry point
- `xexpdiffstate <var>`: Export difftest state to variable


## Usage Examples

```bash
$ make pdb-run
(XiangShan) xload_difftest_ref_so /path/to/riscv64-nemu-interpreter-so
(XiangShan) xdifftest_turn_on_with_ref /path/to/riscv64-nemu-interpreter-so
(XiangShan) xistep 10
(XiangShan) xwatch_commit_pc 0x80000000
(XiangShan) xpc