### PR TITLE
ci(pr-labeler): fix submodule match

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,17 +7,17 @@
 - changed-files:
   - any-glob-to-any-file:
     - src/main/scala/xiangshan/backend/**
-    - fudian/**
-    - yunsuan/**
+    - fudian
+    - yunsuan
 
 "module: memory":
 - changed-files:
   - any-glob-to-any-file:
     - src/main/scala/xiangshan/cache/**
     - src/main/scala/xiangshan/mem/**
-    - coupledL2/**
-    - huancun/**
-    - openLLC/**
+    - coupledL2
+    - huancun
+    - openLLC
 
 "module: top":
 - changed-files:
@@ -32,7 +32,7 @@
   - any-glob-to-any-file:
     - src/main/scala/utils/**
     - macros/**
-    - utility/**
+    - utility
 
 "module: tool":
 - changed-files:
@@ -40,8 +40,8 @@
     - src/main/resources/*
     - src/test/**
     - .github/**
-    - difftest/**
-    - ready-to-run/**
+    - difftest
+    - ready-to-run
     - scripts/**
     - .mill-version
     - .scalafmt.conf
@@ -55,8 +55,8 @@
 - changed-files:
   - any-glob-to-any-file:
     - src/main/scala/device/**
-    - ChiselAIA/**
-    - rocket-chip/**
+    - ChiselAIA
+    - rocket-chip
 
 "module: documentation":
 - changed-files:


### PR DESCRIPTION
It turned out that labeler is using github api to obtain changed file list, so it can't do recursive matching for submodules.

Refer to debug log [here](https://github.com/OpenXiangShan/XiangShan/actions/runs/20943997124/job/60184821011)