### PR TITLE
refactor(mbtb): eliminate mbtb trace warning

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/Bundles.scala
@@ -79,6 +79,14 @@ class MainBtbMeta(implicit p: Parameters) extends MainBtbBundle {
   val entries: Vec[Vec[MainBtbMetaEntry]] = Vec(NumAlignBanks, Vec(NumWay, new MainBtbMetaEntry))
 }
 
+class MainBtbAlignBankTrace(implicit p: Parameters) extends MainBtbBundle {
+  val needWrite: Bool         = Bool()
+  val setIdx:    UInt         = UInt(SetIdxLen.W)
+  val bankIdx:   UInt         = UInt(log2Ceil(NumInternalBanks).W)
+  val wayIdx:    UInt         = UInt(log2Ceil(NumWay).W)
+  val entry:     MainBtbEntry = new MainBtbEntry
+}
+
 class MainBtbTrace(implicit p: Parameters) extends MainBtbBundle {
 
   val startPc:     PrunedAddr      = PrunedAddr(VAddrBits)

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
@@ -62,20 +62,13 @@ class MainBtbAlignBank(
 
       val req: Valid[Req] = Flipped(Valid(new Req))
     }
-    class Trace extends Bundle {
-      val needWrite: Bool         = Bool()
-      val setIdx:    UInt         = UInt(SetIdxLen.W)
-      val bankIdx:   UInt         = UInt(log2Ceil(NumInternalBanks).W)
-      val wayIdx:    UInt         = UInt(log2Ceil(NumWay).W)
-      val entry:     MainBtbEntry = new MainBtbEntry
-    }
 
     val resetDone: Bool      = Output(Bool())
     val stageCtrl: StageCtrl = Input(new StageCtrl)
 
-    val read:  Read  = new Read
-    val write: Write = new Write
-    val trace: Trace = Output(new Trace)
+    val read:  Read                  = new Read
+    val write: Write                 = new Write
+    val trace: MainBtbAlignBankTrace = Output(new MainBtbAlignBankTrace)
 
     // final s3_takenMask (mbtb + tage + sc), used to touch replacer accurately
     val s3_takenMask: Vec[Bool] = Input(Vec(NumWay, Bool()))


### PR DESCRIPTION
```
[779] [warn] <redacted>/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala:156:40: inferred existential type x$7.io.Trace forSome { val x$7: xiangshan.frontend.bpu.mbtb.MainBtbAlignBank }, which cannot be expressed by wildcards, should be enabled
[779] [warn] by making the implicit value scala.language.existentials visible.
[779] [warn] This can be achieved by adding the import clause 'import scala.language.existentials'
[779] [warn] or by setting the compiler option -language:existentials.
[779] [warn] See the Scaladoc for value scala.language.existentials for a discussion
[779] [warn] why the feature should be explicitly enabled.
[779] [warn]   private val finalTrace        = Mux1H(t1_writeAlignBankMask, alignBankTraceVec)
[779] [warn]                                        ^

```