### PR TITLE
chore(bundle): rename all instances of PerfDebugInfo as perfDebugInfo

### DIFF
--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -249,7 +249,7 @@ object Bundles {
     val debug_seqNum = InstSeqNum()
     val instr = UInt(32.W)
     val fusionNum = UInt(2.W)
-    val debugInfo = new PerfDebugInfo
+    val perfDebugInfo = new PerfDebugInfo
     val debug_sim_trig = Bool()
   }
 
@@ -413,7 +413,7 @@ object Bundles {
     val trigger = OptionWrapper(params.trigger, TriggerAction())
     // debug bundle
     val debug = new DebugBundle
-    val debugInfo = new PerfDebugInfo
+    val perfDebugInfo = new PerfDebugInfo
     val debug_seqNum = InstSeqNum()
   }
   // DecodeOutUop --[Rename]--> DynInst
@@ -484,7 +484,7 @@ object Bundles {
 
     // Take snapshot at this CFI inst
     val snapshot        = Bool()
-    val debugInfo       = new PerfDebugInfo
+    val perfDebugInfo   = new PerfDebugInfo
     val debug_seqNum    = InstSeqNum()
     val storeSetHit     = Bool() // inst has been allocated an store set
     val waitForRobIdx   = new RobPtr // store set predicted previous store robIdx
@@ -542,7 +542,7 @@ object Bundles {
         this.debug_seqNum := x.debug_seqNum
         this.instr := x.instr
         this.fusionNum := x.fusionNum
-        this.debugInfo := x.debugInfo
+        this.perfDebugInfo := x.perfDebugInfo
         this.debug_sim_trig.get := x.debug_sim_trig
       })
     }
@@ -999,7 +999,7 @@ object Bundles {
       uop.sqIdx          := this.sqIdx.getOrElse(0.U.asTypeOf(new SqPtr))
       uop.ftqPtr         := this.ftqIdx.getOrElse(0.U.asTypeOf(new FtqPtr))
       uop.ftqOffset      := this.ftqOffset.getOrElse(0.U)
-      uop.debugInfo      := this.perfDebugInfo
+      uop.perfDebugInfo      := this.perfDebugInfo
       uop.debug_seqNum   := this.debug_seqNum
       uop.vpu            := this.vpu.getOrElse(0.U.asTypeOf(new VPUCtrlSignals))
       uop.isRVC          := this.isRVC.getOrElse(false.B)
@@ -1053,7 +1053,7 @@ object Bundles {
     // isFromLoadUnit indicates whether this ExuOutput is issued from LoadUnit (e.g., not so for atomics)
     val isFromLoadUnit = if (params.hasLoadFu) Some(Bool()) else None
     val debug = new DebugBundle
-    val debugInfo = new PerfDebugInfo
+    val perfDebugInfo = new PerfDebugInfo
     val debug_seqNum = InstSeqNum()
   }
 
@@ -1074,7 +1074,7 @@ object Bundles {
     val vxsat = Bool()
     val exceptionVec = ExceptionVec()
     val debug = new DebugBundle
-    val debugInfo = new PerfDebugInfo
+    val perfDebugInfo = new PerfDebugInfo
     val debug_seqNum = InstSeqNum()
 
     this.wakeupSource = s"WB(${params.toString})"
@@ -1097,7 +1097,7 @@ object Bundles {
       this.vxsat := source.vxsat.getOrElse(0.U.asTypeOf(this.vxsat))
       this.exceptionVec := source.exceptionVec.getOrElse(0.U.asTypeOf(this.exceptionVec))
       this.debug := source.debug
-      this.debugInfo := source.debugInfo
+      this.perfDebugInfo := source.perfDebugInfo
       this.debug_seqNum := source.debug_seqNum
     }
 
@@ -1273,7 +1273,7 @@ object Bundles {
       output.flushPipe.foreach(_ := this.uop.flushPipe)
       output.replay.foreach(_ := this.uop.replayInst)
       output.debug := this.debug
-      output.debugInfo := this.uop.debugInfo
+      output.perfDebugInfo := this.uop.perfDebugInfo
       output.debug_seqNum := this.uop.debug_seqNum
       output.lqIdx.foreach(_ := this.uop.lqIdx)
       output.sqIdx.foreach(_ := this.uop.sqIdx)

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -137,7 +137,7 @@ class CtrlBlockImp(
     val delayed = Wire(Valid(new ExuOutput(x.bits.params)))
     delayed.valid := GatedValidRegNext(valid && !killedByOlder)
     delayed.bits := RegEnable(x.bits, x.valid)
-    delayed.bits.debugInfo.writebackTime := GTimer()
+    delayed.bits.perfDebugInfo.writebackTime := GTimer()
     delayed
   }).toSeq
   private val delayedWriteBack = Wire(chiselTypeOf(io.fromWB.wbData))

--- a/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
@@ -767,7 +767,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
   for (i <- 0 until RenameWidth) {
 
     updatedUop(i).connectRenameOutUop(fromRename(i).bits)
-    updatedUop(i).debugInfo.eliminatedMove := fromRename(i).bits.isMove
+    updatedUop(i).perfDebugInfo.eliminatedMove := fromRename(i).bits.isMove
     // For the LUI instruction: psrc(0) is from register file and should always be zero.
     when (fromRename(i).bits.isLUI) {
       updatedUop(i).psrc(0) := 0.U

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -418,7 +418,7 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
   // debug info
   io.out.bits.debug     := 0.U.asTypeOf(io.out.bits.debug)
   io.out.bits.debug.isPerfCnt := funcUnits.map(_.io.csrio.map(_.isPerfCnt)).map(_.getOrElse(false.B)).reduce(_ || _)
-  io.out.bits.debugInfo := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.perfDebugInfo))
+  io.out.bits.perfDebugInfo := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.perfDebugInfo))
   io.out.bits.debug_seqNum := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.debug_seqNum))
 }
 

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -422,7 +422,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     ))
 
     // Assign performance counters
