### PR TITLE
fix(LoadQueueRAR): use lqIdx to check RAR violation

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
@@ -236,12 +236,12 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
 
     query.resp.valid := RegNext(query.req.valid)
     // Generate real violation mask
-    val robIdxMask = VecInit(uop.map(_.robIdx).map(isAfter(_, query.req.bits.uop.robIdx)))
+    val ageMask = VecInit(uop.map(_.lqIdx).map(_ > query.req.bits.uop.lqIdx))
     val matchMaskReg = Wire(Vec(LoadQueueRARSize, Bool()))
     for(i <- 0 until LoadQueueRARSize) {
       matchMaskReg(i) := (allocated(i) &
                          paddrModule.io.releaseViolationMmask(w)(i) &
-                         robIdxMask(i) &&
+                         ageMask(i) &&
                          released(i))
       }
     val matchMask = GatedValidRegNext(matchMaskReg)


### PR DESCRIPTION
This Commit also can solve the issue of vector order index load elements RAR check within instruction.

According to spec, vector order index load need to obey RVWMO at the element level.

<img width="2080" height="724" alt="image" src="https://github.com/user-attachments/assets/54ef8e2e-7cc4-4d31-bc85-47263d70c8fa" />


