### PR TITLE
build: fix forkArgs for xiangshan.test

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -227,7 +227,7 @@ object xiangshan extends ChiselModule {
   object test extends SbtTests with TestModule.ScalaTest {
     def moduleDeps: Seq[JavaModule] = super.moduleDeps ++ Seq(xiangshan, difftest.test)
 
-    def forkArgs: T[Seq[String]] = super.forkArgs
+    def forkArgs: T[Seq[String]] = xiangshan.forkArgs
 
     def scalacOptions: T[Seq[String]] = super.scalacOptions() ++ Seq("-deprecation", "-feature")
 


### PR DESCRIPTION
Previous we only pass forkArgs for xiangshan.runMain, such as JVM_XMX and JVM_XSS. This change also pass forkArgs for xiangshan. test.runMain for sim-verilog.