-    uops(i).debug.foreach(_.debugInfo.renameTime := GTimer())
+    uops(i).debug.foreach(_.perfDebugInfo.renameTime := GTimer())
 
     io.out(i).valid := io.in(i).valid && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !io.rabCommits.isWalk
     io.out(i).bits := uops(i)

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -455,13 +455,13 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       val enqIndex = allocatePtrVec(i).value
       // store uop in data module and debug_microOp Vec
       debug_microOp(enqIndex) := enqUop
-      debug_microOp(enqIndex).debugInfo.dispatchTime := timer
-      debug_microOp(enqIndex).debugInfo.enqRsTime := timer
-      debug_microOp(enqIndex).debugInfo.selectTime := timer
-      debug_microOp(enqIndex).debugInfo.issueTime := timer
-      debug_microOp(enqIndex).debugInfo.writebackTime := timer
-      debug_microOp(enqIndex).debugInfo.tlbFirstReqTime := timer
-      debug_microOp(enqIndex).debugInfo.tlbRespTime := timer
+      debug_microOp(enqIndex).perfDebugInfo.dispatchTime := timer
+      debug_microOp(enqIndex).perfDebugInfo.enqRsTime := timer
+      debug_microOp(enqIndex).perfDebugInfo.selectTime := timer
+      debug_microOp(enqIndex).perfDebugInfo.issueTime := timer
+      debug_microOp(enqIndex).perfDebugInfo.writebackTime := timer
+      debug_microOp(enqIndex).perfDebugInfo.tlbFirstReqTime := timer
+      debug_microOp(enqIndex).perfDebugInfo.tlbRespTime := timer
       debug_lsInfo(enqIndex) := DebugLsInfo.init
       debug_lsTopdownInfo(enqIndex) := LsTopdownInfo.init
       debug_lqIdxValid(enqIndex) := false.B
