### PR TITLE
fix(Csr): fix condition disconnection when write mtinst/htinst

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -277,6 +277,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits.fullva           := io.vecFeedback(i).bits.vaddr
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits.vaNeedExt        := io.vecFeedback(i).bits.vaNeedExt
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits.gpaddr           := io.vecFeedback(i).bits.gpaddr
+    exceptionBuffer.io.req(LoadPipelineWidth + i).bits.isForVSnonLeafPTE:= io.vecFeedback(i).bits.isForVSnonLeafPTE
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.uopIdx       := io.vecFeedback(i).bits.uopidx
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.robIdx       := io.vecFeedback(i).bits.robidx
     exceptionBuffer.io.req(LoadPipelineWidth + i).bits.uop.vpu.vstart   := io.vecFeedback(i).bits.vstart


### PR DESCRIPTION
* Spec:
* For guest-page faults, the trap instruction register is written with a special pseudoinstruction value if:
* (a) the fault is caused by an implicit memory access for VS-stage address translation, and
* (b) a nonzero value (the faulting guest physical address) is written to mtval2 or htval.
* If both conditions are met, the value written to mtinst or htinst must be taken from Table 39; zero is not allowed.
*
* In virtualization, when the vector load generates a guest page fault exception and writes to mtinst/htinst, the condition is not connected.