### PR TITLE
fix(BranchUnit): fix width of `brhRealTarget`

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/wrapper/BranchUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/BranchUnit.scala
@@ -51,7 +51,7 @@ class BranchUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
   io.in.ready := io.out.ready
 
   val brhPredictTarget = io.in.bits.ctrl.predictInfo.get.target
-  val brhRealTarget = addModule.io.target
+  val brhRealTarget = addModule.io.target(VAddrData().dataWidth - 1, 0)
   val targetWrong = dataModule.io.fixedTaken && dataModule.io.taken && (brhRealTarget =/= brhPredictTarget)
   val isMisPred = dataModule.io.mispredict || targetWrong
   io.out.bits.res.data := 0.U


### PR DESCRIPTION
Currently, `brhPredictTarget` is 50bits (sv48x4) while `brhRealTarget` is 64bits and they are zero-extended while comparing. So for Linux, etc. all branches in high address space (i.e. `vaddr[49] == 1`) will be marked as mispredict and do redirect.

This PR compares only lower 50bits of target, the higher bits are checked later (i.e. `checkAccessFault`, etc.) to make sure they are legal address.

DefaultConfig Linux IPC 1.35 -> 2.50 in local test.

JumpUnit does not have the issue:
https://github.com/OpenXiangShan/XiangShan/blob/1f2664717662b7cff611e7aea6ea81b18e1012c3/src/main/scala/xiangshan/backend/fu/wrapper/JumpUnit.scala#L39-L42