@@ -561,12 +561,12 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     when(wb.valid) {
       debug_exuData(wbIdx) := wb.bits.data(0)
       debug_exuDebug(wbIdx) := wb.bits.debug
-      debug_microOp(wbIdx).debugInfo.enqRsTime := wb.bits.debugInfo.enqRsTime
-      debug_microOp(wbIdx).debugInfo.selectTime := wb.bits.debugInfo.selectTime
-      debug_microOp(wbIdx).debugInfo.issueTime := wb.bits.debugInfo.issueTime
-      debug_microOp(wbIdx).debugInfo.writebackTime := wb.bits.debugInfo.writebackTime
-      debug_microOp(wbIdx).debugInfo.tlbFirstReqTime := wb.bits.debugInfo.tlbFirstReqTime
-      debug_microOp(wbIdx).debugInfo.tlbRespTime := wb.bits.debugInfo.tlbRespTime
+      debug_microOp(wbIdx).perfDebugInfo.enqRsTime := wb.bits.perfDebugInfo.enqRsTime
+      debug_microOp(wbIdx).perfDebugInfo.selectTime := wb.bits.perfDebugInfo.selectTime
+      debug_microOp(wbIdx).perfDebugInfo.issueTime := wb.bits.perfDebugInfo.issueTime
+      debug_microOp(wbIdx).perfDebugInfo.writebackTime := wb.bits.perfDebugInfo.writebackTime
+      debug_microOp(wbIdx).perfDebugInfo.tlbFirstReqTime := wb.bits.perfDebugInfo.tlbFirstReqTime
+      debug_microOp(wbIdx).perfDebugInfo.tlbRespTime := wb.bits.perfDebugInfo.tlbRespTime
 
       // debug for lqidx and sqidx
       debug_microOp(wbIdx).lqIdx := wb.bits.lqIdx.getOrElse(0.U.asTypeOf(new LqPtr))
@@ -1381,14 +1381,14 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     XSPerfAccumulate(s"commitCompressCnt${i}", PopCount(io.commits.commitValid.zip(instrSizeCommit).map { case (valid, instrSize) => io.commits.isCommit && valid && instrSize === i.U }))
   )
   XSPerfAccumulate("compressSize", io.commits.commitValid.zip(instrSizeCommit).map { case (valid, instrSize) => Mux(io.commits.isCommit && valid && instrSize > 1.U, instrSize, 0.U) }.reduce(_ +& _))
