### PR TITLE
refactor(Frontend): remove itlb/pmp port from ifu

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -201,8 +201,8 @@ case class XSCoreParameters
     useDmode = false,
     NWays = 48,
   ),
-  itlbPortNum: Int = 1 + 1, // ICache + Ifu
-  ipmpPortNum: Int = 2 + 1, // ICache(PrefetchPipe + MainPipe) + Ifu
+  itlbPortNum: Int = 1, // ICache does not support cross-page fetch in V3, we need only 1 port
+  ipmpPortNum: Int = 2, // ICache(PrefetchPipe + MainPipe)
   ldtlbParameters: TLBParameters = TLBParameters(
     name = "ldtlb",
     NWays = 48,

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -90,24 +90,12 @@ class Ifu(implicit p: Parameters) extends IfuModule
     // debug extension: frontend trigger
     val frontendTrigger: FrontendTdataDistributeIO = Flipped(new FrontendTdataDistributeIO)
 
-    // itlb: req / resp
-    val itlb: TlbRequestIO = new TlbRequestIO
-
-    // pmp: req / resp
-    val pmp: PmpCheckBundle = new PmpCheckBundle
-
     // Backend: csr control
     val csrFsIsOff: Bool = Input(Bool())
   }
   val io: IfuIO = IO(new IfuIO)
-  io.itlb.req.valid  := false.B
-  io.itlb.req.bits   := DontCare
-  io.itlb.req_kill   := false.B
-  io.itlb.resp.ready := true.B
-  io.pmp.req.valid   := false.B
-  io.pmp.req.bits    := DontCare
-  // submodule
 
+  // submodule
   private val preDecoder         = Module(new PreDecode)
   private val instrBoundary      = Module(new InstrBoundary)
   private val predChecker        = Module(new PredChecker)


### PR DESCRIPTION
Now that we disallow cross-page fetch in ICache/Ifu (#4909), we can remove these extra ports