### PR TITLE
timing(bpu): use sram.resetDone instead of r.req.ready

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
@@ -43,7 +43,7 @@ abstract class BasePredictorIO(implicit p: Parameters) extends BpuBundle {
   // fast train for s1 predictors
   val fastTrain: Option[Valid[BpuFastTrain]] = None
 
-  val resetDone: Bool = Output(Bool())
+  val sramResetDone: Bool = Output(Bool())
 }
 
 trait HasFastTrainIO extends BasePredictorIO {

--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -248,12 +248,14 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   s2_ready := s2_fire || !s2_valid
   s3_ready := s3_fire || !s3_valid
 
-  private val resetDone = RegInit(false.B)
-  resetDone := predictors.map(_.io.resetDone).reduce(_ && _)
-  s0_fire   := s1_ready && resetDone
-  s1_fire   := s1_valid && s2_ready && io.toFtq.prediction.ready
-  s2_fire   := s2_valid && s3_ready
-  s3_fire   := s3_valid
+  private val sramResetDone = RegInit(false.B)
+  when(predictors.map(_.io.sramResetDone).reduce(_ && _)) {
+    sramResetDone := true.B
+  }
+  s0_fire := s1_ready && sramResetDone
+  s1_fire := s1_valid && s2_ready && io.toFtq.prediction.ready
+  s2_fire := s2_valid && s3_ready
+  s3_fire := s3_valid
 
   when(s0_fire)(s1_valid := true.B)
     .elsewhen(s1_flush)(s1_valid := false.B)

--- a/src/main/scala/xiangshan/frontend/bpu/FallThroughPredictor.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/FallThroughPredictor.scala
@@ -29,7 +29,7 @@ class FallThroughPredictor(implicit p: Parameters) extends BasePredictor
 
   val io: FallThroughPredictorIO = IO(new FallThroughPredictorIO)
 
-  io.resetDone := true.B
+  io.sramResetDone := true.B
 
   io.trainReady := true.B
 

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
@@ -49,11 +49,7 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
   private val banks     = Seq.tabulate(NumBanks)(i => Module(new AheadBtbBank(i)))
   private val replacers = Seq.fill(NumBanks)(Module(new AheadBtbReplacer))
 
-  private val resetDone = RegInit(false.B)
-  when(banks.map(_.io.readReq.ready).reduce(_ && _)) {
-    resetDone := true.B
-  }
-  io.resetDone := resetDone
+  io.sramResetDone := banks.map(_.io.sramResetDone).reduce(_ && _)
 
   io.trainReady := true.B
 

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtbBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtbBank.scala
@@ -31,6 +31,8 @@ class AheadBtbBank(bandIdx: Int)(implicit p: Parameters) extends AheadBtbModule 
     val readResp:  BankReadResp             = Output(new BankReadResp)
     val writeReq:  Valid[BankWriteReq]      = Flipped(Valid(new BankWriteReq))
     val writeResp: Valid[BankWriteResp]     = Valid(new BankWriteResp)
+
+    val sramResetDone: Bool = Output(Bool())
   }
   val io: BankIO = IO(new BankIO)
 
@@ -59,6 +61,8 @@ class AheadBtbBank(bandIdx: Int)(implicit p: Parameters) extends AheadBtbModule 
   io.readReq.ready := sram.io.r.req.ready
 
   io.readResp.entries := sram.io.r.resp.data
