### PR TITLE
refactor(writeback): refactor Bundle that writeback to Rob and RegFile

### DIFF
--- a/src/main/scala/xiangshan/backend/BackendParams.scala
+++ b/src/main/scala/xiangshan/backend/BackendParams.scala
@@ -164,6 +164,10 @@ case class BackendParams(
     MixedVec(allSchdParams.map(_.genExuOutputValidBundle.flatten).flatten)
   }
 
+  def genWrite2RobBundles(implicit p: Parameters): MixedVec[ValidIO[WriteBackRobBundle]] = {
+    MixedVec(allSchdParams.map(_.genWriteBackRobValidBundle.flatten).flatten)
+  }
+
   def getIntWbArbiterParams: WbArbiterParams = {
     val intWbCfgs: Seq[IntWB] = allSchdParams.flatMap(_.getWbCfgs.flatten.flatten.filter(_.writeInt)).map(_.asInstanceOf[IntWB])
     datapath.WbArbiterParams(intWbCfgs, intPregParams, this)

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -15,7 +15,7 @@ import xiangshan.backend.exu.ExeUnitParams
 import xiangshan.backend.fu.FuType
 import xiangshan.backend.fu.fpu.Bundles.Frm
 import xiangshan.backend.fu.vector.Bundles._
-import xiangshan.backend.issue.{IssueBlockParams, SchedulerType}
+import xiangshan.backend.issue._
 import xiangshan.backend.issue.EntryBundles._
 import xiangshan.backend.regfile._
 import xiangshan.backend.rob.RobPtr
@@ -52,6 +52,56 @@ object Bundles {
       }
     }
   }
+
+  def connectNewExuInput(sink: DecoupledIO[NewExuInput], source: DecoupledIO[ExuInput]) = {
+    sink.valid := source.valid
+    source.ready := sink.ready
+    connectSamePort(sink.bits.ctrl, source.bits)
+    connectSamePort(sink.bits.data, source.bits)
+    connectSamePort(sink.bits.toRF, source.bits)
+    connectSamePort(sink.bits.copy, source.bits)
+    connectSamePort(sink.bits, source.bits)
+    sink.bits.toRobValid := source.valid
+    sink.bits.robIdx     := source.bits.robIdx
+  }
+
+  def connectExuInput(sink: DecoupledIO[ExuInput], source: DecoupledIO[NewExuInput]) = {
+    sink.valid := source.valid
+    source.ready := sink.ready
+    connectSamePort(sink.bits, source.bits.ctrl)
+    connectSamePort(sink.bits, source.bits.data)
+    connectSamePort(sink.bits, source.bits.toRF)
+    connectSamePort(sink.bits, source.bits.copy)
+    connectSamePort(sink.bits, source.bits)
+    sink.bits.robIdx := source.bits.robIdx
+  }
+
+  def connectMemNewExuOutput(sink: DecoupledIO[NewExuOutput], source: DecoupledIO[ExuOutput]) = {
+    sink.valid := source.valid
+    source.ready := sink.ready
+    connectSamePort(sink.bits.toRob.bits, source.bits)
+    connectSamePort(sink.bits, source.bits)
+    sink.bits.toRob.valid             := source.valid
+    sink.bits.toIntRf.foreach(_.valid := source.bits.intWen.get)
+    sink.bits.toIntRf.foreach(_.bits  := source.bits.data(0))
+    sink.bits.toFpRf. foreach(_.valid := source.bits.fpWen.get)
+    sink.bits.toFpRf. foreach(_.bits  := source.bits.data(0))
+    sink.bits.toVecRf.foreach(_.valid := source.bits.vecWen.get)
+    sink.bits.toVecRf.foreach(_.bits  := source.bits.data(0))
+    sink.bits.toV0Rf. foreach(_.valid := source.bits.v0Wen.get)
+    sink.bits.toV0Rf. foreach(_.bits  := source.bits.data(0))
+    sink.bits.toVlRf. foreach(_.valid := source.bits.vlWen.get)
+    sink.bits.toVlRf. foreach(_.bits  := source.bits.data(0))
+  }
+
+  def connectWriteBackRob(sink: WriteBackRobBundle, source: NewExuOutput) = {
+    connectSamePort(sink, source.toRob.bits)
+    connectSamePort(sink, source)
+    sink.data              := source.toIntRf.map(_.bits).getOrElse(0.U(64.W))
+    sink.vecWen. foreach(_ := source.toVecRf.map(_.valid).getOrElse(false.B))
+    sink.v0Wen.  foreach(_ := source.toV0Rf.map(_.valid).getOrElse(false.B))
+  }
+
   // Frontend --[CtrlBlock]--> DecodeInUop
   class DecodeInUop(implicit p: Parameters) extends XSBundle {
     val foldpc = UInt(MemPredPCWidth.W) // for mdp
@@ -1055,6 +1105,91 @@ object Bundles {
     }
   }
 
+  class PredictInfo(implicit p: Parameters) extends XSBundle {
+    val target = UInt(VAddrData().dataWidth.W)
+    val fixedTaken = Bool()
+    val predTaken = Bool()
+  }
+
+  class ExuInputCtrlBundle(val params: ExeUnitParams)(implicit p: Parameters) extends XSBundle {
+    val fuType         = FuType()
+    val fuOpType       = FuOpType()
+    val is0Lat         = Option.when(params.fuConfigs.map(x => x.latency.latencyVal.getOrElse(1) == 0 && !x.hasNoDataWB).reduce(_ || _))(Bool())
+    val rfWen          = Option.when(params.needIntWen)(Bool())
+    val fpWen          = Option.when(params.needFpWen)(Bool())
+    val vecWen         = Option.when(params.needVecWen)(Bool())
+    val v0Wen          = Option.when(params.needV0Wen)(Bool())
+    val vlWen          = Option.when(params.needVlWen)(Bool())
+    val fpu            = Option.when(params.writeFflags)(new FPUCtrlSignals)
+    val vpu            = Option.when(params.needVPUCtrl)(new VPUCtrlSignals)
+    val vialuCtrl      = Option.when(params.needVIaluCtrl)(new VIAluCtrlSignals)
+    val flushPipe      = Option.when(params.flushPipe)(Bool())
+    val rasAction      = Option.when(params.hasRasAction)(BranchAttribute.RasAction())
+    val isRVC          = Option.when(params.hasIsRVC || params.aluNeedPc)(Bool())
+    val ftqIdx         = Option.when(params.needFtqPtr)(new FtqPtr)
+    val ftqOffset      = Option.when(params.needFtqPtrOffset)(UInt(FetchBlockInstOffsetWidth.W))
+    val predictInfo    = Option.when(params.needPdInfo)(new PredictInfo)
+    val dataSources    = Vec(params.numRegSrc, DataSource())
+    val exuSources     = Option.when(params.isIQWakeUpSink)(Vec(params.numRegSrc, ExuSource(params)))
+    val srcTimer       = Option.when(params.isIQWakeUpSink)(Vec(params.numRegSrc, UInt(3.W)))
+    val loadDependency = Option.when(params.needLoadDependency)(Vec(LoadPipelineWidth, UInt(LoadDependencyWidth.W)))
+  }
+
+  class ExuInputDataBundle(val params: ExeUnitParams)(implicit p: Parameters) extends XSBundle {
+    val src = Vec(params.numRegSrc, UInt(params.srcDataBitsMax.W))
+    val vl  = Option.when(params.readVlRf)(Vl())
+    val imm = UInt(64.W)
+    val pc  = Option.when(params.needPc || params.aluNeedPc)(UInt(VAddrData().dataWidth.W))
+    val nextPcOffset = Option.when(params.hasBrhFu)(UInt((FetchBlockInstOffsetWidth + 2).W))
+  }
+
+  class ExuInputToRegFileBundle(val params: ExeUnitParams)(implicit p: Parameters) extends XSBundle {
+    val pdest   = UInt(params.wbPregIdxWidth.W)
+    val pdestVl = Option.when(params.writeVlRf)(UInt(VlPhyRegIdxWidth.W))
+  }
+
+  class ExuCopyBundle(val params: ExeUnitParams, copyWakeupOut: Boolean, copyNum: Int, hasCopySrc: Boolean)(implicit p: Parameters) extends XSBundle {
+    val copySrc    = Option.when(hasCopySrc)(Vec(params.numCopySrc, Vec(if(params.numRegSrc < 2) 1 else 2, UInt(params.srcDataBitsMax.W))))
+    val pdestCopy  = Option.when(copyWakeupOut)(Vec(copyNum, UInt(params.wbPregIdxWidth.W)))
+    val rfWenCopy  = Option.when(copyWakeupOut && params.needIntWen)(Vec(copyNum, Bool()))
+    val fpWenCopy  = Option.when(copyWakeupOut && params.needFpWen)(Vec(copyNum, Bool()))
+    val vecWenCopy = Option.when(copyWakeupOut && params.needVecWen)(Vec(copyNum, Bool()))
+    val v0WenCopy  = Option.when(copyWakeupOut && params.needV0Wen)(Vec(copyNum, Bool()))
+    val vlWenCopy  = Option.when(copyWakeupOut && params.needVlWen)(Vec(copyNum, Bool()))
+    val loadDependencyCopy = Option.when(copyWakeupOut && params.isIQWakeUpSink)(Vec(copyNum, Vec(LoadPipelineWidth, UInt(LoadDependencyWidth.W))))
+  }
+
+  class NewExuInput(val params: ExeUnitParams, copyWakeupOut: Boolean = false, copyNum: Int = 0, hasCopySrc: Boolean = false)(implicit p: Parameters) extends XSBundle {
+    val ctrl           = new ExuInputCtrlBundle(params)
+    val data           = new ExuInputDataBundle(params)
+    val toRobValid     = Bool()
+    val robIdx         = new RobPtr
+    val toRF           = new ExuInputToRegFileBundle(params)
+    val copy           = new ExuCopyBundle(params, copyWakeupOut, copyNum, hasCopySrc)
+    val iqIdx          = UInt(log2Up(MemIQSizeMax).W)  // Only used by store yet
+    val isFirstIssue   = Bool()                        // Only used by store yet
+    val loadWaitBit    = Option.when(params.hasLoadExu)(Bool())
+    val waitForRobIdx  = Option.when(params.hasLoadExu)(new RobPtr) // store set predicted previous store robIdx
+    val storeSetHit    = Option.when(params.hasLoadExu)(Bool())     // inst has been allocated an store set
+    val loadWaitStrict = Option.when(params.hasLoadExu)(Bool())     // load inst will not be executed until ALL former store addr calcuated
+    val ssid           = Option.when(params.hasLoadExu)(UInt(SSIDWidth.W))
+    val numLsElem      = Option.when(params.hasVecLsFu)(NumLsElem())
+    val lqIdx          = Option.when(params.hasLoadExu || params.hasVecLsFu)(new LqPtr)
+    val sqIdx          = Option.when(params.hasLoadExu || params.hasStoreAddrFu || params.hasStdFu || params.hasVecLsFu)(new SqPtr)
+    val perfDebugInfo  = Option.when(backendParams.debugEn)(new PerfDebugInfo())
+    val debug_seqNum   = Option.when(backendParams.debugEn)(InstSeqNum())
+  }
+
+
+  class ExuCrossRegion(val params: SchdBlockParams)(implicit p: Parameters) extends XSBundle {
+    val I2FWakeupOut = Option.when(params.isIntSchd)(ValidIO(new IssueQueueIQWakeUpBundle(params.backendParam.getExuIdxI2F, params.backendParam)))
+    val I2FDataOut   = Option.when(params.isIntSchd)(ValidIO(UInt(XLEN.W)))
+    val I2FDataIn    = Option.when(params.isFpSchd)(Flipped(ValidIO(UInt(XLEN.W))))
+    val F2IWakeupOut = Option.when(params.isFpSchd)(ValidIO(new IssueQueueIQWakeUpBundle(params.backendParam.getExuIdxF2I, params.backendParam)))
+    val F2IDataOut   = Option.when(params.isFpSchd)(ValidIO(UInt(XLEN.W)))
+    val F2IDataIn    = Option.when(params.isIntSchd)(Flipped(ValidIO(UInt(XLEN.W))))
+  }
+
   // ExuInput --[FuncUnit]--> ExuOutput
   class ExuOutput(
     val params: ExeUnitParams,
@@ -1102,6 +1237,52 @@ object Bundles {
     val debug = new DebugBundle
     val perfDebugInfo = OptionWrapper(backendParams.debugEn, new PerfDebugInfo())
     val debug_seqNum = OptionWrapper(backendParams.debugEn, InstSeqNum())
+  }
+
+class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) extends Bundle with HasXSParameter {
+    val vpu          = new VPUCtrlSignals
+    val oldVdPsrc    = UInt(PhyRegIdxWidth.W)
+    val vdIdx        = UInt(3.W)
+    val vdIdxInField = UInt(3.W)
+    val isIndexed    = Bool()
+    val isMasked     = Bool()
+    val isStrided    = Bool()
+    val isWhole      = Bool()
+    val isVecLoad    = Bool()
+    val isVlm        = Bool()
+  }
+  class ExuOutputToRob(val params: ExeUnitParams)(implicit p: Parameters) extends Bundle {
+    val robIdx       = new RobPtr
+    val fflags       = Option.when(params.writeFflags)(UInt(5.W))
+    val wflags       = Option.when(params.writeFflags)(Bool())
+    val vxsat        = Option.when(params.writeVxsat)(Bool())
+    val exceptionVec = Option.when(params.exceptionOut.nonEmpty)(ExceptionVec())
+    val flushPipe    = Option.when(params.flushPipe)(Bool())
+    val trigger      = Option.when(params.trigger)(TriggerAction())
+    val isRVC        = Option.when(params.hasIsRVC)(Bool())
+    val replay       = Option.when(params.replayInst)(Bool())
+    val lqIdx        = Option.when(params.hasLoadFu)(new LqPtr())
+    val sqIdx        = Option.when(params.hasStoreAddrFu || params.hasStdFu)(new SqPtr())
+    val vls          = Option.when(params.hasVLoadFu)(new ExuOutputVLoad(params))
+  }
+  class NewExuOutput(
+    val params: ExeUnitParams,
+  )(implicit
+    val p: Parameters
+  ) extends Bundle with BundleSource with HasXSParameter {
+    val toRob          = ValidIO(new ExuOutputToRob(params))
+    val pdest          = UInt(params.wbPregIdxWidth.W)
+    val pdestVl        = Option.when(params.writeVlRf)(UInt(VlPhyRegIdxWidth.W))
+    val toIntRf        = Option.when(params.writeIntRf)(ValidIO(UInt(params.destDataBitsMax.W)))
+    val toFpRf         = Option.when(params.writeFpRf)(ValidIO(UInt(params.destDataBitsMax.W)))
+    val toVecRf        = Option.when(params.writeVecRf)(ValidIO(UInt(params.destDataBitsMax.W)))
+    val toV0Rf         = Option.when(params.writeV0Rf)(ValidIO(UInt(params.destDataBitsMax.W)))
+    val toVlRf         = Option.when(params.writeVlRf)(ValidIO(UInt(params.destDataBitsMax.W)))
+    val redirect       = Option.when(params.hasRedirect)(ValidIO(new Redirect))
+    val isFromLoadUnit = Option.when(params.hasLoadFu)(Bool())
+    val debug          = new DebugBundle
+    val perfDebugInfo  = Option.when(backendParams.debugEn)(new PerfDebugInfo())
+    val debug_seqNum   = Option.when(backendParams.debugEn)(InstSeqNum())
   }
 
   // ExuOutput + DynInst --> WriteBackBundle
