### PR TITLE
fix(Configs): add `fullAddressBits` parameter to MinimalConfig

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -280,6 +280,7 @@ class MinimalConfig(n: Int = 1) extends Config(
           ways = 8,
           sets = 2048,
           banks = 4,
+          fullAddressBits = 48,
           clientCaches = Seq(L2Param())
         )),
         L3NBanks = 1


### PR DESCRIPTION
* Add `fullAddressBits = 48` to the cache configuration within the OpenLLCParam of `MinimalConfig`

This may fix #5490. At least `make verilog CONFIG=KunminghuV2MinimalConfig` works successfully, and two iterations of CoreMark complete without issues.

<img width="1030" height="577" alt="coremarkpng" src="https://github.com/user-attachments/assets/ddbf6167-10e0-4962-8e1e-877d28398b56" />
