### PR TITLE
timing(L2Top): delay dft for best timing

### DIFF
--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -239,8 +239,12 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       val dft_reset_out = Option.when(hasMbist)(Output(new DFTResetSignals()))
       // val reset_core = IO(Output(Reset()))
     })
-    io.dft_out.zip(io.dft).foreach({ case(a, b) => a := b })
-    io.dft_reset_out.zip(io.dft_reset).foreach({ case(a, b) => a := b })
+    io.dft_out.zip(io.dft).foreach({ case(a, b) =>
+      a := b
+      a.ram_hold := RegNext(b.ram_hold)
+      a.cgen := RegNext(b.cgen)
+    })
+    io.dft_reset_out.zip(io.dft_reset).foreach({ case(a, b) => a := RegNext(b) })
 
     val resetDelayN = Module(new DelayN(UInt(PAddrBits.W), 5))
 

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -174,8 +174,8 @@ class XSTile()(implicit p: Parameters) extends LazyModule
 
     l2top.module.io.dft.zip(io.dft).foreach({ case (a, b) => a := b })
     l2top.module.io.dft_reset.zip(io.dft_reset).foreach({ case (a, b) => a := b })
-    core.module.io.dft.zip(io.dft).foreach({ case (a, b) => a := b })
-    core.module.io.dft_reset.zip(io.dft_reset).foreach({ case (a, b) => a := b })
+    core.module.io.dft.zip(l2top.module.io.dft_out).foreach({ case (a, b) => a := b })
+    core.module.io.dft_reset.zip(l2top.module.io.dft_reset_out).foreach({ case (a, b) => a := b })
 
     if (enableL2) {
       // TODO: add ECC interface of L2


### PR DESCRIPTION
1. add register for boundary singnals in L2Top
2. use `l2top.module.io.dft_out`, `l2top.module.io.dft_reset_out` instead of `io.dft`, `io.dft_reset` to core