### PR TITLE
fix(Memblock): fix vec misalign stuck

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1610,6 +1610,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vsSplit(i).io.vstdMisalign.get.storeMisalignBufferRobIdx := storeMisalignBuffer.io.toVecSplit.robIdx
     vsSplit(i).io.vstdMisalign.get.storeMisalignBufferUopIdx := storeMisalignBuffer.io.toVecSplit.uopIdx
     vsSplit(i).io.vstdMisalign.get.storePipeEmpty := !storeUnits.map(_.io.s0_s1_s2_valid).reduce(_||_)
+    storeUnits(i).io.vecMisalignBlockScalaIssue := vsSplit(i).io.vstdMisalign.get.blockScalaIssue
 
   }
   (0 until VlduCnt).foreach{i =>

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -76,6 +76,8 @@ class StoreUnit(implicit p: Parameters) extends XSModule
     val sqCommitRobIdx = Input(new RobPtr)
 
     val s0_s1_s2_valid = Output(Bool())
+    val vecMisalignBlockScalaIssue = Input(Bool())
+
   })
 
   PerfCCT.updateInstPos(io.stin.bits.uop.debug_seqNum, PerfCCT.InstPos.AtFU.id.U, io.stin.valid, clock, reset)
@@ -87,7 +89,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   // stage 0
   // --------------------------------------------------------------------------------
   // generate addr, use addr to query DCache and DTLB
-  val s0_iss_valid        = io.stin.valid
+  val s0_iss_valid        = io.stin.valid && !io.vecMisalignBlockScalaIssue
   val s0_prf_valid        = io.prefetch_req.valid && io.dcache.req.ready
   val s0_vec_valid        = io.vecstin.valid
   val s0_ma_st_valid      = io.misalign_stin.valid

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -227,6 +227,8 @@ class storeMisaignIO(implicit p: Parameters) extends Bundle{
   val storeMisalignBufferEmpty  = Input(Bool())
   val storeMisalignBufferRobIdx = Input(new RobPtr)
   val storeMisalignBufferUopIdx = Input(UopIdx())
+  val blockScalaIssue           = Output(Bool())
+
 }
 
 class VSplitIO(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle{


### PR DESCRIPTION
Vector misalignment operations can only execute when the store unit is idle. If io.stin.valid(int) remains high (due to replay from various causes), the oldest vector misalignment instruction may never be sent to the store unit for execution.

After modification, we allow the vector store requiring execution to preempt the entry point of store unit s0, thereby preventing the aforementioned issue.