### PR TITLE
feat(AddrField): add extract methods

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Helpers.scala
@@ -74,7 +74,6 @@ trait HalfAlignHelper extends HasBpuParameters {
 
   def getFtqOffset(startVAddr: PrunedAddr, position: UInt): UInt = {
     // given a 5-bit position, calculate the ftqOffset
-    // TODO: select from two 4-bit position? (startVAddr -> mbtb & startVAddr+32 -> mbtb)
     require(
       position.getWidth == CfiPositionWidth,
       s"position width should be $CfiPositionWidth, but got ${position.getWidth}"

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -20,7 +20,6 @@ import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.XSPerfAccumulate
 import utility.XSPerfHistogram
-import utils.AddrField
 import utils.VecRotate
 import xiangshan.frontend.bpu.BasePredictor
 import xiangshan.frontend.bpu.BasePredictorIO
@@ -39,21 +38,7 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   println(f"MainBtb:")
   println(f"  Size(set, way, align, internal): $NumSets * $NumWay * $NumAlignBanks * $NumInternalBanks = $NumEntries")
   println(f"  Address fields:")
-  AddrField(
-    Seq(
-      ("alignOffset", FetchBlockAlignWidth),
-      ("alignBankIdx", AlignBankIdxLen),
-      ("internalBankIdx", InternalBankIdxLen),
-      ("setIdx", SetIdxLen),
-      ("tag", TagWidth)
-    ),
-    maxWidth = Option(VAddrBits),
-    extraFields = Seq(
-      ("replacerSetIdx", FetchBlockAlignWidth, SetIdxLen),
-      ("targetLower", instOffsetBits, TargetWidth),
-      ("position", instOffsetBits, FetchBlockAlignWidth)
-    )
-  ).show(indent = 4)
+  addrFields.show(indent = 4)
 
   /* *** submodules *** */
   private val alignBanks = Seq.tabulate(NumAlignBanks)(alignIdx => Module(new MainBtbAlignBank(alignIdx)))


### PR DESCRIPTION
So we don't have to manually calculate each range like `addr(a+b+c+d-1, a+b+c)`:

```scala
def getTag(pc: PrunedAddr): UInt =
  pc(
    TagWidth + InternalBankIdxLen + SetIdxLen + FetchBlockSizeWidth - 1,
    InternalBankIdxLen + SetIdxLen + FetchBlockSizeWidth
  )
```

will become
```scala
val addrFields = AddrField(
  Seq(
    ("alignOffset", FetchBlockAlignWidth),
    ("alignBankIdx", AlignBankIdxLen),
    ("internalBankIdx", InternalBankIdxLen),
    ("setIdx", SetIdxLen),
    ("tag", TagWidth)
  )
)

def getTag(pc: PrunedAddr): UInt =
  addrFields.extract("tag", pc)
```

This PR also use these methods in mbtb as demo, if acceptable, I can apply this to all predictors

See https://github.com/OpenXiangShan/XiangShan/pull/5274#issuecomment-3595829992