### PR TITLE
misc: ignore venv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -377,3 +377,7 @@ cr*/
 # Bug report files
 bug-report/
 bug-report.tar.gz
+
+# Python virtual environment
+.venv/
+venv/


### PR DESCRIPTION
Some new OS, e.g. Ubuntu 24.04, asks programmer to use virtual environments to install package. Add venv and .venv folder to ignore to avoid git's complaints.