### PR TITLE
feat(imsic,csr): support security external interrupt

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -125,6 +125,10 @@ case class SoCParameters
   EnablePowerDown: Boolean = false
 ){
   require(
+    !IMSICParams.HasTEEIMSIC || (IMSICParams.HasTEEIMSIC && IMSICBusType == device.IMSICBusType.AXI),
+    "HasTEEIMSIC only can be set true with IMSICBusType == AXI"
+  )
+  require(
     L3CacheParamsOpt.isDefined ^ OpenLLCParamsOpt.isDefined || L3CacheParamsOpt.isEmpty && OpenLLCParamsOpt.isEmpty,
     "Atmost one of L3CacheParamsOpt and OpenLLCParamsOpt should be defined"
   )

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -345,6 +345,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     for ((core, i) <- core_with_l2.zipWithIndex) {
       core.module.io.hartId := i.U
       core.module.io.msiInfo := msiInfo
+      core.module.io.teemsiInfo.foreach(_ := msiInfo)
       core.module.io.clintTime := misc.module.clintTime
       io.riscv_halt(i) := core.module.io.cpu_halt
       io.riscv_critical_error(i) := core.module.io.cpu_crtical_error

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -413,6 +413,13 @@ trait HasIMSICImp[+L <: HasIMSIC] { this: BaseXSSocImp with HasAsyncClockImp
   core_with_l2.module.io.msiInfo.valid := u_imsic_bus_top.module.msiio.vld_req
   core_with_l2.module.io.msiInfo.bits := u_imsic_bus_top.module.msiio.data
   u_imsic_bus_top.module.msiio.vld_ack := core_with_l2.module.io.msiAck
+  u_imsic_bus_top.module.teemsiio zip core_with_l2.module.io.teemsiInfo foreach { case (teemsiio, teemsiInfo) =>
+    teemsiInfo.valid := teemsiio.vld_req
+    teemsiInfo.bits := teemsiio.data
+  }
+  u_imsic_bus_top.module.teemsiio zip core_with_l2.module.io.teemsiAck foreach { case (teemsiio, teemsiAck) =>
+    teemsiio.vld_ack := teemsiAck
+  }
 }
 
 trait HasTraceIO { this: BaseXSSoc with HasXSTile =>

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -186,6 +186,14 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
         val fromCore = Input(Bool())
         val toTile = Output(Bool())
       }
+      val teemsiInfo = Option.when(soc.IMSICParams.HasTEEIMSIC)(new Bundle() {
+        val fromTile = Input(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W)))
+        val toCore = Output(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W)))
+      })
+      val teemsiAck = Option.when(soc.IMSICParams.HasTEEIMSIC)(new Bundle {
+        val fromCore = Input(Bool())
+        val toTile = Output(Bool())
+      })
       val cpu_halt = new Bundle() {
         val fromCore = Input(Bool())
         val toTile = Output(Bool())
@@ -248,9 +256,14 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
     // add buffer to satisfy PE
     io.msiInfo.toCore.valid := RegNext(io.msiInfo.fromTile.valid)
     io.msiInfo.toCore.bits := RegEnable(io.msiInfo.fromTile.bits, io.msiInfo.fromTile.valid)
+    io.teemsiInfo.foreach { teemsiInfo =>
+      teemsiInfo.toCore.valid := RegNext(teemsiInfo.fromTile.valid)
+      teemsiInfo.toCore.bits := RegEnable(teemsiInfo.fromTile.bits, teemsiInfo.fromTile.valid)
+    }
     io.cpu_halt.toTile := io.cpu_halt.fromCore
     io.cpu_critical_error.toTile := io.cpu_critical_error.fromCore
     io.msiAck.toTile := io.msiAck.fromCore
+    io.teemsiAck.foreach( teemsiAck => teemsiAck.toTile := teemsiAck.fromCore)
     io.l3Miss.toCore := io.l3Miss.fromTile
     io.clintTime.toCore := io.clintTime.fromTile
     // trace interface

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -86,6 +86,8 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
     val hartId = Input(UInt(hartIdLen.W))
     val msiInfo = Input(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W)))
     val msiAck = Output(Bool())