@@ -1197,6 +1378,104 @@ object Bundles {
       rfWrite.vlWen := this.vlWen
       rfWrite
     }
+  }
+
+  class WriteBackRFBundle(val params: PregWB, backendParams: BackendParams)(implicit val p: Parameters) extends Bundle with BundleSource with HasXSParameter {
+    val rfWen  = Bool()
+    val fpWen  = Bool()
+    val vecWen = Bool()
+    val v0Wen  = Bool()
+    val vlWen  = Bool()
+    val pdest  = UInt(params.pregIdxWidth(backendParams).W)
+    val data   = UInt(params.dataWidth.W)
+
+    this.wakeupSource = s"WB(${params.toString()})"
+
+    def fromExuOutput(source: NewExuOutput, wbType: String) = {
+      this.rfWen  := source.toIntRf.map(_.valid).getOrElse(false.B)
+      this.fpWen  := source.toFpRf.map(_.valid).getOrElse(false.B)
+      this.vecWen := source.toVecRf.map(_.valid).getOrElse(false.B)
+      this.v0Wen  := source.toV0Rf.map(_.valid).getOrElse(false.B)
+      this.vlWen  := source.toVlRf.map(_.valid).getOrElse(false.B)
+      this.pdest  := (if (wbType == "vl") { source.pdestVl.getOrElse(0.U(VlPhyRegIdxWidth.W)) } else { source.pdest })
+      this.data   := (if (wbType == "int") { source.toIntRf.map(_.bits).getOrElse(0.U(params.dataWidth.W)) }
+                      else if (wbType == "fp") { source.toFpRf.map(_.bits).getOrElse(0.U(params.dataWidth.W)) }
+                      else if (wbType == "vf") { source.toVecRf.map(_.bits).getOrElse(0.U(params.dataWidth.W)) } 
+                      else if (wbType == "v0") { source.toV0Rf.map(_.bits).getOrElse(0.U(params.dataWidth.W)) }
+                      else                     { source.toVlRf.map(_.bits).getOrElse(0.U(params.dataWidth.W)) })
+    }
+
+    def asIntRfWriteBundle(fire: Bool): RfWritePortBundle = {
+      val rfWrite = Wire(new RfWritePortBundle(backendParams.intPregParams))
+      rfWrite       := 0.U.asTypeOf(rfWrite)
+      rfWrite.wen   := this.rfWen && fire
+      rfWrite.pdest := this.pdest
+      rfWrite.data  := this.data
+      rfWrite.rfWen := this.rfWen
+      rfWrite
+    }
+
+    def asFpRfWriteBundle(fire: Bool): RfWritePortBundle = {
+      val rfWrite = Wire(new RfWritePortBundle(backendParams.fpPregParams))
+      rfWrite       := 0.U.asTypeOf(rfWrite)
+      rfWrite.wen   := this.fpWen && fire
+      rfWrite.pdest := this.pdest
+      rfWrite.data  := this.data
+      rfWrite.fpWen := this.fpWen
+      rfWrite
+    }
+
+    def asVfRfWriteBundle(fire: Bool): RfWritePortBundle = {
+      val rfWrite = Wire(new RfWritePortBundle(backendParams.vfPregParams))
+      rfWrite        := 0.U.asTypeOf(rfWrite)
+      rfWrite.wen    := this.vecWen && fire
+      rfWrite.pdest  := this.pdest
+      rfWrite.data   := this.data
+      rfWrite.vecWen := this.vecWen
+      rfWrite
+    }
+
+    def asV0RfWriteBundle(fire: Bool): RfWritePortBundle = {
+      val rfWrite = Wire(new RfWritePortBundle(backendParams.v0PregParams))
+      rfWrite       := 0.U.asTypeOf(rfWrite)
+      rfWrite.wen   := this.v0Wen && fire
+      rfWrite.pdest := this.pdest
+      rfWrite.data  := this.data
+      rfWrite.v0Wen := this.v0Wen
+      rfWrite
+    }
+
+    def asVlRfWriteBundle(fire: Bool): RfWritePortBundle = {
+      val rfWrite = Wire(new RfWritePortBundle(backendParams.vlPregParams))
+      rfWrite       := 0.U.asTypeOf(rfWrite)
+      rfWrite.wen   := this.vlWen && fire
+      rfWrite.pdest := this.pdest
+      rfWrite.data  := this.data
+      rfWrite.vlWen := this.vlWen
+      rfWrite
+    }
+  }
+
+  class WriteBackRobBundle(val params: ExeUnitParams, backendParams: BackendParams)(implicit p: Parameters) extends Bundle with BundleSource {
+    val robIdx        = new RobPtr()(p)
+    val flushPipe     = Option.when(params.flushPipe)(Bool())
+    val replay        = Option.when(params.replayInst)(Bool())
+    val redirect      = Option.when(params.hasRedirect)(ValidIO(new Redirect))
+    val fflags        = Option.when(params.writeFflags)(UInt(5.W))
+    val wflags        = Option.when(params.writeFflags)(Bool())
+    val vxsat         = Option.when(params.writeVxsat)(Bool())
+    val exceptionVec  = Option.when(params.exceptionOut.nonEmpty)(ExceptionVec())
+    val lqIdx         = Option.when(params.hasLoadFu)(new LqPtr())
+    val sqIdx         = Option.when(params.hasStoreAddrFu || params.hasStdFu)(new SqPtr())
+    val trigger       = Option.when(params.trigger)(TriggerAction())
+    val vls           = Option.when(params.hasVLoadFu)(new ExuOutputVLoad(params))
+    val data          = UInt(params.destDataBitsMax.W)
+    val pdest         = UInt(params.wbPregIdxWidth.W)
+    val vecWen        = Option.when(params.writeVecRf)(Bool())
+    val v0Wen         = Option.when(params.writeV0Rf)(Bool())
+    val debug         = new DebugBundle
+    val perfDebugInfo = Option.when(backendParams.debugEn)(new PerfDebugInfo())
+    val debug_seqNum  = Option.when(backendParams.debugEn)(InstSeqNum())
   }
 
   // ExuOutput --> ExuBypassBundle --[DataPath]-->ExuInput

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -135,7 +135,7 @@ class CtrlBlockImp(
   private val delayedNotFlushedWriteBack = io.fromWB.wbData.map(x => {
     val valid = x.valid
     val killedByOlder = x.bits.robIdx.needFlush(Seq(s1_s3_redirect, s2_s4_redirect))
-    val delayed = Wire(Valid(new ExuOutput(x.bits.params)))
+    val delayed = Wire(Valid(new WriteBackRobBundle(x.bits.params, backendParams)))
     delayed.valid := GatedValidRegNext(valid && !killedByOlder)
     delayed.bits := RegEnable(x.bits, x.valid)
     delayed.bits.perfDebugInfo.foreach(_.writebackTime := GTimer())
@@ -938,7 +938,7 @@ class CtrlBlockIO()(implicit p: Parameters, params: BackendParams) extends XSBun
     val trapInstInfo = Output(ValidIO(new TrapInstInfo))
   }
   val fromWB = new Bundle {
-    val wbData = Flipped(MixedVec(params.genWrite2CtrlBundles))
+    val wbData = Flipped(MixedVec(params.genWrite2RobBundles))
     val delayedOldestExuRedirect = Flipped(ValidIO(new Redirect)) 
   }
   val redirect = ValidIO(new Redirect)

--- a/src/main/scala/xiangshan/backend/datapath/BypassNetwork.scala
+++ b/src/main/scala/xiangshan/backend/datapath/BypassNetwork.scala
@@ -40,9 +40,9 @@ class BypassNetworkIO()(implicit p: Parameters, params: BackendParams) extends X
   }
 
   class ToExus extends Bundle {
-    val int: MixedVec[MixedVec[DecoupledIO[ExuInput]]] = intSchdParams.genExuInputCopySrcBundle
-    val fp : MixedVec[MixedVec[DecoupledIO[ExuInput]]] = fpSchdParams.genExuInputCopySrcBundle
-    val vf : MixedVec[MixedVec[DecoupledIO[ExuInput]]] = vecSchdParams.genExuInputCopySrcBundle
+    val int: MixedVec[MixedVec[DecoupledIO[NewExuInput]]] = intSchdParams.genNewExuInputCopySrcBundle
+    val fp : MixedVec[MixedVec[DecoupledIO[NewExuInput]]] = fpSchdParams.genNewExuInputCopySrcBundle
+    val vf : MixedVec[MixedVec[DecoupledIO[NewExuInput]]] = vecSchdParams.genNewExuInputCopySrcBundle
   }
 
   class FromExus extends Bundle {
@@ -53,15 +53,20 @@ class BypassNetworkIO()(implicit p: Parameters, params: BackendParams) extends X
     def connectExuOutput(
       getSinkVecN: FromExus => MixedVec[MixedVec[ValidIO[ExuBypassBundle]]]
     )(
-      sourceVecN: MixedVec[MixedVec[DecoupledIO[ExuOutput]]]
+      sourceVecN: MixedVec[MixedVec[DecoupledIO[NewExuOutput]]]
     ): Unit = {
       getSinkVecN(this).zip(sourceVecN).foreach { case (sinkVec, sourcesVec) =>
         sinkVec.zip(sourcesVec).foreach { case (sink, source) =>
-          sink.valid := source.valid || source.bits.params.needDataFromF2I.B && source.bits.intWen.getOrElse(false.B)
-          sink.bits.intWen := source.bits.intWen.getOrElse(false.B) && source.bits.isFromLoadUnit.getOrElse(true.B)
+          sink.valid := source.valid || source.bits.params.needDataFromF2I.B && source.bits.toIntRf.map(_.valid).getOrElse(false.B)
+          sink.bits.intWen := source.bits.toIntRf.map(_.valid).getOrElse(false.B) && source.bits.isFromLoadUnit.getOrElse(true.B)
           sink.bits.pdest := source.bits.pdest
           // int i2f wakeup fstore from fpRegion, so there is not need bypass fp data in int region
-          sink.bits.data := source.bits.data(source.bits.params.getForwardIndex())
+          sink.bits.data := {if (source.bits.params.isIntExeUnit) { source.bits.toIntRf.map(_.bits).getOrElse(0.U(source.bits.params.destDataBitsMax.W)) }
+                        else if (source.bits.params.isFpExeUnit)  { source.bits.toFpRf.map(_.bits).getOrElse(0.U(source.bits.params.destDataBitsMax.W))  }
+                        else if (source.bits.params.isVfExeUnit && source.bits.params.writeVecRf) { source.bits.toVecRf.map(_.bits).getOrElse(0.U(source.bits.params.destDataBitsMax.W)) }
+                        else if (source.bits.params.isVfExeUnit && source.bits.params.writeV0Rf)  { source.bits.toV0Rf.map(_.bits).getOrElse(0.U(source.bits.params.destDataBitsMax.W))  }
+                        else if (source.bits.params.isVfExeUnit && source.bits.params.writeVlRf)  { source.bits.toVlRf.map(_.bits).getOrElse(0.U(source.bits.params.destDataBitsMax.W))  }
+                        else { source.bits.toIntRf.map(_.bits).getOrElse(0.U(source.bits.params.destDataBitsMax.W)) }} 
         }
       }
     }
@@ -76,7 +81,11 @@ class BypassNetwork()(implicit p: Parameters, params: BackendParams) extends XSM
 
   private val fromDPs: Seq[DecoupledIO[ExuInput]] = (io.fromDataPath.int ++ io.fromDataPath.fp ++ io.fromDataPath.vf).flatten.toSeq
   private val fromExus: Seq[ValidIO[ExuBypassBundle]] = (io.fromExus.int ++ io.fromExus.fp ++ io.fromExus.vf).flatten.toSeq
-  private val toExus: Seq[DecoupledIO[ExuInput]] = (io.toExus.int ++ io.toExus.fp ++ io.toExus.vf).flatten.toSeq
+  private val toExusInt: MixedVec[MixedVec[DecoupledIO[ExuInput]]] = Wire(params.intSchdParams.get.genExuInputCopySrcBundle)
+  private val toExusFp: MixedVec[MixedVec[DecoupledIO[ExuInput]]] = Wire(params.fpSchdParams.get.genExuInputCopySrcBundle)
+  private val toExusVf: MixedVec[MixedVec[DecoupledIO[ExuInput]]] = Wire(params.vecSchdParams.get.genExuInputCopySrcBundle)
+  private val toExus: Seq[DecoupledIO[ExuInput]] = (toExusInt ++ toExusFp ++ toExusVf).flatten.toSeq
+  private val toNewExus: Seq[DecoupledIO[NewExuInput]] = (io.toExus.int ++ io.toExus.fp ++ io.toExus.vf).flatten.toSeq
   private val fromDPsRCData: Seq[Vec[UInt]] = io.fromDataPath.rcData.flatten.toSeq
   private val immInfo = io.fromDataPath.immInfo
 
@@ -305,4 +314,6 @@ class BypassNetwork()(implicit p: Parameters, params: BackendParams) extends XSM
     x.data := bypassRCDataVec(i)
     x.tag.foreach(_ := bypassTagVec(i))
   }
+
+  toNewExus.zip(toExus).foreach { case (sink, source) => connectNewExuInput(sink, source) }
 }

