### PR TITLE
refactor(Topdown): make Topdown accurate again

### DIFF
--- a/scripts/top-down/README.md
+++ b/scripts/top-down/README.md
@@ -4,37 +4,115 @@
 
 ## 使用方法
 
-``` shell
+Top-down 分析工具目录结构如下：
+
+```shell
+# tree top-down
+top-down
+├── configs.py
+├── draw.py
+├── README.md
+├── resources
+│   └── spec06_rv64gcb_o2_20m.json
+├── top_down.py
+└── utils.py
+
+1 directories, 6 files
+```
+
+### top_down.py 使用方法
+
+`top_down.py` 是 Top-down 分析的主程序，用法如下：
+
+```shell
 # python top_down.py --help
 usage: generate top-down results
 
 optional arguments:
   -h, --help            show this help message and exit
-  -s STAT_DIR, --stat-dir STAT_DIR
-                        stat output directory
-  -j JSON, --json JSON  specify json file
+  -b BASE_STAT_DIR, --base-stat-dir BASE_STAT_DIR
+                        base stat output directory (required)
+  -r REF_STAT_DIR, --ref-stat-dir REF_STAT_DIR
+                        ref stat output directory (optional)
+  -j JSON, --json JSON  specify json file (required)
+  --base-issue BASE_ISSUE
+                        base issue width (required when both --base-stat-dir and --ref-stat-dir are provided)
+  --ref-issue REF_ISSUE
+                        ref issue width (required when both --base-stat-dir and --ref-stat-dir are provided)
+  --base-label BASE_LABEL
+                        label prefix for base (default: BASE)
+  --ref-label REF_LABEL
+                        label prefix for ref (default: REF)
 ```
 
-举例：
+使用示例如下：
 
-``` shell
-# python top_down.py -s <...>/SPEC06_EmuTasks_1021_0.3_c157cf -j resources/spec06_rv64gcb_o2_20m.json
-# python top_down.py -s <...>/SPEC06_EmuTasks_1215_allbump -j <...>/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/checkpoint-0-0-0/cluster-0-0.json
+```shell
+# python top_down.py -b <...>/SPEC06_EmuTasks_1021_0.3_c157cf -j resources/spec06_rv64gcb_o2_20m.json
+# python top_down.py -b <...>/base_perf_report -r <...>/ref_perf_report -j <...>/checkpoint.json --base-issue 6 --ref-issue 8 --base-label Base --ref-label Feature1
 ```
 
 脚本运行结束后，会生成 `results` 目录：
 
-``` shell
+```shell
 # tree results
 results
-├── result.png
-├── results.csv
-└── results-weighted.csv
+├── result_backend.png
+├── result_custom.png
+├── result_frontend.png
+├── result_mem.png
+├── results_base.csv
+├── results_ref.csv
+├── results-weighted_base.csv
+├── results-weighted_ref.csv
+└── result_total.png
 
-0 directories, 3 files
+0 directories, 9 files
 ```
 
-其中，`result.png` 为 top-down 堆叠条形统计图，`results.csv` 为各采样点的 top-down 计数器，`results-weighted.csv` 为各子项的加权 top-down 计数器。
+其中：
+
+- `result_total.png` 为 Top-down 总体粗粒度聚合堆叠条形图，用于展示各 benchmark 在整体视角下的瓶颈构成。
+- `result_frontend.png`、`result_backend.png`、`result_mem.png` 和 `result_custom.png` 分别对前端、后端、访存及自定义子维度进行进一步拆分，便于从特定维度开展更细粒度的瓶颈分析。
+- `results_base.csv` 与 `results_ref.csv` 保存原始统计结果，按采样点记录各 Top-down 计数器数值。
+- `results-weighted_base.csv` 与 `results-weighted_ref.csv` 则基于原始统计结果，结合各采样点对应权重完成加权汇总，可用于人工检查、后续分析或重新绘图。
+
+### config.py 使用方法
+
+`configs.py` 是 Top-down 分析工具的配置文件，主要可配置项包括：
+
+- **自定义子维度**：用户可在 `configs.py` 中修改 `xs_custom_rename_map`，以将部分阻塞归因重新聚类并生成对应图表。具体格式可参考其他子维度的重命名映射，例如 `xs_frontend_rename_map`。
+- **benchmark_list**：用户可通过配置 `benchmark_list` 选择部分 checkpoint 子项进行单独绘图分析；若未额外指定，则默认对全部 checkpoint 作图。`INT_ONLY` 和 `FP_ONLY` 可用于快速筛选仅整数或仅浮点 benchmark。
+- **xx_ANALYSE**：用户可通过配置此类选项，关闭部分子维度的绘图分析。
+
+### draw.py 使用方法
+
+`draw.py` 是 Top-down 分析工具的绘图脚本，主要用于基于已生成的 `results-weighted.csv` 直接绘图。用法如下：
+
+```shell
+# python3 draw.py --help
+usage: draw top-down stacked bar chart (base/ref weighted csv)
+
+options:
+  -h, --help            show this help message and exit
+  -b BASE_WEIGHTED_CSV, --base-weighted-csv BASE_WEIGHTED_CSV
+                        base weighted csv path (default: results/results-weighted_base.csv)
+  -r REF_WEIGHTED_CSV, --ref-weighted-csv REF_WEIGHTED_CSV
+                        ref weighted csv path (default: results/results-weighted_ref.csv)
+  --base-label BASE_LABEL
+                        base label (default: BASE)
+  --ref-label REF_LABEL
+                        ref label (default: REF)
+```
+
+使用示例如下：
+
+```shell
+# python3 draw.py --base-label Base --ref-label Feature1
+# python3 draw.py -b <...>/xxxresults-weighted_base.csv -r <...>/xxxresults-weighted_ref.csv --base-label Base --ref-label Feature1
+```
+
+---
 
 # <div id="Top-down-Analysis-Tool">Top-down Analysis Tool</div>
 
@@ -42,34 +120,110 @@ This directory contains analysis tool for top-down. After running checkpoints by
 
 ## Usage
 
-``` shell
+The directory structure of the Top-down analysis tool is shown below:
+
+```shell
+# tree top-down
+top-down
+├── configs.py
+├── draw.py
+├── README.md
+├── resources
+│   └── spec06_rv64gcb_o2_20m.json
+├── top_down.py
+└── utils.py
+
+1 directories, 6 files
+```
+
+### How to use top_down.py
+
+`top_down.py` is the main entry of the Top-down analysis tool. Its usage is as follows:
+
+```shell
 # python top_down.py --help
 usage: generate top-down results
 
 optional arguments:
   -h, --help            show this help message and exit
-  -s STAT_DIR, --stat-dir STAT_DIR
-                        stat output directory
-  -j JSON, --json JSON  specify json file
+  -b BASE_STAT_DIR, --base-stat-dir BASE_STAT_DIR
+                        base stat output directory (required)
+  -r REF_STAT_DIR, --ref-stat-dir REF_STAT_DIR
+                        ref stat output directory (optional)
+  -j JSON, --json JSON  specify json file (required)
+  --base-issue BASE_ISSUE
+                        base issue width (required when both --base-stat-dir and --ref-stat-dir are provided)
+  --ref-issue REF_ISSUE
+                        ref issue width (required when both --base-stat-dir and --ref-stat-dir are provided)
+  --base-label BASE_LABEL
+                        label prefix for base (default: BASE)
+  --ref-label REF_LABEL
+                        label prefix for ref (default: REF)
 ```
 
-Some examples:
+Example commands:
 
-``` shell
-# python top_down.py -s <...>/SPEC06_EmuTasks_1021_0.3_c157cf -j resources/spec06_rv64gcb_o2_20m.json
-# python top_down.py -s <...>/SPEC06_EmuTasks_1215_allbump -j <...>/spec06_rv64gcb_O3_20m_gcc12.2.0-intFpcOff-jeMalloc/checkpoint-0-0-0/cluster-0-0.json
+```shell
+# python top_down.py -b <...>/SPEC06_EmuTasks_1021_0.3_c157cf -j resources/spec06_rv64gcb_o2_20m.json
+# python top_down.py -b <...>/base_perf_report -r <...>/ref_perf_report -j <...>/checkpoint.json --base-issue 6 --ref-issue 8 --base-label Base --ref-label Feature1
 ```
 
-A `results` directory would be generated then:
+After execution, a `results` directory will be generated:
 
-``` shell
+```shell
 # tree results
 results
-├── result.png
-├── results.csv
-└── results-weighted.csv
+├── result_backend.png
+├── result_custom.png
+├── result_frontend.png
+├── result_mem.png
+├── results_base.csv
+├── results_ref.csv
+├── results-weighted_base.csv
+├── results-weighted_ref.csv
+└── result_total.png
 
-0 directories, 3 files
+0 directories, 9 files
 ```
 
-The `result.png` is a stacked bar chart of top-down. The `results.csv` contains per-checkpoint top-down counters. And the `results-weighted.csv` contains weighted counters for all sub tests.
+Among them:
+
+- `result_total.png` is the coarse-grained stacked bar chart for overall Top-down analysis, showing the bottleneck composition of each benchmark from a global perspective.
+- `result_frontend.png`, `result_backend.png`, `result_mem.png`, and `result_custom.png` further break down the frontend, backend, memory, and custom sub-dimensions, respectively, making it easier to perform fine-grained bottleneck analysis from specific viewpoints.
+- `results_base.csv` and `results_ref.csv` store the raw statistical results, recording the values of each Top-down counter at each sampling point.
+- `results-weighted_base.csv` and `results-weighted_ref.csv` provide weighted summaries based on the raw results and the corresponding weights of sampling points, and can be used for manual inspection, further analysis, or redrawing figures.
+
+### How to use configs.py
+
+`configs.py` is the configuration file of the Top-down analysis tool. The main configurable items include:
+
+- **Custom sub-dimensions**: Users can modify `xs_custom_rename_map` in `configs.py` to regroup selected stall attributions and generate customized plots. The format can refer to the rename maps of other sub-dimensions, such as `xs_frontend_rename_map`.
+- **benchmark_list**: Users can configure `benchmark_list` to select a subset of checkpoints for standalone plotting and analysis. If not specified, all checkpoints will be plotted by default. `INT_ONLY` and `FP_ONLY` can be used to quickly generate plots for integer-only or floating-point-only benchmarks.
+- **xx_ANALYSE**: Users can disable plotting for selected sub-dimensions through this type of option.
+
+### How to use draw.py
+
+`draw.py` is the plotting script of the Top-down analysis tool. It is mainly used to directly generate figures from the extracted `results-weighted.csv`. Its usage is as follows:
+
+```shell
+# python3 draw.py --help
+usage: draw top-down stacked bar chart (base/ref weighted csv)
+
+options:
+  -h, --help            show this help message and exit
+  -b BASE_WEIGHTED_CSV, --base-weighted-csv BASE_WEIGHTED_CSV
+                        base weighted csv path (default: results/results-weighted_base.csv)
+  -r REF_WEIGHTED_CSV, --ref-weighted-csv REF_WEIGHTED_CSV
+                        ref weighted csv path (default: results/results-weighted_ref.csv)
+  --base-label BASE_LABEL
+                        base label (default: BASE)
+  --ref-label REF_LABEL
+                        ref label (default: REF)
+```
+
+Example commands:
+
+```shell
+# python3 draw.py --base-label Base --ref-label Feature1
+# python3 draw.py -b <...>/xxxresults-weighted_base.csv -r <...>/xxxresults-weighted_ref.csv --base-label Base --ref-label Feature1
+```

--- a/scripts/top-down/configs.py
+++ b/scripts/top-down/configs.py
@@ -1,10 +1,165 @@
 stats_dir = ''
 
-CSV_PATH = 'results/results.csv'
+CSV_BASE = 'results/results_base.csv'
+CSV_REF = 'results/results_ref.csv'
 JSON_FILE = 'resources/spec06_rv64gcb_o2_20m.json'
-OUT_CSV = 'results/results-weighted.csv'
+OUT_BASE = 'results/results-weighted_base.csv'
+OUT_REF = 'results/results-weighted_ref.csv'
+
 INT_ONLY = False