-  val dispatchLatency = commitDebugUop.map(uop => uop.debugInfo.dispatchTime - uop.debugInfo.renameTime)
-  val enqRsLatency = commitDebugUop.map(uop => uop.debugInfo.enqRsTime - uop.debugInfo.dispatchTime)
-  val selectLatency = commitDebugUop.map(uop => uop.debugInfo.selectTime - uop.debugInfo.enqRsTime)
-  val issueLatency = commitDebugUop.map(uop => uop.debugInfo.issueTime - uop.debugInfo.selectTime)
-  val executeLatency = commitDebugUop.map(uop => uop.debugInfo.writebackTime - uop.debugInfo.issueTime)
-  val rsFuLatency = commitDebugUop.map(uop => uop.debugInfo.writebackTime - uop.debugInfo.enqRsTime)
-  val commitLatency = commitDebugUop.map(uop => timer - uop.debugInfo.writebackTime)
-  val tlbLatency = commitDebugUop.map(uop => uop.debugInfo.tlbRespTime - uop.debugInfo.tlbFirstReqTime)
+  val dispatchLatency = commitDebugUop.map(uop => uop.perfDebugInfo.dispatchTime - uop.perfDebugInfo.renameTime)
+  val enqRsLatency = commitDebugUop.map(uop => uop.perfDebugInfo.enqRsTime - uop.perfDebugInfo.dispatchTime)
+  val selectLatency = commitDebugUop.map(uop => uop.perfDebugInfo.selectTime - uop.perfDebugInfo.enqRsTime)
+  val issueLatency = commitDebugUop.map(uop => uop.perfDebugInfo.issueTime - uop.perfDebugInfo.selectTime)
+  val executeLatency = commitDebugUop.map(uop => uop.perfDebugInfo.writebackTime - uop.perfDebugInfo.issueTime)
+  val rsFuLatency = commitDebugUop.map(uop => uop.perfDebugInfo.writebackTime - uop.perfDebugInfo.enqRsTime)
+  val commitLatency = commitDebugUop.map(uop => timer - uop.perfDebugInfo.writebackTime)
+  val tlbLatency = commitDebugUop.map(uop => uop.perfDebugInfo.tlbRespTime - uop.perfDebugInfo.tlbFirstReqTime)
 
   def latencySum(cond: Seq[Bool], latency: Seq[UInt]): UInt = {
     cond.zip(latency).map(x => Mux(x._1, x._2, 0.U)).reduce(_ +& _)
@@ -1445,15 +1445,15 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
         debug_instData.robIdx := idx
         debug_instData.dvaddr := wb.bits.debug.vaddr
         debug_instData.dpaddr := wb.bits.debug.paddr
-        debug_instData.issueTime := wb.bits.debugInfo.issueTime
-        debug_instData.writebackTime := wb.bits.debugInfo.writebackTime
-        debug_instData.dispatchLatency := wb.bits.debugInfo.dispatchTime - wb.bits.debugInfo.renameTime
-        debug_instData.enqRsLatency := wb.bits.debugInfo.enqRsTime - wb.bits.debugInfo.dispatchTime
-        debug_instData.selectLatency := wb.bits.debugInfo.selectTime - wb.bits.debugInfo.enqRsTime
-        debug_instData.issueLatency := wb.bits.debugInfo.issueTime - wb.bits.debugInfo.selectTime
-        debug_instData.executeLatency := wb.bits.debugInfo.writebackTime - wb.bits.debugInfo.issueTime
-        debug_instData.rsFuLatency := wb.bits.debugInfo.writebackTime - wb.bits.debugInfo.enqRsTime
-        debug_instData.tlbLatency := wb.bits.debugInfo.tlbRespTime - wb.bits.debugInfo.tlbFirstReqTime
+        debug_instData.issueTime := wb.bits.perfDebugInfo.issueTime
+        debug_instData.writebackTime := wb.bits.perfDebugInfo.writebackTime
+        debug_instData.dispatchLatency := wb.bits.perfDebugInfo.dispatchTime - wb.bits.perfDebugInfo.renameTime
+        debug_instData.enqRsLatency := wb.bits.perfDebugInfo.enqRsTime - wb.bits.perfDebugInfo.dispatchTime
+        debug_instData.selectLatency := wb.bits.perfDebugInfo.selectTime - wb.bits.perfDebugInfo.enqRsTime
+        debug_instData.issueLatency := wb.bits.perfDebugInfo.issueTime - wb.bits.perfDebugInfo.selectTime
+        debug_instData.executeLatency := wb.bits.perfDebugInfo.writebackTime - wb.bits.perfDebugInfo.issueTime
+        debug_instData.rsFuLatency := wb.bits.perfDebugInfo.writebackTime - wb.bits.perfDebugInfo.enqRsTime
+        debug_instData.tlbLatency := wb.bits.perfDebugInfo.tlbRespTime - wb.bits.perfDebugInfo.tlbFirstReqTime
         debug_instData.exceptType := Cat(wb.bits.exceptionVec.getOrElse(ExceptionVec(false.B)))
         debug_instData.lsInfo := debug_lsInfo(idx)
         // debug_instData.globalID := wb.bits.uop.ctrl.debug_globalID

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
@@ -582,7 +582,7 @@ class LoadMisalignBuffer(val param: ExeUnitParams)(implicit p: Parameters) exten
     x.isVlm := VlduType.isMasked(req.uop.fuOpType) && VlduType.isVecLd(req.uop.fuOpType)
   }
   io.writeBack.bits.isFromLoadUnit.get := true.B
