### PR TITLE
timing(abtb,utage,ubtb): optimize timing of partial prediction logic in BPU S1 stage

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -275,37 +275,53 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   // s0_stall should be exclusive with any other PC source
   s0_stall := !(s1_valid || s3_override || redirect.valid)
 
-  private val s1_ubtbPrediction = ubtb.io.prediction
-  private val s1_abtbPrediction = abtb.io.prediction
-  private val s1_abtbPosition   = abtb.io.abtbResultPos
-  private val s1_utageHitMask   = utage.io.prediction.hitVec
-  private val s1_utageTakenMask = utage.io.prediction.takenVec
-  private val s1_abtbTakenMask = VecInit(s1_abtbPrediction.zipWithIndex.map { case (pred, i) =>
-    pred.valid && (
-      pred.bits.attribute.isDirect ||
-        pred.bits.attribute.isIndirect ||
-        pred.bits.attribute.isConditional && Mux(s1_utageHitMask(i), s1_utageTakenMask(i), pred.bits.taken)
+  private val s1_ubtbPrediction = Wire(new Prediction)
+  private val s1_abtbPrediction = Wire(Vec(NumAheadBtbPredictionEntries, new Prediction))
+  s1_ubtbPrediction := ubtb.io.prediction.bits
+  s1_ubtbPrediction.target := Mux(
+    ubtb.io.prediction.bits.attribute.isReturn && uras.io.specOut.isCanUse,
+    uras.io.specOut.retTarget,
+    ubtb.io.prediction.bits.target
+  )
+  for (i <- 0 until NumAheadBtbPredictionEntries) {
+    s1_abtbPrediction(i) := abtb.io.prediction(i).bits
+  }
+
+  private val s1_abtbPosition       = abtb.io.abtbResultPos
+  private val s1_utageHitMask       = utage.io.prediction.hitVec
+  private val s1_utageTakenMask     = utage.io.prediction.takenVec
+  private val s1_jumpValidVec       = abtb.io.predCtrl.jumpValidVec
+  private val s1_conditonalValidVec = abtb.io.predCtrl.conditionValidVec
+  private val s1_abtbTakenMask = VecInit(abtb.io.prediction.zipWithIndex.map { case (pred, i) =>
+    XSPerfAccumulate(
+      s"abtb_attribute_mismatch_takenCtr${i}",
+      pred.valid && (pred.bits.attribute.isDirect || pred.bits.attribute.isIndirect) && !pred.bits.taken
     )
+    XSPerfAccumulate(
+      s"microTage_false_hit_way${i}",
+      pred.valid && !pred.bits.attribute.isConditional && s1_utageHitMask(i)
+    )
+    s1_jumpValidVec(i) || (s1_conditonalValidVec(i) && Mux(s1_utageHitMask(i), s1_utageTakenMask(i), pred.bits.taken))
   })
 
   private val s1_compareMatrix      = CompareMatrix(s1_abtbPosition)
   private val s1_abtbFirstTakenBrOH = s1_compareMatrix.getLeastElementOH(s1_abtbTakenMask)
   private val s1_abtbFirstTakenBr   = Mux1H(s1_abtbFirstTakenBrOH, s1_abtbPrediction)
-  private val s1_abtbValid          = s1_abtbPrediction.map(_.valid).reduce(_ || _)
+  private val s1_abtbValid          = abtb.io.prediction.map(_.valid).reduce(_ || _)
 
   private val s1_abtbResult = Wire(new Prediction)
-  s1_abtbResult       := s1_abtbFirstTakenBr.bits
-  s1_abtbResult.taken := s1_abtbFirstTakenBrOH.reduce(_ || _)
+  s1_abtbResult       := s1_abtbFirstTakenBr
+  s1_abtbResult.taken := s1_abtbTakenMask.reduce(_ || _)
+  s1_abtbResult.target := Mux(
+    s1_abtbFirstTakenBr.attribute.isReturn && uras.io.specOut.isCanUse,
+    uras.io.specOut.retTarget,
+    s1_abtbFirstTakenBr.target
+  )
   s1_prediction := Mux(
     s1_abtbValid,
     Mux(s1_abtbResult.taken, s1_abtbResult, fallThrough.io.prediction),
-    Mux(s1_ubtbPrediction.bits.taken, s1_ubtbPrediction.bits, fallThrough.io.prediction)
+    Mux(s1_ubtbPrediction.taken, s1_ubtbPrediction, fallThrough.io.prediction)
   )
-
-  private val s1_isRet = s1_prediction.attribute.isReturn
-  when(s1_isRet && uras.io.specOut.isCanUse) {
-    s1_prediction.target := uras.io.specOut.retTarget
-  }
 
   private val s1_taken             = s1_prediction.taken
   private val useAbtb              = s1_abtbValid && s1_abtbResult.taken

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
@@ -33,6 +33,7 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
     val redirectValid: Bool                       = Input(Bool())
     val overrideValid: Bool                       = Input(Bool())
     val prediction:    Vec[Valid[Prediction]]     = Output(Vec(NumAheadBtbPredictionEntries, Valid(new Prediction)))
+    val predCtrl:      AbtbBranchCtrl             = Output(new AbtbBranchCtrl)
     val abtbResult:    Vec[Valid[AheadBtbResult]] = Output(Vec(NumAheadBtbPredictionEntries, Valid(new AheadBtbResult)))
     val abtbResultPos: Vec[UInt]                  = Output(Vec(NumAheadBtbPredictionEntries, UInt(CfiPositionWidth.W)))
     val abtbPos:       Vec[UInt]                  = Output(Vec(NumAheadBtbPredictionEntries, UInt(CfiPositionWidth.W)))
@@ -149,6 +150,8 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
   private val s3_strongBias = RegInit(VecInit.fill(NumWays)(false.B))
 
   private val s1_realEntries = Mux(overrideValid, s3_entries, s1_entries)
+  private val s1_tag         = getTag(s1_startPc)
+  private val s1_realHitMask = VecInit(s1_realEntries.map(entry => entry.valid && entry.tag === s1_tag))
   private val s2_setIdx      = RegEnable(Mux(overrideValid, s3_setIdx, s1_setIdx), s1_fire)
   private val s2_bankIdx     = RegEnable(Mux(overrideValid, s3_bankIdx, s1_bankIdx), s1_fire)
   private val s2_bankMask    = RegEnable(Mux(overrideValid, s3_bankMask, s1_bankMask), s1_fire)
@@ -156,6 +159,7 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
   private val s2_strongBias  = RegEnable(Mux(overrideValid, s3_strongBias, s1_strongBias), s1_fire)
   private val s2_entries     = RegEnable(s1_realEntries, s1_fire)
   private val s2_startPc     = RegEnable(s1_startPc, s1_fire)
+  private val s2_hitMask     = RegEnable(s1_realHitMask, s1_fire)
 
   when(s2_fire) {
     s3_setIdx     := s2_setIdx
@@ -167,13 +171,28 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
     s3_strongBias := s2_strongBias
   }
 
-  private val s2_tag = getTag(s2_startPc)
-  dontTouch(s2_tag)
-  private val s2_hitMask = s2_entries.map(entry => entry.valid && entry.tag === s2_tag)
-  private val s2_hit     = s2_hitMask.reduce(_ || _)
+  // private val s2_tag = getTag(s2_startPc)
+  // dontTouch(s2_tag)
+  // private val s2_hitMask = s2_entries.map(entry => entry.valid && entry.tag === s2_tag)
+  // private val s2_hit     = s2_hitMask.reduce(_ || _)
+  private val s2_hit = s2_hitMask.reduce(_ || _)
 
   // When detect multi-hit, we need to invalidate one entry.
   private val (s2_multiHit, s2_multiHitWayIdx) = detectMultiHit(s2_hitMask, s2_entries.map(_.position))
+
+  private val s2_jumpValidVec      = RegInit(VecInit.fill(NumAheadBtbPredictionEntries)(false.B))
+  private val s2_conditionValidVec = RegInit(VecInit.fill(NumAheadBtbPredictionEntries)(false.B))
+  when(s1_fire) {
+    s2_jumpValidVec := VecInit.tabulate(NumAheadBtbPredictionEntries) {
+      i => (s1_realEntries(i).attribute.isDirect || s1_realEntries(i).attribute.isIndirect) && s1_realHitMask(i)
+    }
+    s2_conditionValidVec := VecInit.tabulate(NumAheadBtbPredictionEntries) {
+      i => s1_realEntries(i).attribute.isConditional && s1_realHitMask(i)
+    }
+  }.elsewhen(s2_flush || s2_fire) {
+    s2_jumpValidVec      := VecInit.fill(NumAheadBtbPredictionEntries)(false.B)
+    s2_conditionValidVec := VecInit.fill(NumAheadBtbPredictionEntries)(false.B)
+  }
 
   io.prediction.zipWithIndex.foreach { case (pred, i) =>
     pred.valid            := s2_valid && s2_hitMask(i)
@@ -182,6 +201,9 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
     pred.bits.attribute   := s2_entries(i).attribute
     pred.bits.target      := getFullTarget(s2_startPc, s2_entries(i).targetLowerBits, s2_entries(i).targetCarry)
   }
+  // Advance the calculation of critical control signals.
+  io.predCtrl.jumpValidVec      := s2_jumpValidVec
+  io.predCtrl.conditionValidVec := s2_conditionValidVec
   io.abtbResult.zipWithIndex.foreach { case (pred, i) =>
     pred.valid             := s2_valid && s2_hitMask(i)
     pred.bits.taken        := s2_ctrResult(i)
@@ -265,6 +287,8 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
         val needDecrease = updateThisSet && isCond && (!t1_trainTaken || t1_trainTaken && posBefore)
         val needIncrease = updateThisSet && isCond && t1_trainTaken && posEqual
 
+        // For timing purposes, the indirect jump branch in the abtb comparison matrix relies on
+        // the default CTR assignment and omits extra attribute checks.
         when(needReset)(ctr.resetWeakPositive())
           .elsewhen(needDecrease)(ctr.selfDecrease())
           .elsewhen(needIncrease)(ctr.selfIncrease())

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
@@ -126,8 +126,10 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
   private val s1_bankIdx  = RegEnable(s0_bankIdx, s0_fire)
   private val s1_bankMask = RegEnable(s0_bankMask, s0_fire)
 
-  private val s1_entries = Mux1H(s1_bankMask, banks.map(_.io.readResp.entries))
-
+  private val s1_entries    = Mux1H(s1_bankMask, banks.map(_.io.readResp.entries))
+  private val s1_ctrVec     = takenCounter(s1_bankIdx)(s1_setIdx)
+  private val s1_ctrResult  = VecInit(s1_ctrVec.map(_.isPositive))
+  private val s1_strongBias = VecInit(s1_ctrVec.map(_.isSaturate))
   /* --------------------------------------------------------------------------------------------------------------
      predict pipeline stage 2 / 3
      - get taken counter result
@@ -138,29 +140,32 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
      - stage 3 is only for fast prediction when override is valid
      -------------------------------------------------------------------------------------------------------------- */
 
-  private val s3_setIdx   = RegInit(0.U.asTypeOf(s1_setIdx))
-  private val s3_bankIdx  = RegInit(0.U.asTypeOf(s1_bankIdx))
-  private val s3_bankMask = RegInit(0.U.asTypeOf(s1_bankMask))
-  private val s3_entries  = RegInit(0.U.asTypeOf(s1_entries))
-  private val s3_startPc  = RegInit(0.U.asTypeOf(s1_startPc))
+  private val s3_setIdx     = RegInit(0.U.asTypeOf(s1_setIdx))
+  private val s3_bankIdx    = RegInit(0.U.asTypeOf(s1_bankIdx))
+  private val s3_bankMask   = RegInit(0.U.asTypeOf(s1_bankMask))
+  private val s3_entries    = RegInit(0.U.asTypeOf(s1_entries))
+  private val s3_startPc    = RegInit(0.U.asTypeOf(s1_startPc))
+  private val s3_ctrResult  = RegInit(VecInit.fill(NumWays)(false.B))
+  private val s3_strongBias = RegInit(VecInit.fill(NumWays)(false.B))
 
   private val s1_realEntries = Mux(overrideValid, s3_entries, s1_entries)
   private val s2_setIdx      = RegEnable(Mux(overrideValid, s3_setIdx, s1_setIdx), s1_fire)
   private val s2_bankIdx     = RegEnable(Mux(overrideValid, s3_bankIdx, s1_bankIdx), s1_fire)
   private val s2_bankMask    = RegEnable(Mux(overrideValid, s3_bankMask, s1_bankMask), s1_fire)
+  private val s2_ctrResult   = RegEnable(Mux(overrideValid, s3_ctrResult, s1_ctrResult), s1_fire)
+  private val s2_strongBias  = RegEnable(Mux(overrideValid, s3_strongBias, s1_strongBias), s1_fire)
   private val s2_entries     = RegEnable(s1_realEntries, s1_fire)
   private val s2_startPc     = RegEnable(s1_startPc, s1_fire)
 
   when(s2_fire) {
-    s3_setIdx   := s2_setIdx
-    s3_bankIdx  := s2_bankIdx
-    s3_bankMask := s2_bankMask
-    s3_entries  := s2_entries
-    s3_startPc  := s2_startPc
+    s3_setIdx     := s2_setIdx
+    s3_bankIdx    := s2_bankIdx
+    s3_bankMask   := s2_bankMask
+    s3_entries    := s2_entries
+    s3_startPc    := s2_startPc
+    s3_ctrResult  := s2_ctrResult
+    s3_strongBias := s2_strongBias
   }
-
-  private val s2_ctrResult  = takenCounter(s2_bankIdx)(s2_setIdx).map(_.isPositive)
-  private val s2_strongBias = takenCounter(s2_bankIdx)(s2_setIdx).map(_.isSaturate)
 
   private val s2_tag = getTag(s2_startPc)
   dontTouch(s2_tag)

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/Bundles.scala
@@ -96,3 +96,8 @@ class AheadBtbResult(implicit p: Parameters) extends AheadBtbBundle {
   val attribute:    BranchAttribute = new BranchAttribute
   val isStrongBias: Bool            = Bool()
 }
+
+class AbtbBranchCtrl(implicit p: Parameters) extends AheadBtbBundle {
+  val jumpValidVec:      Vec[Bool] = Vec(NumAheadBtbPredictionEntries, Bool())
+  val conditionValidVec: Vec[Bool] = Vec(NumAheadBtbPredictionEntries, Bool())
+}

--- a/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
@@ -67,13 +67,16 @@ class MicroBtb(implicit p: Parameters) extends BasePredictor with HasMicroBtbPar
   private val s1_fire = io.stageCtrl.s1_fire && io.enable
 
   private val s1_startPc = RegEnable(s0_startPc, s0_fire)
-  private val s1_tag     = getTag(s1_startPc)
 
-  private val s1_hitOH = VecInit(entries.map(e => e.valid && e.tag === s1_tag)).asUInt
+  private val s0_tag   = getTag(s0_startPc)
+  private val s0_hitOH = VecInit(entries.map(e => e.valid && e.tag === s0_tag)).asUInt
+  private val s1_hitOH = RegEnable(s0_hitOH, 0.U(NumEntries.W), s0_fire)
   assert(PopCount(s1_hitOH) <= 1.U, "MicroBtb s1_hitOH should be one-hot")
   private val s1_hit      = s1_hitOH.orR
   private val s1_hitIdx   = OHToUInt(s1_hitOH)
   private val s1_hitEntry = entries(s1_hitIdx)
+  // Count wrong hits due to the hit entry being replaced by fastTrain in the same cycle.
+  XSPerfAccumulate("false_hit", s1_hit && s1_hitEntry.tag =/= getTag(s1_startPc))
 
   // we do always-taken prediction in ubtb
   io.prediction.valid            := s1_hit

--- a/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
@@ -114,8 +114,21 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
     }
   }
 
+  // Prioritize early position comparison at the cost of ABTB SRAM timing margin,
+  // ensuring glitch-free valid signals for the next stage.
+  private val a1_posHitVec = Wire(Vec(NumAheadBtbPredictionEntries, Vec(NumTables, Vec(NumWays, Bool()))))
+  for (i <- 0 until NumAheadBtbPredictionEntries) {
+    for (j <- 0 until NumTables) {
+      for (k <- 0 until NumWays) {
+        a1_posHitVec(i)(j)(k) :=
+          a1_predEntries(j)(k).valid && (a1_predEntries(j)(k).cfiPosition === io.abtbPosVec(i))
+      }
+    }
+  }
+
   private val a3_readIndex     = RegInit(0.U.asTypeOf(a1_readIndex))
   private val a3_predRead      = RegInit(0.U.asTypeOf(a1_predRead))
+  private val a3_posHitVec     = RegInit(0.U.asTypeOf(a1_posHitVec))
   private val overridePredRead = Wire(Vec(NumTables, Vec(NumWays, new MicroTageTablePred)))
   for (i <- 0 until NumTables) {
     val predTag = computeHashTag(a1_startPc, a1_foldedPathHist, TableInfos, i)
@@ -133,6 +146,8 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
   private val a2_readIndex = RegEnable(Mux(overrideValid, a3_readIndex, a1_readIndex), a1_fire)
   private val a2_predRead =
     RegEnable(Mux(overrideValid, overridePredRead, a1_predRead), 0.U.asTypeOf(a1_predRead), a1_fire)
+  private val a2_posHitVec =
+    RegEnable(Mux(overrideValid, a3_posHitVec, a1_posHitVec), 0.U.asTypeOf(a1_posHitVec), a1_fire)
   private val a2_fromAbtbPos     = RegEnable(io.abtbPosVec, a1_fire)
   private val a2_abtbHitVec      = Wire(Vec(NumAheadBtbPredictionEntries, Bool()))
   private val a2_abtbTakenVec    = Wire(Vec(NumAheadBtbPredictionEntries, Bool()))
@@ -150,8 +165,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
     for (j <- 0 until NumTables) {
       val wayHitVec = Wire(Vec(NumWays, Bool()))
       for (k <- 0 until NumWays) {
-        wayHitVec(k) := (a2_predRead(j)(k).valid && a2_predRead(j)(k).tagHit) &&
-          a2_predRead(j)(k).cfiPosition === a2_fromAbtbPos(i) // io.abtbPrediction(i).bits.cfiPosition
+        wayHitVec(k) := a2_predRead(j)(k).tagHit && a2_posHitVec(i)(j)(k)
       }
       tableHitVec(j) := wayHitVec.asUInt.orR
       val priorityWayHitVec = PriorityEncoderOH(wayHitVec)
@@ -198,6 +212,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
   when(a2_fire) {
     a3_predRead  := a2_predRead
     a3_readIndex := a2_readIndex
+    a3_posHitVec := a2_posHitVec
   }
 
   // ------------ MicroTage is only concerned with conditional branches ---------- //

--- a/src/main/scala/xiangshan/frontend/bpu/utage/MicroTageTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/MicroTageTable.scala
@@ -117,8 +117,8 @@ class MicroTageTable(
 
   // Select data from buffer (if hit) or SRAM (if miss)
   private val readEntries = VecInit(
-    (bufferHit, bufferReadEntries, sramRealReadEntries).zipped.map {
-      case (hit, bufferEntry, sramEntry) => Mux(hit, bufferEntry, sramEntry)
+    (bufferHit zip bufferReadEntries zip sramRealReadEntries).map {
+      case ((hit, bufferEntry), sramEntry) => Mux(hit, bufferEntry, sramEntry)
     }
   )
 


### PR DESCRIPTION
Timing Fixes：
1. ubtb: Advance tag comparison by one stage to reduce fanout and combinational logic in the subsequent stage.
2. abtb: Advance tag comparison by one stage to reduce fanout and combinational logic in the subsequent stage.
3. abtb: Advance TakenCtr read by one stage to mitigate large register file read latency.
4. utage: Advance pos comparison by one stage to reduce downstream combinational logic fanout.
5. phr: Adjust indexing logic to reduce fanout and routing complexity caused by large shifters, while narrowing the shift range.
6. abtb: Leverage the initial assignment of TakenCtr to eliminate redundant branch property checks during direction prediction.

Expect slight performance fluctuations due to the TakenCtr adjustments and simplified branch attribute logic.