### PR TITLE
refactor(Configs): disambiguate config names with explicit bus protocal

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -80,8 +80,8 @@ body:
         Please provide your environment information.
         请提供您的环境信息。
 
-        XiangShan config specifies the XiangShan compilation options specified by `CONFIG=` when compiling XiangShan. If no option is specified, the default is `DefaultConfig`.
-        XiangShan config 为您编译香山时由 `CONFIG=` 指定的香山编译选项，如果没有显示指定，则默认为 `DefaultConfig`。
+        XiangShan config specifies the XiangShan compilation options specified by `CONFIG=` when compiling XiangShan. If no option is specified, the default is `TLConfig`.
+        XiangShan config 为您编译香山时由 `CONFIG=` 指定的香山编译选项，如果没有显示指定，则默认为 `TLConfig`。
       placeholder:
       value: |
         - XiangShan branch:

--- a/.github/ISSUE_TEMPLATE/3-problem.yaml
+++ b/.github/ISSUE_TEMPLATE/3-problem.yaml
@@ -67,8 +67,8 @@ body:
         Please provide your environment information.
         请提供您的环境信息。
 
-        XiangShan config specifies the XiangShan compilation options specified by `CONFIG=` when compiling XiangShan. If no option is specified, the default is `DefaultConfig`.
-        XiangShan config 为您编译香山时由 `CONFIG=` 指定的香山编译选项，如果没有显示指定，则默认为 `DefaultConfig`。
+        XiangShan config specifies the XiangShan compilation options specified by `CONFIG=` when compiling XiangShan. If no option is specified, the default is `TLConfig`.
+        XiangShan config 为您编译香山时由 `CONFIG=` 指定的香山编译选项，如果没有显示指定，则默认为 `TLConfig`。
 
         Tips:
          - gcc version: **run `gcc --version` and paste first line of the output**

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -84,11 +84,11 @@ jobs:
         run: |
           make sim-verilog CHISEL_TARGET=chirrtl
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
-      - name: build MinimalConfig Release emu
+      - name: build TLMinimalConfig Release emu
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
-            --threads 8 --config MinimalConfig --release --trace-fst
-      - name: run MinimalConfig - Linux
+            --threads 8 --config TLMinimalConfig --release --trace-fst
+      - name: run TLMinimalConfig - Linux
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 8 --numa --ci linux-hello-opensbi 2> perf.log
           cat perf.log | sort
@@ -258,11 +258,11 @@ jobs:
       - name: clean up
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
-      - name: build KunminghuV2Config Release emu
+      - name: build CHIConfig Release emu
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
-            --threads 8 --config KunminghuV2Config --release --trace-fst
-      - name: run KunminghuV2Config - Linux
+            --threads 8 --config CHIConfig --release --trace-fst
+      - name: run CHIConfig - Linux
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 8 --numa --ci linux-hello-opensbi 2> perf.log
           cat perf.log | sort

--- a/.github/workflows/perf-template.yml
+++ b/.github/workflows/perf-template.yml
@@ -21,7 +21,7 @@ on:
         description: Config for XiangShan core
         required: false
         type: string
-        default: KunminghuV2Config
+        default: CHIConfig
       benchmark_type:
         required: false
         type: string

--- a/.github/workflows/perf-trigger.yml
+++ b/.github/workflows/perf-trigger.yml
@@ -36,10 +36,10 @@ on:
         required: false
         type: choice
         options:
-          - KunminghuV2Config
-          - DefaultConfig
-          - BackendV2Config
-        default: KunminghuV2Config
+          - CHIConfig
+          - TLConfig
+          - TLBackendV2Config
+        default: CHIConfig
       benchmark_type:
         description: Benchmark type
         required: false

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ JAR = $(BUILD_DIR)/xsgen.jar
 SCALA_FILE = $(shell find ./src/main/scala -name '*.scala')
 TEST_FILE = $(shell find ./src/test/scala -name '*.scala')
 
