### PR TITLE
fix(pmu): fix connection of TopDown interface in backend

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -795,6 +795,12 @@ class TopDownFromL2Top(implicit p: Parameters) extends XSBundle {
   val l3Miss = Bool()
 }
 
+class UopTopDown(implicit p: Parameters) extends XSBundle {
+  val uopsIssued = Output(Bool())
+  val uopsIssuedCnt = Output(UInt((log2Up(p(XSCoreParamsKey).backendParams.allIssueParams.size)).W))
+  val noStoreIssued = Output(Bool())
+}
+
 class LowPowerIO(implicit p: Parameters) extends Bundle {
   /* i_*: SoC -> CPU   o_*: CPU -> SoC */
   val o_cpu_no_op = Output(Bool()) 

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -297,6 +297,11 @@ case class XSCoreParameters
 
   def vlWidth = log2Up(VLEN) + 1
 
+  /* 
+    Top-Down, ExecutionStall used
+  */
+  def fewUops = 4
+
   /**
    * the minimum element length of vector elements
    */

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -328,11 +328,6 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
   dataPath.io.fromBypassNetwork := 0.U.asTypeOf(dataPath.io.fromBypassNetwork)
   dataPath.io.fromPcTargetMem.toDataPathTargetPC := 0.U.asTypeOf(dataPath.io.fromPcTargetMem.toDataPathTargetPC)
   dataPath.io.fromPcTargetMem.toDataPathPC := 0.U.asTypeOf(dataPath.io.fromPcTargetMem.toDataPathPC)
-  dataPath.io.topDownInfo.lqEmpty := false.B
-  dataPath.io.topDownInfo.sqEmpty := false.B
-  dataPath.io.topDownInfo.l1Miss := false.B
-  dataPath.io.topDownInfo.l2TopMiss.l2Miss := false.B
-  dataPath.io.topDownInfo.l2TopMiss.l3Miss := false.B
 
   bypassNetwork.io.fromDataPath.int.foreach(x => x.foreach{ xx =>
       xx.valid := false.B
@@ -731,6 +726,10 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
   io.fpRfRdataOut.foreach(_ := dataPath.io.fpRfRdataOut.get)
   dataPath.io.fpRfRdataIn.foreach(_ := io.fpRfRdataIn.get)
 
+  io.uopTopDown.uopsIssued := dataPath.io.uopTopDown.uopsIssued
+  io.uopTopDown.uopsIssuedCnt := dataPath.io.uopTopDown.uopsIssuedCnt
+  io.uopTopDown.noStoreIssued := dataPath.io.uopTopDown.noStoreIssued
+
   // perf counter
   if (params.isIntSchd) {
     val iqNum = issueQueues.size
@@ -879,5 +878,7 @@ class RegionIO(val params: SchdBlockParams)(implicit p: Parameters) extends XSBu
   val fpIQOut = Option.when(params.isFpSchd)(MixedVec(params.issueBlockParams.map(_.genIssueDecoupledBundle)))
   val fromFpIQ = Option.when(params.isIntSchd)(Flipped(MixedVec(fpSchdParam.issueBlockParams.map(_.genIssueDecoupledBundle))))
   val intToFpIQResp = Option.when(params.isIntSchd)(MixedVec(fpSchdParam.issueBlockParams.map(_.genOGRespBundle)))
+  // TopDown
+  val uopTopDown = new UopTopDown
 }
 

--- a/src/main/scala/xiangshan/backend/TopDownGen.scala
+++ b/src/main/scala/xiangshan/backend/TopDownGen.scala
@@ -1,0 +1,60 @@
+package xiangshan.backend
+
+import org.chipsalliance.cde.config.Parameters
+import chisel3._
+import chisel3.util._
+import xiangshan._
+import utility._
+
+class TopDownGen(implicit p: Parameters) extends XSModule
+  with HasPerfEvents {
+  val io = IO(new TopDownGenIO)
+
+  val uopsIssued = io.intTopDown.uopsIssued || io.fpTopDown.uopsIssued || io.vecTopDown.uopsIssued
+  val uopsIssuedCnt = io.intTopDown.uopsIssuedCnt + io.vecTopDown.uopsIssuedCnt
+  val noStoreIssued = io.intTopDown.noStoreIssued
+
+  val fewUopsIssued = (0 until p(XSCoreParamsKey).fewUops).map(_.U === uopsIssuedCnt).reduce(_ || _)
+
+  val stallLoad = !uopsIssued
+  val stallStore = uopsIssued && noStoreIssued
+
+  val stallLoadDly2 = DelayN(stallLoad, 2)
+  val stallStoreDly2 = DelayN(stallStore, 2)
+
+  val lqEmpty = io.topDownInfo.lqEmpty
+  val sqEmpty = io.topDownInfo.sqEmpty
+  val l1Miss = io.topDownInfo.l1Miss
+  val l2Miss = io.topDownInfo.l2TopMiss.l2Miss
+  val l3Miss = io.topDownInfo.l2TopMiss.l3Miss
+
+  val memStallAnyLoad = stallLoadDly2 && !lqEmpty
+  val memStallStore = stallStoreDly2 && !sqEmpty
+  val memStallL1Miss = memStallAnyLoad && l1Miss
+  val memStallL2Miss = memStallL1Miss && l2Miss
+  val memStallL3Miss = memStallL2Miss && l3Miss
+
+  io.topDownInfo.noUopsIssued := stallLoad
+  
+  XSPerfAccumulate("exec_stall_cycle",   fewUopsIssued)
+  XSPerfAccumulate("mem_stall_store",    memStallStore)
+  XSPerfAccumulate("mem_stall_l1miss",   memStallL1Miss)
+  XSPerfAccumulate("mem_stall_l2miss",   memStallL2Miss)
+  XSPerfAccumulate("mem_stall_l3miss",   memStallL3Miss)
+
+  val perfEvents = Seq(
+    ("EXEC_STALL_CYCLE",  fewUopsIssued),
+    ("MEMSTALL_STORE",    memStallStore),
+    ("MEMSTALL_L1MISS",   memStallL1Miss),
+    ("MEMSTALL_L2MISS",   memStallL2Miss),
+    ("MEMSTALL_L3MISS",   memStallL3Miss),
+  )
+  generatePerfEvent()
+}
+
+class TopDownGenIO(implicit p: Parameters) extends XSBundle {
+  val intTopDown = Flipped(new UopTopDown)
+  val fpTopDown  = Flipped(new UopTopDown)
+  val vecTopDown = Flipped(new UopTopDown)
+  val topDownInfo = new TopDownInfo
+}


### PR DESCRIPTION
Due to changes in the overall structure of the backend module, the TopDown signal is currently connected to 0, so it has been refactored here.