### PR TITLE
feat(Vec): vec store supports partial replay

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -27,14 +27,13 @@ import xiangshan.backend.decode.{ImmUnion, XDecode}
 import xiangshan.backend.fu.FuType
 import xiangshan.backend.rob.RobPtr
 import xiangshan.frontend._
-import xiangshan.mem.{LqPtr, SqPtr}
+import xiangshan.mem.{LqPtr, SqPtr, VLSUBundle}
 import xiangshan.backend.Bundles.{DynInst, UopIdx}
 import xiangshan.backend.fu.vector.Bundles.VType
 import xiangshan.frontend.{AllAheadFoldedHistoryOldestBits, AllFoldedHistories, BPUCtrl, CGHPtr, FtqPtr, FtqToCtrlIO}
 import xiangshan.frontend.{Ftq_Redirect_SRAMEntry, HasBPUParameter, IfuToBackendIO, PreDecodeInfo, RASPtr}
 import xiangshan.cache.HasDCacheParameters
 import utility._
-
 import org.chipsalliance.cde.config.Parameters
 import chisel3.util.BitPat.bitPatToUInt
 import chisel3.util.experimental.decode.EspressoMinimizer
@@ -456,7 +455,7 @@ class SnapshotPort(implicit p: Parameters) extends XSBundle {
   val flushVec = Vec(RenameSnapshotNum, Bool())
 }
 
