### PR TITLE
fix(ittage): select lowest-index branch when multiple-train to avoid assertion

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
@@ -148,15 +148,11 @@ class Ittage(implicit p: Parameters) extends BasePredictor with HasIttageParamet
   )
 
   // Select the branch needed for training
-  val trainBranchIdxOH: Vec[Bool] = VecInit(t1_train.branches.map(b =>
+  val trainBranchIdxVec: Vec[Bool] = VecInit(t1_train.branches.map(b =>
     b.valid && b.bits.attribute.isOtherIndirect && b.bits.taken
   ))
-  assert(
-    PopCount(trainBranchIdxOH) <= 1.U,
-    "At most one branch in branches should be valid and isOtherIndirect for ITTAGE update"
-  )
-  val trainBranchIdx: UInt = OHToUInt(trainBranchIdxOH)
-  val hasTrainBranch: Bool = trainBranchIdxOH.asUInt.orR
+  val trainBranchIdx: UInt = PriorityEncoder(trainBranchIdxVec)
+  val hasTrainBranch: Bool = trainBranchIdxVec.asUInt.orR
 
   // Update condition for ittage
   private val updateValid = hasTrainBranch && RegNext(io.train.valid, init = false.B)


### PR DESCRIPTION
- Due to backend behavior, branches from redirected blocks may still be resolved, so trainBranchIdxOH can become multi-hot instead of one-hot.
- Remove assertion for this and select the lowest-index one.