### PR TITLE
feat(utage): refine MicroTAGE prediction candidate policy

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/utage/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/Parameters.scala
@@ -29,7 +29,7 @@ case class MicroTageParameters(
       new MicroTageInfo(512, 16, 12, 16) // follow Tage.
       // new MicroTageInfo(128, 32, 16, 24)
     ),
-    TakenCtrWidth:       Int = 3,
+    TakenCtrWidth:       Int = 2,
     NumTables:           Int = 2,
     LowTickWidth:        Int = 9,
     HighTickWidth:       Int = 11,


### PR DESCRIPTION
- Only allow low table (tableId=0) to participate in prediction when its taken counter is fully saturated (0 or max), to reduce noise from short-history patterns that flip frequently.
- Higher tables always provide candidates on hit, leveraging their stable long-history predictions.
- Update usefulness decay strategy accordingly: base table uses linear decrement, others use right-shift aging.

This aligns with a design principle: low-history tables adapt quickly but require high confidence to contribute; high-history tables are trusted even in weak states. Meanwhile, the prediction decision logic does not affect the general training logic. Importantly, this prediction decision logic remains orthogonal to the general training logic.