-FP_ONLY = False
+FP_ONLY = True
+
+TOTAL_ANALYSE = True
+BACKEND_ANALYSE = True
+FRONTEND_ANALYSE = True
+MEM_ANALYSE = True
+CUSTOM_ANALYSE = True
+
+# Not benchmark_list canbe add here to specify benchmark to draw, use like:
+# benchmark_list = {'libquantum','h264ref','namd', 'gamess'}
+
+xs_custom_rename_map = {
+    'IntIQFullStallAlu': 'MergeIQFullStall',
+    'IntIQFullStallBrh': 'MergeIQFullStall',
+    'IntIQFullStallOther': 'MergeIQFullStall',
+    'FpIQFullStall': 'MergeIQFullStall',
+    'VecIQFullStall': 'MergeIQFullStall',
+    'LoadIQFullStall': 'MergeIQFullStallLoad',
+    'StoreIQFullStall': 'MergeIQFullStallStore',
+    'OtherIQFullStall': 'MergeIQFullStall',
+
+    'IQEnqPolicyStallIssued': 'MergeIQpolicyStall',
+    'IQEnqPolicyStall': 'MergeIQpolicyStall',
+
+    'LoadDispatchPolicyStall' : 'MergeDispatchPolicyBandwidth',
+    'StoreDispatchPolicyStall': 'MergeDispatchPolicyBandwidth',
+    'OtherDispatchPolicyStall': 'MergeDispatchPolicyBandwidth',
+
+    'BalanceDispatchPolicyStall':     'MergeDispatchPolicyBalance',
+    'BalanceDispatchPolicyStallAlu':  'MergeDispatchPolicyBalance',
+    'BalanceDispatchPolicyStallBrh':  'MergeDispatchPolicyBalance',
+    'BalanceDispatchPolicyStallInt':  'MergeDispatchPolicyBalance',
+    'BalanceDispatchPolicyStallFp':   'MergeDispatchPolicyBalance',
+    'BalanceDispatchPolicyStallVec':  'MergeDispatchPolicyBalance',
+    'BalanceDispatchPolicyStallLoad': 'MergeDispatchPolicyBalance',
+    'BalanceDispatchPolicyStallStore':'MergeDispatchPolicyBalance',
+
+    'NoStall': 'MergeBase',
+    'commitInstr': 'Insts',
+    'total_cycles': 'Cycles',
+}
+
+xs_frontend_rename_map = {
+    'OverrideBubble': 'MergeOverrideBubble',
+    'FtqFullStall': 'MergeFtqFullStall',
+    'FtqUpdateBubble': 'MergeFtqUpdateBubble',
+    'TAGEMissBubble': 'MergeTAGEMissBubble',
+    'SCMissBubble': 'MergeSCMissBubble',
+    'ITTAGEMissBubble': 'MergeITTAGEMissBubble',
+    'RASMissBubble': 'MergeRASMissBubble',
+    'ICacheMissBubble': 'MergeICacheMissBubble',
+    'ITLBMissBubble': 'MergeITLBMissBubble',
+    'BTBMissBubble': 'MergeBTBMissBubble',
+    'FetchFragBubble': 'MergeFetchFragBubble',
+    'FrontendOtherCoreStall': "MergeCoreOther",
+
+    'FlushedInsts': 'MergeBadSpecInst',
+
+    'ControlRedirectStall': 'MergeBadSpec',
+
+    'OtherRedirectStall': 'MergeBadSpec',
+    'OtherRedirectBubble': 'MergeMisc',
+
+
+    'NoStall': 'MergeBase',
+    'commitInstr': 'Insts',
+    'total_cycles': 'Cycles',
+}
+
+xs_backend_rename_map = {
+
+    'DivStall': 'MergeExecStall',
+    'IntNotReadyStall': 'MergeExecStall',
+    'FPNotReadyStall': 'MergeExecStall',
+
+    'RobStall': 'MergeRobStall',
+
+    'FusionBubble' : 'MergeFusion',
+
+    'LoadDispatchPolicyStall':  'MergeDispatchPolicy',
+    'StoreDispatchPolicyStall': 'MergeDispatchPolicy',
+    'OtherDispatchPolicyStall': 'MergeDispatchPolicy',
+
+    'BalanceDispatchPolicyStall':     'MergeDispatchPolicy',
+    'BalanceDispatchPolicyStallAlu':  'MergeDispatchPolicy',
+    'BalanceDispatchPolicyStallBrh':  'MergeDispatchPolicy',
+    'BalanceDispatchPolicyStallInt':  'MergeDispatchPolicy',
+    'BalanceDispatchPolicyStallFp':   'MergeDispatchPolicy',
+    'BalanceDispatchPolicyStallVec':  'MergeDispatchPolicy',
+    'BalanceDispatchPolicyStallLoad': 'MergeDispatchPolicy',
+    'BalanceDispatchPolicyStallStore':'MergeDispatchPolicy',
+
+    'IQEnqPolicyStallIssued': 'MergeIQpolicyStall',
+    'IQEnqPolicyStall': 'MergeIQpolicyStall',
+
+    'IntIQFullStallAlu': 'MergeIQFullStall',
+    'IntIQFullStallBrh': 'MergeIQFullStall',
+    'IntIQFullStallOther': 'MergeIQFullStall',
+    'FpIQFullStall': 'MergeIQFullStall',
+    'VecIQFullStall': 'MergeIQFullStall',
+    'LoadIQFullStall': 'MergeIQFullStall',
+    'StoreIQFullStall': 'MergeIQFullStall',
+    'OtherIQFullStall': 'MergeIQFullStall',
+
+    'ControlRecoveryStall': 'MergeRabWalkStall',
+    'MemVioRecoveryStall': 'MergeRabWalkStall',
+    'OtherRecoveryStall': 'MergeRabWalkStall',
+
+
+    'BackendOtherCoreStall': 'MergeCoreOther',
+
+    'IntFlStall': 'MergeFreelistStall',
+    'FpFlStall': 'MergeFreelistStall',
+    'VecFlStall': 'MergeFreelistStall',
+    'V0FlStall': 'MergeFreelistStall',
+    'VlFlStall': 'MergeFreelistStall',
+    'MultiFlStall': 'MergeFreelistStall',
+
+    'IntFlStallForBank': 'MergeFreelistStall',
+    'FpFlStallForBank': 'MergeFreelistStall',
+
+    'SpecialInsts': 'MergePrivileged',
+
+    'NoStall': 'MergeBase',
+    'commitInstr': 'Insts',
+    'total_cycles': 'Cycles',
+}
+
+xs_mem_rename_map = {
+    'MemNotReadyStall': 'MergeMemNotReadyStall',
+
+    'LoadTLBStall': 'MergeLoadTLBStall',
+    'LoadL1Stall': 'MergeLoadL1Stall',
+    'LoadL2Stall': 'MergeLoadL2Stall',
+    'LoadL3Stall': 'MergeLoadL3Stall',
+    'LoadMemStall': 'MergeLoadMemStall',
+
+    'StoreStall': 'MergeStore',
+
+
+    'AtomicStall': 'MergeAtomicStall',
+
+    'LoadMSHRReplayStall': 'MergeMSHRReplayStall',
+    'LoadVioReplayStall': 'MergeLoadVioReplay',
+
+    'MemVioRedirectStall': 'MergeMemVioRedirect',
+    'MemVioRedirectBubble': 'MergeMemVioRedirect',
+
+    'NoStall': 'MergeBase',
+    'commitInstr': 'Insts',
+    'total_cycles': 'Cycles',
+
+}
 
 xs_coarse_rename_map = {
     'OverrideBubble': 'MergeFrontend',
@@ -18,6 +173,7 @@ xs_coarse_rename_map = {
     'ITLBMissBubble': 'MergeFrontend',
     'BTBMissBubble': 'MergeBadSpec',
     'FetchFragBubble': 'MergeFrontend',
+    'FrontendOtherCoreStall': "MergeCoreOther",
 
     'DivStall': 'MergeCore',
     'IntNotReadyStall': 'MergeCore',
@@ -25,12 +181,44 @@ xs_coarse_rename_map = {
 
     'MemNotReadyStall': 'MergeLoad',
 
+    'RobStall': 'MergeCore',
+
     'IntFlStall': 'MergeFreelistStall',
     'FpFlStall': 'MergeFreelistStall',
     'VecFlStall': 'MergeFreelistStall',
     'V0FlStall': 'MergeFreelistStall',
     'VlFlStall': 'MergeFreelistStall',
     'MultiFlStall': 'MergeFreelistStall',
+
+    'IntFlStallForBank': 'MergeFreelistStall',
+    'FpFlStallForBank': 'MergeFreelistStall',
+
+    'FusionBubble' : 'MergeCore',
+
+    'LoadDispatchPolicyStall':  'MergeCore',
+    'StoreDispatchPolicyStall': 'MergeCore',
+    'OtherDispatchPolicyStall': 'MergeCore',
+
+    'BalanceDispatchPolicyStall':     'MergeCore',
+    'BalanceDispatchPolicyStallAlu':  'MergeCore',
+    'BalanceDispatchPolicyStallBrh':  'MergeCore',
+    'BalanceDispatchPolicyStallInt':  'MergeCore',
+    'BalanceDispatchPolicyStallFp':   'MergeCore',
+    'BalanceDispatchPolicyStallVec':  'MergeCore',
+    'BalanceDispatchPolicyStallLoad': 'MergeCore',
+    'BalanceDispatchPolicyStallStore':'MergeCore',
+
+    'IQEnqPolicyStallIssued': 'MergeCore',
+    'IQEnqPolicyStall': 'MergeCore',
+
+    'IntIQFullStallAlu': 'MergeCore',
+    'IntIQFullStallBrh': 'MergeCore',
+    'IntIQFullStallOther': 'MergeCore',
+    'FpIQFullStall': 'MergeCore',
+    'VecIQFullStall': 'MergeCore',
+    'LoadIQFullStall': 'MergeCore',
+    'StoreIQFullStall': 'MergeCore',
+    'OtherIQFullStall': 'MergeCore',
 
     'LoadTLBStall': 'MergeLoad',
     'LoadL1Stall': 'MergeLoad',
@@ -46,11 +234,17 @@ xs_coarse_rename_map = {
 
     'LoadMSHRReplayStall': 'MergeLoad',
 
-    'ControlRecoveryStall': 'MergeBadSpec',
-    'MemVioRecoveryStall': 'MergeBadSpec',
-    'OtherRecoveryStall': 'MergeBadSpec',
+    'ControlRedirectStall': 'MergeBadSpec',
+    'MemVioRedirectStall': 'MergeBadSpec',
+    'OtherRedirectStall': 'MergeBadSpec',
 
-    'OtherCoreStall': 'MergeCoreOther',
+    'ControlRecoveryStall': 'MergeCore',
+    'MemVioRecoveryStall': 'MergeCore',
+    'OtherRecoveryStall': 'MergeCore',
+
+    'SpecialInsts': 'MergePrivileged',
+
+    'BackendOtherCoreStall': 'MergeCoreOther',
     'NoStall': 'MergeBase',
 
     'MemVioRedirectBubble': 'MergeBadSpec',
@@ -110,58 +304,96 @@ xs_fine_grain_rename_map = {
     'total_cycles': 'Cycles',
 }
 
-XS_CORE_PREFIX = r'\[PERF \]\[time=\s+\d+\] SimTop\.l_soc\.core_with_l2\.core'
+XS_CORE_PREFIX = r'\[PERF\s*\]\[time=\s*\d+\].*?\.core'
 
 targets = {
-    'NoStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: NoStall,\s+(\d+)',
+    'NoStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: NoStall,\s+(\d+)',
+    'OverrideBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: OverrideBubble,\s+(\d+)',
+    'FtqUpdateBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FtqUpdateBubble,\s+(\d+)',
+    'TAGEMissBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: TAGEMissBubble,\s+(\d+)',
+    'SCMissBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: SCMissBubble,\s+(\d+)',
+    'ITTAGEMissBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: ITTAGEMissBubble,\s+(\d+)',
+    'RASMissBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: RASMissBubble,\s+(\d+)',
+    'MemVioRedirectBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: MemVioRedirectBubble,\s+(\d+)',
+    'OtherRedirectBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: OtherRedirectBubble,\s+(\d+)',
+    'FtqFullStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FtqFullStall,\s+(\d+)',
 
-    'OverrideBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: OverrideBubble,\s+(\d+)',
-    'FtqUpdateBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: FtqUpdateBubble,\s+(\d+)',
-    'TAGEMissBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: TAGEMissBubble,\s+(\d+)',
-    'SCMissBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: SCMissBubble,\s+(\d+)',
-    'ITTAGEMissBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: ITTAGEMissBubble,\s+(\d+)',
-    'RASMissBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: RASMissBubble,\s+(\d+)',
-    'MemVioRedirectBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: MemVioRedirectBubble,\s+(\d+)',
-    'OtherRedirectBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: OtherRedirectBubble,\s+(\d+)',
-    'FtqFullStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: FtqFullStall,\s+(\d+)',
+    'ICacheMissBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: ICacheMissBubble,\s+(\d+)',
+    'ITLBMissBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: ITLBMissBubble,\s+(\d+)',
+    'BTBMissBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BTBMissBubble,\s+(\d+)',
+    'FetchFragBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FetchFragBubble,\s+(\d+)',
+    'FrontendOtherCoreStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FrontendOtherCoreStall,\s+(\d+)',
 
-    'ICacheMissBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: ICacheMissBubble,\s+(\d+)',
-    'ITLBMissBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: ITLBMissBubble,\s+(\d+)',
-    'BTBMissBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: BTBMissBubble,\s+(\d+)',
-    'FetchFragBubble': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: FetchFragBubble,\s+(\d+)',
+    'DivStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: DivStall,\s+(\d+)',
+    'IntNotReadyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IntNotReadyStall,\s+(\d+)',
+    'FPNotReadyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FPNotReadyStall,\s+(\d+)',
+    'MemNotReadyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: MemNotReadyStall,\s+(\d+)',
+    'RobStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: RobStall,\s+(\d+)',
 
-    'DivStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: DivStall,\s+(\d+)',
-    'IntNotReadyStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: IntNotReadyStall,\s+(\d+)',
-    'FPNotReadyStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: FPNotReadyStall,\s+(\d+)',
-    'MemNotReadyStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: MemNotReadyStall,\s+(\d+)',
+    'IntFlStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IntFlStall,\s+(\d+)',
+    'FpFlStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FpFlStall,\s+(\d+)',
+    'VecFlStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: VecFlStall,\s+(\d+)',
+    'V0FlStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: V0FlStall,\s+(\d+)',
+    'VlFlStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: VlFlStall,\s+(\d+)',
+    'MultiFlStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: MultiFlStall,\s+(\d+)',
 
-    'IntFlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: IntFlStall,\s+(\d+)',
-    'FpFlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: FpFlStall,\s+(\d+)',
-    'VecFlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: VecFlStall,\s+(\d+)',
-    'V0FlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: V0FlStall,\s+(\d+)',
-    'VlFlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: VlFlStall,\s+(\d+)',
-    'MultiFlStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: MultiFlStall,\s+(\d+)',
+    'IntFlStallForBank': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IntFlStallForBank,\s+(\d+)',
+    'FpFlStallForBank': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FpFlStallForBank,\s+(\d+)',
 
-    'LoadTLBStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: LoadTLBStall,\s+(\d+)',
-    'LoadL1Stall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: LoadL1Stall,\s+(\d+)',
-    'LoadL2Stall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: LoadL2Stall,\s+(\d+)',
-    'LoadL3Stall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: LoadL3Stall,\s+(\d+)',
-    'LoadMemStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: LoadMemStall,\s+(\d+)',
-    'StoreStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: StoreStall,\s+(\d+)',
-    'AtomicStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: AtomicStall,\s+(\d+)',
+    'FusionBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FusionBubble,\s+(\d+)',
 
-    'LoadVioReplayStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: LoadVioReplayStall,\s+(\d+)',
-    'LoadMSHRReplayStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: LoadMSHRReplayStall,\s+(\d+)',
+    'LoadDispatchPolicyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadDispatchPolicyStall,\s+(\d+)',
+    'StoreDispatchPolicyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: StoreDispatchPolicyStall,\s+(\d+)',
+    'OtherDispatchPolicyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: OtherDispatchPolicyStall,\s+(\d+)',
 
-    'ControlRecoveryStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: ControlRecoveryStall,\s+(\d+)',
-    'MemVioRecoveryStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: MemVioRecoveryStall,\s+(\d+)',
-    'OtherRecoveryStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: OtherRecoveryStall,\s+(\d+)',
+    'BalanceDispatchPolicyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BalanceDispatchPolicyStall,\s+(\d+)',
+    'BalanceDispatchPolicyStallAlu': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BalanceDispatchPolicyStallAlu,\s+(\d+)',
+    'BalanceDispatchPolicyStallBrh': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BalanceDispatchPolicyStallBrh,\s+(\d+)',
+    'BalanceDispatchPolicyStallInt': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BalanceDispatchPolicyStallInt,\s+(\d+)',
+    'BalanceDispatchPolicyStallFp':  fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BalanceDispatchPolicyStallFp,\s+(\d+)',
+    'BalanceDispatchPolicyStallVec': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BalanceDispatchPolicyStallVec,\s+(\d+)',
+    'BalanceDispatchPolicyStallLoad': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BalanceDispatchPolicyStallLoad,\s+(\d+)',
+    'BalanceDispatchPolicyStallStore': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BalanceDispatchPolicyStallStore,\s+(\d+)',
 
-    'FlushedInsts': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: FlushedInsts,\s+(\d+)',
-    'OtherCoreStall': fr'{XS_CORE_PREFIX}.backend.inner\.ctrlBlock\.dispatch: OtherCoreStall,\s+(\d+)',
+    'IQEnqPolicyStallIssued': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IQEnqPolicyStallIssued,\s+(\d+)',
+    'IQEnqPolicyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IQEnqPolicyStall,\s+(\d+)',
 
-    "commitInstr": r"\[PERF \]\[time=\s+\d+\] SimTop.l_soc.core_with_l2.core.backend.inner\.ctrlBlock.rob: commitInstr,\s+(\d+)",
-    "total_cycles": r"\[PERF \]\[time=\s+\d+\] SimTop.l_soc.core_with_l2.core.backend.inner\.ctrlBlock.rob: clock_cycle,\s+(\d+)",
+    'IntIQFullStallAlu': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IntIQFullStallAlu,\s+(\d+)',
+    'IntIQFullStallBrh': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IntIQFullStallBrh,\s+(\d+)',
+    'IntIQFullStallOther': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IntIQFullStallOther,\s+(\d+)',
+    'FpIQFullStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FpIQFullStall,\s+(\d+)',
+    'VecIQFullStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: VecIQFullStall,\s+(\d+)',
+    'LoadIQFullStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadIQFullStall,\s+(\d+)',
+    'StoreIQFullStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: StoreIQFullStall,\s+(\d+)',
+    'OtherIQFullStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: OtherIQFullStall,\s+(\d+)',
+
+    'LoadTLBStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadTLBStall,\s+(\d+)',
+    'LoadL1Stall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadL1Stall,\s+(\d+)',
+    'LoadL2Stall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadL2Stall,\s+(\d+)',
+    'LoadL3Stall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadL3Stall,\s+(\d+)',
+    'LoadMemStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadMemStall,\s+(\d+)',
+    'StoreStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: StoreStall,\s+(\d+)',
+    'AtomicStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: AtomicStall,\s+(\d+)',
+
+    'LoadVioReplayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadVioReplayStall,\s+(\d+)',
+    'LoadMSHRReplayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadMSHRReplayStall,\s+(\d+)',
+
+
+    'ControlRedirectStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: ControlRedirectStall,\s+(\d+)',
+    'MemVioRedirectStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: MemVioRedirectStall,\s+(\d+)',
+    'OtherRedirectStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: OtherRedirectStall,\s+(\d+)',
+
+    'ControlRecoveryStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: ControlRecoveryStall,\s+(\d+)',
+    'MemVioRecoveryStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: MemVioRecoveryStall,\s+(\d+)',
+    'OtherRecoveryStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: OtherRecoveryStall,\s+(\d+)',
+
+
+    'FlushedInsts': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FlushedInsts,\s+(\d+)',
+    'SpecialInsts': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: SpecialInsts,\s+(\d+)',
+    'BackendOtherCoreStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BackendOtherCoreStall,\s+(\d+)',
+
+    "commitInstr": fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: commitInstr,\s+(\d+)',
+    "total_cycles": fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: clock_cycle,\s+(\d+)'
 }
 
 

--- a/scripts/top-down/draw.py
+++ b/scripts/top-down/draw.py
@@ -3,12 +3,16 @@ import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
 import configs as cf
+import argparse
+import os.path as osp
 
 
-def draw():
-    results = {
-        'XS': (cf.OUT_CSV, 'XS'),
-    }
+def draw(out_csv_paths=None, labels=None):
+
+    assert len(out_csv_paths) == len(labels)
+    assert 1 <= len(out_csv_paths) <= 2
+
+    results = {labels[i]: (out_csv_paths[i], labels[i]) for i in range(len(out_csv_paths))}
 
     configs = list(results.keys())
 
@@ -19,12 +23,6 @@ def draw():
     hatches = [None] * color_types + ['//'] * color_types + ['|'] * color_types
 
     n_conf = len(configs)
-    # Draw stacked bar chart for each simulator
-    width = 0.8 / n_conf
-    # set figure size:
-
-    fig, ax = plt.subplots()
-    fig.set_size_inches(8.0, 5.0)
 
     x = None
     have_set_label = False
@@ -34,107 +32,238 @@ def draw():
     common_bmk = list(set.intersection(*[set(df.index) for df in dfs]))
     dfs = [df.loc[common_bmk] for df in dfs]
 
+    # Draw stacked bar chart for each simulator
+    # set each width
+
+    total_width = len(dfs[0])
+    if hasattr(cf, "benchmark_list") and cf.benchmark_list is not None and len(cf.benchmark_list)>0:
+        total_width = len(cf.benchmark_list)
+    width = 0.8 / n_conf
+
+    min_width = float(total_width) / 10.0
+    if (width > min_width):
+        width = min_width
+
     rename = True
+
+
+
+    total_analyse = cf.TOTAL_ANALYSE
+    backend_analyse = cf.BACKEND_ANALYSE
+    frontend_analyse = cf.FRONTEND_ANALYSE
+    mem_analyse = cf.MEM_ANALYSE
+    custom_analyse = cf.CUSTOM_ANALYSE
     fine_grain_rename = False
-    renamed_dfs = []
-    for df in dfs:
-        to_drops = []
-        sorted_cols = []
 
-        def rename_with_map(df, rename_map):
-            for k in rename_map:
-                if rename_map[k] is not None:
-                    if rename_map[k].startswith('Merge'):
-                        merged = rename_map[k][5:]
-                        if merged not in df.columns:
-                            df[merged] = df[k]
-                            sorted_cols.append(merged)
+    analyse_jobs = []
+
+    if fine_grain_rename:
+        analyse_jobs.append(("fine", cf.xs_fine_grain_rename_map))
+    else:
+        if total_analyse:
+            analyse_jobs.append(("total", cf.xs_coarse_rename_map))
+        if backend_analyse:
+            analyse_jobs.append(("backend", cf.xs_backend_rename_map))
+        if frontend_analyse:
+            analyse_jobs.append(("frontend", cf.xs_frontend_rename_map))
+        if mem_analyse:
+            analyse_jobs.append(("mem", cf.xs_mem_rename_map))
+        if custom_analyse:
+            analyse_jobs.append(("custom", cf.xs_custom_rename_map))
+    if not analyse_jobs:
+        analyse_jobs.append(("default", cf.xs_coarse_rename_map))
+
+    for tag, current_rename_map in analyse_jobs:
+        # set figure size:
+        fig, ax = plt.subplots()
+        fig.set_size_inches(8.0, 5.0)
+
+        renamed_dfs = []
+        x = None
+        have_set_label = False
+
+        dfs_this = [d.copy(deep=True) for d in dfs]
+
+        for df in dfs_this:
+            to_drops = []
+            sorted_cols = []
+            origin_columns = df.columns
+
+            def rename_with_map(df, rename_map):
+                existing_columns = set(df.columns)
+                for k in rename_map:
+                    if rename_map[k] is not None:
+                        if rename_map[k].startswith('Merge'):
+                            merged = rename_map[k][5:]
+                            if merged not in df.columns:
+                                df[merged] = df[k]
+                                sorted_cols.append(merged)
+                            else:
+                                if merged in origin_columns:
+                                    df[merged] = df[k]
+                                    sorted_cols.append(merged)
+                                else:
+                                    df[merged] += df[k]
                         else:
-                            df[merged] += df[k]
+                            df[rename_map[k]] = df[k]
+                            sorted_cols.append(rename_map[k])
+
+                        to_drops.append(k)
                     else:
-                        df[rename_map[k]] = df[k]
-                        sorted_cols.append(rename_map[k])
+                        sorted_cols.append(k)
+                cols_to_keep = set(sorted_cols) | {'cpi'}
+                cols_to_drop = existing_columns - cols_to_keep
+                df.drop(columns=cols_to_drop, inplace=True)
 
-                    to_drops.append(k)
+            # Merge df columns according to the rename map if value starting with 'Merge'
+            if rename and current_rename_map is not None:
+                rename_with_map(df, current_rename_map)
+                icount = 20 * 10 ** 6
+                if 'BadSpecInst' in df.columns:
+                    df['BadSpecInst'] += df['Base'] - icount
+                if 'Base' in df.columns:
+                    df['Base'] = icount
+
+            df = df.astype(float)
+            renamed_dfs.append(df)
+
+        common_col = list(set.intersection(
+            *[set(df.columns) for df in renamed_dfs]))
+        unique_cols = set()
+        for df in renamed_dfs:
+            unique_col = set(df.columns) - set(common_col)
+            for col in unique_col:
+                unique_cols.add(col)
+        for df in renamed_dfs:
+            for col in unique_cols:
+                if col not in df.columns:
+                    df[col] = 0.0
+            df.sort_index(axis=1, inplace=True)
+
+        put_to_front = ['Base', 'BadSpec']
+
+        tmp_df = renamed_dfs[0].sort_values(by='cpi', ascending=False)
+        bmk_sort = tmp_df.index.tolist()
+
+
+        int_bmks = set(cf.spec_bmks['06']['int'])
+        fp_bmks = set(cf.spec_bmks['06']['float'])
+
+        allow_bmks = None
+        if hasattr(cf, "benchmark_list") and cf.benchmark_list is not None:
+            if len(cf.benchmark_list) > 0:
+                allow_bmks = set(cf.benchmark_list)
+
+
+        def keep_bmk(bmk):
+            # filter by benchmark type first
+            if cf.INT_ONLY and bmk not in int_bmks:
+                return False
+            if cf.FP_ONLY and bmk not in fp_bmks:
+                return False
+
+            # then filter by benchmark_list if provided
+            if allow_bmks is not None and bmk not in allow_bmks:
+                return False
+
+            return True
+
+
+        # ===== filter benchmarks by INT_ONLY / FP_ONLY / benchmark_list =====
+        bmk_sort = [b for b in bmk_sort if keep_bmk(b)]
+
+
+        for df in renamed_dfs:
+            df = df.loc[bmk_sort]
+            existing_columns = [col for col in put_to_front if col in df.columns]
+            df = df[existing_columns + [col for col in df.columns if col not in put_to_front]]
+            df = df.drop(columns=['cpi'])
+            for to_drop in ['ipc', 'cpi', 'Cycles', 'Insts', 'coverage']:
+                if to_drop in df.columns:
+                    df = df.drop(columns=[to_drop])
+
+            # draw stacked bar chart
+            bottom = np.zeros(len(df))
+            highest = 0.0
+            if x is None:
+                x = np.arange(len(df), dtype=float)
+            for component, color, hatch in zip(df.columns, colors[:len(df.columns)], hatches[:len(df.columns)]):
+                if have_set_label:
+                    label = None
                 else:
-                    sorted_cols.append(k)
-            df.drop(columns=to_drops, inplace=True)
+                    label = component
+                ax.bar(x, df[component], bottom=bottom,
+                       width=width, color=color, label=label, edgecolor='black', hatch=hatch)
+                highest = max((bottom + df[component]).max(), highest)
+                bottom += df[component]
+            x += width
+            have_set_label = True
 
-        # Merge df columns according to the rename map if value starting with 'Merge'
-        if rename:
-            if fine_grain_rename:
-                rename_with_map(df, cf.xs_fine_grain_rename_map)
-            else:
-                rename_with_map(df, cf.xs_coarse_rename_map)
+        # replace x tick labels with df.index with rotation
+        ax.set_xticks(x - width * (n_conf + 1) / 2)
+        ax.set_xticklabels(bmk_sort, rotation=90)
+        ax.tick_params(left=False, bottom=False)
+        ax.set_ylabel('Ratio')
+        ax.set_xlabel('SPECCPU 2006 Benchmarks')
+        left_lim = -1.5 * width
+        right_lim = (len(bmk_sort) - 1) + (n_conf - 0.5) * width + width
+        ax.set_xlim(left_lim, right_lim)
 
-            icount = 20 * 10 ** 6
-            if 'BadSpecInst' in df.columns:
-                df['BadSpecInst'] += df['Base'] - icount
-            else:
-                df['BadSpecInst'] = df['Base'] - icount
-            df['Base'] = icount
+        # ---- legend between title and plot, flatter ----
+        handles, labels_ = plt.gca().get_legend_handles_labels()
 
-        df = df.astype(float)
-        renamed_dfs.append(df)
+        if n_conf == 2:
+            ax.set_title(f'[{tag}]: {configs[0]} <-- VS. --> {configs[1]}', pad=35)
+        else:
+            ax.set_title(f'[{tag}]: {configs[0]}', pad=28)
 
-    common_col = list(set.intersection(
-        *[set(df.columns) for df in renamed_dfs]))
-    unique_cols = set()
-    for df in renamed_dfs:
-        unique_col = set(df.columns) - set(common_col)
-        for col in unique_col:
-            unique_cols.add(col)
-    for df in renamed_dfs:
-        for col in unique_cols:
-            if col not in df.columns:
-                df[col] = 0.0
-        df.sort_index(axis=1, inplace=True)
+        ax.legend(
+            list(reversed(handles)),
+            list(reversed(labels_)),
+            fancybox=True,
+            framealpha=0.3,
+            loc='lower center',
+            bbox_to_anchor=(0.5, 1.01),
+            ncol=6,
+            borderaxespad=0.0,
+            handlelength=1.2,
+            columnspacing=0.8,
+            labelspacing=0.2,
+            fontsize=8,
+        )
 
-    put_to_front = ['Base', 'BadSpec']
+        fig.subplots_adjust(top=0.78)
 
-    tmp_df = renamed_dfs[0].sort_values(by='cpi', ascending=False)
-    bmk_sort = tmp_df.index.tolist()
+        out_name = "result.png" if len(analyse_jobs) == 1 else f"result_{tag}.png"
+        fig.savefig(osp.join('results', out_name),
+                    bbox_inches='tight', pad_inches=0.05, dpi=200)
+        plt.close(fig)
 
-    for df in renamed_dfs:
-        df = df.loc[bmk_sort]
-        df = df[put_to_front +
-                [col for col in df.columns if col not in put_to_front]]
-        df = df.drop(columns=['cpi'])
-        for to_drop in ['ipc', 'cpi', 'Cycles', 'Insts', 'coverage']:
-            if to_drop in df.columns:
-                df = df.drop(columns=[to_drop])
+if __name__ == '__main__':
 
-        # draw stacked bar chart
-        bottom = np.zeros(len(df))
-        highest = 0.0
-        if x is None:
-            x = np.arange(len(df), dtype=float)
-        for component, color, hatch in zip(df.columns, colors[:len(df.columns)], hatches[:len(df.columns)]):
-            if have_set_label:
-                label = None
-            else:
-                label = component
-            ax.bar(x, df[component], bottom=bottom,
-                   width=width, color=color, label=label, edgecolor='black', hatch=hatch)
-            highest = max((bottom + df[component]).max(), highest)
-            bottom += df[component]
-        x += width
-        have_set_label = True
-    # replace x tick labels with df.index with rotation
-    ax.set_xticks(x - width * len(results) / n_conf - 0.25)
-    ax.set_xticklabels(bmk_sort, rotation=90)
-    ax.tick_params(left=False, bottom=False)
-    ax.set_ylabel('Slots')
-    ax.set_xlabel('SPECCPU 2006 Benchmarks')
+    parser = argparse.ArgumentParser(usage='draw top-down stacked bar chart (base/ref weighted csv)')
+    parser.add_argument('-b', '--base-weighted-csv', default=cf.OUT_BASE,
+                        help=f'base weighted csv path (default: {cf.OUT_BASE})')
+    parser.add_argument('-r', '--ref-weighted-csv', default=cf.OUT_REF,
+                        help=f'ref weighted csv path (default: {cf.OUT_REF})')
+    parser.add_argument('--base-label', default='BASE',
+                        help=f'base label (default: BASE)')
+    parser.add_argument('--ref-label', default='REF',
+                        help=f'ref label (default: REF)')
+    opt = parser.parse_args()
 
-    handles, labels = plt.gca().get_legend_handles_labels()
-    ax.legend(list(reversed(handles)), list(reversed(labels)), fancybox=True,
-              framealpha=0.3,
-              loc='best',
-              ncol=3,
-              )
-    if n_conf == 2:
-        ax.set_title(f'{configs[0]} <-- VS. --> {configs[1]}')
+    base_csv = opt.base_weighted_csv
+    ref_csv  = opt.ref_weighted_csv
 
-    fig.savefig(osp.join('results', 'result.png'),
-                bbox_inches='tight', pad_inches=0.05, dpi=200)
+    base_exists = bool(base_csv) and osp.exists(base_csv)
+    ref_exists  = bool(ref_csv) and osp.exists(ref_csv)
+
+    assert (base_exists or ref_exists), \
+        f'Neither base nor ref csv exists: base={base_csv}, ref={ref_csv}'
+
+    if base_exists and ref_exists:
+        draw([base_csv, ref_csv], [opt.base_label, opt.ref_label])
+    elif base_exists:
+        draw([base_csv], [opt.base_label])
+    else:
+        draw([ref_csv], [opt.ref_label])

--- a/scripts/top-down/top_down.py
+++ b/scripts/top-down/top_down.py
@@ -13,7 +13,7 @@ import configs as cf
 from draw import draw
 
 
-def batch():
+def batch(out_csv_path: str):
     paths = u.glob_stats(cf.stats_dir, fname='simulator_err.txt')
 
     manager = Manager()
@@ -56,8 +56,7 @@ def batch():
     df = df.reindex(sorted(df.columns), axis=1)
 
     df = df.fillna(0)
-
-    df.to_csv(cf.CSV_PATH, index=True)
+    df.to_csv(out_csv_path, index=True)
 
 
 def proc_input(wl_df: pd.DataFrame, js: dict, workload: str):
@@ -118,13 +117,14 @@ def proc_bmk(bmk_df: pd.DataFrame, js: dict):
     weight_metric = np.matmul(vec_weight.values.reshape(1, -1), metrics.values)
     return weight_metric, metrics.columns
 
-
-def compute_weighted_metrics():
-    df = pd.read_csv(cf.CSV_PATH, index_col=0)
+def compute_weighted_metrics(in_csv_path: str, out_csv_path: str, scale: float = 1.0):
+    df = pd.read_csv(in_csv_path, index_col=0)
     bmks = df['bmk'].unique()
     with open(cf.JSON_FILE, 'r', encoding='utf-8') as f:
         js = json.load(f)
+
     weighted = {}
+    cols = None
     for bmk in bmks:
         if bmk not in cf.spec_bmks['06']['int'] and cf.INT_ONLY:
             continue
@@ -138,29 +138,101 @@ def compute_weighted_metrics():
         else:
             metrics, cols = proc_bmk(df_bmk, js)
         weighted[bmk] = metrics[0]
-    weighted_df = pd.DataFrame.from_dict(
-        weighted, orient='index', columns=cols)
+
+    weighted_df = pd.DataFrame.from_dict(weighted, orient='index', columns=cols)
+
+    # ===== NEW: scale all numeric columns by `scale` (except commitInstr) =====
+    scale = float(scale)
+
+    # only scale numeric columns; exclude commitInstr
+    scale_cols = [c for c in weighted_df.columns if c != 'commitInstr']
+    weighted_df[scale_cols] = weighted_df[scale_cols].astype(float) * scale
+    if 'commitInstr' in weighted_df.columns:
+        weighted_df['commitInstr'] = weighted_df['commitInstr'].astype(float)
+    # =========================================================================
+
     if 'cpi' in weighted_df.columns:
         weighted_df = weighted_df.sort_values(by='cpi', ascending=False)
     else:
         weighted_df = weighted_df.sort_index()
-    weighted_df.to_csv(cf.OUT_CSV)
+    weighted_df.to_csv(out_csv_path)
+
+
+def run_one(tag: str, stat_dir: str, csv_path: str, out_path: str, rename_width: int = 1) -> str:
+    print(f"\n========== RUN {tag} ==========")
+    cf.stats_dir = stat_dir
+    batch(csv_path)
+    compute_weighted_metrics(csv_path, out_path, rename_width)
+    return out_path
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(usage='generate top-down results')
-    parser.add_argument('-s', '--stat-dir', action='store', required=True,
-                        help='stat output directory')
+    parser = argparse.ArgumentParser(usage='generate top-down results for base/ref (optional)')
+    parser.add_argument('-b', '--base-stat-dir', action='store', required=True, default=None,
+                        help='base stat output directory (required)')
+    parser.add_argument('-r', '--ref-stat-dir', action='store', default=None,
+                        help='ref stat output directory (optional)')
     parser.add_argument('-j', '--json', action='store', required=True,
                         help='specify json file', default='resources/spec06_rv64gcb_o2_20m.json')
+    parser.add_argument('--base-issue', type=float, default=None,
+                        help='base issue width (required when both --base-stat-dir and --ref-stat-dir are provided)')
+    parser.add_argument('--ref-issue', type=float, default=None,
+                        help='ref issue width (required when both --base-stat-dir and --ref-stat-dir are provided)')
+    parser.add_argument('--base-label', type=str, default='BASE',
+                        help='label prefix for base (default: BASE)')
+    parser.add_argument('--ref-label', type=str, default='REF',
+                        help='label prefix for ref (default: REF)')
+
     opt = parser.parse_args()
-    cf.stats_dir = opt.stat_dir
+
     cf.JSON_FILE = opt.json
+
     if not osp.exists('results'):
         os.makedirs('results')
+
     if resource.getrlimit(resource.RLIMIT_NOFILE)[0] <= 8192:
         resource.setrlimit(resource.RLIMIT_NOFILE, (8192, 8192))
 
-    batch()
-    compute_weighted_metrics()
-    draw()
+    out_csv_paths = []
+    labels = []
+
+    base_scale = 1.0
+    ref_scale  = 1.0
+
+    if opt.base_stat_dir and opt.ref_stat_dir:
+        if opt.base_issue is None or opt.ref_issue is None:
+            raise SystemExit(
+                "Error: when both --base-stat-dir and --ref-stat-dir are provided, "
+                "you must also provide --base-issue and --ref-issue"
+            )
+        b = float(opt.base_issue)
+        r = float(opt.ref_issue)
+        if b <= 0 or r <= 0:
+            raise SystemExit("Error: --base-issue and --ref-issue must be > 0")
+
+        if b < r:
+            base_scale = r / b
+        elif r < b:
+            ref_scale = b / r
+
+        print(f"[INFO] issue widths: base={b}, ref={r}")
+        print(f"[INFO] computed scales: BASE scale={base_scale:.6f}, REF scale={ref_scale:.6f}")
+    else:
+        print("[INFO] only one stat dir provided -> scale=1.0")
+
+    if opt.base_stat_dir:
+        print(f"[INFO] Run BASE with scale={base_scale:.6f}")
+        out_base = run_one("BASE", opt.base_stat_dir, cf.CSV_BASE, cf.OUT_BASE, base_scale)
+        out_csv_paths.append(out_base)
+        labels.append(opt.base_label)
+
+    if opt.ref_stat_dir:
+        print(f"[INFO] Run REF with scale={ref_scale:.6f}")
+        out_ref = run_one("REF", opt.ref_stat_dir, cf.CSV_REF, cf.OUT_REF, ref_scale)
+        out_csv_paths.append(out_ref)
+        labels.append(opt.ref_label)
+
+    if not out_csv_paths:
+        raise SystemExit("Error: please provide at least one of --base-stat-dir or --ref-stat-dir")
+    draw(out_csv_paths, labels)
+

--- a/scripts/top-down/utils.py
+++ b/scripts/top-down/utils.py
@@ -11,7 +11,7 @@ def to_num(x: str) -> (int, float):
 
 
 def xs_get_stats(stat_file: str, targets: list) -> dict:
-
+    stat_path = expu(stat_file)
     if not os.path.isfile(expu(stat_file)):
         print(stat_file)
     assert os.path.isfile(expu(stat_file))
@@ -47,10 +47,9 @@ def xs_get_stats(stat_file: str, targets: list) -> dict:
     obtained_keys = set(stats.keys())
     not_found_keys = desired_keys - obtained_keys
     if not_found_keys:
-        print(stat_file)
-        print(targets)
-        print(not_found_keys)
-    assert len(not_found_keys) == 0
+        print(f"[WARN] missing keys in {stat_path}: {sorted(not_found_keys)}")
+        for k in not_found_keys:
+            stats[k] = 0
 
     stats['ipc'] = stats['commitInstr'] / stats['total_cycles']
     return stats

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -497,8 +497,8 @@ class CHIFrontendDebugConfig(n: Int = 1) extends Config(
   })
 )
 
-class TLBackendV2Config(n: Int = 1) extends Config(
-  new TLConfig(n).alter((site, here, up) => {
+class CHIBackendV2Config(n: Int = 1) extends Config(
+  new CHIConfig(n).alter((site, here, up) => {
     case XSTileKey => up(XSTileKey).map { p =>
       p.copy(
         EnableBackendV2Config = true,
@@ -546,7 +546,7 @@ class TLBackendV2Config(n: Int = 1) extends Config(
     }
   })
 )
-class BackendV2Config(n: Int = 1) extends TLBackendV2Config(n) with DeprecatedConfigWarning
+class BackendV2Config(n: Int = 1) extends CHIBackendV2Config(n) with DeprecatedConfigWarning
 
 class CVMCompile extends Config((site, here, up) => {
   case CVMParamsKey => up(CVMParamsKey).copy(

--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -777,7 +777,6 @@ class MatchTriggerIO(implicit p: Parameters) extends XSBundle {
 
 class StallReasonIO(width: Int) extends Bundle {
   val reason = Output(Vec(width, UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))
-  val backReason = Flipped(Valid(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))
 }
 
 // custom l2 - l1 interface

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -173,7 +173,6 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   backend.io.mem.sqCanAccept := memBlock.io.mem_to_ooo.lsqio.sqCanAccept
   backend.io.fenceio.sbuffer.sbIsEmpty := memBlock.io.mem_to_ooo.sbIsEmpty
 
-  backend.io.perf.frontendInfo := frontend.io.frontendInfo
   backend.io.perf.memInfo := memBlock.io.memInfo
   backend.io.perf.perfEventsFrontend := frontend.io_perf
   backend.io.perf.perfEventsLsu := memBlock.io_perf

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -233,6 +233,10 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   ctrlBlock.io.toDispatch.wakeUpFp  := fpRegion.io.wakeUpToDispatch
   ctrlBlock.io.toDispatch.wakeUpVec := vecRegion.io.wakeUpToDispatch
   ctrlBlock.io.toDispatch.IQValidNumVec := intRegion.io.IQValidNumVec ++ fpRegion.io.IQValidNumVec ++ vecRegion.io.IQValidNumVec
+  ctrlBlock.io.toDispatch.debugIQValidNumVec.foreach(_ := intRegion.io.debugIQValidNumVec.get ++
+    fpRegion.io.debugIQValidNumVec.get ++ vecRegion.io.debugIQValidNumVec.get)
+  ctrlBlock.io.toDispatch.debugIQEnqHasIssuedVec.foreach(_ := intRegion.io.debugIQEnqHasIssuedVec.get ++
+    fpRegion.io.debugIQEnqHasIssuedVec.get ++ vecRegion.io.debugIQEnqHasIssuedVec.get)
   ctrlBlock.io.toDispatch.ldCancel := io.mem.ldCancel
   // Todo: when add cross domain wake up, it is necessary to add assertions that fp and vec do not have 0 lat fu.
   ctrlBlock.io.toDispatch.og0Cancel := intRegion.io.og0Cancel

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -606,6 +606,7 @@ class CtrlBlockImp(
     rename.io.validVec(i) := decodePipeRename(i).valid
     rename.io.isFusionVec(i) := false.B
     rename.io.fusionCross2FtqVec(i) := false.B
+    decode.io.debugOutValid.get(i) := decodePipeRename(i).valid
   }
 
   for (i <- 0 until RenameWidth - 1) {
@@ -672,6 +673,7 @@ class CtrlBlockImp(
   rename.io.snpt.flushVec := flushVecNext
   rename.io.snptLastEnq.valid := !isEmpty(snpt.io.enqPtr, snpt.io.deqPtr)
   rename.io.snptLastEnq.bits := snpt.io.snapshots((snpt.io.enqPtr - 1.U).value).robIdx.head
+  rename.io.debugDispatchAllFire.foreach(_ := dispatch.io.toRenameAllFire)
 
   for (i <- 0 until RenameWidth - 1) {
     when (fusionDecoder.io.out(i).valid) {
@@ -695,6 +697,9 @@ class CtrlBlockImp(
 
   // pipeline between rename and dispatch
   PipeGroupConnect(renameOut, dispatch.io.fromRename, s1_s3_redirect.valid, dispatch.io.toRenameAllFire, "renamePipeDispatch")
+
+  rename.io.debugOutValidVec.foreach( validVec => validVec := dispatch.io.fromRename.map(_.valid))
+
 
   dispatch.io.redirect := s1_s3_redirect
   val enqRob = Wire(chiselTypeOf(rob.io.enq))
@@ -739,6 +744,8 @@ class CtrlBlockImp(
   dispatch.io.robHeadNotReady := rob.io.headNotReady
   dispatch.io.robFull := rob.io.robFull
   dispatch.io.singleStep := GatedValidRegNext(io.csrCtrl.singlestep)
+  dispatch.io.debugBlockBackward.foreach(_ := rob.io.debugBlockBackward.get)
+  dispatch.io.debugWaitForward.foreach(_ := rob.io.debugWaitForward.get)
 
   val toIssueBlockUops = Seq(io.toIssueBlock.intUops, io.toIssueBlock.fpUops, io.toIssueBlock.vfUops).flatten
   println(s"[CtrlBlock] toIssueBlockUops.size = ${toIssueBlockUops.size}")

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -605,7 +605,7 @@ class CtrlBlockImp(
     rename.io.validVec(i) := decodePipeRename(i).valid
     rename.io.isFusionVec(i) := false.B
     rename.io.fusionCross2FtqVec(i) := false.B
-    decode.io.debugOutValid.get(i) := decodePipeRename(i).valid
+    decode.io.debugOutValid.foreach{ validVec => validVec(i) := decodePipeRename(i).valid}
   }
 
   for (i <- 0 until RenameWidth - 1) {
@@ -697,7 +697,7 @@ class CtrlBlockImp(
   // pipeline between rename and dispatch
   PipeGroupConnect(renameOut, dispatch.io.fromRename, s1_s3_redirect.valid, dispatch.io.toRenameAllFire, "renamePipeDispatch")
 
-  rename.io.debugOutValidVec.get := dispatch.io.fromRename.map(_.valid)
+  rename.io.debugOutValidVec.foreach(_ := dispatch.io.fromRename.map(_.valid))
 
 
   dispatch.io.redirect := s1_s3_redirect

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -698,7 +698,7 @@ class CtrlBlockImp(
   // pipeline between rename and dispatch
   PipeGroupConnect(renameOut, dispatch.io.fromRename, s1_s3_redirect.valid, dispatch.io.toRenameAllFire, "renamePipeDispatch")
 
-  rename.io.debugOutValidVec.foreach( validVec => validVec := dispatch.io.fromRename.map(_.valid))
+  rename.io.debugOutValidVec.get := dispatch.io.fromRename.map(_.valid)
 
 
   dispatch.io.redirect := s1_s3_redirect

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -742,7 +742,8 @@ class CtrlBlockImp(
   dispatch.io.singleStep := GatedValidRegNext(io.csrCtrl.singlestep)
   dispatch.io.debugBlockBackward.foreach(_ := rob.io.debugBlockBackward.get)
   dispatch.io.debugWaitForward.foreach(_ := rob.io.debugWaitForward.get)
-
+  dispatch.io.debugIQValidNumVec.foreach(_ := io.toDispatch.debugIQValidNumVec.get)
+  dispatch.io.debugIQEnqHasIssuedVec.foreach(_ := io.toDispatch.debugIQEnqHasIssuedVec.get)
   val toIssueBlockUops = Seq(io.toIssueBlock.intUops, io.toIssueBlock.fpUops, io.toIssueBlock.vfUops).flatten
   println(s"[CtrlBlock] toIssueBlockUops.size = ${toIssueBlockUops.size}")
   println(s"[CtrlBlock] io.toIssueBlock.intUops.size = ${io.toIssueBlock.intUops.size}")
@@ -886,6 +887,7 @@ class CtrlBlockIO()(implicit p: Parameters, params: BackendParams) extends XSBun
     val allIssueParams = backendParams.allIssueParams.filter(_.StdCnt == 0)
     val allExuParams = allIssueParams.map(_.exuBlockParams).flatten
     val exuNum = allExuParams.size
+    val IQNum = allIssueParams.size
     val maxIQSize = allIssueParams.map(_.numEntries).max
     val IQValidNumVec = Vec(exuNum, Input(UInt(maxIQSize.U.getWidth.W)))
     val og0Cancel = Input(ExuVec())
@@ -901,6 +903,8 @@ class CtrlBlockIO()(implicit p: Parameters, params: BackendParams) extends XSBun
       val vlFromVfIsZero   = Input(Bool())
       val vlFromVfIsVlmax  = Input(Bool())
     }
+    val debugIQValidNumVec = Option.when(backendParams.debugEn)(Vec(IQNum, Input(UInt(maxIQSize.U.getWidth.W))))
+    val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(IQNum, Input(Bool())))
   }
   val toDataPath = new Bundle {
     val flush = ValidIO(new Redirect)

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -419,7 +419,8 @@ class CtrlBlockImp(
   decode.io.fromRob.commitVType := rob.io.toDecode.commitVType
   decode.io.fromRob.walkVType := rob.io.toDecode.walkVType
 
-  decode.io.redirect := s1_s3_redirect.valid || s2_s4_pendingRedirectValid
+  decode.io.redirect.valid := s1_s3_redirect.valid || s2_s4_pendingRedirectValid
+  decode.io.redirect.bits := Mux(s1_s3_redirect.valid, s1_s3_redirect.bits, s2_s4_redirect.bits)
 
   // add decode Buf for in.ready better timing
   /**
@@ -484,7 +485,7 @@ class CtrlBlockImp(
    */
   for (i <- 0 until DecodeWidth) {
     // decodeBufValid update
-    when(decode.io.redirect || decodeBufValid(0) && decodeBufValid(i) && decode.io.in(i).ready && !VecInit(decodeBufNotAccept.drop(i)).asUInt.orR) {
+    when(decode.io.redirect.valid || decodeBufValid(0) && decodeBufValid(i) && decode.io.in(i).ready && !VecInit(decodeBufNotAccept.drop(i)).asUInt.orR) {
       decodeBufValid(i) := false.B
     }.elsewhen(decodeBufValid(i) && VecInit(decodeBufNotAccept.drop(i)).asUInt.orR) {
       decodeBufValid(i) := Mux(decodeBufAcceptNum > DecodeWidth.U - 1.U - i.U, false.B, decodeBufValid(i.U + decodeBufAcceptNum))
@@ -518,7 +519,7 @@ class CtrlBlockImp(
    */
   decode.io.in.zipWithIndex.foreach { case (decodeIn, i) =>
     decodeIn.valid := Mux(decodeBufValid(0), decodeBufValid(i), decodeFromFrontend(i).valid)
-    decodeFromFrontend(i).ready := decodeFromFrontend(0).valid && !decodeBufValid(0) && decodeFromFrontend(i).valid && !decode.io.redirect
+    decodeFromFrontend(i).ready := decodeFromFrontend(0).valid && !decodeBufValid(0) && decodeFromFrontend(i).valid && !decode.io.redirect.valid
     decodeIn.bits := Mux(decodeBufValid(i), decodeBufBits(i), decodeConnectFromFrontend(i))
   }
   /** no valid instr in decode buffer && no valid instr from frontend --> can accept new instr from frontend */
@@ -671,6 +672,13 @@ class CtrlBlockImp(
   rename.io.snpt.flushVec := flushVecNext
   rename.io.snptLastEnq.valid := !isEmpty(snpt.io.enqPtr, snpt.io.deqPtr)
   rename.io.snptLastEnq.bits := snpt.io.snapshots((snpt.io.enqPtr - 1.U).value).robIdx.head
+
+  for (i <- 0 until RenameWidth - 1) {
+    when (fusionDecoder.io.out(i).valid) {
+      // Topdown fusion bubble
+      rename.io.stallReason.in.reason(i + 1) := TopDownCounters.FusionBubble.id.U
+    }
+  }
 
   val renameOut = Wire(chiselTypeOf(dispatch.io.fromRename))
   renameOut.zip(rename.io.out).map{ case (sink, source) => {

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -28,8 +28,7 @@ import xiangshan.backend.Bundles._
 import xiangshan.backend.ctrlblock.{DebugLSIO, DebugLsInfoBundle, LsTopdownInfo, MemCtrl, RedirectGenerator}
 import xiangshan.backend.datapath.DataConfig.{FpData, IntData, V0Data, VAddrData, VecData, VlData}
 import xiangshan.backend.decode.{DecodeStage, FusionDecoder}
-import xiangshan.backend.dispatch.CoreDispatchTopDownIO
-import xiangshan.backend.dispatch.NewDispatch
+import xiangshan.backend.dispatch._
 import xiangshan.backend.fu.vector.Bundles.{VType, Vl}
 import xiangshan.backend.fu.wrapper.CSRToDecode
 import xiangshan.backend.rename.{Rename, RenameTableWrapper, SnapshotGenerator}
@@ -94,7 +93,7 @@ class CtrlBlockImp(
 
   val io = IO(new CtrlBlockIO())
 
-  val dispatch = Module(new NewDispatch)
+  val dispatch = Module(new Dispatch)
   val gpaMem = wrapper.gpaMem.module
   val decode = Module(new DecodeStage)
   val fusionDecoder = Module(new FusionDecoder)

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -720,8 +720,6 @@ class CtrlBlockImp(
   rob.io.enq.req := enqRob.req
   dispatch.io.robHeadFuType := rob.io.debugRobHeadFuType
   dispatch.io.stallReason <> rename.io.stallReason.out
-  dispatch.io.lqCanAccept := io.lqCanAccept
-  dispatch.io.sqCanAccept := io.sqCanAccept
   dispatch.io.fromMem.lcommit := io.fromMemToDispatch.lcommit
   dispatch.io.fromMem.scommit := io.fromMemToDispatch.scommit
   dispatch.io.fromMem.lqDeqPtr := io.fromMemToDispatch.lqDeqPtr
@@ -742,7 +740,6 @@ class CtrlBlockImp(
   dispatch.io.wbPregsVl := io.toDispatch.wbPregsVl
   dispatch.io.vlWriteBackInfo := io.toDispatch.vlWriteBackInfo
   dispatch.io.robHeadNotReady := rob.io.headNotReady
-  dispatch.io.robFull := rob.io.robFull
   dispatch.io.singleStep := GatedValidRegNext(io.csrCtrl.singlestep)
   dispatch.io.debugBlockBackward.foreach(_ := rob.io.debugBlockBackward.get)
   dispatch.io.debugWaitForward.foreach(_ := rob.io.debugWaitForward.get)

--- a/src/main/scala/xiangshan/backend/PipeGroupConnect.scala
+++ b/src/main/scala/xiangshan/backend/PipeGroupConnect.scala
@@ -4,55 +4,103 @@ import chisel3._
 import chisel3.util._
 import xiangshan.TopDownCounters._
 
+class StoreBubbleReason(reasonW: Int) extends Module {
+  val io = IO(new Bundle{
+    val bubbleValid = Input(Bool())
+    val bubbleReason = Input(UInt(reasonW.W))
+    val redirect = Input(Bool())
+    val reasonFire = Input(Bool())
+    val outReasonValid = Output(Bool())
+    val outReason = Output(UInt(reasonW.W))
+  })
+  val NoStallReason = NoStall.id.U
+  val bubbleValidReg = RegInit(false.B)
+  val bubbleReasonReg = RegInit(NoStallReason)
+  val bubblevalidNext = WireDefault(bubbleValidReg)
+  val bubbleReasonNext = WireDefault(bubbleReasonReg)
+
+  val bubbleConsumed = bubbleValidReg && io.reasonFire
+  val canUpdate = (!bubbleValidReg) || bubbleConsumed
+
+  when (io.redirect) {
+    bubblevalidNext := false.B
+    bubbleReasonNext := NoStallReason
+  }.elsewhen(canUpdate && io.bubbleValid) {
+    bubblevalidNext := true.B
+    bubbleReasonNext := io.bubbleReason
+  }.elsewhen(bubbleConsumed) {
+    bubblevalidNext := false.B
+    bubbleReasonNext := NoStallReason
+  }.otherwise {
+    bubblevalidNext := bubbleValidReg
+    bubbleReasonNext := bubbleReasonReg
+  }
+
+  bubbleValidReg := bubblevalidNext
+  bubbleReasonReg := bubbleReasonNext
+
+  dontTouch(bubbleValidReg)
+  dontTouch(bubbleReasonReg)
+
+  io.outReason := Mux(io.bubbleValid && !bubbleValidReg, io.bubbleReason, bubbleReasonReg)
+  io.outReasonValid := bubbleValidReg || io.bubbleValid
+}
+
 class PipelineStallReason(reasonW: Int) extends Module {
   val io = IO(new Bundle{
+    val rightFire = Input(Bool())
+    val rightHasFire = Input(Bool())
     val prePipeStall = Input(Bool())
     val prePipeStallReason = Input(UInt(reasonW.W))
     val prePipeBubble = Input(Bool())
+    val prePipeBubbleReason = Input(UInt(reasonW.W))
     val redirect = Input(Bool())
     val redirectReason = Input(UInt(reasonW.W))
     val currentPipeStall = Input(Bool())
     val currentPipeStallReason = Input(UInt(reasonW.W))
-    val pastPipeFire = Input(Bool())
+    val currentPipeBubble = Input(Bool())
+    val currentPipeBubbleReason = Input(UInt(reasonW.W))
     val outReason = Output(UInt(reasonW.W))
   })
 
   val NoStallReason = NoStall.id.U
-  val reasonReg = RegInit(NoStallReason)
-  val holdBubbleReason = RegInit(false.B)
 
-  val bubbleConsumed = holdBubbleReason && io.pastPipeFire
-  val canUpdate      = (!holdBubbleReason) || bubbleConsumed
+  val redirectReg = RegNext(io.redirect)
+  val redirectReason = RegNext(io.redirectReason)
 
-  val reasonNext = WireDefault(reasonReg)
-  val holdNext   = WireDefault(holdBubbleReason)
+  val prePipeStallReg = RegNext(io.prePipeStall)
+  val prePipeStallReasonReg = RegNext(io.prePipeStallReason)
 
-  when (io.redirect) {
-    reasonNext := io.redirectReason
-    holdNext   := false.B
-  } .elsewhen (canUpdate) {
-    when (io.prePipeStall) {
-      reasonNext := io.prePipeStallReason
-      holdNext   := false.B
-    } .elsewhen (io.prePipeBubble) {
-      reasonNext := io.prePipeStallReason
-      holdNext   := true.B
-    } .elsewhen (io.currentPipeStall) {
-      reasonNext := io.currentPipeStallReason
-      holdNext   := false.B
-    } .otherwise {
+  val currentPipeStallReg = RegNext(io.currentPipeStall)
+  val currentPipeStallReasonReg = RegNext(io.currentPipeStallReason)
+
+  // todo current pipe bubble
+  // todo seperate bubble stall here(with class)
+
+  val currentPipeBubbleReg = RegNext(io.currentPipeBubble)
+  val currentPipeBubbleReasonReg = RegNext(io.currentPipeBubbleReason)
+
+
+  val reasonNext = Wire(UInt(reasonW.W))
+
+  when (io.redirect || redirectReg) {
+    reasonNext := Mux(io.redirect, io.redirectReason, redirectReg)
+  }.otherwise {
+    when (io.rightFire) {
       reasonNext := NoStallReason
-      holdNext   := false.B
+    }.elsewhen(prePipeStallReg && !io.rightHasFire) {
+      reasonNext := prePipeStallReasonReg
+    }.elsewhen (currentPipeStallReg && !io.rightHasFire) {
+      reasonNext := currentPipeStallReasonReg
+    }.elsewhen (io.prePipeBubble) {
+      reasonNext := io.prePipeBubbleReason
+    }.elsewhen (currentPipeBubbleReg){
+      reasonNext := currentPipeBubbleReasonReg
+    }otherwise {
+      reasonNext := NoStallReason
     }
-  } .otherwise {
-    reasonNext := reasonReg
-    holdNext   := holdBubbleReason
   }
-
-  reasonReg := reasonNext
-  holdBubbleReason := holdNext
-
-  io.outReason := reasonReg
+  io.outReason := reasonNext
 }
 
 class PipeGroupConnect[T <: Data](n: Int, gen: => T) extends Module {

--- a/src/main/scala/xiangshan/backend/PipeGroupConnect.scala
+++ b/src/main/scala/xiangshan/backend/PipeGroupConnect.scala
@@ -74,8 +74,12 @@ class PipelineStallReason(reasonW: Int) extends Module {
   val currentPipeStallReg = RegNext(io.currentPipeStall)
   val currentPipeStallReasonReg = RegNext(io.currentPipeStallReason)
 
-  // todo current pipe bubble
-  // todo seperate bubble stall here(with class)
+  /** Attention : as `rename` and `decode` themselves
+   do not generate bubbles, no special handling has been added for them
+   for now.
+   *
+   * Special care is needed if this stage may generate its own bubble in later cases
+   */
 
   val currentPipeBubbleReg = RegNext(io.currentPipeBubble)
   val currentPipeBubbleReasonReg = RegNext(io.currentPipeBubbleReason)

--- a/src/main/scala/xiangshan/backend/PipeGroupConnect.scala
+++ b/src/main/scala/xiangshan/backend/PipeGroupConnect.scala
@@ -66,7 +66,7 @@ class PipelineStallReason(reasonW: Int) extends Module {
   val NoStallReason = NoStall.id.U
 
   val redirectReg = RegNext(io.redirect)
-  val redirectReason = RegNext(io.redirectReason)
+  val redirectReasonReg = RegNext(io.redirectReason)
 
   val prePipeStallReg = RegNext(io.prePipeStall)
   val prePipeStallReasonReg = RegNext(io.prePipeStallReason)
@@ -84,7 +84,7 @@ class PipelineStallReason(reasonW: Int) extends Module {
   val reasonNext = Wire(UInt(reasonW.W))
 
   when (io.redirect || redirectReg) {
-    reasonNext := Mux(io.redirect, io.redirectReason, redirectReg)
+    reasonNext := Mux(io.redirect, io.redirectReason, redirectReasonReg)
   }.otherwise {
     when (io.rightFire) {
       reasonNext := NoStallReason

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -731,6 +731,41 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
   io.uopTopDown.noStoreIssued := dataPath.io.uopTopDown.noStoreIssued
 
   // perf counter
+  val staValidNum = stAddrIQs.map{ case staIQ =>
+    PopCount(staIQ.io.validVec)
+  }
+  val stdValidNum = stDataIQs.map{ case stdIQ =>
+    PopCount(stdIQ.io.validVec)
+  }
+  def andVec(a: Vec[Bool], b: Vec[Bool]): Vec[Bool] =
+    VecInit(a.zip(b).map { case (x, y) => x && y })
+
+  val staNumEnq = params.issueBlockParams.filter(iq => iq.StaCnt > 0).map(_.numEnq)
+  val stdNumEnq = params.issueBlockParams.filter(iq => iq.StdCnt > 0).map(_.numEnq)
+  val staEnqHasIssuedVec = stAddrIQs.zip(staNumEnq).map{ case (staIQ, numEnq) =>
+    andVec(staIQ.io.issuedVec, staIQ.io.validVec).take(numEnq).reduce(_ & _)
+  }
+  val stdEnqHasIssuedVec = stDataIQs.zip(stdNumEnq).map{ case (stdIQ, numEnq) =>
+    andVec(stdIQ.io.issuedVec, stdIQ.io.validVec).take(numEnq).reduce(_ & _)
+  }
+
+
+  val issueQueueValidNumVec: Vec[UInt] = io.debugIQValidNumVec.get
+  issueQueues.filter(_.param.StdCnt == 0).zip(issueQueueValidNumVec).foreach{ case (issueQueue, validNum) =>
+    validNum := PopCount(issueQueue.io.validVec)
+  }
+  staIdx.zipWithIndex.foreach { case (sta, i) =>
+    issueQueueValidNumVec(sta) := Mux(staValidNum(i) > stdValidNum(i), staValidNum(i), stdValidNum(i))
+  }
+
+  val issueQueueEnqHasIssuedVec : Vec[Bool] = io.debugIQEnqHasIssuedVec.get
+  issueQueues.filter(_.param.StdCnt == 0).zip(issueQueueEnqHasIssuedVec).foreach{ case (issueQueue, enqIssued) =>
+    enqIssued := andVec(issueQueue.io.issuedVec, issueQueue.io.validVec).take(issueQueue.param.numEnq).reduce(_ & _)
+  }
+  staIdx.zipWithIndex.foreach { case (sta, i) =>
+    issueQueueEnqHasIssuedVec(sta) := Mux(staValidNum(i) > stdValidNum(i), staEnqHasIssuedVec(i), stdEnqHasIssuedVec(i))
+  }
+
   if (params.isIntSchd) {
     val iqNum = issueQueues.size
     case class FUConfig(filter: UInt => Bool, name: String, paramCheck: IssueBlockParams => Boolean)
@@ -827,6 +862,7 @@ class RegionIO(val params: SchdBlockParams)(implicit p: Parameters) extends XSBu
   val lqDeqPtr = Option.when(params.isVecSchd)(Input(new LqPtr))
   val sqDeqPtr = Option.when(params.isVecSchd)(Input(new SqPtr))
   val allIssueParams = params.issueBlockParams.filter(_.StdCnt == 0)
+  val IQNum = allIssueParams.size
   val IssueQueueDeqSum = allIssueParams.map(_.numDeq).sum
   val maxIQSize = allIssueParams.map(_.numEntries).max
   val IQValidNumVec = Output(Vec(IssueQueueDeqSum, UInt((maxIQSize).U.getWidth.W)))
@@ -886,5 +922,7 @@ class RegionIO(val params: SchdBlockParams)(implicit p: Parameters) extends XSBu
 
   // TopDown
   val uopTopDown = new UopTopDown
+  val debugIQValidNumVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(UInt(maxIQSize.U.getWidth.W))))
+  val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(Bool())))
 }
 

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -750,7 +750,7 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
   }
 
 
-  val issueQueueValidNumVec: Vec[UInt] = io.debugIQValidNumVec.get
+  val issueQueueValidNumVec: Vec[UInt] = io.debugIQValidNumVec.getOrElse(VecInit(Seq.fill(io.IQNum)(0.U)))
   issueQueues.filter(_.param.StdCnt == 0).zip(issueQueueValidNumVec).foreach{ case (issueQueue, validNum) =>
     validNum := PopCount(issueQueue.io.validVec)
   }
@@ -758,7 +758,7 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
     issueQueueValidNumVec(sta) := Mux(staValidNum(i) > stdValidNum(i), staValidNum(i), stdValidNum(i))
   }
 
-  val issueQueueEnqHasIssuedVec : Vec[Bool] = io.debugIQEnqHasIssuedVec.get
+  val issueQueueEnqHasIssuedVec : Vec[Bool] = io.debugIQEnqHasIssuedVec.getOrElse(VecInit(Seq.fill(io.IQNum)(false.B)))
   issueQueues.filter(_.param.StdCnt == 0).zip(issueQueueEnqHasIssuedVec).foreach{ case (issueQueue, enqIssued) =>
     enqIssued := andVec(issueQueue.io.issuedVec, issueQueue.io.validVec).take(issueQueue.param.numEnq).reduce(_ & _)
   }

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -213,10 +213,10 @@ class DecodeStage(implicit p: Parameters) extends XSModule
    * to be sent to complex decoder, with complex decoder ready for new input.
    */
   io.in.zipWithIndex.foreach { case (in, i) =>
-    in.ready := !io.redirect && (
+    in.ready := !io.redirect && ((
       simplePrefixVec(i) && (i.U +& complexNum) < readyCounter ||
       firstComplexOH(i) && (i.U +& complexNum) <= readyCounter && decoderComp.io.in.ready
-    ) && !io.fromRob.isResumeVType
+    ) || !io.in(0).valid) && !io.fromRob.isResumeVType
   }
 
   /** final instruction decoding result */

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -343,7 +343,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule
     bubbleStore.io.bubbleValid := frontendBubbleValid
     bubbleStore.io.bubbleReason := Mux(frontendReason(i) === NoStall.id.U, FrontendOtherCoreStall.id.U, frontendReason(i))
     bubbleStore.io.redirect := io.redirect.valid
-    bubbleStore.io.reasonFire := outAllFire && !decodeStall
+    bubbleStore.io.reasonFire := outHasValidAllFire && !decodeStall
 
     frontendBubbleValidVec(i) := bubbleStore.io.outReasonValid
     frontendBubbleReasonVec(i) := bubbleStore.io.outReason

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -348,9 +348,10 @@ class DecodeStage(implicit p: Parameters) extends XSModule
     frontendBubbleValidVec(i) := bubbleStore.io.outReasonValid
     frontendBubbleReasonVec(i) := bubbleStore.io.outReason
   }
-
-  dontTouch(frontendBubbleValidVec)
-  dontTouch(frontendBubbleReasonVec)
+  if (backendParams.debugEn){
+    dontTouch(frontendBubbleValidVec)
+    dontTouch(frontendBubbleReasonVec)
+  }
   // current pipe
   // current stall
 
@@ -361,6 +362,8 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   ))
 
   // current bubble
+  /** Attention: Special care is needed if this stage may generate its own bubble in later cases
+   */
   val decodeBubble = false.B
   val decodeBubbleReason = 0.U
 

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -309,8 +309,8 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   // bad pseculation  (rabwalk)
   val debugRedirect = RegEnable(io.redirect.bits, io.redirect.valid)
   val recStall      = io.fromRob.isResumeVType
-  val ctrlRecStall  = debugRedirect.debugIsCtrl
-  val mvioRecStall  = debugRedirect.debugIsMemVio
+  val ctrlRecStall  = debugRedirect.debugIsCtrl && recStall
+  val mvioRecStall  = debugRedirect.debugIsMemVio && recStall
   val otherRecStall = recStall && !(ctrlRecStall || mvioRecStall)
 
 

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -318,7 +318,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   val inValidVec = io.in.map(_.valid)
   val inReadyVec = io.in.map(_.ready)
   val outReadyVec = io.out.map(_.ready)
-  val outValidVec = io.debugOutValid.get
+  val outValidVec = io.debugOutValid.getOrElse(VecInit.fill(RenameWidth)(false.B))
   val outFireVec = outReadyVec.zip(outValidVec).map { case (ready, valid) =>
     ready && valid
   }

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -365,13 +365,12 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   val decodeBubbleReason = 0.U
 
   io.stallReason.out.reason.zipWithIndex.foreach{ case (stallReason, idx) =>
-    val inValid = inValidVec(idx)
-    val outValid = outValidVec(idx)
+    val outFire = outFireVec(idx)
     val inReason = io.stallReason.in.reason(idx)
     // TopDown collect pre pipe reason
     val prePipeStall = frontendStall
     val prePipeBubble = frontendBubbleValidVec(idx)
-    // TODO
+    // TopDown collect pre pipe bubble
     val prePipeStallReason = Mux(inReason === NoStall.id.U, FrontendOtherCoreStall.id.U, inReason)
     val prePipeBubbleReason = frontendBubbleReasonVec(idx)
     // other reason like out.ready will be collect by next stage dispatch
@@ -379,7 +378,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule
     //      assert(!reset.asBool && (!inValid) && (inReason === NoStall.id.U || inReason === OtherCoreStall.id.U),
     //        "[TopDown]: Rename has no instruction in ,but reason is null")
     //    }
-    // TopDown count current stage stall
+    // TopDown collect current stage stall
     val redirect = redirectStall
     val redirectReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
       ctrlRedirectStall  -> ControlRedirectStall.id.U,
@@ -387,9 +386,11 @@ class DecodeStage(implicit p: Parameters) extends XSModule
       otherRedirectStall -> OtherRedirectStall.id.U,
     ))
 
+    // as decode not generate bubble now, Topdown donot collect current stage Bubble
+    // if decode generate bubble later, Topdown should add here
 
     val stallReasonPipe = Module(new PipelineStallReason(log2Ceil(TopDownCounters.NumStallReasons.id)))
-    stallReasonPipe.io.rightFire := outFireVec(idx)
+    stallReasonPipe.io.rightFire := outFire
     stallReasonPipe.io.rightHasFire := outHasValidAllFire
     stallReasonPipe.io.prePipeStall := prePipeStall
     stallReasonPipe.io.prePipeStallReason := prePipeStallReason
@@ -405,7 +406,6 @@ class DecodeStage(implicit p: Parameters) extends XSModule
     stallReason := stallReasonPipe.io.outReason
   }
 
-  io.stallReason.in.backReason := 0.U.asTypeOf(io.stallReason.in.backReason)
 
   io.toCSR.trapInstInfo.valid := RegNext(hasIllegalInst && !io.redirect.valid)
   io.toCSR.trapInstInfo.bits.fromDecodedInst(RegNext(illegalInst))

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -22,10 +22,12 @@ import chisel3.util._
 import utility._
 import utils._
 import xiangshan._
+import xiangshan.TopDownCounters._
 import xiangshan.backend.rename.RatReadPort
 import xiangshan.backend.Bundles._
 import xiangshan.backend.fu.vector.Bundles.{VType, Vl}
 import xiangshan.backend.fu.FuType
+import xiangshan.backend.PipelineStallReason
 import xiangshan.backend.fu.wrapper.CSRToDecode
 import yunsuan.VpermType
 import xiangshan.ExceptionNO.{illegalInstr, virtualInstr}
@@ -40,7 +42,7 @@ class DecodeStageIO(implicit p: Parameters) extends XSBundle {
   private val numVecRegSrc = backendParams.numVecRegSrc
   private val numVecRatPorts = numVecRegSrc
 
-  val redirect = Input(Bool())
+  val redirect = Flipped(ValidIO(new Redirect))
   val canAccept = Output(Bool())
   // from Ibuffer
   val in = Vec(DecodeWidth, Flipped(DecoupledIO(new DecodeInUop)))
@@ -163,15 +165,15 @@ class DecodeStage(implicit p: Parameters) extends XSModule
     inst.valid := in.valid
     inst.bits := in.bits.instr
   }
-  // when io.redirect is True, never update vtype
-  vtypeGen.io.canUpdateVType := decoderComp.io.in.fire && decoderComp.io.in.bits.simpleDecodedInst.isVset && !io.redirect
+  // when io.redirect.valid is True, never update vtype
+  vtypeGen.io.canUpdateVType := decoderComp.io.in.fire && decoderComp.io.in.bits.simpleDecodedInst.isVset && !io.redirect.valid
   vtypeGen.io.walkToArchVType := io.fromRob.walkToArchVType
   vtypeGen.io.commitVType := io.fromRob.commitVType
   vtypeGen.io.walkVType := io.fromRob.walkVType
   vtypeGen.io.vsetvlVType := io.vsetvlVType
 
   //Comp 1
-  decoderComp.io.redirect := io.redirect
+  decoderComp.io.redirect := io.redirect.valid
   decoderComp.io.csrCtrl := io.csrCtrl
   decoderComp.io.vtypeBypass := vtypeGen.io.vtype
   // The input inst of decoderComp is latched last cycle.
@@ -199,7 +201,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   val hasVectorInst = VecInit(decoders.map(x => FuType.FuTypeOrR(x.io.deq.decodedInst.fuType, FuType.vecArithOrMem ++ FuType.vecVSET))).asUInt.orR
 
   /** condition of acceptation: no redirection, ready from rename/complex decoder, no resumeVType */
-  canAccept := !io.redirect && (io.out.head.ready || decoderComp.io.in.ready) && !io.fromRob.isResumeVType
+  canAccept := !io.redirect.valid && (io.out.head.ready || decoderComp.io.in.ready) && !io.fromRob.isResumeVType
 
   io.canAccept := canAccept
 
@@ -213,7 +215,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule
    * to be sent to complex decoder, with complex decoder ready for new input.
    */
   io.in.zipWithIndex.foreach { case (in, i) =>
-    in.ready := !io.redirect && ((
+    in.ready := !io.redirect.valid && ((
       simplePrefixVec(i) && (i.U +& complexNum) < readyCounter ||
       firstComplexOH(i) && (i.U +& complexNum) <= readyCounter && decoderComp.io.in.ready
     ) || !io.in(0).valid) && !io.fromRob.isResumeVType
@@ -296,18 +298,75 @@ class DecodeStage(implicit p: Parameters) extends XSModule
 
   debug_globalCounter := debug_globalCounter + PopCount(io.out.map(_.fire))
 
-  io.stallReason.in.backReason := io.stallReason.out.backReason
-  io.stallReason.out.reason.zip(io.stallReason.in.reason).zip(io.in.map(_.valid)).foreach { case ((out, in), valid) =>
-    out := Mux(io.stallReason.out.backReason.valid,
-               io.stallReason.out.backReason.bits,
-               in)
+  // bad speculation (redirect)
+  val redirectStall      = io.redirect.valid
+  val ctrlRedirectStall  = io.redirect.bits.debugIsCtrl
+  val mvioRedirectStall  = io.redirect.bits.debugIsMemVio
+  val otherRedirectStall = redirectStall && !(ctrlRedirectStall || mvioRedirectStall)
+
+  // bad pseculation  (rabwalk)
+  val debugRedirect = RegEnable(io.redirect.bits, io.redirect.valid)
+  val recStall      = io.fromRob.isResumeVType
+  val ctrlRecStall  = debugRedirect.debugIsCtrl
+  val mvioRecStall  = debugRedirect.debugIsMemVio
+  val otherRecStall = recStall && !(ctrlRecStall || mvioRecStall)
+
+
+  // Topdown
+  val inValidVec = io.in.map(_.valid)
+  val outValidVec = io.out.map(_.valid)
+  val outFireVec = io.out.map(_.fire)
+
+  io.stallReason.out.reason.zipWithIndex.foreach{ case (stallReason, idx) =>
+    val inValid = inValidVec(idx)
+    val outValid = outValidVec(idx)
+    val inReason = io.stallReason.in.reason(idx)
+    // TopDown collect pre pipe reason
+    val prePipeStall = !inValidVec.reduce(_||_)
+    val prePipeBubble = !inValid
+    // TODO
+    val prePipeStallReason = Mux(inReason === NoStall.id.U, FrontendOtherCoreStall.id.U, inReason)
+    // other reason like out.ready will be collect by next stage dispatch
+    //    if (backendParams.debugEn) {
+    //      assert(!reset.asBool && (!inValid) && (inReason === NoStall.id.U || inReason === OtherCoreStall.id.U),
+    //        "[TopDown]: Rename has no instruction in ,but reason is null")
+    //    }
+    // TopDown count current stage stall
+    val decodeStall = inValid && !outValid
+    val decodeStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+      ctrlRecStall  -> ControlRecoveryStall.id.U,
+      mvioRecStall  -> MemVioRecoveryStall.id.U,
+      otherRecStall -> OtherRecoveryStall.id.U,
+    ))
+    val redirect = redirectStall
+    val redirectReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+      ctrlRedirectStall  -> ControlRedirectStall.id.U,
+      mvioRedirectStall  -> MemVioRedirectStall.id.U,
+      otherRedirectStall -> OtherRedirectStall.id.U,
+    ))
+
+    val renameFire = outFireVec.reduce(_||_)
+
+    val stallReasonPipe = Module(new PipelineStallReason(log2Ceil(TopDownCounters.NumStallReasons.id)))
+    stallReasonPipe.io.prePipeStall := prePipeStall
+    stallReasonPipe.io.prePipeStallReason := prePipeStallReason
+    stallReasonPipe.io.prePipeBubble := prePipeBubble
+    stallReasonPipe.io.redirect := redirect
+    stallReasonPipe.io.redirectReason := redirectReason
+    stallReasonPipe.io.currentPipeStall := decodeStall
+    stallReasonPipe.io.currentPipeStallReason := decodeStallReason
+    stallReasonPipe.io.pastPipeFire := renameFire
+
+    stallReason := stallReasonPipe.io.outReason
   }
 
-  io.toCSR.trapInstInfo.valid := RegNext(hasIllegalInst && !io.redirect)
+  io.stallReason.in.backReason := 0.U.asTypeOf(io.stallReason.in.backReason)
+
+  io.toCSR.trapInstInfo.valid := RegNext(hasIllegalInst && !io.redirect.valid)
   io.toCSR.trapInstInfo.bits.fromDecodedInst(RegNext(illegalInst))
 
   val recoveryFlag = RegInit(false.B)
-  when(io.redirect) {
+  when(io.redirect.valid) {
     recoveryFlag := true.B
   }.elsewhen(io.in.map(_.fire).reduce(_ || _)) {
     recoveryFlag := false.B

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -96,6 +96,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val exuNum = allExuParams.size
   val maxIQSize = allIssueParams.map(_.numEntries).max
   val IQEnqSum = allIssueParams.map(_.numEnq).sum
+  val issueQueueNum = allIssueParams.size
 
   val io = IO(new Bundle {
     // from rename
@@ -155,6 +156,8 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     val robHeadNotReady = Input(Bool())
     val debugBlockBackward = Option.when(backendParams.debugEn)(Input(Bool()))
     val debugWaitForward   = Option.when(backendParams.debugEn)(Input(Bool()))
+    val debugIQValidNumVec = Option.when(backendParams.debugEn)(Vec(issueQueueNum, Input(UInt(maxIQSize.U.getWidth.W))))
+    val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(issueQueueNum, Input(Bool())))
     val debugTopDown = new Bundle {
       val fromRob = Flipped(new RobDispatchTopDownIO)
       val fromCore = new CoreDispatchTopDownIO
@@ -186,7 +189,6 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
 
   val renameWidth = io.fromRename.size
   val issueQueueCount = io.IQValidNumVec
-  val issueQueueNum = allIssueParams.size
   // int fp vec v0
   val numRegType = 4
   val idxRegTypeInt = allFuConfigs.map(x => {
@@ -963,26 +965,36 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val fuMapIQReadyCntVec = fuTypeMapIQIdx.map { iqVec =>
     iqVec.map( iqidx => iqReadyVec(iqidx)).reduce(_ +& _)
   }
-  val fuMapTest = fuTypeMapIQIdx.zipWithIndex.foreach { case (iqVec,idx) =>
-    iqVec.map(iqidx => allIssueParams(iqidx).numEnq).sum
-    println(s"Dispatch: futype: ${idx} numenq: ${iqVec.map(iqidx => allIssueParams(iqidx).numEnq).sum}")
-  }
   val fuMapIQBandWidthVec = Wire(Vec(FuType.num, UInt(log2Ceil(IQEnqSum).W)))
-  fuMapIQBandWidthVec:= fuTypeMapIQIdx.map { iqVec =>
+  fuMapIQBandWidthVec := fuTypeMapIQIdx.map { iqVec =>
     iqVec.map( iqidx => allIssueParams(iqidx).numEnq).sum.asUInt
   }
+  val issueQueueSizeVec = Wire(Vec(issueQueueNum, UInt(maxIQSize.U.getWidth.W)))
+  issueQueueSizeVec := allIssueParams.map{ param =>
+    // Now only when iq has two clear entry, instruction can enq
+    (param.numEntries - 2).asUInt
+  }
+
   val fuTypes = fromRename.map(_.bits.fuType)
   val firedVec = fromRename.map(_.fire)
   val inValidVec = fromRename.map(_.valid)
   val inReadyVec = fromRename.map(_.ready)
+  val issueQueueNumVec = io.debugIQValidNumVec.getOrElse(VecInit(Seq.fill(RenameWidth)(0.U)))
+  val issueQueueEnqHasIssuedVec = io.debugIQEnqHasIssuedVec.getOrElse(VecInit(Seq.fill(RenameWidth)(0.U)))
   val fromRenameMapIQReadyCntVec = Wire(Vec(RenameWidth, UInt(log2Ceil(io.toIssueQueues.length).W)))
   val fromRenameMapIQBandWidthVec = Wire(Vec(RenameWidth, UInt(log2Ceil(IQEnqSum).W)))
+  val fromRenameMapIQValidNumVec = Wire(Vec(RenameWidth, UInt(maxIQSize.U.getWidth.W)))
+  val fromRenameMapIQSizeVec = Wire(Vec(RenameWidth, UInt(maxIQSize.U.getWidth.W)))
+  val fromRenameMapIQEnqHasIssuedVec = Wire(Vec(RenameWidth, Bool()))
   fromRenameMapIQReadyCntVec := fuTypes.map { fuType =>
     Mux1H(fuType, fuMapIQReadyCntVec )
   }
   fromRenameMapIQBandWidthVec := fuTypes.map { fuType =>
     Mux1H(fuType, fuMapIQBandWidthVec)
   }
+  fromRenameMapIQValidNumVec := (0 until RenameWidth).map{ idx => Mux1H(uopSelIQ(idx), issueQueueNumVec)}
+  fromRenameMapIQSizeVec := (0 until RenameWidth).map{ idx => Mux1H(uopSelIQ(idx), issueQueueSizeVec)}
+  fromRenameMapIQEnqHasIssuedVec := VecInit((0 until RenameWidth).map{idx => Mux1H(uopSelIQ(idx), issueQueueEnqHasIssuedVec)})
 
   val fuTypeCountVec = (0 until RenameWidth).map { i =>
     (0 until FuType.num).map { fid =>
@@ -998,12 +1010,21 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   }
   val fromRenameFutypeNotOverIQ = Wire(Vec(RenameWidth, Bool()))
   fromRenameFutypeNotOverIQ := (0 until RenameWidth).map{ idx =>
-    inValidVec(idx) && (fromRenameSameFuNumVec(idx) < fromRenameMapIQReadyCntVec(idx))
+    inValidVec(idx) && (fromRenameSameFuNumVec(idx) <= fromRenameMapIQReadyCntVec(idx))
   }
 
   val fromRenameFutypeOvecIQEnqBandwidth = Wire(Vec(RenameWidth, Bool()))
   fromRenameFutypeOvecIQEnqBandwidth := (0 until RenameWidth).map{ idx =>
     inValidVec(idx) && (fromRenameSameFuNumVec(idx) > fromRenameMapIQBandWidthVec(idx))
+  }
+
+  val fromRenameMapIQNotFull = Wire(Vec(RenameWidth, Bool()))
+  fromRenameMapIQNotFull := (0 until RenameWidth).map{ idx =>
+    inValidVec(idx) && (fromRenameMapIQValidNumVec(idx) <= fromRenameMapIQSizeVec(idx))
+  }
+  val fromRenameMapIQEnqHasIssuedNotFull = Wire(Vec(RenameWidth, Bool()))
+  fromRenameMapIQEnqHasIssuedNotFull := (0 until RenameWidth).map{ idx =>
+    fromRenameMapIQNotFull(idx) && fromRenameMapIQEnqHasIssuedVec(idx)
   }
 
   dontTouch(fromRenameMapIQReadyCntVec)
@@ -1012,6 +1033,12 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   dontTouch(fromRenameMapIQBandWidthVec)
   dontTouch(fromRenameFutypeOvecIQEnqBandwidth)
   dontTouch(fuMapIQBandWidthVec)
+  dontTouch(issueQueueSizeVec)
+  dontTouch(fromRenameMapIQValidNumVec)
+  dontTouch(fromRenameMapIQSizeVec)
+  dontTouch(fromRenameMapIQNotFull)
+  dontTouch(fromRenameMapIQEnqHasIssuedVec)
+  dontTouch(fromRenameMapIQEnqHasIssuedNotFull)
 
 
   // prepipe stall
@@ -1054,15 +1081,17 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     FuType.isStoreVstore(issueQueueStallFutype) -> BalanceDispatchPolicyStallStore.id.U ,
   ))
   val issueQueueStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
-    fromRenameFutypeNotOverIQ(0)                -> balanceDispatchStallReason ,
-    FuType.isAlu(issueQueueStallFutype)         -> IntIQFullStallAlu.id.U     ,
-    FuType.isBJU(issueQueueStallFutype)         -> IntIQFullStallBrh.id.U     ,
-    FuType.isInt(issueQueueStallFutype)         -> IntIQFullStallOther.id.U   ,
-    FuType.isFArith(issueQueueStallFutype)      -> FpIQFullStall.id.U         ,
-    FuType.isVArith(issueQueueStallFutype)      -> VecIQFullStall.id.U        ,
-    FuType.isLoadVload(issueQueueStallFutype)   -> LoadIQFullStall.id.U       ,
-    FuType.isStoreVstore(issueQueueStallFutype) -> StoreIQFullStall.id.U      ,
-    issueQueueStall                             -> OtherIQFullStall.id.U      ,
+    fromRenameFutypeNotOverIQ(0)                -> balanceDispatchStallReason  ,
+    fromRenameMapIQEnqHasIssuedNotFull(0)       -> IQEnqPolicyStallIssued.id.U ,
+    fromRenameMapIQNotFull(0)                   -> IQEnqPolicyStall.id.U       ,
+    FuType.isAlu(issueQueueStallFutype)         -> IntIQFullStallAlu.id.U      ,
+    FuType.isBJU(issueQueueStallFutype)         -> IntIQFullStallBrh.id.U      ,
+    FuType.isInt(issueQueueStallFutype)         -> IntIQFullStallOther.id.U    ,
+    FuType.isFArith(issueQueueStallFutype)      -> FpIQFullStall.id.U          ,
+    FuType.isVArith(issueQueueStallFutype)      -> VecIQFullStall.id.U         ,
+    FuType.isLoadVload(issueQueueStallFutype)   -> LoadIQFullStall.id.U        ,
+    FuType.isStoreVstore(issueQueueStallFutype) -> StoreIQFullStall.id.U       ,
+    issueQueueStall                             -> OtherIQFullStall.id.U       ,
   ))
 
   val dispatchlsqStall = dispatchlsqBubbleVec.reduce(_ && _)
@@ -1093,7 +1122,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val dispatchBubbleReasonVecReg = Reg(chiselTypeOf(io.stallReason.reason))
 
   //TODO explain
-  val dispatchBandWidthPolicyBubble = fromRenameFutypeOvecIQEnqBandwidth.reduce(_ || _)
+  val dispatchBandWidthPolicyBubble = PriorityMux(issueQueueStallVec, fromRenameFutypeOvecIQEnqBandwidth)
   val dispatchBandWidthPolicyBubbleFutype = PriorityMux(fromRenameFutypeOvecIQEnqBandwidth, fuTypes)
   val dispatchBandWidthPolicyBubbleReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
     FuType.isLoadVload(dispatchBandWidthPolicyBubbleFutype)   -> LoadDispatchPolicyStall.id.U  ,
@@ -1101,18 +1130,23 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     dispatchBandWidthPolicyBubble                             -> OtherDispatchPolicyStall.id.U ,
   ))
 
+  val issueQueueEnqPolicyStallIssued = PriorityMux(issueQueueStallVec, fromRenameMapIQEnqHasIssuedNotFull)
+  val issueQueueEnqPolicyStall = PriorityMux(issueQueueStallVec, fromRenameMapIQNotFull)
+
   val issueQueueBubble = issueQueueStallVec.reduce(_ || _)
 
   val issueQueueBubbleReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
-    balanceDispatchStall                        -> balanceDispatchStallReason ,
+    balanceDispatchStall                        -> balanceDispatchStallReason  ,
     dispatchBandWidthPolicyBubble               -> dispatchBandWidthPolicyBubbleReason ,
-    FuType.isAlu(issueQueueStallFutype)         -> IntIQFullStallAlu.id.U     ,
-    FuType.isBJU(issueQueueStallFutype)         -> IntIQFullStallBrh.id.U     ,
-    FuType.isInt(issueQueueStallFutype)         -> IntIQFullStallOther.id.U   ,
-    FuType.isFArith(issueQueueStallFutype)      -> FpIQFullStall.id.U         ,
-    FuType.isVArith(issueQueueStallFutype)      -> VecIQFullStall.id.U        ,
-    FuType.isLoadVload(issueQueueStallFutype)   -> LoadIQFullStall.id.U       ,
-    FuType.isStoreVstore(issueQueueStallFutype) -> StoreIQFullStall.id.U      ,
+    issueQueueEnqPolicyStallIssued              -> IQEnqPolicyStallIssued.id.U ,
+    issueQueueEnqPolicyStall                    -> IQEnqPolicyStall.id.U       ,
+    FuType.isAlu(issueQueueStallFutype)         -> IntIQFullStallAlu.id.U      ,
+    FuType.isBJU(issueQueueStallFutype)         -> IntIQFullStallBrh.id.U      ,
+    FuType.isInt(issueQueueStallFutype)         -> IntIQFullStallOther.id.U    ,
+    FuType.isFArith(issueQueueStallFutype)      -> FpIQFullStall.id.U          ,
+    FuType.isVArith(issueQueueStallFutype)      -> VecIQFullStall.id.U         ,
+    FuType.isLoadVload(issueQueueStallFutype)   -> LoadIQFullStall.id.U        ,
+    FuType.isStoreVstore(issueQueueStallFutype) -> StoreIQFullStall.id.U       ,
   ))
 
 

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -180,7 +180,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     fromRenameUpdate(i).bits.ftqOffset := fromRename(i).bits.ftqLastOffset
     fromRenameUpdate(i).bits.ftqPtr := fromRename(i).bits.ftqPtr + fromRename(i).bits.crossFtq
     fromRenameUpdate(i).bits.isRVC := fromRename(i).bits.lastIsRVC
-    fromRenameUpdate(i).bits.rasAction := 
+    fromRenameUpdate(i).bits.rasAction :=
       Itype.isPush(fromRename(i).bits.traceBlockInPipe.itype) ## Itype.isPop(fromRename(i).bits.traceBlockInPipe.itype)
   }
 
@@ -931,15 +931,15 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     else (io.fromRename(i-1).fire && !io.fromRename(i).valid && io.fromRename(i-1).bits.debug.get.fusionNum =/= 0.U)
   }
 
-  val dispatchPolicyStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
-    val result = uopSelIQMatrix.map(_(iqidx)).map(x => x > issue.numEnq.U)
-    result
-  }}.transpose
-  val dispatchPolicyStallVec = VecInit(dispatchPolicyStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
-    // TODO: explain
-    val block = blockList.reduce(_ || _)
-    uop.valid && block
-  })
+//  val dispatchPolicyStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
+//    val result = uopSelIQMatrix.map(_(iqidx)).map(x => x > issue.numEnq.U)
+//    result
+//  }}.transpose
+//  val dispatchPolicyStallVec = VecInit(dispatchPolicyStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
+//    // TODO: explain
+//    val block = blockList.reduce(_ || _)
+//    uop.valid && block
+//  })
 
   temp = 0
   val iqReadyVec = allIssueParams.map{ case issue =>
@@ -950,7 +950,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   }
   val fuTypeMapIQIdx = fuMapIQIdx.map(_._2)
   val issueQueueStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
-    val result = uopSelIQMatrix.map(_(iqidx)).map(x => !iqReadyVec(iqidx).orR && x.orR && x <= issue.numEnq.U)
+    val result = uopSelIQMatrix.map(_(iqidx)).map(x => (!iqReadyVec(iqidx).orR && x.orR && x <= issue.numEnq.U) || x > issue.numEnq.U)
     result
   }}.transpose
   val issueQueueStallVec = VecInit(issueQueueStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
@@ -960,34 +960,59 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
 
   val dispatchlsqBubbleVec = VecInit(allowDispatch.map(!_))
 
-  val fuReadyIQCntVec = fuTypeMapIQIdx.map { iqVec =>
-    iqVec.map( iqidx => iqReadyVec(iqidx)).reduce(_ + _)
+  val fuMapIQReadyCntVec = fuTypeMapIQIdx.map { iqVec =>
+    iqVec.map( iqidx => iqReadyVec(iqidx)).reduce(_ +& _)
+  }
+  val fuMapTest = fuTypeMapIQIdx.zipWithIndex.foreach { case (iqVec,idx) =>
+    iqVec.map(iqidx => allIssueParams(iqidx).numEnq).sum
+    println(s"Dispatch: futype: ${idx} numenq: ${iqVec.map(iqidx => allIssueParams(iqidx).numEnq).sum}")
+  }
+  val fuMapIQBandWidthVec = Wire(Vec(FuType.num, UInt(log2Ceil(IQEnqSum).W)))
+  fuMapIQBandWidthVec:= fuTypeMapIQIdx.map { iqVec =>
+    iqVec.map( iqidx => allIssueParams(iqidx).numEnq).sum.asUInt
   }
   val fuTypes = fromRename.map(_.bits.fuType)
   val firedVec = fromRename.map(_.fire)
   val inValidVec = fromRename.map(_.valid)
   val inReadyVec = fromRename.map(_.ready)
-  val fromRenameReadyIQCntVec = Wire(Vec(RenameWidth, UInt(log2Ceil(io.toIssueQueues.length).W)))
-  fromRenameReadyIQCntVec := fuTypes.map { fuType =>
-      Mux1H(fuType, fuReadyIQCntVec)
+  val fromRenameMapIQReadyCntVec = Wire(Vec(RenameWidth, UInt(log2Ceil(io.toIssueQueues.length).W)))
+  val fromRenameMapIQBandWidthVec = Wire(Vec(RenameWidth, UInt(log2Ceil(IQEnqSum).W)))
+  fromRenameMapIQReadyCntVec := fuTypes.map { fuType =>
+    Mux1H(fuType, fuMapIQReadyCntVec )
+  }
+  fromRenameMapIQBandWidthVec := fuTypes.map { fuType =>
+    Mux1H(fuType, fuMapIQBandWidthVec)
   }
 
-  val fuTypeCountVec = (0 until FuType.num).map{ fid =>
-    PopCount(fromRename.map(in => in.bits.fuType(fid) && in.valid))
+  val fuTypeCountVec = (0 until RenameWidth).map { i =>
+    (0 until FuType.num).map { fid =>
+      PopCount((0 to i).map { idx =>
+        fromRename(idx).valid && fromRename(idx).bits.fuType(fid)
+      })
+    }
   }
 
   val fromRenameSameFuNumVec = Wire(Vec(RenameWidth, UInt(log2Ceil(RenameWidth).W)))
   for( i <- 0 until RenameWidth) {
-    fromRenameSameFuNumVec(i) := Mux1H(fuTypes(i), fuTypeCountVec)
+    fromRenameSameFuNumVec(i) := Mux1H(fuTypes(i), fuTypeCountVec(i))
   }
   val fromRenameFutypeNotOverIQ = Wire(Vec(RenameWidth, Bool()))
   fromRenameFutypeNotOverIQ := (0 until RenameWidth).map{ idx =>
-    inValidVec(idx) && (fromRenameSameFuNumVec(idx) < fromRenameReadyIQCntVec(idx))
+    inValidVec(idx) && (fromRenameSameFuNumVec(idx) < fromRenameMapIQReadyCntVec(idx))
   }
 
-  dontTouch(fromRenameReadyIQCntVec)
+  val fromRenameFutypeOvecIQEnqBandwidth = Wire(Vec(RenameWidth, Bool()))
+  fromRenameFutypeOvecIQEnqBandwidth := (0 until RenameWidth).map{ idx =>
+    inValidVec(idx) && (fromRenameSameFuNumVec(idx) > fromRenameMapIQBandWidthVec(idx))
+  }
+
+  dontTouch(fromRenameMapIQReadyCntVec)
   dontTouch(fromRenameSameFuNumVec)
   dontTouch(fromRenameFutypeNotOverIQ)
+  dontTouch(fromRenameMapIQBandWidthVec)
+  dontTouch(fromRenameFutypeOvecIQEnqBandwidth)
+  dontTouch(fuMapIQBandWidthVec)
+
 
   // prepipe stall
   val renameStall  = !inValidVec.reduce(_ || _)
@@ -1006,28 +1031,38 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val roblsqStall = robStall ||  lsqStall
   val lqStall  = lsqEnqCtrl.io.lqStall.getOrElse(false.B)
   val sqStall  = lsqEnqCtrl.io.sqStall.getOrElse(false.B)
-  val roblsqStallReason = MuxCase(NoStall.id.U, Seq(
+  val roblsqStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
     (FuType.isAMO(robHeadFutype) && io.robHeadNotReady)                      -> AtomicStall.id.U          ,
     ((FuType.isStoreVstore(robHeadFutype) && io.robHeadNotReady) || sqStall) -> StoreStall.id.U           ,
     ((FuType.isLoadVload(robHeadFutype) && io.robHeadNotReady) || lqStall)   -> ldReason                  ,
     (FuType.isDivSqrt(robHeadFutype) && io.robHeadNotReady)                  -> DivStall.id.U             ,
     (FuType.isInt(robHeadFutype) && io.robHeadNotReady)                      -> IntNotReadyStall.id.U     ,
     (FuType.isFArith(robHeadFutype) && io.robHeadNotReady)                   -> FPNotReadyStall.id.U      ,
-    (robStall)                                                               -> RobStall.id.U             ,
+    (robStall || lsqStall)                                                   -> RobStall.id.U             ,
   ))
 
   val issueQueueStall = issueQueueStallVec(0)
   val issueQueueStallFutype = PriorityMux(issueQueueStallVec, fuTypes)
-  val issueQueueStallReason = MuxCase(NoStall.id.U, Seq(
-    fromRenameFutypeNotOverIQ(0)                -> BalanceDispatchPolicyStall.id.U ,
-    FuType.isAlu(issueQueueStallFutype)         -> IntIQFullStallAlu.id.U          ,
-    FuType.isBJU(issueQueueStallFutype)         -> IntIQFullStallBrh.id.U          ,
-    FuType.isInt(issueQueueStallFutype)         -> IntIQFullStallOther.id.U        ,
-    FuType.isFArith(issueQueueStallFutype)      -> FpIQFullStall.id.U              ,
-    FuType.isVArith(issueQueueStallFutype)      -> VecIQFullStall.id.U             ,
-    FuType.isLoadVload(issueQueueStallFutype)   -> LoadIQFullStall.id.U            ,
-    FuType.isStoreVstore(issueQueueStallFutype) -> StoreIQFullStall.id.U           ,
-    issueQueueStall                             -> OtherIQFullStall.id.U           ,
+  val balanceDispatchStall = PriorityMux(issueQueueStallVec, fromRenameFutypeNotOverIQ)
+  val balanceDispatchStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+    FuType.isAlu(issueQueueStallFutype)         -> BalanceDispatchPolicyStallAlu.id.U   ,
+    FuType.isBJU(issueQueueStallFutype)         -> BalanceDispatchPolicyStallBrh.id.U   ,
+    FuType.isInt(issueQueueStallFutype)         -> BalanceDispatchPolicyStallInt.id.U   ,
+    FuType.isFArith(issueQueueStallFutype)      -> BalanceDispatchPolicyStallFp.id.U    ,
+    FuType.isVArith(issueQueueStallFutype)      -> BalanceDispatchPolicyStallVec.id.U   ,
+    FuType.isLoadVload(issueQueueStallFutype)   -> BalanceDispatchPolicyStallLoad.id.U  ,
+    FuType.isStoreVstore(issueQueueStallFutype) -> BalanceDispatchPolicyStallStore.id.U ,
+  ))
+  val issueQueueStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+    fromRenameFutypeNotOverIQ(0)                -> balanceDispatchStallReason ,
+    FuType.isAlu(issueQueueStallFutype)         -> IntIQFullStallAlu.id.U     ,
+    FuType.isBJU(issueQueueStallFutype)         -> IntIQFullStallBrh.id.U     ,
+    FuType.isInt(issueQueueStallFutype)         -> IntIQFullStallOther.id.U   ,
+    FuType.isFArith(issueQueueStallFutype)      -> FpIQFullStall.id.U         ,
+    FuType.isVArith(issueQueueStallFutype)      -> VecIQFullStall.id.U        ,
+    FuType.isLoadVload(issueQueueStallFutype)   -> LoadIQFullStall.id.U       ,
+    FuType.isStoreVstore(issueQueueStallFutype) -> StoreIQFullStall.id.U      ,
+    issueQueueStall                             -> OtherIQFullStall.id.U      ,
   ))
 
   val dispatchlsqStall = dispatchlsqBubbleVec.reduce(_ && _)
@@ -1038,7 +1073,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   ))
 
   // block backward will not stall whole pipe in current cycle
-  val specialInstructionStall = hasSpecialInst || blockedByWaitForward.reduce(_ || _) 
+  val specialInstructionStall = hasSpecialInst || blockedByWaitForward.reduce(_ || _)
   val specialInstructionStallReason = SpecialInsts.id.U
 
   dispatchStallReason := MuxCase(BackendOtherCoreStall.id.U, Seq(
@@ -1057,29 +1092,29 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val dispatchBubbleValidReg     = RegInit(VecInit.fill(renameWidth)(false.B))
   val dispatchBubbleReasonVecReg = Reg(chiselTypeOf(io.stallReason.reason))
 
+  //TODO explain
+  val dispatchBandWidthPolicyBubble = fromRenameFutypeOvecIQEnqBandwidth.reduce(_ || _)
+  val dispatchBandWidthPolicyBubbleFutype = PriorityMux(fromRenameFutypeOvecIQEnqBandwidth, fuTypes)
+  val dispatchBandWidthPolicyBubbleReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+    FuType.isLoadVload(dispatchBandWidthPolicyBubbleFutype)   -> LoadDispatchPolicyStall.id.U  ,
+    FuType.isStoreVstore(dispatchBandWidthPolicyBubbleFutype) -> StoreDispatchPolicyStall.id.U ,
+    dispatchBandWidthPolicyBubble                             -> OtherDispatchPolicyStall.id.U ,
+  ))
 
   val issueQueueBubble = issueQueueStallVec.reduce(_ || _)
-  val issueQueueBubbleFutype = PriorityMux(issueQueueStallVec, fuTypes)
-  val balanceDispatchStall = PriorityMux(issueQueueStallVec, fromRenameFutypeNotOverIQ)
 
-  val issueQueueBubbleReason = MuxCase(NoStall.id.U, Seq(
-    balanceDispatchStall                         -> BalanceDispatchPolicyStall.id.U ,
-    FuType.isAlu(issueQueueBubbleFutype)         -> IntIQFullStallAlu.id.U          ,
-    FuType.isBJU(issueQueueBubbleFutype)         -> IntIQFullStallBrh.id.U          ,
-    FuType.isInt(issueQueueBubbleFutype)         -> IntIQFullStallOther.id.U        ,
-    FuType.isFArith(issueQueueBubbleFutype)      -> FpIQFullStall.id.U              ,
-    FuType.isVArith(issueQueueBubbleFutype)      -> VecIQFullStall.id.U             ,
-    FuType.isLoadVload(issueQueueBubbleFutype)   -> LoadIQFullStall.id.U            ,
-    FuType.isStoreVstore(issueQueueBubbleFutype) -> StoreIQFullStall.id.U           ,
+  val issueQueueBubbleReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+    balanceDispatchStall                        -> balanceDispatchStallReason ,
+    dispatchBandWidthPolicyBubble               -> dispatchBandWidthPolicyBubbleReason ,
+    FuType.isAlu(issueQueueStallFutype)         -> IntIQFullStallAlu.id.U     ,
+    FuType.isBJU(issueQueueStallFutype)         -> IntIQFullStallBrh.id.U     ,
+    FuType.isInt(issueQueueStallFutype)         -> IntIQFullStallOther.id.U   ,
+    FuType.isFArith(issueQueueStallFutype)      -> FpIQFullStall.id.U         ,
+    FuType.isVArith(issueQueueStallFutype)      -> VecIQFullStall.id.U        ,
+    FuType.isLoadVload(issueQueueStallFutype)   -> LoadIQFullStall.id.U       ,
+    FuType.isStoreVstore(issueQueueStallFutype) -> StoreIQFullStall.id.U      ,
   ))
-  //TODO explain
-  val dispatchPolicyBubble = dispatchPolicyStallVec.reduce(_ || _)
-  val dispatchPolicyBubbleFutype = PriorityMux(dispatchPolicyStallVec, fuTypes)
-  val dispatchPolicyBubbleReason = MuxCase(NoStall.id.U, Seq(
-    FuType.isLoadVload(dispatchPolicyBubbleFutype)   -> LoadDispatchPolicyStall.id.U  ,
-    FuType.isStoreVstore(dispatchPolicyBubbleFutype) -> StoreDispatchPolicyStall.id.U ,
-    dispatchPolicyBubble                             -> OtherDispatchPolicyStall.id.U ,
-  ))
+
 
   val dispatchlsqBubble = dispatchlsqBubbleVec.reduce(_ || _)
   val dispatchlsqBubbleFutype = PriorityMux(dispatchlsqBubbleVec , fuTypes)
@@ -1097,19 +1132,17 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val allDispatchBubbleMatrix = VecInit(
     specialInstructionBubbleVec,
     issueQueueStallVec,
-    dispatchPolicyStallVec,
     dispatchlsqBubbleVec,
     dispatchBubbleVec
   )
   val allDispatchReasonVec = VecInit(
-    specialInstructionBubbleReason ,
-    issueQueueBubbleReason         ,
-    dispatchPolicyBubbleReason     ,
-    dispatchlsqBubbleReason        ,
-    dispatchOtherBubbleReason      ,
+    specialInstructionBubbleReason          ,
+    issueQueueBubbleReason                  ,
+    dispatchlsqBubbleReason                 ,
+    dispatchOtherBubbleReason               ,
   )
 
-  val dispatchPriorityBubbleidx = Wire(UInt(log2Up(allDispatchBubbleMatrix.length).W))
+  val dispatchPriorityBubbleidx = Wire(UInt(log2Up(RenameWidth).W))
   val dispatchPriorityBubbleReasonidx = Wire(UInt(log2Up(allDispatchReasonVec.length).W))
   dispatchPriorityBubbleidx := PriorityEncoder(dispatchBubbleVec)
   val dispatchPriorityBubbleVec = allDispatchBubbleMatrix.map{ bubbleVec => bubbleVec(dispatchPriorityBubbleidx)}

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -891,8 +891,6 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
 
   private val canAccept = !hasValidInstr || !hasSpecialInstr && io.enqRob.canAccept
 
-  // TODO explain
-  val isWaitForwardorBlockBackwardVec = VecInit(((isWaitForward.asUInt | isBlockBackward.asUInt)<<1)(renameWidth - 1, 0).asBools)
   val isWaitForwardOrBlockBackward = isWaitForward.asUInt.orR || isBlockBackward.asUInt.orR
   val hasSpecialInst = io.debugBlockBackward.getOrElse(false.B) || io.debugWaitForward.getOrElse(false.B)
   val renameFireCnt = PopCount(fromRename.map(_.fire))
@@ -933,15 +931,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     else (io.fromRename(i-1).fire && !io.fromRename(i).valid && io.fromRename(i-1).bits.debug.get.fusionNum =/= 0.U)
   }
 
-//  val dispatchPolicyStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
-//    val result = uopSelIQMatrix.map(_(iqidx)).map(x => x > issue.numEnq.U)
-//    result
-//  }}.transpose
-//  val dispatchPolicyStallVec = VecInit(dispatchPolicyStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
-//    // TODO: explain
-//    val block = blockList.reduce(_ || _)
-//    uop.valid && block
-//  })
+  // Topdown collect start
 
   temp = 0
   val iqReadyVec = allIssueParams.map{ case issue =>
@@ -979,13 +969,17 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val firedVec = fromRename.map(_.fire)
   val inValidVec = fromRename.map(_.valid)
   val inReadyVec = fromRename.map(_.ready)
-  val issueQueueNumVec = io.debugIQValidNumVec.getOrElse(VecInit(Seq.fill(RenameWidth)(0.U)))
-  val issueQueueEnqHasIssuedVec = io.debugIQEnqHasIssuedVec.getOrElse(VecInit(Seq.fill(RenameWidth)(0.U)))
+  val issueQueueNumVec = io.debugIQValidNumVec.getOrElse(VecInit(Seq.fill(issueQueueNum)(0.U)))
+  val issueQueueEnqHasIssuedVec = io.debugIQEnqHasIssuedVec.getOrElse(VecInit(Seq.fill(issueQueueNum)(0.U)))
+
+
   val fromRenameMapIQReadyCntVec = Wire(Vec(RenameWidth, UInt(log2Ceil(io.toIssueQueues.length).W)))
   val fromRenameMapIQBandWidthVec = Wire(Vec(RenameWidth, UInt(log2Ceil(IQEnqSum).W)))
   val fromRenameMapIQValidNumVec = Wire(Vec(RenameWidth, UInt(maxIQSize.U.getWidth.W)))
   val fromRenameMapIQSizeVec = Wire(Vec(RenameWidth, UInt(maxIQSize.U.getWidth.W)))
   val fromRenameMapIQEnqHasIssuedVec = Wire(Vec(RenameWidth, Bool()))
+
+
   fromRenameMapIQReadyCntVec := fuTypes.map { fuType =>
     Mux1H(fuType, fuMapIQReadyCntVec )
   }
@@ -1005,41 +999,44 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   }
 
   val fromRenameSameFuNumVec = Wire(Vec(RenameWidth, UInt(log2Ceil(RenameWidth).W)))
+  val fromRenameFutypeNotOverIQ = Wire(Vec(RenameWidth, Bool()))
+  val fromRenameFutypeOvecIQEnqBandwidth = Wire(Vec(RenameWidth, Bool()))
+  val fromRenameMapIQNotFull = Wire(Vec(RenameWidth, Bool()))
+  val fromRenameMapIQEnqHasIssuedNotFull = Wire(Vec(RenameWidth, Bool()))
+
   for( i <- 0 until RenameWidth) {
     fromRenameSameFuNumVec(i) := Mux1H(fuTypes(i), fuTypeCountVec(i))
   }
-  val fromRenameFutypeNotOverIQ = Wire(Vec(RenameWidth, Bool()))
+  // compare futype num and port ready count num
   fromRenameFutypeNotOverIQ := (0 until RenameWidth).map{ idx =>
     inValidVec(idx) && (fromRenameSameFuNumVec(idx) <= fromRenameMapIQReadyCntVec(idx))
   }
 
-  val fromRenameFutypeOvecIQEnqBandwidth = Wire(Vec(RenameWidth, Bool()))
   fromRenameFutypeOvecIQEnqBandwidth := (0 until RenameWidth).map{ idx =>
     inValidVec(idx) && (fromRenameSameFuNumVec(idx) > fromRenameMapIQBandWidthVec(idx))
   }
 
-  val fromRenameMapIQNotFull = Wire(Vec(RenameWidth, Bool()))
   fromRenameMapIQNotFull := (0 until RenameWidth).map{ idx =>
     inValidVec(idx) && (fromRenameMapIQValidNumVec(idx) <= fromRenameMapIQSizeVec(idx))
   }
-  val fromRenameMapIQEnqHasIssuedNotFull = Wire(Vec(RenameWidth, Bool()))
+
   fromRenameMapIQEnqHasIssuedNotFull := (0 until RenameWidth).map{ idx =>
     fromRenameMapIQNotFull(idx) && fromRenameMapIQEnqHasIssuedVec(idx)
   }
-
-  dontTouch(fromRenameMapIQReadyCntVec)
-  dontTouch(fromRenameSameFuNumVec)
-  dontTouch(fromRenameFutypeNotOverIQ)
-  dontTouch(fromRenameMapIQBandWidthVec)
-  dontTouch(fromRenameFutypeOvecIQEnqBandwidth)
-  dontTouch(fuMapIQBandWidthVec)
-  dontTouch(issueQueueSizeVec)
-  dontTouch(fromRenameMapIQValidNumVec)
-  dontTouch(fromRenameMapIQSizeVec)
-  dontTouch(fromRenameMapIQNotFull)
-  dontTouch(fromRenameMapIQEnqHasIssuedVec)
-  dontTouch(fromRenameMapIQEnqHasIssuedNotFull)
-
+  if (backendParams.debugEn) {
+    dontTouch(fromRenameMapIQReadyCntVec)
+    dontTouch(fromRenameSameFuNumVec)
+    dontTouch(fromRenameFutypeNotOverIQ)
+    dontTouch(fromRenameMapIQBandWidthVec)
+    dontTouch(fromRenameFutypeOvecIQEnqBandwidth)
+    dontTouch(fuMapIQBandWidthVec)
+    dontTouch(issueQueueSizeVec)
+    dontTouch(fromRenameMapIQValidNumVec)
+    dontTouch(fromRenameMapIQSizeVec)
+    dontTouch(fromRenameMapIQNotFull)
+    dontTouch(fromRenameMapIQEnqHasIssuedVec)
+    dontTouch(fromRenameMapIQEnqHasIssuedNotFull)
+  }
 
   // prepipe stall
   val renameStall  = !inValidVec.reduce(_ || _)
@@ -1068,6 +1065,13 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     (robStall || lsqStall)                                                   -> RobStall.id.U             ,
   ))
 
+  /** BalanceDispatchStall or Bubble: IQ can enq, but fail to dispatch cause stall/bubble
+   *  - like: Alu IQ now has 4 ready enq port, and dispatch get 3 alu instructions. However,
+   *  some alu instruction fail to dispatch and cause stall
+   *  - TODO: Since the statistics here are collected by the same `FuType`, the accounting may be imprecise for
+   *  instructions that share an IQ. However, such cases are relatively rare for now, and they are currently
+   *  misattributed to `IQFull`.
+   */
   val issueQueueStall = issueQueueStallVec(0)
   val issueQueueStallFutype = PriorityMux(issueQueueStallVec, fuTypes)
   val balanceDispatchStall = PriorityMux(issueQueueStallVec, fromRenameFutypeNotOverIQ)
@@ -1112,16 +1116,21 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     specialInstructionStall -> specialInstructionStallReason ,
   ))
 
-  // todo exchage bundle
-  // current bubble
+  /** current pipe bubble : dispatch or after dispatch cause not first instruction stall including:
+   *  - Dispatch Policy bubble: bandwidth, balance
+   *  - issuequeue full: full, not full but cannot enter
+   *  - dispatch lsq cannot enter
+   *  - special instruction: wait forward block backward
+   */
   val dispatchBubble = !inReadyVec.reduce(_ && _) && !dispatchStall
   val dispatchBubbleReason       = Wire(chiselTypeOf(io.stallReason.reason(0)))
   val dispatchBubbleValid        = WireInit(VecInit.fill(renameWidth)(false.B))
-//  val dispatchBubbleReasonVec    = Wire(chiselTypeOf(io.stallReason.reason))
   val dispatchBubbleValidReg     = RegInit(VecInit.fill(renameWidth)(false.B))
   val dispatchBubbleReasonVecReg = Reg(chiselTypeOf(io.stallReason.reason))
 
-  //TODO explain
+  /** DispatchBandWidthPolicyBubble: For specific futype: dispatch width over IQ enq width cause dispatch bubble
+   *  - like: load IQ only has 6 enq width , 8 loads cause 2 bubble in dispatch
+   */
   val dispatchBandWidthPolicyBubble = PriorityMux(issueQueueStallVec, fromRenameFutypeOvecIQEnqBandwidth)
   val dispatchBandWidthPolicyBubbleFutype = PriorityMux(fromRenameFutypeOvecIQEnqBandwidth, fuTypes)
   val dispatchBandWidthPolicyBubbleReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
@@ -1130,6 +1139,10 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     dispatchBandWidthPolicyBubble                             -> OtherDispatchPolicyStall.id.U ,
   ))
 
+  /** IssueQueue Stall has two type:(select iq stall and has no other not stall iq can accept this futype)
+   *  - IQ full : IQ has less then 2 empty entries
+   *  - IQ Not full but cannot enter : IQ has >= 2 empty entries but cannot enter(not trans or enq issued)
+   */
   val issueQueueEnqPolicyStallIssued = PriorityMux(issueQueueStallVec, fromRenameMapIQEnqHasIssuedNotFull)
   val issueQueueEnqPolicyStall = PriorityMux(issueQueueStallVec, fromRenameMapIQNotFull)
 
@@ -1149,7 +1162,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     FuType.isStoreVstore(issueQueueStallFutype) -> StoreIQFullStall.id.U       ,
   ))
 
-
+  /** Dispatch lsq Bubble : lsq cannot enter */
   val dispatchlsqBubble = dispatchlsqBubbleVec.reduce(_ || _)
   val dispatchlsqBubbleFutype = PriorityMux(dispatchlsqBubbleVec , fuTypes)
   val dispatchlsqBubbleReason = MuxCase(NoStall.id.U, Seq(
@@ -1157,6 +1170,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     FuType.isStoreVstore(dispatchlsqBubbleFutype) -> StoreIQFullStall.id.U ,
   ))
 
+  /** Special Instruction bubble: wait forward or block backward */
   val specialInstructionBubbleVec = VecInit((blockedByWaitForward zip notBlockedByPrevious).map{case (a,b) => a | !b })
   val specialInstructionBubbleReason = SpecialInsts.id.U
 
@@ -1183,14 +1197,18 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   dispatchPriorityBubbleReasonidx := PriorityEncoder(dispatchPriorityBubbleVec)
   dispatchBubbleReason := allDispatchReasonVec(dispatchPriorityBubbleReasonidx)
 
-  dontTouch(dispatchPriorityBubbleidx)
-  dontTouch(dispatchPriorityBubbleReasonidx)
-  dontTouch(dispatchBubbleReason)
-  dontTouch(dispatchStall)
-  dontTouch(issueQueueStallVec)
+  if (backendParams.debugEn){
+    dontTouch(dispatchPriorityBubbleidx)
+    dontTouch(dispatchPriorityBubbleReasonidx)
+    dontTouch(dispatchBubbleReason)
+    dontTouch(dispatchStall)
+    dontTouch(issueQueueStallVec)
+  }
 
-  // next cycle bubble store until all fire
-  // all fire cannot have bubble at current cycle
+  /** next cycle bubble store until all fire
+   * - In later cycles, a bubble may override an earlier bubble once it becomes valid
+   * - however, when `allFire` occurs, any existing bubble must reflect the original cause that first generated it
+   */
   for (i <- 0 until RenameWidth) {
     when(io.redirect.valid || io.toRenameAllFire){
       dispatchBubbleValidReg(i) := false.B
@@ -1230,11 +1248,11 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     ))
 
 
-    // prepipe bubble and current pipe bubble will not happen together
     // prepipe bubble release
     val prePipeBubbleRelease = renameBubble && !inValid && !dispatchBubbleValidReg(idx)
     val prePipeBubbleReason = inReason
 
+    // current pipe bubble release
     val currentPipeBubbleRelease = !inValid && dispatchBubbleValidReg(idx)
     val currentPipeBubbleReason = dispatchBubbleReasonVecReg(idx)
 

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -1249,7 +1249,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
 
 
     // prepipe bubble release
-    val prePipeBubbleRelease = renameBubble && !inValid && !dispatchBubbleValidReg(idx)
+    val prePipeBubbleRelease = renameBubble && !inValid && (inReason =/= NoStall.id.U)
     val prePipeBubbleReason = inReason
 
     // current pipe bubble release

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -49,17 +49,17 @@ class CoreDispatchTopDownIO extends Bundle {
   val fromMem = Flipped(new MemCoreTopDownIO)
 }
 // TODO delete trigger message from frontend to iq
-class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with HasVLSUParameters {
+class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with HasVLSUParameters {
   // std IQ donot need dispatch, only copy sta IQ, but need sta IQ's ready && std IQ's ready
   val allIssueParams = backendParams.allIssueParams.filter(_.StdCnt == 0)
   val allExuParams = allIssueParams.map(_.exuBlockParams).flatten
   val allFuConfigs = allExuParams.map(_.fuConfigs).flatten.toSet.toSeq
   val sortedFuConfigs = allFuConfigs.sortBy(_.fuType.id)
-  println(s"[NewDispatch] ${allExuParams.map(_.name)}")
-  println(s"[NewDispatch] ${allFuConfigs.map(_.name)}")
-  println(s"[NewDispatch] ${allFuConfigs.map(_.fuType.id)}")
-  println(s"[NewDispatch] ${sortedFuConfigs.map(_.name)}")
-  println(s"[NewDispatch] ${sortedFuConfigs.map(_.fuType.id)}")
+  println(s"[Dispatch] ${allExuParams.map(_.name)}")
+  println(s"[Dispatch] ${allFuConfigs.map(_.name)}")
+  println(s"[Dispatch] ${allFuConfigs.map(_.fuType.id)}")
+  println(s"[Dispatch] ${sortedFuConfigs.map(_.name)}")
+  println(s"[Dispatch] ${sortedFuConfigs.map(_.fuType.id)}")
   val fuConfigsInIssueParams = allIssueParams.map(_.allExuParams.map(_.fuConfigs).flatten.toSet.toSeq)
   val fuMapIQIdx = sortedFuConfigs.map( fu => {
     val fuInIQIdx = fuConfigsInIssueParams.zipWithIndex.filter { case (f, i) => f.contains(fu) }.map(_._2)
@@ -67,7 +67,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
    }
   )
   fuMapIQIdx.map { case (fu, iqidx) =>
-    println(s"[NewDispatch] ${fu.name} $iqidx")
+    println(s"[Dispatch] ${fu.name} $iqidx")
   }
   val sameIQIdxFus = fuMapIQIdx.map{ case (fu, iqidx) =>
     fuMapIQIdx.filter(_._2 == iqidx).map(_._1) -> iqidx
@@ -75,10 +75,10 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
   val needMultiIQ = sameIQIdxFus.sortBy(_._1.head.fuType.id).filter(_._2.size > 1)
   val needSingleIQ = sameIQIdxFus.sortBy(_._1.head.fuType.id).filter(_._2.size == 1)
   needMultiIQ.map { case (fus, iqidx) =>
-    println(s"[NewDispatch] needMultiIQ: ${fus.map(_.name)} $iqidx")
+    println(s"[Dispatch] needMultiIQ: ${fus.map(_.name)} $iqidx")
   }
   needSingleIQ.map { case (fus, iqidx) =>
-    println(s"[NewDispatch] needSingleIQ: ${fus.map(_.name)} $iqidx")
+    println(s"[Dispatch] needSingleIQ: ${fus.map(_.name)} $iqidx")
   }
   val fuConfigsInExuParams = allExuParams.map(_.fuConfigs)
   val fuMapExuIdx = sortedFuConfigs.map { case fu => {
@@ -214,11 +214,11 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
       xx.zipWithIndex.filter(y => VlRegSrcDataSet.contains(y._1)).map(_._2)
     }).flatten
   }).flatten.toSet.toSeq.sorted
-  println(s"[NewDispatch] idxRegTypeInt: $idxRegTypeInt")
-  println(s"[NewDispatch] idxRegTypeFp: $idxRegTypeFp")
-  println(s"[NewDispatch] idxRegTypeVec: $idxRegTypeVec")
-  println(s"[NewDispatch] idxRegTypeV0: $idxRegTypeV0")
-  println(s"[NewDispatch] idxRegTypeVl: $idxRegTypeVl")
+  println(s"[Dispatch] idxRegTypeInt: $idxRegTypeInt")
+  println(s"[Dispatch] idxRegTypeFp: $idxRegTypeFp")
+  println(s"[Dispatch] idxRegTypeVec: $idxRegTypeVec")
+  println(s"[Dispatch] idxRegTypeV0: $idxRegTypeV0")
+  println(s"[Dispatch] idxRegTypeVl: $idxRegTypeVl")
   val numRegSrc: Int = issueBlockParams.map(_.exuBlockParams.map(
     x => if (x.hasStdFu) x.numRegSrc + 1 else x.numRegSrc
   ).max).max
@@ -417,7 +417,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     val suffix = fus.map(_.name).mkString("_")
     val iqNum = exuidx.size
     val iqidx = allIssueParams.map(_.exuBlockParams.map(_.fuConfigs).flatten.toSet.toSeq).zipWithIndex.filter{x => fus.toSet.subsetOf(x._1.toSet)}.map(_._2)
-    println(s"[NewDispatch] ${fus.map(_.name)};iqidx:$iqidx;exuIdx:$exuidx")
+    println(s"[Dispatch] ${fus.map(_.name)};iqidx:$iqidx;exuIdx:$exuidx")
     val compareMatrix = Wire(Vec(iqNum, Vec(iqNum, Bool()))).suggestName(s"compareMatrix_$suffix")
     for (i <- 0 until iqNum) {
       for (j <- 0 until iqNum) {
@@ -571,7 +571,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
   val lsqEnqCtrl = Module(new LsqEnqCtrl)
 
   // TODO: check lsqEnqCtrl redirect logic
-  // here is RegNext because dispatch2iq use s2_s4_redirect, newDispatch use s1_s3_redirect
+  // here is RegNext because dispatch2iq use s2_s4_redirect, Dispatch use s1_s3_redirect
   lsqEnqCtrl.io.redirect := RegNext(io.redirect)
   lsqEnqCtrl.io.lcommit := io.fromMem.lcommit
   lsqEnqCtrl.io.scommit := io.fromMem.scommit
@@ -949,9 +949,6 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     ready
   }
   val fuTypeMapIQIdx = fuMapIQIdx.map(_._2)
-  fuTypeMapIQIdx.map { case (iqidx) =>
-    println(s"[NewDispatch] $iqidx")
-  }
   val issueQueueStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
     val result = uopSelIQMatrix.map(_(iqidx)).map(x => !iqReadyVec(iqidx).orR && x.orR && x <= issue.numEnq.U)
     result

--- a/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
@@ -928,36 +928,99 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
 
   val decodeReason = RegNextN(io.stallReason.reason, 2)
   val renameReason = RegNext(io.stallReason.reason)
+  
+  temp = 0
+  val dispatchPolicyStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
+    val result = uopSelIQMatrix.map(_(iqidx)).map(x => x > issue.numEnq.U)
+    temp = temp + issue.numEnq
+    result
+  }}.transpose
+  val dispatchPolicyStallReason1 = dispatchPolicyStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
+    // TODO: explain
+    val block = blockList.reduce(_ || _)
+    uop.valid && block
+  }
+  val dispatchPolicyStallReason2 = fromRename.map(uop =>
+    !fromRename(0).valid && fromRename.map(_.valid).reduce(_ || _) && !uop.valid)
+
+  temp = 0
+  val issueQueueStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
+    val result = uopSelIQMatrix.map(_(iqidx)).map(x => !io.toIssueQueues(temp).ready && x.orR && x <= issue.numEnq.U)
+    temp = temp + issue.numEnq
+    result
+  }}.transpose
+  val issueQueueStall = issueQueueStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
+    val block = blockList.reduce(_ || _)
+    uop.valid && block
+  }
+
+
 
   val stallReason = Wire(chiselTypeOf(io.stallReason.reason))
   val firedVec = fromRename.map(_.fire)
   io.stallReason.backReason.valid := !canAccept
+  // TODO : rob不可接收直接归到other core?
   io.stallReason.backReason.bits := TopDownCounters.OtherCoreStall.id.U
-  stallReason.zip(io.stallReason.reason).zip(firedVec).zipWithIndex.zip(fusedVec).map { case ((((update, in), fire), idx), fused) =>
+  stallReason.zip(io.stallReason.reason).zip(firedVec).zipWithIndex.zip(fusedVec).foreach { case ((((update, in), fire), idx), fused) =>
     val headIsInt = FuType.isInt(io.robHeadFuType)  && io.robHeadNotReady
     val headIsFp  = FuType.isFArith(io.robHeadFuType)   && io.robHeadNotReady
     val headIsDiv = FuType.isDivSqrt(io.robHeadFuType) && io.robHeadNotReady
     val headIsLd  = io.robHeadFuType === FuType.ldu.U && io.robHeadNotReady || !io.lqCanAccept
     val headIsSt  = io.robHeadFuType === FuType.stu.U && io.robHeadNotReady || !io.sqCanAccept
-    val headIsAmo = io.robHeadFuType === FuType.mou.U && io.robHeadNotReady
+    val headIsAmo = io.robHead.getDebugFuType === FuType.mou.U && io.robHeadNotReady
     val headIsLs  = headIsLd || headIsSt
     val robLsFull = io.robFull || !io.lqCanAccept || !io.sqCanAccept
+    val dispatchStallIsLoad    = (FuType.isLoad(fromRename(idx).bits.fuType) && dispatchPolicyStallReason1(idx)) ||
+      (FuType.isLoad(fromRename(renameWidth - 1).bits.fuType) && dispatchPolicyStallReason2(idx))
+    val dispatchStallIsStore   = (FuType.isStore(fromRename(idx).bits.fuType) && dispatchPolicyStallReason1(idx)) ||
+      (FuType.isStore(fromRename(renameWidth - 1).bits.fuType) && dispatchPolicyStallReason2(idx))
+    val dispatchStall          = dispatchPolicyStallReason1(idx) || dispatchPolicyStallReason2(idx)
+    val lsqStallDispatch       = fromRename(idx).valid && !lsqCanAccept
+
+    val issueQueueStallIsAlu   = FuType.isAlu(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
+    val issueQueueStallIsBrh   = FuType.isBJU(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
+    val issueQueueStallIsInt   = FuType.isInt(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
+    val issueQueueStallIsFp    = FuType.isFArith(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
+    val issueQueueStallIsVec   = FuType.isVArithMem(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
+    val issueQueueStallIsLoad  = FuType.isLoad(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
+    val issueQueueStallIsStore = FuType.isStore(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
 
     import TopDownCounters._
+    // TODO: temporarily fix miss frontend bubble
+    val frontendMissBubble     = !fromRename.map(_.valid).reduce(_ || _) && (decodeReason(idx) === NoStall.id.U)
+
+
     update := MuxCase(OtherCoreStall.id.U, Seq(
       // fire
-      (fire || fused                                     ) -> NoStall.id.U          ,
+      (fire || fused                                     ) -> NoStall.id.U                  ,
+      // dispatch stall
+      // dispatch policy stall
+      (dispatchStallIsLoad                               ) -> LoadDispatchPolicyStall.id.U  ,
+      (dispatchStallIsStore                              ) -> StoreDispatchPolicyStall.id.U ,
+      (dispatchStall                                     ) -> OtherDispatchPolicyStall.id.U ,
+      // loadstore queue stall dispatch
+      (lsqStallDispatch                                  ) -> LoadStoreStallDispatch.id.U   ,
+
       // dispatch not stall / core stall from decode or rename
-      (in =/= OtherCoreStall.id.U && in =/= NoStall.id.U ) -> in                    ,
+      (in =/= OtherCoreStall.id.U && in =/= NoStall.id.U ) -> in                            ,
+      // issuequeue stall dispatch
+      (issueQueueStallIsAlu                              ) -> IntIQFullStallAlu.id.U        ,
+      (issueQueueStallIsBrh                              ) -> IntIQFullStallBrh.id.U        ,
+      (issueQueueStallIsInt                              ) -> IntIQFullStallOther.id.U      ,
+      (issueQueueStallIsFp                               ) -> FpIQFullStall.id.U            ,
+      (issueQueueStallIsVec                              ) -> VecIQFullStall.id.U           ,
+      (issueQueueStallIsLoad                             ) -> LoadIQFullStall.id.U          ,
+      (issueQueueStallIsStore                            ) -> StoreIQFullStall.id.U         ,
       // rob stall
-      (headIsAmo                                         ) -> AtomicStall.id.U      ,
-      (headIsSt                                          ) -> StoreStall.id.U       ,
-      (headIsLd                                          ) -> ldReason              ,
-      (headIsDiv                                         ) -> DivStall.id.U         ,
-      (headIsInt                                         ) -> IntNotReadyStall.id.U ,
-      (headIsFp                                          ) -> FPNotReadyStall.id.U  ,
-      (renameReason(idx) =/= NoStall.id.U                ) -> renameReason(idx)     ,
-      (decodeReason(idx) =/= NoStall.id.U                ) -> decodeReason(idx)     ,
+      (headIsAmo                                         ) -> AtomicStall.id.U              ,
+      (headIsSt                                          ) -> StoreStall.id.U               ,
+      (headIsLd                                          ) -> ldReason                      ,
+      (headIsDiv                                         ) -> DivStall.id.U                 ,
+      (headIsInt                                         ) -> IntNotReadyStall.id.U         ,
+      (headIsFp                                          ) -> FPNotReadyStall.id.U          ,
+      (renameReason(idx) =/= NoStall.id.U                ) -> renameReason(idx)             ,
+      (decodeReason(idx) =/= NoStall.id.U                ) -> decodeReason(idx)             ,
+      (frontendMissBubble                                ) -> ICacheMissBubble.id.U         ,
     ))
   }
 

--- a/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
@@ -914,23 +914,23 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
   val l2Miss = io.debugTopDown.fromCore.l2MissMatch
   val l3Miss = io.debugTopDown.fromCore.l3MissMatch
 
-  val ldReason = Mux(l3Miss, TopDownCounters.LoadMemStall.id.U,
-  Mux(l2Miss, TopDownCounters.LoadL3Stall.id.U,
-  Mux(l1Miss, TopDownCounters.LoadL2Stall.id.U,
-  Mux(notIssue, TopDownCounters.MemNotReadyStall.id.U,
-  Mux(tlbMiss, TopDownCounters.LoadTLBStall.id.U,
-  Mux(tlbReplay, TopDownCounters.LoadTLBStall.id.U,
-  Mux(mshrReplay, TopDownCounters.LoadMSHRReplayStall.id.U,
-  Mux(vioReplay, TopDownCounters.LoadVioReplayStall.id.U,
-  TopDownCounters.LoadL1Stall.id.U))))))))
+  val ldReason = Mux(l3Miss, LoadMemStall.id.U,
+  Mux(l2Miss, LoadL3Stall.id.U,
+  Mux(l1Miss, LoadL2Stall.id.U,
+  Mux(notIssue, MemNotReadyStall.id.U,
+  Mux(tlbMiss, LoadTLBStall.id.U,
+  Mux(tlbReplay, LoadTLBStall.id.U,
+  Mux(mshrReplay, LoadMSHRReplayStall.id.U,
+  Mux(vioReplay, LoadVioReplayStall.id.U,
+  LoadL1Stall.id.U))))))))
 
   val fusedVec = (0 until RenameWidth).map{ case i =>
     if (i == 0 || !backendParams.debugEn) false.B
     else (io.fromRename(i-1).fire && !io.fromRename(i).valid && io.fromRename(i-1).bits.debug.get.fusionNum =/= 0.U)
   }
 
-  val decodeReason = RegNextN(io.stallReason.reason, 2)
-  val renameReason = RegNext(io.stallReason.reason)
+//  val decodeReason = RegNextN(io.stallReason.reason, 2)
+//  val renameReason = RegNext(io.stallReason.reason)
   
   temp = 0
   val dispatchPolicyStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
@@ -938,18 +938,11 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     temp = temp + issue.numEnq
     result
   }}.transpose
-  val dispatchPolicyStallReason1 = dispatchPolicyStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
+  val dispatchPolicyStallVec = dispatchPolicyStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
     // TODO: explain
     val block = blockList.reduce(_ || _)
     uop.valid && block
   }
-  val fuTypes = (0 until RenameWidth).map(idx => fromRename(idx).bits.fuType)
-  val dispatchPolicyStallFutype = PriorityMux(dispatchPolicyStallReason1, fuTypes)
-  val dispatchPolicyStallReason2 = MuxCase(OtherCoreStall.id.U, Seq(
-    FuType.isLoad (dispatchPolicyStallFutype) -> LoadDispatchPolicyStall.id.U ,
-    FuType.isStore(dispatchPolicyStallFutype) -> StoreDispatchPolicyStall.id.U,
-    dispatchPolicyStallReason1.reduce(_||_)   -> OtherDispatchPolicyStall.id.U,
-  ))
 
   temp = 0
   val issueQueueStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
@@ -957,73 +950,142 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     temp = temp + issue.numEnq
     result
   }}.transpose
-  val issueQueueStall = issueQueueStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
+  val issueQueueStallVec = issueQueueStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
     val block = blockList.reduce(_ || _)
     uop.valid && block
   }
-  val robStall = !isWaitForwardOrBlockBackward && !io.enqRob.canAccept
 
+  val dispatchlsqBubbleVec = allowDispatch.map(!_)
+
+
+
+
+  // TODO delete it
+  io.stallReason.backReason := 0.U.asTypeOf(io.stallReason.backReason)
+
+  val fuTypes = fromRename.map(_.bits.fuType)
+  val firedVec = fromRename.map(_.fire)
+  val inValidVec = fromRename.map(_.valid)
+  val inReadyVec = fromRename.map(_.ready)
+  // current stall
+  val dispatchStall = !(inReadyVec.reduce(_ || _))
+  val dispatchStallReason = Wire(chiselTypeOf(io.stallReason.reason(0)))
+
+
+  val robHeadFutype = io.robHeadFuType
+  val robStall = !isWaitForwardOrBlockBackward && !io.enqRob.canAccept
+  val lsqStall = !lsqCanAccept
+  val roblsqStall = robStall ||  lsqStall
+  val lqStall  = lsqEnqCtrl.io.lqStall.getOrElse(false.B)
+  val sqStall  = lsqEnqCtrl.io.sqStall.getOrElse(false.B)
+  val roblsqStallReason = MuxCase(NoStall.id.U, Seq(
+    (FuType.isAMO(robHeadFutype) && io.robHeadNotReady)                      -> AtomicStall.id.U          ,
+    ((FuType.isStoreVstore(robHeadFutype) && io.robHeadNotReady) || sqStall) -> StoreStall.id.U           ,
+    ((FuType.isLoadVload(robHeadFutype) && io.robHeadNotReady) || lqStall)   -> ldReason                  ,
+    (FuType.isDivSqrt(robHeadFutype) && io.robHeadNotReady)                  -> DivStall.id.U             ,
+    (FuType.isInt(robHeadFutype) && io.robHeadNotReady)                      -> IntNotReadyStall.id.U     ,
+    (FuType.isFArith(robHeadFutype) && io.robHeadNotReady)                   -> FPNotReadyStall.id.U      ,
+    (robStall)                                                               -> RobStall.id.U             ,
+  ))
+
+  dispatchStallReason := MuxCase(NoStall.id.U, Seq(
+    roblsqStall        -> roblsqStallReason        ,
+  ))
+
+  // current bubble
+  val dispatchBubble = !(inReadyVec.reduce(_ && _)) && !dispatchStall
+  val dispatchBubbleReason = Wire(chiselTypeOf(io.stallReason.reason(0)))
+  val dispatchBubbleReg = RegInit(false.B)
+  val dispatchBubbleReasonReg = RegInit(NoStall.id.U)
+
+  val issueQueueBubble = issueQueueStallVec.reduce(_ || _)
+  val issueQueueBubbleFutype = PriorityMux(issueQueueStallVec, fuTypes)
+  val issueQueueBubbleReason = MuxCase(NoStall.id.U, Seq(
+    FuType.isAlu(issueQueueBubbleFutype)         -> IntIQFullStallAlu.id.U        ,
+    FuType.isBJU(issueQueueBubbleFutype)         -> IntIQFullStallBrh.id.U        ,
+    FuType.isInt(issueQueueBubbleFutype)         -> IntIQFullStallOther.id.U      ,
+    FuType.isFArith(issueQueueBubbleFutype)      -> FpIQFullStall.id.U            ,
+    FuType.isVArith(issueQueueBubbleFutype)      -> VecIQFullStall.id.U           ,
+    FuType.isLoadVload(issueQueueBubbleFutype)   -> LoadIQFullStall.id.U          ,
+    FuType.isStoreVstore(issueQueueBubbleFutype) -> StoreIQFullStall.id.U         ,
+  ))
+  //TODO explain
+  val dispatchPolicyBubble = dispatchPolicyStallVec.reduce(_ || _)
+  val dispatchPolicyBubbleFutype = PriorityMux(dispatchPolicyStallVec, fuTypes)
+  val dispatchPolicyBubbleReason = MuxCase(NoStall.id.U, Seq(
+    FuType.isLoadVload(dispatchPolicyBubbleFutype)   -> LoadDispatchPolicyStall.id.U  ,
+    FuType.isStoreVstore(dispatchPolicyBubbleFutype) -> StoreDispatchPolicyStall.id.U ,
+    dispatchPolicyBubble                             -> OtherDispatchPolicyStall.id.U ,
+  ))
+
+  val dispatchlsqBubble = dispatchlsqBubbleVec .reduce(_ || _)
+  val dispatchlsqBubbleFutype = PriorityMux(dispatchlsqBubbleVec , fuTypes)
+  val dispatchlsqBubbleReason = MuxCase(NoStall.id.U, Seq(
+    FuType.isLoadVload(dispatchlsqBubbleFutype)   -> LoadIQFullStall.id.U  ,
+    FuType.isStoreVstore(dispatchlsqBubbleFutype) -> StoreIQFullStall.id.U ,
+  ))
+
+  val specialInstructionBubble = isWaitForwardOrBlockBackward
+  val specialInstructionBubbleReason = SpecialInsts.id.U
+
+  dispatchBubbleReason := MuxCase(NoStall.id.U, Seq(
+    issueQueueBubble          -> issueQueueBubbleReason         ,
+    dispatchPolicyBubble      -> dispatchPolicyBubbleReason     ,
+    dispatchlsqBubble         -> dispatchlsqBubbleReason        ,
+    dispatchBubble            -> BackendOtherCoreStall.id.U     ,
+    specialInstructionBubble  -> specialInstructionBubbleReason ,
+  ))
+
+  // store bubble reason
+  when(io.redirect.valid || io.toRenameAllFire){
+    dispatchBubbleReg := false.B
+    dispatchBubbleReasonReg := NoStall.id.U
+  }.elsewhen(dispatchBubble && !dispatchBubbleReg) {
+    dispatchBubbleReg := true.B
+    dispatchBubbleReasonReg := dispatchBubbleReason
+  }.otherwise {
+    dispatchBubbleReg := dispatchBubbleReg
+    dispatchBubbleReasonReg := dispatchBubbleReasonReg
+  }
 
 
   val stallReason = Wire(chiselTypeOf(io.stallReason.reason))
-  val firedVec = fromRename.map(_.fire)
-  io.stallReason.backReason.valid := !canAccept || dispatchPolicyStallReason1.reduce(_ || _)
-  io.stallReason.backReason.bits := Mux(dispatchPolicyStallReason1.reduce(_ || _), dispatchPolicyStallReason2,
-    TopDownCounters.OtherCoreStall.id.U)
-  stallReason.zip(io.stallReason.reason).zip(firedVec).zipWithIndex.zip(fusedVec).foreach { case ((((update, in), fire), idx), fused) =>
-    val robHeadIsInt = FuType.isInt(io.robHeadFuType)     && io.robHeadNotReady && robStall
-    val robHeadIsFp  = FuType.isFArith(io.robHeadFuType)  && io.robHeadNotReady && robStall
-    val robHeadIsDiv = FuType.isDivSqrt(io.robHeadFuType) && io.robHeadNotReady && robStall
-    val robHeadIsLd  = FuType.isLoad(io.robHeadFuType)    && io.robHeadNotReady && robStall
-    val robHeadIsSt  = FuType.isStore(io.robHeadFuType)   && io.robHeadNotReady && robStall
-    val robHeadIsAmo = FuType.isAMO(io.robHeadFuType)     && io.robHeadNotReady && robStall
-    val lqStall      = !lsqCanAccept && enqLsqIO.needAlloc(0).asBool
-    val sqStall      = !lsqCanAccept && enqLsqIO.needAlloc(1).asBool
-    val robLsFull = io.robFull || !io.lqCanAccept || !io.sqCanAccept
-    val dispatchStallIsLoad    = FuType.isLoad (dispatchPolicyStallFutype) && dispatchPolicyStallReason1(idx)
-    val dispatchStallIsStore   = FuType.isStore(dispatchPolicyStallFutype) && dispatchPolicyStallReason1(idx)
-    val dispatchStall          = dispatchPolicyStallReason1(idx)
 
-    val issueQueueStallIsAlu   = FuType.isAlu(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
-    val issueQueueStallIsBrh   = FuType.isBJU(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
-    val issueQueueStallIsInt   = FuType.isInt(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
-    val issueQueueStallIsFp    = FuType.isFArith(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
-    val issueQueueStallIsVec   = FuType.isVArithMem(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
-    val issueQueueStallIsLoad  = FuType.isLoad(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
-    val issueQueueStallIsStore = FuType.isStore(fromRename(idx).bits.fuType) && issueQueueStall(idx) && !robLsFull
+//  io.stallReason.backReason.valid := !canAccept || dispatchPolicyStallReason1.reduce(_ || _)
+//  io.stallReason.backReason.bits := Mux(dispatchPolicyStallReason1.reduce(_ || _), dispatchPolicyStallReason2,
+//    BackendOtherCoreStall.id.U)
+  stallReason.zip(io.stallReason.reason).zip(firedVec).zipWithIndex.foreach { case (((update, inReason), fire), idx) =>
+    val inValid = inValidVec(idx)
+    val inReady = inReadyVec(idx)
 
-    import TopDownCounters._
-    // TODO: temporarily fix miss frontend bubble
-    val frontendMissBubble     = !fromRename.map(_.valid).reduce(_ || _) && (decodeReason(idx) === NoStall.id.U)
+    // bubble back pressure
+    val currentPipeBackPressure = dispatchBubbleReg
+    val currentPipeBackPressureReason = dispatchBubbleReasonReg
 
+    // TopDown collect pre pipe reason
+    val prePipeStall   = !inValid
+    val prePipeStallReason = inReason
+//    if (backendParams.debugEn){
+//      assert((!reset.asBool && !inValid && !dispatchPolicyStallReason2) && (inReason === NoStall.id.U || inReason === BackendOtherCoreStall.id.U),
+//        "[TopDown]: Dispatch has no instruction in ,but reason is null")
+//    }
 
-    update := MuxCase(OtherCoreStall.id.U, Seq(
-      // fire
-      (fire || fused                                     ) -> NoStall.id.U                  ,
-      // issuequeue stall dispatch
-      (issueQueueStallIsAlu                              ) -> IntIQFullStallAlu.id.U        ,
-      (issueQueueStallIsBrh                              ) -> IntIQFullStallBrh.id.U        ,
-      (issueQueueStallIsInt                              ) -> IntIQFullStallOther.id.U      ,
-      (issueQueueStallIsFp                               ) -> FpIQFullStall.id.U            ,
-      (issueQueueStallIsVec                              ) -> VecIQFullStall.id.U           ,
-      (issueQueueStallIsLoad                             ) -> LoadIQFullStall.id.U          ,
-      (issueQueueStallIsStore                            ) -> StoreIQFullStall.id.U         ,
-      //  core stall from decode or rename
-      (in =/= OtherCoreStall.id.U && in =/= NoStall.id.U ) -> in                            ,
-      // rob stall
-      (robHeadIsAmo                                      ) -> AtomicStall.id.U              ,
-      (robHeadIsSt && sqStall                            ) -> StoreStall.id.U               ,
-      (robHeadIsLd && lqStall                            ) -> ldReason                      ,
-      (robHeadIsDiv                                      ) -> DivStall.id.U                 ,
-      (robHeadIsInt                                      ) -> IntNotReadyStall.id.U         ,
-      (robHeadIsFp                                       ) -> FPNotReadyStall.id.U          ,
-      // dispatch policy stall
-      (dispatchStallIsLoad                               ) -> LoadDispatchPolicyStall.id.U  ,
-      (dispatchStallIsStore                              ) -> StoreDispatchPolicyStall.id.U ,
-      (dispatchStall                                     ) -> OtherDispatchPolicyStall.id.U ,
-      (renameReason(idx) =/= NoStall.id.U                ) -> renameReason(idx)             ,
-      (decodeReason(idx) =/= NoStall.id.U                ) -> decodeReason(idx)             ,
-      (frontendMissBubble                                ) -> ICacheMissBubble.id.U         ,
+    // TopDown collect current stage stall
+    val currentPipeStall = !inReady || dispatchBlock
+    val currentPipeStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+      // current cycle stall
+      (dispatchStall                                       ) -> dispatchStallReason         ,
+      // current cycle bubble
+      (dispatchBubble                                      ) -> dispatchBubbleReason             ,
+    ))
+
+    update := MuxCase(BackendOtherCoreStall.id.U, Seq(
+      (fire                                                 ) -> NoStall.id.U                  ,
+      (currentPipeBackPressure                              ) -> currentPipeBackPressureReason ,
+      (prePipeStall && (prePipeStallReason =/= NoStall.id.U)) -> prePipeStallReason            ,
+      (currentPipeStall                                     ) -> currentPipeStallReason        ,
+//      // TODO
+//      (decodeReason(idx) =/= NoStall.id.U                   ) -> decodeReason(idx)             ,
     ))
   }
 

--- a/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/NewDispatch.scala
@@ -152,10 +152,7 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     // perf only
     val robHeadFuType = Input(FuType())
     val stallReason = Flipped(new StallReasonIO(RenameWidth))
-    val lqCanAccept = Input(Bool())
-    val sqCanAccept = Input(Bool())
     val robHeadNotReady = Input(Bool())
-    val robFull = Input(Bool())
     val debugBlockBackward = Option.when(backendParams.debugEn)(Input(Bool()))
     val debugWaitForward   = Option.when(backendParams.debugEn)(Input(Bool()))
     val debugTopDown = new Bundle {
@@ -934,13 +931,8 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     else (io.fromRename(i-1).fire && !io.fromRename(i).valid && io.fromRename(i-1).bits.debug.get.fusionNum =/= 0.U)
   }
 
-//  val decodeReason = RegNextN(io.stallReason.reason, 2)
-//  val renameReason = RegNext(io.stallReason.reason)
-  
-  temp = 0
   val dispatchPolicyStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
     val result = uopSelIQMatrix.map(_(iqidx)).map(x => x > issue.numEnq.U)
-    temp = temp + issue.numEnq
     result
   }}.transpose
   val dispatchPolicyStallVec = VecInit(dispatchPolicyStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
@@ -950,9 +942,18 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
   })
 
   temp = 0
+  val iqReadyVec = allIssueParams.map{ case issue =>
+    val readyVec = io.toIssueQueues.slice(temp, temp + issue.numEnq).map(_.ready)
+    val ready = PopCount(readyVec)
+    temp += issue.numEnq
+    ready
+  }
+  val fuTypeMapIQIdx = fuMapIQIdx.map(_._2)
+  fuTypeMapIQIdx.map { case (iqidx) =>
+    println(s"[NewDispatch] $iqidx")
+  }
   val issueQueueStallMatrix = allIssueParams.zipWithIndex.map { case (issue, iqidx) => {
-    val result = uopSelIQMatrix.map(_(iqidx)).map(x => !io.toIssueQueues(temp).ready && x.orR && x <= issue.numEnq.U)
-    temp = temp + issue.numEnq
+    val result = uopSelIQMatrix.map(_(iqidx)).map(x => !iqReadyVec(iqidx).orR && x.orR && x <= issue.numEnq.U)
     result
   }}.transpose
   val issueQueueStallVec = VecInit(issueQueueStallMatrix.zip(fromRename).map{ case (blockList, uop) =>
@@ -962,13 +963,35 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
 
   val dispatchlsqBubbleVec = VecInit(allowDispatch.map(!_))
 
-  // TODO delete it
-  io.stallReason.backReason := 0.U.asTypeOf(io.stallReason.backReason)
-
+  val fuReadyIQCntVec = fuTypeMapIQIdx.map { iqVec =>
+    iqVec.map( iqidx => iqReadyVec(iqidx)).reduce(_ + _)
+  }
   val fuTypes = fromRename.map(_.bits.fuType)
   val firedVec = fromRename.map(_.fire)
   val inValidVec = fromRename.map(_.valid)
   val inReadyVec = fromRename.map(_.ready)
+  val fromRenameReadyIQCntVec = Wire(Vec(RenameWidth, UInt(log2Ceil(io.toIssueQueues.length).W)))
+  fromRenameReadyIQCntVec := fuTypes.map { fuType =>
+      Mux1H(fuType, fuReadyIQCntVec)
+  }
+
+  val fuTypeCountVec = (0 until FuType.num).map{ fid =>
+    PopCount(fromRename.map(in => in.bits.fuType(fid) && in.valid))
+  }
+
+  val fromRenameSameFuNumVec = Wire(Vec(RenameWidth, UInt(log2Ceil(RenameWidth).W)))
+  for( i <- 0 until RenameWidth) {
+    fromRenameSameFuNumVec(i) := Mux1H(fuTypes(i), fuTypeCountVec)
+  }
+  val fromRenameFutypeNotOverIQ = Wire(Vec(RenameWidth, Bool()))
+  fromRenameFutypeNotOverIQ := (0 until RenameWidth).map{ idx =>
+    inValidVec(idx) && (fromRenameSameFuNumVec(idx) < fromRenameReadyIQCntVec(idx))
+  }
+
+  dontTouch(fromRenameReadyIQCntVec)
+  dontTouch(fromRenameSameFuNumVec)
+  dontTouch(fromRenameFutypeNotOverIQ)
+
   // prepipe stall
   val renameStall  = !inValidVec.reduce(_ || _)
   val renameBubble = !inValidVec.reduce(_ && _) && !renameStall
@@ -999,14 +1022,15 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
   val issueQueueStall = issueQueueStallVec(0)
   val issueQueueStallFutype = PriorityMux(issueQueueStallVec, fuTypes)
   val issueQueueStallReason = MuxCase(NoStall.id.U, Seq(
-    FuType.isAlu(issueQueueStallFutype)         -> IntIQFullStallAlu.id.U        ,
-    FuType.isBJU(issueQueueStallFutype)         -> IntIQFullStallBrh.id.U        ,
-    FuType.isInt(issueQueueStallFutype)         -> IntIQFullStallOther.id.U      ,
-    FuType.isFArith(issueQueueStallFutype)      -> FpIQFullStall.id.U            ,
-    FuType.isVArith(issueQueueStallFutype)      -> VecIQFullStall.id.U           ,
-    FuType.isLoadVload(issueQueueStallFutype)   -> LoadIQFullStall.id.U          ,
-    FuType.isStoreVstore(issueQueueStallFutype) -> StoreIQFullStall.id.U         ,
-    issueQueueStall                             -> OtherIQFullStall.id.U         ,
+    fromRenameFutypeNotOverIQ(0)                -> BalanceDispatchPolicyStall.id.U ,
+    FuType.isAlu(issueQueueStallFutype)         -> IntIQFullStallAlu.id.U          ,
+    FuType.isBJU(issueQueueStallFutype)         -> IntIQFullStallBrh.id.U          ,
+    FuType.isInt(issueQueueStallFutype)         -> IntIQFullStallOther.id.U        ,
+    FuType.isFArith(issueQueueStallFutype)      -> FpIQFullStall.id.U              ,
+    FuType.isVArith(issueQueueStallFutype)      -> VecIQFullStall.id.U             ,
+    FuType.isLoadVload(issueQueueStallFutype)   -> LoadIQFullStall.id.U            ,
+    FuType.isStoreVstore(issueQueueStallFutype) -> StoreIQFullStall.id.U           ,
+    issueQueueStall                             -> OtherIQFullStall.id.U           ,
   ))
 
   val dispatchlsqStall = dispatchlsqBubbleVec.reduce(_ && _)
@@ -1039,15 +1063,17 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
 
   val issueQueueBubble = issueQueueStallVec.reduce(_ || _)
   val issueQueueBubbleFutype = PriorityMux(issueQueueStallVec, fuTypes)
+  val balanceDispatchStall = PriorityMux(issueQueueStallVec, fromRenameFutypeNotOverIQ)
 
   val issueQueueBubbleReason = MuxCase(NoStall.id.U, Seq(
-    FuType.isAlu(issueQueueBubbleFutype)         -> IntIQFullStallAlu.id.U        ,
-    FuType.isBJU(issueQueueBubbleFutype)         -> IntIQFullStallBrh.id.U        ,
-    FuType.isInt(issueQueueBubbleFutype)         -> IntIQFullStallOther.id.U      ,
-    FuType.isFArith(issueQueueBubbleFutype)      -> FpIQFullStall.id.U            ,
-    FuType.isVArith(issueQueueBubbleFutype)      -> VecIQFullStall.id.U           ,
-    FuType.isLoadVload(issueQueueBubbleFutype)   -> LoadIQFullStall.id.U          ,
-    FuType.isStoreVstore(issueQueueBubbleFutype) -> StoreIQFullStall.id.U         ,
+    balanceDispatchStall                         -> BalanceDispatchPolicyStall.id.U ,
+    FuType.isAlu(issueQueueBubbleFutype)         -> IntIQFullStallAlu.id.U          ,
+    FuType.isBJU(issueQueueBubbleFutype)         -> IntIQFullStallBrh.id.U          ,
+    FuType.isInt(issueQueueBubbleFutype)         -> IntIQFullStallOther.id.U        ,
+    FuType.isFArith(issueQueueBubbleFutype)      -> FpIQFullStall.id.U              ,
+    FuType.isVArith(issueQueueBubbleFutype)      -> VecIQFullStall.id.U             ,
+    FuType.isLoadVload(issueQueueBubbleFutype)   -> LoadIQFullStall.id.U            ,
+    FuType.isStoreVstore(issueQueueBubbleFutype) -> StoreIQFullStall.id.U           ,
   ))
   //TODO explain
   val dispatchPolicyBubble = dispatchPolicyStallVec.reduce(_ || _)
@@ -1086,8 +1112,8 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     dispatchOtherBubbleReason      ,
   )
 
-  val dispatchPriorityBubbleidx = Wire(UInt(5.W))
-  val dispatchPriorityBubbleReasonidx = Wire(UInt(5.W))
+  val dispatchPriorityBubbleidx = Wire(UInt(log2Up(allDispatchBubbleMatrix.length).W))
+  val dispatchPriorityBubbleReasonidx = Wire(UInt(log2Up(allDispatchReasonVec.length).W))
   dispatchPriorityBubbleidx := PriorityEncoder(dispatchBubbleVec)
   val dispatchPriorityBubbleVec = allDispatchBubbleMatrix.map{ bubbleVec => bubbleVec(dispatchPriorityBubbleidx)}
   dispatchPriorityBubbleReasonidx := PriorityEncoder(dispatchPriorityBubbleVec)
@@ -1129,10 +1155,6 @@ class NewDispatch(implicit p: Parameters) extends XSModule with HasPerfEvents wi
     // TopDown collect pre pipe reason
     val prePipeStall   = renameStall
     val prePipeStallReason = inReason
-//    if (backendParams.debugEn){
-//      assert((!reset.asBool && !inValid && !dispatchPolicyStallReason2) && (inReason === NoStall.id.U || inReason === BackendOtherCoreStall.id.U),
-//        "[TopDown]: Dispatch has no instruction in ,but reason is null")
-//    }
 
     // TopDown collect current stage stall
     val currentPipeStall = dispatchStall || dispatchBubble

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -65,13 +65,6 @@ class PerfCounterIO(implicit p: Parameters) extends XSBundle {
   val perfEventsLsu       = Vec(numCSRPCntLsu, new PerfEvent)
   val perfEventsHc        = Vec(numPCntHc * coreParams.L2NBanks + 1, new PerfEvent)
   val retiredInstr = UInt(7.W)
-  val frontendInfo = new Bundle {
-    val ibufFull  = Bool()
-    val bpuInfo = new Bundle {
-      val bpRight = UInt(XLEN.W)
-      val bpWrong = UInt(XLEN.W)
-    }
-  }
   val ctrlInfo = new Bundle {
     val robFull   = Bool()
     val intdqFull = Bool()

--- a/src/main/scala/xiangshan/backend/fu/FuType.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuType.scala
@@ -209,6 +209,10 @@ object FuType extends ChiselOHEnum {
 
   def isBlockBackCompress(fuType: UInt): Bool = FuTypeOrR(fuType, blockBackCompress)
 
+  def isStoreVstore(fuType: UInt): Bool = isStore(fuType) || isVStore(fuType)
+
+  def isLoadVload(fuType: UInt): Bool = isLoad(fuType) || isVLoad(fuType)
+
   val functionNameMap = Map(
     jmp -> "jmp",
     brh -> "brh",

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -936,8 +936,6 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   val renameBubble = false.B
   val renameBubbleReason = 0.U
 
-  //TODO :delete?
-  io.stallReason.in.backReason := 0.U.asTypeOf(io.stallReason.in.backReason)
 
   io.stallReason.out.reason.zipWithIndex.foreach{ case (stallReason, idx) =>
     val inValid = inValidVec(idx)
@@ -948,16 +946,12 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     val prePipeBubble = decodeBubbleValidVec(idx)
     val prePipeStallReason = inReason
     val prePieBubbleReason = decodeBubbleReasonVec(idx)
-    // other reason like out.ready will be collect by next stage dispatch
-    //    if (backendParams.debugEn) {
-    //      assert(!reset.asBool && (!inValid) && (inReason === NoStall.id.U || inReason === OtherCoreStall.id.U),
-    //        "[TopDown]: Rename has no instruction in ,but reason is null")
-    //    }
     // TopDown count current stage stall
     val redirect = redirectStall
     val redirectReason = redirectStallReason
 
-//    val dispatchHasFire = outFireVec.reduce(_ || _)
+    // as decode not generate bubble now, Topdown donot collect current stage Bubble
+    // if decode generate bubble later, Topdown should add here
 
     val stallReasonPipe = Module(new PipelineStallReason(log2Ceil(TopDownCounters.NumStallReasons.id)))
     stallReasonPipe.io.rightFire := outFireVec(idx)

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -27,7 +27,7 @@ import xiangshan.TopDownCounters._
 import xiangshan.backend.Bundles.{DecodeOutUop, RenameOutUop, connectSamePort}
 import xiangshan.backend.decode.{FusionDecodeInfo, ImmUnion, Imm_Z, XSDebugDecode}
 import xiangshan.backend.fu.FuType
-import xiangshan.backend.PipelineStallReason
+import xiangshan.backend.{StoreBubbleReason, PipelineStallReason}
 import xiangshan.backend.rename.freelist._
 import xiangshan.backend.rob.{RobEnqIO, RobPtr}
 import xiangshan.mem.mdp._
@@ -93,6 +93,8 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     val diff_vl_rat      = Option.when(backendParams.basicDebugEn)(Output(Vec(1, UInt(PhyRegIdxWidth.W))))
     val ratSnpt = Input(new SnapshotPort)
     // perf only
+    val debugDispatchAllFire = OptionWrapper(backendParams.debugEn, Input(Bool()))
+    val debugOutValidVec = OptionWrapper(backendParams.debugEn, Vec(RenameWidth, Input(Bool())))
     val stallReason = new Bundle {
       val in = Flipped(new StallReasonIO(RenameWidth))
       val out = new StallReasonIO(RenameWidth)
@@ -839,11 +841,54 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     }
   }
 
+
+  val inValidVec = io.in.map(_.valid)
+  val inReadyVec = io.in.map(_.ready)
+  val outValidVec = io.debugOutValidVec.getOrElse(VecInit.fill(RenameWidth)(false.B))
+  val outReadyVec = io.out.map(_.ready)
+  val outFireVec = outReadyVec.zip(outValidVec).map { case (ready, valid) =>
+    ready && valid
+  }
+  val dispatchAllFire = io.debugDispatchAllFire.getOrElse(false.B)
+
+  // pre pipe stall/bubble
+  val decodeReason = io.stallReason.in.reason
+  val decodeStall  = !inValidVec.reduce(_ || _)
+  val decodeBubble = !inValidVec.reduce(_ && _) && !decodeStall
+  val renameStall = !(inReadyVec.reduce(_ || _))
+  val renameStallReason = Wire(chiselTypeOf(io.stallReason.in.reason(0)))
+
+  val outHasValidAllFire = outValidVec.reduce(_ || _) && dispatchAllFire
+
+
+  val decodeBubbleValidVec = WireInit(VecInit.fill(RenameWidth)(false.B))
+  val decodeBubbleReasonVec = Wire(chiselTypeOf(io.stallReason.in.reason))
+
+  // prepipe bubble
+  for (i <- 0 until RenameWidth) {
+    val decodeBubbleValid = decodeBubble && !inValidVec(i)
+    val bubbleStore = Module(new StoreBubbleReason(log2Ceil(TopDownCounters.NumStallReasons.id)))
+    bubbleStore.io.bubbleValid := decodeBubbleValid
+    bubbleStore.io.bubbleReason := decodeReason(i)
+    bubbleStore.io.redirect := io.redirect.valid
+    bubbleStore.io.reasonFire := dispatchAllFire && !renameStall
+
+    decodeBubbleValidVec(i) := bubbleStore.io.outReasonValid
+    decodeBubbleReasonVec(i) := bubbleStore.io.outReason
+  }
+
+  // current pipe
+  // current stall
   // bad speculation (redirect)
-  val redirectStall      = io.redirect.valid
-  val ctrlRedirectStall  = io.redirect.bits.debugIsCtrl
-  val mvioRedirectStall  = io.redirect.bits.debugIsMemVio
-  val otherRedirectStall = redirectStall && !(ctrlRedirectStall || mvioRedirectStall)
+  val redirectStall       = io.redirect.valid
+  val ctrlRedirectStall   = io.redirect.bits.debugIsCtrl
+  val mvioRedirectStall   = io.redirect.bits.debugIsMemVio
+  val otherRedirectStall  = redirectStall && !(ctrlRedirectStall || mvioRedirectStall)
+  val redirectStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+    ctrlRedirectStall  -> ControlRedirectStall.id.U,
+    mvioRedirectStall  -> MemVioRedirectStall.id.U,
+    otherRedirectStall -> OtherRedirectStall.id.U,
+  ))
 
   // bad pseculation  (rabwalk)
   val debugRedirect = RegEnable(io.redirect.bits, io.redirect.valid)
@@ -851,6 +896,11 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   val ctrlRecStall  = debugRedirect.debugIsCtrl
   val mvioRecStall  = debugRedirect.debugIsMemVio
   val otherRecStall = recStall && !(ctrlRecStall || mvioRecStall)
+  val recStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+    ctrlRecStall  -> ControlRecoveryStall.id.U,
+    mvioRecStall  -> MemVioRecoveryStall.id.U,
+    otherRecStall -> OtherRecoveryStall.id.U,
+  ))
   XSPerfAccumulate("recovery_stall", recStall)
   XSPerfAccumulate("control_recovery_stall", ctrlRecStall && recStall)
   XSPerfAccumulate("mem_violation_recovery_stall", mvioRecStall && recStall)
@@ -869,22 +919,35 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     !v0FreeList.io.canAllocate,
     !vlFreeList.io.canAllocate,
   )) > 1.U
-  // other stall
-  val otherStall = notRecStall && !intFlStall && !fpFlStall && !vecFlStall && !v0FlStall && !vlFlStall
+
+  renameStallReason := MuxCase(BackendOtherCoreStall.id.U, Seq(
+    redirectStall -> redirectStallReason,
+    recStall      -> recStallReason,
+    multiFlStall  -> MultiFlStall.id.U,
+    intFlStall    -> IntFlStall.id.U,
+    fpFlStall     -> FpFlStall.id.U,
+    vecFlStall    -> VecFlStall.id.U,
+    v0FlStall     -> V0FlStall.id.U,
+    vlFlStall     -> VlFlStall.id.U,
+  ))
+
+  // current pipe bubble
+  // Attention: rename does not generate bubble itself
+  val renameBubble = false.B
+  val renameBubbleReason = 0.U
+
   //TODO :delete?
   io.stallReason.in.backReason := 0.U.asTypeOf(io.stallReason.in.backReason)
-  val inValidVec = io.in.map(_.valid)
-  val outValidVec = io.out.map(_.valid)
-  val outFireVec = io.out.map(_.fire)
-  val decodeReason = io.stallReason.in.reason
+
   io.stallReason.out.reason.zipWithIndex.foreach{ case (stallReason, idx) =>
     val inValid = inValidVec(idx)
     val outValid = outValidVec(idx)
     val inReason = decodeReason(idx)
     // TopDown collect pre pipe reason
-    val prePipeStall = !inValidVec.reduce(_||_)
-    val prePipeBubble = !inValid && (inReason =/= NoStall.id.U)
+    val prePipeStall = decodeStall
+    val prePipeBubble = decodeBubbleValidVec(idx)
     val prePipeStallReason = inReason
+    val prePieBubbleReason = decodeBubbleReasonVec(idx)
     // other reason like out.ready will be collect by next stage dispatch
     //    if (backendParams.debugEn) {
     //      assert(!reset.asBool && (!inValid) && (inReason === NoStall.id.U || inReason === OtherCoreStall.id.U),
@@ -892,35 +955,23 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     //    }
     // TopDown count current stage stall
     val redirect = redirectStall
-    val redirectReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
-      ctrlRedirectStall  -> ControlRedirectStall.id.U,
-      mvioRedirectStall  -> MemVioRedirectStall.id.U,
-      otherRedirectStall -> OtherRedirectStall.id.U,
-    ))
+    val redirectReason = redirectStallReason
 
-    val renameStall = inValid && !outValid
-    val renameStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
-      ctrlRecStall  -> ControlRecoveryStall.id.U,
-      mvioRecStall  -> MemVioRecoveryStall.id.U,
-      otherRecStall -> OtherRecoveryStall.id.U,
-      multiFlStall  -> MultiFlStall.id.U,
-      intFlStall    -> IntFlStall.id.U,
-      fpFlStall     -> FpFlStall.id.U,
-      vecFlStall    -> VecFlStall.id.U,
-      v0FlStall     -> V0FlStall.id.U,
-      vlFlStall     -> VlFlStall.id.U,
-    ))
-    val dispatchFire = outFireVec.reduce(_||_)
+//    val dispatchHasFire = outFireVec.reduce(_ || _)
 
     val stallReasonPipe = Module(new PipelineStallReason(log2Ceil(TopDownCounters.NumStallReasons.id)))
+    stallReasonPipe.io.rightFire := outFireVec(idx)
+    stallReasonPipe.io.rightHasFire := outHasValidAllFire
     stallReasonPipe.io.prePipeStall := prePipeStall
     stallReasonPipe.io.prePipeStallReason := prePipeStallReason
     stallReasonPipe.io.prePipeBubble := prePipeBubble
+    stallReasonPipe.io.prePipeBubbleReason := prePieBubbleReason
     stallReasonPipe.io.redirect := redirect
     stallReasonPipe.io.redirectReason := redirectReason
     stallReasonPipe.io.currentPipeStall := renameStall
     stallReasonPipe.io.currentPipeStallReason := renameStallReason
-    stallReasonPipe.io.pastPipeFire := dispatchFire
+    stallReasonPipe.io.currentPipeBubble := renameBubble
+    stallReasonPipe.io.currentPipeBubbleReason := renameBubbleReason
 
     stallReason := stallReasonPipe.io.outReason
   }

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -871,7 +871,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     bubbleStore.io.bubbleValid := decodeBubbleValid
     bubbleStore.io.bubbleReason := decodeReason(i)
     bubbleStore.io.redirect := io.redirect.valid
-    bubbleStore.io.reasonFire := dispatchAllFire && !renameStall
+    bubbleStore.io.reasonFire := outHasValidAllFire && !renameStall
 
     decodeBubbleValidVec(i) := bubbleStore.io.outReasonValid
     decodeBubbleReasonVec(i) := bubbleStore.io.outReason

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -932,7 +932,8 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   ))
 
   // current pipe bubble
-  // Attention: rename does not generate bubble itself
+  /** Attention: Special care is needed if this stage may generate its own bubble in later cases
+   */
   val renameBubble = false.B
   val renameBubbleReason = 0.U
 

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -23,9 +23,11 @@ import chisel3.util.experimental.decode.TruthTable
 import utility._
 import utils._
 import xiangshan._
+import xiangshan.TopDownCounters._
 import xiangshan.backend.Bundles.{DecodeOutUop, RenameOutUop, connectSamePort}
 import xiangshan.backend.decode.{FusionDecodeInfo, ImmUnion, Imm_Z, XSDebugDecode}
 import xiangshan.backend.fu.FuType
+import xiangshan.backend.PipelineStallReason
 import xiangshan.backend.rename.freelist._
 import xiangshan.backend.rob.{RobEnqIO, RobPtr}
 import xiangshan.mem.mdp._
@@ -836,49 +838,91 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
       assert(x.bits.ldest =/= 0.U, "rfWen cannot be 1 when Int regfile ldest is 0")
     }
   }
+
+  // bad speculation (redirect)
+  val redirectStall      = io.redirect.valid
+  val ctrlRedirectStall  = io.redirect.bits.debugIsCtrl
+  val mvioRedirectStall  = io.redirect.bits.debugIsMemVio
+  val otherRedirectStall = redirectStall && !(ctrlRedirectStall || mvioRedirectStall)
+
+  // bad pseculation  (rabwalk)
   val debugRedirect = RegEnable(io.redirect.bits, io.redirect.valid)
-  // bad speculation
-  val recStall = io.redirect.valid || io.rabCommits.isWalk
-  val ctrlRecStall = Mux(io.redirect.valid, io.redirect.bits.debugIsCtrl, io.rabCommits.isWalk && debugRedirect.debugIsCtrl)
-  val mvioRecStall = Mux(io.redirect.valid, io.redirect.bits.debugIsMemVio, io.rabCommits.isWalk && debugRedirect.debugIsMemVio)
+  val recStall      = io.rabCommits.isWalk
+  val ctrlRecStall  = debugRedirect.debugIsCtrl
+  val mvioRecStall  = debugRedirect.debugIsMemVio
   val otherRecStall = recStall && !(ctrlRecStall || mvioRecStall)
   XSPerfAccumulate("recovery_stall", recStall)
-  XSPerfAccumulate("control_recovery_stall", ctrlRecStall)
-  XSPerfAccumulate("mem_violation_recovery_stall", mvioRecStall)
-  XSPerfAccumulate("other_recovery_stall", otherRecStall)
-  // freelist stall
+  XSPerfAccumulate("control_recovery_stall", ctrlRecStall && recStall)
+  XSPerfAccumulate("mem_violation_recovery_stall", mvioRecStall && recStall)
+  XSPerfAccumulate("other_recovery_stall", otherRecStall && recStall)
+  // freelist stall (we temporarily make the priority: int > fp > vec > v0 > vl)
   val notRecStall = !io.out.head.valid && !recStall
-  val intFlStall = notRecStall && inHeadValid && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !intFreeList.io.canAllocate
-  val fpFlStall = notRecStall && inHeadValid && intFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !fpFreeList.io.canAllocate
-  val vecFlStall = notRecStall && inHeadValid && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !vecFreeList.io.canAllocate
-  val v0FlStall = notRecStall && inHeadValid && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && vlFreeList.io.canAllocate && !v0FreeList.io.canAllocate
-  val vlFlStall = notRecStall && inHeadValid && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && !vlFreeList.io.canAllocate
-  val multiFlStall = notRecStall && inHeadValid && (PopCount(Cat(
+  val intFlStall  = !intFreeList.io.canAllocate
+  val fpFlStall   = !fpFreeList.io.canAllocate
+  val vecFlStall  = !vecFreeList.io.canAllocate
+  val v0FlStall   = !v0FreeList.io.canAllocate
+  val vlFlStall   = !vlFreeList.io.canAllocate
+  val multiFlStall = PopCount(Cat(
     !intFreeList.io.canAllocate,
     !fpFreeList.io.canAllocate,
     !vecFreeList.io.canAllocate,
     !v0FreeList.io.canAllocate,
     !vlFreeList.io.canAllocate,
-  )) > 1.U)
+  )) > 1.U
   // other stall
-  val otherStall = notRecStall && !intFlStall && !fpFlStall && !vecFlStall && !v0FlStall && !vlFlStall && !multiFlStall
+  val otherStall = notRecStall && !intFlStall && !fpFlStall && !vecFlStall && !v0FlStall && !vlFlStall
+  //TODO :delete?
+  io.stallReason.in.backReason := 0.U.asTypeOf(io.stallReason.in.backReason)
+  val inValidVec = io.in.map(_.valid)
+  val outValidVec = io.out.map(_.valid)
+  val outFireVec = io.out.map(_.fire)
+  val decodeReason = io.stallReason.in.reason
+  io.stallReason.out.reason.zipWithIndex.foreach{ case (stallReason, idx) =>
+    val inValid = inValidVec(idx)
+    val outValid = outValidVec(idx)
+    val inReason = decodeReason(idx)
+    // TopDown collect pre pipe reason
+    val prePipeStall = !inValidVec.reduce(_||_)
+    val prePipeBubble = !inValid && (inReason =/= NoStall.id.U)
+    val prePipeStallReason = inReason
+    // other reason like out.ready will be collect by next stage dispatch
+    //    if (backendParams.debugEn) {
+    //      assert(!reset.asBool && (!inValid) && (inReason === NoStall.id.U || inReason === OtherCoreStall.id.U),
+    //        "[TopDown]: Rename has no instruction in ,but reason is null")
+    //    }
+    // TopDown count current stage stall
+    val redirect = redirectStall
+    val redirectReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+      ctrlRedirectStall  -> ControlRedirectStall.id.U,
+      mvioRedirectStall  -> MemVioRedirectStall.id.U,
+      otherRedirectStall -> OtherRedirectStall.id.U,
+    ))
 
-  io.stallReason.in.backReason.valid := io.stallReason.out.backReason.valid || !io.in.head.ready
-  io.stallReason.in.backReason.bits := Mux(io.stallReason.out.backReason.valid, io.stallReason.out.backReason.bits,
-    MuxCase(TopDownCounters.OtherCoreStall.id.U, Seq(
-      ctrlRecStall  -> TopDownCounters.ControlRecoveryStall.id.U,
-      mvioRecStall  -> TopDownCounters.MemVioRecoveryStall.id.U,
-      otherRecStall -> TopDownCounters.OtherRecoveryStall.id.U,
-      intFlStall    -> TopDownCounters.IntFlStall.id.U,
-      fpFlStall     -> TopDownCounters.FpFlStall.id.U,
-      vecFlStall    -> TopDownCounters.VecFlStall.id.U,
-      v0FlStall     -> TopDownCounters.V0FlStall.id.U,
-      vlFlStall     -> TopDownCounters.VlFlStall.id.U,
-      multiFlStall  -> TopDownCounters.MultiFlStall.id.U,
-    )
-  ))
-  io.stallReason.out.reason.zip(io.stallReason.in.reason).zip(io.in.map(_.valid)).foreach { case ((out, in), valid) =>
-    out := Mux(io.stallReason.in.backReason.valid, io.stallReason.in.backReason.bits, in)
+    val renameStall = inValid && !outValid
+    val renameStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+      ctrlRecStall  -> ControlRecoveryStall.id.U,
+      mvioRecStall  -> MemVioRecoveryStall.id.U,
+      otherRecStall -> OtherRecoveryStall.id.U,
+      multiFlStall  -> MultiFlStall.id.U,
+      intFlStall    -> IntFlStall.id.U,
+      fpFlStall     -> FpFlStall.id.U,
+      vecFlStall    -> VecFlStall.id.U,
+      v0FlStall     -> V0FlStall.id.U,
+      vlFlStall     -> VlFlStall.id.U,
+    ))
+    val dispatchFire = outFireVec.reduce(_||_)
+
+    val stallReasonPipe = Module(new PipelineStallReason(log2Ceil(TopDownCounters.NumStallReasons.id)))
+    stallReasonPipe.io.prePipeStall := prePipeStall
+    stallReasonPipe.io.prePipeStallReason := prePipeStallReason
+    stallReasonPipe.io.prePipeBubble := prePipeBubble
+    stallReasonPipe.io.redirect := redirect
+    stallReasonPipe.io.redirectReason := redirectReason
+    stallReasonPipe.io.currentPipeStall := renameStall
+    stallReasonPipe.io.currentPipeStallReason := renameStallReason
+    stallReasonPipe.io.pastPipeFire := dispatchFire
+
+    stallReason := stallReasonPipe.io.outReason
   }
 
   XSDebug(io.rabCommits.isWalk, p"Walk Recovery Enabled\n")

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -122,6 +122,8 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     })
     val debug_ls = Flipped(new DebugLSIO)
     val debugRobHeadFuType = Output(FuType())