+
+  io.sramResetDone := sram.io.resetDone
 
   /* --------------------------------------------------------------------------------------------------------------
      write

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
@@ -53,8 +53,6 @@ class Ittage(implicit p: Parameters) extends BasePredictor with HasIttageParamet
 
   val io: IttageIO = IO(new IttageIO)
 
-  io.resetDone := true.B // FIXME: sram read ready
-
   io.trainReady := true.B
 
   private val s0_startPc = io.startPc
@@ -72,6 +70,8 @@ class Ittage(implicit p: Parameters) extends BasePredictor with HasIttageParamet
       val t = Module(new IttageTable(info.Size, info.HistoryLength, TagWidth, i))
       t
   }
+
+  io.sramResetDone := tables.map(_.io.sramResetDone).reduce(_ && _)
 
   private val useAltOnNa = RegInit((1 << (UseAltOnNaWidth - 1)).U(UseAltOnNaWidth.W))
   private val tickCnt    = RegInit(TickCounter.Zero)

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/IttageTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/IttageTable.scala
@@ -68,6 +68,8 @@ class IttageTable(
     val req:    DecoupledIO[Req] = Flipped(DecoupledIO(new Req))
     val resp:   Valid[Resp]      = Output(Valid(new Resp))
     val update: Update           = Input(new Update)
+
+    val sramResetDone: Bool = Output(Bool())
   }
 
   val io: IttageTableIO = IO(new IttageTableIO)
@@ -149,6 +151,9 @@ class IttageTable(
       suffix = Option(s"bpu_ittage_bank$bankIdx")
     )).suggestName(s"ittage_table_bank$bankIdx")
   }
+
+  io.sramResetDone := tables.map(_.io.resetDone).reduce(_ && _)
+
   private val mbistPl = MbistPipeline.PlaceMbistPipeline(1, "MbistPipeIttage", hasMbist)
   tables.zipWithIndex.foreach { case (bank, idx) =>
     bank.io.r.req.valid       := io.req.fire && s0_bankMask(idx)

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -50,7 +50,7 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   /* *** submodules *** */
   private val alignBanks = Seq.tabulate(NumAlignBanks)(alignIdx => Module(new MainBtbAlignBank(alignIdx)))
 
-  io.resetDone := alignBanks.map(_.io.resetDone).reduce(_ && _)
+  io.sramResetDone := alignBanks.map(_.io.sramResetDone).reduce(_ && _)
 
   io.trainReady := true.B
 

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
@@ -67,8 +67,8 @@ class MainBtbAlignBank(
       val req: Valid[Req] = Flipped(Valid(new Req))
     }
 
-    val resetDone: Bool      = Output(Bool())
-    val stageCtrl: StageCtrl = Input(new StageCtrl)
+    val sramResetDone: Bool      = Output(Bool())
+    val stageCtrl:     StageCtrl = Input(new StageCtrl)
 
     val read:  Read                  = new Read
     val write: Write                 = new Write
@@ -90,7 +90,7 @@ class MainBtbAlignBank(
 
   private val replacer = Module(new MainBtbReplacer)
 
-  io.resetDone := internalBanks.map(_.io.resetDone).reduce(_ && _)
+  io.sramResetDone := internalBanks.map(_.io.sramResetDone).reduce(_ && _)
 
   /* *** s0 ***
    * send read req to internal banks (srams)

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbInternalBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbInternalBank.scala
@@ -71,7 +71,7 @@ class MainBtbInternalBank(
       val req: Valid[Req] = Flipped(Valid(new Req))
     }
 
-    val resetDone: Bool = Output(Bool())
+    val sramResetDone: Bool = Output(Bool())
 
     val read:         Read         = new Read
     val writeEntry:   WriteEntry   = new WriteEntry
@@ -132,11 +132,7 @@ class MainBtbInternalBank(
     flow = true
   ))
 
-  private val resetDone = RegInit(false.B)
-  when(entrySrams.map(_.io.r.req.ready).reduce(_ && _) && counterSram.io.r.req.ready) {
-    resetDone := true.B
-  }
-  io.resetDone := resetDone
+  io.sramResetDone := entrySrams.map(_.io.resetDone).reduce(_ && _) && counterSram.io.resetDone
 
   /* *** sram -> io *** */
   // handle entry & counter together

--- a/src/main/scala/xiangshan/frontend/bpu/ras/MicroRas.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/MicroRas.scala
@@ -61,8 +61,8 @@ class MicroRas(implicit p: Parameters) extends BasePredictor with HasRasParamete
     val fullRetAddr: PrunedAddr      = Input(PrunedAddr(VAddrBits)) // Current top of the main RAS
   }
   val io = IO(new MicroRasIO)
-  io.resetDone  := true.B
-  io.trainReady := true.B
+  io.sramResetDone := true.B
+  io.trainReady    := true.B
 
   // Track whether S2/S3 stages contain pending push/pop operations
   private val s2_hasPush = RegInit(false.B)

