### PR TITLE
fix(bpu): fix decoupled train

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
@@ -38,7 +38,8 @@ abstract class BasePredictorIO(implicit p: Parameters) extends BpuBundle {
   // predict request
   val startPc: PrunedAddr = Input(PrunedAddr(VAddrBits))
   // resolve train
-  val train: DecoupledIO[BpuTrain] = Flipped(Decoupled(new BpuTrain))
+  val trainReady: Bool     = Output(Bool())
+  val train:      BpuTrain = Input(new BpuTrain)
   // fast train for s1 predictors
   val fastTrain: Option[Valid[BpuFastTrain]] = None
 

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -329,6 +329,8 @@ class StageCtrl(implicit p: Parameters) extends BpuBundle {
   val s1_fire: Bool = Bool()
   val s2_fire: Bool = Bool()
   val s3_fire: Bool = Bool()
+
+  val t0_fire: Bool = Bool()
 }
 
 // sub predictors -> Bpu top

--- a/src/main/scala/xiangshan/frontend/bpu/FallThroughPredictor.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/FallThroughPredictor.scala
@@ -31,7 +31,7 @@ class FallThroughPredictor(implicit p: Parameters) extends BasePredictor
 
   io.resetDone := true.B
 
-  io.train.ready := true.B
+  io.trainReady := true.B
 
   /* *** predict stage 0 *** */
   private val s0_fire    = io.stageCtrl.s0_fire

--- a/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
@@ -51,7 +51,7 @@ class Ras(implicit p: Parameters) extends BasePredictor with HasRasParameters wi
 
   io.resetDone := true.B
 
-  io.train.ready := true.B
+  io.trainReady := true.B
 
   def alignMask: UInt = ((~0.U(VAddrBits.W)) << FetchBlockAlignWidth).asUInt
 


### PR DESCRIPTION
When some predictor (currently only tage) is not ready for train, ftq will continuously send the same valid train to Bpu. If other predictors uses their own `io.train.fire` (i.e. `ftqTrain.valid && self.ready`), they might train multiple times on a same entry, which is bad.

We need each predictor to use the same `ftqTrain.fire` (i.e. `ftqTrain.valid && allPredictors.map(_.ready).reduce(_ || _)`) to avoid the issue.