### PR TITLE
timing(StoreMisalignBuffer): optimize timing of `s2_canEnq`

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -161,7 +161,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   canEnq := !req_valid && !reqRedirect && reqSelValid
   val robMatch = req_valid && io.rob.pendingst && (io.rob.pendingPtr === req.uop.robIdx)
 
-  val s2_canEnq = GatedRegNext(canEnq)
+  val s2_canEnq = RegNext(canEnq)
   val s2_reqSelPort = GatedRegNext(reqSelPort)
   val s2_needRevoke = s2_canEnq && (0 until enqPortNum).map {
     case i => io.enq(i).revoke && s2_reqSelPort === i.U

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -423,7 +423,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s1_mis_align = s1_valid && !s1_tlb_miss && !s1_in.isHWPrefetch && !s1_isCbo && !s1_out.nc && !s1_out.mmio &&
                       GatedValidRegNext(io.csrCtrl.hd_misalign_st_enable) && s1_in.isMisalign && !s1_in.misalignWith16Byte &&
                       !s1_trigger_breakpoint && !s1_trigger_debug_mode
-  val s1_toMisalignBufferValid = s1_valid && !s1_tlb_miss && !s1_in.isHWPrefetch &&
+  val s1_toMisalignBufferValid = s1_valid && !s1_in.isHWPrefetch &&
     !s1_frm_mabuf && !s1_isCbo && s1_in.isMisalign && !s1_in.misalignWith16Byte &&
     GatedValidRegNext(io.csrCtrl.hd_misalign_st_enable)
   io.misalign_enq.req.valid := s1_toMisalignBufferValid && !s1_misalignNeedReplay
@@ -495,7 +495,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
 
   val s2_mis_align = s2_valid && RegEnable(s1_mis_align, s1_fire)
   // goto misalignBuffer
-  io.misalign_enq.revoke := s2_exception
+  io.misalign_enq.revoke := s2_exception || s2_in.tlbMiss
   val s2_misalignNeedReplay = RegEnable(s1_toMisalignBufferValid && (!io.misalign_enq.req.ready || s1_misalignNeedReplay), false.B, s1_fire)
   val s2_misalignBufferNack = !io.misalign_enq.revoke && s2_misalignNeedReplay
 


### PR DESCRIPTION
see: https://github.com/OpenXiangShan/XiangShan/pull/5580
To be on the safe side, I think revoke is a relatively safe measure :)