-CONFIG ?= DefaultConfig
+CONFIG ?= TLConfig
 NUM_CORES ?= 1
 ISSUE ?= E.b
 CHISEL_TARGET ?= systemverilog

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ make idea
 Example:
 
 ```bash
-make emu CONFIG=MinimalConfig EMU_THREADS=2 -j10
+make emu CONFIG=TLMinimalConfig EMU_THREADS=2 -j10
 ./build/emu -b 0 -e 0 -i ./ready-to-run/coremark-2-iteration.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so
 ```
 

--- a/readme.zh-cn.md
+++ b/readme.zh-cn.md
@@ -111,7 +111,7 @@ make idea
 运行示例：
 
 ```bash
-make emu CONFIG=MinimalConfig EMU_THREADS=2 -j10
+make emu CONFIG=TLMinimalConfig EMU_THREADS=2 -j10
 ./build/emu -b 0 -e 0 -i ./ready-to-run/coremark-2-iteration.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so
 ```
 

--- a/scripts/generate_all.sh
+++ b/scripts/generate_all.sh
@@ -5,7 +5,7 @@ cd $NOOP_HOME
 
 for module in Frontend Backend MemBlock L2Top XSTile XSTop
 do
-  python3 scripts/parser.py $module --config DefaultConfig --prefix bosc_ --sram-replace --xs-home $(pwd) > generate_$module.log
+  python3 scripts/parser.py $module --config TLConfig --prefix bosc_ --sram-replace --xs-home $(pwd) > generate_$module.log
   mv generate_$module.log bosc_${module}-Release*
 done
 

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -61,7 +61,7 @@ object ArgParser {
     c.newInstance(1.asInstanceOf[Object]).asInstanceOf[Parameters]
   }
   def parse(args: Array[String]): (Parameters, Array[String], Array[String]) = {
-    val default = new DefaultConfig(1)
+    val default = new TLConfig(1)
     var firrtlOpts = Array[String]()
     var firtoolOpts = Array[String]()
     @tailrec

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -78,7 +78,7 @@ class BaseConfig(n: Int) extends Config((site, here, up) => {
 // * L1 cache included
 // * L2 cache NOT included
 // * L3 cache included
-class MinimalConfig(n: Int = 1) extends Config(
+class TLMinimalConfig(n: Int = 1) extends Config(
   new BaseConfig(n).alter((site, here, up) => {
     case XSTileKey => up(XSTileKey).map(
       p => p.copy(
@@ -287,10 +287,11 @@ class MinimalConfig(n: Int = 1) extends Config(
       )
   })
 )
+class MinimalConfig(n: Int = 1) extends TLMinimalConfig(n) with DeprecatedConfigWarning
 
 // Non-synthesizable MinimalConfig, for fast simulation only
-class MinimalSimConfig(n: Int = 1) extends Config(
-  new MinimalConfig(n).alter((site, here, up) => {
+class TLMinimalSimConfig(n: Int = 1) extends Config(
+  new TLMinimalConfig(n).alter((site, here, up) => {
     case XSTileKey => up(XSTileKey).map(_.copy(
       dcacheParametersOpt = None,
       softPTW = true
@@ -301,6 +302,7 @@ class MinimalSimConfig(n: Int = 1) extends Config(
     )
   })
 )
+class MinimalSimConfig(n: Int = 1) extends TLMinimalSimConfig(n) with DeprecatedConfigWarning
 
 case class WithNKBL1D(n: Int, ways: Int = 8) extends Config((site, here, up) => {
   case XSTileKey =>
@@ -433,13 +435,15 @@ class WithL3DebugConfig extends Config(
   L3CacheConfig("256KB", inclusive = false) ++ L2CacheConfig("64KB")
 )
 
-class MinimalL3DebugConfig(n: Int = 1) extends Config(
-  new WithL3DebugConfig ++ new MinimalConfig(n)
+class TLMinimalL3DebugConfig(n: Int = 1) extends Config(
+  new WithL3DebugConfig ++ new TLMinimalConfig(n)
 )
+class MinimalL3DebugConfig(n: Int = 1) extends TLMinimalL3DebugConfig(n) with DeprecatedConfigWarning
 
-class DefaultL3DebugConfig(n: Int = 1) extends Config(
+class TLDefaultL3DebugConfig(n: Int = 1) extends Config(
   new WithL3DebugConfig ++ new BaseConfig(n)
 )
+class DefaultL3DebugConfig(n: Int = 1) extends TLDefaultL3DebugConfig(n) with DeprecatedConfigWarning
 
 class WithFuzzer extends Config((site, here, up) => {
   case DebugOptionsKey => up(DebugOptionsKey).copy(
@@ -462,8 +466,8 @@ class WithFuzzer extends Config((site, here, up) => {
   }
 })
 
-class FrontendDebugConfig(n: Int = 1) extends Config(
-  (new DefaultConfig(n)).alter((site, here, up) => {
+class TLFrontendDebugConfig(n: Int = 1) extends Config(
+  (new TLConfig(n)).alter((site, here, up) => {
     case XSTileKey => up(XSTileKey).map{ p => p.copy(
       frontendParameters = p.frontendParameters.copy(
         bpuParameters = p.frontendParameters.bpuParameters.copy(
@@ -492,9 +496,10 @@ class FrontendDebugConfig(n: Int = 1) extends Config(
     )
   })
 )
+class FrontendDebugConfig(n: Int = 1) extends TLFrontendDebugConfig(n) with DeprecatedConfigWarning
 
-class BackendV2Config(n: Int = 1) extends Config(
-  new DefaultConfig(n).alter((site, here, up) => {
+class TLBackendV2Config(n: Int = 1) extends Config(
+  new TLConfig(n).alter((site, here, up) => {
     case XSTileKey => up(XSTileKey).map { p =>
       p.copy(
         EnableBackendV2Config = true,
@@ -542,6 +547,7 @@ class BackendV2Config(n: Int = 1) extends Config(
     }
   })
 )
+class BackendV2Config(n: Int = 1) extends TLBackendV2Config(n) with DeprecatedConfigWarning
 
 class CVMCompile extends Config((site, here, up) => {
   case CVMParamsKey => up(CVMParamsKey).copy(
@@ -565,67 +571,75 @@ class CVMTestCompile extends Config((site, here, up) => {
     HasBitmapCheckDefault = true))
 })
 
-class MinimalAliasDebugConfig(n: Int = 1) extends Config(
+class TLMinimalAliasDebugConfig(n: Int = 1) extends Config(
   L3CacheConfig("512KB", inclusive = false)
     ++ L2CacheConfig("256KB", inclusive = true)
     ++ WithNKBL1D(128)
-    ++ new MinimalConfig(n)
+    ++ new TLMinimalConfig(n)
 )
+class MinimalAliasDebugConfig(n: Int = 1) extends TLMinimalAliasDebugConfig(n) with DeprecatedConfigWarning
 
-class MediumConfig(n: Int = 1) extends Config(
+class TLMediumConfig(n: Int = 1) extends Config(
   L3CacheConfig("4MB", inclusive = false, banks = 4)
     ++ L2CacheConfig("512KB", inclusive = true)
     ++ WithNKBL1D(128)
     ++ new BaseConfig(n)
 )
+class MediumConfig(n: Int = 1) extends TLMediumConfig(n) with DeprecatedConfigWarning
 
-class FuzzConfig(dummy: Int = 0) extends Config(
+class CHIFuzzConfig(dummy: Int = 0) extends Config(
   new WithFuzzer
-    ++ new KunminghuV2Config(1)
+    ++ new CHIConfig(1)
 )
+class FuzzConfig(dummy: Int = 0) extends CHIFuzzConfig(dummy) with DeprecatedConfigWarning
 
-class DefaultConfig(n: Int = 1) extends Config(
+class TLConfig(n: Int = 1) extends Config(
   L3CacheConfig("16MB", inclusive = false, banks = 4, ways = 16)
     ++ L2CacheConfig("1MB", inclusive = true, banks = 4)
     ++ WithNKBL1D(64, ways = 4)
     ++ new BaseConfig(n)
 )
+class DefaultConfig(n: Int = 1) extends TLConfig(n) with DeprecatedConfigWarning
 
-class CVMConfig(n: Int = 1) extends Config(
+class TLCVMConfig(n: Int = 1) extends Config(
   new CVMCompile
-    ++ new DefaultConfig(n)
+    ++ new TLConfig(n)
 )
+class CVMConfig(n: Int = 1) extends TLCVMConfig(n) with DeprecatedConfigWarning
 
-class CVMTestConfig(n: Int = 1) extends Config(
+class TLCVMTestConfig(n: Int = 1) extends Config(
   new CVMTestCompile
-    ++ new DefaultConfig(n)
+    ++ new TLConfig(n)
 )
+class CVMTestConfig(n: Int = 1) extends TLCVMTestConfig(n) with DeprecatedConfigWarning
 
 class WithCHI extends Config((_, _, _) => {
   case EnableCHI => true
 })
 
-class KunminghuV2Config(n: Int = 1) extends Config(
+class CHIConfig(n: Int = 1) extends Config(
   L2CacheConfig("1MB", inclusive = true, banks = 4, tp = false)
-    ++ new DefaultConfig(n)
+    ++ new TLConfig(n)
     ++ new WithCHI
 )
+class KunminghuV2Config(n: Int = 1) extends CHIConfig(n) with DeprecatedConfigWarning
 
-class KunminghuV2MinimalConfig(n: Int = 1) extends Config(
+class CHIMinimalConfig(n: Int = 1) extends Config(
   L2CacheConfig("128KB", inclusive = true, banks = 1, tp = false)
     ++ WithNKBL1D(32, ways = 4)
-    ++ new MinimalConfig(n)
+    ++ new TLMinimalConfig(n)
     ++ new WithCHI
 )
+class KunminghuV2MinimalConfig(n: Int = 1) extends CHIMinimalConfig(n) with DeprecatedConfigWarning
 
 class XSNoCTopConfig(n: Int = 1) extends Config(
-  (new KunminghuV2Config(n)).alter((site, here, up) => {
+  (new CHIConfig(n)).alter((site, here, up) => {
     case SoCParamsKey => up(SoCParamsKey).copy(UseXSNoCTop = true)
   })
 )
 
 class XSNoCTopMinimalConfig(n: Int = 1) extends Config(
-  (new KunminghuV2MinimalConfig(n)).alter((site, here, up) => {
+  (new CHIMinimalConfig(n)).alter((site, here, up) => {
     case SoCParamsKey => up(SoCParamsKey).copy(UseXSNoCTop = true)
   })
 )
@@ -642,7 +656,7 @@ class XSNoCDiffTopMinimalConfig(n: Int = 1) extends Config(
   })
 )
 
-class FpgaDefaultConfig(n: Int = 1) extends Config(
+class TLFpgaDefaultConfig(n: Int = 1) extends Config(
   (L3CacheConfig("3MB", inclusive = false, banks = 1, ways = 6)
     ++ L2CacheConfig("1MB", inclusive = true, banks = 4)
     ++ WithNKBL1D(64, ways = 4)
@@ -658,8 +672,9 @@ class FpgaDefaultConfig(n: Int = 1) extends Config(
     )
   })
 )
+class FpgaDefaultConfig(n: Int = 1) extends TLFpgaDefaultConfig(n) with DeprecatedConfigWarning
 
-class FpgaDiffDefaultConfig(n: Int = 1) extends Config(
+class TLFpgaDiffDefaultConfig(n: Int = 1) extends Config(
   (L3CacheConfig("3MB", inclusive = false, banks = 1, ways = 6)
     ++ L2CacheConfig("1MB", inclusive = true, banks = 4)
     ++ WithNKBL1D(64, ways = 4)
@@ -676,9 +691,10 @@ class FpgaDiffDefaultConfig(n: Int = 1) extends Config(
     )
   })
 )
+class FpgaDiffDefaultConfig(n: Int = 1) extends TLFpgaDiffDefaultConfig(n) with DeprecatedConfigWarning
 
-class FpgaDiffMinimalConfig(n: Int = 1) extends Config(
-  (new MinimalConfig(n)).alter((site, here, up) => {
+class TLFpgaDiffMinimalConfig(n: Int = 1) extends Config(
+  (new TLMinimalConfig(n)).alter((site, here, up) => {
     case DebugOptionsKey => up(DebugOptionsKey).copy(
       AlwaysBasicDiff = true,
       AlwaysBasicDB = false
@@ -691,3 +707,15 @@ class FpgaDiffMinimalConfig(n: Int = 1) extends Config(
     )
   })
 )
+class FpgaDiffMinimalConfig(n: Int = 1) extends TLFpgaDiffMinimalConfig(n) with DeprecatedConfigWarning
+
+trait DeprecatedConfigWarning {
+  val className = this.getClass().getSimpleName()
+  val parentClassName = this.getClass().getSuperclass().getSimpleName()
+  Console.println(
+    Console.WHITE ++ Console.BOLD ++ Console.MAGENTA_B ++ Console.BLINK ++
+    s"[Warning] $className is deprecated. Use $parentClassName instead." ++
+    Console.RESET
+  )
+  Thread.sleep(10000)
+}

--- a/src/main/scala/xiangshan/backend/fu/vector/Mgtu.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/Mgtu.scala
@@ -21,7 +21,6 @@ package xiangshan.backend.fu.vector
 import org.chipsalliance.cde.config.Parameters
 import chisel3._
 import chisel3.util._
-import top.{ArgParser, BaseConfig, DefaultConfig}
 import xiangshan._
 import xiangshan.backend.fu.vector.Bundles.{Vl}
 import yunsuan.vector._

--- a/src/main/scala/xiangshan/backend/fu/vector/Mgu.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/Mgu.scala
@@ -24,7 +24,7 @@ import chisel3.util._
 import chisel3.simulator.scalatest.ChiselSim
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import top.{ArgParser, BaseConfig, DefaultConfig}
+import top.{ArgParser, TLConfig}
 import xiangshan._
 import xiangshan.backend.fu.vector.Bundles.{VSew, Vl}
 import xiangshan.backend.fu.vector.Utils.VecDataToMaskDataVec
@@ -211,7 +211,7 @@ object VerilogMgu extends App {
 
 class MguTest extends AnyFlatSpec with Matchers with ChiselSim {
 
-  val defaultConfig = (new DefaultConfig).alterPartial({
+  val defaultConfig = (new TLConfig).alterPartial({
     case XSCoreParamsKey => XSCoreParameters()
   })
 

--- a/src/test/scala/cache/WpuTest.scala
+++ b/src/test/scala/cache/WpuTest.scala
@@ -3,14 +3,14 @@ package cache
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import org.scalatest.flatspec.AnyFlatSpec
-import top.DefaultConfig
+import top.TLConfig
 import xiangshan.cache.wpu.DCacheWpuWrapper
 import xiangshan.{XSCoreParamsKey, XSTileKey}
 
 class WpuBasicTest extends AnyFlatSpec with ChiselSim {
   behavior of "DCacheWPU"
   it should ("run") in {
-    val defaultConfig = (new DefaultConfig)
+    val defaultConfig = (new TLConfig)
     implicit val config = defaultConfig.alterPartial({
       case XSCoreParamsKey => defaultConfig(XSTileKey).head.copy()
     })

--- a/src/test/scala/xiangshan/XSTester.scala
+++ b/src/test/scala/xiangshan/XSTester.scala
@@ -8,12 +8,12 @@ import svsim.CommonCompilationSettings.VerilogPreprocessorDefine
 import svsim.verilator.Backend.CompilationSettings.{TraceKind, TraceStyle}
 import org.scalatest.flatspec._
 import org.scalatest.matchers.should._
-import top.{ArgParser, DefaultConfig}
+import top.TLConfig
 import xiangshan.backend.regfile.IntPregParams
 
 abstract class XSTester extends AnyFlatSpec with ChiselSim with Matchers {
   behavior of "XiangShan Module"
-  val defaultConfig = (new DefaultConfig)
+  val defaultConfig = (new TLConfig)
   implicit val config: org.chipsalliance.cde.config.Parameters = defaultConfig.alterPartial({
     // Get XSCoreParams and pass it to the "small module"
     case XSCoreParamsKey => defaultConfig(XSTileKey).head.copy(

--- a/src/test/scala/xiangshan/backend/fu/VsetModuleMain.scala
+++ b/src/test/scala/xiangshan/backend/fu/VsetModuleMain.scala
@@ -4,13 +4,13 @@ import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import top.DefaultConfig
+import top.TLConfig
 import xiangshan.backend.fu.vector.Bundles.{VLmul, VSew}
 import xiangshan.{VSETOpType, XSCoreParameters, XSCoreParamsKey, XSTileKey}
 
 class VsetModuleMain extends AnyFlatSpec with Matchers with ChiselSim {
 
-  val defaultConfig = (new DefaultConfig).alterPartial({
+  val defaultConfig = (new TLConfig).alterPartial({
     case XSCoreParamsKey => XSCoreParameters()
   })
 

--- a/src/test/scala/xiangshan/backend/fu/vector/ByteMaskTailGenTest.scala
+++ b/src/test/scala/xiangshan/backend/fu/vector/ByteMaskTailGenTest.scala
@@ -4,7 +4,7 @@ import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import top.DefaultConfig
+import top.TLConfig
 import xiangshan.backend.fu.vector.Bundles.VSew
 import xiangshan.{XSCoreParameters, XSCoreParamsKey}
 
@@ -12,7 +12,7 @@ class ByteMaskTailGenTest extends AnyFlatSpec with Matchers with ChiselSim {
 
   println("Generating the ByteMaskTailGen hardware")
 
-  val defaultConfig = (new DefaultConfig).alterPartial({
+  val defaultConfig = (new TLConfig).alterPartial({
     case XSCoreParamsKey => XSCoreParameters()
   })
 

--- a/src/test/scala/xiangshan/frontend/FrontendTrigger.scala
+++ b/src/test/scala/xiangshan/frontend/FrontendTrigger.scala
@@ -4,14 +4,14 @@ import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import top.DefaultConfig
+import top.TLConfig
 import utility.{LogUtilsOptions, LogUtilsOptionsKey}
 import xiangshan.{DebugOptionsKey, XSCoreParameters, XSCoreParamsKey}
 import xiangshan.frontend.PrunedAddrInit
 
 
 class FrontendTriggerTest extends AnyFlatSpec with Matchers with ChiselSim {
-  implicit val defaultConfig: org.chipsalliance.cde.config.Parameters = (new DefaultConfig).alterPartial {
+  implicit val defaultConfig: org.chipsalliance.cde.config.Parameters = (new TLConfig).alterPartial {
     case XSCoreParamsKey => XSCoreParameters()
   }.alter((site, here, up) => {
     case LogUtilsOptionsKey => LogUtilsOptions(


### PR DESCRIPTION
This PR unifies the naming of all Configs to a format prefixed with the corresponding bus protocol, eliminating potential ambiguities regarding bus protocols caused by Config names.

In the past, Config names were assigned in a rather arbitrary manner, making it difficult for both users and developers to intuitively identify the bus protocol a Config corresponds to from its name. Given that different bus protocols exhibit significant differences in scenarios such as performance evaluation, they should be clearly distinguished.

Worse still, some existing Config names are even misleading. Take KunminghuV2Config and BackendV2Config as examples: their naming conventions are highly similar, which could lead one to mistakenly assume they are associated with the same bus protocol. In reality, however, the former is for the CHI protocol, while the latter is for the TileLink protocol.

To address this issue, this PR renames all Configs whose names do not directly reflect their underlying bus protocols. All Configs in this PR now start with TL, CHI, or XSNoCTop, representing TileLink, CHI, and the special CHI XSNoCTop integration respectively.

Meanwhile, to avoid breaking existing tools and workflows, the original names are temporarily retained. When these legacy names are used, a prominent warning message will be printed, accompanied by a 10-second pause to ensure full attention. Users and developers are supposed to adopt to the new Config names as soon as possible.

I acknowledge that this PR may introduce certain compatibility side effects in the future. For instance, modified scripts and workflows will no longer work directly with older versions of the XiangShan framework. Nevertheless, considering that CHI will be adopted as the default configuration going forward, I believe it is beneficial to phase out generic names such as DefaultConfig as early as possible.

Feel free to leave any comment about this PR.