--- a/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
@@ -52,7 +52,8 @@ class Ras(implicit p: Parameters) extends BasePredictor with HasRasParameters wi
 
   val io: RasIO = IO(new RasIO)
 
-  io.resetDone := true.B
+  // Ras used Regfile instead of SRAM to store entires
+  io.sramResetDone := true.B
 
   io.trainReady := true.B
 

--- a/src/main/scala/xiangshan/frontend/bpu/sc/Sc.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/sc/Sc.scala
@@ -92,15 +92,13 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
 
   private val scThreshold = RegInit(VecInit.tabulate(NumWays)(_ => ThresholdCounter.Init))
 
-  private val resetDone = RegInit(false.B)
-  when(pathTable.map(_.io.resetDone).reduce(_ && _) &&
-    globalTable.map(_.io.resetDone).reduce(_ && _) &&
-    bwTable.map(_.io.resetDone).reduce(_ && _) &&
-    imliTable.io.resetDone &&
-    biasTable.io.resetDone) {
-    resetDone := true.B
-  }
-  io.resetDone := resetDone
+  io.sramResetDone := (
+    pathTable.map(_.io.sramResetDone) ++
+      globalTable.map(_.io.sramResetDone) ++
+      bwTable.map(_.io.sramResetDone) :+
+      imliTable.io.sramResetDone :+
+      biasTable.io.sramResetDone
+  ).reduce(_ && _)
 
   io.trainReady := true.B
 

--- a/src/main/scala/xiangshan/frontend/bpu/sc/ScTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/sc/ScTable.scala
@@ -33,10 +33,10 @@ class ScTable(
 )(implicit p: Parameters)
     extends ScModule with HasScParameters with Helpers {
   class ScTableIO extends ScBundle {
-    val req:       Valid[ScTableReq] = Flipped(Valid(new ScTableReq(numSets, numWays)))
-    val resp:      Vec[ScEntry]      = Output(Vec(numWays, new ScEntry()))
-    val update:    ScTableTrain      = Input(new ScTableTrain(numSets, numWays))
-    val resetDone: Bool              = Output(Bool())
+    val req:           Valid[ScTableReq] = Flipped(Valid(new ScTableReq(numSets, numWays)))
+    val resp:          Vec[ScEntry]      = Output(Vec(numWays, new ScEntry()))
+    val update:        ScTableTrain      = Input(new ScTableTrain(numSets, numWays))
+    val sramResetDone: Bool              = Output(Bool())
   }
 
   val io = IO(new ScTableIO())
@@ -83,7 +83,7 @@ class ScTable(
       bank.io.r.req.bits.setIdx := reqSetIdx
   }
 
-  io.resetDone := sram.map(_.io.r.req.ready).reduce(_ && _)
+  io.sramResetDone := sram.map(_.io.resetDone).reduce(_ && _)
 
   private val respBankMask = RegEnable(reqBankMask, io.req.valid)
   io.resp := Mux1H(respBankMask.asBools, sram.map(_.io.r.resp.data))

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
@@ -53,11 +53,7 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
   private val useAltOnNaVec = RegInit(VecInit.fill(NumUseAltOnNa)(UseAltOnNaCounter.Zero))
 
   /* *** reset *** */
-  private val resetDone = RegInit(false.B)
-  when(tables.map(_.io.resetDone).reduce(_ && _)) {
-    resetDone := true.B
-  }
-  io.resetDone := resetDone
+  io.sramResetDone := tables.map(_.io.sramResetDone).reduce(_ && _)
 
   /* --------------------------------------------------------------------------------------------------------------
      predict pipeline stage 0

--- a/src/main/scala/xiangshan/frontend/bpu/tage/TageTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/TageTable.scala
@@ -35,7 +35,7 @@ class TageTable(
     val trainReadResp:   TableReadResp        = Output(new TableReadResp)
     val writeReq:        Valid[TableWriteReq] = Flipped(Valid(new TableWriteReq))
     val resetUseful:     Bool                 = Input(Bool())
-    val resetDone:       Bool                 = Output(Bool())
+    val sramResetDone:   Bool                 = Output(Bool())
   }
 
   val io: TageTableIO = IO(new TageTableIO)
@@ -154,7 +154,7 @@ class TageTable(
     )
   )
 
-  io.resetDone := entrySram.flatten.map(_.io.r.req.ready).reduce(_ && _)
+  io.sramResetDone := entrySram.flatten.map(_.io.resetDone).reduce(_ && _)
 
   XSPerfAccumulate("predict_read", io.predictReadReq.valid)
   XSPerfAccumulate("train_read", io.trainReadReq.valid)

--- a/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
@@ -42,8 +42,8 @@ class MicroBtb(implicit p: Parameters) extends BasePredictor with HasMicroBtbPar
   println(f"  Address fields:")
   addrFields.show(indent = 4)
 
-  io.resetDone  := true.B
-  io.trainReady := true.B
+  io.sramResetDone := true.B
+  io.trainReady    := true.B
 
   /* *** submodules *** */
   private val entries = RegInit(VecInit(Seq.fill(NumEntries)(0.U.asTypeOf(new MicroBtbEntry))))

--- a/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
@@ -51,7 +51,6 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
     val redirectValid:  Bool                       = Input(Bool())
   }
   val io: MicroTageIO = IO(new MicroTageIO)
