### PR TITLE
timing: add register for boundry signals in memblock and l2top

### DIFF
--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -252,7 +252,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
     beu.module.io.errors.uncache := io.beu_errors.uncache
     resetDelayN.io.in := io.reset_vector.fromTile
     io.reset_vector.toCore := resetDelayN.io.out
-    io.hartId.toCore := io.hartId.fromTile
+    io.hartId.toCore := RegNext(io.hartId.fromTile)
     // add buffer to satisfy PE
     io.msiInfo.toCore.valid := RegNext(io.msiInfo.fromTile.valid)
     io.msiInfo.toCore.bits := RegEnable(io.msiInfo.fromTile.bits, io.msiInfo.fromTile.valid)
@@ -260,12 +260,12 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       teemsiInfo.toCore.valid := RegNext(teemsiInfo.fromTile.valid)
       teemsiInfo.toCore.bits := RegEnable(teemsiInfo.fromTile.bits, teemsiInfo.fromTile.valid)
     }
-    io.cpu_halt.toTile := io.cpu_halt.fromCore
-    io.cpu_critical_error.toTile := io.cpu_critical_error.fromCore
+    io.cpu_halt.toTile := RegNext(io.cpu_halt.fromCore)
+    io.cpu_critical_error.toTile := RegNext(io.cpu_critical_error.fromCore)
     io.msiAck.toTile := io.msiAck.fromCore
     io.teemsiAck.foreach( teemsiAck => teemsiAck.toTile := teemsiAck.fromCore)
-    io.l3Miss.toCore := io.l3Miss.fromTile
-    io.clintTime.toCore := io.clintTime.fromTile
+    io.l3Miss.toCore := RegNext(io.l3Miss.fromTile)
+    io.clintTime.toCore := DelayNWithValid(io.clintTime.fromTile, 1)
     // trace interface
     val traceToTile = io.traceCoreInterface.toTile
     val traceFromCore = io.traceCoreInterface.fromCore

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -26,7 +26,7 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.amba.axi4._
 import system.HasSoCParameter
 import top.{ArgParser, BusPerfMonitor, Generator}
-import utility.{ChiselDB, Constantin, DFTResetSignals, DelayN, FileRegisters, ResetGen, TLClientsMerger, TLEdgeBuffer, TLLogger}
+import utility._
 import utility.sram.SramBroadcastBundle
 import coupledL2.EnableCHI
 import coupledL2.tl2chi.PortIO
@@ -53,10 +53,10 @@ class XSTile()(implicit p: Parameters) extends LazyModule
   val plic_int_node = l2top.inner.plic_int_node
   val debug_int_node = l2top.inner.debug_int_node
   val nmi_int_node = l2top.inner.nmi_int_node
-  memBlock.clint_int_sink := clint_int_node
-  memBlock.plic_int_sink :*= plic_int_node
-  memBlock.debug_int_sink := debug_int_node
-  memBlock.nmi_int_sink := nmi_int_node
+  memBlock.clint_int_sink := IntBuffer() := clint_int_node
+  memBlock.plic_int_sink :*= IntBuffer() :*= plic_int_node
+  memBlock.debug_int_sink := IntBuffer() := debug_int_node
+  memBlock.nmi_int_sink   := IntBuffer() := nmi_int_node
   memBlock.beu_local_int_sink := l2top.inner.beu_local_int_source_buffer
 
   // =========== Components' Connection ============

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1994,15 +1994,15 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     )
   ))
   io.mem_to_ooo.topToBackendBypass match { case x =>
-    x.hartId            := io.hartId
+    x.hartId            := RegNext(io.hartId)
     x.l2FlushDone       := RegNext(io.l2_flush_done)
-    x.externalInterrupt.msip  := outer.clint_int_sink.in.head._1(0)
-    x.externalInterrupt.mtip  := outer.clint_int_sink.in.head._1(1)
-    x.externalInterrupt.meip  := outer.plic_int_sink.in.head._1(0)
-    x.externalInterrupt.seip  := outer.plic_int_sink.in.last._1(0)
-    x.externalInterrupt.debug := outer.debug_int_sink.in.head._1(0)
-    x.externalInterrupt.nmi.nmi_31 := outer.nmi_int_sink.in.head._1(0) | outer.beu_local_int_sink.in.head._1(0)
-    x.externalInterrupt.nmi.nmi_43 := outer.nmi_int_sink.in.head._1(1)
+    x.externalInterrupt.msip  := RegNext(outer.clint_int_sink.in.head._1(0))
+    x.externalInterrupt.mtip  := RegNext(outer.clint_int_sink.in.head._1(1))
+    x.externalInterrupt.meip  := RegNext(outer.plic_int_sink.in.head._1(0))
+    x.externalInterrupt.seip  := RegNext(outer.plic_int_sink.in.last._1(0))
+    x.externalInterrupt.debug := RegNext(outer.debug_int_sink.in.head._1(0))
+    x.externalInterrupt.nmi.nmi_31 := RegNext(outer.nmi_int_sink.in.head._1(0) | outer.beu_local_int_sink.in.head._1(0))
+    x.externalInterrupt.nmi.nmi_43 := RegNext(outer.nmi_int_sink.in.head._1(1))
     x.msiInfo           := DelayNWithValid(io.fromTopToBackend.msiInfo, 1)
     x.teemsiInfo zip io.fromTopToBackend.teemsiInfo foreach { case (x_teemsiInfo, io_teemsiInfo) =>
       x_teemsiInfo        := DelayNWithValid(io_teemsiInfo, 1)
@@ -2016,10 +2016,10 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
 
   io.inner_hartId := io.hartId
   io.inner_reset_vector := RegNext(io.outer_reset_vector)
-  io.outer_cpu_halt := io.ooo_to_mem.backendToTopBypass.cpuHalted
+  io.outer_cpu_halt := RegNext(io.ooo_to_mem.backendToTopBypass.cpuHalted)
   io.outer_l2_flush_en := io.ooo_to_mem.csrCtrl.flush_l2_enable
   io.outer_power_down_en := io.ooo_to_mem.csrCtrl.power_down_enable
-  io.outer_cpu_critical_error := io.ooo_to_mem.backendToTopBypass.cpuCriticalError
+  io.outer_cpu_critical_error := RegNext(io.ooo_to_mem.backendToTopBypass.cpuCriticalError)
   io.outer_msi_ack := io.ooo_to_mem.backendToTopBypass.msiAck
   io.outer_teemsi_ack zip io.ooo_to_mem.backendToTopBypass.teemsiAck foreach { case (teemsi_ack, teemsiAck) =>
     teemsi_ack := teemsiAck


### PR DESCRIPTION
Include:
1.  Input signals: `nmi, plic, debug, clint`, `hartid`, `clinttime`, `l3miss`
2.  Output signals: `cpu_halt`, `cpu_critical_error` 
`msiinfo` has been piped by previous commit
