### PR TITLE
ci: avoid shallow clone when checkout

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -34,6 +34,9 @@ jobs:
     name: Generate Verilog
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -112,6 +115,9 @@ jobs:
     name: EMU - Basics
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -203,6 +209,9 @@ jobs:
     name: EMU - CHI
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -249,6 +258,9 @@ jobs:
     name: EMU - Performance
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -356,6 +368,9 @@ jobs:
     name: EMU - SimFrontend
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -418,6 +433,9 @@ jobs:
     name: EMU - MC
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -455,6 +473,9 @@ jobs:
     name: SIMV - Basics
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,9 @@ jobs:
     name: Nightly Regression(master) - Checkpoints
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -112,6 +115,8 @@ jobs:
         - uses: actions/checkout@v4
           with:
             ref: kunminghu-v3
+            fetch-depth: 0
+            submodules: true
         - name: set env
           run: |
             export HEAD_SHA=${{ github.run_number }}

--- a/.github/workflows/perf-template.yml
+++ b/.github/workflows/perf-template.yml
@@ -59,6 +59,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.set_test.outputs.commit_sha }}
+          fetch-depth: 0
+          submodules: true
 
       - name: Set env
         run: |


### PR DESCRIPTION
We found that the shallow clone make something broken on self-hosted runner. Self-hosted runner won't clean up the work directory and will reuse the repo folder.