### PR TITLE
refactor(mbtb,Tage): add VecRotate util

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -25,5 +25,6 @@ docstrings.style = keep
 
 project.includePaths = [
   "glob:**/src/main/scala/xiangshan/frontend/**.scala",
-  "glob:**/src/main/scala/utils/EnumUInt.scala"
+  "glob:**/src/main/scala/utils/EnumUInt.scala",
+  "glob:**/src/main/scala/utils/VecRotate.scala"
 ]

--- a/src/main/scala/utils/VecRotate.scala
+++ b/src/main/scala/utils/VecRotate.scala
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package utils
+
+import chisel3._
+import chisel3.util._
+import math.pow
+
+/** Utility class for Vec[T] rotation
+ * @example {{{
+ *   // rotate right by 3
+ *   val s0_rotateNum = 3.U(3.W)
+ *   val s0_rotator = VecRotate(rotateNum, storeOneHot = true)
+ *   val s0_vec = VecInit.tabulate(8)(i => i.U(8.W))      // 0,1,2,3,4,5,6,7
+ *   val s0_rotatedVec = rotator.rotate(vec)              // 5,6,7,0,1,2,3,4
+ *   // we can do some operations to rotatedVec, for example, vec addition
+ *   adder.io.in1 := s0_rotatedVec
+ *   adder.io.in2 := s0_rotatedVec
+ *   // the processing may take some cycles, lets say 1 cycle here
+ *   val s1_processedVec := adder.io.out                  // 10,12,14,0,2,4,6,8
+ *   // register the rotator to align the pipeline stage
+ *   // if we're using storeOneHot = true, here uses 8 bits of register. If not, only 3 bits are needed
+ *   val s1_rotator = RegNext(s0_rotator)
+ *   // if we're using storeOneHot = true, in this `revert` call, no decoder(i.e. UIntToOH) is needed
+ *   val s1_finalVec = s1_rotator.revert(s1_processedVec) // 0,2,4,6,8,10,12,14
+ * }}}
+ */
+class VecRotate(
+    vecLength:   Int,
+    storeOneHot: Boolean, // this is only useful when we do Reg(VecRotate)
+    direction:   Boolean
+) extends Bundle {
+  val n: UInt = UInt((if (storeOneHot) vecLength else log2Ceil(vecLength)).W)
+
+  private def getRotatedIdx(idx: Int, num: Int, direction: Boolean): Int =
+    if (direction == VecRotate.Direction.Right)
+      (idx + vecLength - num) % vecLength
+    else
+      (idx + num) % vecLength
+
+  private def doRotate[T <: Data](vec: Vec[T], direction: Boolean): Vec[T] = {
+    require(vec.length == vecLength, s"Input Vec length ${vec.length} does not match the required length $vecLength")
+    // generate one-hot encoding of n if needed
+    val idxOH = if (storeOneHot) n else UIntToOH(n)
+    // generate all possible rotations
+    val rotations = VecInit((0 until vecLength).map { rotateNum =>
+      VecInit((0 until vecLength).map(i => vec(getRotatedIdx(i, rotateNum, direction))))
+    })
+    // select the correct rotation
+    Mux1H(idxOH, rotations)
+  }
+
+  def rotate[T <: Data](vec: Vec[T]): Vec[T] =
+    doRotate(vec, direction)
+
+  def revert[T <: Data](vec: Vec[T]): Vec[T] =
+    doRotate(vec, !direction)
+}
+
+object VecRotate {
+  /* Direction constants
+   * (0,1,2,3) rotated left by 1 -> (1,2,3,0)
+   * (0,1,2,3) rotated right by 1 -> (3,0,1,2)
+   * NOTE: If you do a Vec[Bool].asUInt.rotateLeft, it's actually doing a VecRotate(vec, Right).asUInt.
+   *       This is because the MSB is on the left side in Chisel's UInt representation,
+   *       but we usually think of the LSB on the left side in vector representation
+   */
+  object Direction {
+    def Right: Boolean = false
+    def Left:  Boolean = true
+  }
+
+  def apply(
+      rotateNum:   UInt,
+      storeOneHot: Boolean = false,
+      direction:   Boolean = Direction.Right
+  ): VecRotate = {
+    val rotator = Wire(new VecRotate(pow(2, rotateNum.getWidth).toInt, storeOneHot, direction))
+    rotator.n := (if (storeOneHot) UIntToOH(rotateNum) else rotateNum)
+    rotator
+  }
+}

