### PR TITLE
fix(uncache): revert the last fix and correct the fix logic

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/Uncache.scala
+++ b/src/main/scala/xiangshan/cache/dcache/Uncache.scala
@@ -360,9 +360,10 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
   val e0_allocWaitSame = e0_allocWaitSameVec.reduce(_ || _)
   val e0_sid = Mux(e0_canMerge, e0_mergeIdx, e0_allocIdx)
   val e0_reject = do_uarch_drain || (!e0_canMerge && !e0_invalidVec.asUInt.orR) || e0_rejectVec.reduce(_ || _)
+  req_ready := !e0_reject
 
   // e0_fire is used to guarantee that it will not be rejected
-  when(e0_canMerge && e0_req_valid){
+  when(e0_canMerge && e0_fire){
     entries(e0_mergeIdx).update(e0_req)
   }.elsewhen(e0_canAlloc && e0_fire){
     entries(e0_allocIdx).set(e0_req)
@@ -371,8 +372,6 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
       states(e0_allocIdx).setWaitSame(true.B)
     }
   }
-
-  req_ready := !e0_reject
 
   /* e1: return accept */
   io.lsq.idResp.valid := RegNext(e0_fire)


### PR DESCRIPTION
When canMerge is confilct with rejectVec.orR, it should not be "keeping former" to guarantee the functional correction.

In this case, this request should not enter the buffer. So use `e0_canMerge && e0_fire` not `e0_canMerge && e0_req_valid` for the update logic.