### PR TITLE
fix(mbtb): remove `!crossPage` from `internalBank.r.req.valid`

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
@@ -109,10 +109,7 @@ class MainBtbAlignBank(
   assert(!s0_fire || s0_alignBankIdx === alignIdx.U, "MainBtbAlignBank alignIdx mismatch")
 
   internalBanks.zipWithIndex.foreach { case (b, i) =>
-    // NOTE: if crossPage, we need to drop the entries to satisfy Ifu/ICache's requirement,
-    //       so we also can drop read req to save power.
-    // FIXME: but this might be timing critical, need to be verified.
-    b.io.read.req.valid       := s0_fire && s0_internalBankMask(i) && !s0_crossPage
+    b.io.read.req.valid       := s0_fire && s0_internalBankMask(i)
     b.io.read.req.bits.setIdx := s0_setIdx
   }
 


### PR DESCRIPTION
`meta.rawHit` need sram results to be valid, if we do not read sram when `crossPage`, update can using invalid `rawHit`.

Also its timing is really bad, connecting `abtb.prediction` -> `s0_pc` -> `s0_crossPage` -> `sram.r.req.valid` -> `sram.w.req.ready` -> `writebuffer.deq.ready`