### PR TITLE
fix(tlb): fixed the freeze caused by the needGpa

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -23,11 +23,11 @@ import chisel3.util._
 import xiangshan._
 import utils._
 import utility._
-import xiangshan.backend.rob.RobPtr
+import xiangshan.backend.rob.{RobLsqIO, RobPtr}
 import xiangshan.backend.fu.util.HasCSRConst
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.tilelink._
-import xiangshan.backend.fu.{PMPReqBundle, PMPConfig}
+import xiangshan.backend.fu.{PMPConfig, PMPReqBundle}
 import xiangshan.backend.fu.PMPBundle
 
 
@@ -572,6 +572,7 @@ class TlbReq(implicit p: Parameters) extends TlbBundle {
   // do not translate, but still do pmp/pma check
   val no_translate = Output(Bool())
   val pmp_addr = Output(UInt(PAddrBits.W)) // load s1 send prefetch paddr
+  val frm_mabuf = Output(Bool())
   val debug = new Bundle {
     val pc = Output(UInt(XLEN.W))
     val robIdx = Output(new RobPtr)
@@ -698,6 +699,7 @@ class TlbIO(Width: Int, nRespDups: Int = 1, q: TLBParameters)(implicit p: Parame
   val replace = if (q.outReplace) Flipped(new TlbReplaceIO(Width, q)) else null
   val pmp = Vec(Width, ValidIO(new PMPReqBundle(q.lgMaxSize)))
   val tlbreplay = Vec(Width, Output(Bool()))
+  val robPendingPtr = Input(new RobPtr)
 }
 
 class VectorTlbPtwIO(Width: Int)(implicit p: Parameters) extends TlbBundle {

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -116,6 +116,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   val resp_s1_isLeaf = RegInit(false.B)
   val resp_s1_isFakePte = RegInit(false.B)
   val hasGpf = Wire(Vec(Width, Bool()))
+  val need_replay = WireInit(VecInit.fill(Width) {false.B})
 
   val Sv39Enable = csr.satp.mode === 8.U
   val Sv48Enable = csr.satp.mode === 9.U
@@ -133,6 +134,8 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     (Sv39vsEnable || Sv48vsEnable || Sv39x4Enable || Sv48x4Enable) &&
     (mode(i) < ModeM)
   )
+  val isRobMatch = (0 until Width).map(i => req_out(i).debug.robIdx === io.robPendingPtr)
+  val canGetGpa =  (0 until Width).map(i => isRobMatch(i) || TlbCmd.isExec(req_out(i).cmd) || req_out(i).frm_mabuf)
 
   val useReqS1Paddr = (0 until Width).map(i => RegNext(req(i).bits.no_translate))
   val privNeedTranslate = (0 until Width).map(i => (vmEnable(i) || s2xlateEnable(i)))
@@ -291,15 +294,20 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       resp_gpa_refill := false.B
       need_gpa_vpn := 0.U
     }.elsewhen (req_out_v(i) && !p_hit && !(resp_gpa_refill && need_gpa_vpn_hit) && !isOnlys2xlate && hasGpf(i) && need_gpa === false.B && !io.requestor(i).req_kill && !isPrefetch && !currentRedirect && !lastCycleRedirect) {
-      maybe_need_gpa_not_allow_refill := true.B
-      need_gpa_wire := true.B
-      need_gpa := true.B
-      need_gpa_vpn := get_pn(req_out(i).vaddr)
-      resp_gpa_refill := false.B
-      need_gpa_robidx := req_out(i).debug.robIdx
-      when (p_hit_fast) {
-        need_clear_need_gpa := true.B
+      when(canGetGpa(i)) {
+        maybe_need_gpa_not_allow_refill := true.B
+        need_gpa_wire := true.B
+        need_gpa := true.B
+        need_gpa_vpn := get_pn(req_out(i).vaddr)
+        resp_gpa_refill := false.B
+        need_gpa_robidx := req_out(i).debug.robIdx
+        when (p_hit_fast) {
+          need_clear_need_gpa := true.B
+        }
+      } .otherwise {
+        need_replay(i) := true.B
       }
+
     }.elsewhen (ptw.resp.fire && need_gpa && need_gpa_vpn === ptw.resp.bits.getVpn(need_gpa_vpn)) {
       resp_gpa_gvpn := Mux(ptw.resp.bits.s2xlate === onlyStage2, ptw.resp.bits.s2.entry.tag, ptw.resp.bits.s1.genGVPN(need_gpa_vpn))
       resp_s1_level := ptw.resp.bits.s1.entry.level.get
@@ -524,7 +532,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
 
     when (req_out_v(idx) && missVec(idx)) {
       // NOTE: for an miss tlb request: either send a ptw request, or ask for a replay
-      when (ptw_just_back || ptw_already_back) {
+      when (ptw_just_back || ptw_already_back || need_replay(idx)) {
         io.tlbreplay(idx) := true.B;
       } .elsewhen (need_gpa && !need_gpa_vpn_hit && !resp_gpa_refill) {
         // not send any unrelated ptw request when l1tlb is in need_gpa state
@@ -533,7 +541,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
         io.ptw.req(idx).valid := true.B;
       }
     }
-
+    dontTouch(need_replay(idx))
     when (io.requestor(idx).req_kill && GatedValidRegNext(io.requestor(idx).req.fire)) {
       io.ptw.req(idx).valid := false.B
       io.tlbreplay(idx) := true.B

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -168,7 +168,8 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
   itlb.io.hartId := io.hartId
   itlb.io.base_connect(sfence, tlbCsr)
   itlb.io.flushPipe.foreach(_ := icache.io.itlbFlushPipe)
-  itlb.io.redirect := DontCare // itlb has flushpipe, don't need redirect signal
+  itlb.io.redirect      := DontCare // itlb has flushpipe, don't need redirect signal
+  itlb.io.robPendingPtr := DontCare // only lsu
 
   val itlb_ptw = Wire(new VectorTlbPtwIO(coreParams.itlbPortNum))
   itlb_ptw.connect(itlb.io.ptw)

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -875,6 +875,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   io.iTLBInter.req.bits.debug.robIdx       := DontCare
   io.iTLBInter.req.bits.debug.isFirstIssue := DontCare
   io.iTLBInter.req.bits.pmp_addr           := DontCare
+  io.iTLBInter.req.bits.frm_mabuf          := DontCare
   // whats the difference between req_kill and req.bits.kill?
   io.iTLBInter.req_kill := false.B
   // wait for itlb response in m_tlbResp state

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -704,6 +704,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   dtlb.map(_.csr := tlbcsr)
   dtlb.map(_.flushPipe.map(a => a := false.B)) // non-block doesn't need
   dtlb.map(_.redirect := redirect)
+  dtlb.map(_.robPendingPtr := io.ooo_to_mem.lsqio.pendingPtr)
   if (refillBothTlb) {
     require(ldtlbParams.outReplace == sttlbParams.outReplace)
     require(ldtlbParams.outReplace == hytlbParams.outReplace)

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -277,6 +277,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.no_translate       := s0_hw_prf_select  // hw b.reqetch addr does not need to be translated
   io.tlb.req.bits.debug.pc           := s0_uop.pc
   io.tlb.req.bits.debug.isFirstIssue := s0_isFirstIssue
+  io.tlb.req.bits.frm_mabuf          := DontCare
 
   // query DCache
   // for load

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -396,6 +396,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.memidx.idx         := s0_sel_src.uop.lqIdx.value
   io.tlb.req.bits.debug.robIdx       := s0_sel_src.uop.robIdx
   io.tlb.req.bits.no_translate       := s0_tlb_no_query  // hardware prefetch and fast replay does not need to be translated, need this signal for pmp check
+  io.tlb.req.bits.frm_mabuf          := s0_sel_src.frm_mabuf  // hardware prefetch and fast replay does not need to be translated, need this signal for pmp check
   io.tlb.req.bits.debug.pc           := s0_sel_src.uop.pc
   io.tlb.req.bits.debug.isFirstIssue := s0_sel_src.isFirstIssue
 

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -221,6 +221,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.memidx.idx         := s0_mem_idx
   io.tlb.req.bits.debug.robIdx       := s0_rob_idx
   io.tlb.req.bits.no_translate       := false.B
+  io.tlb.req.bits.frm_mabuf          := s0_use_flow_ma
   io.tlb.req.bits.debug.pc           := s0_pc
   io.tlb.req.bits.debug.isFirstIssue := s0_isFirstIssue
   io.tlb.req_kill                    := false.B

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -619,6 +619,7 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
     tlb_req_arb.io.in(i).bits.hlvx := DontCare
     tlb_req_arb.io.in(i).bits.hyperinst := DontCare
     tlb_req_arb.io.in(i).bits.pmp_addr  := DontCare
+    tlb_req_arb.io.in(i).bits.frm_mabuf  := DontCare
   }
 
   assert(PopCount(s0_tlb_fire_vec) <= 1.U, "s0_tlb_fire_vec should be one-hot or empty")

--- a/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
@@ -984,6 +984,7 @@ class PrefetchFilter()(implicit p: Parameters) extends XSModule with HasSMSModul
     tlb_req_arb.io.in(i).bits.hlvx := DontCare
     tlb_req_arb.io.in(i).bits.hyperinst := DontCare
     tlb_req_arb.io.in(i).bits.pmp_addr := DontCare
+    tlb_req_arb.io.in(i).bits.frm_mabuf := DontCare
 
     val pending_req_vec = ent.region_bits & (~ent.filter_bits).asUInt
     val first_one_offset = PriorityMux(


### PR DESCRIPTION
needgpa must wait for the replayqueue to resend the request before clearing. 
During high needgpa phases, it blocks other instructions' TLB miss PTW requests. If the instruction causing the needgpa is a younger instruction while all older instructions are TLB misses, the replayqueue's age-based selection mechanism prevents the younger needgpa instruction from being reissued. Consequently, the older instructions requiring TLB ptw reqs may never complete.

After modification, only the oldest instruction that generated a GPF is permitted to trigger a needgpa. Additionally, since misalignbuffer requests have the highest priority, requests originating from misalignbuffer are permitted to trigger a needgpa.