### PR TITLE
fix(prefetch): enable decr mode in StreamPrefetcher

### DIFF
--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -348,6 +348,15 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
   XSPerfAccumulate("s1_active_plus_one_hit", s1_valid && s1_plus_one_hit)
   XSPerfAccumulate("s1_active_minus_one_hit", s1_valid && s1_minus_one_hit)
 
+  val stream_array_table = ChiselDB.createTable("StreamArrayTable" + p(XSCoreParamsKey).HartId.toString, new StreamBitVectorBundle, basicDB = false)
+  stream_array_table.log(
+    data = array(s1_index),
+    en = s1_alloc && valids(s1_index),
+    site = "StreamArrayTable",
+    clock = clock,
+    reset = reset
+  )
+
   // s2: trigger prefetch if hit active bit vector, compute meta of prefetch req
   val s2_valid = GatedValidRegNext(s1_valid)
   val s2_index = RegEnable(s1_index, s1_valid)

--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -42,7 +42,7 @@ trait HasStreamPrefetchHelper extends HasL1PrefetchHelper {
   val DEPTH_LOOKAHEAD = 8
   val DEPTH_BITS = log2Up(DEPTH_CACHE_BLOCKS) + DEPTH_LOOKAHEAD
 
-  val ENABLE_DECR_MODE = false
+  val ENABLE_DECR_MODE = true
   val ENABLE_STRICT_ACTIVE_DETECTION = true
   val USE_STREAM_FIXED_DEPTH = true
 

--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -306,8 +306,8 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
                             RegEnable(s0_minus_one_hit, s0_valid) && array(s1_minus_one_index).active
   val s1_region_tag = RegEnable(s0_region_tag, s0_valid)
   val s1_region_bits = RegEnable(s0_region_bits, s0_valid)
-  val s1_alloc = s1_valid && !s1_hit
-  val s1_update = s1_valid && s1_hit
+  val s1_alloc = s1_valid && !s1_hit && (s1_miss || s1_pfHit)
+  val s1_update = s1_valid && s1_hit && (s1_miss || s1_pfHit)
   val s1_pf_l1_incr_vaddr = Cat(region_to_block_addr(s1_region_tag, s1_region_bits) + l1_depth, 0.U(BLOCK_OFFSET.W))
   val s1_pf_l1_decr_vaddr = Cat(region_to_block_addr(s1_region_tag, s1_region_bits) - l1_depth, 0.U(BLOCK_OFFSET.W))
   val s1_pf_l2_incr_vaddr = Cat(region_to_block_addr(s1_region_tag, s1_region_bits) + l2_depth, 0.U(BLOCK_OFFSET.W))

--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -196,11 +196,12 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
 
   // s0: generate region tag, parallel match
   val s0_can_accept = Wire(Bool())
-  val s0_valid = io.train_req.fire
+  val s0_fire = io.train_req.fire
   val s0_pc    = io.train_req.bits.pc
   val s0_vaddr = io.train_req.bits.vaddr
   val s0_miss  = io.train_req.bits.miss
   val s0_pfHit = io.train_req.bits.pfHitStream
+  val s0_valid = s0_fire && (s0_miss || s0_pfHit)
   val s0_region_bits = get_region_bits(s0_vaddr)
   val s0_region_tag = get_region_tag(s0_vaddr)
   val s0_region_tag_plus_one = get_region_tag(s0_vaddr) + 1.U
@@ -306,8 +307,8 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
                             RegEnable(s0_minus_one_hit, s0_valid) && array(s1_minus_one_index).active
   val s1_region_tag = RegEnable(s0_region_tag, s0_valid)
   val s1_region_bits = RegEnable(s0_region_bits, s0_valid)
-  val s1_alloc = s1_valid && !s1_hit && (s1_miss || s1_pfHit)
-  val s1_update = s1_valid && s1_hit && (s1_miss || s1_pfHit)
+  val s1_alloc = s1_valid && !s1_hit
+  val s1_update = s1_valid && s1_hit
   val s1_pf_l1_incr_vaddr = Cat(region_to_block_addr(s1_region_tag, s1_region_bits) + l1_depth, 0.U(BLOCK_OFFSET.W))
   val s1_pf_l1_decr_vaddr = Cat(region_to_block_addr(s1_region_tag, s1_region_bits) - l1_depth, 0.U(BLOCK_OFFSET.W))
   val s1_pf_l2_incr_vaddr = Cat(region_to_block_addr(s1_region_tag, s1_region_bits) + l2_depth, 0.U(BLOCK_OFFSET.W))

--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -315,12 +315,7 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
   val s1_pf_l2_decr_vaddr = Cat(region_to_block_addr(s1_region_tag, s1_region_bits) - l2_depth, 0.U(BLOCK_OFFSET.W))
   val s1_pf_l3_incr_vaddr = Cat(region_to_block_addr(s1_region_tag, s1_region_bits) + l3_depth, 0.U(BLOCK_OFFSET.W))
   val s1_pf_l3_decr_vaddr = Cat(region_to_block_addr(s1_region_tag, s1_region_bits) - l3_depth, 0.U(BLOCK_OFFSET.W))
-  // TODO: remove this
-  val strict_trigger_const = Constantin.createRecord(s"StreamStrictTrigger_${p(XSCoreParamsKey).HartId}", initValue = 1)
-  // If use strict triggering mode, the stream prefetcher will only trigger prefetching
-  // under **cache miss or prefetch hit stream**, but will still perform training on the entire memory access trace.
-  val s1_can_trigger = Mux(strict_trigger_const.orR, s1_miss || s1_pfHit, true.B)
-  val s1_can_send_pf = Mux(s1_update, !((array(s1_index).bit_vec & UIntToOH(s1_region_bits)).orR), true.B) && s1_can_trigger
+  val s1_can_send_pf = Mux(s1_update, !((array(s1_index).bit_vec & UIntToOH(s1_region_bits)).orR), true.B)
   // Check s0 s1 same region, avoid duplicate alloc
   val s1_s0_same_region = region_hash_tag(s1_region_tag) === region_hash_tag(s0_region_tag)
   // s1 replace the s0 region entry

--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
@@ -238,9 +238,8 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
         s2_loadPcVec(i),
         s3_loadPcVec(i)
       )
