### PR TITLE
ci(emu): try kill orphan emu before checkout

### DIFF
--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -100,6 +100,9 @@ jobs:
       fail-fast: false
       max-parallel: 4
     steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
       - uses: actions/checkout@v6
         with:
           submodules: true
@@ -205,6 +208,9 @@ jobs:
       fail-fast: false
       max-parallel: 12 # TODO: increase this to 16 after dropping legacy workflow
     steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
       - uses: actions/checkout@v6
         with:
           submodules: true

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -33,6 +33,9 @@ jobs:
     timeout-minutes: 900
     name: Generate Verilog
     steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -118,6 +121,9 @@ jobs:
     timeout-minutes: 900
     name: EMU - Basics
     steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -213,6 +219,9 @@ jobs:
     timeout-minutes: 900
     name: EMU - GSIM
     steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -242,6 +251,9 @@ jobs:
     timeout-minutes: 900
     name: EMU - CHI
     steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -295,6 +307,9 @@ jobs:
     timeout-minutes: 500
     name: EMU - SimFrontend
     steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -361,6 +376,9 @@ jobs:
     timeout-minutes: 900
     name: EMU - MC
     steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
Workaround for this:
<img width="2554" height="266" alt="image" src="https://github.com/user-attachments/assets/8482e0d4-085b-42d6-b8d3-53c6cc12004a" />

My guesses on the root cause:
1. `xiangshan.py` uses `subprocess.Popen` to start a `emu` process.
2. When a job is cancelled manually or aborted due to network issue, cirunner will send a SIGINT to `xiangshan.py`, and after a few seconds, if `xiangshan.py` still alive, cirrunner will send a SIGTERM instead.
3. These signals kill the `python` process but fails to propagate to the `emu` process.
4. When cirunner picks another job, the `checkout` step tries to cleanup workspace, e.g. `rm build/emu`, but `build/emu` file is still opened by the `emu` process, so nfs refuses to remove it, instead rename it to `.nfsxxx`.
6. The `checkout` step still wants to cleanup workspace, e.g. `rm .nfsxxx`, and fails.

An ideal solution should be modify `xiangshan.py` and make it possible to propagate SIGTERM to every child process, but I have no idea on how.

This PR simply checks and kills for orphan emu processes before `checkout`.