+    val teemsiInfo = Option.when(soc.IMSICParams.HasTEEIMSIC)(Input(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W))))
+    val teemsiAck = Option.when(soc.IMSICParams.HasTEEIMSIC)(Output(Bool()))
     val clintTime = Input(ValidIO(UInt(64.W)))
     val reset_vector = Input(UInt(PAddrBits.W))
     val cpu_halt = Output(Bool())
@@ -198,6 +200,9 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   // top -> memBlock
   memBlock.io.fromTopToBackend.clintTime := io.clintTime
   memBlock.io.fromTopToBackend.msiInfo := io.msiInfo
+  memBlock.io.fromTopToBackend.teemsiInfo zip io.teemsiInfo foreach { case (memBlock_teemsiInfo, io_teemsiInfo) =>
+    memBlock_teemsiInfo := io_teemsiInfo
+  }
   memBlock.io.hartId := io.hartId
   memBlock.io.l2_flush_done := io.l2_flush_done
   memBlock.io.outer_reset_vector := io.reset_vector
@@ -263,6 +268,9 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   io.power_down_en := memBlock.io.outer_power_down_en
   io.cpu_critical_error := memBlock.io.outer_cpu_critical_error
   io.msiAck := memBlock.io.outer_msi_ack
+  io.teemsiAck zip memBlock.io.outer_teemsi_ack foreach { case (io_teemsiAck, memBlock_outer_teemsi_ack) =>
+    io_teemsiAck := memBlock_outer_teemsi_ack
+  }
   io.beu_errors.icache <> memBlock.io.outer_beu_errors_icache
   io.beu_errors.dcache <> memBlock.io.dcacheError
   io.beu_errors.uncache <> memBlock.io.uncacheError

--- a/src/main/scala/xiangshan/XSTileWrap.scala
+++ b/src/main/scala/xiangshan/XSTileWrap.scala
@@ -78,6 +78,8 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
       val hartId = Input(UInt(hartIdLen.W))
       val msiInfo = Input(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W)))
       val msiAck = Output(Bool())
+      val teemsiInfo = Option.when(soc.IMSICParams.HasTEEIMSIC)(Input(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W))))
+      val teemsiAck = Option.when(soc.IMSICParams.HasTEEIMSIC)(Output(Bool()))
       val reset_vector = Input(UInt(PAddrBits.W))
       val cpu_halt = Output(Bool())
       val cpu_crtical_error = Output(Bool())
@@ -130,12 +132,28 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
     tile.module.io.hartId := io.hartId
     tile.module.io.msiInfo.valid := msi_vld_cpu
     tile.module.io.msiInfo.bits := msi_data_cpu
+
+    tile.module.io.teemsiInfo zip io.teemsiInfo foreach { case (tile_teemsiInfo, io_teemsiInfo) =>
+      // sync about msiinfo
+      val teemsi_vld_cpu = WireInit(false.B)
+      val teemsi_data_cpu = WireInit(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W),0.U)
+      withClockAndReset(clock, reset_sync) {
+        val teemsi_vld_sync = AsyncResetSynchronizerShiftReg(io_teemsiInfo.valid, 3, 0)
+        teemsi_vld_cpu := RegNext(teemsi_vld_sync)
+        teemsi_data_cpu := RegEnable(io_teemsiInfo.bits, teemsi_vld_sync)
+      }
+      tile_teemsiInfo.valid := teemsi_vld_cpu
+      tile_teemsiInfo.bits := teemsi_data_cpu
+    }
     tile.module.io.reset_vector := io.reset_vector
     tile.module.io.dft.zip(io.dft).foreach({ case (a, b) => a := b })
     tile.module.io.dft_reset.zip(io.dft_reset).foreach({ case (a, b) => a := b })
     io.cpu_halt := tile.module.io.cpu_halt
     io.cpu_crtical_error := tile.module.io.cpu_crtical_error
     io.msiAck := tile.module.io.msiAck
