### PR TITLE
ci(labeler): add 'note: submodule bump' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -55,6 +55,7 @@
   - any-glob-to-any-file:
     - src/main/scala/device/**
     - ChiselAIA
+    - ChiselIOPMP
     - rocket-chip
 
 "module: documentation":
@@ -63,6 +64,21 @@
     - images/**
     - "**.md"
     - LICENSE
+
+"note: submodule bump":
+- changed-files:
+  - any-glob-to-any-file:
+    - .gitmodules
+    - ChiselAIA
+    - ChiselIOPMP
+    - coupledL2
+    - difftest
+    - huancun
+    - openLLC
+    - ready-to-run
+    - rocket-chip
+    - utility
+    - yunsuan
 
 "topic: functionality":
 - head-branch:


### PR DESCRIPTION
To notify maintainers this bumps submodule, need extra attention when merging this, to prevent reverse/unintended bumps

also: add ChiselIOPMP(#5499) change to 'module: other'