### PR TITLE
feat(dcache): add read-write conflict detection to LoadPipe s0

### DIFF
--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -884,7 +884,8 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
     deq.bits.common.loadDependency.foreach(_.zip(finalLoadDependency(i)).foreach { case (sink, source) => sink := source})
     // when alu select jump uop, src0's dataSource change to imm
     if (params.aluDeqNeedPickJump && (i == 0)) {
-      deq.bits.common.dataSources(0).value := Mux(entries.io.aluDeqSelectJump.get, DataSource.imm, finalDataSources(i)(0).value)
+      val src0IsReadReg = finalDataSources(i)(0).readReg
+      deq.bits.common.dataSources(0).value := Mux(entries.io.aluDeqSelectJump.get && src0IsReadReg, DataSource.imm, finalDataSources(i)(0).value)
     }
     else if (params.aluDeqNeedPickJump && (i == 1)) {
       // assign jump uop form alu deq

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1347,8 +1347,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     // TODO: remove replay and nack
     ldu(w).io.nack := false.B
 
-    ldu(w).io.wr_conflict.valid := mainPipe.io.data_write.valid
-    ldu(w).io.wr_conflict.bits := mainPipe.io.data_write.bits.wmask
+    ldu(w).io.writehint.valid := mainPipe.io.data_write.valid
+    ldu(w).io.writehint.bits := mainPipe.io.data_write.bits.wmask
 
     ldu(w).io.disable_ld_fast_wakeup :=
       bankedDataArray.io.disable_ld_fast_wakeup(w) // load pipe fast wake up should be disabled when bank conflict

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1347,6 +1347,9 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     // TODO: remove replay and nack
     ldu(w).io.nack := false.B
 
+    ldu(w).io.wr_conflict.valid := mainPipe.io.data_write.valid
+    ldu(w).io.wr_conflict.bits := mainPipe.io.data_write.bits.wmask
+
     ldu(w).io.disable_ld_fast_wakeup :=
       bankedDataArray.io.disable_ld_fast_wakeup(w) // load pipe fast wake up should be disabled when bank conflict
   }

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -117,7 +117,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
   val wr_conflict_check = Wire(Bool())
 
-  // ready can wait for valid
+  // ready depends on valid
   io.lsu.req.ready := ((!io.nack && not_nacked_ready) || (io.nack && nacked_ready)) && !wr_conflict_check
   io.meta_read.valid := io.lsu.req.fire && !io.nack
   io.tag_read.valid := io.lsu.req.fire && !io.nack

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -70,7 +70,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
     val wbq_block_miss_req = Input(Bool())
 
     // write hint from main pipe
-    val writehint = Flipped(Valid(Bits(DCacheBanks.W)))
+    val writehint = Flipped(Valid(UInt(DCacheBanks.W)))
 
     // update state vec in replacement algo
     val replace_access = ValidIO(new ReplacementAccessBundle)

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -136,7 +136,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   assert(RegNext(!(s0_valid && (s0_req.cmd =/= MemoryOpConstants.M_XRD && s0_req.cmd =/= MemoryOpConstants.M_PFR && s0_req.cmd =/= MemoryOpConstants.M_PFW))), "LoadPipe only accepts load req / softprefetch read or write!")
   dump_pipeline_reqs("LoadPipe s0", s0_valid, s0_req)
 
-  wr_conflict_check := io.wr_conflict.valid && (io.wr_conflict.bits & s0_bank_oh).orR
+  wr_conflict_check := io.lsu.req.valid && io.wr_conflict.valid && (io.wr_conflict.bits & s0_bank_oh).orR
 
   // wpu
   // val dwpu = Module(new DCacheWpuWrapper)

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -138,8 +138,8 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   assert(RegNext(!(s0_valid && (s0_req.cmd =/= MemoryOpConstants.M_XRD && s0_req.cmd =/= MemoryOpConstants.M_PFR && s0_req.cmd =/= MemoryOpConstants.M_PFW))), "LoadPipe only accepts load req / softprefetch read or write!")
   dump_pipeline_reqs("LoadPipe s0", s0_valid, s0_req)
 
-  wr_conflict_check := io.lsu.req.valid && io.writehint.valid && (io.writehint.bits & s0_bank_oh).orR
-  XSPerfAccumulate("wr_conflict_no_ready", wr_conflict_check)
+  wr_conflict_check := io.writehint.valid && (io.writehint.bits & s0_bank_oh).orR
+  XSPerfAccumulate("wr_conflict_no_ready", io.lsu.req.valid && wr_conflict_check)
 
   // wpu
   // val dwpu = Module(new DCacheWpuWrapper)


### PR DESCRIPTION
Original: When DataArray read/write conflicts happen, it usually triggers a fast replay. 

Modify: Check for potential DataArray read/write conflicts in LoadPipe s0, block and reduce one fast replay.

Performance: spec2006 0.3 cov base cr251226-a9a429a1e improved 0.041

These changes triggered a backend bug:

fix(jalr): correct alu uop's src0 DataSource for jump uop's src0 canceled by og0cancel

I have verified that the fix was successful.