+    io.teemsiAck zip tile.module.io.teemsiAck foreach { case (io_teemsiAck, tile_teemsiAck) =>
+      io_teemsiAck := tile_teemsiAck
+    }
     io.hartIsInReset := tile.module.io.hartIsInReset
     io.traceCoreInterface <> tile.module.io.traceCoreInterface
     io.debugTopDown <> tile.module.io.debugTopDown
@@ -187,6 +205,7 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
     }
     dontTouch(io.hartId)
     dontTouch(io.msiInfo)
+    io.teemsiInfo.foreach(dontTouch(_))
     io.pwrdown_req_n.foreach(dontTouch(_))
     io.pwrdown_ack_n.foreach(dontTouch(_))
     io.iso_en.foreach(dontTouch(_))

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -572,6 +572,10 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   csrin.hartId := io.fromTop.hartId
   csrin.msiInfo.valid := RegNext(io.fromTop.msiInfo.valid)
   csrin.msiInfo.bits := RegEnable(io.fromTop.msiInfo.bits, io.fromTop.msiInfo.valid)
+  csrin.teemsiInfo zip io.fromTop.teemsiInfo foreach { case (csrin_teemsiInfo, fromTop_teemsiInfo) =>
+    csrin_teemsiInfo.valid := RegNext(fromTop_teemsiInfo.valid)
+    csrin_teemsiInfo.bits := RegEnable(fromTop_teemsiInfo.bits, fromTop_teemsiInfo.valid)
+  }
   csrin.clintTime.valid := RegNext(io.fromTop.clintTime.valid)
   csrin.clintTime.bits := RegEnable(io.fromTop.clintTime.bits, io.fromTop.clintTime.valid)
   csrin.l2FlushDone := RegNext(io.fromTop.l2FlushDone)
@@ -953,6 +957,9 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
 
   io.toTop.cpuCriticalError := csrio.criticalErrorState
   io.toTop.msiAck := csrio.msiAck
+  io.toTop.teemsiAck zip csrio.teemsiAck foreach { case (toTop_teemsiAck, csrio_teemsiAck) =>
+    toTop_teemsiAck := csrio_teemsiAck
+  }
 }
 
 class BackendMemIO(implicit p: Parameters, params: BackendParams) extends XSBundle {
@@ -1053,14 +1060,16 @@ class TopToBackendBundle(implicit p: Parameters) extends XSBundle with HasSoCPar
   val hartId            = Output(UInt(hartIdLen.W))
   val externalInterrupt = Output(new ExternalInterruptIO)
   val msiInfo           = Output(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W)))
+  val teemsiInfo        = Option.when(soc.IMSICParams.HasTEEIMSIC)(Output(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W))))
   val clintTime         = Output(ValidIO(UInt(64.W)))
   val l2FlushDone       = Output(Bool())
 }
 
