### PR TITLE
ci(perf): bump version & upload score to artifact & merge path

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,49 +5,42 @@ on:
     - cron: '33 15 * * *'
 
 jobs:
-  performance-test:
+  run:
+    name: Run Performance Test
     uses: ./.github/workflows/perf-template.yml
     with:
       test_branch: kunminghu-v3
-      perf_report_dir: /nfs/home/cirunner/perf-report-nightly
+      perf_report_dir: /nfs/home/cirunner/perf-report-custom
       benchmark_type: gcc15-spec06-0.3c
       servers: all
 
-  diff-report:
-    needs: performance-test
+  report:
+    name: Generate Report
+    needs: run
     runs-on: perf
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Compute paths
+      - uses: actions/checkout@v6
+      - name: Link current report
         run: |
-          XS_CONFIG=CHIConfig
-          PERF_DIR=/nfs/home/cirunner/perf-report-nightly
-          # determine the most recent report directory for this config
-          SPEC_DIR=$(ls -td $PERF_DIR/cr*-${XS_CONFIG} 2>/dev/null | head -n1 || true)
-          if [ -n "$SPEC_DIR" ]; then
-            # extract date and short sha from dirname: cr<date>-<sha>-<config>
-            base=$(basename "$SPEC_DIR")
-            DATE=${base#cr}; DATE=${DATE%%-*}
-            SHORT_SHA=${base#cr${DATE}-}; SHORT_SHA=${SHORT_SHA%%-*}
-          else
-            DATE=$(date +%y%m%d)
-            SHORT_SHA="unknown"
-          fi
-          echo "SPEC_DIR=$SPEC_DIR" >> $GITHUB_ENV
-          echo "PERF_DIR=$PERF_DIR" >> $GITHUB_ENV
-          echo "XS_CONFIG=$XS_CONFIG" >> $GITHUB_ENV
-          echo "DATE=$DATE" >> $GITHUB_ENV
-          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+          ln -s "${{ needs.run.outputs.SPEC_DIR }}" "${{ needs.run.outputs.PERF_DIR }}/nightly-${{ needs.run.outputs.DATE }}"
+      - name: Find previous commit
+        run: |
+          PREV_DIR=$(ls -td "${{ needs.run.outputs.PERF_DIR }}/nightly-*" | grep -v "nightly-${{ needs.run.outputs.DATE }}" | head -n1 || true)
+          echo "Found previous report: $PREV_DIR"
+          PREV_DIR=$(readlink -f "$PREV_DIR")
+          echo "Resolved to: $PREV_DIR"
+          echo "PREV_DIR=$PREV_DIR" >> $GITHUB_ENV
       - name: Diff with previous result
         run: |
           echo "### :bar_chart: Diff with previous run" >> $GITHUB_STEP_SUMMARY
-          PREV_DIR=$(ls -td $PERF_DIR/cr*-${XS_CONFIG} 2>/dev/null | grep -v "cr${DATE}-${SHORT_SHA}-${XS_CONFIG}" | head -n1 || true)
           if [ -n "$PREV_DIR" ] && [ -f "$PREV_DIR/score.txt" ]; then
             echo "Comparing with $PREV_DIR" >> $GITHUB_STEP_SUMMARY
-            python3 $GITHUB_WORKSPACE/.github/workflows/nightly_perf_diff.py "$SPEC_DIR/score.txt" "$PREV_DIR/score.txt" >> $GITHUB_STEP_SUMMARY
+            python3 $GITHUB_WORKSPACE/.github/workflows/nightly_perf_diff.py "${{ needs.run.outputs.SCORE_FILE }}" "$PREV_DIR/score.txt" >> $GITHUB_STEP_SUMMARY
           else
             echo "No previous score.txt found" >> $GITHUB_STEP_SUMMARY
           fi
+      - name: Upload report
+        uses: actions/upload-artifact@v7
+        with:
+          name: score
+          path: ${{ needs.run.outputs.SCORE_FILE }}

--- a/.github/workflows/perf-template.yml
+++ b/.github/workflows/perf-template.yml
@@ -47,6 +47,25 @@ on:
         description: Directory for all spec reports
         required: true
         type: string
+    outputs:
+      SHORT_SHA:
+        description: Short git commit sha used in this run
+        value: ${{ jobs.run.outputs.SHORT_SHA }}
+      DATE:
+        description: Commit date in yymmdd format used in this run
+        value: ${{ jobs.run.outputs.DATE }}
+      PERF_DIR:
+        description: Base directory for performance reports
+        value: ${{ inputs.perf_report_dir }}
+      SPEC_DIR:
+        description: Output report directory for this performance run
+        value: ${{ jobs.run.outputs.SPEC_DIR }}
+      CONFIG:
+        description: XiangShan config used in this run
+        value: ${{ inputs.xs_config }}
+      SCORE_FILE:
+        description: Path to the score.txt generated in this run
+        value: ${{ jobs.run.outputs.SPEC_DIR }}/score.txt
 
 jobs:
   run:
@@ -55,6 +74,10 @@ jobs:
     #At most 2 days to finish
     timeout-minutes: 7200
     name: Checkpoints
+    outputs:
+      SHORT_SHA: ${{ steps.set_env.outputs.SHORT_SHA }}
+      DATE: ${{ steps.set_env.outputs.DATE }}
+      SPEC_DIR: ${{ steps.set_env.outputs.SPEC_DIR }}
     steps:
       - name: Set test branch or commit
         id: set_test
@@ -63,18 +86,22 @@ jobs:
           echo "commit_sha=${{ inputs.test_branch }}" >> $GITHUB_OUTPUT
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.set_test.outputs.commit_sha }}
           fetch-depth: 0
           submodules: true
 
       - name: Set env