--- a/src/main/scala/xiangshan/backend/datapath/VldMergeUnit.scala
+++ b/src/main/scala/xiangshan/backend/datapath/VldMergeUnit.scala
@@ -4,7 +4,7 @@ import org.chipsalliance.cde.config.Parameters
 import chisel3._
 import chisel3.util._
 import xiangshan._
-import xiangshan.backend.Bundles.ExuOutput
+import xiangshan.backend.Bundles._
 import xiangshan.backend.exu.ExeUnitParams
 import xiangshan.backend.fu.vector.{ByteMaskTailGen, Mgu, VldMgu, VecInfo}
 import xiangshan.mem.GenUSMaskRegVL
@@ -15,42 +15,42 @@ class VldMergeUnit(val params: ExeUnitParams)(implicit p: Parameters) extends XS
 
   io.writeback.ready := io.writebackAfterMerge.ready
 
-  val wbReg = Reg(Valid(new ExuOutput(params)))
+  val wbReg = Reg(Valid(new NewExuOutput(params)))
   val mgu = Module(new VldMgu(VLEN))
   val vdAfterMerge = Wire(UInt(VLEN.W))
 
-  val wbFire = !io.writeback.bits.robIdx.needFlush(io.flush) && io.writeback.fire
+  val wbFire = !io.writeback.bits.toRob.bits.robIdx.needFlush(io.flush) && io.writeback.fire
   wbReg.bits := Mux(io.writeback.fire, io.writeback.bits, wbReg.bits)
   wbReg.valid := wbFire
-  mgu.io.in.vd := wbReg.bits.data(0)
+  mgu.io.in.vd := wbReg.bits.toVecRf.map(_.bits).getOrElse(0.U(params.destDataBitsMax.W))
   // oldVd is contained in data and is already masked with new data
-  mgu.io.in.oldVd := wbReg.bits.data(0)
-  mgu.io.in.mask := Mux(wbReg.bits.vls.get.vpu.vm, Fill(VLEN, 1.U(1.W)), wbReg.bits.vls.get.vpu.vmask)
+  mgu.io.in.oldVd := wbReg.bits.toVecRf.map(_.bits).getOrElse(0.U(params.destDataBitsMax.W))
+  mgu.io.in.mask := Mux(wbReg.bits.toRob.bits.vls.get.vpu.vm, Fill(VLEN, 1.U(1.W)), wbReg.bits.toRob.bits.vls.get.vpu.vmask)
   mgu.io.in.info.valid := wbReg.valid
-  mgu.io.in.info.ta := wbReg.bits.vls.get.isMasked || wbReg.bits.vls.get.vpu.vta
-  mgu.io.in.info.ma := wbReg.bits.vls.get.vpu.vma
-  mgu.io.in.info.vl := wbReg.bits.vls.get.vpu.vl
-  mgu.io.in.info.vstart := wbReg.bits.vls.get.vpu.vstart
-  mgu.io.in.info.eew := wbReg.bits.vls.get.vpu.veew
-  mgu.io.in.info.vsew := wbReg.bits.vls.get.vpu.vsew
-  mgu.io.in.info.vdIdx := wbReg.bits.vls.get.vdIdxInField
-  mgu.io.in.info.vlmul := wbReg.bits.vls.get.vpu.vlmul
+  mgu.io.in.info.ta := wbReg.bits.toRob.bits.vls.get.isMasked || wbReg.bits.toRob.bits.vls.get.vpu.vta
+  mgu.io.in.info.ma := wbReg.bits.toRob.bits.vls.get.vpu.vma
+  mgu.io.in.info.vl := wbReg.bits.toRob.bits.vls.get.vpu.vl
+  mgu.io.in.info.vstart := wbReg.bits.toRob.bits.vls.get.vpu.vstart
+  mgu.io.in.info.eew := wbReg.bits.toRob.bits.vls.get.vpu.veew
+  mgu.io.in.info.vsew := wbReg.bits.toRob.bits.vls.get.vpu.vsew
+  mgu.io.in.info.vdIdx := wbReg.bits.toRob.bits.vls.get.vdIdxInField
+  mgu.io.in.info.vlmul := wbReg.bits.toRob.bits.vls.get.vpu.vlmul
   mgu.io.in.info.narrow := false.B  // never narrow
   mgu.io.in.info.dstMask := false.B // vlm need not mask
-  mgu.io.in.isIndexedVls := wbReg.bits.vls.get.isIndexed
+  mgu.io.in.isIndexedVls := wbReg.bits.toRob.bits.vls.get.isIndexed
 
   //For the uop whose vl is modified by first-only-fault, the data written back can be used directly
-  vdAfterMerge := Mux(wbReg.bits.vlWen.getOrElse(false.B), wbReg.bits.data(0), mgu.io.out.vd)
+  vdAfterMerge := Mux(wbReg.bits.toVlRf.map(_.valid).getOrElse(false.B), wbReg.bits.toVecRf.map(_.bits).getOrElse(0.U(params.destDataBitsMax.W)), mgu.io.out.vd)
 
   io.writebackAfterMerge.valid := wbReg.valid
   io.writebackAfterMerge.bits := wbReg.bits
-  io.writebackAfterMerge.bits.vecWen.foreach(_ := wbReg.bits.vecWen.get)
-  io.writebackAfterMerge.bits.v0Wen.foreach(_ := wbReg.bits.v0Wen.get)
-  io.writebackAfterMerge.bits.data := VecInit(Seq.fill(params.wbPathNum)(vdAfterMerge))
+  io.writebackAfterMerge.bits.toVecRf.foreach(_.valid := wbReg.bits.toVecRf.map(_.valid).getOrElse(false.B))
+  io.writebackAfterMerge.bits.toV0Rf.foreach(_.valid := wbReg.bits.toV0Rf.map(_.valid).getOrElse(false.B))
+  io.writebackAfterMerge.bits.toVecRf.foreach(_.bits := vdAfterMerge)
 }
 
 class VldMergeUnitIO(param: ExeUnitParams)(implicit p: Parameters) extends XSBundle {
   val flush = Flipped(ValidIO(new Redirect))
-  val writeback = Flipped(DecoupledIO(new ExuOutput(param)))
-  val writebackAfterMerge = DecoupledIO(new ExuOutput(param))
+  val writeback = Flipped(DecoupledIO(new NewExuOutput(param)))
+  val writebackAfterMerge = DecoupledIO(new NewExuOutput(param))
 }

--- a/src/main/scala/xiangshan/backend/datapath/WbArbiter.scala
+++ b/src/main/scala/xiangshan/backend/datapath/WbArbiter.scala
@@ -4,13 +4,13 @@ import org.chipsalliance.cde.config.Parameters
 import chisel3._
 import chisel3.util._
 import utility.XSError
+import xiangshan._
 import xiangshan.backend.BackendParams
-import xiangshan.backend.Bundles.{ExuOutput, WriteBackBundle}
+import xiangshan.backend.Bundles._
 import xiangshan.backend.datapath.DataConfig._