-  io.writeBack.bits.debugInfo := req.uop.debugInfo
+  io.writeBack.bits.perfDebugInfo := req.uop.perfDebugInfo
   io.writeBack.bits.debug.isMMIO := globalMMIO
   io.writeBack.bits.debug.isNCIO := globalNC && !globalMemBackTypeMM
   io.writeBack.bits.debug.isPerfCnt := false.B

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
@@ -355,7 +355,7 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
     redirect.bits.stFtqOffset := stFtqOffset(i)
     redirect.bits.level       := RedirectLevel.flush
     redirect.bits.target      := rollbackLqWb(i).bits.pc
-    redirect.bits.debug_runahead_checkpoint_id := rollbackLqWb(i).bits.debugInfo.runahead_checkpoint_id
+    redirect.bits.debug_runahead_checkpoint_id := rollbackLqWb(i).bits.perfDebugInfo.runahead_checkpoint_id
     redirect
   })
   io.rollback := allRedirect

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -560,7 +560,7 @@ class LoadQueueUncache(implicit p: Parameters) extends XSModule
     redirect.bits.ftqOffset   := reqSelUops(i).ftqOffset
     redirect.bits.level       := RedirectLevel.flush
     redirect.bits.target      := reqSelUops(i).pc // TODO: check if need pc
-    redirect.bits.debug_runahead_checkpoint_id := reqSelUops(i).debugInfo.runahead_checkpoint_id
+    redirect.bits.debug_runahead_checkpoint_id := reqSelUops(i).perfDebugInfo.runahead_checkpoint_id
     redirect
   })
   val oldestOneHot = selectOldestRedirect(allRedirect)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -615,7 +615,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   io.writeBack.bits.debug.isPerfCnt := false.B
   io.writeBack.bits.debug.paddr := req.paddr
   io.writeBack.bits.debug.vaddr := req.vaddr