-  private val resetDone = RegInit(false.B)
   io.trainReady := true.B
 
   // Ahead pipeline implementation. Advantage: get data one cycle earlier.
@@ -77,10 +76,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
       )).io
       t
   }
-  when(tables.map(_.resetDone).reduce(_ && _)) {
-    resetDone := true.B
-  }
-  io.resetDone := resetDone
+  io.sramResetDone := tables.map(_.sramResetDone).reduce(_ && _)
   // High-order tables have longer history, better discrimination, relatively stable,
   // and lower access frequency. No need to frequently clean dead entries based on useful counters.
   private val lowTickCounter  = RegInit(0.U((LowTickWidth + 1).W))

--- a/src/main/scala/xiangshan/frontend/bpu/utage/MicroTageTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/MicroTageTable.scala
@@ -43,11 +43,11 @@ class MicroTageTable(
     class MicroTageResp extends Bundle {
       val readEntries: Vec[MicroTageEntry] = Vec(numWay, new MicroTageEntry)
     }
-    val req:         Valid[MicroTageReq] = Input(Valid(new MicroTageReq))
-    val resps:       MicroTageResp       = Output(new MicroTageResp)
-    val train:       MicroTageTrain      = new MicroTageTrain(numWay, numSets)
-    val usefulReset: Bool                = Input(Bool())
-    val resetDone:   Bool                = Output(Bool())
+    val req:           Valid[MicroTageReq] = Input(Valid(new MicroTageReq))
+    val resps:         MicroTageResp       = Output(new MicroTageResp)
+    val train:         MicroTageTrain      = new MicroTageTrain(numWay, numSets)
+    val usefulReset:   Bool                = Input(Bool())
+    val sramResetDone: Bool                = Output(Bool())
   }
   val io = IO(new MicroTageTableIO)
   // Write buffer to handle write conflicts
@@ -97,7 +97,7 @@ class MicroTageTable(
     bank.io.r.req.bits.setIdx := bankReadInnerIndex
   }
 
-  io.resetDone := entrySram.map(_.io.r.req.ready).reduce(_ && _)
+  io.sramResetDone := entrySram.map(_.io.resetDone).reduce(_ && _)
 
   // Pipeline stage: capture bank selection from previous cycle
   private val a1_bankOH = RegNext(bankOH, 0.U(numBanks.W))


### PR DESCRIPTION
Currently we're using resetDone := sram.io.r.req.ready, this introduces a critical path from io.train to resetDone reg (train.valid -> sram.io.w.req.valid -> sram.io.r.req.ready -> resetDone).

See:
- https://github.com/OpenXiangShan/Utility/pull/141

In that PR we made resetState accessible via io.resetDone, this PR utilize that to improve Bpu timing

Also:
- rename `resetDone` to `sramResetDone` to prevent ambiguity with Tage's `resetUseful`