+    val debugBlockBackward = Option.when(backendParams.debugEn)(Output(Bool()))
+    val debugWaitForward   = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugEnqLsq = Input(new LsqEnqIO)
     val debugHeadLsIssue = Input(Bool())
     val lsTopdownInfo = Vec(LduCnt + HyuCnt, Input(new LsTopdownInfo))
@@ -433,6 +435,9 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   when(io.commits.hasWalkInstr || io.commits.hasCommitInstr) {
     hasWaitForward := false.B
   }
+
+  io.debugWaitForward.foreach(_ := hasWaitForward)
+  io.debugBlockBackward.foreach(_ := hasBlockBackward)
 
   // The wait-for-interrupt (WFI) instruction waits in the ROB until an interrupt might need servicing.
   // io.csr.wfiEvent will be asserted if the WFI can resume execution, and we change the state to s_wfi_idle.

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -454,22 +454,12 @@ object BlameBpuSource {
   }
 }
 
-class BpuPerfInfo(implicit p: Parameters) extends FrontendBundle {
-  val bpRight: UInt = UInt(XLEN.W)
-  val bpWrong: UInt = UInt(XLEN.W)
-}
-
 class BpuTopDownInfo(implicit p: Parameters) extends FrontendBundle {
   val btbMissBubble:    Bool = Bool()
   val tageMissBubble:   Bool = Bool()
   val scMissBubble:     Bool = Bool()
   val ittageMissBubble: Bool = Bool()
   val rasMissBubble:    Bool = Bool()
-}
-
-class FrontendPerfInfo(implicit p: Parameters) extends FrontendBundle {
-  val ibufFull: Bool        = Bool()
-  val bpuInfo:  BpuPerfInfo = new BpuPerfInfo
 }
 
 class FrontendDebugTopDownInfo(implicit p: Parameters) extends FrontendBundle {

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -46,11 +46,6 @@ import xiangshan.frontend.icache.ICacheTopdownInfo
 import xiangshan.frontend.instruncache.InstrUncacheReq
 import xiangshan.frontend.instruncache.InstrUncacheResp
 
-class FrontendTopDownBundle(implicit p: Parameters) extends FrontendBundle {
-  val reasons:    Vec[Bool] = Vec(TopDownCounters.NumStallReasons.id, Bool())
-  val stallWidth: UInt      = UInt(FetchBlockInstOffsetWidth.W)
-}
-
 class BpuToFtqIO(implicit p: Parameters) extends FrontendBundle {
   val prediction: DecoupledIO[BpuPrediction] = Decoupled(new BpuPrediction)
   val meta:       DecoupledIO[BpuMeta]       = Decoupled(new BpuMeta)
@@ -142,10 +137,9 @@ class FtqToIfuIO(implicit p: Parameters) extends FrontendBundle {
     val fetch:       Vec[FetchRequestBundle] = Vec(FetchPorts, new FetchRequestBundle)
     val topdownInfo: FrontendTopDownBundle   = new FrontendTopDownBundle
   }
-  val req:             DecoupledIO[FtqToIfuReq] = Decoupled(new FtqToIfuReq)
-  val redirect:        Valid[Redirect]          = Valid(new Redirect)
-  val topdownRedirect: Valid[Redirect]          = Valid(new Redirect) // TODO: what's this for?
-  val flushFromBpu:    BpuFlushInfo             = new BpuFlushInfo
+  val req:          DecoupledIO[FtqToIfuReq] = Decoupled(new FtqToIfuReq)
+  val redirect:     Valid[Redirect]          = Valid(new Redirect)
+  val flushFromBpu: BpuFlushInfo             = new BpuFlushInfo
 }
 
 class FrontendRedirect(implicit p: Parameters) extends FrontendBundle {
@@ -454,12 +448,36 @@ object BlameBpuSource {
   }
 }
 
-class BpuTopDownInfo(implicit p: Parameters) extends FrontendBundle {
+class BackendRedirectTopdown(implicit p: Parameters) extends FrontendBundle {
+  val backendRedirect:         Bool = Bool()
+  val controlFlowRedirect:     Bool = Bool()
+  val memoryViolationRedirect: Bool = Bool()
+
   val btbMissBubble:    Bool = Bool()
   val tageMissBubble:   Bool = Bool()
   val scMissBubble:     Bool = Bool()
   val ittageMissBubble: Bool = Bool()
   val rasMissBubble:    Bool = Bool()
+}
+
+class FrontendTopDownBundle(implicit p: Parameters) extends FrontendBundle {
+  val reasons:    Vec[Bool] = Vec(TopDownCounters.NumStallReasons.id, Bool())
+  val stallWidth: UInt      = UInt(FetchBlockInstOffsetWidth.W)
+
+  def backendRedirectOverride(backendRedirectTopdown: BackendRedirectTopdown): Unit =
+    when(backendRedirectTopdown.backendRedirect) {
+      when(backendRedirectTopdown.controlFlowRedirect) {
+        reasons(TopDownCounters.BTBMissBubble.id)    := backendRedirectTopdown.btbMissBubble
+        reasons(TopDownCounters.TAGEMissBubble.id)   := backendRedirectTopdown.tageMissBubble
+        reasons(TopDownCounters.SCMissBubble.id)     := backendRedirectTopdown.scMissBubble
+        reasons(TopDownCounters.ITTAGEMissBubble.id) := backendRedirectTopdown.ittageMissBubble
+        reasons(TopDownCounters.RASMissBubble.id)    := backendRedirectTopdown.rasMissBubble
+      }.elsewhen(backendRedirectTopdown.memoryViolationRedirect) {
+        reasons(TopDownCounters.MemVioRedirectBubble.id) := true.B
+      }.otherwise {
+        reasons(TopDownCounters.OtherRedirectBubble.id) := true.B
+      }
+    }
 }
 
 class FrontendDebugTopDownInfo(implicit p: Parameters) extends FrontendBundle {

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -87,7 +87,6 @@ class FrontendIO(implicit p: Parameters) extends FrontendBundle {
   val resetInFrontend: Bool = Output(Bool())
 
   // perf
-  val frontendInfo: FrontendPerfInfo         = Output(new FrontendPerfInfo)
   val debugTopDown: FrontendDebugTopDownInfo = Flipped(new FrontendDebugTopDownInfo)
 
   // mbist
@@ -244,7 +243,6 @@ class FrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBase(
   ftq.io.fromBackend <> io.backend.toFtq
   io.backend.fromFtq := ftq.io.toBackend
   io.backend.fromIfu := ifu.io.toBackend
-  io.frontendInfo.bpuInfo <> ftq.io.bpuInfo
 
   ibuffer.io.flush           := needFlush
   ibuffer.io.controlRedirect := flushControlRedirect
@@ -266,7 +264,6 @@ class FrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBase(
 
   itlbRepeater1.io.debugTopDown.robHeadVaddr := io.debugTopDown.robHeadVaddr.map(_.toUInt)
 
-  io.frontendInfo.ibufFull := RegNext(ibuffer.io.full)
   io.resetInFrontend       := reset.asBool
 
   // PFEvent

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -137,9 +137,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBase(
   private val ibuffer      = Module(new IBuffer)
   private val ftq          = Module(new Ftq)
 
-  private val needFlush            = RegNext(io.backend.toFtq.redirect.valid)
-  private val flushControlRedirect = RegNext(io.backend.toFtq.redirect.bits.debugIsCtrl)
-  private val flushMemVioRedirect  = RegNext(io.backend.toFtq.redirect.bits.debugIsMemVio)
+  private val needFlush = RegNext(io.backend.toFtq.redirect.valid)
 
   private val tlbCsr  = DelayN(io.tlbCsr, TlbCsrPortDelay)
   private val csrCtrl = DelayN(io.csrCtrl, CsrCtrlPortDelay)
@@ -245,10 +243,11 @@ class FrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBase(
   io.backend.fromIfu := ifu.io.toBackend
 
   ibuffer.io.flush           := needFlush
-  ibuffer.io.controlRedirect := flushControlRedirect
-  ibuffer.io.memVioRedirect  := flushMemVioRedirect
-  ibuffer.io.bpuTopDownInfo  := ftq.io.bpuTopDownInfo
   ibuffer.io.decodeCanAccept := io.backend.canAccept
+
+  // Topdown analysis
+  ifu.io.backendRedirectTopdown     := ftq.io.backendRedirectTopdown
+  ibuffer.io.backendRedirectTopdown := ftq.io.backendRedirectTopdown
 
   io.backend.cfVec <> ibuffer.io.out
   io.backend.stallReason <> ibuffer.io.stallReason
@@ -264,7 +263,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBase(
 
   itlbRepeater1.io.debugTopDown.robHeadVaddr := io.debugTopDown.robHeadVaddr.map(_.toUInt)
 
-  io.resetInFrontend       := reset.asBool
+  io.resetInFrontend := reset.asBool
 
   // PFEvent
   private val pfevent = Module(new PFEvent)

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -34,9 +34,9 @@ import utility.XSPerfPriorityAccumulate
 import xiangshan.RedirectLevel
 import xiangshan.TopDownCounters
 import xiangshan.backend.CtrlToFtqIO
+import xiangshan.frontend.BackendRedirectTopdown
 import xiangshan.frontend.BlameBpuSource
 import xiangshan.frontend.BpuToFtqIO
-import xiangshan.frontend.BpuTopDownInfo
 import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.FetchRequestBundle
 import xiangshan.frontend.FrontendTopDownBundle
@@ -70,8 +70,8 @@ class Ftq(implicit p: Parameters) extends FtqModule
     val fromBackend: CtrlToFtqIO = Flipped(new CtrlToFtqIO)
     val toBackend:   FtqToCtrlIO = new FtqToCtrlIO
 
-    // for perf
-    val bpuTopDownInfo: BpuTopDownInfo = Output(new BpuTopDownInfo)
+    // Topdown analysis
+    val backendRedirectTopdown: BackendRedirectTopdown = Output(new BackendRedirectTopdown)
   }
 
   val io: FtqIO = IO(new FtqIO)
@@ -271,19 +271,6 @@ class Ftq(implicit p: Parameters) extends FtqModule
 
   io.toIfu.req.bits.fetch(1) := 0.U.asTypeOf(new FetchRequestBundle)
 
-  // toIFU topdown counters
-  val topdown_stage = RegInit(0.U.asTypeOf(new FrontendTopDownBundle()))
-  // only driven by clock, not valid-ready
-  topdown_stage                 := io.fromBpu.topdownReasons
-  io.toIfu.req.bits.topdownInfo := topdown_stage
-  when(backendRedirect.valid) {
-    // TODO: reasoning back to each BP component
-    when(backendRedirect.bits.debugIsMemVio) {
-      topdown_stage.reasons(TopDownCounters.MemVioRedirectBubble.id)                 := true.B
-      io.toIfu.req.bits.topdownInfo.reasons(TopDownCounters.MemVioRedirectBubble.id) := true.B
-    }
-  }
-
   // --------------------------------------------------------------------------------
   // Interaction with backend
   // --------------------------------------------------------------------------------
@@ -384,15 +371,31 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // --------------------------------------------------------------------------------
   // Performance monitoring
   // --------------------------------------------------------------------------------
-  // io.toIfu.req.bits.topdownInfo is assigned above
-  io.toIfu.topdownRedirect := backendRedirect
 
-  io.bpuTopDownInfo.btbMissBubble    := false.B // TODO: add more info to distinguish
-  io.bpuTopDownInfo.tageMissBubble   := RegNext(backendRedirect.valid && backendRedirect.bits.attribute.isConditional)
-  io.bpuTopDownInfo.scMissBubble     := false.B // TODO: add SC info
-  io.bpuTopDownInfo.ittageMissBubble := RegNext(backendRedirect.valid && backendRedirect.bits.attribute.needIttage)
-  io.bpuTopDownInfo.rasMissBubble    := RegNext(backendRedirect.valid && backendRedirect.bits.attribute.isReturn)
+  // Topdown analysis
+  io.backendRedirectTopdown.backendRedirect         := backendRedirect.valid
+  io.backendRedirectTopdown.controlFlowRedirect     := backendRedirect.bits.debugIsCtrl
+  io.backendRedirectTopdown.memoryViolationRedirect := backendRedirect.bits.debugIsMemVio
 
+  io.backendRedirectTopdown.btbMissBubble    := false.B // TODO: add more info to distinguish
+  io.backendRedirectTopdown.tageMissBubble   := backendRedirect.bits.attribute.isConditional
+  io.backendRedirectTopdown.scMissBubble     := false.B // TODO: add SC info
+  io.backendRedirectTopdown.ittageMissBubble := backendRedirect.bits.attribute.needIttage
+  io.backendRedirectTopdown.rasMissBubble    := backendRedirect.bits.attribute.isReturn
+
+  private val topdownStage = RegInit(0.U.asTypeOf(new FrontendTopDownBundle))
+  // only driven by clock, not valid-ready
+  topdownStage := io.fromBpu.topdownReasons
+  topdownStage.backendRedirectOverride(io.backendRedirectTopdown)
+  io.toIfu.req.bits.topdownInfo := topdownStage
+
+  when(distanceBetween(bpuPtr(0), commitPtr(0)) < FtqSize.U) {
+    topdownStage.reasons(TopDownCounters.FtqFullStall.id) := true.B
+  }.elsewhen(distanceBetween(bpuPtr(0), ifuPtr(0)) < BpRunAheadDistance.U && bpTrainStallCnt < BpTrainStallLimit.U) {
+    topdownStage.reasons(TopDownCounters.FtqUpdateBubble.id) := true.B
+  }
+
+  // Hardware performance monitors
   val perfEvents: Seq[(String, UInt)] = Seq()
   generatePerfEvent()
 

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -35,7 +35,6 @@ import xiangshan.RedirectLevel
 import xiangshan.TopDownCounters
 import xiangshan.backend.CtrlToFtqIO
 import xiangshan.frontend.BlameBpuSource
-import xiangshan.frontend.BpuPerfInfo
 import xiangshan.frontend.BpuToFtqIO
 import xiangshan.frontend.BpuTopDownInfo
 import xiangshan.frontend.ExceptionType
@@ -70,8 +69,6 @@ class Ftq(implicit p: Parameters) extends FtqModule
 
     val fromBackend: CtrlToFtqIO = Flipped(new CtrlToFtqIO)
     val toBackend:   FtqToCtrlIO = new FtqToCtrlIO
-
-    val bpuInfo: BpuPerfInfo = Output(new BpuPerfInfo)
 
     // for perf
     val bpuTopDownInfo: BpuTopDownInfo = Output(new BpuTopDownInfo)
@@ -387,7 +384,6 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // --------------------------------------------------------------------------------
   // Performance monitoring
   // --------------------------------------------------------------------------------
-  io.bpuInfo := DontCare
   // io.toIfu.req.bits.topdownInfo is assigned above
   io.toIfu.topdownRedirect := backendRedirect
 

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -389,9 +389,9 @@ class Ftq(implicit p: Parameters) extends FtqModule
   topdownStage.backendRedirectOverride(io.backendRedirectTopdown)
   io.toIfu.req.bits.topdownInfo := topdownStage
 
-  when(distanceBetween(bpuPtr(0), commitPtr(0)) < FtqSize.U) {
+  when(!(distanceBetween(bpuPtr(0), commitPtr(0)) < FtqSize.U)) {
     topdownStage.reasons(TopDownCounters.FtqFullStall.id) := true.B
-  }.elsewhen(distanceBetween(bpuPtr(0), ifuPtr(0)) < BpRunAheadDistance.U && bpTrainStallCnt < BpTrainStallLimit.U) {
+  }.elsewhen(!(distanceBetween(bpuPtr(0), ifuPtr(0)) < BpRunAheadDistance.U && bpTrainStallCnt < BpTrainStallLimit.U)) {
     topdownStage.reasons(TopDownCounters.FtqUpdateBubble.id) := true.B
   }
 

--- a/src/main/scala/xiangshan/frontend/ibuffer/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/ibuffer/IBuffer.scala
@@ -365,14 +365,21 @@ class IBuffer(implicit p: Parameters) extends IBufferModule with HasCircularQueu
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // TopDown
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  private val topdownStage = RegInit(0.U.asTypeOf(new FrontendTopDownBundle))
-  topdownStage := io.in.bits.topdownInfo
-  topdownStage.backendRedirectOverride(io.backendRedirectTopdown)
+  private def numStages     = 2
+  private val topdownStages = RegInit(VecInit(Seq.fill(numStages)(0.U.asTypeOf(new FrontendTopDownBundle))))
 
-  private val matchBubble   = Wire(UInt(log2Up(TopDownCounters.NumStallReasons.id).W))
-  private val deqValidCount = PopCount(validVec.asBools)
+  topdownStages(0) := io.in.bits.topdownInfo
+  for (i <- 1 until numStages) {
+    topdownStages(i) := topdownStages(i - 1)
+  }
+
+  topdownStages.foreach(_.backendRedirectOverride(io.backendRedirectTopdown))
+
+  private val deqValidCount = PopCount(io.out.map(_.valid))
   private val deqWasteCount = DecodeWidth.U - deqValidCount
-  matchBubble := (TopDownCounters.NumStallReasons.id - 1).U - PriorityEncoder(topdownStage.reasons.reverse)
+  private val matchBubble = (TopDownCounters.NumStallReasons.id - 1).U - PriorityEncoder(
+    topdownStages(numStages - 1).reasons.reverse
+  )
 
   io.stallReason.reason.foreach(_ := 0.U)
   for (i <- 0 until DecodeWidth) {
@@ -381,7 +388,7 @@ class IBuffer(implicit p: Parameters) extends IBufferModule with HasCircularQueu
     }
   }
 
-  when(!(deqWasteCount === DecodeWidth.U || topdownStage.reasons.asUInt.orR)) {
+  when(!(deqWasteCount === DecodeWidth.U || topdownStages(numStages - 1).reasons.asUInt.orR)) {
     // should set reason for FetchFragmentationStall
     // topdownStage.reasons(TopDownCounters.FetchFragmentationStall.id) := true.B
     for (i <- 0 until DecodeWidth) {
@@ -389,11 +396,6 @@ class IBuffer(implicit p: Parameters) extends IBufferModule with HasCircularQueu
         io.stallReason.reason(DecodeWidth - i - 1) := TopDownCounters.FetchFragBubble.id.U
       }
     }
-  }
-
-  when(io.stallReason.backReason.valid) {
-    // Backend always overrides frontend reasons
-    io.stallReason.reason.map(_ := io.stallReason.backReason.bits)
   }
 
   // Debug info

--- a/src/main/scala/xiangshan/frontend/ibuffer/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/ibuffer/IBuffer.scala
@@ -366,7 +366,7 @@ class IBuffer(implicit p: Parameters) extends IBufferModule with HasCircularQueu
   // TopDown
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   private def numStages     = 2
-  private val topdownStages = RegInit(VecInit(Seq.fill(numStages)(0.U.asTypeOf(new FrontendTopDownBundle))))
+  private val topdownStages = RegInit(VecInit.fill(numStages)(0.U.asTypeOf(new FrontendTopDownBundle)))
 
   topdownStages(0) := io.in.bits.topdownInfo
   for (i <- 1 until numStages) {
@@ -378,7 +378,7 @@ class IBuffer(implicit p: Parameters) extends IBufferModule with HasCircularQueu
   private val deqValidCount = PopCount(io.out.map(_.valid))
   private val deqWasteCount = DecodeWidth.U - deqValidCount
   private val matchBubble = (TopDownCounters.NumStallReasons.id - 1).U - PriorityEncoder(
-    topdownStages(numStages - 1).reasons.reverse
+    topdownStages.last.reasons.reverse
   )
 
   io.stallReason.reason.foreach(_ := 0.U)
@@ -388,7 +388,7 @@ class IBuffer(implicit p: Parameters) extends IBufferModule with HasCircularQueu
     }
   }
 
-  when(!(deqWasteCount === DecodeWidth.U || topdownStages(numStages - 1).reasons.asUInt.orR)) {
+  when(!(deqWasteCount === DecodeWidth.U || topdownStages.last.reasons.asUInt.orR)) {
     // should set reason for FetchFragmentationStall
     // topdownStage.reasons(TopDownCounters.FetchFragmentationStall.id) := true.B
     for (i <- 0 until DecodeWidth) {

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -28,6 +28,7 @@ import utility.XORFold
 import xiangshan.FrontendTdataDistributeIO
 import xiangshan.cache.mmu.HasTlbConst
 import xiangshan.cache.mmu.TlbRequestIO
+import xiangshan.frontend.BackendRedirectTopdown
 import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.FetchToIBuffer
 import xiangshan.frontend.FrontendRedirect
@@ -76,6 +77,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
     // Backend: csr control
     val csrFsIsOff: Bool = Input(Bool())
+
+    // Topdown analysis
+    val backendRedirectTopdown: BackendRedirectTopdown = Input(new BackendRedirectTopdown)
   }
   val io: IfuIO = IO(new IfuIO)
 
@@ -809,9 +813,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
   perfAnalyzer.io.ifuPerfCtrl.fromBpuFlush     := s0_flushFromBpu(0) || s1_flushFromBpu(0) // FIXME
   perfAnalyzer.io.ifuPerfCtrl.fromICacheBubble := s1_valid && !s1_iCacheRespValid
 
-  perfAnalyzer.io.topdownIn.icacheTopdown   := io.fromICache.topdown
-  perfAnalyzer.io.topdownIn.ftqTopdown      := fromFtq.req.bits.topdownInfo
-  perfAnalyzer.io.topdownIn.topdownRedirect := fromFtq.topdownRedirect
+  perfAnalyzer.io.topdownIn.icacheTopdown          := io.fromICache.topdown
+  perfAnalyzer.io.topdownIn.ftqTopdown             := io.fromFtq.req.bits.topdownInfo
+  perfAnalyzer.io.topdownIn.backendRedirectTopdown := io.backendRedirectTopdown
 
   perfAnalyzer.io.perfInfo.icachePerfInfo                 := s3_icachePerfInfo
   perfAnalyzer.io.perfInfo.checkPerfInfo.valid(0)         := wbValid && wbFirstValid

--- a/src/main/scala/xiangshan/frontend/ifu/IfuPerfAnalysis.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/IfuPerfAnalysis.scala
@@ -90,7 +90,7 @@ class IfuPerfAnalysis(implicit p: Parameters) extends IfuModule {
 
   private def numOfStage = 3
   require(numOfStage > 1, "Ifu numOfStage must be greater than 1")
-  private val topdownStages = RegInit(VecInit(Seq.fill(numOfStage)(0.U.asTypeOf(new FrontendTopDownBundle))))
+  private val topdownStages = RegInit(VecInit.fill(numOfStage)(0.U.asTypeOf(new FrontendTopDownBundle)))
   // bubble events in IFU, only happen in stage 1
   private val icacheMissBubble = icacheTopdown.iCacheMissBubble
   private val itlbMissBubble   = icacheTopdown.itlbMissBubble

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -341,6 +341,9 @@ class LsqEnqCtrl(implicit p: Parameters) extends XSModule
     val lqFreeCount = Output(UInt(log2Up(VirtualLoadQueueSize + 1).W))
     val sqFreeCount = Output(UInt(log2Up(StoreQueueSize + 1).W))
     val enqLsq = Flipped(new LsqEnqIO)
+    // for topdown
+    val lqStall = OptionWrapper(backendParams.debugEn, Output(Bool()))
+    val sqStall = OptionWrapper(backendParams.debugEn, Output(Bool()))
   })
 
   val lqPtr = RegInit(0.U.asTypeOf(new LqPtr))
@@ -402,6 +405,10 @@ class LsqEnqCtrl(implicit p: Parameters) extends XSModule
   // after the last redirect, new instructions may enter but previously redirect has not been resolved (updated according to the cancel count from LSQ).
   // To solve the issue easily, we block enqueue when t3_update, which is RegNext(t2_update).
   io.enq.canAccept := RegNext(ldCanAccept && sqCanAccept && !t2_update)
+  // for Topdown
+  io.lqStall.foreach(_ := !ldCanAccept || t2_update)
+  io.sqStall.foreach(_ := !sqCanAccept || t2_update)
+
   val lqOffset = Wire(Vec(io.enq.resp.length, UInt(lqPtr.value.getWidth.W)))
   val sqOffset = Wire(Vec(io.enq.resp.length, UInt(sqPtr.value.getWidth.W)))
   for ((resp, i) <- io.enq.resp.zipWithIndex) {

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -1004,7 +1004,7 @@ package object xiangshan {
     val VecIQFullStall = Value("VecIQFullStall")
     val LoadIQFullStall = Value("LoadIQFullStall")
     val StoreIQFullStall = Value("StoreIQFullStall")
-    val MultiIssueStall = Value("MultiIssueStall")
+    val OtherIQFullStall = Value("OtherIQFullStall")
 
     // memblock
     val LoadTLBStall = Value("LoadTLBStall")

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -992,8 +992,6 @@ package object xiangshan {
     val LoadDispatchPolicyStall = Value("LoadDispatchPolicyStall")
     val StoreDispatchPolicyStall = Value("StoreDispatchPolicyStall")
     val OtherDispatchPolicyStall = Value("OtherDispatchPolicyStall")
-    // load store queue stall dispatch
-    val LoadStoreStallDispatch = Value("LoadStoreQueueStallDispatch")
     // dispatch stall for issuequeue full
     val IntIQFullStallAlu = Value("IntIQFullStallAlu")
     val IntIQFullStallBrh = Value("IntIQFullStallBrh")

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -1004,6 +1004,8 @@ package object xiangshan {
     val BalanceDispatchPolicyStallVec = Value("BalanceDispatchPolicyStallVec")
     val BalanceDispatchPolicyStallLoad = Value("BalanceDispatchPolicyStallLoad")
     val BalanceDispatchPolicyStallStore = Value("BalanceDispatchPolicyStallStore")
+    val IQEnqPolicyStallIssued = Value("IQEnqPolicyStallIssued")
+    val IQEnqPolicyStall = Value("IQEnqPolicyStall")
     val IntIQFullStallAlu = Value("IntIQFullStallAlu")
     val IntIQFullStallBrh = Value("IntIQFullStallBrh")
     val IntIQFullStallOther = Value("IntIQFullStallOther")

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -986,6 +986,22 @@ package object xiangshan {
     val V0FlStall = Value("V0FlStall")
     val VlFlStall = Value("VlFlStall")
     val MultiFlStall = Value("MultiFlStall")
+    // dispatch stall
+    // dispatch stall for dispatch policy
+    // TODO: explain only load store exist
+    val LoadDispatchPolicyStall = Value("LoadDispatchPolicyStall")
+    val StoreDispatchPolicyStall = Value("StoreDispatchPolicyStall")
+    val OtherDispatchPolicyStall = Value("OtherDispatchPolicyStall")
+    // load store queue stall dispatch
+    val LoadStoreStallDispatch = Value("LoadStoreQueueStallDispatch")
+    // dispatch stall for issuequeue full
+    val IntIQFullStallAlu = Value("IntIQFullStallAlu")
+    val IntIQFullStallBrh = Value("IntIQFullStallBrh")
+    val IntIQFullStallOther = Value("IntIQFullStallOther")
+    val FpIQFullStall = Value("FpIQFullStall")
+    val VecIQFullStall = Value("VecIQFullStall")
+    val LoadIQFullStall = Value("LoadIQFullStall")
+    val StoreIQFullStall = Value("StoreIQFullStall")
 
     // memblock
     val LoadTLBStall = Value("LoadTLBStall")

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -995,9 +995,15 @@ package object xiangshan {
     // TODO: explain only load store exist
     val LoadDispatchPolicyStall = Value("LoadDispatchPolicyStall")
     val StoreDispatchPolicyStall = Value("StoreDispatchPolicyStall")
-    val BalanceDispatchPolicyStall = Value("BalanceDispatchPolicyStall")
     val OtherDispatchPolicyStall = Value("OtherDispatchPolicyStall")
     // dispatch stall for issuequeue full
+    val BalanceDispatchPolicyStallAlu = Value("BalanceDispatchPolicyStallAlu")
+    val BalanceDispatchPolicyStallBrh = Value("BalanceDispatchPolicyStallBrh")
+    val BalanceDispatchPolicyStallInt = Value("BalanceDispatchPolicyStallInt")
+    val BalanceDispatchPolicyStallFp = Value("BalanceDispatchPolicyStallFp")
+    val BalanceDispatchPolicyStallVec = Value("BalanceDispatchPolicyStallVec")
+    val BalanceDispatchPolicyStallLoad = Value("BalanceDispatchPolicyStallLoad")
+    val BalanceDispatchPolicyStallStore = Value("BalanceDispatchPolicyStallStore")
     val IntIQFullStallAlu = Value("IntIQFullStallAlu")
     val IntIQFullStallBrh = Value("IntIQFullStallBrh")
     val IntIQFullStallOther = Value("IntIQFullStallOther")

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -972,6 +972,7 @@ package object xiangshan {
     val ITLBMissBubble = Value("ITLBMissBubble")
     val BTBMissBubble = Value("BTBMissBubble")
     val FetchFragBubble = Value("FetchFragBubble")
+    val FrontendOtherCoreStall = Value("FrontendOtherCoreStall")
 
     // backend
     // long inst stall at rob head
@@ -979,6 +980,7 @@ package object xiangshan {
     val IntNotReadyStall = Value("IntNotReadyStall") // int-inst at rob head not issue
     val FPNotReadyStall = Value("FPNotReadyStall") // fp-inst at rob head not issue
     val MemNotReadyStall = Value("MemNotReadyStall") // mem-inst at rob head not issue
+    val RobStall = Value("RobStall")
     // freelist full
     val IntFlStall = Value("IntFlStall")
     val FpFlStall = Value("FpFlStall")
@@ -986,6 +988,8 @@ package object xiangshan {
     val V0FlStall = Value("V0FlStall")
     val VlFlStall = Value("VlFlStall")
     val MultiFlStall = Value("MultiFlStall")
+    // fusion bubble
+    val FusionBubble = Value("FusionBubble")
     // dispatch stall
     // dispatch stall for dispatch policy
     // TODO: explain only load store exist
@@ -1000,6 +1004,7 @@ package object xiangshan {
     val VecIQFullStall = Value("VecIQFullStall")
     val LoadIQFullStall = Value("LoadIQFullStall")
     val StoreIQFullStall = Value("StoreIQFullStall")
+    val MultiIssueStall = Value("MultiIssueStall")
 
     // memblock
     val LoadTLBStall = Value("LoadTLBStall")
@@ -1015,13 +1020,17 @@ package object xiangshan {
     val LoadMSHRReplayStall = Value("LoadMSHRReplayStall")
 
     // bad speculation
+    val ControlRedirectStall = Value("ControlRedirectStall")
+    val MemVioRedirectStall = Value("MemVioRedirectStall")
+    val OtherRedirectStall = Value("OtherRedirectStall")
     val ControlRecoveryStall = Value("ControlRecoveryStall")
     val MemVioRecoveryStall = Value("MemVioRecoveryStall")
     val OtherRecoveryStall = Value("OtherRecoveryStall")
 
     val FlushedInsts = Value("FlushedInsts") // control flushed, memvio flushed, others
+    val SpecialInsts = Value("SpecialInsts")
 
-    val OtherCoreStall = Value("OtherCoreStall")
+    val BackendOtherCoreStall = Value("BackendOtherCoreStall")
 
     val NumStallReasons = Value("NumStallReasons")
   }

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -995,6 +995,7 @@ package object xiangshan {
     // TODO: explain only load store exist
     val LoadDispatchPolicyStall = Value("LoadDispatchPolicyStall")
     val StoreDispatchPolicyStall = Value("StoreDispatchPolicyStall")
+    val BalanceDispatchPolicyStall = Value("BalanceDispatchPolicyStall")
     val OtherDispatchPolicyStall = Value("OtherDispatchPolicyStall")
     // dispatch stall for issuequeue full
     val IntIQFullStallAlu = Value("IntIQFullStallAlu")


### PR DESCRIPTION
The initial objective is to eliminate the `OtherCoreStall` reason in current topdown report. However, there seems to be much more problems with the topdown system. This PR tries to fix the long-broken topdown system across the whole core.

The main change is that the original stall-reason summarization based on cross-stage bypassing—which led to a large number of unattributable cases categorized as `OtherCore` reasons—has been replaced with a more precise attribution scheme that propagates with slots stage by stage through the pipeline. Each pipeline stage is responsible for receiving forwarded reasons from the previous stage, masking out invalid attributions, analyzing the causes local to the current stage, packaging the blocking reasons from the current stage’s perspective, and passing them to the next stage. Eventually, from the perspective of the dispatch stage, the final blocking attribution is obtained.

In addition, this PR also refines the backend attribution logic, including more fine-grained attribution for dispatch-to-IQ blocking, as well as attribution for ROB stall, LSQ stall, and others. The top-down related scripts have also been updated, with several new features added, including comparison support, cross-issue-queue-count comparison, multi-subdimension plotting, and standalone execution of the plotting script.

As well as some miscellaneous related changes: `new dispatch` has been renamed to `dispatch`, and `BackendV2Config` has been changed to the CHI configuration.

After the above changes, the original goal has been largely achieved: in the checkpoint results, there are almost no unattributable cases left, except for a small remaining attribution failure related to the IBuffer, which will be addressed in the future.