### PR TITLE
feat(abtb): save setIdx and bankMask to meta

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/abtb/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/Bundles.scala
@@ -68,6 +68,8 @@ class ReplacerIO(implicit p: Parameters) extends AheadBtbBundle {
 
 class AheadBtbMeta(implicit p: Parameters) extends AheadBtbBundle {
   val valid:           Bool                 = Bool()
+  val setIdx:          UInt                 = UInt(SetIdxWidth.W)
+  val bankMask:        UInt                 = UInt(NumBanks.W)
   val hitMask:         Vec[Bool]            = Vec(NumWays, Bool())
   val attributes:      Vec[BranchAttribute] = Vec(NumWays, new BranchAttribute)
   val positions:       Vec[UInt]            = Vec(NumWays, UInt(CfiPositionWidth.W))


### PR DESCRIPTION
This pr save `setIdx` and `bankMask` to  meta, thus we can easily get `setIdx` and `bankMask`, instead of get these from `s4_startPc`. And we do not need to maintain `s4_startPc` in `Bpu` top.