-import xiangshan.backend.regfile.RfWritePortBundle
-import xiangshan.{Redirect, XSBundle, XSModule}
 import xiangshan.backend.fu.vector.Bundles.Vstart
 import xiangshan.backend.issue.SchdBlockParams
+import xiangshan.backend.regfile.RfWritePortBundle
 
 class WbArbiterDispatcherIO[T <: Data](private val gen: T, n: Int) extends Bundle {
   val in = Flipped(DecoupledIO(gen))
@@ -38,20 +38,20 @@ class WbArbiterDispatcher[T <: Data](private val gen: T, n: Int, acceptCond: T =
 
 class WbArbiterIO()(implicit p: Parameters, params: WbArbiterParams) extends XSBundle {
   val flush = Flipped(ValidIO(new Redirect))
-  val in: MixedVec[DecoupledIO[WriteBackBundle]] = Flipped(params.genInput)
-  val out: MixedVec[ValidIO[WriteBackBundle]] = params.genOutput
+  val in: MixedVec[DecoupledIO[WriteBackRFBundle]] = Flipped(params.genNewInput)
+  val out: MixedVec[ValidIO[WriteBackRFBundle]] = params.genNewOutput
 
-  def inGroup: Map[Int, Seq[DecoupledIO[WriteBackBundle]]] = in.groupBy(_.bits.params.port).map(x => (x._1, x._2.sortBy(_.bits.params.priority).toSeq))
+  def inGroup: Map[Int, Seq[DecoupledIO[WriteBackRFBundle]]] = in.groupBy(_.bits.params.port).map(x => (x._1, x._2.sortBy(_.bits.params.priority).toSeq))
 }
 
 class RealWBCollideChecker(params: WbArbiterParams)(implicit p: Parameters) extends XSModule {
   val io = IO(new WbArbiterIO()(p, params))
 
-  private val inGroup: Map[Int, Seq[DecoupledIO[WriteBackBundle]]] = io.inGroup
+  private val inGroup: Map[Int, Seq[DecoupledIO[WriteBackRFBundle]]] = io.inGroup
 
-  private val arbiters: Seq[Option[RealWBArbiter[WriteBackBundle]]] = Seq.tabulate(params.numOut) { x => {
+  private val arbiters: Seq[Option[RealWBArbiter[WriteBackRFBundle]]] = Seq.tabulate(params.numOut) { x => {
     if (inGroup.contains(x)) {
-      Some(Module(new RealWBArbiter(new WriteBackBundle(inGroup.values.head.head.bits.params, backendParams), inGroup(x).length)))
+      Some(Module(new RealWBArbiter(new WriteBackRFBundle(inGroup.values.head.head.bits.params, backendParams), inGroup(x).length)))
     } else {
       None
     }
@@ -88,11 +88,11 @@ class WbDataPathIO()(implicit p: Parameters, params: BackendParams, schdParams: 
     val hartId = Input(UInt(8.W))
   }
 
-  val fromIntExu: MixedVec[MixedVec[DecoupledIO[ExuOutput]]] = Flipped(params.intSchdParams.get.genExuOutputDecoupledBundle)
+  val fromIntExu: MixedVec[MixedVec[DecoupledIO[NewExuOutput]]] = Flipped(params.intSchdParams.get.genNewExuOutputDecoupledBundle)
 
-  val fromFpExu: MixedVec[MixedVec[DecoupledIO[ExuOutput]]] = Flipped(params.fpSchdParams.get.genExuOutputDecoupledBundle)
+  val fromFpExu: MixedVec[MixedVec[DecoupledIO[NewExuOutput]]] = Flipped(params.fpSchdParams.get.genNewExuOutputDecoupledBundle)
 
-  val fromVfExu: MixedVec[MixedVec[DecoupledIO[ExuOutput]]] = Flipped(params.vecSchdParams.get.genExuOutputDecoupledBundle)
+  val fromVfExu: MixedVec[MixedVec[DecoupledIO[NewExuOutput]]] = Flipped(params.vecSchdParams.get.genNewExuOutputDecoupledBundle)
 
   val fromCSR = Input(new Bundle {
     val vstart = Vstart()
@@ -105,7 +105,7 @@ class WbDataPathIO()(implicit p: Parameters, params: BackendParams, schdParams: 
   val toVlPreg = Output(backendParams.genVlWriteBackBundle)
 
   val toCtrlBlock = new Bundle {
-    val writeback: MixedVec[ValidIO[ExuOutput]] = MixedVec(schdParams.genExuOutputValidBundle.flatten)
+    val writeback: MixedVec[ValidIO[WriteBackRobBundle]] = MixedVec(schdParams.genWriteBackRobValidBundle.flatten)
   }
 }
 
@@ -116,7 +116,7 @@ class WbDataPath(params: BackendParams, schdParams: SchdBlockParams)(implicit p:
   val fromExuPre = collection.mutable.Seq() ++ (io.fromIntExu ++ io.fromFpExu ++ io.fromVfExu).flatten
   val wbReplaceVld = fromExuPre
   if (schdParams.isVecSchd) {
-    val fromExuVld: Seq[DecoupledIO[ExuOutput]] = fromExuPre.filter(_.bits.params.hasVLoadFu).toSeq
+    val fromExuVld: Seq[DecoupledIO[NewExuOutput]] = fromExuPre.filter(_.bits.params.hasVLoadFu).toSeq
     val vldMgu: Seq[VldMergeUnit] = fromExuVld.map(x => Module(new VldMergeUnit(x.bits.params)))
     vldMgu.zip(fromExuVld).foreach { case (mgu, exu) =>
       mgu.io.flush := io.flush
@@ -124,7 +124,7 @@ class WbDataPath(params: BackendParams, schdParams: SchdBlockParams)(implicit p:
       // Since xs will flush pipe, when vstart is not 0 and execute vector mem inst, the value of vstart in CSR is the
       // first element of this vector instruction. When exception occurs, the vstart in writeback bundle is the new one,
       // So this vstart should never be used as the beginning of vector mem operation.
-      mgu.io.writeback.bits.vls.get.vpu.vstart := io.fromCSR.vstart
+      mgu.io.writeback.bits.toRob.bits.vls.get.vpu.vstart := io.fromCSR.vstart
     }
     val vldIdx: Seq[Int] = vldMgu.map(x => fromExuPre.indexWhere(_.bits.params == x.params))
     println("vldIdx: " + vldIdx)
@@ -169,12 +169,12 @@ class WbDataPath(params: BackendParams, schdParams: SchdBlockParams)(implicit p:
   val vlArbiterInputsWireY = vlArbiterInputsWire.filter(_.bits.params.writeVlRf)
   val vlArbiterInputsWireN = vlArbiterInputsWire.filterNot(_.bits.params.writeVlRf)
 
-  def acceptCond(exuOutput: ExuOutput): (Seq[Bool], Bool) = {
-    val intWen = exuOutput.intWen.getOrElse(false.B)
-    val fpwen  = exuOutput.fpWen.getOrElse(false.B)
-    val vecWen = exuOutput.vecWen.getOrElse(false.B)
-    val v0Wen  = exuOutput.v0Wen.getOrElse(false.B)
-    val vlWen  = exuOutput.vlWen.getOrElse(false.B)
+  def acceptCond(exuOutput: NewExuOutput): (Seq[Bool], Bool) = {
+    val intWen = exuOutput.toIntRf.map(_.valid).getOrElse(false.B)
+    val fpwen  = exuOutput.toFpRf.map(_.valid).getOrElse(false.B)
+    val vecWen = exuOutput.toVecRf.map(_.valid).getOrElse(false.B)
+    val v0Wen  = exuOutput.toV0Rf.map(_.valid).getOrElse(false.B)
+    val vlWen  = exuOutput.toVlRf.map(_.valid).getOrElse(false.B)
     (Seq(intWen, fpwen, vecWen, v0Wen, vlWen), !intWen && !fpwen && !vecWen && !v0Wen && !vlWen)
   }
 
@@ -305,7 +305,7 @@ class WbDataPath(params: BackendParams, schdParams: SchdBlockParams)(implicit p:
   intWbArbiter.io.flush <> io.flush
   require(intWbArbiter.io.in.size == intArbiterInputsWireY.size, s"intWbArbiter input size: ${intWbArbiter.io.in.size}, all int wb size: ${intArbiterInputsWireY.size}")
   intWbArbiter.io.in.zip(intArbiterInputsWireY).foreach { case (arbiterIn, in) =>
-    arbiterIn.valid := in.valid && in.bits.intWen.get
+    arbiterIn.valid := in.valid && in.bits.toIntRf.map(_.valid).getOrElse(false.B)
     in.ready := arbiterIn.ready
     arbiterIn.bits.fromExuOutput(in.bits, "int")
   }
@@ -316,9 +316,8 @@ class WbDataPath(params: BackendParams, schdParams: SchdBlockParams)(implicit p:
   require(fpWbArbiter.io.in.size == fpArbiterInputsWireY.size, s"fpWbArbiter input size: ${fpWbArbiter.io.in.size}, all fp wb size: ${fpArbiterInputsWireY.size}")
   fpWbArbiter.io.in.zip(fpArbiterInputsWireY).foreach { case (arbiterIn, in) =>
     println(s"[WbDataPath_fpWbArbiter] fpArbiterInputsWireY.name = ${in.bits.params.name}")
-    println(s"[WbDataPath_fpWbArbiter] fpArbiterInputsWireY.data.size = ${in.bits.data.size}")
     println(s"[WbDataPath_fpWbArbiter] arbiterIn.bits.params.port,priority = ${arbiterIn.bits.params.port},${arbiterIn.bits.params.priority}")
-    arbiterIn.valid := in.valid && (in.bits.fpWen.getOrElse(false.B))
+    arbiterIn.valid := in.valid && in.bits.toFpRf.map(_.valid).getOrElse(false.B)
     in.ready := arbiterIn.ready
     arbiterIn.bits.fromExuOutput(in.bits, "fp")
   }
@@ -327,7 +326,7 @@ class WbDataPath(params: BackendParams, schdParams: SchdBlockParams)(implicit p:
   vfWbArbiter.io.flush <> io.flush
   require(vfWbArbiter.io.in.size == vfArbiterInputsWireY.size, s"vfWbArbiter input size: ${vfWbArbiter.io.in.size}, all vf wb size: ${vfArbiterInputsWireY.size}")
   vfWbArbiter.io.in.zip(vfArbiterInputsWireY).foreach { case (arbiterIn, in) =>
-    arbiterIn.valid := in.valid && (in.bits.vecWen.getOrElse(false.B))
+    arbiterIn.valid := in.valid && in.bits.toVecRf.map(_.valid).getOrElse(false.B)
     in.ready := arbiterIn.ready
     arbiterIn.bits.fromExuOutput(in.bits, "vf")
   }
@@ -336,7 +335,7 @@ class WbDataPath(params: BackendParams, schdParams: SchdBlockParams)(implicit p:
   v0WbArbiter.io.flush <> io.flush
   require(v0WbArbiter.io.in.size == v0ArbiterInputsWireY.size, s"v0WbArbiter input size: ${v0WbArbiter.io.in.size}, all v0 wb size: ${v0ArbiterInputsWireY.size}")
   v0WbArbiter.io.in.zip(v0ArbiterInputsWireY).foreach { case (arbiterIn, in) =>
-    arbiterIn.valid := in.valid && (in.bits.v0Wen.getOrElse(false.B))
+    arbiterIn.valid := in.valid && in.bits.toV0Rf.map(_.valid).getOrElse(false.B)
     in.ready := arbiterIn.ready
     arbiterIn.bits.fromExuOutput(in.bits, "v0")
   }
@@ -345,7 +344,7 @@ class WbDataPath(params: BackendParams, schdParams: SchdBlockParams)(implicit p:
   vlWbArbiter.io.flush <> io.flush
   require(vlWbArbiter.io.in.size == vlArbiterInputsWireY.size, s"vlWbArbiter input size: ${vlWbArbiter.io.in.size}, all vl wb size: ${vlArbiterInputsWireY.size}")
   vlWbArbiter.io.in.zip(vlArbiterInputsWireY).foreach { case (arbiterIn, in) =>
-    arbiterIn.valid := in.valid && (in.bits.vlWen.getOrElse(false.B))
+    arbiterIn.valid := in.valid && in.bits.toVlRf.map(_.valid).getOrElse(false.B)
     in.ready := arbiterIn.ready
     arbiterIn.bits.fromExuOutput(in.bits, "vl")
   }
@@ -381,8 +380,8 @@ class WbDataPath(params: BackendParams, schdParams: SchdBlockParams)(implicit p:
   io.toV0Preg := toV0Preg
   io.toVlPreg := toVlPreg
   io.toCtrlBlock.writeback.zip(wb2Ctrl).foreach { case (sink, source) =>
-    sink.valid := source.valid
-    sink.bits := source.bits
+    connectWriteBackRob(sink.bits, source.bits)
+    sink.valid := source.bits.toRob.valid
     source.ready := true.B
   }
 }

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -23,7 +23,7 @@ import chisel3.util._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utility._
 import xiangshan.backend.fu.{CSRFileIO, FenceIO, FuType, FuncUnitInput, UncertainLatency}
-import xiangshan.backend.Bundles.{ExuInput, ExuOutput, IssueQueueIQWakeUpBundle, VIAluCtrlSignals}
+import xiangshan.backend.Bundles._
 import xiangshan.{AddrTransType, FPUCtrlSignals, HasXSParameter, Redirect, Resolve, XSBundle, XSModule}
 import xiangshan.backend.datapath.WbConfig._
 import xiangshan.backend.fu.vector.Bundles.{VType, Vxrm}
@@ -34,8 +34,8 @@ import xiangshan._
 
 class ExeUnitIO(params: ExeUnitParams)(implicit p: Parameters) extends XSBundle {
   val flush = Flipped(ValidIO(new Redirect()))
-  val in = Flipped(DecoupledIO(new ExuInput(params, hasCopySrc = true)))
-  val out = DecoupledIO(new ExuOutput(params))
+  val in = Flipped(DecoupledIO(new NewExuInput(params, hasCopySrc = true)))
+  val out = DecoupledIO(new NewExuOutput(params))
   val uncertainWakeupOut = Option.when(params.needUncertainWakeup)(DecoupledIO(new IssueQueueIQWakeUpBundle(params.exuIdx, params.backendParam, params.copyWakeupOut, params.copyNum)))
   val csrin = Option.when(params.hasCSR)(new CSRInput)
   val csrio = Option.when(params.hasCSR)(new CSRFileIO)
@@ -143,20 +143,20 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
     fu.io.flush <> io.flush
   }
 
-  def acceptCond(input: ExuInput): Seq[Bool] = {
+  def acceptCond(input: NewExuInput): Seq[Bool] = {
     input.params.fuConfigs.map(_.fuSel(input))
   }
 
-  val in1ToN = Module(new Dispatcher(new ExuInput(exuParams), funcUnits.length, acceptCond))
+  val in1ToN = Module(new Dispatcher(new NewExuInput(exuParams), funcUnits.length, acceptCond))
 
   // ExeUnit.in <---> Dispatcher.in
   in1ToN.io.in.valid := io.in.valid
   in1ToN.io.in.bits := io.in.bits
   io.in.ready := in1ToN.io.in.ready
 
-  def pipelineReg(init: ExuInput, valid: Bool, latency: Int, flush: ValidIO[Redirect]): (Seq[ExuInput], Seq[Bool]) = {
+  def pipelineReg(init: NewExuInput, valid: Bool, latency: Int, flush: ValidIO[Redirect]): (Seq[NewExuInput], Seq[Bool]) = {
     val validVec = valid +: Seq.fill(latency)(RegInit(false.B))
-    val inVec = init +: Seq.fill(latency)(Reg(new ExuInput(exuParams)))
+    val inVec = init +: Seq.fill(latency)(Reg(new NewExuInput(exuParams)))
     val robIdxVec = inVec.map(_.robIdx)
     // if flush(0), valid 0 will not given, so set flushVec(0) to false.B
     val flushVec = validVec.zip(robIdxVec).map(x => x._1 && x._2.needFlush(flush))
@@ -170,34 +170,35 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
   val inPipe = pipelineReg(io.in.bits, io.in.valid, latencyMax, io.flush)
   // Dispatcher.out <---> FunctionUnits
   in1ToN.io.out.zip(funcUnits.map(_.io.in)).foreach {
-    case (source: DecoupledIO[ExuInput], sink: DecoupledIO[FuncUnitInput]) =>
+    case (source: DecoupledIO[NewExuInput], sink: DecoupledIO[FuncUnitInput]) =>
       sink.valid := source.valid
       source.ready := sink.ready
 
-      sink.bits.data.pc          .foreach(x => x := source.bits.pc.get)
-      sink.bits.data.nextPcOffset.foreach(x => x := source.bits.nextPcOffset.get)
-      sink.bits.data.imm         := source.bits.imm
-      sink.bits.ctrl.fuOpType    := source.bits.fuOpType
+      sink.bits.data.pc          .foreach(x => x := source.bits.data.pc.get)
+      sink.bits.data.nextPcOffset.foreach(x => x := source.bits.data.nextPcOffset.get)
+      sink.bits.data.imm         := source.bits.data.imm
+      sink.bits.ctrl.fuOpType    := source.bits.ctrl.fuOpType
+      sink.bits.ctrl.toRobValid  := source.bits.toRobValid
       sink.bits.ctrl.robIdx      := source.bits.robIdx
-      sink.bits.ctrl.pdest       := source.bits.pdest
-      sink.bits.ctrl.pdestVl     .foreach(x => x := source.bits.pdestVl.get)
-      sink.bits.ctrl.rfWen       .foreach(x => x := source.bits.rfWen.get)
-      sink.bits.ctrl.fpWen       .foreach(x => x := source.bits.fpWen.get)
-      sink.bits.ctrl.vecWen      .foreach(x => x := source.bits.vecWen.get)
-      sink.bits.ctrl.v0Wen       .foreach(x => x := source.bits.v0Wen.get)
-      sink.bits.ctrl.vlWen       .foreach(x => x := source.bits.vlWen.get)
-      sink.bits.ctrl.flushPipe   .foreach(x => x := source.bits.flushPipe.get)
-      sink.bits.ctrl.isRVC       .foreach(x => x := source.bits.isRVC.get)
-      sink.bits.ctrl.rasAction   .foreach(x=> x  := source.bits.rasAction.get)
-      sink.bits.ctrl.ftqIdx      .foreach(x => x := source.bits.ftqIdx.get)
-      sink.bits.ctrl.ftqOffset   .foreach(x => x := source.bits.ftqOffset.get)
-      sink.bits.ctrl.predictInfo .foreach(x => x := source.bits.predictInfo.get)
-      sink.bits.ctrl.fpu         .foreach(x => x := source.bits.fpu.get)
-      sink.bits.ctrl.vpu         .foreach(x => x := source.bits.vpu.get)
+      sink.bits.ctrl.pdest       := source.bits.toRF.pdest
+      sink.bits.ctrl.pdestVl     .foreach(x => x := source.bits.toRF.pdestVl.get)
+      sink.bits.ctrl.rfWen       .foreach(x => x := source.bits.ctrl.rfWen.get)
+      sink.bits.ctrl.fpWen       .foreach(x => x := source.bits.ctrl.fpWen.get)
+      sink.bits.ctrl.vecWen      .foreach(x => x := source.bits.ctrl.vecWen.get)
+      sink.bits.ctrl.v0Wen       .foreach(x => x := source.bits.ctrl.v0Wen.get)
+      sink.bits.ctrl.vlWen       .foreach(x => x := source.bits.ctrl.vlWen.get)
+      sink.bits.ctrl.flushPipe   .foreach(x => x := source.bits.ctrl.flushPipe.get)
+      sink.bits.ctrl.isRVC       .foreach(x => x := source.bits.ctrl.isRVC.get)
+      sink.bits.ctrl.rasAction   .foreach(x=> x  := source.bits.ctrl.rasAction.get)
+      sink.bits.ctrl.ftqIdx      .foreach(x => x := source.bits.ctrl.ftqIdx.get)
+      sink.bits.ctrl.ftqOffset   .foreach(x => x := source.bits.ctrl.ftqOffset.get)
+      sink.bits.ctrl.predictInfo .foreach(x => x := source.bits.ctrl.predictInfo.get)
+      sink.bits.ctrl.fpu         .foreach(x => x := source.bits.ctrl.fpu.get)
+      sink.bits.ctrl.vpu         .foreach(x => x := source.bits.ctrl.vpu.get)
+      sink.bits.ctrl.vialuCtrl   .foreach(x => x := source.bits.ctrl.vialuCtrl.get)
       sink.bits.ctrl.vpu         .foreach(x => x.fpu.isFpToVecInst := 0.U)
       sink.bits.ctrl.vpu         .foreach(x => x.fpu.isFP32Instr   := 0.U)
       sink.bits.ctrl.vpu         .foreach(x => x.fpu.isFP64Instr   := 0.U)
-      sink.bits.ctrl.vialuCtrl   .foreach(x => x := source.bits.vialuCtrl.get)
       sink.bits.perfDebugInfo    .foreach(_ := source.bits.perfDebugInfo.get)
       sink.bits.debug_seqNum     .foreach(_ := source.bits.debug_seqNum.get)
   }
@@ -210,23 +211,24 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
       val sink = fu.io.in.bits.ctrlPipe.get(i)
       val source = inPipe._1(i)
       fu.io.in.bits.validPipe.get(i) := inPipe._2(i)
-      sink.fuOpType := source.fuOpType
+      sink.fuOpType := source.ctrl.fuOpType
+      sink.toRobValid := source.toRobValid
       sink.robIdx := source.robIdx
-      sink.pdest := source.pdest
-      sink.pdestVl.foreach(_ := source.pdestVl.get)
-      sink.rfWen.foreach(x => x := source.rfWen.get)
-      sink.fpWen.foreach(x => x := source.fpWen.get)
-      sink.vecWen.foreach(x => x := source.vecWen.get)
-      sink.v0Wen.foreach(x => x := source.v0Wen.get)
-      sink.vlWen.foreach(x => x := source.vlWen.get)
-      sink.flushPipe.foreach(x => x := source.flushPipe.get)
-      sink.isRVC.foreach(x => x := source.isRVC.get)
-      sink.rasAction.foreach(x => x := source.rasAction.get)
-      sink.ftqIdx.foreach(x => x := source.ftqIdx.get)
-      sink.ftqOffset.foreach(x => x := source.ftqOffset.get)
-      sink.predictInfo.foreach(x => x := source.predictInfo.get)
-      sink.fpu.foreach(x => x := source.fpu.get)
-      sink.vpu.foreach(x => x := source.vpu.get)
+      sink.pdest := source.toRF.pdest
+      sink.pdestVl.foreach(_ := source.toRF.pdestVl.get)
+      sink.rfWen.foreach(      x => x := source.ctrl.rfWen.get)
+      sink.fpWen.foreach(      x => x := source.ctrl.fpWen.get)
+      sink.vecWen.foreach(     x => x := source.ctrl.vecWen.get)
+      sink.v0Wen.foreach(      x => x := source.ctrl.v0Wen.get)
+      sink.vlWen.foreach(      x => x := source.ctrl.vlWen.get)
+      sink.flushPipe.foreach(  x => x := source.ctrl.flushPipe.get)
+      sink.isRVC.foreach(      x => x := source.ctrl.isRVC.get)
+      sink.rasAction.foreach(  x => x := source.ctrl.rasAction.get)
+      sink.ftqIdx.foreach(     x => x := source.ctrl.ftqIdx.get)
+      sink.ftqOffset.foreach(  x => x := source.ctrl.ftqOffset.get)
+      sink.predictInfo.foreach(x => x := source.ctrl.predictInfo.get)
+      sink.fpu.foreach(x => x := source.ctrl.fpu.get)
+      sink.vpu.foreach(x => x := source.ctrl.vpu.get)
       sink.vpu.foreach(x => x.fpu.isFpToVecInst := 0.U)
       sink.vpu.foreach(x => x.fpu.isFP32Instr := 0.U)
       sink.vpu.foreach(x => x.fpu.isFP64Instr := 0.U)
@@ -234,20 +236,20 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
       sink.vialuCtrl.foreach(x => x := 0.U.asTypeOf(new VIAluCtrlSignals))
       val sinkData = fu.io.in.bits.dataPipe.get(i)
       val sourceData = inPipe._1(i)
-      sinkData.src.zip(sourceData.src).foreach { case (fuSrc, exuSrc) => fuSrc := exuSrc }
-      sinkData.vl.foreach(_ := sourceData.vl.get)
-      sinkData.pc.foreach(x => x := sourceData.pc.get)
-      sinkData.nextPcOffset.foreach(x => x := sourceData.nextPcOffset.get)
-      sinkData.imm := sourceData.imm
+      sinkData.src.zip(sourceData.data.src).foreach { case (fuSrc, exuSrc) => fuSrc := exuSrc }
+      sinkData.vl.foreach(_ := sourceData.data.vl.get)
+      sinkData.pc.foreach(x => x := sourceData.data.pc.get)
+      sinkData.nextPcOffset.foreach(x => x := sourceData.data.nextPcOffset.get)
+      sinkData.imm := sourceData.data.imm
     }
   }
 
   funcUnits.zip(exuParams.idxCopySrc).map{ case(fu, idx) =>
-    (fu.io.in.bits.data.src).zip(io.in.bits.src).foreach { case(fuSrc, exuSrc) => fuSrc := exuSrc }
+    (fu.io.in.bits.data.src).zip(io.in.bits.data.src).foreach { case(fuSrc, exuSrc) => fuSrc := exuSrc }
     if(fu.cfg.srcNeedCopy) {
-      (fu.io.in.bits.data.src).zip(io.in.bits.copySrc.get(idx)).foreach { case(fuSrc, copySrc) => fuSrc := copySrc }
+      (fu.io.in.bits.data.src).zip(io.in.bits.copy.copySrc.get(idx)).foreach { case(fuSrc, copySrc) => fuSrc := copySrc }
     }
-    fu.io.in.bits.data.vl.foreach(_ := io.in.bits.vl.get)
+    fu.io.in.bits.data.vl.foreach(_ := io.in.bits.data.vl.get)
   }
 
   private val OutresVecs = funcUnits.map { fu =>
@@ -286,59 +288,77 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
   private val fuVlWenVec = funcUnits.map(x => x.cfg.needVlWen.B && x.io.out.bits.ctrl.vlWen.getOrElse(false.B))
   // FunctionUnits <---> ExeUnit.out
 
-  private val outDataVec = Seq(
-    Some(fuOutresVec.map(_.data)),
-    Option.when(funcUnits.exists(_.cfg.writeIntRf)) {
-      if (exuParams.needDataFromF2I) {
-        (funcUnits.zip(fuOutresVec).filter { case (fu, _) => fu.cfg.writeIntRf }.map { case (_, fuout) => fuout.data } :+ io.F2IDataIn.get.bits)
+  private val outData = fuOutresVec.map(_.data)
+
+  private val outIntDataValid = Option.when(funcUnits.exists(_.cfg.writeIntRf))(WireInit(false.B))
+  private val outFpDataValid  = Option.when(funcUnits.exists(_.cfg.writeFpRf)) (WireInit(false.B))
+  private val outVecDataValid = Option.when(funcUnits.exists(_.cfg.writeVecRf))(WireInit(false.B))
+  private val outV0DataValid  = Option.when(funcUnits.exists(_.cfg.writeV0Rf)) (WireInit(false.B))
+  private val outVlDataValid  = Option.when(funcUnits.exists(_.cfg.writeVlRf)) (WireInit(false.B))
+  private val outIntData = Option.when(funcUnits.exists(_.cfg.writeIntRf))(WireInit(0.U(exuParams.destDataBitsMax.W)))
+  private val outFpData  = Option.when(funcUnits.exists(_.cfg.writeFpRf)) (WireInit(0.U(exuParams.destDataBitsMax.W)))
+  private val outVecData = Option.when(funcUnits.exists(_.cfg.writeVecRf))(WireInit(0.U(exuParams.destDataBitsMax.W)))
+  private val outV0Data  = Option.when(funcUnits.exists(_.cfg.writeV0Rf)) (WireInit(0.U(exuParams.destDataBitsMax.W)))
+  private val outVlData  = Option.when(funcUnits.exists(_.cfg.writeVlRf)) (WireInit(0.U(exuParams.destDataBitsMax.W)))
+
+  Option.when(funcUnits.exists(_.cfg.writeIntRf)) {
+    val vld = if (exuParams.needDataFromF2I) {
+        (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeIntRf }.map { case (fu, fuoutOH) =>
+          !io.F2IDataIn.get.valid && fuoutOH && fu.io.out.bits.ctrl.rfWen.getOrElse(false.B) } :+ io.F2IDataIn.get.valid)
+      } else {
+        (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeIntRf }.map { case (fu, fuoutOH) =>
+          fuoutOH && fu.io.out.bits.ctrl.rfWen.getOrElse(false.B) })
       }
-      else {
+    val data = if (exuParams.needDataFromF2I) {
+        (funcUnits.zip(fuOutresVec).filter { case (fu, _) => fu.cfg.writeIntRf }.map { case (_, fuout) => fuout.data } :+ io.F2IDataIn.get.bits)
+      } else {
         (funcUnits.zip(fuOutresVec).filter { case (fu, _) => fu.cfg.writeIntRf }.map { case (_, fuout) => fuout.data })
       }
-    },
-    Option.when(funcUnits.exists(_.cfg.writeFpRf)){
-      if (exuParams.needDataFromI2F){
-        (funcUnits.zip(fuOutresVec).filter { case (fu, _) => fu.cfg.writeFpRf }.map{ case (_, fuout) => fuout.data} :+ io.I2FDataIn.get.bits)
-      }
-      else{
-        (funcUnits.zip(fuOutresVec).filter { case (fu, _) => fu.cfg.writeFpRf }.map{ case (_, fuout) => fuout.data})
-      }
-    },
-    Option.when(funcUnits.exists(_.cfg.writeVecRf))
-      (funcUnits.zip(fuOutresVec).filter{ case (fu, _) => fu.cfg.writeVecRf}.map{ case(_, fuout) => fuout.data}),
-    Option.when(funcUnits.exists(_.cfg.writeV0Rf))
-      (funcUnits.zip(fuOutresVec).filter{ case (fu, _) => fu.cfg.writeV0Rf}.map{ case(_, fuout) => fuout.data}),
-    Option.when(funcUnits.exists(_.cfg.writeVlRf))
-      (funcUnits.zip(fuOutresVec).filter{ case (fu, _) => fu.cfg.writeVlRf}.map{ case(_, fuout) => fuout.data}),
-  ).flatten
-  private val outDataValidOH = Seq(
-    Some(fuOutValidOH),
-    Option.when(funcUnits.exists(_.cfg.writeIntRf)) {
-      // io.F2IDataIn.get.valid and funcUnits may valid at same time when they write different reg file
-      if (exuParams.needDataFromF2I) {
-        (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeIntRf }.map { case (_, fuoutOH) => !io.F2IDataIn.get.valid && fuoutOH } :+ io.F2IDataIn.get.valid)
+    outIntDataValid.foreach(_ := Cat(vld).orR)
+    outIntData.foreach(_ := Mux1H(vld, data))
+  }
+  Option.when(funcUnits.exists(_.cfg.writeFpRf)) {
+    val vld = if (exuParams.needDataFromI2F) {
+        (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeFpRf }.map { case (fu, fuoutOH) =>
+          !io.I2FDataIn.get.valid && fuoutOH && fu.io.out.bits.ctrl.fpWen.getOrElse(false.B) } :+ io.I2FDataIn.get.valid)
       } else {
-        (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeIntRf }.map { case (_, fuoutOH) => fuoutOH })
+        (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeFpRf }.map { case (fu, fuoutOH) =>
+          fuoutOH && fu.io.out.bits.ctrl.fpWen.getOrElse(false.B) })
       }
-    },
-    Option.when(funcUnits.exists(_.cfg.writeFpRf)){
-      if (exuParams.needDataFromI2F) {
-        (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeFpRf }.map { case (_, fuoutOH) => !io.I2FDataIn.get.valid && fuoutOH } :+ io.I2FDataIn.get.valid)
+    val data = if (exuParams.needDataFromI2F) {
+        (funcUnits.zip(fuOutresVec).filter { case (fu, _) => fu.cfg.writeFpRf }.map { case (_, fuout) => fuout.data } :+ io.I2FDataIn.get.bits)
+      } else {
+        (funcUnits.zip(fuOutresVec).filter { case (fu, _) => fu.cfg.writeFpRf }.map { case (_, fuout) => fuout.data })
       }
-      else {
-        (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeFpRf }.map { case (_, fuoutOH) => fuoutOH})
-      }
-    },
-    Option.when(funcUnits.exists(_.cfg.writeVecRf))
-      (funcUnits.zip(fuOutValidOH).filter{ case (fu, _) => fu.cfg.writeVecRf}.map{ case(_, fuoutOH) => fuoutOH}),
-    Option.when(funcUnits.exists(_.cfg.writeV0Rf))
-      (funcUnits.zip(fuOutValidOH).filter{ case (fu, _) => fu.cfg.writeV0Rf}.map{ case(_, fuoutOH) => fuoutOH}),
-    Option.when(funcUnits.exists(_.cfg.writeVlRf))
-      (funcUnits.zip(fuOutValidOH).filter{ case (fu, _) => fu.cfg.writeVlRf}.map{ case(_, fuoutOH) => fuoutOH}),
-  ).flatten
+    outFpDataValid.foreach(_ := Cat(vld).orR)
+    outFpData.foreach(_ := Mux1H(vld, data))
+  }
+  Option.when(funcUnits.exists(_.cfg.writeVecRf)) {
+    val vld = (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeVecRf }.map { case (fu, fuoutOH) =>
+      fuoutOH && fu.io.out.bits.ctrl.vecWen.getOrElse(false.B) })
+    val data = (funcUnits.zip(fuOutresVec).filter { case (fu, _) => fu.cfg.writeVecRf }.map { case (_, fuout) => fuout.data })
+    outVecDataValid.foreach(_ := Cat(vld).orR)
+    outVecData.foreach(_ := Mux1H(vld, data))
+  }
+  Option.when(funcUnits.exists(_.cfg.writeV0Rf)) {
+    val vld = (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeV0Rf }.map { case (fu, fuoutOH) =>
+      fuoutOH && fu.io.out.bits.ctrl.v0Wen.getOrElse(false.B) })
+    val data = (funcUnits.zip(fuOutresVec).filter { case (fu, _) => fu.cfg.writeV0Rf }.map { case (_, fuout) => fuout.data })
+    outV0DataValid.foreach(_ := Cat(vld).orR)
+    outV0Data.foreach(_ := Mux1H(vld, data))
+  }
+  Option.when(funcUnits.exists(_.cfg.writeVlRf)) {
+    val vld = (funcUnits.zip(fuOutValidOH).filter { case (fu, _) => fu.cfg.writeVlRf }.map { case (fu, fuoutOH) =>
+      fuoutOH && fu.io.out.bits.ctrl.vlWen.getOrElse(false.B) })
+    val data = (funcUnits.zip(fuOutresVec).filter { case (fu, _) => fu.cfg.writeVlRf }.map { case (_, fuout) => fuout.data })
+    outVlDataValid.foreach(_ := Cat(vld).orR)
+    outVlData.foreach(_ := Mux1H(vld, data))
+  }
 
   val criticalErrors = funcUnits.filter(fu => fu.cfg.needCriticalErrors).flatMap(fu => fu.getCriticalErrors)
   generateCriticalErrors()
+
+  val F2IIntWen = io.F2IDataIn.getOrElse(0.U.asTypeOf(ValidIO(UInt(XLEN.W)))).valid
 
   io.out.valid := Cat(fuOutValidOH).orR
   funcUnits.foreach{ fu =>
@@ -381,24 +401,29 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
   }
   }
   // select one fu's result
-  io.out.bits.data := VecInit(outDataVec.zip(outDataValidOH).map{ case(data, validOH) => Mux1H(validOH, data)})
-  io.out.bits.robIdx := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.robIdx))
-  io.out.bits.pdest := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.pdest))
-  io.out.bits.pdestVl.foreach(_ := Mux1H(fuOutValidOH, funcUnits.map(_.io.out.bits.ctrl.pdestVl.getOrElse(0.U))))
-  val F2IIntWen = io.F2IDataIn.getOrElse(0.U.asTypeOf(ValidIO(UInt(XLEN.W)))).valid
-  io.out.bits.intWen.foreach(x => x := Mux1H(fuOutValidOH, fuIntWenVec) || F2IIntWen)
-  io.out.bits.fpWen.foreach(x => x := Mux1H(fuOutValidOH, fuFpWenVec))
-  io.out.bits.vecWen.foreach(x => x := Mux1H(fuOutValidOH, fuVecWenVec))
-  io.out.bits.v0Wen.foreach(x => x := Mux1H(fuOutValidOH, fuV0WenVec))
-  io.out.bits.vlWen.foreach(x => x := Mux1H(fuOutValidOH, fuVlWenVec))
-  io.out.bits.redirect.foreach(x => x := Mux1H((fuOutValidOH zip fuRedirectVec).filter(_._2.isDefined).map(x => (x._1, x._2.get))))
-  io.out.bits.fflags.foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.fflags.getOrElse(0.U.asTypeOf(io.out.bits.fflags.get)))))
-  io.out.bits.wflags.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.fpu.getOrElse(0.U.asTypeOf(new FPUCtrlSignals)).wflags)))
-  io.out.bits.vxsat.foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.vxsat.getOrElse(0.U.asTypeOf(io.out.bits.vxsat.get)))))
-  io.out.bits.exceptionVec.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec.getOrElse(0.U.asTypeOf(io.out.bits.exceptionVec.get)))))
-  io.out.bits.flushPipe.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.flushPipe.getOrElse(0.U.asTypeOf(io.out.bits.flushPipe.get)))))
-  io.out.bits.replay.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.replay.getOrElse(0.U.asTypeOf(io.out.bits.replay.get)))))
-  io.out.bits.isRVC.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.isRVC.getOrElse(false.B))))
+
+  io.out.bits.toIntRf.          foreach(x => x.valid := Mux1H(fuOutValidOH, fuIntWenVec) || F2IIntWen)
+  io.out.bits.toIntRf.          foreach(x => x.bits  := outIntData.get)
+  io.out.bits.toFpRf.           foreach(x => x.valid := Mux1H(fuOutValidOH, fuFpWenVec))
+  io.out.bits.toFpRf.           foreach(x => x.bits  := outFpData.get)
+  io.out.bits.toVecRf.          foreach(x => x.valid := Mux1H(fuOutValidOH, fuVecWenVec))
+  io.out.bits.toVecRf.          foreach(x => x.bits  := outVecData.get)
+  io.out.bits.toV0Rf.           foreach(x => x.valid := Mux1H(fuOutValidOH, fuV0WenVec))
+  io.out.bits.toV0Rf.           foreach(x => x.bits  := outV0Data.get)
+  io.out.bits.toVlRf.           foreach(x => x.valid := Mux1H(fuOutValidOH, fuVlWenVec))
+  io.out.bits.toVlRf.           foreach(x => x.bits  := outVlData.get)
+  io.out.bits.pdest                                  := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.pdest))
+  io.out.bits.pdestVl.                foreach(x => x := Mux1H(fuOutValidOH, funcUnits.map(_.io.out.bits.ctrl.pdestVl.getOrElse(0.U))))
+  io.out.bits.redirect.               foreach(x => x := Mux1H((fuOutValidOH zip fuRedirectVec).filter(_._2.isDefined).map(x => (x._1, x._2.get))))
+  io.out.bits.toRob.valid                            := Mux1H(fuOutValidOH, funcUnits.map(_.io.out.bits.ctrl.toRobValid))
+  io.out.bits.toRob.bits.robIdx                      := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.robIdx))
+  io.out.bits.toRob.bits.fflags.      foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.fflags.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.fflags.get)))))
+  io.out.bits.toRob.bits.wflags.      foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.fpu.getOrElse(0.U.asTypeOf(new FPUCtrlSignals)).wflags)))
+  io.out.bits.toRob.bits.vxsat.       foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.vxsat.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.vxsat.get)))))
+  io.out.bits.toRob.bits.exceptionVec.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.exceptionVec.get)))))
+  io.out.bits.toRob.bits.flushPipe.   foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.flushPipe.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.flushPipe.get)))))
+  io.out.bits.toRob.bits.replay.      foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.replay.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.replay.get)))))
+  io.out.bits.toRob.bits.isRVC.       foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.isRVC.getOrElse(false.B))))
 
   io.toFrontendBJUResolve.foreach{ case resolve => {
     val bjus = funcUnits.filter(x => x.cfg.isJmp || x.cfg.isBrh)

--- a/src/main/scala/xiangshan/backend/exu/ExeUnitParams.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnitParams.scala
@@ -4,7 +4,7 @@ import org.chipsalliance.cde.config.Parameters
 import chisel3._
 import chisel3.util._
 import xiangshan.backend.BackendParams
-import xiangshan.backend.Bundles.{ExuBypassBundle, ExuInput, ExuOutput}
+import xiangshan.backend.Bundles.{ExuBypassBundle, ExuInput, NewExuInput, ExuOutput}
 import xiangshan.backend.datapath.DataConfig.DataConfig
 import xiangshan.backend.datapath.RdConfig._
 import xiangshan.backend.datapath.WbConfig._
@@ -15,6 +15,8 @@ import xiangshan.backend.fu.FuConfig.{BrhCfg, JmpCfg, needUncertainWakeupFuConfi
 import xiangshan.backend.issue.{FpScheduler, IntScheduler, IssueBlockParams, SchedulerType, VecScheduler}
 
 import scala.collection.mutable
+import xiangshan.backend.Bundles.NewExuOutput
+import xiangshan.backend.Bundles.WriteBackRobBundle
 
 case class ExeUnitParams(
   name          : String,
@@ -487,8 +489,20 @@ case class ExeUnitParams(
     new ExuInput(this, hasCopySrc = true)
   }
 
+  def genNewExuInputCopySrcBundle(implicit p: Parameters): NewExuInput = {
+    new NewExuInput(this, hasCopySrc = true)
+  }
+
   def genExuOutputBundle(implicit p: Parameters): ExuOutput = {
     new ExuOutput(this)
+  }
+
+  def genNewExuOutputBundle(implicit p: Parameters): NewExuOutput = {
+    new NewExuOutput(this)
+  }
+
+  def genWriteBackRobBundle(implicit p: Parameters): WriteBackRobBundle = {
+    new WriteBackRobBundle(this, backendParam)
   }
 
   def genExuBypassBundle(implicit p: Parameters): ExuBypassBundle = {

--- a/src/main/scala/xiangshan/backend/exu/ExuBlock.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExuBlock.scala
@@ -22,8 +22,8 @@ class ExuBlock(implicit p: Parameters, params: SchdBlockParams) extends XSModule
     Module(xx.genExuModule).suggestName("exu" + xx.name + "_" + xx.fuConfigs.map(_.name).distinct.map(_.capitalize).reduce(_ ++ _))
   ))
   params.issueBlockParams.filter(x => !x.isMemBlockIQ).flatMap(_.exuBlockParams.map(xx => println(s"[ExuBlock] ${xx.name}")))
-  private val ins: collection.IndexedSeq[DecoupledIO[ExuInput]] = io.in.flatten
-  private val outs: collection.IndexedSeq[DecoupledIO[ExuOutput]] = io.out.flatten
+  private val ins: collection.IndexedSeq[DecoupledIO[NewExuInput]] = io.in.flatten
+  private val outs: collection.IndexedSeq[DecoupledIO[NewExuOutput]] = io.out.flatten
   println(s"[ExuBlock] ins.size = ${ins.size}")
   println(s"[ExuBlock] exus.size = ${exus.size}")
   println(s"[ExuBlock] outs.size = ${outs.size}")
@@ -31,8 +31,8 @@ class ExuBlock(implicit p: Parameters, params: SchdBlockParams) extends XSModule
     exu.io.flush <> io.flush
     exu.io.csrio.foreach(exuio => io.csrio.get <> exuio)
     exu.io.csrin.foreach(exuio => io.csrin.get <> exuio)
-    exu.io.I2FDataIn.foreach(exuio => io.I2FDataIn.get <> exuio)
-    exu.io.F2IDataIn.foreach(exuio => io.F2IDataIn.get <> exuio)
+    exu.io.I2FDataIn.foreach(exuio => io.cross.I2FDataIn.get <> exuio)
+    exu.io.F2IDataIn.foreach(exuio => io.cross.F2IDataIn.get <> exuio)
     exu.io.fenceio.foreach(exuio => io.fenceio.get <> exuio)
     exu.io.frm.foreach(exuio => exuio := RegNext(io.frm.get))  // each vf exu pipe frm from csr
     exu.io.vxrm.foreach(exuio => io.vxrm.get <> exuio)
@@ -53,36 +53,34 @@ class ExuBlock(implicit p: Parameters, params: SchdBlockParams) extends XSModule
     val fromBJUResolve = bjuExus.map(_.io.toFrontendBJUResolve.get)
     io.toFrontendBJUResolve.get := fromBJUResolve
   }
-  io.I2FWakeupOut.foreach{ x =>
+  io.cross.I2FWakeupOut.foreach{ x =>
     val exuI2FIn = exus.filter(x => x.exuParams.fuConfigs.contains(I2fCfg)).head.io.in
     x := 0.U.asTypeOf(x)
-    x.valid := exuI2FIn.valid && exuI2FIn.bits.fpWen.get
-    x.bits.fpWen := exuI2FIn.bits.fpWen.get
-    x.bits.pdest := exuI2FIn.bits.pdest
+    x.valid := exuI2FIn.valid && exuI2FIn.bits.ctrl.fpWen.get
+    x.bits.fpWen := exuI2FIn.bits.ctrl.fpWen.get
+    x.bits.pdest := exuI2FIn.bits.toRF.pdest
   }
-  io.F2IWakeupOut.foreach { x =>
+  io.cross.F2IWakeupOut.foreach { x =>
     val exuF2IIn = exus.filter(x => x.exuParams.fuConfigs.contains(FcmpCfg)).head.io.in
     x := 0.U.asTypeOf(x)
-    x.valid := exuF2IIn.valid && exuF2IIn.bits.rfWen.get
-    x.bits.rfWen := exuF2IIn.bits.rfWen.get
-    x.bits.pdest := exuF2IIn.bits.pdest
+    x.valid := exuF2IIn.valid && exuF2IIn.bits.ctrl.rfWen.get
+    x.bits.rfWen := exuF2IIn.bits.ctrl.rfWen.get
+    x.bits.pdest := exuF2IIn.bits.toRF.pdest
   }
   io.uncertainWakeupOut.foreach{ x =>
     x.zip(exus.filter(exu => exu.io.uncertainWakeupOut.nonEmpty).map(_.io.uncertainWakeupOut.get)).map{ case (sink, source) =>
       sink <> source
     }
   }
-  val fpDataIdx = 2
-  io.I2FDataOut.foreach { x =>
+  io.cross.I2FDataOut.foreach { x =>
     val i2fFuOut = exus.filter(exu => exu.exuParams.hasi2fFu).head.io.out
-    x.valid := i2fFuOut.valid && i2fFuOut.bits.fpWen.get
-    x.bits := i2fFuOut.bits.data(fpDataIdx)
+    x.valid := i2fFuOut.valid && i2fFuOut.bits.toFpRf.get.valid
+    x.bits := i2fFuOut.bits.toFpRf.get.bits
   }
-  val intDataIdx = 1
-  io.F2IDataOut.foreach { x =>
+  io.cross.F2IDataOut.foreach { x =>
     val f2iFuOut = exus.filter(exu => exu.exuParams.hasf2iFu).head.io.out
-    x.valid := f2iFuOut.valid && f2iFuOut.bits.intWen.get
-    x.bits := f2iFuOut.bits.data(intDataIdx)
+    x.valid := f2iFuOut.valid && f2iFuOut.bits.toIntRf.get.valid
+    x.bits := f2iFuOut.bits.toIntRf.get.bits
   }
   exus.find(_.io.csrio.nonEmpty).map(_.io.csrio.get).foreach { csrio =>
     exus.map(_.io.instrAddrTransType.foreach(_ := csrio.instrAddrTransType))
@@ -105,16 +103,11 @@ class ExuBlock(implicit p: Parameters, params: SchdBlockParams) extends XSModule
 class ExuBlockIO(implicit p: Parameters, params: SchdBlockParams) extends XSBundle {
   val flush = Flipped(ValidIO(new Redirect))
   // in(i)(j): issueblock(i), exu(j)
-  val in: MixedVec[MixedVec[DecoupledIO[ExuInput]]] = Flipped(params.genExuInputCopySrcBundleNoMemBlock)
+  val in: MixedVec[MixedVec[DecoupledIO[NewExuInput]]] = Flipped(params.genNewExuInputCopySrcBundleNoMemBlock)
   // out(i)(j): issueblock(i), exu(j).
-  val out: MixedVec[MixedVec[DecoupledIO[ExuOutput]]] = params.genExuOutputDecoupledBundleNoMemBlock
+  val out: MixedVec[MixedVec[DecoupledIO[NewExuOutput]]] = params.genNewExuOutputDecoupledBundleNoMemBlock
+  val cross = new ExuCrossRegion(params)
   val uncertainWakeupOut = Option.when(params.issueBlockParams.map(_.needUncertainWakeupFromExu).reduce(_ ||_))(params.genExuWakeUpOutValidBundle)
-  val I2FWakeupOut = Option.when(params.isIntSchd)(ValidIO(new IssueQueueIQWakeUpBundle(params.backendParam.getExuIdxI2F, params.backendParam)))
-  val I2FDataOut = Option.when(params.isIntSchd)(ValidIO(UInt(XLEN.W)))
-  val I2FDataIn= Option.when(params.isFpSchd)(Flipped(ValidIO(UInt(XLEN.W))))
-  val F2IWakeupOut = Option.when(params.isFpSchd)(ValidIO(new IssueQueueIQWakeUpBundle(params.backendParam.getExuIdxF2I, params.backendParam)))
-  val F2IDataOut = Option.when(params.isFpSchd)(ValidIO(UInt(XLEN.W)))
-  val F2IDataIn = Option.when(params.isIntSchd)(Flipped(ValidIO(UInt(XLEN.W))))
   val toFrontendBJUResolve = Option.when(params.isIntSchd)(Vec(backendParams.BrhCnt, Valid(new Resolve)))
   val csrio = Option.when(params.hasCSR)(new CSRFileIO)
   val csrin = Option.when(params.hasCSR)(new CSRInput)

--- a/src/main/scala/xiangshan/backend/fu/Fence.scala
+++ b/src/main/scala/xiangshan/backend/fu/Fence.scala
@@ -83,6 +83,7 @@ class Fence(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
   io.in.ready := state === s_idle
   io.out.valid := state =/= s_idle && state =/= s_wait
   io.out.bits.res.data := 0.U
+  io.out.bits.ctrl.toRobValid := uop.ctrl.toRobValid
   io.out.bits.ctrl.robIdx := uop.ctrl.robIdx
   io.out.bits.ctrl.pdest := uop.ctrl.pdest
   io.out.bits.ctrl.flushPipe.get := uop.ctrl.flushPipe.get

--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -3,7 +3,7 @@ package xiangshan.backend.fu
 import chisel3._
 import org.chipsalliance.cde.config.Parameters
 import xiangshan.ExceptionNO._
-import xiangshan.backend.Bundles.ExuInput
+import xiangshan.backend.Bundles.{ExuInput, NewExuInput}
 import xiangshan.backend.datapath.DataConfig._
 import xiangshan.backend.decode._
 import xiangshan.backend.fu.fpu.{IntFPToVec, IntToFP}
@@ -99,10 +99,10 @@ case class FuConfig (
 
   def readFp: Boolean = numFpSrc > 0
 
-  def fuSel(uop: ExuInput): Bool = {
+  def fuSel(uop: NewExuInput): Bool = {
     // Don't add more shit here!!!
     // Todo: add new FuType to distinguish f2i, f2f
-    uop.fuType === this.fuType.U
+    uop.ctrl.fuType === this.fuType.U
   }
 
   /**

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -313,6 +313,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   val pdestReg = RegEnable(io.in.bits.ctrl.pdest, io.in.fire)
   io.outRFWenAhead3Cycle.get := rfWenReg
   io.outPdestAhead3Cycle.get := pdestReg
+  io.out.bits.ctrl.toRobValid := RegEnable(io.in.bits.ctrl.toRobValid, io.in.fire)
   io.out.bits.ctrl.robIdx := Mux(isXRetReg, robIdxReg, DelayNWithValid(robIdxReg, csrModOutValid, 3)._2)
   io.out.bits.ctrl.pdest := DelayNWithValid(RegEnable(io.in.bits.ctrl.pdest, io.in.fire), csrModOutValid, 3)._2
   io.out.bits.ctrl.rfWen.foreach(_ := Mux(isXRetReg, rfWenReg, DelayNWithValid(rfWenReg, csrModOutValid, 3)._2))

--- a/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
@@ -394,12 +394,28 @@ case class IssueBlockParams(
     MixedVec(this.exuBlockParams.map(x => DecoupledIO(x.genExuInputCopySrcBundle)))
   }
 
+  def genNewExuInputDecoupledCopySrcBundle(implicit p: Parameters): MixedVec[DecoupledIO[NewExuInput]] = {
+    MixedVec(this.exuBlockParams.map(x => DecoupledIO(x.genNewExuInputCopySrcBundle)))
+  }
+
   def genExuOutputDecoupledBundle(implicit p: Parameters): MixedVec[DecoupledIO[ExuOutput]] = {
     MixedVec(this.exuParams.map(x => DecoupledIO(x.genExuOutputBundle)))
   }
 
+  def genNewExuOutputDecoupledBundle(implicit p: Parameters): MixedVec[DecoupledIO[NewExuOutput]] = {
+    MixedVec(this.exuParams.map(x => DecoupledIO(x.genNewExuOutputBundle)))
+  }
+
   def genExuOutputValidBundle(implicit p: Parameters): MixedVec[ValidIO[ExuOutput]] = {
     MixedVec(this.exuParams.map(x => ValidIO(x.genExuOutputBundle)))
+  }
+
+  def genNewExuOutputValidBundle(implicit p: Parameters): MixedVec[ValidIO[NewExuOutput]] = {
+    MixedVec(this.exuParams.map(x => ValidIO(x.genNewExuOutputBundle)))
+  }
+
+  def genWriteBackRobValidBundle(implicit p: Parameters): MixedVec[ValidIO[WriteBackRobBundle]] = {
+    MixedVec(this.exuParams.map(x => ValidIO(x.genWriteBackRobBundle)))
   }
 
   def genExuBypassValidBundle(implicit p: Parameters): MixedVec[ValidIO[ExuBypassBundle]] = {

--- a/src/main/scala/xiangshan/backend/issue/SchdBlockParams.scala
+++ b/src/main/scala/xiangshan/backend/issue/SchdBlockParams.scala
@@ -136,16 +136,32 @@ case class SchdBlockParams(
     MixedVec(this.issueBlockParams.map(_.genExuInputDecoupledCopySrcBundle))
   }
 
+  def genNewExuInputCopySrcBundle(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[NewExuInput]]] = {
+    MixedVec(this.issueBlockParams.map(_.genNewExuInputDecoupledCopySrcBundle))
+  }
+
   def genExuInputCopySrcBundleMemBlock(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[ExuInput]]] = {
     MixedVec(this.issueBlockParams.filter(_.isMemBlockIQ).map(_.genExuInputDecoupledCopySrcBundle))
+  }
+
+  def genNewExuInputCopySrcBundleMemBlock(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[NewExuInput]]] = {
+    MixedVec(this.issueBlockParams.filter(_.isMemBlockIQ).map(_.genNewExuInputDecoupledCopySrcBundle))
   }
 
   def genExuOutputDecoupledBundle(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[ExuOutput]]] = {
     MixedVec(this.issueBlockParams.map(_.genExuOutputDecoupledBundle))
   }
 
+  def genNewExuOutputDecoupledBundle(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[NewExuOutput]]] = {
+    MixedVec(this.issueBlockParams.map(_.genNewExuOutputDecoupledBundle))
+  }
+
   def genExuOutputDecoupledBundleMemBlock(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[ExuOutput]]] = {
     MixedVec(this.issueBlockParams.filter(_.isMemBlockIQ).map(_.genExuOutputDecoupledBundle))
+  }
+
+  def genNewExuOutputDecoupledBundleMemBlock(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[NewExuOutput]]] = {
+    MixedVec(this.issueBlockParams.filter(_.isMemBlockIQ).map(_.genNewExuOutputDecoupledBundle))
   }
 
   def genExuOutputDecoupledBundleLoad(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[ExuOutput]]] = {
@@ -156,12 +172,28 @@ case class SchdBlockParams(
     MixedVec(this.issueBlockParams.filterNot(_.isMemBlockIQ).map(_.genExuInputDecoupledCopySrcBundle))
   }
 
+  def genNewExuInputCopySrcBundleNoMemBlock(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[NewExuInput]]] = {
+    MixedVec(this.issueBlockParams.filterNot(_.isMemBlockIQ).map(_.genNewExuInputDecoupledCopySrcBundle))
+  }
+
   def genExuOutputDecoupledBundleNoMemBlock(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[ExuOutput]]] = {
     MixedVec(this.issueBlockParams.filterNot(_.isMemBlockIQ).map(_.genExuOutputDecoupledBundle))
+  }
+  
+  def genNewExuOutputDecoupledBundleNoMemBlock(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[NewExuOutput]]] = {
+    MixedVec(this.issueBlockParams.filterNot(_.isMemBlockIQ).map(_.genNewExuOutputDecoupledBundle))
   }
 
   def genExuOutputValidBundle(implicit p: Parameters): MixedVec[MixedVec[ValidIO[ExuOutput]]] = {
     MixedVec(this.issueBlockParams.map(_.genExuOutputValidBundle))
+  }
+
+  def genNewExuOutputValidBundle(implicit p: Parameters): MixedVec[MixedVec[ValidIO[NewExuOutput]]] = {
+    MixedVec(this.issueBlockParams.map(_.genNewExuOutputValidBundle))
+  }
+
+  def genWriteBackRobValidBundle(implicit p: Parameters): MixedVec[MixedVec[ValidIO[WriteBackRobBundle]]] = {
+    MixedVec(this.issueBlockParams.map(_.genWriteBackRobValidBundle))
   }
 
   def genExuBypassValidBundle(implicit p: Parameters): MixedVec[MixedVec[ValidIO[ExuBypassBundle]]] = {


### PR DESCRIPTION
1. Split the writeback paths for ROB and register-file (control/data) to enable timing optimization.
2. Perform an initial refactor/cleanup of functional-unit input/output bundles; subsequent PRs will further migrate all FU I/O bundles to the new bundle definitions.