-class RSFeedback(isVector: Boolean = false)(implicit p: Parameters) extends XSBundle {
+class RSFeedback(isVector: Boolean = false)(implicit p: Parameters) extends VLSUBundle {
   val robIdx = new RobPtr
   val hit = Bool()
   val flushState = Bool()
@@ -464,6 +463,9 @@ class RSFeedback(isVector: Boolean = false)(implicit p: Parameters) extends XSBu
   val dataInvalidSqIdx = new SqPtr
   val sqIdx = new SqPtr
   val lqIdx = new LqPtr
+  val isVecPartReplay = Option.when(isVector)(Bool())
+  val vecReplayMask   = Option.when(isVector)(UInt(VLENB.W))
+  val vecReplayMbIdx  = Option.when(isVector)(UInt(vsmBindexBits.W))
 }
 
 class MemRSFeedbackIO(isVector: Boolean = false)(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -751,6 +751,9 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
         memScheduler.io.vecLoadFinalIssueResp(i)(j).bits.uopIdx.foreach(_ := toMem(i)(j).bits.vpu.get.vuopIdx)
         memScheduler.io.vecLoadFinalIssueResp(i)(j).bits.sqIdx.foreach(_ := toMem(i)(j).bits.sqIdx.get)
         memScheduler.io.vecLoadFinalIssueResp(i)(j).bits.lqIdx.foreach(_ := toMem(i)(j).bits.lqIdx.get)
+        memScheduler.io.vecLoadFinalIssueResp(i)(j).bits.isVecPartReplay.foreach(_:= false.B)
+        memScheduler.io.vecLoadFinalIssueResp(i)(j).bits.vecReplayMask  .foreach(_:= 0.U)
+        memScheduler.io.vecLoadFinalIssueResp(i)(j).bits.vecReplayMbIdx .foreach(_:= 0.U)
       }
 
       NewPipelineConnect(
@@ -773,6 +776,9 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
             resp.bits.sqIdx.get := toMem(i)(j).bits.sqIdx.get
             resp.bits.lqIdx.get := toMem(i)(j).bits.lqIdx.get
             resp.bits.resp := RespType.success
+            resp.bits.isVecPartReplay.foreach(_:= false.B)
+            resp.bits.vecReplayMask  .foreach(_:= 0.U)
+            resp.bits.vecReplayMbIdx .foreach(_:= 0.U)
         }
         if (backendParams.debugEn){
           dontTouch(memScheduler.io.vecLoadIssueResp(i)(j))
@@ -788,6 +794,9 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
     source.ready := sink.ready
     sink.bits.iqIdx              := source.bits.iqIdx
     sink.bits.isFirstIssue       := source.bits.isFirstIssue
+    sink.bits.isVecPartReplay.foreach(_ := source.bits.isVecPartReplay.get)
+    sink.bits.vecReplayMask.  foreach(_ := source.bits.vecReplayMask.get)
+    sink.bits.vecReplayMbIdx. foreach(_ := source.bits.vecReplayMbIdx.get)
     sink.bits.uop                := 0.U.asTypeOf(sink.bits.uop)
     sink.bits.src                := 0.U.asTypeOf(sink.bits.src)
     sink.bits.src.zip(source.bits.src).foreach { case (l, r) => l := r}

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -20,8 +20,7 @@ import xiangshan.backend.issue.EntryBundles._
 import xiangshan.backend.regfile.{RfReadPortWithConfig, RfWritePortWithConfig}
 import xiangshan.backend.rob.RobPtr
 import xiangshan.frontend._
-import xiangshan.mem.{LqPtr, SqPtr}
-import xiangshan.mem.{VecMissalignedDebugBundle}
+import xiangshan.mem.{HasVLSUParameters, LqPtr, SqPtr, VLSUBundle, VecMissalignedDebugBundle}
 import yunsuan.vector.VIFuParam
 import xiangshan.backend.trace._
 import utility._
@@ -603,7 +602,7 @@ object Bundles {
   }
 
   // DataPath --[ExuInput]--> Exu
-  class ExuInput(val params: ExeUnitParams, copyWakeupOut:Boolean = false, copyNum:Int = 0, hasCopySrc: Boolean = false)(implicit p: Parameters) extends XSBundle {
+  class ExuInput(val params: ExeUnitParams, copyWakeupOut:Boolean = false, copyNum:Int = 0, hasCopySrc: Boolean = false)(implicit p: Parameters) extends XSBundle with HasVLSUParameters {
     val fuType        = FuType()
     val fuOpType      = FuOpType()
     val src           = Vec(params.numRegSrc, UInt(params.srcDataBitsMax.W))
@@ -653,6 +652,10 @@ object Bundles {
     val exuSources = OptionWrapper(params.isIQWakeUpSink, Vec(params.numRegSrc, ExuSource(params)))
     val srcTimer = OptionWrapper(params.isIQWakeUpSink, Vec(params.numRegSrc, UInt(3.W)))
     val loadDependency = OptionWrapper(params.needLoadDependency, Vec(LoadPipelineWidth, UInt(LoadDependencyWidth.W)))
+    // for vector mem
+    val isVecPartReplay = Option.when(params.hasVStoreFu)(Bool())
+    val vecReplayMask   = Option.when(params.hasVStoreFu)(UInt(VLENB.W))
+    val vecReplayMbIdx  = Option.when(params.hasVStoreFu)(UInt(vsmBindexBits.W))
 
     val perfDebugInfo = new PerfDebugInfo()
     val debug_seqNum = InstSeqNum()
@@ -695,6 +698,9 @@ object Bundles {
       this.numLsElem     .foreach(_ := source.common.numLsElem.get)
       this.srcTimer      .foreach(_ := source.common.srcTimer.get)
       this.loadDependency.foreach(_ := source.common.loadDependency.get.map(_ << 1))
+      this.isVecPartReplay.foreach(_ := source.common.isVecPartReplay.get)
+      this.vecReplayMask.foreach(_ := source.common.vecReplayMask.get)
+      this.vecReplayMbIdx.foreach(_ := source.common.vecReplayMbIdx.get)
     }
   }
 
@@ -946,12 +952,15 @@ object Bundles {
     val pdest = UInt(PhyRegIdxWidth.W)
   }
 
-  class MemExuInput(isVector: Boolean = false)(implicit p: Parameters) extends XSBundle {
+  class MemExuInput(isVector: Boolean = false)(implicit p: Parameters) extends VLSUBundle {
     val uop = new DynInst
     val src = if (isVector) Vec(5, UInt(VLEN.W)) else Vec(3, UInt(XLEN.W))
     val iqIdx = UInt(log2Up(MemIQSizeMax).W)
     val isFirstIssue = Bool()
     val flowNum      = OptionWrapper(isVector, NumLsElem())
+    val isVecPartReplay = Option.when(isVector)(Bool())
+    val vecReplayMask   = Option.when(isVector)(UInt(VLENB.W))
+    val vecReplayMbIdx  = Option.when(isVector)(UInt(vsmBindexBits.W))
 
     def src_rs1 = src(0)
     def src_rs2 = src(1)

--- a/src/main/scala/xiangshan/backend/datapath/DataPath.scala
+++ b/src/main/scala/xiangshan/backend/datapath/DataPath.scala
@@ -625,6 +625,9 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
           og0resp.bits.lqIdx.foreach(_ := 0.U.asTypeOf(new LqPtr))
           og0resp.bits.resp             := RespType.block
           og0resp.bits.fuType           := fromIQ(iqIdx)(iuIdx).bits.common.fuType
+          og0resp.bits.isVecPartReplay.foreach(_:= false.B)
+          og0resp.bits.vecReplayMask  .foreach(_:= 0.U)
+          og0resp.bits.vecReplayMbIdx .foreach(_:= 0.U)
 
           val og1resp = toIU.og1resp
           og1FailedVec2(iqIdx)(iuIdx)   := s1_toExuValid(iqIdx)(iuIdx) && !s1_toExuReady(iqIdx)(iuIdx)
@@ -633,6 +636,9 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
           og1resp.bits.uopIdx.foreach(_ := s1_toExuData(iqIdx)(iuIdx).vpu.get.vuopIdx)
           og1resp.bits.sqIdx.foreach(_ :=  0.U.asTypeOf(new SqPtr))
           og1resp.bits.lqIdx.foreach(_ :=  0.U.asTypeOf(new LqPtr))
+          og1resp.bits.isVecPartReplay.foreach(_:= false.B)
+          og1resp.bits.vecReplayMask  .foreach(_:= 0.U)
+          og1resp.bits.vecReplayMbIdx .foreach(_:= 0.U)
           // respType:  success    -> IQ entry clear
           //            uncertain  -> IQ entry no action
           //            block      -> IQ entry issued set false, then re-issue

--- a/src/main/scala/xiangshan/backend/datapath/Og2ForVector.scala
+++ b/src/main/scala/xiangshan/backend/datapath/Og2ForVector.scala
@@ -67,6 +67,9 @@ class Og2ForVector(params: BackendParams)(implicit p: Parameters) extends XSModu
           og2Resp.bits.fuType := s2_toExuData(iqId)(exuId).fuType
           og2Resp.bits.sqIdx.foreach(_ := 0.U.asTypeOf(new SqPtr))
           og2Resp.bits.lqIdx.foreach(_ := 0.U.asTypeOf(new LqPtr))
+          og2Resp.bits.isVecPartReplay.foreach(_:= false.B)
+          og2Resp.bits.vecReplayMask  .foreach(_:= 0.U)
+          og2Resp.bits.vecReplayMbIdx .foreach(_:= 0.U)
       }
   }
   io.toBypassNetworkImmInfo := io.fromOg1ImmInfo.zip(s1_validVec2.flatten).map{

--- a/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
+++ b/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
@@ -14,10 +14,11 @@ import xiangshan.backend.fu.vector.Bundles.NumLsElem
 import xiangshan.backend.rob.RobPtr
 import xiangshan.mem.{LqPtr, SqPtr}
 import xiangshan.mem.Bundles.MemWaitUpdateReqBundle
+import xiangshan.mem.HasVLSUParameters
 
 object EntryBundles extends HasCircularQueuePtrHelper {
 
-  class Status(implicit p: Parameters, params: IssueBlockParams) extends XSBundle {
+  class Status(implicit p: Parameters, params: IssueBlockParams) extends XSBundle with HasVLSUParameters {
     //basic status
     val robIdx                = new RobPtr
     val fuType                = IQFuType()
@@ -31,6 +32,9 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     val deqPortIdx            = UInt(1.W)
     //vector mem status
     val vecMem                = Option.when(params.isVecMemIQ)(new StatusVecMemPart)
+    val isVecPartReplay       = Option.when(params.isVecMemIQ)(Bool())
+    val vecReplayMask         = Option.when(params.isVecMemIQ)(UInt(VLENB.W))
+    val vecReplayMbIdx        = Option.when(params.isVecMemIQ)(UInt(vsmBindexBits.W))
 
     def srcReady: Bool        = {
       VecInit(srcStatus.map(_.srcState).map(SrcState.isReady)).asUInt.andR
@@ -65,13 +69,16 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     val numLsElem             = NumLsElem()
   }
 
-  class EntryDeqRespBundle(implicit p: Parameters, val params: IssueBlockParams) extends XSBundle {
+  class EntryDeqRespBundle(implicit p: Parameters, val params: IssueBlockParams) extends XSBundle with HasVLSUParameters {
     val robIdx                = new RobPtr
     val resp                  = RespType()
     val fuType                = FuType()
     val uopIdx                = Option.when(params.isVecMemIQ)(Output(UopIdx()))
     val sqIdx                 = Option.when(params.needFeedBackSqIdx)(new SqPtr())
     val lqIdx                 = Option.when(params.needFeedBackLqIdx)(new LqPtr())
+    val isVecPartReplay       = Option.when(params.isVecMemIQ)(Bool())
+    val vecReplayMask         = Option.when(params.isVecMemIQ)(UInt(VLENB.W))
+    val vecReplayMbIdx        = Option.when(params.isVecMemIQ)(UInt(vsmBindexBits.W))
   }
 
   object RespType {
@@ -282,6 +289,9 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     val respIssueFail                                  = commonIn.issueResp.valid && RespType.isBlocked(commonIn.issueResp.bits.resp)
     entryUpdate.status.robIdx                         := status.robIdx
     entryUpdate.status.fuType                         := IQFuType.readFuType(status.fuType, params.getFuCfgs.map(_.fuType))
+    entryUpdate.status.isVecPartReplay.foreach(_      := commonIn.issueResp.bits.isVecPartReplay.get)
+    entryUpdate.status.vecReplayMask  .foreach(_      := Mux(commonIn.issueResp.bits.isVecPartReplay.get, commonIn.issueResp.bits.vecReplayMask .get, entryReg.status.vecReplayMask .get))
+    entryUpdate.status.vecReplayMbIdx .foreach(_      := Mux(commonIn.issueResp.bits.isVecPartReplay.get, commonIn.issueResp.bits.vecReplayMbIdx.get, entryReg.status.vecReplayMbIdx.get))
     entryUpdate.status.srcStatus.zip(status.srcStatus).zipWithIndex.foreach { case ((srcStatusNext, srcStatus), srcIdx) =>
       val srcLoadCancel = common.srcLoadCancelVec(srcIdx)
       val loadTransCancel = common.srcLoadTransCancelVec(srcIdx)

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -304,6 +304,9 @@ class IssueQueueImp(override val wrapper: IssueQueue)(implicit p: Parameters, va
       enq.valid                                                 := s0_doEnqSelValidVec(enqIdx)
       enq.bits.status.robIdx                                    := s0_enqBits(enqIdx).robIdx
       enq.bits.status.fuType                                    := IQFuType.readFuType(VecInit(s0_enqBits(enqIdx).fuType.asBools), params.getFuCfgs.map(_.fuType))
+      enq.bits.status.isVecPartReplay.foreach(_                 := false.B)
+      enq.bits.status.vecReplayMask.foreach(_                   := 0.U)
+      enq.bits.status.vecReplayMbIdx.foreach(_                  := 0.U)
       val numLsrc = s0_enqBits(enqIdx).srcType.size.min(enq.bits.status.srcStatus.map(_.srcType).size)
       for(j <- 0 until numLsrc) {
         enq.bits.status.srcStatus(j).psrc                       := s0_enqBits(enqIdx).psrc(j)
@@ -588,6 +591,9 @@ class IssueQueueImp(override val wrapper: IssueQueue)(implicit p: Parameters, va
     deqResp.bits.lqIdx.foreach(_ := DontCare)
     deqResp.bits.fuType := deqBeforeDly(i).bits.common.fuType
     deqResp.bits.uopIdx.foreach(_ := DontCare)
+    deqResp.bits.isVecPartReplay.foreach(_:= false.B)
+    deqResp.bits.vecReplayMask  .foreach(_:= 0.U)
+    deqResp.bits.vecReplayMbIdx .foreach(_:= 0.U)
   }
 
   //fuBusyTable
@@ -1107,6 +1113,9 @@ class IssueQueueMemAddrImp(override val wrapper: IssueQueue)(implicit p: Paramet
     slowResp.bits.lqIdx.foreach( _ := memIO.feedbackIO(i).feedbackSlow.bits.lqIdx)
     slowResp.bits.resp   := Mux(memIO.feedbackIO(i).feedbackSlow.bits.hit, RespType.success, RespType.block)
     slowResp.bits.fuType := DontCare
+    slowResp.bits.isVecPartReplay.foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.isVecPartReplay.get)
+    slowResp.bits.vecReplayMask  .foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.vecReplayMask  .get)
+    slowResp.bits.vecReplayMbIdx .foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.vecReplayMbIdx .get)
   }
 
   entries.io.fromMem.get.fastResp.zipWithIndex.foreach { case (fastResp, i) =>
@@ -1116,6 +1125,9 @@ class IssueQueueMemAddrImp(override val wrapper: IssueQueue)(implicit p: Paramet
     fastResp.bits.lqIdx.foreach( _ := memIO.feedbackIO(i).feedbackFast.bits.lqIdx)
     fastResp.bits.resp   := Mux(memIO.feedbackIO(i).feedbackFast.bits.hit, RespType.success, RespType.block)
     fastResp.bits.fuType := DontCare
+    fastResp.bits.isVecPartReplay.foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.isVecPartReplay.get)
+    fastResp.bits.vecReplayMask  .foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.vecReplayMask  .get)
+    fastResp.bits.vecReplayMbIdx .foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.vecReplayMbIdx .get)
   }
 
   // load wakeup
@@ -1195,6 +1207,9 @@ class IssueQueueVecMemImp(override val wrapper: IssueQueue)(implicit p: Paramete
     slowResp.bits.resp             := Mux(memIO.feedbackIO(i).feedbackSlow.bits.hit, RespType.success, RespType.block)
     slowResp.bits.fuType           := DontCare
     slowResp.bits.uopIdx.get       := DontCare
+    slowResp.bits.isVecPartReplay.foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.isVecPartReplay.get)
+    slowResp.bits.vecReplayMask  .foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.vecReplayMask  .get)
+    slowResp.bits.vecReplayMbIdx .foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.vecReplayMbIdx .get)
   }
 
   entries.io.fromMem.get.fastResp.zipWithIndex.foreach { case (fastResp, i) =>
@@ -1205,6 +1220,9 @@ class IssueQueueVecMemImp(override val wrapper: IssueQueue)(implicit p: Paramete
     fastResp.bits.resp             := Mux(memIO.feedbackIO(i).feedbackFast.bits.hit, RespType.success, RespType.block)
     fastResp.bits.fuType           := DontCare
     fastResp.bits.uopIdx.get       := DontCare
+    fastResp.bits.isVecPartReplay.foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.isVecPartReplay.get)
+    fastResp.bits.vecReplayMask  .foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.vecReplayMask  .get)
+    fastResp.bits.vecReplayMbIdx .foreach(_ := memIO.feedbackIO(i).feedbackSlow.bits.vecReplayMbIdx .get)
   }
 
   entries.io.vecMemIn.get.sqDeqPtr := memIO.sqDeqPtr.get
@@ -1214,6 +1232,9 @@ class IssueQueueVecMemImp(override val wrapper: IssueQueue)(implicit p: Paramete
     deq.bits.common.sqIdx.foreach(_ := deqEntryVec(i).bits.status.vecMem.get.sqIdx)
     deq.bits.common.lqIdx.foreach(_ := deqEntryVec(i).bits.status.vecMem.get.lqIdx)
     deq.bits.common.numLsElem.foreach(_ := deqEntryVec(i).bits.status.vecMem.get.numLsElem)
+    deq.bits.common.isVecPartReplay.foreach(_ := deqEntryVec(i).bits.status.isVecPartReplay.get)
+    deq.bits.common.vecReplayMask  .foreach(_ := deqEntryVec(i).bits.status.vecReplayMask  .get)
+    deq.bits.common.vecReplayMbIdx .foreach(_ := deqEntryVec(i).bits.status.vecReplayMbIdx .get)
     if (params.isVecLduIQ) {
       deq.bits.common.ftqIdx.get := deqEntryVec(i).bits.payload.ftqPtr
       deq.bits.common.ftqOffset.get := deqEntryVec(i).bits.payload.ftqOffset

--- a/src/main/scala/xiangshan/mem/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/Bundles.scala
@@ -93,6 +93,7 @@ object Bundles {
     val vecBaseVaddr = UInt(VAddrBits.W)
     val vecVaddrOffset = UInt(VAddrBits.W)
     val vecTriggerMask = UInt((VLEN/8).W)
+    val splitIndx = UInt(flowIdxBits.W)
     // 1: vector active element or scala mem operation, 0: vector not active element
     val vecActive = Bool()
     // val flowPtr             = new VlflowPtr() // VLFlowQueue ptr

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1599,6 +1599,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vsSplit(i).io.in.valid := io.ooo_to_mem.issueVldu(i).valid &&
                               vStoreCanAccept(i) && !isSegment
     vsSplit(i).io.toMergeBuffer <> vsMergeBuffer(i).io.fromSplit.head
+    vsSplit(i).io.threshold.valid := vsMergeBuffer(i).io.toSplit.threshold
+    vsSplit(i).io.threshold.bits  := lsq.io.sqDeqPtr
     NewPipelineConnect(
       vsSplit(i).io.out, storeUnits(i).io.vecstin, storeUnits(i).io.vecstin.fire,
       Mux(vsSplit(i).io.out.fire, vsSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect), storeUnits(i).io.vecstin.bits.uop.robIdx.needFlush(io.redirect)),
@@ -1618,8 +1620,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vlSplit(i).io.in.valid := io.ooo_to_mem.issueVldu(i).valid &&
                               vLoadCanAccept(i) && !isSegment && !isFixVlUop(i)
     vlSplit(i).io.toMergeBuffer <> vlMergeBuffer.io.fromSplit(i)
-    vlSplit(i).io.threshold.get.valid := vlMergeBuffer.io.toSplit.get.threshold
-    vlSplit(i).io.threshold.get.bits  := lsq.io.lqDeqPtr
+    vlSplit(i).io.threshold.valid := vlMergeBuffer.io.toSplit.threshold
+    vlSplit(i).io.threshold.bits  := lsq.io.lqDeqPtr
     NewPipelineConnect(
       vlSplit(i).io.out, loadUnits(i).io.vecldin, loadUnits(i).io.vecldin.fire,
       Mux(vlSplit(i).io.out.fire, vlSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect), loadUnits(i).io.vecldin.bits.uop.robIdx.needFlush(io.redirect)),

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
@@ -595,6 +595,7 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
   io.vecWriteBack.bits.vstart               := req.uop.vpu.vstart
   io.vecWriteBack.bits.vecTriggerMask       := req.vecTriggerMask
   io.vecWriteBack.bits.nc                   := globalNC
+  io.vecWriteBack.bits.splitIndx            := DontCare
 
 
   val flush = req_valid && req.uop.robIdx.needFlush(io.redirect)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -636,6 +636,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
       wb.bits.vstart            := req.uop.vpu.vstart
       wb.bits.vecTriggerMask    := 0.U
       wb.bits.nc                := globalNC
+      wb.bits.splitIndx         := req.splitIndx
     }
   }
 

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1839,6 +1839,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.vecldout.bits.vstart := s3_vecout.vstart
   io.vecldout.bits.vecTriggerMask := s3_vecout.vecTriggerMask
   io.vecldout.bits.nc := DontCare
+  io.vecldout.bits.splitIndx := DontCare
 
   io.vecldout.valid := s3_out.valid && !s3_out.bits.uop.robIdx.needFlush(io.redirect) && s3_vecout.isvec && !s3_mis_align && !s3_frm_mabuf //||
   // TODO: check this, why !io.lsq.uncache.bits.isVls before?

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -133,6 +133,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s0_alignedType  = s0_vecstin.alignedType
   val s0_mBIndex      = s0_vecstin.mBIndex
   val s0_vecBaseVaddr = s0_vecstin.basevaddr
+  val s0_vecSplitIdx = s0_vecstin.splitIndx
   val s0_isFinalSplit = io.misalign_stin.valid && io.misalign_stin.bits.isFinalSplit
 
   // generate addr
@@ -266,6 +267,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   }
   s0_out.isFrmMisAlignBuf := s0_use_flow_ma
   s0_out.isFinalSplit := s0_isFinalSplit
+  s0_out.splitIndx := s0_vecSplitIdx
 //  s0_out.uop.exceptionVec(storeAddrMisaligned) := Mux(s0_use_non_prf_flow, (!s0_addr_aligned || s0_vecstin.uop.exceptionVec(storeAddrMisaligned) && s0_vecActive), false.B) && !s0_misalignWith16Byte
 
   io.st_mask_out.valid       := s0_use_flow_rs || s0_use_flow_vec
@@ -622,6 +624,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
       sx_in(i).gpaddr      := s3_in.gpaddr
       sx_in(i).isForVSnonLeafPTE     := s3_in.isForVSnonLeafPTE
       sx_in(i).vecTriggerMask := s3_in.vecTriggerMask
+      sx_in(i).splitIndx := s3_in.splitIndx
       sx_in(i).hasException := s3_exception
       sx_in_vec(i)         := s3_in.isvec
       sx_ready(i) := !s3_valid(i) || sx_in(i).output.uop.robIdx.needFlush(io.redirect) || (if (RAWTotalDelayCycles == 0) io.stout.ready else sx_ready(i+1))
@@ -672,6 +675,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.vecstout.bits.isForVSnonLeafPTE     := sx_last_in.isForVSnonLeafPTE
   io.vecstout.bits.vstart      := sx_last_in.output.uop.vpu.vstart
   io.vecstout.bits.vecTriggerMask := sx_last_in.vecTriggerMask
+  io.vecstout.bits.splitIndx := sx_last_in.splitIndx
   // io.vecstout.bits.reg_offset.map(_ := DontCare)
   // io.vecstout.bits.elemIdx.map(_ := sx_last_in.elemIdx)
   // io.vecstout.bits.elemIdxInsideVd.map(_ := DontCare)

--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -54,8 +54,11 @@ class MBufferBundle(implicit p: Parameters) extends VLSUBundle{
   val isForVSnonLeafPTE= Bool()
   val fof              = Bool()
   val vlmax            = UInt(elemIdxBits.W)
+  val isPartReplay     = OptionWrapper(backendParams.debugEn, Bool())
+  val replayFlowNum    = UInt(flowIdxBits.W)
+  val replayFlowMask   = UInt(16.W)
 
-  def allReady(): Bool = (flowNum === 0.U)
+  def allReady(): Bool = flowNum === 0.U
 }
 
 abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUModule{
@@ -88,6 +91,9 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     sink.originVl     := source.uop.vpu.vl
     sink.vaddr        := source.vaddr
     sink.vstart       := 0.U
+    sink.isPartReplay.foreach(_ := false.B)
+    sink.replayFlowNum := 0.U
+    sink.replayFlowMask := 0.U
   }
   def DeqConnect(source: MBufferBundle): MemExuOutput = {
     val sink               = WireInit(0.U.asTypeOf(new MemExuOutput(isVector = true)))
@@ -180,15 +186,20 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
   // handle the situation where multiple ports are going to write the same uop queue entry
   // select the oldest exception and count the flownum of the pipeline writeback.
   val mergePortMatrix        = Wire(Vec(pipeWidth, Vec(pipeWidth, Bool())))
+  val mergePortMatrixMiss    = Wire(Vec(pipeWidth, Vec(pipeWidth, Bool())))
   val mergePortMatrixHasExcp = Wire(Vec(pipeWidth, Vec(pipeWidth, Bool())))
   val mergedByPrevPortVec    = Wire(Vec(pipeWidth, Bool()))
   (0 until pipeWidth).map{case i => (0 until pipeWidth).map{case j =>
-    val mergePortValid = (j == i).B ||
-      (j > i).B &&
-      io.fromPipeline(j).bits.mBIndex === io.fromPipeline(i).bits.mBIndex &&
-      io.fromPipeline(j).valid
+    val mergePortValid =
+      ((j == i).B ||
+      (j > i).B && io.fromPipeline(j).bits.mBIndex === io.fromPipeline(i).bits.mBIndex && io.fromPipeline(j).valid)
+    val mergePortMiss =
+      !io.fromPipeline(j).bits.hit &&
+      ((j == i).B ||
+      (j > i).B && io.fromPipeline(j).bits.mBIndex === io.fromPipeline(i).bits.mBIndex && io.fromPipeline(j).valid)
 
     mergePortMatrix(i)(j)        := mergePortValid
+    mergePortMatrixMiss(i)(j)    := mergePortMiss
     mergePortMatrixHasExcp(i)(j) := mergePortValid && (io.fromPipeline(j).bits.hasException || TriggerAction.isDmode(io.fromPipeline(j).bits.trigger))
   }}
   (0 until pipeWidth).map{case i =>
@@ -202,6 +213,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
   val mergedByPrevPortVecWrap    = if(isVStore) mergedByPrevPortVec else RegNext(mergedByPrevPortVec)
   if (backendParams.debugEn){
     dontTouch(mergePortMatrix)
+    dontTouch(mergePortMatrixMiss)
     dontTouch(mergePortMatrixHasExcp)
     dontTouch(mergedByPrevPortVec)
   }
@@ -308,6 +320,19 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     val latchMergeByPre  = if(isVStore) mergedByPrevPortVec(i) else RegEnable(mergedByPrevPortVec(i), pipewb.valid)
     when(latchWbValid && !latchMergeByPre){
       entries(latchWbIndex).flowNum := entries(latchWbIndex).flowNum - latchFlowNum
+
+      if (isVStore) {
+        val isUnitStride = LSUOpType.isAllUS(entries(wbIndex).uop.fuOpType)
+        when(!io.fromPipeline(i).bits.hit && !isUnitStride) {
+          val replayFlowNumOffset = PopCount(mergePortMatrixMiss(i))
+          val replayFlowMask = (0 until pipeWidth).map{case i => (0 until pipeWidth).map{case j =>
+            UIntToOH(io.fromPipeline(i).bits.splitIndx, VLENB) & Fill(VLENB, mergePortMatrix(i)(j))
+          }.reduce(_ | _)}
+
+          entries(latchWbIndex).replayFlowNum := entries(latchWbIndex).replayFlowNum + replayFlowNumOffset
+          entries(latchWbIndex).replayFlowMask := entries(latchWbIndex).replayFlowMask | replayFlowMask(i)
+        }
+      }
     }
 
     when(pipewb.valid){
@@ -316,6 +341,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     }
     when(pipewb.valid && !pipewb.bits.hit){
       needRSReplay(wbIndex) := true.B
+      entries(wbIndex).isPartReplay.foreach(_ := true.B)
     }
     pipewb.ready := true.B
     XSError((entries(latchWbIndex).flowNum - latchFlowNum > entries(latchWbIndex).flowNum) && latchWbValid && !latchMergeByPre, s"entry: $latchWbIndex, FlowWriteback overflow!!\n")
@@ -329,38 +355,52 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     }
   }
    val selPolicy = SelectOne("circ", uopFinish, deqWidth) // select one entry to deq
-   private val pipelineOut              = Wire(Vec(deqWidth, DecoupledIO(new MemExuOutput(isVector = true))))
-   private val writeBackOut             = Wire(Vec(deqWidth, DecoupledIO(new MemExuOutput(isVector = true))))
-   private val writeBackOutExceptionVec = writeBackOut.map(_.bits.uop.exceptionVec)
+   val pipelineOut              = Wire(Vec(deqWidth, DecoupledIO(new MemExuOutput(isVector = true))))
+   val writeBackOut             = Wire(Vec(deqWidth, DecoupledIO(new MemExuOutput(isVector = true))))
+   val writeBackOutExceptionVec = writeBackOut.map(_.bits.uop.exceptionVec)
    for(((port, lsqport), i) <- (pipelineOut zip io.toLsq).zipWithIndex){
     val canGo    = port.ready
     val (selValid, selOHVec) = selPolicy.getNthOH(i + 1)
     val entryIdx = OHToUInt(selOHVec)
     val selEntry = entries(entryIdx)
     val selAllocated = allocated(entryIdx)
+    val selNeedRSReplay = needRSReplay(entryIdx)
+    val selIsUnitStride = LSUOpType.isAllUS(selEntry.uop.fuOpType)
     val selFire  = selValid && canGo
-    when(selFire){
-      freeMaskVec(entryIdx) := selAllocated
-      allocated(entryIdx)   := false.B
-      uopFinish(entryIdx)   := false.B
+    val canDeq = selFire && !selNeedRSReplay
+    when(selFire) {
       needRSReplay(entryIdx):= false.B
+      selEntry.replayFlowNum := 0.U
+      selEntry.replayFlowMask := 0.U
+      uopFinish(entryIdx)   := false.B
+
+      when (!selNeedRSReplay || selIsUnitStride) {
+        freeMaskVec(entryIdx) := selAllocated
+        allocated(entryIdx)   := false.B
+      } .otherwise {
+        selEntry.flowNum := selEntry.replayFlowNum
+      }
     }
+
     //writeback connect
-    port.valid   := selFire && selAllocated && !needRSReplay(entryIdx) && !selEntry.uop.robIdx.needFlush(io.redirect)
+    port.valid   := canDeq && selAllocated && !selEntry.uop.robIdx.needFlush(io.redirect)
     port.bits    := DeqConnect(selEntry)
     //to lsq
     lsqport.bits := ToLsqConnect(selEntry) // when uopwriteback, free MBuffer entry, write to lsq
-    lsqport.valid:= selFire && selAllocated && !needRSReplay(entryIdx)
+    lsqport.valid:= canDeq && selAllocated
     //to RS
     val feedbackOut                       = WireInit(0.U.asTypeOf(io.feedback(i).bits)).suggestName(s"feedbackOut_${i}")
     val feedbackValid                     = selFire && selAllocated
-    feedbackOut.hit                      := !needRSReplay(entryIdx)
+    feedbackOut.hit                      := !selNeedRSReplay
     feedbackOut.robIdx                   := selEntry.uop.robIdx
     feedbackOut.sourceType               := selEntry.sourceType
     feedbackOut.flushState               := selEntry.flushState
     feedbackOut.dataInvalidSqIdx         := DontCare
     feedbackOut.sqIdx                    := selEntry.uop.sqIdx
     feedbackOut.lqIdx                    := selEntry.uop.lqIdx
+    feedbackOut.isVecPartReplay.foreach(_:= selNeedRSReplay && !selIsUnitStride)
+    feedbackOut.vecReplayMask.foreach(_  := selEntry.replayFlowMask)
+    feedbackOut.vecReplayMbIdx.foreach(_ := entryIdx)
 
     io.feedback(i).valid                 := RegNext(feedbackValid)
     io.feedback(i).bits                  := RegEnable(feedbackOut, feedbackValid)
@@ -389,7 +429,7 @@ class VLMergeBufferImp(implicit p: Parameters) extends BaseVMergeBuffer(isVStore
     enablePreAlloc = false,
     moduleName = "VLoad MergeBuffer freelist"
   ))
-  io.toSplit.get.threshold := freeCount <= 6.U
+  io.toSplit.threshold := freeCount <= 6.U
 
   //merge data
   val flowWbElemIdx     = Wire(Vec(pipeWidth, UInt(elemIdxBits.W)))
@@ -479,5 +519,11 @@ class VSMergeBufferImp(implicit p: Parameters) extends BaseVMergeBuffer(isVStore
     sink.uop.vpu.vstart   := source.vstart
     sink.vecDebug.get     := DontCare
     sink
+  }
+
+  io.toSplit.threshold := freeCount <= 3.U
+
+  if (backendParams.debugEn) {
+    entries.map(x => dontTouch(x.isPartReplay.get))
   }
 }

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -40,8 +40,16 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
   //TODO vdIdxReg should no longer be useful, don't delete it for now
   val vdIdxReg = RegInit(0.U(3.W))
 
+  val mergeBufferNack = io.threshold.valid && ({
+    (isVStore, io.threshold.bits) match {
+      case (true,  p: SqPtr) => p =/= io.in.bits.uop.sqIdx
+      case (false, p: LqPtr) => p =/= io.in.bits.uop.lqIdx
+      case _ => throw new Exception("Pointer type mismatch!")
+    }
+  })
+
   val s1_ready = WireInit(false.B)
-  io.in.ready := s1_ready
+  io.in.ready := s1_ready && !mergeBufferNack
 
   /**-----------------------------------------------------------
     * s0 stage
@@ -106,6 +114,7 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
   val flowsPrevThisUop = (uopIdxInField << flowsLog2).asUInt // # of flows before this uop in a field
   val flowsPrevThisVd = (vdIdxInField << numFlowsSameVdLog2).asUInt // # of flows before this vd in a field
   val flowsIncludeThisUop = ((uopIdxInField +& 1.U) << flowsLog2).asUInt // # of flows before this uop besides this uop
+//  val flowNum = Mux(io.in.bits.isVecPartReplay.get, PopCount(io.in.bits.vecReplayMask.get), io.in.bits.flowNum.get)
   val flowNum = io.in.bits.flowNum.get
   // max index in vd, only use in index instructions for calculate index
   val maxIdxInVdIndex = GenVLMAX(Mux(s0_emul.asSInt > 0.S, 0.U, s0_emul), s0_eew)
@@ -127,10 +136,10 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
   val srcMask = GenFlowMask(Mux(s0_vm, Fill(VLEN, 1.U(1.W)), io.in.bits.src_mask), vvstart, evl, true)
   val srcMaskShiftBits = Mux(isSpecialIndexed, flowsPrevThisUop, flowsPrevThisVd)
 
-  val flowMask = ((srcMask &
-    UIntToMask(flowsIncludeThisUop.asUInt, VLEN + 1) &
-    (~UIntToMask(flowsPrevThisUop.asUInt, VLEN)).asUInt
-  ) >> srcMaskShiftBits)(VLENB - 1, 0)
+  val flowMask = Mux(io.in.bits.isVecPartReplay.get,
+    io.in.bits.vecReplayMask.get,
+    ((srcMask & UIntToMask(flowsIncludeThisUop.asUInt, VLEN + 1) &
+    (~UIntToMask(flowsPrevThisUop.asUInt, VLEN)).asUInt) >> srcMaskShiftBits)(VLENB - 1, 0))
   val indexedSrcMask = (srcMask >> flowsPrevThisVd).asUInt //only for index instructions
 
   // Used to calculate the element index.
@@ -172,6 +181,8 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
     x.preIsSplit  := s0_preIsSplit
     x.alignedType := broadenAligendType
     x.indexVlMaxInVd := indexVlMaxInVd
+    x.isVecPartReplay := io.in.bits.isVecPartReplay.get
+    x.vecReplayMbIdx := io.in.bits.vecReplayMbIdx.get
   }
   s0_valid := io.in.valid && !s0_kill
   /**-------------------------------------
@@ -182,7 +193,7 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
   val s1_valid         = RegInit(false.B)
   val s1_kill          = Wire(Bool())
   val s1_in            = Wire(new VLSBundle(isVStore))
-  val s1_can_go        = io.out.ready && io.toMergeBuffer.req.ready
+  val s1_can_go        = io.out.ready && (io.toMergeBuffer.req.ready || s1_in.isVecPartReplay && s1_valid)
   val s1_fire          = s1_valid && !s1_kill && s1_can_go
 
   s1_ready         := s1_kill || !s1_valid || s1_can_go
@@ -238,7 +249,7 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
   s1_kill               := s1_in.uop.robIdx.needFlush(io.redirect)
 
   // query mergeBuffer
-  io.toMergeBuffer.req.valid             := io.out.ready && s1_valid// only can_go will get MergeBuffer entry
+  io.toMergeBuffer.req.valid             := io.out.ready && s1_valid && !s1_in.isVecPartReplay// only can_go will get MergeBuffer entry
   io.toMergeBuffer.req.bits.flowNum      := activeNum
   io.toMergeBuffer.req.bits.data         := s1_in.data
   io.toMergeBuffer.req.bits.uop          := s1_in.uop
@@ -258,12 +269,12 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
 //    XSError(vdIdxReg + 1.U === 0.U, s"Overflow! The number of vd should be less than 8\n")
 //  }
   // out connect
-  io.out.valid          := s1_valid && io.toMergeBuffer.resp.valid // if activeNum == 0, this uop do nothing, can be killed.
+  io.out.valid          := s1_valid && (io.toMergeBuffer.resp.valid || s1_in.isVecPartReplay) // if activeNum == 0, this uop do nothing, can be killed.
   io.out.bits           := s1_in
   io.out.bits.uopOffset := uopOffset
   io.out.bits.uopAddr   := s1_in.baseAddr + uopOffset
   io.out.bits.stride    := stride
-  io.out.bits.mBIndex   := io.toMergeBuffer.resp.bits.mBIndex
+  io.out.bits.mBIndex   := Mux(s1_in.isVecPartReplay, s1_in.vecReplayMbIdx, io.toMergeBuffer.resp.bits.mBIndex)
   io.out.bits.usLowBitsAddr := usLowBitsAddr
   io.out.bits.usAligned128  := usAligned128
   io.out.bits.usMask        := usMask
@@ -397,6 +408,7 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
     x.uop_unit_stride_fof   := DontCare
     x.isFirstIssue          := DontCare
     x.mBIndex               := issueMbIndex
+    x.splitIndx             := splitIdx
   }
 
   // redirect
@@ -529,11 +541,10 @@ class VLSplitImp(implicit p: Parameters) extends VLSUModule{
   val io = IO(new VSplitIO(isVStore=false))
   val splitPipeline = Module(new VLSplitPipelineImp())
   val splitBuffer = Module(new VLSplitBufferImp())
-  val mergeBufferNack = io.threshold.get.valid && io.threshold.get.bits =/= io.in.bits.uop.lqIdx
   // Split Pipeline
   splitPipeline.io.in <> io.in
-  io.in.ready := splitPipeline.io.in.ready && !mergeBufferNack
   splitPipeline.io.redirect <> io.redirect
+  splitPipeline.io.threshold <> io.threshold
   io.toMergeBuffer <> splitPipeline.io.toMergeBuffer
 
   // skid buffer
@@ -555,6 +566,7 @@ class VSSplitImp(implicit p: Parameters) extends VLSUModule{
   // Split Pipeline
   splitPipeline.io.in <> io.in
   splitPipeline.io.redirect <> io.redirect
+  splitPipeline.io.threshold <> io.threshold
   io.toMergeBuffer <> splitPipeline.io.toMergeBuffer
 
   // skid buffer

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -79,6 +79,12 @@ class VLSBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBun
   val usLowBitsAddr       = UInt((log2Up(maxMemByteNum)).W)
   val usAligned128        = Bool()
   val usMask              = UInt((VLENB*2).W) // for unit-stride split
+
+  // Vec Store Replay
+  val isVecPartReplay     = Bool()
+  val vecReplayMbIdx      = UInt(vsmBindexBits.W)
+  val vecReplayFlowMask   = UInt(16.W)
+
 }
 
 object VSFQFeedbackType {
@@ -137,6 +143,7 @@ class VecPipelineFeedbackIO(isVStore: Boolean=false) (implicit p: Parameters) ex
   val reg_offset           = OptionWrapper(!isVStore, UInt(vOffsetBits.W))
   val elemIdxInsideVd      = OptionWrapper(!isVStore, UInt(elemIdxBits.W)) // element index in scope of vd
   val vecdata              = OptionWrapper(!isVStore, UInt(VLEN.W))
+  val splitIndx            = UInt(flowIdxBits.W)
 }
 
 class VecPipeBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle {
@@ -157,6 +164,7 @@ class VecPipeBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLS
   val mBIndex             = if(isVStore) UInt(vsmBindexBits.W) else UInt(vlmBindexBits.W)
   val elemIdx             = UInt(elemIdxBits.W)
   val elemIdxInsideVd     = UInt(elemIdxBits.W) // only use in unit-stride
+  val splitIndx           = UInt(flowIdxBits.W)
 }
 
 object VecFeedbacks {
@@ -236,7 +244,7 @@ class VSplitIO(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBund
   val out                 = Decoupled(new VecPipeBundle(isVStore))// to scala pipeline
   val vstd                = OptionWrapper(isVStore, Valid(new MemExuOutput(isVector = true)))
   val vstdMisalign        = OptionWrapper(isVStore, new storeMisaignIO)
-  val threshold            = OptionWrapper(!isVStore, Flipped(ValidIO(new LqPtr)))
+  val threshold           = if(isVStore) Flipped(ValidIO(new SqPtr)) else Flipped(ValidIO(new LqPtr))
 }
 
 class VSplitPipelineIO(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle{
@@ -244,6 +252,7 @@ class VSplitPipelineIO(isVStore: Boolean=false)(implicit p: Parameters) extends 
   val in                  = Flipped(Decoupled(new MemExuInput(isVector = true)))
   val toMergeBuffer       = new ToMergeBufferIO(isVStore) // req mergebuffer entry, inactive elem issue
   val out                 = Decoupled(new VLSBundle())// to split buffer
+  val threshold           = if(isVStore) Flipped(ValidIO(new SqPtr)) else Flipped(ValidIO(new LqPtr))
 }
 
 class VSplitBufferIO(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle{
@@ -256,10 +265,10 @@ class VSplitBufferIO(isVStore: Boolean=false)(implicit p: Parameters) extends VL
 
 class VMergeBufferIO(isVStore : Boolean=false)(implicit p: Parameters) extends VLSUBundle{
   val redirect            = Flipped(ValidIO(new Redirect))
-  val fromPipeline        = if(isVStore) Vec(StorePipelineWidth, Flipped(DecoupledIO(new VecPipelineFeedbackIO(isVStore)))) else Vec(LoadPipelineWidth, Flipped(DecoupledIO(new VecPipelineFeedbackIO(isVStore))))
+  val fromPipeline        = if(isVStore) Vec(VSUopWritebackWidth, Flipped(DecoupledIO(new VecPipelineFeedbackIO(isVStore)))) else Vec(LoadPipelineWidth, Flipped(DecoupledIO(new VecPipelineFeedbackIO(isVStore))))
   val fromSplit           = if(isVStore) Vec(VecStorePipelineWidth, new FromSplitIO) else Vec(VecLoadPipelineWidth, new FromSplitIO) // req mergebuffer entry, inactive elem issue
   val uopWriteback        = if(isVStore) Vec(VSUopWritebackWidth, DecoupledIO(new MemExuOutput(isVector = true))) else Vec(VLUopWritebackWidth, DecoupledIO(new MemExuOutput(isVector = true)))
-  val toSplit             = OptionWrapper(!isVStore, new FeedbackToSplitIO())
+  val toSplit             = new FeedbackToSplitIO()
   val toLsq               = if(isVStore) Vec(VSUopWritebackWidth, ValidIO(new FeedbackToLsqIO)) else Vec(VLUopWritebackWidth, ValidIO(new FeedbackToLsqIO)) // for lsq deq
   val feedback            = if(isVStore) Vec(VSUopWritebackWidth, ValidIO(new RSFeedback(isVector = true))) else Vec(VLUopWritebackWidth, ValidIO(new RSFeedback(isVector = true)))//for rs replay
 

--- a/src/main/scala/xiangshan/mem/vector/VecCommon.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecCommon.scala
@@ -303,6 +303,7 @@ class VecMemExuOutput(isVector: Boolean = false)(implicit p: Parameters) extends
   val gpaddr      = UInt(GPAddrBits.W)
   val isForVSnonLeafPTE = Bool()
   val vecTriggerMask = UInt((VLEN/8).W)
+  val splitIndx = UInt(flowIdxBits.W)
 }
 
 object MulNum {


### PR DESCRIPTION
Vector memory access instructions may involve page table lookups exceeding the TLB capacity.
Previously, when any element within a UOP experienced a TLB miss, the vec store would reissue the entire UOP based on the Issue Queue. Even if some elements within that UOP had already completed execution, the entire UOP would be reissued to the pipeline. This could lead to deadlocks caused by ping-pong TLB contention between elements within a single UOP or across multiple UOPs.

---

Now, we employ a mask to mark completed elements. When reissuing a uop, elements that have already executed will not be re-emitted to the pipeline, thereby preventing the aforementioned deadlock.

---

Additionally, due to the mechanism's specific nature, when a vec store generates an exception, the exception information must be saved in the mergebuffer. Consequently, reissued uops do not exit the mergebuffer, potentially causing the mergebuffer to become completely full while waiting for uops. 
Previously, when the mergebuffer was full, vec stores were not allowed to be issued, which could prevent locally reissued vec stores from being issued and cause deadlocks.
To resolve this, we now enforce age-based execution when the merge buffer nears capacity.

---

Co-authored-by: xiaofeibao-xjtu <59299641+xiaofeibao-xjtu@users.noreply.github.com>
