### PR TITLE
feat(log): add AddrField util to print address fields

### DIFF
--- a/src/main/scala/utils/AddrField.scala
+++ b/src/main/scala/utils/AddrField.scala
@@ -1,0 +1,138 @@
+// Copyright (c) 2024-2025 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2020-2021 Peng Cheng Laboratory
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package utils
+
+/** Utility to print fields(i.e. tag, setIdx, offset) extracted from an address
+ *
+ * @example {{{
+ *   val test = AddrField(
+ *     Seq(
+ *       ("offset", 12), // we use offset starts from bit 0, width 12
+ *       ("setIdx", 4),  // and setIdx starts from bit 12, width 4
+ *       ("tag"   , 16), // and tag starts from bit 16, width 16
+ *     ),
+ *     maxWidth = Option(64), // we have 64 bits in total
+ *     extraFields = Seq(
+ *       ("anotherSetIdx", 6, 20), // we have another index starts from bit 6, width 20
+ *     )
+ *   )
+ *
+ *   test.show()
+ *   // 64| 63..32 | 31..16 | 15..12 | 11...0 |
+ *   //   | unused |    tag | setIdx | offset |
+ *   //                | 25..............6 |
+ *   //                |     anotherSetIdx |
+ *
+ *   test.showList()
+ *   // offset: [11:0]
+ *   // setIdx: [15:12]
+ *   //    tag: [31:16]
+ *   // anotherSetIdx: [25:6]
+ * }}}
+ */
+class AddrField(
+    fields:      Seq[(String, Int)],           // name, width
+    maxWidth:    Option[Int] = None,
+    extraFields: Seq[(String, Int, Int)] = Nil // name, start, width
+) {
+  private class Field(
+      val name:  String,
+      val start: Int,
+      val width: Int
+  ) {
+    val end: Int = start + width - 1
+
+    private val startString = start.toString
+    private val endString   = end.toString
+
+    def fieldLength:   Int = name.length max (startString.length + endString.length + 2)
+    def maxNameLength: Int = fields.map(_._1.length).max
+
+    def formatName(fieldLength: Int = fieldLength): String =
+      String.format(s" %${fieldLength max 1}s ", name)
+
+    def formatStart(fieldLength: Int = fieldLength): String =
+      if (end == start)
+        f" ${"." * ((fieldLength - startString.length) max 1)}$startString "
+      else
+        f" $endString${"." * ((fieldLength - startString.length - endString.length) max 1)}$startString "
+
+    override def toString: String =
+      String.format(s"%${maxNameLength}s: [%d:%d]", name, end, start)
+  }
+
+  private var currentStart = 0
+  private val fieldInstances = fields.map { case (name, width) =>
+    val field = new Field(name, currentStart, width)
+    currentStart += width
+    field
+  }
+
+  private val end = maxWidth.getOrElse(currentStart)
+
+  private val unusedFieldInstance =
+    Option.when(end != currentStart)(new Field("unused", currentStart, end - currentStart))
+
+  private val extraFieldInstances = extraFields.map { case (name, start, width) =>
+    new Field(name, start, width)
+  }
+
+  def format(indent: Int = 0): Seq[String] = {
+    val allInstances = (unusedFieldInstance ++ fieldInstances.reverse).toSeq
+    Seq(
+      "%s%d|%s|".format(
+        " " * indent,
+        end,
+        allInstances.map(_.formatStart()).mkString("|")
+      ),
+      "%s|%s|".format(
+        " " * (indent + end.toString.length),
+        allInstances.map(_.formatName()).mkString("|")
+      )
+    ) ++ extraFieldInstances.map { field =>
+      def getOffset(p: Int, f: Field): Int = ((p - f.start).toFloat / (f.width - 1) * f.fieldLength).toInt
+
+      val startIdx = allInstances.indexWhere(f => f.end >= field.start && f.start <= field.start)
+      val startOffset = getOffset(field.start, allInstances(startIdx))
+
+      val endIdx = allInstances.indexWhere(f => f.end >= field.end && f.start <= field.end)
+      val endOffset = getOffset(field.end, allInstances(endIdx))
+
+      val leftPosition = allInstances.take(endIdx + 1).foldLeft(indent)(_ + _.fieldLength + 3) - endOffset - 1
+      val rightPosition = allInstances.take(startIdx + 1).foldLeft(indent)(_ + _.fieldLength + 3) - startOffset - 1
+
+      val leftPadding = leftPosition
+      val innerLength = rightPosition - leftPosition
+
+      f"${" " * leftPadding}|${field.formatStart(innerLength)}|\n${" " * leftPadding}|${field.formatName(innerLength)}|"
+    }
+  }
+
+  def show(indent: Int = 0): Unit =
+    println(format(indent).mkString("\n"))
+
+  def showList(): Unit =
+    (fieldInstances ++ extraFieldInstances).foreach(println)
+}
+
+object AddrField {
+  def apply(
+      fields:      Seq[(String, Int)],
+      maxWidth:    Option[Int] = None,
+      extraFields: Seq[(String, Int, Int)] = Nil
+  ): AddrField =
+    new AddrField(fields, maxWidth, extraFields)
+}

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -20,6 +20,7 @@ import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.XSPerfAccumulate
 import utility.XSPerfHistogram