--- a/src/main/scala/xiangshan/frontend/bpu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Helpers.scala
@@ -161,25 +161,6 @@ trait TargetFixHelper extends HasBpuParameters {
   }
 }
 
-trait RotateHelper {
-
-  /**
-   * Circular shift a Vec to the right by idx.
-   * For example, vecRotateRight(Vec(a, b, c, d), 1.U) = Vec(d, a, b, c).
-   */
-  def vecRotateRight[T <: Data](vec: Vec[T], idx: UInt): Vec[T] = {
-    require(isPow2(vec.length))
-    require(idx.getWidth == log2Ceil(vec.length))
-    val len = vec.length
-    // generate all possible results of rotation
-    val rotations = (0 until len).map { i =>
-      val rotatedIndices = (0 until len).map(j => (j + i) % len)
-      i.U -> VecInit(rotatedIndices.map(idx => vec(idx)))
-    }
-    MuxLookup(idx, vec)(rotations)
-  }
-}
-
 trait PhrHelper {
   def computeFoldedHist(hist: UInt, compLen: Int)(histLen: Int): UInt =
     if (histLen > 0) {

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/Helpers.scala
@@ -21,11 +21,10 @@ import xiangshan.HasXSParameter
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.bpu.CrossPageHelper
 import xiangshan.frontend.bpu.HalfAlignHelper
-import xiangshan.frontend.bpu.RotateHelper
 import xiangshan.frontend.bpu.TargetFixHelper
 
 trait Helpers extends HasMainBtbParameters
-    with HasXSParameter with TargetFixHelper with RotateHelper with HalfAlignHelper with CrossPageHelper {
+    with HasXSParameter with TargetFixHelper with HalfAlignHelper with CrossPageHelper {
   def getSetIndex(pc: PrunedAddr): UInt =
     pc(SetIdxLen + InternalBankIdxLen + FetchBlockSizeWidth - 1, InternalBankIdxLen + FetchBlockSizeWidth)
 

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
@@ -31,7 +31,7 @@ class MainBtbAlignBank(
     class Read extends Bundle {
       class Req extends Bundle {
         // NOTE: this startVAddr is not from Bpu top, it's calculated in MainBtb top
-        // i.e. vecRotateRight(VecInit.tabulate(NumAlignBanks)(startVAddr + _ * alignSize), startAlignIdx)(alignIdx)
+        // i.e. (VecInit.tabulate(NumAlignBanks)(startVAddr + _ * alignSize))(alignIdx) rotated right by startAlignIdx
         val startVAddr:    PrunedAddr = new PrunedAddr(VAddrBits)
         val posHigherBits: UInt       = UInt(AlignBankIdxLen.W)
         val crossPage:     Bool       = Bool()

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Helpers.scala
@@ -20,10 +20,9 @@ import chisel3.util._
 import xiangshan.HasXSParameter
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.bpu.HalfAlignHelper
-import xiangshan.frontend.bpu.RotateHelper
 import xiangshan.frontend.bpu.history.phr.PhrAllFoldedHistories
 
-trait Helpers extends HasTageParameters with HasXSParameter with RotateHelper with HalfAlignHelper {
+trait Helpers extends HasTageParameters with HasXSParameter with HalfAlignHelper {
   def getBaseTableSetIndex(pc: PrunedAddr): UInt =
     pc(BaseTableSetIdxWidth - 1 + BankIdxWidth + FetchBlockSizeWidth, BankIdxWidth + FetchBlockSizeWidth)
 


### PR DESCRIPTION
... for later re-use in ICache

also:
- fix rotate direction, the original `(j + i) % len` is actually rotating left, `(j + len - i) % len` is right
- fix tage base table `io.takenCtrs`, it needs the opposite direction of `startVAddr` to recover original order

Though, the above fixes should not have changes in final verilog now, as rotating to left or right behaves the same with `len = 2`

and:
- add comments in mbtb & Tage for explanation of rotation
- remove unused imports