### PR TITLE
fix(LoadUnit): raise af for unalign access on MMIO region

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -286,7 +286,10 @@ class LoadUnitS0(param: ExeUnitParams)(
     */
   val needAlignCheckSources = Seq(replayHiPrio, fastReplay, replayLoPrio, vectorIssue, scalarIssue)
   val needAlignCheckValids = needAlignCheckSources.map(_.valid)
-  val noAlignCheckSources = sources.filterNot(needAlignCheckSources.contains) // unalign tail, hardware prefetch
+  val alwaysUnalignSources = Seq(unalignTail)
+  val alwaysUnalign = Cat(alwaysUnalignSources.map(_.fire)).orR
+  val alwaysAlignSources = Seq(prefetchHiConf, prefetchLoConf)
+  val noAlignCheckSources = alwaysUnalignSources ++ alwaysAlignSources // unalign tail, hardware prefetch
   val noAlignCheck = Cat(noAlignCheckSources.map(_.fire)).orR || isPrefetch // unalign tail, hardware & software prefetch
   val needAlignCheck = !noAlignCheck
 
@@ -294,7 +297,7 @@ class LoadUnitS0(param: ExeUnitParams)(
   val _align = ParallelPriorityMux(needAlignCheckValids, alignCheckResults._1)
   val _crossWordInsideBank = ParallelPriorityMux(needAlignCheckValids, alignCheckResults._2)
   val _crossBank = ParallelPriorityMux(needAlignCheckValids, alignCheckResults._3)
-  val align = noAlignCheck || _align
+  val align = !alwaysUnalign && (noAlignCheck || _align)
   val crossWordInsideBank = needAlignCheck && _crossWordInsideBank
   val crossBank = needAlignCheck && _crossBank
   val readWholeBank = unalignTail.valid || crossWordInsideBank
@@ -914,12 +917,13 @@ class LoadUnitS2(param: ExeUnitParams)(
   // load access fault
   val afUnaccessable = uop.exceptionVec(loadAccessFault) || pmpUnaccessable
   val afVectorUncache = accessType.isVector() && isUncache
+  val afUnalignMMIO = !in.align.get && isMMIO
   val afTagError = io.dcacheResp.bits.tag_error && tlbHit && io.csrCtrl.cache_error_enable
   val afForwardDenied = Wire(Bool())
   val afBypassDenied = Wire(Bool())
-  val af = afUnaccessable || afVectorUncache || afTagError || afForwardDenied || afBypassDenied
+  val af = afUnaccessable || afVectorUncache || afUnalignMMIO || afTagError || afForwardDenied || afBypassDenied
   // load address misaligned
-  val am = !in.align.get && accessType.isScalar() && isUncache && !pmpUnaccessable
+  val am = !in.align.get && accessType.isScalar() && isNC && !pmpUnaccessable
   // hardware error
   val hweForwardCorrupt = Wire(Bool())
   val hweBypassCorrupt = Wire(Bool())


### PR DESCRIPTION
This pr fixes #5695 for v3. According to RISC-V spec: Non-idempotent regions might not support misaligned accesses. Misaligned accesses to such regions should raise access-fault exceptions, indicating that software should not emulate the misaligned access using multiple smaller accesses, which could cause unexpected side effects.

Therefore, unalign accesses to MMIO region should raise an af exception instead of a misalign exception. This commit fixes this issue. Unalign access to NC region still raises misalign exception for its idempotent memory attribute. Besides it should be noted that store has the same bug, which will be fixed in the subsequent StoreUnit refactoring.