### PR TITLE
feat(Parameters): add `hartIDDmodeWidth` for Customization

### DIFF
--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -94,6 +94,10 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case MaxHartIdBits => hartidbits.toInt
           }), tail)
+        case "--hartid-dmode-width" :: width :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case XSTileKey => up(XSTileKey).map(_.copy(hartIDDmodeWidth = width.toInt))
+          }), tail)
         case "--with-dramsim3" :: tail =>
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(UseDRAMSim = true)

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -40,6 +40,7 @@ case class YamlConfig(
   L2CacheConfig: Option[L2CacheConfig],
   L3CacheConfig: Option[L3CacheConfig],
   HartIDBits: Option[Int],
+  HartIDDmodeWidth: Option[Int],
   DebugAttachProtocals: Option[List[String]],
   DebugModuleParams: Option[DebugModuleParams],
   WFIResume: Option[Boolean],
@@ -116,6 +117,11 @@ object YamlParser {
     yamlConfig.HartIDBits.foreach { bits =>
       newConfig = newConfig.alter((site, here, up) => {
         case MaxHartIdBits => bits
+      })
+    }
+    yamlConfig.HartIDDmodeWidth.foreach { width =>
+      newConfig = newConfig.alter((site, here, up) => {
+        case XSTileKey => up(XSTileKey).map(_.copy(hartIDDmodeWidth = width))
       })
     }
     yamlConfig.DebugModuleParams.foreach { params =>

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -351,6 +351,7 @@ case class XSCoreParameters
   softPTW: Boolean = false, // dpi-c l2tlb debug only
   softPTWDelay: Int = 1,
   wfiResume: Boolean = true,
+  hartIDDmodeWidth: Int = -1, // only for Customization
 ){
   def ISABase = "rv64i"
   def ISAExtensions = Seq(
@@ -594,6 +595,7 @@ trait HasXSParameter {
   val minFLen = 32
   val fLen = 64
   def hartIdLen = p(MaxHartIdBits)
+  def hartIDDmodeWidth = coreParams.hartIDDmodeWidth
   val xLen = XLEN
 
   def HasBitmapCheck = coreParams.HasBitmapCheck

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
@@ -384,7 +384,8 @@ trait MachineLevel { self: NewCSR =>
     val ALL = RO(hartIdLen - 1, 0)
   }) {
     val hartid = IO(Input(UInt(hartIdLen.W)))
-    this.regOut.ALL := hartid
+    val dmode  = IO(Input(Bool()))
+    this.regOut.ALL := (if(hartIDDmodeWidth > 0) Mux(dmode, hartid(hartIDDmodeWidth - 1, 0), hartid) else hartid)
   })
     .setAddr(CSRs.mhartid)
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -542,6 +542,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   }
 
   mhartid.hartid := this.io.fromTop.hartId
+  mhartid.dmode  := debugMode
 
   pmpcfgs.zipWithIndex.foreach { case (mod, i) =>
     mod.w.wen   := wenLegalReg && (addr === (CSRs.pmpcfg0 + i / 8 * 2).U)


### PR DESCRIPTION
When `hartIDDmodeWidth` is larger than 0, only the lower `hartIDDmodeWidth` bit(s) of mhartid can be read in debug mode.