### PR TITLE
ci(nightly): use make init to checkout submodules

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,9 +13,7 @@ jobs:
     # Build + 8 checkpoints * 1-hour timeout
     name: Nightly Regression(master) - Checkpoints
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
+      - uses: actions/checkout@v4
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -26,6 +24,8 @@ jobs:
           echo "GCPT_RESTORE_BIN=/nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin" >> $GITHUB_ENV
           mkdir -p /nfs/home/ci-runner/xs-perf/${HEAD_SHA}
           mkdir -p /nfs/home/ci-runner/xs-wave/${HEAD_SHA}
+      - name: init submodules
+        run: make init
       - name: clean up
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
@@ -109,10 +109,9 @@ jobs:
       # Build + 8 checkpoints * 1-hour timeout
       name: Nightly Regression(kunminghu-v3) - Checkpoints
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
           with:
             ref: kunminghu-v3
-            submodules: 'recursive'
         - name: set env
           run: |
             export HEAD_SHA=${{ github.run_number }}
@@ -123,6 +122,8 @@ jobs:
             echo "GCPT_RESTORE_BIN=/nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin" >> $GITHUB_ENV
             mkdir -p /nfs/home/ci-runner/xs-perf/${HEAD_SHA}
             mkdir -p /nfs/home/ci-runner/xs-wave/${HEAD_SHA}
+        - name: init submodules
+          run: make init
         - name: clean up
           run: |
             python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean


### PR DESCRIPTION
Previously, nightly ci use actions/checkout to checkout out submodules recursively, which is a massive and meaningless consumption. This patch turns to use make init as other ci workflows to initialize only necessary submodules.

This patch also update actions/checkout to v4.