### PR TITLE
timing(MemBlock): paddr generated by TLB does not require additional Mux

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -936,8 +936,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   s1_vaddr_hi         := s1_in.vaddr(VAddrBits - 1, 6)
   s1_vaddr_lo         := s1_in.vaddr(5, 0)
   s1_vaddr            := Cat(s1_vaddr_hi, s1_vaddr_lo)
-  s1_paddr_dup_lsu    := Mux(s1_in.tlbNoQuery, s1_in.paddr, io.tlb.resp.bits.paddr(0))
-  s1_paddr_dup_dcache := Mux(s1_in.tlbNoQuery, s1_in.paddr, io.tlb.resp.bits.paddr(1))
+  s1_paddr_dup_lsu    := io.tlb.resp.bits.paddr(0)
+  s1_paddr_dup_dcache := io.tlb.resp.bits.paddr(1)
   s1_gpaddr_dup_lsu   := Mux(s1_in.isFastReplay, s1_in.paddr, io.tlb.resp.bits.gpaddr(0))
 
   when (s1_tlb_memidx.is_ld && io.tlb.resp.valid && !s1_tlb_miss && s1_tlb_memidx.idx === s1_in.uop.lqIdx.value) {


### PR DESCRIPTION
Previously, after the TLB generated the Paddr, an additional multiplexing operation was performed during the LDU. This step was actually unnecessary. By adjusting the sequence, we have eliminated this redundant circuit logic for the multiplexer.

`tlb_req.valid` isn't always true, so `tlb_req.no_translate` needs to use RegNext, which might seem a bit odd.
But it doesn't matter. We just need to centralize the paddr selection logic in one place. For now, we'll unify the paddr arbitration selection within the TLB, ensuring the paddr retrieved by the TLB is the last Mux.