+        id: set_env
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
           DATE=$(git show -s --format=%cd --date=format:%y%m%d HEAD)
           echo "SCRIPTS_HOME=/nfs/home/share/ci-workloads/env-scripts" >> $GITHUB_ENV
           echo "SPEC_DIR=${{ inputs.perf_report_dir }}/cr${DATE}-${SHORT_SHA}-${{ inputs.xs_config }}" >> $GITHUB_ENV
+          echo "SHORT_SHA=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "DATE=${DATE}" >> $GITHUB_OUTPUT
+          echo "SPEC_DIR=${{ inputs.perf_report_dir }}/cr${DATE}-${SHORT_SHA}-${{ inputs.xs_config }}" >> $GITHUB_OUTPUT
           
           if [[ -z "${{ inputs.servers }}" ]]; then
             if [[ "${{ inputs.emulator }}" == "gsim" ]]; then

--- a/.github/workflows/perf-v3.yml
+++ b/.github/workflows/perf-v3.yml
@@ -13,9 +13,22 @@ on:
         default: kunminghu-v3
 
 jobs:
-  performance-test:
+  run:
+    name: Run Performance Test
     uses: ./.github/workflows/perf-template.yml
     with:
       test_branch: ${{ github.event.inputs.test_branch }}
       perf_report_dir: /nfs/home/cirunner/perf-report-kmhv3
       servers: all
+
+  report:
+    name: Generate Report
+    needs: run
+    runs-on: perf
+    steps:
+      - uses: actions/checkout@v6
+      - name: Upload report
+        uses: actions/upload-artifact@v7
+        with:
+          name: score
+          path: ${{ needs.run.outputs.SCORE_FILE }}


### PR DESCRIPTION
- bump actions/checkout version to v6 following #5703, [node20 is reaching EOL](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
- upload score.txt to artifacts following #5635, so outside scripts like [XiangShan-Dashboard](https://github.com/ngc7331/XiangShan-Dashboard) can access it.
- add outputs of perf-template, so we dont need to caculate pathes.
  - utilize this to re-write nightly
- merge `/nfs/home/cirunner/perf-report-nightly` to `-custom`, so the same commit+config+benchmark will not be ran multiple times, and we can use nightly as baseline of manually-triggered perf-trigger.
- do not use `with: fetch-depth: 0` in nightly, we don't need full git history just to generate report.