### PR TITLE
fix(StoreUnit): fix stuck of misalign Store

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -525,7 +525,8 @@ class StoreUnit(implicit p: Parameters) extends XSModule
 
   // prefetch related
   io.lsq_replenish.miss := io.dcache.resp.fire && io.dcache.resp.bits.miss // miss info
-  io.lsq_replenish.updateAddrValid := !s2_mis_align && (!s2_frm_mabuf || s2_out.isFinalSplit) || s2_exception
+  io.lsq_replenish.updateAddrValid := !s2_mis_align && (!s2_frm_mabuf || s2_out.isFinalSplit) ||
+    !s2_in.isvec && s2_exception && !s2_misalignNeedReplay || s2_in.isvec && s2_exception
   io.lsq_replenish.isvec := s2_out.isvec || s2_frm_mab_vec
 
   io.lsq_replenish.hasException := (ExceptionNO.selectByFu(s2_out.uop.exceptionVec, StaCfg).asUInt.orR ||


### PR DESCRIPTION
Previously:

When misalign store need to replay and have exception, it will update `waitStoreS2` of storeQueue, The situation mentioned before will lead to `cmtPtr` of storeQueue move, which will lead to `s0_misalignNeedReplay` always true.

Currently:

When misalign store need to replay, it will not to update `waitStoreS2`.