### PR TITLE
fix(Unalign, Store): fix corner case of unalign store

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1253,9 +1253,9 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     // dtlb
     stu.io.tlb          <> dtlb_st.head.requestor(i)
     stu.io.pmp          <> pmp_check(LduCnt + HyuCnt + 1 + i).resp
-    stu.io.sqDeqPtr     <> lsq.io.sqDeqPtr
-    stu.io.sqDeqUopIdx  <> lsq.io.sqDeqUopIdx
-    stu.io.sqDeqRobIdx  <> lsq.io.sqDeqRobIdx
+    stu.io.sqCommitPtr     <> lsq.io.sqCommitPtr
+    stu.io.sqCommitUopIdx  <> lsq.io.sqCommitUopIdx
+    stu.io.sqCommitRobIdx  <> lsq.io.sqCommitRobIdx
 
     // -------------------------
     // Store Triggers

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -115,8 +115,9 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
     val sqCanAccept = Output(Bool())
     val lqDeqPtr = Output(new LqPtr)
     val sqDeqPtr = Output(new SqPtr)
-    val sqDeqUopIdx = Output(UopIdx())
-    val sqDeqRobIdx = Output(new RobPtr)
+    val sqCommitPtr = Output(new SqPtr)
+    val sqCommitUopIdx = Output(UopIdx())
+    val sqCommitRobIdx = Output(new RobPtr)
     val exceptionAddr = new ExceptionAddrIO
     val loadMisalignFull = Input(Bool())
     val misalignAllowSpec = Input(Bool())
@@ -160,8 +161,9 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   storeQueue.io.enq.lqCanAccept := loadQueue.io.enq.canAccept
   io.lqDeqPtr := loadQueue.io.lqDeqPtr
   io.sqDeqPtr := storeQueue.io.sqDeqPtr
-  io.sqDeqRobIdx := storeQueue.io.sqDeqRobIdx
-  io.sqDeqUopIdx := storeQueue.io.sqDeqUopIdx
+  io.sqCommitRobIdx := storeQueue.io.sqCommitRobIdx
+  io.sqCommitUopIdx := storeQueue.io.sqCommitUopIdx
+  io.sqCommitPtr    := storeQueue.io.sqCommitPtr
   io.rarValidCount := loadQueue.io.rarValidCount
   for (i <- io.enq.req.indices) {
     loadQueue.io.enq.needAlloc(i)      := io.enq.needAlloc(i)(0)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -194,8 +194,9 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     val stDataReadyVec = Output(Vec(StoreQueueSize, Bool()))
     val stIssuePtr = Output(new SqPtr)
     val sqDeqPtr = Output(new SqPtr)
-    val sqDeqUopIdx = Output(UopIdx())
-    val sqDeqRobIdx = Output(new RobPtr)
+    val sqCommitPtr = Output(new SqPtr)
+    val sqCommitUopIdx = Output(UopIdx())
+    val sqCommitRobIdx = Output(new RobPtr)
     val sqFull = Output(Bool())
     val sqCancelCnt = Output(UInt(log2Up(StoreQueueSize + 1).W))
     val sqDeq = Output(UInt(log2Ceil(EnsbufferWidth + 1).W))
@@ -500,8 +501,6 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   io.stDataReadySqPtr := dataReadyPtrExt
   io.stIssuePtr := enqPtrExt(0)
   io.sqDeqPtr := deqPtrExt(0)
-  io.sqDeqUopIdx := uop(deqPtrExt(0).value).uopIdx
-  io.sqDeqRobIdx := uop(deqPtrExt(0).value).robIdx
 
   /**
     * Writeback store from store units
@@ -1160,6 +1159,9 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
   commitCount := PopCount(commitVec)
   cmtPtrExt := cmtPtrExt.map(_ + commitCount)
+  io.sqCommitPtr := cmtPtrExt(0)
+  io.sqCommitUopIdx := uop(cmtPtrExt(0).value).uopIdx
+  io.sqCommitRobIdx := uop(cmtPtrExt(0).value).robIdx
 
   /**
    * committed stores will not be cancelled and can be sent to lower level.

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -71,9 +71,9 @@ class StoreUnit(implicit p: Parameters) extends XSModule
     val misalign_enq = new MisalignBufferEnqIO
     // trigger
     val fromCsrTrigger = Input(new CsrTriggerBundle)
-    val sqDeqPtr       = Input(new SqPtr)
-    val sqDeqUopIdx    = Input(UopIdx())
-    val sqDeqRobIdx    = Input(new RobPtr())
+    val sqCommitPtr    = Input(new SqPtr)
+    val sqCommitUopIdx = Input(UopIdx())
+    val sqCommitRobIdx = Input(new RobPtr)
 
     val s0_s1_s2_valid = Output(Bool())
   })
@@ -180,7 +180,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   )) + s0_addr_low
   val s0_rs_corss16Bytes = s0_addr_Up_low(4) =/= s0_addr_low(4)
   val s0_misalignWith16Byte = !s0_rs_corss16Bytes && !s0_addr_aligned && !s0_use_flow_prf
-  val s0_misalignNeedReplay = (s0_use_flow_vec || s0_rs_corss16Bytes) && !(s0_uop.sqIdx === io.sqDeqPtr || s0_uop.robIdx === io.sqDeqRobIdx && s0_uop.uopIdx === io.sqDeqUopIdx)
+  val s0_misalignNeedReplay = (s0_use_flow_vec || s0_rs_corss16Bytes) && !(s0_uop.sqIdx === io.sqCommitPtr || s0_uop.robIdx === io.sqCommitRobIdx && s0_uop.uopIdx === io.sqCommitUopIdx)
   s0_is128bit := Mux(s0_use_flow_ma, io.misalign_stin.bits.is128bit, is128Bit(s0_vecstin.alignedType) || s0_misalignWith16Byte)
 
   s0_fullva := Mux(


### PR DESCRIPTION
[time 0]:    ROB commit a store robIdx = 0x88, flag = 0 (**Store0**); StoreQueue did not write it to sbuffer yet.

             long long ago, The store which was committed at [time 0] not write to Sbuffer.

[time N]:    Dispatch a unalign store, robIdx = 0x7c, flag = 0 (**Store1**)

[time N+x1]: Dispatch a unalign store, robIdx = 0x88, flag = 0 (**Store2**)

[time N+x2]: The store which was committed at [time 0] not write to Sbuffer, deqPtr points to this request (Store0). The store of [time N+x1] (Store2) was issued, then, it enter the StoreMisalignBuffer.

[NOTE]:      Store2 is not oldest store of unalign, but the robIdx which was pointed by deqPtr is same as Store2 at [time N+x2], therefore, Store2 was mistakenly regarded as the oldest, Store2 should not enter the StoreMisalignBuffer.

[time N+x3]: Store1 issued, occupy the StoreMisalignBuffer, but do not write the Store2, which lead to hang.

This Patch use CmtPtr to indicate the oldest store of not committed yet.