### PR TITLE
Update configs and fixed 4-core mmio issue of nanhu-G core

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -206,6 +206,7 @@ trait HaveAXI4PeripheralPort { this: BaseSoC =>
   )))
 
   peripheralNode :=
+    AXI4UserYanker() :=
     AXI4IdIndexer(idBits = 2) :=
     AXI4Buffer() :=
     AXI4Buffer() :=

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -282,7 +282,7 @@ class WithNKBL3(n: Int, ways: Int = 8, inclusive: Boolean = true, banks: Int = 1
           address = 0x39000000,
           numCores = tiles.size
         )),
-        sramClkDivBy2 = true,
+        sramClkDivBy2 = false,
         sramDepthDiv = 4,
         tagECC = None,
         dataECC = None,
@@ -452,11 +452,6 @@ class NanHuGFPGAConfig(n: Int = 1) extends Config(
     case DebugOptionsKey => up(DebugOptionsKey).copy(
       AlwaysBasicDiff = false
     )
-    case SoCParamsKey => up(SoCParamsKey).copy(
-      L3CacheParamsOpt = Some(up(SoCParamsKey).L3CacheParamsOpt.get.copy(
-        sramClkDivBy2 = false,
-      ))
-    )
   })
 )
 
@@ -468,12 +463,10 @@ class MinimalFPGAConfig(n: Int = 1) extends Config(
   })
 )
 
-class NanHuGServeConfig(n: Int = 1) extends Config(
-  new NanHuGFPGAConfig(n).alter((site, here, up) => {
-    case SoCParamsKey => up(SoCParamsKey).copy(
-      L3CacheParamsOpt = Some(up(SoCParamsKey).L3CacheParamsOpt.get.copy(
-        sramClkDivBy2 = false,
-      ))
+class DefaultFPGAConfig(n: Int = 1) extends Config(
+  new DefaultConfig(n).alter((site, here, up) => {
+    case DebugOptionsKey => up(DebugOptionsKey).copy(
+      AlwaysBasicDiff = false
     )
   })
 )


### PR DESCRIPTION
Modify default sramClkDivBy2 option

Added a AXI4UserYanker() in peripheralNode for 4-core mmio id issue