-      pf.io.ld_in(i).valid := source.valid && source.bits.isFirstIssue && (
-        source.bits.miss || isFromStream(source.bits.meta_prefetch)
-      )&& !source.bits.is_from_hw_pf // && isLoadAccess(source.bits.uop)
+      pf.io.ld_in(i).valid := source.valid && source.bits.isFirstIssue && !source.bits.is_from_hw_pf
+      // && isLoadAccess(source.bits.uop)
       pf.io.ld_in(i).bits := source.bits
     }
 

--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
@@ -238,8 +238,9 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
         s2_loadPcVec(i),
         s3_loadPcVec(i)
       )
-      pf.io.ld_in(i).valid := source.valid && source.bits.isFirstIssue && !source.bits.is_from_hw_pf
-      // && isLoadAccess(source.bits.uop)
+      pf.io.ld_in(i).valid := source.valid && source.bits.isFirstIssue && (
+        source.bits.miss || isFromStream(source.bits.meta_prefetch)
+      )&& !source.bits.is_from_hw_pf // && isLoadAccess(source.bits.uop)
       pf.io.ld_in(i).bits := source.bits
     }
 


### PR DESCRIPTION
* enable decr mode in StreamPrefetcher,  good returns on soplex.
* update the stream flow direction during stream prefetch training, rather than only during allocation.
* Instead of performing training on the entire memory access trace, we use the cache miss or prefetch hit stream for training. Previously, training was conducted using the memory access trace, and prefetching was triggered by the cache miss or prefetch hit stream.
* fix a bug where the array would be incorrectly updated when s1 replace the s0 region entry.
<img width="1482" height="2051" alt="image" src="https://github.com/user-attachments/assets/f45db00a-088f-4b09-a498-b187455191a9" />