### PR TITLE
feat(SimTop): set SimMemBytes with --sim-mem-size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,11 @@ endif
 override SIM_ARGS += --with-dramsim3
 endif
 
+# SimAXIMem size in GB (for sim-verilog only)
+ifneq ($(SIM_MEM_SIZE),)
+override SIM_ARGS += --sim-mem-size $(SIM_MEM_SIZE)
+endif
+
 # run emu with chisel-db
 ifeq ($(WITH_CHISELDB),1)
 override SIM_ARGS += --with-chiseldb

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -199,6 +199,10 @@ object ArgParser {
                 OpenLLCParamsOpt = openLLCParam
               )
           }), tail)
+        case "--sim-mem-size" :: value :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(SimMemSize = value.toLong * 1024 * 1024 * 1024) // GB
+          }), tail)
         case "--dfx" :: value :: tail =>
           nextOption(config.alter((site, here, up) => {
             case DFTOptionsKey => up(DFTOptionsKey).copy(EnableMbist = value.toBoolean)

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -524,6 +524,7 @@ case class DebugOptions
   EnablePerfDebug: Boolean = true,
   PerfLevel: String = "VERBOSE",
   EnableXMR: Boolean = true,
+  SimMemSize: Long = 8190L * 1024 * 1024 * 1024, // same as PMA, (0x80000000L, 0x80000000000L)
   UseDRAMSim: Boolean = false,
   EnableConstantin: Boolean = false,
   EnableChiselDB: Boolean = false,

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -110,7 +110,7 @@ class XiangShanSim(implicit p: Parameters) extends Module with HasDiffTestInterf
 
   val l_simAXIMem = AXI4MemorySlave(
     l_memXbar.memNode,
-    8190L * 1024 * 1024 * 1024,
+    debugOpts.SimMemSize,
     useBlackBox = true,
     dynamicLatency = debugOpts.UseDRAMSim
   )


### PR DESCRIPTION
By default we set SimAXIMem size at 8190L*1024*1024*1024, same as PMA (0x80000000L, 0x80000000000L).

However, the default mem size (nearly 8TB) is too large for some env like Palladium, and 8GB/16GB is enough for most workloads. So this change support setting membytes with --sim-mem-size in GB.

Example usage:
make sim-verilog SIM_MEM_SIZE=8
which means memBytes is 8GB (8L*1024*1024*1024).

Same to PR #5598 on `kunminghu-v2` branch