### PR TITLE
chore(make): delete out folder when `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,7 @@ sim-verilog: $(call docker-deps,$(SIM_TOP_V))
 clean:
 	$(MAKE) -C ./difftest clean
 	rm -rf $(BUILD_DIR)
+	rm -rf out
 
 init:
 	git submodule update --init


### PR DESCRIPTION
Picked from #5202.

Switching to V3 in a repository previously built for V2 will cause build failures due to the contents of the out folder, and vice versa.