### PR TITLE
feat(bpu): use abtb result when abtb and ubtb positions match

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -295,7 +295,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
       fallThrough.io.prediction,
       Seq(
         (s1_realUbtbTaken && abtb.io.prediction.taken) -> Mux(
-          ubtb.io.prediction.cfiPosition <= abtb.io.prediction.cfiPosition,
+          ubtb.io.prediction.cfiPosition < abtb.io.prediction.cfiPosition,
           ubtb.io.prediction,
           abtb.io.prediction
         ),


### PR DESCRIPTION
When the position is the same, excluding indirect jumps, the effects of uBTB and aBTB are identical. In the case of indirect jumps, aBTB carries some historical information, which maybe be beneficial for prediction.