### PR TITLE
timing(StoreUnit): adjust misaligned replay logic

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -496,8 +496,8 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s2_mis_align = s2_valid && RegEnable(s1_mis_align, s1_fire) && !s2_exception
   // goto misalignBuffer
   io.misalign_enq.revoke := s2_exception
-  val s2_misalignBufferNack = !io.misalign_enq.revoke &&
-    RegEnable(s1_toMisalignBufferValid && (!io.misalign_enq.req.ready || s1_misalignNeedReplay), false.B, s1_fire)
+  val s2_misalignNeedReplay = RegEnable(s1_toMisalignBufferValid && (!io.misalign_enq.req.ready || s1_misalignNeedReplay), false.B, s1_fire)
+  val s2_misalignBufferNack = !io.misalign_enq.revoke && s2_misalignNeedReplay
 
   // feedback tlb miss to RS in store_s2
   val feedback_slow_valid = WireInit(false.B)
@@ -505,7 +505,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   feedback_slow_valid := s1_feedback.valid && !s1_out.uop.robIdx.needFlush(io.redirect) && !s1_out.isvec && !s1_frm_mabuf
   io.feedback_slow.valid := GatedValidRegNext(feedback_slow_valid)
   io.feedback_slow.bits  := RegEnable(s1_feedback.bits, feedback_slow_valid)
-  io.feedback_slow.bits.hit  := RegEnable(s1_feedback.bits.hit, feedback_slow_valid) && !s2_misalignBufferNack
+  io.feedback_slow.bits.hit  := RegEnable(s1_feedback.bits.hit, feedback_slow_valid) && !s2_misalignNeedReplay
 
   val s2_vecFeedback = RegNext(!s1_out.uop.robIdx.needFlush(io.redirect) && s1_feedback.bits.hit && s1_feedback.valid) &&
                        !s2_misalignBufferNack && s2_in.isvec && !s2_frm_mabuf


### PR DESCRIPTION
If the `storeMisalignBuffer(SMB)` is full, the backend must be notified to resend. Previously, if the `SMB` was full but triggered an exception, it would revoke the enq storeMisalignBuffer and notify the backend that resending was unnecessary.

This resulted in the following timing path:
**pmp => exception => revoke => feedback_slow.bits.hit => issueQueueSta**

We will modify this to:
When notifying the backend to resend, we will not check whether `revoke` is required. Even if it is sent to the pipeline again, it will theoretically be flushed due to the exception redirect.