### PR TITLE
fix(YamlParser): turn on safe to solve reset on pending tranaction

### DIFF
--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -97,7 +97,7 @@ object YamlParser {
     yamlConfig.EnableCHIAsyncBridge.foreach { enable =>
       newConfig = newConfig.alter((site, here, up) => {
         case SoCParamsKey => up(SoCParamsKey).copy(
-          EnableCHIAsyncBridge = Option.when(enable)(AsyncQueueParams(depth = 16, sync = 3, safe = false))
+          EnableCHIAsyncBridge = Option.when(enable)(AsyncQueueParams(depth = 16, sync = 3, safe = true))
         )
       })
     }


### PR DESCRIPTION
In commit https://github.com/OpenXiangShan/XiangShan/commit/eec2464832ac4b3aa79268d61bbf5d6b14c7ffb6, we only enabled the safe switch for CHIAsynBridge in SoC.scala. However, when generating configurations using YAML, the modification to the safe switch did not take effect. Therefore, this change also enables the safe switch for CHIAsynBridge in YamlParser.