### PR TITLE
refactor(Bpu): unify pc naming

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -780,7 +780,7 @@ class CtrlBlockImp(
 
   pcMem.io.wen.head   := GatedValidRegNext(io.frontend.fromFtq.wen)
   pcMem.io.waddr.head := RegEnable(io.frontend.fromFtq.ftqIdx, io.frontend.fromFtq.wen)
-  pcMem.io.wdata.head := RegEnable(io.frontend.fromFtq.startVAddr, io.frontend.fromFtq.wen)
+  pcMem.io.wdata.head := RegEnable(io.frontend.fromFtq.startPc, io.frontend.fromFtq.wen)
 
   io.toDataPath.flush := s2_s4_redirect
   io.toExuBlock.flush := s2_s4_redirect

--- a/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
@@ -36,7 +36,7 @@ abstract class BasePredictorIO(implicit p: Parameters) extends BpuBundle {
   // predict stage control
   val stageCtrl: StageCtrl = Input(new StageCtrl)
   // predict request
-  val startVAddr: PrunedAddr = Input(PrunedAddr(VAddrBits))
+  val startPc: PrunedAddr = Input(PrunedAddr(VAddrBits))
   // resolve train
   val train: DecoupledIO[BpuTrain] = Flipped(Decoupled(new BpuTrain))
   // fast train for s1 predictors

--- a/src/main/scala/xiangshan/frontend/bpu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Helpers.scala
@@ -21,64 +21,67 @@ import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
 
 trait HalfAlignHelper extends HasBpuParameters {
-  def getAlignedAddrUpper(addr: PrunedAddr): UInt =
-    addr(addr.length - 1, FetchBlockAlignWidth)
+  def getAlignedPcUpper(pc: PrunedAddr): UInt =
+    pc(pc.length - 1, FetchBlockAlignWidth)
 
-  def getAlignedAddr(addr: PrunedAddr): PrunedAddr =
+  def getAlignedPc(pc: PrunedAddr): PrunedAddr =
     PrunedAddrInit(Cat(
-      getAlignedAddrUpper(addr),
+      getAlignedPcUpper(pc),
       0.U(FetchBlockAlignWidth.W)
     ))
 
-  def getNextAlignedAddr(startVAddr: PrunedAddr): PrunedAddr = {
-    val nextAlignedVAddrUpperBits = getAlignedAddrUpper(startVAddr) + 1.U
-    PrunedAddrInit(Cat(nextAlignedVAddrUpperBits, 0.U(FetchBlockAlignWidth.W)))
+  def getNextAlignedPc(pc: PrunedAddr): PrunedAddr = {
+    val nextAlignedPcUpperBits = getAlignedPcUpper(pc) + 1.U
+    PrunedAddrInit(Cat(nextAlignedPcUpperBits, 0.U(FetchBlockAlignWidth.W)))
   }
 
-  def getBranchVAddr(startVAddr: PrunedAddr, position: UInt): PrunedAddr = {
-    val branchVAddrUpperBits = startVAddr(VAddrBits - 1, FetchBlockAlignWidth) + position(CfiPositionWidth - 1)
-    PrunedAddrInit(Cat(branchVAddrUpperBits, position(CfiPositionWidth - 2, 0), 0.U))
+  def getCfiPcFromPosition(startPc: PrunedAddr, position: UInt): PrunedAddr = {
+    val cfiPcUpperBits = startPc(startPc.length - 1, FetchBlockAlignWidth) + position(CfiPositionWidth - 1)
+    PrunedAddrInit(Cat(cfiPcUpperBits, position(CfiPositionWidth - 2, 0), 0.U(instOffsetBits.W)))
   }
 
-  def getAlignedInstOffset(addr: PrunedAddr): UInt =
-    // given an instruction address, return the offset of the instruction in the fetch block
+  def getCfiPcFromOffset(startPc: PrunedAddr, ftqOffset: UInt): PrunedAddr =
+    startPc + (ftqOffset << instOffsetBits.U).asUInt
+
+  def getAlignedInstOffset(pc: PrunedAddr): UInt =
+    // given an instruction pc, return the offset of the instruction in the fetch block
     // example:
     // if Rvc enabled, aligned to 2B, and if fetch block is aligned to 32B, then:
-    // - addr 10 is the inst at offset(5) in fb(0)
-    // - addr 68 is the inst at offset(2) in fb(2)
+    // - pc 10 is the inst at offset(5) in fb(0)
+    // - pc 68 is the inst at offset(2) in fb(2)
     // if Rvc disabled, aligned to 4B
-    addr(FetchBlockAlignWidth - 1, instOffsetBits)
+    pc(FetchBlockAlignWidth - 1, instOffsetBits)
 
-  def getAlignedPosition(startVAddr: PrunedAddr, ftqOffset: UInt): (UInt, Bool) = {
-    /* ftqOffset is relative to fetch block startVAddr (0 <= ftqOffset < 64B), aligned to inst
-     * we want position to be relative to 32B-aligned startVAddr, also aligned to inst
+  def getAlignedPosition(startPc: PrunedAddr, ftqOffset: UInt): (UInt, Bool) = {
+    /* ftqOffset is relative to fetch block startPc (0 <= ftqOffset < 64B), aligned to inst
+     * we want position to be relative to 32B-aligned startPc, also aligned to inst
      * assume Rvc enabled (if not, all the 'bit' below should minus 1)
-     * so, we use the lower 4 bits (inst aligned) of startVAddr, adding 5 bits ftqOffset, to get 6 bits fullPosition
+     * so, we use the lower 4 bits (inst aligned) of startPc, adding 5 bits ftqOffset, to get 6 bits fullPosition
      * if bit 5 (carry) is set, the position is illegal (out of 2 * 32B aligned fetch block)
      * then we take the lower 5 bits as position
      * addr = 0     ...   2     ...   8     ...                   ...   40    ...                   ...   64    ...
      *                    |           |                                 |                                 |
      *                    |           ftqOffset = 3, position = 4       ftqOffset = 19, position = 20     illegal
-     *                    startVAddr(4, 1) = 1
+     *                    startPc(4, 1) = 1
      * addr = 32    ...   62    ...   64    ...                   ...   94    ...                   ...   96    ...
      *                    |           |                                 |                                 |
      *                    |           ftqOffset = 1, position = 16      ftqOffset = 16, position = 31     illegal
-     *                    startVAddr(4, 1) = 15
+     *                    startPc(4, 1) = 15
      * and, for predictors using 4-bit position, we can just take the lower 4 bits of the returned position
      */
-    val fullPosition = ftqOffset +& getAlignedInstOffset(startVAddr)
+    val fullPosition = ftqOffset +& getAlignedInstOffset(startPc)
     val position     = fullPosition(CfiPositionWidth - 1, 0)
     val carry        = fullPosition(CfiPositionWidth)
     (position, carry)
   }
 
-  def getFtqOffset(startVAddr: PrunedAddr, position: UInt): UInt = {
+  def getFtqOffset(startPc: PrunedAddr, position: UInt): UInt = {
     // given a 5-bit position, calculate the ftqOffset
     require(
       position.getWidth == CfiPositionWidth,
       s"position width should be $CfiPositionWidth, but got ${position.getWidth}"
     )
-    position - getAlignedInstOffset(startVAddr)
+    position - getAlignedInstOffset(startPc)
   }
 }
 
@@ -88,10 +91,10 @@ trait CrossPageHelper extends HasBpuParameters {
     // get virtual page number (VPN) from a virtual address
     addr(addr.length - 1, PageOffsetWidth)
 
-  def isCrossPage(startVAddr: PrunedAddr, target: PrunedAddr): Bool =
+  def isCrossPage(startPc: PrunedAddr, target: PrunedAddr): Bool =
     // a simplified version of isCrossPage, to tell if a single fetch block can cross page
     // we only need to check the LSB of VPN, as +FetchBlockSize can only cross 1 boundary
-    startVAddr(PageOffsetWidth) =/= target(PageOffsetWidth)
+    startPc(PageOffsetWidth) =/= target(PageOffsetWidth)
 
   def isCrossPageFull(addr1: PrunedAddr, addr2: PrunedAddr): Bool =
     // check full VPN
@@ -108,50 +111,50 @@ trait TargetFixHelper extends HasBpuParameters {
   // abstract getTargetUpper function, to be implemented by sub-predictors.
   // basically, it should be `vAddr(VAddrBits - 1, TargetLowerBitsWidth + instOffsetBits)`,
   // where TargetLowerBitsWidth differs for different predictors.
-  def getTargetUpper(vAddr: PrunedAddr): UInt
+  def getTargetUpper(pc: PrunedAddr): UInt
 
-  def getTargetCarry(startVAddr: PrunedAddr, fullTarget: PrunedAddr): TargetCarry = {
-    val startVAddrUpper = getTargetUpper(startVAddr)
-    val targetUpper     = getTargetUpper(fullTarget)
+  def getTargetCarry(startPc: PrunedAddr, fullTarget: PrunedAddr): TargetCarry = {
+    val startPcUpper = getTargetUpper(startPc)
+    val targetUpper  = getTargetUpper(fullTarget)
     MuxCase(
       TargetCarry.Fit,
       Seq(
-        (targetUpper > startVAddrUpper) -> TargetCarry.Overflow,
-        (targetUpper < startVAddrUpper) -> TargetCarry.Underflow
+        (targetUpper > startPcUpper) -> TargetCarry.Overflow,
+        (targetUpper < startPcUpper) -> TargetCarry.Underflow
       )
     )
   }
 
   def fixTargetUpper(
-      startVAddrUpper: UInt,
-      targetCarry:     TargetCarry,
-      // pre-computed startVAddrUpper+-1 for timing, default is not needed
-      startVAddrUpperPlusOne:  Option[UInt] = None,
-      startVAddrUpperMinusOne: Option[UInt] = None
+      startPcUpper: UInt,
+      targetCarry:  TargetCarry,
+      // pre-computed startPcUpper+-1 for timing, default is not needed
+      startPcUpperPlusOne:  Option[UInt] = None,
+      startPcUpperMinusOne: Option[UInt] = None
   ): UInt =
     MuxCase(
-      startVAddrUpper,
+      startPcUpper,
       Seq(
-        targetCarry.isOverflow  -> startVAddrUpperPlusOne.getOrElse(startVAddrUpper + 1.U),
-        targetCarry.isUnderflow -> startVAddrUpperMinusOne.getOrElse(startVAddrUpper - 1.U)
+        targetCarry.isOverflow  -> startPcUpperPlusOne.getOrElse(startPcUpper + 1.U),
+        targetCarry.isUnderflow -> startPcUpperMinusOne.getOrElse(startPcUpper - 1.U)
       )
     )
 
   // ubtb and abtb can select whether to use the targetCarry or not, so Option[TargetCarry]
   def getFullTarget(
-      startVAddr:  PrunedAddr,
+      startPc:     PrunedAddr,
       target:      UInt,
       targetCarry: Option[TargetCarry],
-      // pre-computed startVAddrUpper+-1 for timing, default is not needed
-      startVAddrUpperPlusOne:  Option[UInt] = None,
-      startVAddrUpperMinusOne: Option[UInt] = None
+      // pre-computed startPcUpper+-1 for timing, default is not needed
+      startPcUpperPlusOne:  Option[UInt] = None,
+      startPcUpperMinusOne: Option[UInt] = None
   ): PrunedAddr = {
-    val startVAddrUpper = getTargetUpper(startVAddr)
+    val startPcUpper = getTargetUpper(startPc)
     PrunedAddrInit(Cat(
       if (targetCarry.isDefined) // `if (EnableTargetFix)` in ubtb and abtb
-        fixTargetUpper(startVAddrUpper, targetCarry.get, startVAddrUpperPlusOne, startVAddrUpperMinusOne)
+        fixTargetUpper(startPcUpper, targetCarry.get, startPcUpperPlusOne, startPcUpperMinusOne)
       else
-        startVAddrUpper,    // (VAddrBits - 1, TargetWidth + instOffsetBits)
+        startPcUpper,       // (VAddrBits - 1, TargetWidth + instOffsetBits)
       target,               // (TargetWidth + instOffsetBits - 1, instOffsetBits)
       0.U(instOffsetBits.W) // (instOffsetBits - 1, 0)
     ))

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/Helpers.scala
@@ -30,7 +30,7 @@ trait Helpers extends HasAheadBtbParameters with TargetFixHelper {
     pc(TagWidth + instOffsetBits - 1, instOffsetBits)
 
   def getTargetUpper(pc: PrunedAddr): UInt =
-    pc(VAddrBits - 1, TargetLowerBitsWidth + instOffsetBits)
+    pc(pc.length - 1, TargetLowerBitsWidth + instOffsetBits)
 
   def getTargetLowerBits(target: PrunedAddr): UInt =
     target(TargetLowerBitsWidth + instOffsetBits - 1, instOffsetBits)

--- a/src/main/scala/xiangshan/frontend/bpu/history/ghr/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/ghr/Bundles.scala
@@ -39,8 +39,8 @@ class GhrMeta(implicit p: Parameters) extends GhrBundle {
 }
 
 class GhrRedirect(implicit p: Parameters) extends GhrBundle {
-  val valid:      Bool       = Bool()
-  val startVAddr: PrunedAddr = PrunedAddr(VAddrBits)
-  val taken:      Bool       = Bool()
-  val meta:       GhrMeta    = new GhrMeta
+  val valid: Bool       = Bool()
+  val cfiPc: PrunedAddr = PrunedAddr(VAddrBits)
+  val taken: Bool       = Bool()
+  val meta:  GhrMeta    = new GhrMeta
 }

--- a/src/main/scala/xiangshan/frontend/bpu/history/ghr/Ghr.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/ghr/Ghr.scala
@@ -73,7 +73,7 @@ class Ghr(implicit p: Parameters) extends GhrModule with Helpers {
   private val r0_oldPositions  = io.redirect.meta.position
   private val r0_oldHits       = io.redirect.meta.hitMask
   private val r0_taken         = io.redirect.taken
-  private val r0_takenPosition = getAlignedInstOffset(io.redirect.startVAddr) // FIXME: position calculate maybe wrong
+  private val r0_takenPosition = getAlignedInstOffset(io.redirect.cfiPc) // FIXME: position calculate maybe wrong
   private val r0_lessThanPc = r0_oldPositions.zip(r0_oldHits).map {
     case (pos, hit) => hit && (pos < r0_takenPosition)
   } // positions less than redirect branch pc

--- a/src/main/scala/xiangshan/frontend/bpu/history/phr/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/phr/Bundles.scala
@@ -45,7 +45,7 @@ object PhrPtr {
 class PhrUpdateData(implicit p: Parameters) extends PhrBundle with HasPhrParameters {
   val valid:     Bool                  = Bool()
   val taken:     Bool                  = Bool()
-  val pc:        PrunedAddr            = PrunedAddr(VAddrBits)
+  val cfiPc:     PrunedAddr            = PrunedAddr(VAddrBits)
   val target:    PrunedAddr            = PrunedAddr(VAddrBits)
   val phrMeta:   PhrMeta               = new PhrMeta()
   val foldedPhr: PhrAllFoldedHistories = new PhrAllFoldedHistories(AllFoldedHistoryInfo)
@@ -60,12 +60,12 @@ class PhrUpdate(implicit p: Parameters) extends PhrBundle {
 
   val s1_valid:      Bool       = Bool()
   val s1_prediction: Prediction = new Prediction()
-  val s1_pc:         PrunedAddr = PrunedAddr(VAddrBits)
+  val s1_startPc:    PrunedAddr = PrunedAddr(VAddrBits)
 
   val s3_override:   Bool       = Bool()
   val s3_phrMeta:    PhrMeta    = new PhrMeta()
   val s3_prediction: Prediction = new Prediction()
-  val s3_pc:         PrunedAddr = PrunedAddr(VAddrBits)
+  val s3_startPc:    PrunedAddr = PrunedAddr(VAddrBits)
 }
 
 class PhrMeta(implicit p: Parameters) extends PhrBundle {

--- a/src/main/scala/xiangshan/frontend/bpu/history/phr/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/phr/Helpers.scala
@@ -56,12 +56,6 @@ trait Helpers extends HasPhrParameters with HalfAlignHelper {
     res.asUInt
   }
 
-  def getBranchAddr(addr: PrunedAddr, cfiPosition: UInt): PrunedAddr = {
-    val alignedAddr = Cat(getAlignedAddrUpper(addr), 0.U(FetchBlockAlignWidth.W))
-    val brOffset    = Cat(cfiPosition, 0.U(instOffsetBits.W))
-    PrunedAddrInit(alignedAddr + brOffset)
-  }
-
   def pathHash(pc: PrunedAddr, target: PrunedAddr): UInt = {
     val hash = Cat(pc(9, 1), 0.U(4.W)) ^ target(16, 2) // magic numbers
     hash(PathHashWidth - 1, 0)

--- a/src/main/scala/xiangshan/frontend/bpu/history/phr/Phr.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/phr/Phr.scala
@@ -87,27 +87,27 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
   private val s3_overrideData = WireInit(0.U.asTypeOf(new PhrUpdateData))
 
   private val updateData   = WireInit(0.U.asTypeOf(new PhrUpdateData))
-  private val updatePc     = WireInit(0.U.asTypeOf(PrunedAddr(VAddrBits)))
+  private val updateCfiPc  = WireInit(0.U.asTypeOf(PrunedAddr(VAddrBits)))
   private val updateTarget = WireInit(0.U.asTypeOf(PrunedAddr(VAddrBits)))
   private val redirectPhr  = WireInit(0.U(PhrHistoryLength.W))
 
   redirectData.valid   := io.train.redirect.valid
   redirectData.taken   := io.train.redirect.bits.taken
-  redirectData.pc      := io.train.redirect.bits.cfiPc
+  redirectData.cfiPc   := io.train.redirect.bits.cfiPc
   redirectData.target  := io.train.redirect.bits.target
   redirectData.phrMeta := io.train.redirect.bits.speculationMeta.phrMeta
 
   s3_override               := io.train.s3_override
   s3_overrideData.valid     := s3_override
   s3_overrideData.taken     := io.train.s3_prediction.taken
-  s3_overrideData.pc        := getBranchAddr(io.train.s3_pc, io.train.s3_prediction.cfiPosition)
+  s3_overrideData.cfiPc     := getCfiPcFromPosition(io.train.s3_startPc, io.train.s3_prediction.cfiPosition)
   s3_overrideData.target    := io.train.s3_prediction.target
   s3_overrideData.phrMeta   := io.train.s3_phrMeta
   s3_overrideData.foldedPhr := s3_foldedPhrReg
 
   s1_overrideData.valid              := s1_valid
   s1_overrideData.taken              := io.train.s1_prediction.taken
-  s1_overrideData.pc                 := getBranchAddr(io.train.s1_pc, io.train.s1_prediction.cfiPosition)
+  s1_overrideData.cfiPc              := getCfiPcFromPosition(io.train.s1_startPc, io.train.s1_prediction.cfiPosition)
   s1_overrideData.target             := io.train.s1_prediction.target
   s1_overrideData.foldedPhr          := s1_foldedPhrReg
   s1_overrideData.phrMeta.phrPtr     := s1_phrPtr
@@ -122,13 +122,13 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
     )
   )
 
-  updatePc     := updateData.pc
+  updateCfiPc  := updateData.cfiPc
   updateTarget := updateData.target
 
   /*
    * phr := (phr<<Shamt) ^ hash
    */
-  private val hash      = pathHash(updatePc, updateTarget)
+  private val hash      = pathHash(updateCfiPc, updateTarget)
   private val shiftBits = hash(Shamt - 1, 0)
   private val hashHigh  = hash(PathHashWidth - 1, Shamt)
 
@@ -246,8 +246,8 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
     val commitTaken = commit.branches(0).bits.taken
     val commitTakenPc = Mux(
       commitValid && commit.branches(0).bits.mispredict.asBools.reduce(_ || _),
-      commit.startVAddr,
-      getBranchAddr(commit.startVAddr, commit.branches(0).bits.cfiPosition)
+      commit.startPc,
+      getCfiPcFromPosition(commit.startPc, commit.branches(0).bits.cfiPosition)
     )
     val commitShiftBits = shiftCommitBits(commitTakenPc)
 

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Helpers.scala
@@ -20,6 +20,9 @@ import chisel3.util._
 import xiangshan.frontend.PrunedAddr
 
 trait Helpers extends HasIttageParameters {
-  def targetGetRegion(target: PrunedAddr): UInt = target(VAddrBits - 1, TargetOffsetWidth)
-  def targetGetOffset(target: PrunedAddr): UInt = target(TargetOffsetWidth - 1, 0)
+  def targetGetRegion(target: PrunedAddr): UInt =
+    target(target.length - 1, TargetOffsetWidth)
+
+  def targetGetOffset(target: PrunedAddr): UInt =
+    target(TargetOffsetWidth - 1, 0)
 }

--- a/src/main/scala/xiangshan/frontend/bpu/ras/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/Bundles.scala
@@ -113,7 +113,7 @@ class RasCommitInfo(implicit p: Parameters) extends RasBundle {
 
 class RasRedirectInfo(implicit p: Parameters) extends RasBundle {
   val attribute: BranchAttribute = new BranchAttribute
-  val brPc:      PrunedAddr      = PrunedAddr(VAddrBits)
+  val cfiPc:     PrunedAddr      = PrunedAddr(VAddrBits)
   val meta:      RasInternalMeta = new RasInternalMeta
   val level:     UInt            = RedirectLevel()
 }

--- a/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
@@ -92,7 +92,7 @@ class Ras(implicit p: Parameters) extends BasePredictor with HasRasParameters wi
   stack.redirect.isRet  := redirect.bits.attribute.isReturn && (redirect.bits.level === 0.U)
   stack.redirect.meta   := redirect.bits.meta
   // Redirected branch PC points to end of instruction.
-  stack.redirect.callAddr := redirect.bits.brPc + 2.U
+  stack.redirect.callAddr := redirect.bits.cfiPc + 2.U
 
   private val commitValid    = RegNext(io.commit.valid, init = false.B)
   private val commitInfo     = RegEnable(io.commit.bits, io.commit.valid)

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Bundles.scala
@@ -103,8 +103,8 @@ class UpdateInfo(implicit p: Parameters) extends TageBundle {
 }
 
 class ConditionalBranchTrace(implicit p: Parameters) extends TageBundle {
-  val startVAddr:  PrunedAddr = PrunedAddr(VAddrBits)
-  val branchVAddr: PrunedAddr = PrunedAddr(VAddrBits)
+  val startPc: PrunedAddr = PrunedAddr(VAddrBits)
+  val cfiPc:   PrunedAddr = PrunedAddr(VAddrBits)
 
   val hasProvider:       Bool            = Bool()
   val providerTableIdx:  UInt            = UInt(TableIdxWidth.W)

--- a/src/main/scala/xiangshan/frontend/bpu/ubtb/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ubtb/Helpers.scala
@@ -21,11 +21,11 @@ import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.bpu.TargetFixHelper
 
 trait Helpers extends HasMicroBtbParameters with TargetFixHelper {
-  def getTag(vAddr: PrunedAddr): UInt =
-    vAddr(TagWidth + instOffsetBits - 1, instOffsetBits)
+  def getTag(pc: PrunedAddr): UInt =
+    pc(TagWidth + instOffsetBits - 1, instOffsetBits)
 
-  def getTargetUpper(vAddr: PrunedAddr): UInt =
-    vAddr(VAddrBits - 1, TargetWidth + instOffsetBits)
+  def getTargetUpper(pc: PrunedAddr): UInt =
+    pc(pc.length - 1, TargetWidth + instOffsetBits)
 
   def getEntryTarget(fullTarget: PrunedAddr): UInt =
     fullTarget(TargetWidth + instOffsetBits - 1, instOffsetBits)

--- a/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
@@ -59,7 +59,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
   private val tickCounter = RegInit(0.U((TickWidth + 1).W))
   // Predict
   tables.foreach { t =>
-    t.req.startPc        := io.startVAddr
+    t.req.startPc        := io.startPc
     t.req.foldedPathHist := io.foldedPathHist
     t.usefulReset        := tickCounter(TickWidth)
   }
@@ -186,7 +186,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
     t.update.bits.usefulValid := (t0_providerMask(i) && t0_histTableNeedUpdate) &&
       (t0_histHitMisPred || (baseNotMatchHistPred && fastTrainHasPredBr))
 
-    t.update.bits.startPc                := io.fastTrain.get.bits.startVAddr
+    t.update.bits.startPc                := io.fastTrain.get.bits.startPc
     t.update.bits.allocTaken             := t0_allocTaken
     t.update.bits.allocCfiPosition       := t0_allocCfiPosition
     t.update.bits.updateTaken            := t0_updateTaken
@@ -234,20 +234,20 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
     (idx, tag)
   }
 
-  private val (s0_idxTable0, s0_tagTable0) = computeHash(io.startVAddr.toUInt, io.foldedPathHist, 0)
-  private val (s0_idxTable1, s0_tagTable1) = computeHash(io.startVAddr.toUInt, io.foldedPathHist, 1)
+  private val (s0_idxTable0, s0_tagTable0) = computeHash(io.startPc.toUInt, io.foldedPathHist, 0)
+  private val (s0_idxTable1, s0_tagTable1) = computeHash(io.startPc.toUInt, io.foldedPathHist, 1)
 
   predMeta.bits.testUseMicroTage  := false.B // no use, only for placeholder.
   predMeta.bits.testPredIdx0      := s0_idxTable0
   predMeta.bits.testPredTag0      := s0_tagTable0
   predMeta.bits.testPredIdx1      := s0_idxTable1
   predMeta.bits.testPredTag1      := s0_tagTable1
-  predMeta.bits.testPredStartAddr := io.startVAddr.toUInt
+  predMeta.bits.testPredStartAddr := io.startPc.toUInt
 
   private val (trainIdx0, trainTag0) =
-    computeHash(io.fastTrain.get.bits.startVAddr.toUInt, io.foldedPathHistForTrain, 0)
+    computeHash(io.fastTrain.get.bits.startPc.toUInt, io.foldedPathHistForTrain, 0)
   private val (trainIdx1, trainTag1) =
-    computeHash(io.fastTrain.get.bits.startVAddr.toUInt, io.foldedPathHistForTrain, 1)
+    computeHash(io.fastTrain.get.bits.startPc.toUInt, io.foldedPathHistForTrain, 1)
 
   XSPerfAccumulate(
     "train_useMicroTage_and_override_fromFastTrain",

--- a/src/main/scala/xiangshan/frontend/bpu/utage/MicroTageTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/MicroTageTable.scala
@@ -20,7 +20,6 @@ import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import scala.math.min
 import utility.XSPerfAccumulate
-import xiangshan.backend.datapath.DataConfig.VAddrBits
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.bpu.FoldedHistoryInfo
 import xiangshan.frontend.bpu.SaturateCounter

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -25,7 +25,7 @@ import xiangshan.frontend.bpu.BranchAttribute
 import xiangshan.frontend.bpu.BranchInfo
 
 class FtqEntry(implicit p: Parameters) extends FtqBundle {
-  val startVAddr:     PrunedAddr  = PrunedAddr(VAddrBits)
+  val startPc:        PrunedAddr  = PrunedAddr(VAddrBits)
   val takenCfiOffset: Valid[UInt] = Valid(UInt(CfiPositionWidth.W))
 }
 
@@ -35,9 +35,9 @@ class MetaEntry(implicit p: Parameters) extends FtqBundle {
 }
 
 class ResolveEntry(implicit p: Parameters) extends FtqBundle {
-  val ftqIdx:     FtqPtr     = new FtqPtr
-  val flushed:    Bool       = Bool()
-  val startVAddr: PrunedAddr = PrunedAddr(VAddrBits)
+  val ftqIdx:  FtqPtr     = new FtqPtr
+  val flushed: Bool       = Bool()
+  val startPc: PrunedAddr = PrunedAddr(VAddrBits)
   // TODO: Reconsider branch number
   val branches: Vec[Valid[BranchInfo]] = Vec(ResolveEntryBranchNumber, Valid(new BranchInfo))
 }
@@ -73,7 +73,7 @@ class BpuFlushInfo(implicit p: Parameters) extends FtqBundle with HasCircularQue
 
 class FtqToCtrlIO(implicit p: Parameters) extends FtqBundle {
   // write to backend pc mem
-  val wen:        Bool       = Output(Bool())
-  val ftqIdx:     UInt       = Output(UInt(FtqPtr.width.W))
-  val startVAddr: PrunedAddr = Output(PrunedAddr(VAddrBits))
+  val wen:     Bool       = Output(Bool())
+  val ftqIdx:  UInt       = Output(UInt(FtqPtr.width.W))
+  val startPc: PrunedAddr = Output(PrunedAddr(VAddrBits))
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -180,7 +180,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
   }
 
   when((prediction.fire || bpuS3Redirect) && !redirect.valid) {
-    entryQueue(predictionPtr.value).startVAddr     := prediction.bits.startVAddr
+    entryQueue(predictionPtr.value).startPc        := prediction.bits.startPc
     entryQueue(predictionPtr.value).takenCfiOffset := prediction.bits.takenCfiOffset
   }
 
@@ -232,7 +232,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
   io.toICache.prefetchReq.bits.startVAddr := Mux(
     redirectNext.valid,
     PrunedAddrInit(redirectNext.bits.target),
-    entryQueue(pfPtr(0).value).startVAddr
+    entryQueue(pfPtr(0).value).startPc
   )
   io.toICache.prefetchReq.bits.nextCachelineVAddr :=
     io.toICache.prefetchReq.bits.startVAddr + (CacheLineSize / 8).U
@@ -254,20 +254,20 @@ class Ftq(implicit p: Parameters) extends FtqModule
 
   // TODO: consider BPU bypass
   io.toICache.fetchReq.valid                   := ifuReqValid
-  io.toICache.fetchReq.bits.startVAddr         := entryQueue(ifuPtr(0).value).startVAddr
-  io.toICache.fetchReq.bits.nextCachelineVAddr := entryQueue(ifuPtr(0).value).startVAddr + (CacheLineSize / 8).U
+  io.toICache.fetchReq.bits.startVAddr         := entryQueue(ifuPtr(0).value).startPc
+  io.toICache.fetchReq.bits.nextCachelineVAddr := entryQueue(ifuPtr(0).value).startPc + (CacheLineSize / 8).U
   io.toICache.fetchReq.bits.ftqIdx             := ifuPtr(0)
   io.toICache.fetchReq.bits.takenCfiOffset     := entryQueue(ifuPtr(0).value).takenCfiOffset.bits
   io.toICache.fetchReq.bits.isBackendException := backendException.hasException && backendExceptionPtr === ifuPtr(0)
 
   io.toIfu.req.valid                    := ifuReqValid
   io.toIfu.req.bits.fetch(0).valid      := ifuReqValid
-  io.toIfu.req.bits.fetch(0).startVAddr := entryQueue(ifuPtr(0).value).startVAddr
+  io.toIfu.req.bits.fetch(0).startVAddr := entryQueue(ifuPtr(0).value).startPc
   io.toIfu.req.bits.fetch(0).nextStartVAddr := MuxCase(
-    entryQueue(ifuPtr(1).value).startVAddr,
+    entryQueue(ifuPtr(1).value).startPc,
     Seq(
       (bpuPtr(0) === ifuPtr(0)) -> prediction.bits.target,
-      (bpuPtr(0) === ifuPtr(1)) -> prediction.bits.startVAddr
+      (bpuPtr(0) === ifuPtr(1)) -> prediction.bits.startPc
     )
   )
   io.toIfu.req.bits.fetch(0).nextCachelineVAddr := io.toIfu.req.bits.fetch(0).startVAddr + (CacheLineSize / 8).U
@@ -279,9 +279,9 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // Interaction with backend
   // --------------------------------------------------------------------------------
 
-  io.toBackend.wen        := (prediction.fire || bpuS3Redirect) && !redirect.valid
-  io.toBackend.ftqIdx     := predictionPtr.value
-  io.toBackend.startVAddr := prediction.bits.startVAddr
+  io.toBackend.wen     := (prediction.fire || bpuS3Redirect) && !redirect.valid
+  io.toBackend.ftqIdx  := predictionPtr.value
+  io.toBackend.startPc := prediction.bits.startPc
 
   // --------------------------------------------------------------------------------
   // Redirect from backend and IFU
@@ -302,11 +302,11 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // TODO: only valid should be needed
   io.toIfu.redirect.bits := DontCare
 
-  io.toBpu.redirect.valid                := redirect.valid
-  io.toBpu.redirect.bits.cfiPc           := redirect.bits.pc + (redirect.bits.ftqOffset << 1).asUInt
-  io.toBpu.redirect.bits.target          := redirect.bits.target
-  io.toBpu.redirect.bits.taken           := redirect.bits.taken
-  io.toBpu.redirect.bits.attribute       := redirect.bits.attribute
+  io.toBpu.redirect.valid          := redirect.valid
+  io.toBpu.redirect.bits.cfiPc     := getCfiPcFromOffset(PrunedAddrInit(redirect.bits.pc), redirect.bits.ftqOffset)
+  io.toBpu.redirect.bits.target    := redirect.bits.target
+  io.toBpu.redirect.bits.taken     := redirect.bits.taken
+  io.toBpu.redirect.bits.attribute := redirect.bits.attribute
   io.toBpu.redirect.bits.speculationMeta := speculationQueue(redirect.bits.ftqIdx.value)
   io.toBpu.redirectFromIFU               := ifuRedirect.valid
 
@@ -322,7 +322,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
   io.toBpu.train.valid           := resolveQueue.io.bpuTrain.valid
   resolveQueue.io.bpuTrain.ready := io.toBpu.train.ready
   io.toBpu.train.bits.meta       := metaQueueResolve(resolveQueue.io.bpuTrain.bits.ftqIdx.value)
-  io.toBpu.train.bits.startVAddr := resolveQueue.io.bpuTrain.bits.startVAddr
+  io.toBpu.train.bits.startPc    := resolveQueue.io.bpuTrain.bits.startPc
   io.toBpu.train.bits.branches   := resolveQueue.io.bpuTrain.bits.branches
 
   // --------------------------------------------------------------------------------

--- a/src/main/scala/xiangshan/frontend/ftq/ResolveQueue.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/ResolveQueue.scala
@@ -104,9 +104,9 @@ class ResolveQueue(implicit p: Parameters) extends FtqModule with HalfAlignHelpe
 
   resolve.zipWithIndex.foreach { case (branch, i) =>
     when(branch.valid && !full) {
-      mem(enqIndex(i)).valid           := true.B
-      mem(enqIndex(i)).bits.ftqIdx     := branch.bits.ftqIdx
-      mem(enqIndex(i)).bits.startVAddr := branch.bits.pc
+      mem(enqIndex(i)).valid        := true.B
+      mem(enqIndex(i)).bits.ftqIdx  := branch.bits.ftqIdx
+      mem(enqIndex(i)).bits.startPc := branch.bits.pc
 
       val firstEmpty = mem(enqIndex(i)).bits.branches.indexWhere(!_.valid)
       val branchSlot = mem(enqIndex(i)).bits.branches(firstEmpty + PopCount(hitPrevious(i)))

--- a/src/main/scala/xiangshan/frontend/simfrontend/SimFrontend.scala
+++ b/src/main/scala/xiangshan/frontend/simfrontend/SimFrontend.scala
@@ -265,9 +265,9 @@ class SimFrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBa
     )
   }
 
-  io.backend.fromFtq.wen        := fetchHelper.io.out_ftqPackData(6)
-  io.backend.fromFtq.ftqIdx     := fetchHelper.io.out_ftqPackData(5, 0)
-  io.backend.fromFtq.startVAddr := PrunedAddrInit(fetchHelper.io.out_ftqPc)
+  io.backend.fromFtq.wen     := fetchHelper.io.out_ftqPackData(6)
+  io.backend.fromFtq.ftqIdx  := fetchHelper.io.out_ftqPackData(5, 0)
+  io.backend.fromFtq.startPc := PrunedAddrInit(fetchHelper.io.out_ftqPc)
 
   XSPerfAccumulate("all_redirect", io.backend.toFtq.redirect.valid)
   XSPerfAccumulate("mispred_redirect", io.backend.toFtq.redirect.valid && io.backend.toFtq.redirect.bits.isMisPred)


### PR DESCRIPTION
- `startPc`: virtual address of the start of a predict/fetch block
- `cfiPc`: virtual address of a control-flow-instruction
- `alignedPc`: `startPc` aligned to `FetchBlockAlignSize` bits
- `pc`: should be only used in helper functions, can accept both `startPc` and `cfiPc`

`startVAddr` in ICache/Ifu is unchanged since we want to distinguish between virtual address and physical address there

also: rename `DummyBpuIO` to `BpuIO`