### PR TITLE
fix(StoreUnit): fix multi-writeback when storeMisalignBuffer full

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -493,7 +493,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   // TODO: dcache resp
   io.dcache.resp.ready := true.B
 
-  val s2_mis_align = s2_valid && RegEnable(s1_mis_align, s1_fire) && !s2_exception
+  val s2_mis_align = s2_valid && RegEnable(s1_mis_align, s1_fire)
   // goto misalignBuffer
   io.misalign_enq.revoke := s2_exception
   val s2_misalignNeedReplay = RegEnable(s1_toMisalignBufferValid && (!io.misalign_enq.req.ready || s1_misalignNeedReplay), false.B, s1_fire)
@@ -516,7 +516,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   s2_misalign_stout.bits.need_rep := RegEnable(s1_tlb_miss, s1_fire)
   io.misalign_stout := s2_misalign_stout
 
-  val s2_misalign_cango = !s2_mis_align || s2_in.isvec && s2_misalignBufferNack
+  val s2_misalign_cango = !s2_mis_align || s2_in.isvec && (s2_misalignNeedReplay || s2_exception) || !s2_in.isvec && !s2_misalignNeedReplay && s2_exception
 
   // mmio and exception
   io.lsq_replenish := s2_out


### PR DESCRIPTION
Previous:

If StoreMisalignBuffer is full and the store have exception, the store will be writebacked and will be replay from RS, which will lead to this store was writeback multiples times.

If the store writeback multiple times, it will lead to `uopNum` overflow, when rob is unable to handle exceptions in a prompt manner.

Current:

If scalar store none exception:

	[1]. needReplay: not writeback

	[2]. !needReplay: not writeback

If scalar store have exception:

	[1]. needReplay: not writeback

	[2]. !needReplay: writeback

If vector store have exception or needReplay, it need to writeback.