### PR TITLE
ci(emu-performace): use node servers only

### DIFF
--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -34,7 +34,9 @@ jobs:
     name: EMU - Performance - Build
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' }}
-    runs-on: builder
+    runs-on:
+      - node # Run on node servers for the moment, as gsim is having performance issue on open servers
+      - builder
     outputs:
       cluster: ${{ steps.save.outputs.cluster }}
     timeout-minutes: 120


### PR DESCRIPTION
GSIM is having performance issue on open servers (~2-10x of runtime on node servers, while verilator is ~1-2x), see runs in #5650 