-  io.writeBack.bits.debugInfo := req.uop.debugInfo
+  io.writeBack.bits.perfDebugInfo := req.uop.perfDebugInfo
   io.writeBack.bits.debug_seqNum := req.uop.debug_seqNum
 
   io.vecWriteBack.zipWithIndex.map{

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -567,7 +567,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     }
     when (io.storeAddrIn(i).fire) {
       uop(stWbIndex) := io.storeAddrIn(i).bits.uop
-      uop(stWbIndex).debugInfo := io.storeAddrIn(i).bits.uop.debugInfo
+      uop(stWbIndex).perfDebugInfo := io.storeAddrIn(i).bits.uop.perfDebugInfo
       uop(stWbIndex).debug_seqNum := io.storeAddrIn(i).bits.uop.debug_seqNum
     }
     XSInfo(io.storeAddrIn(i).fire && !io.storeAddrIn(i).bits.isFrmMisAlignBuf,
@@ -1062,7 +1062,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   io.mmioStout.bits.flushPipe.foreach(_ := deqCanDoCbo) // flush Pipeline to keep order in CMO
   io.mmioStout.bits.sqIdx.foreach(_ := deqPtrExt(0))
   io.mmioStout.bits.trigger.foreach(_ := uncacheUop.trigger)
-  io.mmioStout.bits.debugInfo := uncacheUop.debugInfo
+  io.mmioStout.bits.perfDebugInfo := uncacheUop.perfDebugInfo
   io.mmioStout.bits.debug_seqNum := uncacheUop.debug_seqNum
   io.mmioStout.bits.debug.isMMIO := true.B
   io.mmioStout.bits.debug.isNCIO := false.B
@@ -1085,7 +1085,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   io.cboZeroStout.bits.flushPipe.foreach(_ := cboZeroUop.flushPipe) // false.B ?
   io.cboZeroStout.bits.sqIdx.foreach(_ := cboZeroSqIdx)
   io.cboZeroStout.bits.trigger.foreach(_ := cboZeroUop.trigger)
-  io.cboZeroStout.bits.debugInfo := cboZeroUop.debugInfo
+  io.cboZeroStout.bits.perfDebugInfo := cboZeroUop.perfDebugInfo
   io.cboZeroStout.bits.debug_seqNum := cboZeroUop.debug_seqNum
 
   when (cboZeroWaitFlushSb && io.flushSbuffer.empty) {

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -58,7 +58,7 @@ class LoadToLsqReplayIO(implicit p: Parameters) extends XSBundle
   // replay cause
   val cause           = Vec(LoadReplayCauses.allCauses, Bool())
   // performance debug information
-  val debug           = new PerfDebugInfo
+  val perfDebugInfo   = new PerfDebugInfo
   // tlb hint
   val tlb_id          = UInt(log2Up(loadfiltersize).W)
   val tlb_full        = Bool()
@@ -764,9 +764,9 @@ class LoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModul
   s0_out.isMisalign := (!s0_addr_aligned || s0_sel_src.uop.exceptionVec(loadAddrMisaligned)) && s0_sel_src.vecActive
   s0_out.forward_tlDchannel := s0_src_select_vec(super_rep_idx)
   when(io.tlb.req.valid && (s0_sel_src.isFirstIssue || s0_sel_src.repForTlbMiss)) {
-    s0_out.uop.debugInfo.tlbFirstReqTime := GTimer()
+    s0_out.uop.perfDebugInfo.tlbFirstReqTime := GTimer()
   }.otherwise{
-    s0_out.uop.debugInfo.tlbFirstReqTime := s0_sel_src.uop.debugInfo.tlbFirstReqTime
+    s0_out.uop.perfDebugInfo.tlbFirstReqTime := s0_sel_src.uop.perfDebugInfo.tlbFirstReqTime
   }
   s0_out.schedIndex     := s0_sel_src.sched_idx
   //for Svpbmt Nc
@@ -892,11 +892,11 @@ class LoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModul
   s1_gpaddr_dup_lsu   := Mux(s1_in.isFastReplay, s1_in.paddr, io.tlb.resp.bits.gpaddr(0))
 
   when (io.tlb.resp.valid && !s1_tlb_miss) {
-    s1_out.uop.debugInfo.tlbRespTime := GTimer()
+    s1_out.uop.perfDebugInfo.tlbRespTime := GTimer()
   }.elsewhen (io.tlb.resp.valid && s1_tlb_miss) {
-    s1_out.uop.debugInfo.tlbRespTime := s1_in.uop.debugInfo.tlbFirstReqTime
+    s1_out.uop.perfDebugInfo.tlbRespTime := s1_in.uop.perfDebugInfo.tlbFirstReqTime
   }.otherwise {
-    s1_out.uop.debugInfo.tlbRespTime := s1_in.uop.debugInfo.tlbRespTime
+    s1_out.uop.perfDebugInfo.tlbRespTime := s1_in.uop.perfDebugInfo.tlbRespTime
   }
 
   io.tlb.req_kill   := s1_kill || s1_dly_err
@@ -965,7 +965,7 @@ class LoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModul
   s1_out.isForVSnonLeafPTE := io.tlb.resp.bits.isForVSnonLeafPTE
   s1_out.tlbMiss           := s1_tlb_miss
   s1_out.ptwBack           := io.tlb.resp.bits.ptwBack
-  s1_out.rep_info.debug    := s1_in.uop.debugInfo
+  s1_out.rep_info.perfDebugInfo    := s1_in.uop.perfDebugInfo
   s1_out.rep_info.nuke     := s1_nuke && !s1_sw_prf
   s1_out.delayedLoadError  := s1_dly_err
   s1_out.nc := (s1_nc || Pbmt.isNC(s1_pbmt)) && !s1_prf
@@ -1327,7 +1327,7 @@ class LoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModul
   s2_out.rep_info.rep_carry       := io.dcache.resp.bits.replayCarry
   s2_out.rep_info.mshr_id         := io.dcache.resp.bits.mshr_id
   s2_out.rep_info.last_beat       := s2_in.paddr(log2Up(refillBytes))
-  s2_out.rep_info.debug           := s2_in.uop.debugInfo
+  s2_out.rep_info.perfDebugInfo           := s2_in.uop.perfDebugInfo
   s2_out.rep_info.tlb_id          := io.tlb_hint.id
   s2_out.rep_info.tlb_full        := io.tlb_hint.full
 
@@ -1518,7 +1518,7 @@ class LoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModul
   io.rollback.bits.ftqOffset := s3_out.bits.uop.ftqOffset
   io.rollback.bits.level     := Mux(s3_rep_frm_fetch || s3_frm_mis_flush, RedirectLevel.flush, RedirectLevel.flushAfter)
   io.rollback.bits.target    := s3_out.bits.uop.pc
-  io.rollback.bits.debug_runahead_checkpoint_id := s3_out.bits.uop.debugInfo.runahead_checkpoint_id
+  io.rollback.bits.debug_runahead_checkpoint_id := s3_out.bits.uop.perfDebugInfo.runahead_checkpoint_id
   /* <------- DANGEROUS: Don't change sequence here ! -------> */
 
   io.lsq.ldin.bits.uop := s3_out.bits.uop
@@ -1583,7 +1583,7 @@ class LoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModul
   s3_wb.debug.isPerfCnt := false.B
   s3_wb.debug.paddr := s3_in.paddr
   s3_wb.debug.vaddr := s3_in.vaddr
-  s3_wb.debugInfo := s3_out.bits.uop.debugInfo
+  s3_wb.perfDebugInfo := s3_out.bits.uop.perfDebugInfo
   s3_wb.debug_seqNum := s3_out.bits.uop.debug_seqNum
 
   val s3_ld_wb_meta = Wire(new ExuOutput(param))

--- a/src/main/scala/xiangshan/mem/pipeline/StdExeUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StdExeUnit.scala
@@ -47,7 +47,7 @@ class StdExeUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSMod
   io.out.bits.robIdx := io.in.bits.robIdx
   io.out.bits.pdest := io.in.bits.pdest
   io.out.bits.sqIdx.foreach(_ := io.in.bits.sqIdx.get)
-  io.out.bits.debugInfo := io.in.bits.perfDebugInfo
+  io.out.bits.perfDebugInfo := io.in.bits.perfDebugInfo
   io.out.bits.debug_seqNum := io.in.bits.debug_seqNum
 
   io.atomicData.valid := io.in.fire && FuType.storeIsAMO(io.in.bits.fuType)

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -263,7 +263,7 @@ class StoreUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModu
   s0_out.isMisalign      := s0_isMisalign
   s0_out.vecBaseVaddr := s0_vecBaseVaddr
   when(s0_valid && s0_isFirstIssue) {
-    s0_out.uop.debugInfo.tlbFirstReqTime := GTimer()
+    s0_out.uop.perfDebugInfo.tlbFirstReqTime := GTimer()
   }
   s0_out.isFrmMisAlignBuf := s0_use_flow_ma
   s0_out.isFinalSplit := s0_isFinalSplit
@@ -420,7 +420,7 @@ class StoreUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModu
   val s1_tlb_memidx = io.tlb.resp.bits.memidx
   when(s1_tlb_memidx.is_st && io.tlb.resp.valid && !s1_tlb_miss && s1_tlb_memidx.idx === s1_out.uop.sqIdx.value) {
     // printf("Store idx = %d\n", s1_tlb_memidx.idx)
-    s1_out.uop.debugInfo.tlbRespTime := GTimer()
+    s1_out.uop.perfDebugInfo.tlbRespTime := GTimer()
   }
   val s1_mis_align = s1_valid && !s1_tlb_miss && !s1_in.isHWPrefetch && !s1_isCbo && !s1_out.nc && !s1_out.mmio &&
                       GatedValidRegNext(io.csrCtrl.hd_misalign_st_enable) && s1_in.isMisalign && !s1_in.misalignWith16Byte &&
@@ -602,7 +602,7 @@ class StoreUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModu
   s3_out.debug.isPerfCnt := false.B
   s3_out.debug.paddr := s3_in.paddr
   s3_out.debug.vaddr := s3_in.vaddr
-  s3_out.debugInfo := s3_in.uop.debugInfo
+  s3_out.perfDebugInfo := s3_in.uop.perfDebugInfo
   s3_out.debug_seqNum := s3_in.uop.debug_seqNum
 
   XSError(s3_valid && s3_in.isvec && s3_in.vecActive && !s3_in.mask.orR, "In vecActive, mask complement should not be 0")

--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -122,7 +122,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
       vls.isVecLoad := VlduType.isVecLd(source.uop.fuOpType)
       vls.isVlm := VlduType.isMasked(source.uop.fuOpType) && VlduType.isVecLd(source.uop.fuOpType)
     })