+import utils.AddrField
 import utils.VecRotate
 import xiangshan.frontend.bpu.BasePredictor
 import xiangshan.frontend.bpu.BasePredictorIO
@@ -33,6 +34,26 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   }
 
   val io: MainBtbIO = IO(new MainBtbIO)
+
+  // print params
+  println(f"MainBtb:")
+  println(f"  Size(set, way, align, internal): $NumSets * $NumWay * $NumAlignBanks * $NumInternalBanks = $NumEntries")
+  println(f"  Address fields:")
+  AddrField(
+    Seq(
+      ("alignOffset", FetchBlockAlignWidth),
+      ("alignBankIdx", AlignBankIdxLen),
+      ("internalBankIdx", InternalBankIdxLen),
+      ("setIdx", SetIdxLen),
+      ("tag", TagWidth)
+    ),
+    maxWidth = Option(VAddrBits),
+    extraFields = Seq(
+      ("replacerSetIdx", FetchBlockAlignWidth, SetIdxLen),
+      ("targetLower", instOffsetBits, TargetWidth),
+      ("position", instOffsetBits, FetchBlockAlignWidth)
+    )
+  ).show(indent = 4)
 
   /* *** submodules *** */
   private val alignBanks = Seq.tabulate(NumAlignBanks)(alignIdx => Module(new MainBtbAlignBank(alignIdx)))

--- a/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
@@ -29,6 +29,7 @@ import freechips.rocketchip.diplomacy.LazyModuleImp
 import org.chipsalliance.cde.config.Parameters
 import utility.HasPerfEvents
 import utility.XSPerfAccumulate
+import utils.AddrField
 import xiangshan.L1CacheErrorInfo
 import xiangshan.SoftIfetchPrefetchBundle
 import xiangshan.WfiReqBundle
@@ -79,6 +80,21 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   println(s"  CtrlUnit:")
   println(s"    Enabled: $EnableCtrlUnit")
   println(s"    Address: ${icacheParameters.ctrlUnitParameters.Address}")
+  println(s"  Address fields:")
+  AddrField(
+    Seq(
+      ("bankOffset", rowOffBits),
+      ("bankIdx", log2Ceil(DataBanks)),
+      ("(virtual) setIdx", idxBits),
+      ("(virtual) tag (unused)", vtagBits)
+    ),
+    maxWidth = Option(VAddrBits),
+    extraFields = Seq(
+      ("(physical) tag", pgUntagBits, tagBits),
+      ("blockOffset", 0, blockOffBits),
+      ("blockPAddr", blockOffBits, PAddrBits - blockOffBits)
+    ) ++ AliasTagBits.map(w => ("aliasTag", pgIdxBits, w))
+  ).show(indent = 4)
 
   val (bus, edge) = outer.clientNode.out.head
 


### PR DESCRIPTION
... to help debugging

also add use of this util in MainBtb / ICache

Showcase:

```
[750] MainBtb:
[750]   Size(set, way, align, internal): 256 * 4 * 2 * 4 = 8192
[750]   Address fields:
[750]     50| 49..31 | 30..15 | 14...7 | 6.............5 | ...........4 | 3.........0 |
[750]       | unused |    tag | setIdx | internalBankIdx | alignBankIdx | alignOffset |
[750]                            | 11.................................4 |
[750]                            |                       replacerSetIdx |
[750]                    | 20....................................................1 |
[750]                    |                                             targetLower |
[750]                                                                | 4.........1 |
[750]                                                                |    position |
```