### PR TITLE
fix(uncache): fix forwarding order hazard when `mem_acquire` is not fired

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/Uncache.scala
+++ b/src/main/scala/xiangshan/cache/dcache/Uncache.scala
@@ -155,7 +155,7 @@ class UncacheEntryState(implicit p: Parameters) extends DCacheBundle {
   def can2Lsq(): Bool = valid && waitReturn
   def canMerge(): Bool = valid && !inflight
   def isFwdOld(): Bool = valid && (inflight || waitReturn)
-  def isFwdNew(): Bool = valid && !inflight && !waitReturn
+  def isFwdNew(): Bool = valid && !inflight && !waitReturn && waitSame
 
   def setValid(x: Bool): Unit = { valid := x}
   def setInflight(x: Bool): Unit = { inflight := x}
@@ -298,7 +298,7 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
 
   def canMergeSecondary(eid: UInt): Bool = {
     // old entry is not inflight and senting
-    states(eid).canMerge() && !(q0_canSent && q0_canSentIdx === eid)
+    states(eid).canMerge() && !(mem_acquire.fire && q0_canSentIdx === eid)
   }
 
   /******************************************************************


### PR DESCRIPTION
`q0_canSent` only means an entry is selected, not actually sent.
When `mem_acquire` does not fire, that entry is still not `inflight` in the next cycle, but a new request may merge and be marked waitSame.

This breaks old/new classification in forwarding: two entries that should match `isFwdOld` and `isFwdNew` separately can both be treated as `isFwdNew`, so forwarding loses ordering and may return wrong data.

Use real send handshake semantics to gate state/merge behavior, so unsent entries are not treated as sent and forwarding order remains correct.