### PR TITLE
ci(emu-performance): split upload step

### DIFF
--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -119,19 +119,12 @@ jobs:
             ${{ matrix.with-restore-bin && '--gcpt-restore-bin /nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin' || '' }} \
             2> stderr.log | tee stdout.log
           cat stderr.log | sort | tee stderr-sorted.log
+          grep -oP 'IPC = \K\d+\.\d+' stdout.log > "${PERF_HOME}/ipc-legacy-${{ matrix.name }}"
+          echo "IPC: $(cat "${PERF_HOME}/ipc-legacy-${{ matrix.name }}")"
       - name: Archive log
         if: always()
         run: |
           tar -czvf "${PERF_HOME}/legacy_${{ matrix.name }}.tar.gz" stdout.log stderr-sorted.log
-      - name: Generate report
-        run: |
-          grep -oP 'IPC = \K\d+\.\d+' stdout.log > ipc-legacy-${{ matrix.name }}
-          echo "IPC: $(cat ipc-legacy-${{ matrix.name }})"
-      - name: Upload report
-        uses: actions/upload-artifact@v7
-        with:
-          archive: false
-          path: ipc-legacy-${{ matrix.name }}
 
   run:
     name: EMU - Performance - Run
@@ -225,28 +218,35 @@ jobs:
             ${CKPT} \
             2> stderr.log | tee stdout.log
           cat stderr.log | sort | tee stderr-sorted.log
+          grep -oP 'IPC = \K\d+\.\d+' stdout.log > "${PERF_HOME}/ipc-${{ matrix.name }}_${{ matrix.ckpt }}"
+          echo "IPC: $(cat "${PERF_HOME}/ipc-${{ matrix.name }}_${{ matrix.ckpt }}")"
       - name: Archive log
         if: always()
         run: |
           tar -czvf "${PERF_HOME}/${{ matrix.name }}_${{ matrix.ckpt }}.tar.gz" stdout.log stderr-sorted.log
-      - name: Generate report
-        run: |
-          grep -oP 'IPC = \K\d+\.\d+' stdout.log > ipc-${{ matrix.name }}_${{ matrix.ckpt }}
-          echo "IPC: $(cat ipc-${{ matrix.name }}_${{ matrix.ckpt }})"
+
+  upload:
+    name: EMU - Performance - Upload
+    needs:
+      - build # needed to get the cluster info
+      - run
+      - run-legacy # TODO: drop this
+    runs-on:
+      - ${{ needs.build.outputs.cluster }} # use same cluster as builder/runner to access NFS
+      - runner
+    steps:
       - name: Upload report
         uses: actions/upload-artifact@v7
         with:
-          archive: false
-          path: ipc-${{ matrix.name }}_${{ matrix.ckpt }}
+          name: ipc-reports
+          path: ${{ env.PERF_HOME }}/ipc-*
 
   summary:
     name: EMU - Performance - Summary
     permissions:
       actions: read # to download upstream artifact
       pull-requests: write # to post PR comment
-    needs:
-      - run
-      - run-legacy # TODO: drop this
+    needs: upload
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
We observed loads of `Failed to FinalizeArtifact: Unable to make request: ECONNRESET` failure and have to re-run checkpoint.

This PR saves ipc result to a NFS path and upload them using a separate step, so:
1. Failure frequency is reduced, we don't have 39 upload jobs but only 1.
2. Even if failed, we can retry uploading only, without re-run checkpoint.

I've considered use purely self-hosted runner + NFS so we don't need upload/download artifacts, but:
1. This will break backward compatibility and my other scripts (e.g. weekly IPC tracker) downloading IPC data from artifact will become unusable.
2. GitHub-hosted runner have preinstalled `gh` cli so we can find upstream action run_id easily, with self-hosted we need `curl api.github.com` manually

So I'd prefer current solution.