### PR TITLE
timing(IssueQueue): add og1Payload for int IQ to fix entries selection timing

### DIFF
--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -424,6 +424,11 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
         source.io.deqDelay(i).ready := s.ready && iqOut(i).ready
       }
     }
+    dataPath.io.fromIntIQDeqOg1Payload.get.zip(issueQueues).zip(io.intIQOut.get).map { case ((sink, source), iqOut) =>
+      sink.zipWithIndex.map { case (s, i) =>
+        s := source.io.deqOg1Payload(i)
+      }
+    }
     // for write int regfile and resp
     dataPath.io.fromFpIQ.zip(io.fromFpIQ.get).map { case (sink, source) =>
       sink <> source

--- a/src/main/scala/xiangshan/backend/datapath/BypassNetwork.scala
+++ b/src/main/scala/xiangshan/backend/datapath/BypassNetwork.scala
@@ -205,14 +205,14 @@ class BypassNetwork()(implicit p: Parameters, params: BackendParams) extends XSM
     }
     exuInput.bits.vl.foreach { _ := fromDPs(exuIdx).bits.vl.get }
 
-    if (exuParm.hasBrhFu) {
+    if (exuParm.hasBrhFu || exuParm.hasCSR || exuParm.hasFence) {
       val thisPcOffset = exuInput.bits.getPcOffset()
       val nextPcOffset = exuInput.bits.getNextPcOffset()
       val isJALR = FuType.isJump(fuType) && JumpOpType.jumpOpisJalr(fuOpType)
       val immBJU = imm + Mux(isJALR, 0.U, SignExt(thisPcOffset, imm.getWidth))
       val immCsrFence = immInfo(exuIdx).imm
       exuInput.bits.imm := Mux((FuType.isCsr(fuType) || FuType.isFence(fuType))&& exuParm.hasCSR.B, immCsrFence, immBJU)
-      exuInput.bits.nextPcOffset.get := nextPcOffset
+      exuInput.bits.nextPcOffset.foreach(_ := nextPcOffset)
       dontTouch(isJALR)
       dontTouch(immBJU)
       dontTouch(immCsrFence)

--- a/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
+++ b/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
@@ -457,6 +457,10 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     if(isEnq) {
       commonOut.entry.bits.status                     := status
     }
+    if (isEnq || !isComp) {
+      // Enq and Simp can back to back trans
+      commonOut.entry.bits.payload.og1Payload         := RegNext(entryReg.payload.og1Payload)
+    }
     commonOut.issueTimerRead                          := status.issueTimer
     commonOut.deqPortIdxRead                          := status.deqPortIdx
 

--- a/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
@@ -414,6 +414,10 @@ case class IssueBlockParams(
     MixedVec(exuBlockParams.filterNot(_.fakeUnit).map(x => ValidIO(new IssueQueueIssueBundle(this, x))))
   }
 
+  def genIssueDeqOg1PayloadBundle(implicit p: Parameters): MixedVec[Og1Payload] = {
+    MixedVec(exuBlockParams.filterNot(_.fakeUnit).map(x => new Og1Payload(x.issueBlockParam)))
+  }
+
   def genExuWakeUpOutValidBundle(implicit p: Parameters): MixedVec[DecoupledIO[IssueQueueIQWakeUpBundle]] = {
     val uncertainExuParams = this.allExuParams.filter(_.needUncertainWakeup)
     MixedVec(uncertainExuParams.map(param => {

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -56,6 +56,7 @@ class IssueQueueIO()(implicit p: Parameters, params: IssueBlockParams) extends X
   val srcReadyVec = Output(Vec(params.numEntries, Bool()))
 
   val deqDelay: MixedVec[DecoupledIO[IssueQueueIssueBundle]] = params.genIssueDecoupledBundle// = deq.cloneType
+  val deqOg1Payload: MixedVec[Og1Payload] = params.genIssueDeqOg1PayloadBundle
   def allWakeUp = wakeupFromWB ++ wakeupFromIQ
 }
 
@@ -324,7 +325,10 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
       enq.bits.status.firstIssue                                := false.B
       enq.bits.status.issueTimer                                := 0.U
       enq.bits.status.deqPortIdx                                := 0.U
-      enq.bits.payload                                          := s0_enqBits(enqIdx)
+      connectSamePort(enq.bits.payload, s0_enqBits(enqIdx))
+      // for IssueQueueSta imm width is not 32
+      enq.bits.payload.imm.foreach(_                            := s0_enqBits(enqIdx).imm.get)
+      connectSamePort(enq.bits.payload.og1Payload, enq.bits.payload)
     }
     entriesIO.og0Resp                                           := io.og0Resp
     entriesIO.og1Resp                                           := io.og1Resp
@@ -345,6 +349,10 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
       entriesIO.simpEntryOldestSel.foreach(_(deqIdx)            := simpEntryOldestSel.get(deqIdx))
       entriesIO.compEntryOldestSel.foreach(_(deqIdx)            := compEntryOldestSel.get(deqIdx))
       entriesIO.othersEntryOldestSel.foreach(_(deqIdx)          := othersEntryOldestSel(deqIdx))
+      entriesIO.enqEntryOldestSelDelay(deqIdx)                  := RegNext(enqEntryOldestSel(deqIdx))
+      entriesIO.simpEntryOldestSelDelay.foreach(_(deqIdx)       := RegNext(simpEntryOldestSel.get(deqIdx)))
+      entriesIO.compEntryOldestSelDelay.foreach(_(deqIdx)       := RegNext(compEntryOldestSel.get(deqIdx)))
+      entriesIO.othersEntryOldestSelDelay.foreach(_(deqIdx)     := RegNext(othersEntryOldestSel(deqIdx)))
       entriesIO.subDeqRequest.foreach(_(deqIdx)                 := subDeqRequest.get)
       entriesIO.subDeqSelOH.foreach(_(deqIdx)                   := subDeqSelOHVec.get(deqIdx))
     }
@@ -968,6 +976,7 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
     sink.valid := source.valid
     sink.bits := source.bits
   }
+  io.deqOg1Payload := entries.io.deqOg1Payload
   if(backendParams.debugEn) {
     dontTouch(deqDelay)
     dontTouch(io.deqDelay)


### PR DESCRIPTION
Pipeline (by one cycle) and select a subset of signals that are only used in OG1 to optimize the IQ selection timing.
Follow-up PRs will further improve this by refining/splitting the payload, and after timing validation, rolling the changes out to all IQs.
