### PR TITLE
feat(perf-trigger): add 0.3 & 0.8 option for gcc15 & xscc

### DIFF
--- a/.github/workflows/perf-trigger.yml
+++ b/.github/workflows/perf-trigger.yml
@@ -45,7 +45,11 @@ on:
         required: false
         type: choice
         options:
+          - gcc15-spec06-0.3c
+          - gcc15-spec06-0.8c
           - gcc15-spec06-1.0c
+          - xscc-spec06-0.3c
+          - xscc-spec06-0.8c
           - xscc-spec06-1.0c
           - gcc12-spec06-0.3c
           - gcc12-spec06-0.8c


### PR DESCRIPTION
I forgot to add this option in https://github.com/OpenXiangShan/XiangShan/pull/5661.

 I am guilty. qaq