### PR TITLE
fix(imsic_axi_top): Register for output ports of imsic tl signals

### DIFF
--- a/src/main/scala/device/imsic_axi_top.scala
+++ b/src/main/scala/device/imsic_axi_top.scala
@@ -43,6 +43,7 @@ class imsic_bus_top(implicit p: Parameters) extends LazyModule with HasSoCParame
       fromMem :=
         TLWidthWidget(4) :=
         TLFIFOFixer() :=
+        TLBuffer() :=
         TLBuffer(BufferParams.pipe) :=
         tlnode
     }


### PR DESCRIPTION
Add parameter pipe for TLBuffer, to make output signals of ram are register, and satisfy rule of spyglass lint.