### PR TITLE
ci(perf-trigger): add note option

### DIFF
--- a/.github/workflows/perf-trigger.yml
+++ b/.github/workflows/perf-trigger.yml
@@ -1,8 +1,15 @@
 name: Performance Regression Trigger
 
+run-name: "${{ github.event.inputs.note }} - ${{ github.event.inputs.test_branch }} - ${{ github.event.inputs.benchmark_type }}"
+
 on:
   workflow_dispatch:
     inputs:
+      note:
+        description: Test note, will be displayed in the title
+        required: false
+        type: string
+        default: Performance Regression
       test_branch:
         description: Branch or commit to run performance test on
         required: false


### PR DESCRIPTION
It's hard to distinguish different perf regressions triggered manually:
![](https://github.com/user-attachments/assets/2795d923-4df3-494a-8b30-0bc144aa7f3a)

This PR adds a note (or, name) option to the trigger and will compose the displayed title as `note - branch - type` for easier use.

Showcase:
![](https://github.com/user-attachments/assets/e9c235d0-8229-471c-b5cd-e3024acb6579)