-class BackendToTopBundle extends Bundle {
+class BackendToTopBundle(implicit p: Parameters) extends XSBundle with HasSoCParameter{
   val cpuHalted = Output(Bool())
   val cpuCriticalError = Output(Bool())
   val msiAck = Output(Bool())
+  val teemsiAck = Option.when(soc.IMSICParams.HasTEEIMSIC)(Output(Bool()))
 }
 
 class BackendIO(implicit p: Parameters, params: BackendParams) extends XSBundle with HasSoCParameter {

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -35,6 +35,7 @@ import xiangshan.backend.rob.RobPtr
 import utils.MathUtils.{BigIntGenMask, BigIntNot}
 import xiangshan.backend.trace._
 import freechips.rocketchip.rocket.CSRs
+import system.HasSoCParameter
 
 class FpuCsrIO extends Bundle {
   val fflags = Output(Valid(UInt(5.W)))
@@ -83,7 +84,7 @@ class PerfCounterIO(implicit p: Parameters) extends XSBundle {
   }
 }
 
-class CSRFileIO(implicit p: Parameters) extends XSBundle {
+class CSRFileIO(implicit p: Parameters) extends XSBundle with HasSoCParameter {
   val hartId = Input(UInt(hartIdLen.W))
   // output (for func === CSROpType.jmp)
   val perf = Input(new PerfCounterIO)
@@ -120,6 +121,7 @@ class CSRFileIO(implicit p: Parameters) extends XSBundle {
   val instrAddrTransType = Output(new AddrTransType)
   // ack for axireg from imsic. which indicates imsic can work actively
   val msiAck = Output(Bool())
+  val teemsiAck = Option.when(soc.IMSICParams.HasTEEIMSIC)(Output(Bool()))
 }
 
 class VtypeStruct(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRAIA.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRAIA.scala
@@ -308,6 +308,7 @@ class AIAToCSRBundle(implicit p: Parameters) extends XSBundle with HasSoCParamet
   })
   val meip    = Bool()
   val seip    = Bool()
+  val notice_pending = Bool()
   val vseip   = UInt(soc.IMSICParams.geilen.W)
   val mtopei  = new TopEIBundle
   val stopei  = new TopEIBundle

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/InterruptBundle.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/InterruptBundle.scala
@@ -148,7 +148,7 @@ class InterruptPendingBundle extends CSRBundle {
   val LC45IP   = RO(45)
   val LC46IP   = RO(46)
   val LC47IP   = RO(47)
-  val LC48IP   = RO(48)
+  val LC48IP   = RO(48) //Another safe-mode(TEE/REE) notice-pending interrupt
   val LC49IP   = RO(49)
   val LC50IP   = RO(50)
   val LC51IP   = RO(51)
@@ -241,7 +241,7 @@ class InterruptEnableBundle extends CSRBundle {
   val LC45IE   = RO(45)
   val LC46IE   = RO(46)
   val LC47IE   = RO(47)
-  val LC48IE   = RO(48)
+  val LC48IE   = RO(48) //Another safe-mode(TEE/REE) notice-pending interrupt
   val LC49IE   = RO(49)
   val LC50IE   = RO(50)
   val LC51IE   = RO(51)
@@ -327,6 +327,8 @@ object InterruptNO {
   final val COI = 13
   final val LPRASEI = 35
   final val HPRASEI = 43
+  //Another safe-mode(TEE/REE) notice-pending interrupt
+  final val ASNI = 48
 
   val privArchGroup = Seq(
     MEI, MSI, MTI,
@@ -367,7 +369,7 @@ object InterruptNO {
 
   val customLowestGroup = Seq(
     51, 25, 50,
-    49, 24, 48,
+    49, 24, ASNI,
   )
 
   val interruptDefaultPrio = customHighestGroup ++

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/InterruptFilter.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/InterruptFilter.scala
@@ -37,7 +37,7 @@ class InterruptFilter extends Module {
   val miprios = io.in.miprios
   val hsiprios = io.in.hsiprios
   val hviprios = Cat(hviprio2.asUInt, hviprio1.asUInt)
-  val fromAIAValid = io.in.fromAIA.meip || io.in.fromAIA.seip
+  val fromAIAValid = io.in.fromAIA.meip || io.in.fromAIA.seip || io.in.fromAIA.notice_pending
   val platformValid = io.in.platform.meip || io.in.platform.seip
 
   /**
@@ -615,6 +615,7 @@ class InterruptFilterIO extends Bundle {
     val fromAIA = new Bundle {
       val meip = Bool()
       val seip = Bool()
+      val notice_pending = Bool()
     }
   })
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
@@ -16,6 +16,7 @@ import xiangshan.backend.fu.PerfCounterIO
 import xiangshan.backend.fu.NewCSR.CSRConfig._
 import xiangshan.backend.fu.NewCSR.CSRFunc._
 import xiangshan.backend.fu.util.CSRConst._
+import system.HasSoCParameter
 
 import scala.collection.immutable.SeqMap
 
@@ -51,7 +52,7 @@ trait MachineLevel { self: NewCSR =>
   val mideleg = Module(new CSRModule("Mideleg", new MidelegBundle))
     .setAddr(CSRs.mideleg)
 
-  val mie = Module(new CSRModule("Mie", new MieBundle) with HasIpIeBundle {
+  val mie = Module(new CSRModule("Mie", new MieBundle) with HasIpIeBundle with HasSoCParameter {
     val fromHie  = IO(Flipped(new HieToMie))
     val fromSie  = IO(Flipped(new SieToMie))
     val fromVSie = IO(Flipped(new VSieToMie))
@@ -112,6 +113,10 @@ trait MachineLevel { self: NewCSR =>
 
     // 14~63 read only 0
     regOut.getLocal.filterNot(_.lsb == InterruptNO.COI).foreach(_ := 0.U)
+    if (soc.IMSICParams.HasTEEIMSIC) {
+      reg.LC48IE := Mux(wen, wdata.LC48IE, reg.LC48IE)
+      regOut.LC48IE := reg.LC48IE
+    }
   }).setAddr(CSRs.mie)
 
   val mtvec = Module(new CSRModule("Mtvec", new XtvecBundle))
@@ -211,6 +216,7 @@ trait MachineLevel { self: NewCSR =>
     with HasMachineEnvBundle
     with HasLocalInterruptReqBundle
     with HasAIABundle
+    with HasSoCParameter
   {
     // Alias write in
     val fromMvip = IO(Flipped(new MvipToMip))
@@ -296,6 +302,11 @@ trait MachineLevel { self: NewCSR =>
       reg.LCOFIP := lcofiReq
     }.otherwise {
       reg.LCOFIP := reg.LCOFIP
+    }
+
+    if (soc.IMSICParams.HasTEEIMSIC) {
+      // bit 48 LCOFIP
+      regOut.LC48IP := aiaToCSR.notice_pending
     }
   }).setAddr(CSRs.mip)
 
@@ -640,6 +651,8 @@ class MidelegBundle extends InterruptBundle {
 class MieBundle extends InterruptEnableBundle {
   this.getNonLocal.foreach(_.setRW().withReset(0.U))
   this.LCOFIE.setRW().withReset(0.U)
+  // add MIE.LC48IE for AIA
+  this.LC48IE.setRW().withReset(0.U)
 }
 
 class MipBundle extends InterruptPendingBundle {

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -391,6 +391,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   intrMod.io.in.platform.seip := platformIRP.SEIP
   intrMod.io.in.fromAIA.meip := fromAIA.meip
   intrMod.io.in.fromAIA.seip := fromAIA.seip
+  intrMod.io.in.fromAIA.notice_pending := fromAIA.notice_pending
 
   val intrVec = RegEnable(intrMod.io.out.interruptVec.bits, 0.U, intrMod.io.out.interruptVec.valid)
   val debug = RegEnable(intrMod.io.out.debug, false.B, intrMod.io.out.interruptVec.valid)
@@ -675,6 +676,7 @@ class NewCSR(implicit val p: Parameters) extends Module
         m.aiaToCSR.mtopei  := fromAIA.mtopei
         m.aiaToCSR.stopei  := fromAIA.stopei
         m.aiaToCSR.vstopei := fromAIA.vstopei
+        m.aiaToCSR.notice_pending := fromAIA.notice_pending
       case _ =>
     }
     mod match {

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -203,7 +203,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   trapTvalMod.io.fromCtrlBlock.flush := io.flush
   trapTvalMod.io.fromCtrlBlock.robDeqPtr := io.csrio.get.robDeqPtr
 
-  val imsic = Module(new aia.IMSIC(soc.IMSICParams))
+  val imsic = Module(new aia.IMSIC_WRAP(soc.IMSICParams))
   imsic.fromCSR.addr.valid := csrMod.toAIA.addr.valid
   imsic.fromCSR.addr.bits.addr := csrMod.toAIA.addr.bits.addr
   imsic.fromCSR.addr.bits.virt := csrMod.toAIA.addr.bits.v.asUInt.asBool
@@ -229,6 +229,17 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   imsic.msiio.vld_req := io.csrin.get.msiInfo.valid
   imsic.msiio.data := io.csrin.get.msiInfo.bits
   io.csrio.get.msiAck := imsic.msiio.vld_ack
+
+  imsic.teemsiio.foreach { teemsiio =>
+    teemsiio.vld_req := io.csrin.get.teemsiInfo.get.valid
+    teemsiio.data := io.csrin.get.teemsiInfo.get.bits
+    io.csrio.get.teemsiAck.get := teemsiio.vld_ack
+  }
+  csrMod.fromAIA.notice_pending := false.B
+  imsic.sec.foreach { imsicsec =>
+    imsicsec.cmode := csrMod.io.tlb.mbmc.CMODE.asBool
+    csrMod.fromAIA.notice_pending := imsicsec.notice_pending
+  }
 
   private val exceptionVec = WireInit(0.U.asTypeOf(ExceptionVec())) // Todo:
 
@@ -380,6 +391,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
 class CSRInput(implicit p: Parameters) extends XSBundle with HasSoCParameter {
   val hartId = Input(UInt(8.W))
   val msiInfo = Input(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W)))
+  val teemsiInfo = Option.when(soc.IMSICParams.HasTEEIMSIC)(Input(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W))))
   val criticalErrorState = Input(Bool())
   val clintTime = Input(ValidIO(UInt(64.W)))
   val l2FlushDone = Input(Bool())

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -335,6 +335,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     // All the signals from/to frontend/backend to/from bus will go through MemBlock
     val fromTopToBackend = Input(new Bundle {
       val msiInfo   = ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W))
+      val teemsiInfo   = Option.when(soc.IMSICParams.HasTEEIMSIC)(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W)))
       val clintTime = ValidIO(UInt(64.W))
     })
     val inner_hartId = Output(UInt(hartIdLen.W))
@@ -345,6 +346,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     val outer_power_down_en = Output(Bool())
     val outer_cpu_critical_error = Output(Bool())
     val outer_msi_ack = Output(Bool())
+    val outer_teemsi_ack = Option.when(soc.IMSICParams.HasTEEIMSIC)(Output(Bool()))
     val inner_beu_errors_icache = Input(new L1BusErrorUnitInfo)
     val outer_beu_errors_icache = Output(new L1BusErrorUnitInfo)
     val inner_hc_perfEvents = Output(Vec(numPCntHc * coreParams.L2NBanks + 1, new PerfEvent))
@@ -2002,6 +2004,9 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     x.externalInterrupt.nmi.nmi_31 := outer.nmi_int_sink.in.head._1(0) | outer.beu_local_int_sink.in.head._1(0)
     x.externalInterrupt.nmi.nmi_43 := outer.nmi_int_sink.in.head._1(1)
     x.msiInfo           := DelayNWithValid(io.fromTopToBackend.msiInfo, 1)
+    x.teemsiInfo zip io.fromTopToBackend.teemsiInfo foreach { case (x_teemsiInfo, io_teemsiInfo) =>
+      x_teemsiInfo        := DelayNWithValid(io_teemsiInfo, 1)
+    }
     x.clintTime         := DelayNWithValid(io.fromTopToBackend.clintTime, 1)
   }
 
@@ -2016,6 +2021,9 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   io.outer_power_down_en := io.ooo_to_mem.csrCtrl.power_down_enable
   io.outer_cpu_critical_error := io.ooo_to_mem.backendToTopBypass.cpuCriticalError
   io.outer_msi_ack := io.ooo_to_mem.backendToTopBypass.msiAck
+  io.outer_teemsi_ack zip io.ooo_to_mem.backendToTopBypass.teemsiAck foreach { case (teemsi_ack, teemsiAck) =>
+    teemsi_ack := teemsiAck
+  }
   io.outer_beu_errors_icache := RegNext(io.inner_beu_errors_icache)
   io.inner_hc_perfEvents <> RegNext(io.outer_hc_perfEvents)
   io.outer_l2PfCtrl := DelayN(io.ooo_to_mem.csrCtrl.pf_ctrl.toL2PrefetchCtrl(), 2)


### PR DESCRIPTION
- The security interruption scheme instantiat two sets of IMSICs for REE and TEE, and selects one of them as the source of the external interruption through the `cmode` signal.
- Add  ASNI(Another Safe-mode Notify Interrupt), which is used to indicate that there are pending interruptions in the interruption files of the S or VS of IMSIC in a non-current safe mode(`cmode`). 
- The ASNI interrupt number uses the `Custom Group` interrupt number `48`.