-    sink.debugInfo := source.uop.debugInfo
+    sink.perfDebugInfo := source.uop.perfDebugInfo
     sink.debug_seqNum := source.uop.debug_seqNum
     sink
   }
@@ -514,7 +514,7 @@ class VSMergeBufferImp(implicit p: Parameters) extends BaseVMergeBuffer(isVStore
       vls.isVecLoad := VlduType.isVecLd(source.uop.fuOpType)
       vls.isVlm := VlduType.isMasked(source.uop.fuOpType) && VlduType.isVecLd(source.uop.fuOpType)
     })
-    sink.debugInfo := source.uop.debugInfo
+    sink.perfDebugInfo := source.uop.perfDebugInfo
     sink.debug_seqNum := source.uop.debug_seqNum
     sink
   }

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -932,7 +932,7 @@ class VSegmentUnit(val param: ExeUnitParams)(implicit p: Parameters) extends VLS
       vls.isVecLoad := VlduType.isVecLd(fofBuffer.fuOpType)
       vls.isVlm := VlduType.isMasked(fofBuffer.fuOpType) && VlduType.isVecLd(fofBuffer.fuOpType)
     })
-    writebackOut.debugInfo := fofBuffer.debugInfo
+    writebackOut.perfDebugInfo := fofBuffer.perfDebugInfo
     writebackOut.debug_seqNum := fofBuffer.debug_seqNum
   }.otherwise{
     writebackOut.data := VecInit(Seq.fill(param.wbPathNum)(data(deqPtr.value)))
@@ -964,7 +964,7 @@ class VSegmentUnit(val param: ExeUnitParams)(implicit p: Parameters) extends VLS
       vls.isVlm := VlduType.isMasked(instMicroOp.uop.fuOpType) && VlduType.isVecLd(instMicroOp.uop.fuOpType)
     })
     writebackOut.debug := DontCare
-    writebackOut.debugInfo := uopq(deqPtr.value).uop.debugInfo
+    writebackOut.perfDebugInfo := uopq(deqPtr.value).uop.perfDebugInfo
     writebackOut.debug_seqNum := uopq(deqPtr.value).uop.debug_seqNum
   }
 

--- a/src/main/scala/xiangshan/mem/vector/VfofBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VfofBuffer.scala
@@ -155,7 +155,7 @@ class VfofBuffer(val param: ExeUnitParams)(implicit p: Parameters) extends VLSUM
     vls.vpu.vl := entries.vl
     vls.vpu.vmask := Fill(VLEN, 1.U)
   })
-  io.uopWriteback.bits.debugInfo := entries.uop.debugInfo
+  io.uopWriteback.bits.perfDebugInfo := entries.uop.perfDebugInfo
   io.uopWriteback.bits.debug_seqNum := entries.uop.debug_seqNum
 
 }


### PR DESCRIPTION
* To make sure they can be connected correctly by same name connection.