### PR TITLE
fix(StoreUnit): fix the revoke logic of misalignbuffer

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -498,7 +498,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
 
   val s2_mis_align = s2_valid && RegEnable(s1_mis_align, s1_fire)
   // goto misalignBuffer
-  io.misalign_enq.revoke := s2_exception || s2_in.tlbMiss
+  io.misalign_enq.revoke := s2_exception || RegNext(s1_tlb_miss)
   val s2_misalignNeedReplay = RegEnable(s1_toMisalignBufferValid && (!io.misalign_enq.req.ready || s1_misalignNeedReplay), false.B, s1_fire)
   val s2_misalignBufferNack = !io.misalign_enq.revoke && s2_misalignNeedReplay
 


### PR DESCRIPTION
s2_in.tlb_miss should not be used because s2_in is not assigned a value when s1_tlbmiss occurs. :angry: