### PR TITLE
ci: always generate summary even if jobs failed

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -184,6 +184,7 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 16 --numa --ci zcb-test 2> /dev/zero
       - name: Generate summary
+        if: always()
         run: |
           echo "## Emu - Basics summary" >> $GITHUB_STEP_SUMMARY
           echo "| Testcase | IPC |" >> $GITHUB_STEP_SUMMARY
@@ -332,6 +333,7 @@ jobs:
           cat perf.log | sort | tee $PERF_HOME/astar.log
           echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
       - name: Generate summary
+        if: always()
         run: |
           echo "## Emu - Performance summary" >> $GITHUB_STEP_SUMMARY
           echo "| Testcase | IPC |" >> $GITHUB_STEP_SUMMARY
@@ -400,6 +402,7 @@ jobs:
           echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
 
       - name: Generate summary
+        if: always()
         run: |
           echo "## Emu - SimFrontend summary" >> $GITHUB_STEP_SUMMARY
           echo "| Testcase | IPC |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/perf-template.yml
+++ b/.github/workflows/perf-template.yml
@@ -105,6 +105,7 @@ jobs:
           find $NOOP_HOME/build/ -maxdepth 1 -name "*.fst" -exec mv {} $SPEC_DIR \;
 
       - name: Report SPEC CPU2006 score
+        if: always()
         run: |
           cd $PERF_HOME
           python3 xs_autorun_multiServer.py $CKPT_HOME $CKPT_JSON_PATH \
@@ -118,6 +119,7 @@ jobs:
           # cp $SPEC_DIR/score.txt $GITHUB_WORKSPACE/result/score.txt
 
       - name: Summary result
+        if: always()
         run: |
           echo "### :rocket: Performance Test Result" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
We'll get empty score for failed/skipped jobs, but we can get all successful jobs and may be of some help.

This also works for time-out cancellations, as long as all `if: always()` block completes within the 5‑minute forced-terminate window according to [here](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always) and [here](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-cancellation)