### PR TITLE
feat(clockGate): support disable clockgate with parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ endif
 # emu for the release version
 RELEASE_ARGS += --fpga-platform --disable-all --remove-assert --reset-gen --firtool-opt --ignore-read-enable-mem
 ifeq ($(FPGA), 1)
-override DEBUG_ARGS	+= --fpga-platform --disable-all --remove-assert
+override DEBUG_ARGS	+= --fpga-platform --disable-all --remove-assert --disable-clockgate
 else
 override DEBUG_ARGS	+= --enable-difftest
 endif

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -48,6 +48,7 @@ object ArgParser {
       |--with-rollingdb
       |--disable-perf
       |--disable-alwaysdb
+      |--disable-clockgate
       |--enable-dfx
       |""".stripMargin
 
@@ -140,6 +141,10 @@ object ArgParser {
         case "--disable-alwaysdb" :: tail =>
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(AlwaysBasicDB = false)
+          }), tail)
+        case "--disable-clockgate" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case XSTileKey => up(XSTileKey).map(_.copy(EnableClockGate = false))
           }), tail)
         case "--xstop-prefix" :: value :: tail =>
           nextOption(config.alter((site, here, up) => {

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -25,7 +25,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tile.{BusErrorUnit, BusErrorUnitParams, BusErrors, MaxHartIdBits}
 import freechips.rocketchip.tilelink._
-import coupledL2.{EnableCHI, L2ParamKey, PrefetchCtrlFromCore}
+import coupledL2.{EnableCHI, EnableL2ClockGate, L2ParamKey, PrefetchCtrlFromCore}
 import coupledL2.tl2tl.TL2TLCoupledL2
 import coupledL2.tl2chi.{CHIIssue, PortIO, TL2CHICoupledL2, CHIAddrWidthKey, NonSecureKey}
 import huancun.BankBitsKey
@@ -117,6 +117,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
         PrivateClintRange = if(UsePrivateClint) Some(TIMERRange) else None
       )
       case EnableCHI => p(EnableCHI)
+      case EnableL2ClockGate => EnableClockGate
       case CHIIssue => p(CHIIssue)
       case CHIAddrWidthKey => p(CHIAddrWidthKey)
       case NonSecureKey => p(NonSecureKey)

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -187,7 +187,7 @@ class DataSRAMBank(index: Int)(implicit p: Parameters) extends DCacheModule {
       shouldReset = false,
       holdRead = false,
       singlePort = true,
-      withClockGate = true,
+      withClockGate = EnableClockGate,
       hasMbist = hasMbist,
       hasSramCtl = hasSramCtl,
       suffix = Some("dcsh_dat")

--- a/src/main/scala/xiangshan/cache/dcache/meta/TagArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/meta/TagArray.scala
@@ -75,7 +75,7 @@ class TagSRAMBank(index: Int)(implicit p: Parameters) extends AbstractTagArray {
   }
 
   val tag_array = Module(new SRAMTemplate(UInt(encTagBits.W), set = nSets, way = DCacheWayDiv,
-    shouldReset = false, holdRead = false, singlePort = true, withClockGate = true,
+    shouldReset = false, holdRead = false, singlePort = true, withClockGate = EnableClockGate,
     hasMbist = hasMbist,  hasSramCtl = hasSramCtl, suffix = Some("dcsh_tag")))
 
   val wen = rst || io.write.valid

--- a/src/main/scala/xiangshan/cache/mmu/BitmapCheck.scala
+++ b/src/main/scala/xiangshan/cache/mmu/BitmapCheck.scala
@@ -454,9 +454,11 @@ class BitmapCache(implicit p: Parameters) extends XSModule with HasPtwConst {
   PipelineConnect(stageDelay, stageResp, stageResp.ready, flush)
   stageResp.ready := !stageResp.valid || io.resp.ready
 
-  val te = ClockGate.genTeSink
-  val bc_masked_clock = ClockGate(te.cgen, stageReq.fire | (!flush && io.refill.valid) | mbistBC.map(_.mbist.req).getOrElse(false.B), clock)
-  bitmapcache.clock := bc_masked_clock
+  if (EnableClockGate) {
+    val te = ClockGate.genTeSink
+    val bc_masked_clock = ClockGate(te.cgen, stageReq.fire | (!flush && io.refill.valid) | mbistBC.map(_.mbist.req).getOrElse(false.B), clock)
+    bitmapcache.clock := bc_masked_clock
+  }
 
   val ppn_search = stageReq.bits.tag
   val ridx = genPtwBCSetIdx(ppn_search)

--- a/src/main/scala/xiangshan/frontend/FTB.scala
+++ b/src/main/scala/xiangshan/frontend/FTB.scala
@@ -501,7 +501,7 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
       shouldReset = true,
       holdRead = false,
       singlePort = true,
-      withClockGate = true,
+      withClockGate = EnableClockGate,
       hasMbist = hasMbist,
       hasSramCtl = hasSramCtl
     ))

--- a/src/main/scala/xiangshan/frontend/ITTAGE.scala
+++ b/src/main/scala/xiangshan/frontend/ITTAGE.scala
@@ -277,7 +277,7 @@ class ITTageTable(
     holdRead = true,
     singlePort = true,
     useBitmask = true,
-    withClockGate = true,
+    withClockGate = EnableClockGate,
     hasMbist = hasMbist,
     hasSramCtl = hasSramCtl
   ))

--- a/src/main/scala/xiangshan/frontend/SC.scala
+++ b/src/main/scala/xiangshan/frontend/SC.scala
@@ -88,7 +88,7 @@ class SCTable(val nRows: Int, val ctrBits: Int, val histLen: Int)(implicit p: Pa
     shouldReset = true,
     holdRead = true,
     singlePort = true,
-    withClockGate = true,
+    withClockGate = EnableClockGate,
     hasMbist = hasMbist,
     hasSramCtl = hasSramCtl
   )))

--- a/src/main/scala/xiangshan/frontend/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/Tage.scala
@@ -175,7 +175,7 @@ class TageBTable(implicit p: Parameters) extends XSModule with TBTParams {
       shouldReset = false,
       singlePort = true,
       holdRead = true,
-      withClockGate = true,
+      withClockGate = EnableClockGate,
       hasMbist = hasMbist,
       hasSramCtl = hasSramCtl
     )
@@ -351,7 +351,7 @@ class TageTable(
     extraReset = true,
     holdRead = true,
     singlePort = true,
-    withClockGate = true,
+    withClockGate = EnableClockGate,
     hasMbist = hasMbist,
     hasSramCtl = hasSramCtl
   ))
@@ -366,7 +366,7 @@ class TageTable(
       shouldReset = true,
       holdRead = true,
       singlePort = true,
-      withClockGate = true,
+      withClockGate = EnableClockGate,
       hasMbist = hasMbist,
       hasSramCtl = hasSramCtl
     ))

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -278,7 +278,7 @@ class ICacheMetaArray(implicit p: Parameters) extends ICacheArray with HasICache
       shouldReset = true,
       holdRead = true,
       singlePort = true,
-      withClockGate = true,
+      withClockGate = EnableClockGate,
       hasMbist = hasMbist,
       hasSramCtl = hasSramCtl
     ))
@@ -802,7 +802,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
 //      shouldReset = true,
 //      holdRead = true,
 //      singlePort = true,
-//      withClockGate = true
+//      withClockGate = EnableClockGate
 //    ))
 //
 //    sramBank.io.r.req.valid := io.read.req(bank).valid

--- a/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
@@ -595,7 +595,7 @@ class PatternHistoryTable()(implicit p: Parameters) extends XSModule with HasSMS
     set = smsParams.pht_size / smsParams.pht_ways,
     way =smsParams.pht_ways,
     singlePort = true,
-    withClockGate = true,
+    withClockGate = EnableClockGate,
     hasMbist = hasMbist,
     hasSramCtl = hasSramCtl
   ))


### PR DESCRIPTION
This change support disable all existing ClockGate except from global clock in XSNoCTop, with command `--disable-clockgate`.

Note currently we only use this arg for FPGA Difftest, it will not affect release code now.