### PR TITLE
refactor(exception): use sparse vector (SparseVec) for exception vector

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -23,7 +23,7 @@ import chisel3.util.BitPat.bitPatToUInt
 import chisel3.util.experimental.decode.EspressoMinimizer
 
 import utility._
-import utils._
+import _root_.utils.{OptionWrapper, NamedUInt}
 
 import org.chipsalliance.cde.config.Parameters
 
@@ -95,7 +95,7 @@ class CtrlFlow(implicit p: Parameters) extends XSBundle {
   val instr = UInt(32.W)
   val pc = UInt(VAddrBits.W)
   val foldpc = UInt(MemPredPCWidth.W)
-  val exceptionVec = ExceptionVec()
+  val exceptionVec = ExceptSparseVec(ExceptionNO.fromFrontendSet)
   val backendException = Bool()
   val trigger = TriggerAction()
   val isRvc = Bool()
@@ -807,8 +807,8 @@ class UopTopDown(implicit p: Parameters) extends XSBundle {
 
 class LowPowerIO(implicit p: Parameters) extends Bundle {
   /* i_*: SoC -> CPU   o_*: CPU -> SoC */
-  val o_cpu_no_op = Output(Bool()) 
-  //physical power down 
+  val o_cpu_no_op = Output(Bool())
+  //physical power down
   val i_cpu_pwrdown_req_n = Input(Bool())
   val o_cpu_pwrdown_ack_n = Output(Bool())
   // power on/off sequence control for Core iso/rst

--- a/src/main/scala/xiangshan/DbEntry.scala
+++ b/src/main/scala/xiangshan/DbEntry.scala
@@ -48,7 +48,7 @@ class InstInfoEntry(implicit p: Parameters) extends XSBundle{
   // val commitLatency = UInt(XLEN.W) // can not record when writing back
   val tlbLatency = UInt(XLEN.W)  // original requirements is L1toL2TlbLatency
   val lsInfo = new DebugLsInfo
-  val exceptType = UInt(ExceptionVec.ExceptionVecSize.W)
+  val exceptType = UInt(ExceptSparseVec.ExceptionVecSize.W)
 }
 
 class LoadInfoEntry(implicit p: Parameters) extends XSBundle{

--- a/src/main/scala/xiangshan/backend/BackendParams.scala
+++ b/src/main/scala/xiangshan/backend/BackendParams.scala
@@ -445,6 +445,9 @@ case class BackendParams(
   def getV0WBExeGroup : Map[Int, Seq[ExeUnitParams]] = allRealExuParams.filter(_.getV0WBPort .nonEmpty).groupBy(_.getV0WBPort.get.port)
   def getVlWBExeGroup : Map[Int, Seq[ExeUnitParams]] = allRealExuParams.filter(_.getVlWBPort .nonEmpty).groupBy(_.getVlWBPort.get.port)
 
+  def exceptionOut = allExuParams.flatMap(_.exceptionOut).distinct.sorted
+  def getExceptionOutList = allRealExuParams.map(_.exceptionOut).filter(_.nonEmpty)
+
   private def isContinuous(portIndices: Seq[Int]): Boolean = {
     val portIndicesSet = portIndices.toSet
     portIndicesSet.min == 0 && portIndicesSet.max == portIndicesSet.size - 1

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -93,6 +93,7 @@ object Bundles {
     sink.bits.toV0Rf. foreach(_.bits  := source.bits.data(0))
     sink.bits.toVlRf. foreach(_.valid := source.bits.vlWen.get)
     sink.bits.toVlRf. foreach(_.bits  := source.bits.data(0))
+    ExceptSparseVec.connect(sink.bits.toRob.bits.exceptionVec, source.bits.exceptionVec.getOrElse(0.U.asTypeOf(ExceptionVec())))
   }
 
   def connectWriteBackRob(sink: WriteBackRobBundle, source: NewExuOutput) = {
@@ -101,6 +102,7 @@ object Bundles {
     sink.data              := source.toIntRf.map(_.bits).getOrElse(0.U(64.W))
     sink.vecWen. foreach(_ := source.toVecRf.map(_.valid).getOrElse(false.B))
     sink.v0Wen.  foreach(_ := source.toV0Rf.map(_.valid).getOrElse(false.B))
+    sink.exceptionVec.foreach(ExceptSparseVec.connect(_, source.toRob.bits.exceptionVec))
   }
 
   // Frontend --[CtrlBlock]--> DecodeInUop

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -93,7 +93,6 @@ object Bundles {
     sink.bits.toV0Rf. foreach(_.bits  := source.bits.data(0))
     sink.bits.toVlRf. foreach(_.valid := source.bits.vlWen.get)
     sink.bits.toVlRf. foreach(_.bits  := source.bits.data(0))
-    ExceptSparseVec.connect(sink.bits.toRob.bits.exceptionVec, source.bits.exceptionVec.getOrElse(0.U.asTypeOf(ExceptionVec())))
   }
 
   def connectWriteBackRob(sink: WriteBackRobBundle, source: NewExuOutput) = {
@@ -102,13 +101,12 @@ object Bundles {
     sink.data              := source.toIntRf.map(_.bits).getOrElse(0.U(64.W))
     sink.vecWen. foreach(_ := source.toVecRf.map(_.valid).getOrElse(false.B))
     sink.v0Wen.  foreach(_ := source.toV0Rf.map(_.valid).getOrElse(false.B))
-    sink.exceptionVec.foreach(ExceptSparseVec.connect(_, source.toRob.bits.exceptionVec))
   }
 
   // Frontend --[CtrlBlock]--> DecodeInUop
   class DecodeInUop(implicit p: Parameters) extends XSBundle {
     val foldpc = UInt(MemPredPCWidth.W) // for mdp
-    val exceptionVec = ExceptionVec()
+    val exceptionVec = ExceptSparseVec(ExceptionNO.fromFrontendSet)
     val isFetchMalAddr = Bool()
     val trigger = TriggerAction()
     val isRVC = Bool()
@@ -137,7 +135,7 @@ object Bundles {
   // DecodeInUop --[Decode]--> DecodeOutUop
   class DecodeOutUop(implicit p: Parameters) extends XSBundle {
     val foldpc = UInt(MemPredPCWidth.W) // for mdp
-    val exceptionVec = ExceptionVec()
+    val exceptionVec = ExceptSparseVec(ExceptionNO.decodeSet)
     val isFetchMalAddr = Bool()
     val trigger = TriggerAction()
     val isRVC = Bool()
@@ -200,7 +198,8 @@ object Bundles {
     }
 
     def connectDecodeInUop(source: DecodeInUop): Unit = {
-      connectSamePort(this, source)
+      (this: Data).waiveAll :<= (source: Data).waiveAll
+      this.exceptionVec extendFrom source.exceptionVec
       this.debug.foreach(x => connectSamePort(x, source.debug.get))
     }
   }
@@ -231,7 +230,7 @@ object Bundles {
 
   class RenameOutUop(implicit p: Parameters) extends XSBundle {
     def numSrc = backendParams.numSrc
-    val exceptionVec = ExceptionVec()
+    val exceptionVec = ExceptSparseVec(ExceptionNO.decodeSet)
     val isFetchMalAddr = Bool()
     val trigger = TriggerAction()
     val isRVC = Bool()
@@ -530,7 +529,7 @@ object Bundles {
     val wflags = OptionWrapper(params.writeFflags, Bool())
     val fflags = OptionWrapper(params.writeFflags, UInt(5.W))
     val vxsat = OptionWrapper(params.writeVxsat, Bool())
-    val exceptionVec = OptionWrapper(params.exceptionOut.nonEmpty, ExceptionVec())
+    val exceptionVec = ExceptSparseVec()
     val flushPipe = OptionWrapper(params.flushPipe, Bool())
     val replay = OptionWrapper(params.replayInst, Bool())
     val trigger = OptionWrapper(params.trigger, TriggerAction())
@@ -546,7 +545,7 @@ object Bundles {
     val instr           = UInt(32.W)
     val pc              = UInt(VAddrBits.W)
     val foldpc          = UInt(MemPredPCWidth.W)
-    val exceptionVec    = ExceptionVec()
+    val exceptionVec    = ExceptSparseVec() // TODO: optimize valid indices
     val isFetchMalAddr  = Bool()
     val hasException    = Bool()
     val trigger         = TriggerAction()
@@ -1304,7 +1303,7 @@ object Bundles {
     val fflags       = if (params.writeFflags)  Some(UInt(5.W))               else None
     val wflags       = if (params.writeFflags)  Some(Bool())                  else None
     val vxsat        = if (params.writeVxsat)   Some(Bool())                  else None
-    val exceptionVec = if (params.exceptionOut.nonEmpty) Some(ExceptionVec()) else None
+    val exceptionVec = ExceptSparseVec(params.exceptionOut)
     val flushPipe    = if (params.flushPipe)    Some(Bool())                  else None
     val replay       = if (params.replayInst)   Some(Bool())                  else None
     val lqIdx        = if (params.hasLoadFu)    Some(new LqPtr())             else None
@@ -1468,7 +1467,7 @@ class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) exte
     val redirect = ValidIO(new Redirect)
     val fflags = UInt(5.W)
     val vxsat = Bool()
-    val exceptionVec = ExceptionVec()
+    val exceptionVec = ExceptSparseVec()
     val debug = new DebugBundle
     val perfDebugInfo = OptionWrapper(backendParams.debugEn, new PerfDebugInfo())
     val debug_seqNum = OptionWrapper(backendParams.debugEn, InstSeqNum())
@@ -1491,7 +1490,7 @@ class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) exte
       this.redirect := source.redirect.getOrElse(0.U.asTypeOf(this.redirect))
       this.fflags := source.fflags.getOrElse(0.U.asTypeOf(this.fflags))
       this.vxsat := source.vxsat.getOrElse(0.U.asTypeOf(this.vxsat))
-      this.exceptionVec := source.exceptionVec.getOrElse(0.U.asTypeOf(this.exceptionVec))
+      this.exceptionVec extendFrom source.exceptionVec
       this.debug := source.debug
       this.perfDebugInfo.foreach(_ := source.perfDebugInfo.get)
       this.debug_seqNum.foreach(_ := source.debug_seqNum.get)
@@ -1632,7 +1631,7 @@ class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) exte
     val fflags        = Option.when(params.writeFflags)(UInt(5.W))
     val wflags        = Option.when(params.writeFflags)(Bool())
     val vxsat         = Option.when(params.writeVxsat)(Bool())
-    val exceptionVec  = Option.when(params.exceptionOut.nonEmpty)(ExceptionVec())
+    val exceptionVec  = ExceptSparseVec(params.exceptionOut)
     val lqIdx         = Option.when(params.hasLoadFu)(new LqPtr())
     val sqIdx         = Option.when(params.hasStoreAddrFu || params.hasStdFu)(new SqPtr())
     val trigger       = Option.when(params.trigger)(TriggerAction())
@@ -1661,7 +1660,7 @@ class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) exte
     val pc = UInt(VAddrData().dataWidth.W)
     val instr = UInt(32.W)
     val commitType = CommitType()
-    val exceptionVec = ExceptionVec()
+    val exceptionVec = ExceptSparseVec() // TODO: optimize valid indices
     val isPcBkpt = Bool()
     val isFetchMalAddr = Bool()
     val gpaddr = UInt(XLEN.W)
@@ -1763,7 +1762,7 @@ class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) exte
       output.vecWen.foreach(_ := this.uop.vecWen)
       output.v0Wen.foreach(_ := this.uop.v0Wen)
       output.vlWen.foreach(_ := this.uop.vlWen)
-      output.exceptionVec.foreach(_ := this.uop.exceptionVec)
+      output.exceptionVec := this.uop.exceptionVec
       output.flushPipe.foreach(_ := this.uop.flushPipe)
       output.replay.foreach(_ := this.uop.replayInst)
       output.debug := this.debug

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -93,7 +93,6 @@ object Bundles {
     sink.bits.toV0Rf. foreach(_.bits  := source.bits.data(0))
     sink.bits.toVlRf. foreach(_.valid := source.bits.vlWen.get)
     sink.bits.toVlRf. foreach(_.bits  := source.bits.data(0))
-    ExceptSparseVec.connect(sink.bits.toRob.bits.exceptionVec, source.bits.exceptionVec.getOrElse(0.U.asTypeOf(ExceptionVec())))
   }
 
   def connectWriteBackRob(sink: WriteBackRobBundle, source: NewExuOutput) = {
@@ -102,7 +101,6 @@ object Bundles {
     sink.data              := source.toIntRf.map(_.bits).getOrElse(0.U(64.W))
     sink.vecWen. foreach(_ := source.toVecRf.map(_.valid).getOrElse(false.B))
     sink.v0Wen.  foreach(_ := source.toV0Rf.map(_.valid).getOrElse(false.B))
-    sink.exceptionVec.foreach(ExceptSparseVec.connect(_, source.toRob.bits.exceptionVec))
   }
 
   // Frontend --[CtrlBlock]--> DecodeInUop

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -93,6 +93,7 @@ object Bundles {
     sink.bits.toV0Rf. foreach(_.bits  := source.bits.data(0))
     sink.bits.toVlRf. foreach(_.valid := source.bits.vlWen.get)
     sink.bits.toVlRf. foreach(_.bits  := source.bits.data(0))
+    ExceptSparseVec.connect(sink.bits.toRob.bits.exceptionVec, source.bits.exceptionVec.getOrElse(0.U.asTypeOf(ExceptionVec())))
   }
 
   def connectWriteBackRob(sink: WriteBackRobBundle, source: NewExuOutput) = {
@@ -101,6 +102,7 @@ object Bundles {
     sink.data              := source.toIntRf.map(_.bits).getOrElse(0.U(64.W))
     sink.vecWen. foreach(_ := source.toVecRf.map(_.valid).getOrElse(false.B))
     sink.v0Wen.  foreach(_ := source.toV0Rf.map(_.valid).getOrElse(false.B))
+    sink.exceptionVec.foreach(ExceptSparseVec.connect(_, source.toRob.bits.exceptionVec))
   }
 
   // Frontend --[CtrlBlock]--> DecodeInUop
@@ -1349,7 +1351,7 @@ class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) exte
     val fflags       = Option.when(params.writeFflags)(UInt(5.W))
     val wflags       = Option.when(params.writeFflags)(Bool())
     val vxsat        = Option.when(params.writeVxsat)(Bool())
-    val exceptionVec = Option.when(params.exceptionOut.nonEmpty)(ExceptionVec())
+    val exceptionVec = ExceptSparseVec(params.exceptionOut)
     val flushPipe    = Option.when(params.flushPipe)(Bool())
     val trigger      = Option.when(params.trigger)(TriggerAction())
     val isRVC        = Option.when(params.needIsRVC)(Bool())

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -22,7 +22,6 @@ import chisel3.util._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utility._
 import utils._
-import xiangshan.ExceptionNO._
 import xiangshan._
 import xiangshan.backend.Bundles._
 import xiangshan.backend.ctrlblock.{DebugLSIO, DebugLsInfoBundle, LsTopdownInfo, MemCtrl, RedirectGenerator}

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -148,7 +148,7 @@ class CtrlBlockImp(
   }
   val delayedNotFlushedWriteBackNeedFlush = Wire(Vec(params.allExuParams.filter(_.needExceptionGen).length, Bool()))
   delayedNotFlushedWriteBackNeedFlush := delayedNotFlushedWriteBack.filter(_.bits.params.needExceptionGen).map{ x =>
-    x.bits.exceptionVec.get.asUInt.orR || x.bits.flushPipe.getOrElse(false.B) || x.bits.replay.getOrElse(false.B) ||
+    x.bits.exceptionVec.orR || x.bits.flushPipe.getOrElse(false.B) || x.bits.replay.getOrElse(false.B) ||
       (if (x.bits.trigger.nonEmpty) TriggerAction.isDmode(x.bits.trigger.get) else false.B)
   }
 
@@ -596,7 +596,7 @@ class CtrlBlockImp(
   rename.io.ratSnpt.snptSelect := snptSelect
   rename.io.ratSnpt.flushVec := flushVec
 
-  val decodeHasException = decode.io.out.map(x => x.bits.exceptionVec.asUInt.orR || (!TriggerAction.isNone(x.bits.trigger)))
+  val decodeHasException = decode.io.out.map(x => x.bits.exceptionVec.orR || (!TriggerAction.isNone(x.bits.trigger)))
   // fusion decoder
   fusionDecoder.io.disableFusion := disableFusion
   for (i <- 0 until DecodeWidth) {

--- a/src/main/scala/xiangshan/backend/datapath/BypassNetwork.scala
+++ b/src/main/scala/xiangshan/backend/datapath/BypassNetwork.scala
@@ -7,7 +7,7 @@ import utility.{GatedValidRegNext, SignExt, ZeroExt}
 import utils.SeqUtils._
 import xiangshan._
 import xiangshan.backend.BackendParams
-import xiangshan.backend.Bundles.{ExuBypassBundle, ExuInput, ExuOutput, ExuVec, ImmInfo}
+import xiangshan.backend.Bundles.{ExuBypassBundle, ExuInput, ExuVec, ImmInfo}
 import xiangshan.backend.issue._
 import xiangshan.backend.datapath.DataConfig.RegDataMaxWidth
 import xiangshan.backend.decode.ImmUnion

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -30,7 +30,6 @@ import xiangshan.backend.fu.FuType
 import xiangshan.backend.{PipelineStallReason, StoreBubbleReason}
 import xiangshan.backend.fu.wrapper.CSRToDecode
 import yunsuan.VpermType
-import xiangshan.ExceptionNO.{illegalInstr, virtualInstr}
 import xiangshan.frontend.ftq.FtqPtr
 
 class DecodeStageIO(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -24,7 +24,7 @@ import freechips.rocketchip.rocket.CustomInstructions._
 import freechips.rocketchip.util.uintToBitPat
 import utility._
 import utils._
-import xiangshan.ExceptionNO.{EX_II, breakPoint, illegalInstr, virtualInstr}
+import xiangshan.ExceptionNO.{breakPoint, illegalInstr, virtualInstr}
 import xiangshan._
 import xiangshan.backend.fu.FuType
 import xiangshan.backend.Bundles.{DecodeInUop, DecodeOutUop}
@@ -912,7 +912,7 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
     io.fromCSR.virtualInst.cboI       && isCboInval
 
 
-  decodedInst.exceptionVec(illegalInstr) := exceptionII || io.enq.decodeInUop.exceptionVec(EX_II)
+  decodedInst.exceptionVec(illegalInstr) := exceptionII || io.enq.decodeInUop.exceptionVec(illegalInstr)
   decodedInst.exceptionVec(virtualInstr) := exceptionVI
 
   //update exceptionVec: from frontend trigger's breakpoint exception. To reduce 1 bit of overhead in ibuffer entry.

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala
@@ -24,7 +24,6 @@ import freechips.rocketchip.rocket.Instructions
 import freechips.rocketchip.util.uintToBitPat
 import utils._
 import utility._
-import xiangshan.ExceptionNO.illegalInstr
 import xiangshan._
 import xiangshan.backend.fu.fpu.FPU
 import xiangshan.backend.fu.FuType

--- a/src/main/scala/xiangshan/backend/decode/UopInfoGen.scala
+++ b/src/main/scala/xiangshan/backend/decode/UopInfoGen.scala
@@ -24,7 +24,6 @@ import freechips.rocketchip.rocket.Instructions
 import freechips.rocketchip.util.uintToBitPat
 import utils._
 import utility._
-import xiangshan.ExceptionNO.illegalInstr
 import xiangshan._
 import xiangshan.backend.fu.fpu.FPU
 import xiangshan.backend.fu.FuType

--- a/src/main/scala/xiangshan/backend/decode/VecDecoder.scala
+++ b/src/main/scala/xiangshan/backend/decode/VecDecoder.scala
@@ -7,7 +7,6 @@ import chisel3.util._
 import freechips.rocketchip.util.uintToBitPat
 import freechips.rocketchip.rocket.Instructions._
 import utils._
-import xiangshan.ExceptionNO.illegalInstr
 import xiangshan.backend.fu.FuType
 import xiangshan._
 import yunsuan.{VfpuType, VipuType, VimacType, VpermType, VialuFixType, VfaluType, VmoveType, VfmaType, VfdivType, VfcvtType, VidivType, FcmpOpCode}

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -420,7 +420,6 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
   io.out.bits.toRob.bits.fflags.      foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.fflags.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.fflags.get)))))
   io.out.bits.toRob.bits.wflags.      foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.fpu.getOrElse(0.U.asTypeOf(new FPUCtrlSignals)).wflags)))
   io.out.bits.toRob.bits.vxsat.       foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.vxsat.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.vxsat.get)))))
-  // io.out.bits.toRob.bits.exceptionVec.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.exceptionVec.get)))))
   io.out.bits.toRob.bits.exceptionVec := ExceptSparseVec.mux1h(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec))
   io.out.bits.toRob.bits.flushPipe.   foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.flushPipe.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.flushPipe.get)))))
   io.out.bits.toRob.bits.replay.      foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.replay.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.replay.get)))))

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -422,9 +422,6 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
   io.out.bits.toRob.bits.vxsat.       foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.vxsat.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.vxsat.get)))))
   // io.out.bits.toRob.bits.exceptionVec.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.exceptionVec.get)))))
   io.out.bits.toRob.bits.exceptionVec := ExceptSparseVec.mux1h(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec))
-  // io.out.bits.toRob.bits.exceptionVec.foreach(
-  //   ExceptSparseVec.connect(_, ExceptSparseVec.mux1h(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec)))
-  // )
   io.out.bits.toRob.bits.flushPipe.   foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.flushPipe.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.flushPipe.get)))))
   io.out.bits.toRob.bits.replay.      foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.replay.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.replay.get)))))
   io.out.bits.toRob.bits.isRVC.       foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.isRVC.getOrElse(false.B))))

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -24,7 +24,7 @@ import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utility._
 import xiangshan.backend.fu.{CSRFileIO, FenceIO, FuType, FuncUnitInput, UncertainLatency}
 import xiangshan.backend.Bundles._
-import xiangshan.{AddrTransType, FPUCtrlSignals, HasXSParameter, Redirect, Resolve, XSBundle, XSModule}
+import xiangshan.{AddrTransType, FPUCtrlSignals, HasXSParameter, Redirect, Resolve, XSBundle, XSModule, ExceptSparseVec}
 import xiangshan.backend.datapath.WbConfig._
 import xiangshan.backend.fu.vector.Bundles.{VType, Vxrm}
 import xiangshan.backend.fu.fpu.Bundles.Frm
@@ -420,7 +420,10 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
   io.out.bits.toRob.bits.fflags.      foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.fflags.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.fflags.get)))))
   io.out.bits.toRob.bits.wflags.      foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.fpu.getOrElse(0.U.asTypeOf(new FPUCtrlSignals)).wflags)))
   io.out.bits.toRob.bits.vxsat.       foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.vxsat.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.vxsat.get)))))
-  io.out.bits.toRob.bits.exceptionVec.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.exceptionVec.get)))))
+  // io.out.bits.toRob.bits.exceptionVec.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.exceptionVec.get)))))
+  io.out.bits.toRob.bits.exceptionVec.foreach(
+    ExceptSparseVec.connect(_, ExceptSparseVec.mux1h(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec)))
+  )
   io.out.bits.toRob.bits.flushPipe.   foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.flushPipe.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.flushPipe.get)))))
   io.out.bits.toRob.bits.replay.      foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.replay.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.replay.get)))))
   io.out.bits.toRob.bits.isRVC.       foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.isRVC.getOrElse(false.B))))

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -421,9 +421,10 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
   io.out.bits.toRob.bits.wflags.      foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.fpu.getOrElse(0.U.asTypeOf(new FPUCtrlSignals)).wflags)))
   io.out.bits.toRob.bits.vxsat.       foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.vxsat.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.vxsat.get)))))
   // io.out.bits.toRob.bits.exceptionVec.foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.exceptionVec.get)))))
-  io.out.bits.toRob.bits.exceptionVec.foreach(
-    ExceptSparseVec.connect(_, ExceptSparseVec.mux1h(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec)))
-  )
+  io.out.bits.toRob.bits.exceptionVec := ExceptSparseVec.mux1h(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec))
+  // io.out.bits.toRob.bits.exceptionVec.foreach(
+  //   ExceptSparseVec.connect(_, ExceptSparseVec.mux1h(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec)))
+  // )
   io.out.bits.toRob.bits.flushPipe.   foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.flushPipe.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.flushPipe.get)))))
   io.out.bits.toRob.bits.replay.      foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.replay.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.replay.get)))))
   io.out.bits.toRob.bits.isRVC.       foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.isRVC.getOrElse(false.B))))

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -24,7 +24,6 @@ import freechips.rocketchip.util._
 import utility.MaskedRegMap.WritableMask
 import utils._
 import utility._
-import xiangshan.ExceptionNO._
 import xiangshan._
 import xiangshan.backend.fu.util._
 import xiangshan.cache._

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -28,6 +28,7 @@ import xiangshan.ExceptionNO._
 import xiangshan._
 import xiangshan.backend.fu.util._
 import xiangshan.cache._
+import xiangshan.backend.BackendParams
 import xiangshan.backend.Bundles.{ExceptionInfo, TrapInstInfo}
 import xiangshan.backend.fu.NewCSR.CSREvents.TargetPCBundle
 import xiangshan.backend.fu.NewCSR.CSRNamedConstant.ContextStatus

--- a/src/main/scala/xiangshan/backend/fu/Fence.scala
+++ b/src/main/scala/xiangshan/backend/fu/Fence.scala
@@ -20,7 +20,6 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.XSDebug
-import xiangshan.ExceptionNO.{illegalInstr, virtualInstr}
 import xiangshan._
 
 class FenceIO(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/fu/Fence.scala
+++ b/src/main/scala/xiangshan/backend/fu/Fence.scala
@@ -86,7 +86,7 @@ class Fence(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
   io.out.bits.ctrl.robIdx := uop.ctrl.robIdx
   io.out.bits.ctrl.pdest := uop.ctrl.pdest
   io.out.bits.ctrl.flushPipe.get := uop.ctrl.flushPipe.get
-  io.out.bits.ctrl.exceptionVec.get := 0.U.asTypeOf(io.out.bits.ctrl.exceptionVec.get)
+  io.out.bits.ctrl.exceptionVec.init
   io.out.bits.perfDebugInfo.foreach(_ := io.in.bits.perfDebugInfo.get)
   io.out.bits.debug_seqNum.foreach(_ := io.in.bits.debug_seqNum.get)
 

--- a/src/main/scala/xiangshan/backend/fu/Fence.scala
+++ b/src/main/scala/xiangshan/backend/fu/Fence.scala
@@ -86,7 +86,6 @@ class Fence(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
   io.out.bits.ctrl.robIdx := uop.ctrl.robIdx
   io.out.bits.ctrl.pdest := uop.ctrl.pdest
   io.out.bits.ctrl.flushPipe.get := uop.ctrl.flushPipe.get
-  io.out.bits.ctrl.exceptionVec.init
   io.out.bits.perfDebugInfo.foreach(_ := io.in.bits.perfDebugInfo.get)
   io.out.bits.debug_seqNum.foreach(_ := io.in.bits.debug_seqNum.get)
 

--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -440,7 +440,7 @@ object FuConfig {
     writeIntRf = true,
     writeFpRf = true,
     latency = UncertainLatency(3),
-    exceptionOut = Seq(loadAddrMisaligned, loadAccessFault, loadPageFault, loadGuestPageFault, breakPoint, hardwareError),
+    exceptionOut = Seq(loadAddrMisaligned, loadAccessFault, loadPageFault, loadGuestPageFault, storeAddrMisaligned, storeAccessFault, storePageFault, storeGuestPageFault, breakPoint, hardwareError), // for sc from atomics unit
     flushPipe = false,
     replayInst = false,
     hasLoadError = true,

--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -369,7 +369,6 @@ object FuConfig {
     ),
     piped = false,
     latency = UncertainLatency(),
-    exceptionOut = Seq(illegalInstr, virtualInstr),
     flushPipe = true
   )
 

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -300,7 +300,7 @@ trait HasPipelineReg { this: FuncUnit =>
   if (cfg.exceptionOut.nonEmpty) {
     val outVstart = ctrlVec.last.vpu.get.vstart
     val vstartIllegal = outVstart =/= 0.U
-    io.out.bits.ctrl.exceptionVec.init
+    io.out.bits.ctrl.exceptionVec.zeroInit()
     require(cfg.exceptionOut.contains(ExceptionNO.illegalInstr),
       "HasPipelineReg trait with non-empty excptionOut must have illegal instruction exception output")
     io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := vstartIllegal

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -11,7 +11,7 @@ import xiangshan.backend.rob.RobPtr
 import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.backend.datapath.DataConfig._
 import xiangshan.backend.fu.vector.Bundles.{VType, Vl, Vxsat}
-import xiangshan.ExceptionNO.illegalInstr
+import xiangshan.ExceptionNO
 import xiangshan.backend.fu.wrapper.{CSRInput, CSRToDecode}
 import xiangshan.frontend.bpu.{BranchAttribute, BranchInfo}
 
@@ -80,7 +80,7 @@ class FuncUnitCtrlOutput(cfg: FuConfig)(implicit p: Parameters) extends XSBundle
   val vecWen        = OptionWrapper(cfg.needVecWen, Bool())
   val v0Wen         = OptionWrapper(cfg.needV0Wen, Bool())
   val vlWen         = OptionWrapper(cfg.needVlWen, Bool())
-  val exceptionVec  = OptionWrapper(cfg.exceptionOut.nonEmpty, ExceptionVec())
+  val exceptionVec  = ExceptSparseVec(cfg.exceptionOut)
   val flushPipe     = OptionWrapper(cfg.flushPipe,  Bool())
   val replay        = OptionWrapper(cfg.replayInst, Bool())
   val isRVC         = OptionWrapper(cfg.hasIsRVC, Bool())
@@ -300,8 +300,10 @@ trait HasPipelineReg { this: FuncUnit =>
   if (cfg.exceptionOut.nonEmpty) {
     val outVstart = ctrlVec.last.vpu.get.vstart
     val vstartIllegal = outVstart =/= 0.U
-    io.out.bits.ctrl.exceptionVec.get := 0.U.asTypeOf(io.out.bits.ctrl.exceptionVec.get)
-    io.out.bits.ctrl.exceptionVec.get(illegalInstr) := vstartIllegal
+    io.out.bits.ctrl.exceptionVec.init
+    require(cfg.exceptionOut.contains(ExceptionNO.illegalInstr),
+      "HasPipelineReg trait with non-empty excptionOut must have illegal instruction exception output")
+    io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(vstartIllegal)
   }
 
   def regEnable(i: Int): Bool = validVec(i - 1) && rdyVec(i - 1)

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -303,7 +303,7 @@ trait HasPipelineReg { this: FuncUnit =>
     io.out.bits.ctrl.exceptionVec.init
     require(cfg.exceptionOut.contains(ExceptionNO.illegalInstr),
       "HasPipelineReg trait with non-empty excptionOut must have illegal instruction exception output")
-    io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(vstartIllegal)
+    io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := vstartIllegal
   }
 
   def regEnable(i: Int): Bool = validVec(i - 1) && rdyVec(i - 1)

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/MNretEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/MNretEvent.scala
@@ -4,8 +4,6 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.{SignExt, ZeroExt}
-import xiangshan.ExceptionNO
-import xiangshan.ExceptionNO._
 import xiangshan.backend.fu.NewCSR.CSRBundles.{CauseBundle, OneFieldBundle, PrivState}
 import xiangshan.backend.fu.NewCSR.CSRConfig.{VaddrMaxWidth, XLEN}
 import xiangshan.backend.fu.NewCSR.CSRDefines.{HgatpMode, PrivMode, SatpMode, VirtMode}

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/MretEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/MretEvent.scala
@@ -4,8 +4,6 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.{SignExt, ZeroExt}
-import xiangshan.ExceptionNO
-import xiangshan.ExceptionNO._
 import xiangshan.backend.fu.NewCSR.CSRBundles.{CauseBundle, OneFieldBundle, PrivState}
 import xiangshan.backend.fu.NewCSR.CSRConfig.{VaddrMaxWidth, XLEN}
 import xiangshan.backend.fu.NewCSR.CSRDefines.{HgatpMode, PrivMode, SatpMode, VirtMode}

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/SretEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/SretEvent.scala
@@ -4,8 +4,6 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.{SignExt, ZeroExt}
-import xiangshan.ExceptionNO
-import xiangshan.ExceptionNO._
 import xiangshan.backend.fu.NewCSR.CSRBundles.{CauseBundle, OneFieldBundle, PrivState}
 import xiangshan.backend.fu.NewCSR.CSRConfig.{VaddrMaxWidth, XLEN}
 import xiangshan.backend.fu.NewCSR.CSRDefines.{HgatpMode, PrivMode, SatpMode, VirtMode}

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryDEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryDEvent.scala
@@ -4,8 +4,6 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.{SignExt, ZeroExt, GatedValidRegNext}
-import xiangshan.{ExceptionNO, HasXSParameter, TriggerAction}
-import xiangshan.ExceptionNO._
 import xiangshan.backend.fu.NewCSR
 import xiangshan.backend.fu.NewCSR.CSRBundles.{CauseBundle, OneFieldBundle, PrivState}
 import xiangshan.backend.fu.NewCSR.CSRConfig.{VaddrMaxWidth, XLEN}

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMNEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMNEvent.scala
@@ -4,7 +4,6 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.SignExt
-import xiangshan.ExceptionNO
 import xiangshan.backend.fu.NewCSR.CSRBundles.{CauseBundle, OneFieldBundle, PrivState}
 import xiangshan.backend.fu.NewCSR.CSRConfig.{VaddrMaxWidth, XLEN}
 import xiangshan.backend.fu.NewCSR._

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/Debug.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/Debug.scala
@@ -6,8 +6,8 @@ import org.chipsalliance.cde.config.Parameters
 import xiangshan.cache.HasDCacheParameters
 import xiangshan.backend.fu.NewCSR.CSRBundles.PrivState
 import xiangshan.backend.fu.util.SdtrigExt
-import xiangshan._
 import utils._
+import xiangshan._
 
 class Debug(implicit val p: Parameters) extends Module with HasXSParameter {
   val io = IO(new DebugIO)

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/InterruptFilter.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/InterruptFilter.scala
@@ -4,7 +4,6 @@ import chisel3._
 import chisel3.util._
 import utility.{DelayN, GatedValidRegNext}
 import utils._
-import xiangshan.ExceptionNO
 import xiangshan.backend.fu.NewCSR.CSRBundles.{CauseBundle, PrivState, XtvecBundle}
 import xiangshan.backend.fu.NewCSR.CSRDefines.{PrivMode, XtvecMode}
 import xiangshan.backend.fu.NewCSR.InterruptNO

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -19,7 +19,6 @@ import xiangshan.backend.rob.RobPtr
 import xiangshan._
 import xiangshan.backend.fu.PerfCounterIO
 import xiangshan.backend.fu.util.CSRConst
-import xiangshan.ExceptionNO._
 import xiangshan.backend.trace._
 import xiangshan.backend.decode.isa.CSRs
 

--- a/src/main/scala/xiangshan/backend/fu/vector/VecNonPipedFuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/VecNonPipedFuncUnit.scala
@@ -47,7 +47,7 @@ class VecNonPipedFuncUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUni
   if (cfg.exceptionOut.nonEmpty) {
     val outVstart = outCtrl.vpu.get.vstart
     val vstartIllegal = outVstart =/= 0.U
-    io.out.bits.ctrl.exceptionVec.init
+    io.out.bits.ctrl.exceptionVec.zeroInit()
     require(cfg.exceptionOut.contains(ExceptionNO.illegalInstr),
       "VecNonPipedFuncUnit with non-empty excptionOut must have illegal instruction exception output")
     io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := vstartIllegal

--- a/src/main/scala/xiangshan/backend/fu/vector/VecNonPipedFuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/VecNonPipedFuncUnit.scala
@@ -7,7 +7,7 @@ import utility.DataHoldBypass
 import xiangshan.backend.fu.vector.Bundles.VConfig
 import xiangshan.backend.fu.vector.utils.ScalaDupToVector
 import xiangshan.backend.fu.{FuConfig, FuncUnit}
-import xiangshan.ExceptionNO.illegalInstr
+import xiangshan.ExceptionNO
 import yunsuan.VialuFixType
 
 class VecNonPipedFuncUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
@@ -47,8 +47,10 @@ class VecNonPipedFuncUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUni
   if (cfg.exceptionOut.nonEmpty) {
     val outVstart = outCtrl.vpu.get.vstart
     val vstartIllegal = outVstart =/= 0.U
-    io.out.bits.ctrl.exceptionVec.get := 0.U.asTypeOf(io.out.bits.ctrl.exceptionVec.get)
-    io.out.bits.ctrl.exceptionVec.get(illegalInstr) := vstartIllegal
+    io.out.bits.ctrl.exceptionVec.init
+    require(cfg.exceptionOut.contains(ExceptionNO.illegalInstr),
+      "VecNonPipedFuncUnit with non-empty excptionOut must have illegal instruction exception output")
+    io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(vstartIllegal)
   }
 
   connectNonPipedCtrlSingal

--- a/src/main/scala/xiangshan/backend/fu/vector/VecNonPipedFuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/VecNonPipedFuncUnit.scala
@@ -50,7 +50,7 @@ class VecNonPipedFuncUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUni
     io.out.bits.ctrl.exceptionVec.init
     require(cfg.exceptionOut.contains(ExceptionNO.illegalInstr),
       "VecNonPipedFuncUnit with non-empty excptionOut must have illegal instruction exception output")
-    io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(vstartIllegal)
+    io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := vstartIllegal
   }
 
   connectNonPipedCtrlSingal

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -297,7 +297,6 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   io.outValidAhead3Cycle.get := csrModOutValid
   val isXRetReg = RegEnable(isXRet, false.B, io.in.fire)
   io.out.valid := Mux(isXRetReg, csrModOutValid, DelayN(csrModOutValid, 3))
-  // io.out.bits.ctrl.exceptionVec.get := Mux(isXRetReg, exceptionVec, DelayNWithValid(exceptionVec, csrModOutValid, 3)._2)
   io.out.bits.ctrl.exceptionVec := ExceptSparseVec.mux2(
     isXRetReg,
     exceptionVec,

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -240,9 +240,8 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
     csrMod.fromAIA.notice_pending := imsicsec.notice_pending
   }
 
-  // private val exceptionVec = WireInit(0.U.asTypeOf(ExceptionVec())) // Todo:
   private val exceptionVec = Wire(ExceptSparseVec(cfg.exceptionOut))
-  // exceptionVec.foreach(_.foreach(_ := false.B))
+  exceptionVec.zeroInit()
   exceptionVec(EX_BP    ) := DataHoldBypass(isEbreak, false.B, io.in.fire)
   exceptionVec(EX_MCALL ) := DataHoldBypass(isEcall && privState.isModeM, false.B, io.in.fire)
   exceptionVec(EX_HSCALL) := DataHoldBypass(isEcall && privState.isModeHS, false.B, io.in.fire)

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -240,15 +240,16 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
     csrMod.fromAIA.notice_pending := imsicsec.notice_pending
   }
 
-  private val exceptionVec = WireInit(0.U.asTypeOf(ExceptionVec())) // Todo:
-
-  exceptionVec(EX_BP    ) := DataHoldBypass(isEbreak, false.B, io.in.fire)
-  exceptionVec(EX_MCALL ) := DataHoldBypass(isEcall && privState.isModeM, false.B, io.in.fire)
-  exceptionVec(EX_HSCALL) := DataHoldBypass(isEcall && privState.isModeHS, false.B, io.in.fire)
-  exceptionVec(EX_VSCALL) := DataHoldBypass(isEcall && privState.isModeVS, false.B, io.in.fire)
-  exceptionVec(EX_UCALL ) := DataHoldBypass(isEcall && privState.isModeHUorVU, false.B, io.in.fire)
-  exceptionVec(EX_II    ) := csrMod.io.out.bits.EX_II
-  exceptionVec(EX_VI    ) := csrMod.io.out.bits.EX_VI
+  // private val exceptionVec = WireInit(0.U.asTypeOf(ExceptionVec())) // Todo:
+  private val exceptionVec = Wire(ExceptSparseVec(cfg.exceptionOut))
+  // exceptionVec.foreach(_.foreach(_ := false.B))
+  exceptionVec.getAndAssign(EX_BP    )(DataHoldBypass(isEbreak, false.B, io.in.fire))
+  exceptionVec.getAndAssign(EX_MCALL )(DataHoldBypass(isEcall && privState.isModeM, false.B, io.in.fire))
+  exceptionVec.getAndAssign(EX_HSCALL)(DataHoldBypass(isEcall && privState.isModeHS, false.B, io.in.fire))
+  exceptionVec.getAndAssign(EX_VSCALL)(DataHoldBypass(isEcall && privState.isModeVS, false.B, io.in.fire))
+  exceptionVec.getAndAssign(EX_UCALL )(DataHoldBypass(isEcall && privState.isModeHUorVU, false.B, io.in.fire))
+  exceptionVec.getAndAssign(EX_II    )(csrMod.io.out.bits.EX_II)
+  exceptionVec.getAndAssign(EX_VI    )(csrMod.io.out.bits.EX_VI)
 
   val isXRet = valid && func === CSROpType.jmp && !isEcall && !isEbreak
 
@@ -297,7 +298,12 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   io.outValidAhead3Cycle.get := csrModOutValid
   val isXRetReg = RegEnable(isXRet, false.B, io.in.fire)
   io.out.valid := Mux(isXRetReg, csrModOutValid, DelayN(csrModOutValid, 3))
-  io.out.bits.ctrl.exceptionVec.get := Mux(isXRetReg, exceptionVec, DelayNWithValid(exceptionVec, csrModOutValid, 3)._2)
+  // io.out.bits.ctrl.exceptionVec.get := Mux(isXRetReg, exceptionVec, DelayNWithValid(exceptionVec, csrModOutValid, 3)._2)
+  ExceptSparseVec.connect(
+    io.out.bits.ctrl.exceptionVec,
+    // Mux(isXRetReg, exceptionVec, exceptionVec.mapExist(x => DelayNWithValid(x, csrModOutValid, 3)._2))
+    ExceptSparseVec.mux2(isXRetReg, exceptionVec, exceptionVec.mapExist(x => DelayNWithValid(x, csrModOutValid, 3)._2))
+  )
   io.out.bits.ctrl.flushPipe.get := Mux(isXRetReg, flushPipe, DelayNWithValid(flushPipe, csrModOutValid, 3)._2)
   io.out.bits.res.data := DelayNWithValid(csrMod.io.out.bits.rData, csrModOutValid, 3)._2
 

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -243,13 +243,13 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   // private val exceptionVec = WireInit(0.U.asTypeOf(ExceptionVec())) // Todo:
   private val exceptionVec = Wire(ExceptSparseVec(cfg.exceptionOut))
   // exceptionVec.foreach(_.foreach(_ := false.B))
-  exceptionVec.getAndAssign(EX_BP    )(DataHoldBypass(isEbreak, false.B, io.in.fire))
-  exceptionVec.getAndAssign(EX_MCALL )(DataHoldBypass(isEcall && privState.isModeM, false.B, io.in.fire))
-  exceptionVec.getAndAssign(EX_HSCALL)(DataHoldBypass(isEcall && privState.isModeHS, false.B, io.in.fire))
-  exceptionVec.getAndAssign(EX_VSCALL)(DataHoldBypass(isEcall && privState.isModeVS, false.B, io.in.fire))
-  exceptionVec.getAndAssign(EX_UCALL )(DataHoldBypass(isEcall && privState.isModeHUorVU, false.B, io.in.fire))
-  exceptionVec.getAndAssign(EX_II    )(csrMod.io.out.bits.EX_II)
-  exceptionVec.getAndAssign(EX_VI    )(csrMod.io.out.bits.EX_VI)
+  exceptionVec(EX_BP    ) := DataHoldBypass(isEbreak, false.B, io.in.fire)
+  exceptionVec(EX_MCALL ) := DataHoldBypass(isEcall && privState.isModeM, false.B, io.in.fire)
+  exceptionVec(EX_HSCALL) := DataHoldBypass(isEcall && privState.isModeHS, false.B, io.in.fire)
+  exceptionVec(EX_VSCALL) := DataHoldBypass(isEcall && privState.isModeVS, false.B, io.in.fire)
+  exceptionVec(EX_UCALL ) := DataHoldBypass(isEcall && privState.isModeHUorVU, false.B, io.in.fire)
+  exceptionVec(EX_II    ) := csrMod.io.out.bits.EX_II
+  exceptionVec(EX_VI    ) := csrMod.io.out.bits.EX_VI
 
   val isXRet = valid && func === CSROpType.jmp && !isEcall && !isEbreak
 
@@ -299,10 +299,10 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   val isXRetReg = RegEnable(isXRet, false.B, io.in.fire)
   io.out.valid := Mux(isXRetReg, csrModOutValid, DelayN(csrModOutValid, 3))
   // io.out.bits.ctrl.exceptionVec.get := Mux(isXRetReg, exceptionVec, DelayNWithValid(exceptionVec, csrModOutValid, 3)._2)
-  ExceptSparseVec.connect(
-    io.out.bits.ctrl.exceptionVec,
-    // Mux(isXRetReg, exceptionVec, exceptionVec.mapExist(x => DelayNWithValid(x, csrModOutValid, 3)._2))
-    ExceptSparseVec.mux2(isXRetReg, exceptionVec, exceptionVec.mapExist(x => DelayNWithValid(x, csrModOutValid, 3)._2))
+  io.out.bits.ctrl.exceptionVec := ExceptSparseVec.mux2(
+    isXRetReg,
+    exceptionVec,
+    exceptionVec.map(x => DelayNWithValid(x, csrModOutValid, 3)._2)
   )
   io.out.bits.ctrl.flushPipe.get := Mux(isXRetReg, flushPipe, DelayNWithValid(flushPipe, csrModOutValid, 3)._2)
   io.out.bits.res.data := DelayNWithValid(csrMod.io.out.bits.rData, csrModOutValid, 3)._2

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VCVT.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VCVT.scala
@@ -176,7 +176,7 @@ class VCVT(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg) 
     Fill(32, result(31)) ## result(31, 0),
     result
   )
-  io.out.bits.ctrl.exceptionVec.get(ExceptionNO.illegalInstr) := mgu.io.out.illegal
+  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
 }
 
 class VectorCvtTopIO(vlen: Int, xlen: Int) extends Bundle{

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VCVT.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VCVT.scala
@@ -176,7 +176,7 @@ class VCVT(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg) 
     Fill(32, result(31)) ## result(31, 0),
     result
   )
-  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
+  io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := mgu.io.out.illegal
 }
 
 class VectorCvtTopIO(vlen: Int, xlen: Int) extends Bundle{

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFALU.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFALU.scala
@@ -505,7 +505,7 @@ class VFAlu(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg)
   // when dest is mask, the result need to be masked by mgtu
   io.out.bits.res.data := Mux(notModifyVd, outOldVd, Mux(outVecCtrl.isDstMask, mgtu.io.out.vd, mgu.io.out.vd) & resultFpMask)
   io.out.bits.res.fflags.get := Mux(notModifyVd, 0.U(5.W), outFFlags)
-  io.out.bits.ctrl.exceptionVec.get(ExceptionNO.illegalInstr) := mgu.io.out.illegal
+  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
 
 }
 

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFALU.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFALU.scala
@@ -505,8 +505,7 @@ class VFAlu(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg)
   // when dest is mask, the result need to be masked by mgtu
   io.out.bits.res.data := Mux(notModifyVd, outOldVd, Mux(outVecCtrl.isDstMask, mgtu.io.out.vd, mgu.io.out.vd) & resultFpMask)
   io.out.bits.res.fflags.get := Mux(notModifyVd, 0.U(5.W), outFFlags)
-  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
-
+  io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := mgu.io.out.illegal
 }
 
 class VFMgu(vlen:Int)(implicit p: Parameters) extends Module{

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFDivSqrt.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFDivSqrt.scala
@@ -155,5 +155,5 @@ class VFDivSqrt(cfg: FuConfig)(implicit p: Parameters) extends VecNonPipedFuncUn
   mgu.io.in.info.dstMask := outVecCtrl.isDstMask
   mgu.io.in.isIndexedVls := false.B
   io.out.bits.res.data := mgu.io.out.vd
-  io.out.bits.ctrl.exceptionVec.get(ExceptionNO.illegalInstr) := mgu.io.out.illegal
+  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
 }

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFDivSqrt.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFDivSqrt.scala
@@ -155,5 +155,5 @@ class VFDivSqrt(cfg: FuConfig)(implicit p: Parameters) extends VecNonPipedFuncUn
   mgu.io.in.info.dstMask := outVecCtrl.isDstMask
   mgu.io.in.isIndexedVls := false.B
   io.out.bits.res.data := mgu.io.out.vd
-  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
+  io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := mgu.io.out.illegal
 }

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFMA.scala
@@ -162,5 +162,5 @@ class VFMA(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg) 
   mgu.io.in.info.dstMask := outVecCtrl.isDstMask
   mgu.io.in.isIndexedVls := false.B
   io.out.bits.res.data := mgu.io.out.vd
-  io.out.bits.ctrl.exceptionVec.get(ExceptionNO.illegalInstr) := mgu.io.out.illegal
+  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
 }

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFMA.scala
@@ -162,5 +162,5 @@ class VFMA(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg) 
   mgu.io.in.info.dstMask := outVecCtrl.isDstMask
   mgu.io.in.isIndexedVls := false.B
   io.out.bits.res.data := mgu.io.out.vd
-  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
+  io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := mgu.io.out.illegal
 }

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VIAluFix.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VIAluFix.scala
@@ -111,7 +111,7 @@ class VIAluFix(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(c
 
   private val maxUopIdx = VLEN / 8
   private val numBytes = maxUopIdx
-  
+
   private val activeEn = Wire(UInt(numBytes.W))
   private val agnosticEn = Wire(UInt(numBytes.W))
   activeEn := mgu.io.out.activeEn
@@ -137,7 +137,7 @@ class VIAluFix(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(c
   private val outNarrowVd = Mux(outVuopIdx0,
     Cat(narrowVd, outOldVd(dataWidth / 2 - 1, 0)),
     Cat(outOldVd(dataWidth - 1, dataWidth / 2), narrowVd))
-  
+
   private val outVd = Mux(outNarrow, outNarrowVd, vd)
 
   private val resVecByte = Wire(Vec(numBytes, UInt(8.W)))
@@ -151,7 +151,7 @@ class VIAluFix(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(c
   private val outVsewOH = RegEnable(vsewOH, valid)
 
   private val addCarryCmpMask = Mux1H(outVsewOH, Seq(8, 4, 2, 1).map(i =>
-    Cat(vIAluFixPoints.map(_.io.out.addCarryCmpMask(i - 1, 0)).reverse)  
+    Cat(vIAluFixPoints.map(_.io.out.addCarryCmpMask(i - 1, 0)).reverse)
   ))
 
   private val dstMgu = Module(new DstMgu(dataWidth))

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VIDiv.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VIDiv.scala
@@ -67,5 +67,5 @@ class VIDiv(cfg: FuConfig)(implicit p: Parameters) extends VecNonPipedFuncUnit(c
   mgu.io.in.info.dstMask := outVecCtrl.isDstMask
   mgu.io.in.isIndexedVls := false.B
   io.out.bits.res.data := Mux(notModifyVd, outOldVd, mgu.io.out.vd)
-  io.out.bits.ctrl.exceptionVec.get(ExceptionNO.illegalInstr) := mgu.io.out.illegal
+  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
 }

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VIDiv.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VIDiv.scala
@@ -67,5 +67,5 @@ class VIDiv(cfg: FuConfig)(implicit p: Parameters) extends VecNonPipedFuncUnit(c
   mgu.io.in.info.dstMask := outVecCtrl.isDstMask
   mgu.io.in.isIndexedVls := false.B
   io.out.bits.res.data := Mux(notModifyVd, outOldVd, mgu.io.out.vd)
-  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
+  io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := mgu.io.out.illegal
 }

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VIMacU.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VIMacU.scala
@@ -147,5 +147,5 @@ class VIMacU(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg
 
   io.out.bits.res.data := mgu.io.out.vd
   io.out.bits.res.vxsat.get := (outVxsat & mgu.io.out.active).orR
-  io.out.bits.ctrl.exceptionVec.get(ExceptionNO.illegalInstr) := mgu.io.out.illegal
+  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
 }

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VIMacU.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VIMacU.scala
@@ -147,5 +147,5 @@ class VIMacU(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg
 
   io.out.bits.res.data := mgu.io.out.vd
   io.out.bits.res.vxsat.get := (outVxsat & mgu.io.out.active).orR
-  io.out.bits.ctrl.exceptionVec.getAndAssign(ExceptionNO.illegalInstr)(mgu.io.out.illegal)
+  io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := mgu.io.out.illegal
 }

--- a/src/main/scala/xiangshan/backend/rename/CompressUnit.scala
+++ b/src/main/scala/xiangshan/backend/rename/CompressUnit.scala
@@ -49,7 +49,7 @@ class CompressUnit(implicit p: Parameters) extends XSModule{
     }
   })
 
-  val noExc = io.in.map(in => !in.bits.exceptionVec.asUInt.orR && !TriggerAction.isDmode(in.bits.trigger))
+  val noExc = io.in.map(in => !in.bits.exceptionVec.orR && !TriggerAction.isDmode(in.bits.trigger))
   val uopCanCompress = io.in.map(_.bits.canRobCompress)
   val canCompress = io.in.zip(noExc).zip(uopCanCompress).map { case ((in, noExc), canComp) =>
     in.valid && in.bits.lastUop && noExc && canComp

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -31,7 +31,6 @@ import xiangshan.backend.{StoreBubbleReason, PipelineStallReason}
 import xiangshan.backend.rename.freelist._
 import xiangshan.backend.rob.{RobEnqIO, RobPtr}
 import xiangshan.mem.mdp._
-import xiangshan.ExceptionNO._
 import xiangshan.backend.fu.FuType._
 import xiangshan.mem.{EewLog2, GenUSWholeEmul}
 import xiangshan.mem.GenRealFlowNum

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -405,7 +405,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
 
   val isMove = Wire(Vec(RenameWidth, Bool()))
   isMove zip io.in.map(_.bits) foreach {
-    case (move, in) => move := Mux(in.exceptionVec.asUInt.orR, false.B, in.isMove)
+    case (move, in) => move := Mux(in.exceptionVec.orR, false.B, in.isMove)
   }
 
   val walkNeedIntDest = WireDefault(VecInit(Seq.fill(RenameWidth)(false.B)))
@@ -474,7 +474,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     uops(i).robIdx := robIdxHead + PopCount(io.in.zip(needRobFlags).zip(io.validVec).take(i).map{ case((in, needRobFlag), valid) => valid && in.bits.lastUop && needRobFlag})
     instrSize(i) := instrSizesVec(i) + io.fusionCross2FtqVec(i)
     uops(i).debug.foreach(_.fusionNum := PopCount(compressMasksVec(i) & Cat(io.isFusionVec.reverse)))
-    val hasExceptionExceptFlushPipe = Cat(selectFrontend(uops(i).exceptionVec) :+ uops(i).exceptionVec(illegalInstr) :+ uops(i).exceptionVec(virtualInstr)).orR || TriggerAction.isDmode(uops(i).trigger)
+    val hasExceptionExceptFlushPipe = uops(i).exceptionVec.orR || TriggerAction.isDmode(uops(i).trigger)
     when(isMove(i) || hasExceptionExceptFlushPipe) {
       uops(i).numWB := 0.U
     }
@@ -763,7 +763,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   val allowSnpt = if (EnableRenameSnapshot) notInSameSnpt && !lastCycleCreateSnpt && io.in.head.bits.firstUop else false.B
   io.out.zip(io.in).foreach{ case (out, in) => out.bits.snapshot := allowSnpt && FuType.isJump(in.bits.fuType) && in.fire }
   io.out.map{ x =>
-    x.bits.hasException := Cat(selectFrontend(x.bits.exceptionVec) :+ x.bits.exceptionVec(illegalInstr) :+ x.bits.exceptionVec(virtualInstr)).orR || TriggerAction.isDmode(x.bits.trigger)
+    x.bits.hasException := x.bits.exceptionVec.orR || TriggerAction.isDmode(x.bits.trigger)
   }
   if(backendParams.debugEn){
     dontTouch(robIdxHeadNext)

--- a/src/main/scala/xiangshan/backend/rob/ExceptionGen.scala
+++ b/src/main/scala/xiangshan/backend/rob/ExceptionGen.scala
@@ -25,7 +25,6 @@ import utility._
 import utils._
 import xiangshan._
 import xiangshan.backend.BackendParams
-import xiangshan.backend.Bundles.connectSamePort
 import xiangshan.backend.fu.{FuConfig, FuType}
 import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.mem.{LqPtr, LsqEnqIO, SqPtr}

--- a/src/main/scala/xiangshan/backend/rob/ExceptionGen.scala
+++ b/src/main/scala/xiangshan/backend/rob/ExceptionGen.scala
@@ -25,6 +25,7 @@ import utility._
 import utils._
 import xiangshan._
 import xiangshan.backend.BackendParams
+import xiangshan.backend.Bundles.connectSamePort
 import xiangshan.backend.fu.{FuConfig, FuType}
 import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.mem.{LqPtr, LsqEnqIO, SqPtr}
@@ -32,14 +33,16 @@ import xiangshan.backend.fu.vector.Bundles.VType
 import xiangshan.backend.rename.SnapshotGenerator
 
 class ExceptionGen(params: BackendParams)(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelper {
+  val allExceptions = ExceptionNO.exceptionGenSet(params)
+
   val io = IO(new Bundle {
     val redirect = Input(Valid(new Redirect))
     val flush = Input(Bool())
-    val enq = Vec(RenameWidth, Flipped(ValidIO(new RobExceptionInfo)))
+    val enq = Vec(RenameWidth, Flipped(ValidIO(new RobExceptionInfo(ExceptionNO.decodeSet))))
     // csr + load + store + varith + vload + vstore
-    val wb = Vec(params.numException, Flipped(ValidIO(new RobExceptionInfo)))
-    val out = ValidIO(new RobExceptionInfo)
-    val state = ValidIO(new RobExceptionInfo)
+    val wb = MixedVec(params.getExceptionOutList.map { x => Flipped(ValidIO(new RobExceptionInfo(x))) } )
+    val out = ValidIO(new RobExceptionInfo(allExceptions))
+    val state = ValidIO(new RobExceptionInfo(allExceptions))
   })
 
   val wbExuParams = params.allExuParams.filter(_.exceptionOut.nonEmpty)
@@ -50,7 +53,7 @@ class ExceptionGen(params: BackendParams)(implicit p: Parameters) extends XSModu
       if (valid.length == 1) {
         (valid, bits)
       } else if (valid.length == 2) {
-        val res = Seq.fill(2)(Wire(ValidIO(chiselTypeOf(bits(0)))))
+        val res = Seq.fill(2)(Wire(ValidIO(new RobExceptionInfo(allExceptions))))
         for (i <- res.indices) {
           res(i).valid := valid(i)
           res(i).bits := bits(i)
@@ -72,22 +75,32 @@ class ExceptionGen(params: BackendParams)(implicit p: Parameters) extends XSModu
 
 
   val currentValid = RegInit(false.B)
-  val current = Reg(new RobExceptionInfo)
+  val current = Reg(new RobExceptionInfo(allExceptions))
+
+  val enqAllExcept = Wire(Vec(RenameWidth, Valid(new RobExceptionInfo(allExceptions))))
+  val wbAllExcept = Wire(Vec(params.numException, Valid(new RobExceptionInfo(allExceptions))))
+
+  enqAllExcept.zip(io.enq) foreach { case (sink, source) =>
+    (sink: Data).waiveAll :<= (source: Data).waiveAll
+    sink.bits.exceptionVec extendFrom source.bits.exceptionVec
+    sink.bits.flushPipe := source.bits.flushPipe && !source.bits.hasException
+  }
+  wbAllExcept.zip(io.wb) foreach { case (sink, source) =>
+    (sink: Data).waiveAll :<= (source: Data).waiveAll
+    sink.bits.exceptionVec extendFrom source.bits.exceptionVec
+  }
 
   // orR the exceptionVec
   val lastCycleFlush = RegNext(io.flush)
-  val enq_s0_valid = VecInit(io.enq.map(e => e.valid && e.bits.has_exception && !lastCycleFlush))
-  val enq_s0_bits = WireInit(VecInit(io.enq.map(_.bits)))
-  enq_s0_bits zip io.enq foreach { case (sink, source) =>
-    sink.flushPipe := source.bits.flushPipe && !source.bits.hasException
-  }
+  val enq_s0_valid = VecInit(enqAllExcept.map(e => e.valid && e.bits.has_exception && !lastCycleFlush))
+  val enq_s0_bits = WireInit(VecInit(enqAllExcept.map(_.bits)))
 
   // s0: compare wb in 6 groups
-  val csr_wb = io.wb.zip(wbExuParams).filter(_._2.fuConfigs.filter(t => t.isCsr).nonEmpty).map(_._1)
-  val load_wb = io.wb.zip(wbExuParams).filter(_._2.fuConfigs.filter(_.fuType == FuType.ldu).nonEmpty).map(_._1)
-  val store_wb = io.wb.zip(wbExuParams).filter(_._2.fuConfigs.filter(t => t.isSta || t.fuType == FuType.mou).nonEmpty).map(_._1)
-  val varith_wb = io.wb.zip(wbExuParams).filter(_._2.fuConfigs.filter(_.isVecArith).nonEmpty).map(_._1)
-  val vls_wb = io.wb.zip(wbExuParams).filter(_._2.fuConfigs.exists(x => FuType.FuTypeOrR(x.fuType, FuType.vecMem))).map(_._1)
+  val csr_wb = wbAllExcept.zip(wbExuParams).filter(_._2.fuConfigs.filter(t => t.isCsr).nonEmpty).map(_._1)
+  val load_wb = wbAllExcept.zip(wbExuParams).filter(_._2.fuConfigs.filter(_.fuType == FuType.ldu).nonEmpty).map(_._1)
+  val store_wb = wbAllExcept.zip(wbExuParams).filter(_._2.fuConfigs.filter(t => t.isSta || t.fuType == FuType.mou).nonEmpty).map(_._1)
+  val varith_wb = wbAllExcept.zip(wbExuParams).filter(_._2.fuConfigs.filter(_.isVecArith).nonEmpty).map(_._1)
+  val vls_wb = wbAllExcept.zip(wbExuParams).filter(_._2.fuConfigs.exists(x => FuType.FuTypeOrR(x.fuType, FuType.vecMem))).map(_._1)
 
   val writebacks = Seq(csr_wb, load_wb, store_wb, varith_wb, vls_wb)
   val in_wb_valids = writebacks.map(_.map(w => w.valid && w.bits.has_exception && !lastCycleFlush))
@@ -100,7 +113,7 @@ class ExceptionGen(params: BackendParams)(implicit p: Parameters) extends XSModu
   val s0_out_bits = wb_bits.zip(wb_valid).map{ case(b, v) => RegEnable(b, v)}
 
   // s1: compare last six and current flush
-  val s1_valid = VecInit(s0_out_valid.zip(s0_out_bits).map{ case (v, b) => v && !(b.robIdx.needFlush(io.redirect) || io.flush) })
+  val s1_valid = VecInit(s0_out_valid.zip(s0_out_bits).map{ case (v, bits) => v && !(bits.robIdx.needFlush(io.redirect) || io.flush) })
   val s1_out_bits = RegEnable(getOldest(s0_out_valid, s0_out_bits), s1_valid.asUInt.orR)
   val s1_out_valid = RegNext(s1_valid.asUInt.orR)
 
@@ -126,9 +139,9 @@ class ExceptionGen(params: BackendParams)(implicit p: Parameters) extends XSModu
         // s1 is older than current and caused by wb, set current.isEnqExcp to false
         current.isEnqExcp := false.B
       }.elsewhen (current.robIdx === s1_out_bits.robIdx) {
-        current.exceptionVec := Mux(isVecUpdate, s1_out_bits.exceptionVec, current.exceptionVec)
+        current.exceptionVec := ExceptSparseVec.mux2(isVecUpdate, s1_out_bits.exceptionVec, current.exceptionVec)
         current.hasException := Mux(isVecUpdate, s1_out_bits.hasException, current.hasException)
-        current.flushPipe := (s1_out_bits.flushPipe || current.flushPipe) && !s1_out_bits.exceptionVec.asUInt.orR
+        current.flushPipe := (s1_out_bits.flushPipe || current.flushPipe) && !s1_out_bits.exceptionVec.orR
         current.replayInst := s1_out_bits.replayInst || current.replayInst
         current.singleStep := s1_out_bits.singleStep || current.singleStep
         current.trigger   := Mux(isVecUpdate, s1_out_bits.trigger,    current.trigger)

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -485,7 +485,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
         hasWaitForward := true.B
       }
       val enqTriggerActionIsDebugMode = TriggerAction.isDmode(io.enq.req(i).bits.trigger)
-      val enqHasException = ExceptionNO.selectFrontend(enqUop.exceptionVec).asUInt.orR
+      val enqHasException = enqUop.exceptionVec.orR
       when(enqUop.isWFI && !enqHasException && !enqTriggerActionIsDebugMode) {
         hasWFI := true.B
       }
@@ -612,7 +612,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val deqNeedFlush = deqPtrEntry.needFlush && deqPtrEntry.commit_v && deqPtrEntry.commit_w
   val deqHitExceptionGenState = exceptionDataRead.valid && exceptionDataRead.bits.robIdx === deqPtr
   val deqNeedFlushAndHitExceptionGenState = deqNeedFlush && deqHitExceptionGenState
-  val exceptionGenStateIsException = exceptionDataRead.bits.exceptionVec.asUInt.orR || exceptionDataRead.bits.singleStep || TriggerAction.isDmode(exceptionDataRead.bits.trigger)
+  val exceptionGenStateIsException = exceptionDataRead.bits.exceptionVec.orR || exceptionDataRead.bits.singleStep || TriggerAction.isDmode(exceptionDataRead.bits.trigger)
   val deqHasException = deqNeedFlushAndHitExceptionGenState && exceptionGenStateIsException && RegNext(RegNext(deqPtrEntry.commit_w))
   val deqHasFlushPipe = deqNeedFlushAndHitExceptionGenState && exceptionDataRead.bits.flushPipe && !deqHasException && RegNext(RegNext(deqPtrEntry.commit_w))
   val deqHasReplayInst = deqNeedFlushAndHitExceptionGenState && exceptionDataRead.bits.replayInst
@@ -675,7 +675,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   io.exception.bits.isForVSnonLeafPTE := io.readGPAMemData.isForVSnonLeafPTE
   io.exception.bits.instr := RegEnable(debug_deqUop.debug_instr.getOrElse(0.U), exceptionHappen)
   io.exception.bits.commitType := RegEnable(deqPtrEntry.commitType, exceptionHappen)
-  io.exception.bits.exceptionVec := RegEnable(exceptionDataRead.bits.exceptionVec, exceptionHappen)
+  io.exception.bits.exceptionVec extendFrom RegEnable(exceptionDataRead.bits.exceptionVec, exceptionHappen)
   // fetch trigger fire or execute ebreak
   io.exception.bits.isPcBkpt := RegEnable(
     exceptionDataRead.bits.exceptionVec(ExceptionNO.EX_BP) && (
@@ -1186,7 +1186,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     exceptionGen.io.enq(i).bits.robIdx := io.enq.req(i).bits.robIdx
     exceptionGen.io.enq(i).bits.ftqPtr := io.enq.req(i).bits.ftqPtr
     exceptionGen.io.enq(i).bits.ftqOffset := io.enq.req(i).bits.ftqOffset
-    exceptionGen.io.enq(i).bits.exceptionVec := ExceptionNO.selectFrontend(io.enq.req(i).bits.exceptionVec)
+    exceptionGen.io.enq(i).bits.exceptionVec := io.enq.req(i).bits.exceptionVec
     exceptionGen.io.enq(i).bits.hasException := io.enq.req(i).bits.hasException
     exceptionGen.io.enq(i).bits.isEnqExcp := io.enq.req(i).bits.hasException
     exceptionGen.io.enq(i).bits.isFetchMalAddr := io.enq.req(i).bits.isFetchMalAddr
@@ -1222,8 +1222,8 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     // only enq inst use ftqPtr to read gpa
     exc_wb.bits.ftqPtr          := 0.U.asTypeOf(exc_wb.bits.ftqPtr)
     exc_wb.bits.ftqOffset       := 0.U.asTypeOf(exc_wb.bits.ftqOffset)
-    exc_wb.bits.exceptionVec    := wb.bits.exceptionVec.get
-    exc_wb.bits.hasException    := wb.bits.exceptionVec.get.asUInt.orR // Todo: use io.writebackNeedFlush(i) instead
+    exc_wb.bits.exceptionVec    := wb.bits.exceptionVec
+    exc_wb.bits.hasException    := wb.bits.exceptionVec.orR // Todo: use io.writebackNeedFlush(i) instead
     exc_wb.bits.isEnqExcp       := false.B
     exc_wb.bits.isFetchMalAddr  := false.B
     exc_wb.bits.flushPipe       := wb.bits.flushPipe.getOrElse(false.B)
@@ -1233,7 +1233,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     exc_wb.bits.crossPageIPFFix := false.B
     val trigger = wb.bits.trigger.getOrElse(TriggerAction.None).asTypeOf(exc_wb.bits.trigger)
     exc_wb.bits.trigger := trigger
-    exc_wb.bits.vstartEn := (if (wb.bits.vls.nonEmpty) wb.bits.exceptionVec.get.asUInt.orR || TriggerAction.isDmode(trigger) else 0.U)
+    exc_wb.bits.vstartEn := (if (wb.bits.vls.nonEmpty) wb.bits.exceptionVec.orR || TriggerAction.isDmode(trigger) else 0.U)
     exc_wb.bits.vstart := (if (wb.bits.vls.nonEmpty) wb.bits.vls.get.vpu.vstart else 0.U)
     exc_wb.bits.vuopIdx := (if (wb.bits.vls.nonEmpty) wb.bits.vls.get.vpu.vuopIdx else 0.U)
     exc_wb.bits.isVecLoad := wb.bits.vls.map(_.isVecLoad).getOrElse(false.B)
@@ -1470,7 +1470,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
         debug_instData.executeLatency := wb.bits.perfDebugInfo.get.writebackTime - wb.bits.perfDebugInfo.get.issueTime
         debug_instData.rsFuLatency := wb.bits.perfDebugInfo.get.writebackTime - wb.bits.perfDebugInfo.get.enqRsTime
         debug_instData.tlbLatency := wb.bits.perfDebugInfo.get.tlbRespTime - wb.bits.perfDebugInfo.get.tlbFirstReqTime
-        debug_instData.exceptType := Cat(wb.bits.exceptionVec.getOrElse(ExceptionVec(false.B)))
+        debug_instData.exceptType := wb.bits.exceptionVec.asUInt
         debug_instData.lsInfo := debug_lsInfo(idx)
         // debug_instData.globalID := wb.bits.uop.ctrl.debug_globalID
         // debug_instData.instType := wb.bits.uop.ctrl.fuType

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -288,7 +288,7 @@ class RobDebugRollingIO extends Bundle {
   val robTrueCommit = Output(UInt(64.W))
 }
 
-class RobExceptionInfo(implicit p: Parameters) extends XSBundle {
+class RobExceptionInfo(exceptList: Seq[Int]=ExceptionNO.all)(implicit p: Parameters) extends XSBundle {
   // val valid = Bool()
   val robIdx = new RobPtr
   val ftqPtr = new FtqPtr
@@ -298,7 +298,7 @@ class RobExceptionInfo(implicit p: Parameters) extends XSBundle {
   // This signal is valid iff currentValid is true
   // 0: is execute exception, 1: is fetch exception
   val isEnqExcp = Bool()
-  val exceptionVec = ExceptionVec()
+  val exceptionVec = ExceptSparseVec(exceptList)
   val isFetchMalAddr = Bool()
   val flushPipe = Bool()
   val isVset = Bool()

--- a/src/main/scala/xiangshan/backend/rob/RobDeqPtrWrapper.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobDeqPtrWrapper.scala
@@ -33,7 +33,7 @@ import xiangshan.backend.Bundles.{DynInst, ExceptionInfo, ExuOutput}
 import xiangshan.backend.fu.vector.Bundles.VType
 import xiangshan.backend.rename.SnapshotGenerator
 
-class NewRobDeqPtrWrapper(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelper {
+class NewRobDeqPtrWrapper(implicit p: Parameters, params: BackendParams) extends XSModule with HasCircularQueuePtrHelper {
   val io = IO(new Bundle {
     // for commits/flush
     val state = Input(UInt(2.W))
@@ -41,7 +41,7 @@ class NewRobDeqPtrWrapper(implicit p: Parameters) extends XSModule with HasCircu
     val deq_w = Vec(CommitWidth, Input(Bool()))
     val hasCommitted = Vec(CommitWidth, Input(Bool()))
     val allCommitted = Input(Bool())
-    val exception_state = Flipped(ValidIO(new RobExceptionInfo))
+    val exception_state = Flipped(ValidIO(new RobExceptionInfo(ExceptionNO.exceptionGenSet(params))))
     // for flush: when exception occurs, reset deqPtrs to range(0, CommitWidth)
     val intrBitSetReg = Input(Bool())
     val allowOnlyOneCommit = Input(Bool())

--- a/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
@@ -134,6 +134,7 @@ class IBufOutEntry(implicit p: Parameters) extends IBufferBundle {
     cf.instr                                         := inst
     cf.pc                                            := pc.toUInt
     cf.foldpc                                        := foldpc
+    cf.exceptionVec.zeroInit()
     cf.exceptionVec(ExceptionNO.instrPageFault)      := exceptionType.isPf
     cf.exceptionVec(ExceptionNO.instrGuestPageFault) := exceptionType.isGpf
     cf.exceptionVec(ExceptionNO.instrAccessFault)    := exceptionType.isAf

--- a/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
@@ -23,7 +23,6 @@ import utility.InstSeqNum
 import utils.EnumUInt
 import xiangshan.CtrlFlow
 import xiangshan.ExceptionNO
-import xiangshan.ExceptionVec
 import xiangshan.TriggerAction
 import xiangshan.XSCoreParamsKey
 import xiangshan.frontend.ExceptionType
@@ -135,7 +134,6 @@ class IBufOutEntry(implicit p: Parameters) extends IBufferBundle {
     cf.instr                                         := inst
     cf.pc                                            := pc.toUInt
     cf.foldpc                                        := foldpc
-    cf.exceptionVec                                  := 0.U.asTypeOf(ExceptionVec())
     cf.exceptionVec(ExceptionNO.instrPageFault)      := exceptionType.isPf
     cf.exceptionVec(ExceptionNO.instrGuestPageFault) := exceptionType.isGpf
     cf.exceptionVec(ExceptionNO.instrAccessFault)    := exceptionType.isAf

--- a/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
@@ -131,10 +131,10 @@ class IBufOutEntry(implicit p: Parameters) extends IBufferBundle {
 
   def toCtrlFlow: CtrlFlow = {
     val cf = Wire(new CtrlFlow)
+    cf.exceptionVec.zeroInit()
     cf.instr                                         := inst
     cf.pc                                            := pc.toUInt
     cf.foldpc                                        := foldpc
-    cf.exceptionVec.zeroInit()
     cf.exceptionVec(ExceptionNO.instrPageFault)      := exceptionType.isPf
     cf.exceptionVec(ExceptionNO.instrGuestPageFault) := exceptionType.isGpf
     cf.exceptionVec(ExceptionNO.instrAccessFault)    := exceptionType.isAf

--- a/src/main/scala/xiangshan/mem/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/Bundles.scala
@@ -138,7 +138,7 @@ object Bundles {
       output.vecWen.foreach(_ := this.uop.vecWen)
       output.v0Wen.foreach(_ := this.uop.v0Wen)
       output.vlWen.foreach(_ := this.uop.vlWen)
-      output.exceptionVec.foreach(_ := this.uop.exceptionVec)
+      output.exceptionVec := this.uop.exceptionVec
       output.flushPipe.foreach(_ := this.uop.flushPipe)
       output.replay.foreach(_ := this.uop.replayInst)
       // output.debug := this.debug

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -30,7 +30,6 @@ import utility.mbist.{MbistInterface, MbistPipeline}
 import utility.sram.{SramBroadcastBundle, SramHelper}
 import utils._
 import xiangshan._
-import xiangshan.ExceptionNO._
 import xiangshan.backend.ctrlblock.{DebugLSIO, LsTopdownInfo}
 import xiangshan.backend.datapath.NewPipelineConnect
 import xiangshan.backend.fu.FuType._

--- a/src/main/scala/xiangshan/mem/lsqueue/ExceptionInfoGen.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/ExceptionInfoGen.scala
@@ -21,7 +21,6 @@ import difftest.common.DifftestMem
 import org.chipsalliance.cde.config.Parameters
 import top.ArgParser
 import utility._
-import xiangshan.ExceptionNO.hardwareError
 import xiangshan._
 import xiangshan.backend.Bundles.{MemExuOutput, UopIdx, connectSamePort}
 import xiangshan.backend.datapath.NewPipelineConnect

--- a/src/main/scala/xiangshan/mem/lsqueue/ExceptionInfoGen.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/ExceptionInfoGen.scala
@@ -33,8 +33,8 @@ import xiangshan.mem.Bundles.LqWriteBundle
 class MemExceptionInfo(implicit p: Parameters) extends XSBundle {
   val robIdx            = new RobPtr
   val uopIdx            = UopIdx()
-  val exceptionVec      = ExceptionVec()
-  def hasException      = exceptionVec.asUInt.orR
+  val exceptionVec      = ExceptSparseVec() // TODO: optimize valid indices
+  def hasException      = exceptionVec.orR
 
   val vaddr             = UInt(XLEN.W)
   val vaNeedExt         = Bool()

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -22,7 +22,6 @@ import chisel3.util._
 import utils._
 import utility._
 import xiangshan._
-import xiangshan.ExceptionNO._
 import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.backend._
 import xiangshan.backend.fu.fpu._

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -661,7 +661,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       allocated(enqIndex) := true.B
       scheduled(enqIndex) := false.B
       uop(enqIndex)       := enq.bits.uop
-      uop(enqIndex).exceptionVec.init
+      uop(enqIndex).exceptionVec.zeroInit()
       isNC(enqIndex)      := enq.bits.nc && enq.bits.rep_info.cause(LoadReplayCauses.C_UNCACHE)
       vecReplay(enqIndex).isvec := enq.bits.isvec
       vecReplay(enqIndex).isLastElem := enq.bits.isLastElem

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -661,7 +661,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       allocated(enqIndex) := true.B
       scheduled(enqIndex) := false.B
       uop(enqIndex)       := enq.bits.uop
-      uop(enqIndex).exceptionVec := 0.U.asTypeOf(enq.bits.uop.exceptionVec)
+      uop(enqIndex).exceptionVec.init
       isNC(enqIndex)      := enq.bits.nc && enq.bits.rep_info.cause(LoadReplayCauses.C_UNCACHE)
       vecReplay(enqIndex).isvec := enq.bits.isvec
       vecReplay(enqIndex).isLastElem := enq.bits.isLastElem

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -354,7 +354,7 @@ class LoadQueueUncache(implicit p: Parameters) extends XSModule
     !s2_req(i).uop.robIdx.needFlush(RegNext(io.redirect)) &&
     !s2_req(i).uop.robIdx.needFlush(io.redirect)
   })
-  val s2_has_exception = s2_req.map(x => ExceptionNO.selectByFu(x.uop.exceptionVec, LduCfg).asUInt.orR)
+  val s2_has_exception = s2_req.map(x => x.uop.exceptionVec.selectByFu(LduCfg).orR)
   val s2_need_replay = s2_req.map { req =>
      req.rep_info.need_rep && !req.rep_info.mmioOrNc}
 
@@ -474,7 +474,7 @@ class LoadQueueUncache(implicit p: Parameters) extends XSModule
   ))
   io.exceptionInfo.valid := Cat(entries.map(_.io.exception.valid)).orR
   io.exceptionInfo.bits.robIdx       := exceptionEntry.uop.robIdx
-  io.exceptionInfo.bits.exceptionVec := ExceptionNO.selectByFu(exceptionEntry.uop.exceptionVec, LduCfg)
+  io.exceptionInfo.bits.exceptionVec extendFrom exceptionEntry.uop.exceptionVec.selectByFu(LduCfg)
   io.exceptionInfo.bits.vaddr        := exceptionEntry.fullva
   io.exceptionInfo.bits.gpaddr       := exceptionEntry.gpaddr
   io.exceptionInfo.bits.isForVSnonLeafPTE := exceptionEntry.isForVSnonLeafPTE

--- a/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
@@ -1026,7 +1026,7 @@ abstract class NewStoreQueueBase(implicit p: Parameters) extends LSQModule {
     val writeBackValid = uncacheState === UncacheState.writeback || cboState === CboState.writeback
     val writeBackToRob = Wire(new MemToRob(staParams.head))
     writeBackToRob.robIdx := dataEntries.head.uop.robIdx
-    writeBackToRob.exceptionVec.init
+    writeBackToRob.exceptionVec.zeroInit()
     writeBackToRob.exceptionVec(hardwareError) := hasHardwareError
     writeBackToRob.exceptionVec(storeAccessFault) := hasAccessFault // override
     writeBackToRob.trigger.foreach(_ := DontCare)

--- a/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
@@ -1026,11 +1026,9 @@ abstract class NewStoreQueueBase(implicit p: Parameters) extends LSQModule {
     val writeBackValid = uncacheState === UncacheState.writeback || cboState === CboState.writeback
     val writeBackToRob = Wire(new MemToRob(staParams.head))
     writeBackToRob.robIdx := dataEntries.head.uop.robIdx
-    writeBackToRob.exceptionVec.foreach{ case x =>
-      x := ExceptionNO.selectByFu(0.U.asTypeOf(ExceptionVec()), StaCfg)
-      x(hardwareError) := hasHardwareError
-      x(storeAccessFault) := hasAccessFault
-    }
+    writeBackToRob.exceptionVec.init
+    writeBackToRob.exceptionVec(hardwareError) := hasHardwareError
+    writeBackToRob.exceptionVec(storeAccessFault) := hasAccessFault // override
     writeBackToRob.trigger.foreach(_ := DontCare)
     writeBackToRob.isRVC.foreach(_ := DontCare)
     writeBackToRob.sqIdx.foreach(_ := io.rdataPtrExt.head)
@@ -1048,7 +1046,7 @@ abstract class NewStoreQueueBase(implicit p: Parameters) extends LSQModule {
 
     io.exceptionInfo.valid             := writeBackValid
     io.exceptionInfo.bits.robIdx       := dataEntries.head.uop.robIdx
-    io.exceptionInfo.bits.exceptionVec := ExceptionNO.selectByFu(writeBackToRob.exceptionVec.get, StaCfg)
+    io.exceptionInfo.bits.exceptionVec extendFrom writeBackToRob.exceptionVec
     // TODO: why not fullVaddr and why don't have gpaddr ?
     io.exceptionInfo.bits.vaddr        := dataEntries.head.vaddr
     io.exceptionInfo.bits.gpaddr       := 0.U.asTypeOf(io.exceptionInfo.bits.gpaddr)

--- a/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
@@ -249,7 +249,7 @@ class VirtualLoadQueue(implicit p: Parameters) extends XSModule
     val need_rep = io.ldin(i).bits.rep_info.need_rep
     val need_valid = io.ldin(i).bits.updateAddrValid
     when (io.ldin(i).valid) {
-      val hasExceptions = ExceptionNO.selectByFu(io.ldin(i).bits.uop.exceptionVec, LduCfg).asUInt.orR
+      val hasExceptions = io.ldin(i).bits.uop.exceptionVec.selectByFu(LduCfg).orR
       when (!need_rep && need_valid && !io.ldin(i).bits.isvec) {
         committed(loadWbIndex) := true.B
         //  Debug info

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -104,7 +104,7 @@ class AtomicsUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSMo
   val rd = Cat(rd_h, rd_l)
   val stdCnt = RegInit(0.U(log2Ceil(stds.length + 1).W))
 
-  val exceptionVec = RegInit(0.U.asTypeOf(ExceptionVec()))
+  val exceptionVec = RegInit(ExceptSparseVec.zeros(param.exceptionOut))
   val trigger = RegInit(TriggerAction.None)
   val atom_override_xtval = RegInit(false.B)
   val have_sent_first_tlb_req = RegInit(false.B)
@@ -464,7 +464,7 @@ class AtomicsUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSMo
   io.exceptionInfo.bits.vaddr             := vaddr
   io.exceptionInfo.bits.gpaddr            := gpaddr
   io.exceptionInfo.bits.isForVSnonLeafPTE := isForVSnonLeafPTE
-  io.exceptionInfo.bits.exceptionVec      := exceptionVec
+  io.exceptionInfo.bits.exceptionVec extendFrom exceptionVec
   io.exceptionInfo.bits.vaNeedExt         := false.B
   io.exceptionInfo.bits.isHyper           := false.B
   io.exceptionInfo.bits.uopIdx            := 0.U.asTypeOf(io.exceptionInfo.bits.uopIdx)
@@ -524,7 +524,7 @@ class AtomicsUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSMo
     port.bits.pdest := Mux(state === s_finish2, pdest2, pdest1)
   }
   io.out.toRob.bits.robIdx := uop.robIdx
-  io.out.toRob.bits.exceptionVec.foreach(_ := exceptionVec)
+  io.out.toRob.bits.exceptionVec := exceptionVec
   io.out.toRob.bits.trigger.foreach(_ := trigger)
   io.out.toRob.bits.isRVC.foreach(_ := uop.isRVC)
   io.out.toRob.bits.lqIdx.foreach(_ := uop.lqIdx)

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -929,8 +929,8 @@ class LoadUnitS2(param: ExeUnitParams)(
   val hweBypassCorrupt = Wire(Bool())
   val hwe = uop.exceptionVec(hardwareError) || hweForwardCorrupt || hweBypassCorrupt
 
-  val exceptionVec = WireInit(uop.exceptionVec)
-  val exception = TriggerAction.isDmode(uop.trigger) || ExceptionNO.selectByFu(exceptionVec, LduCfg).asUInt.orR
+  val exceptionVec = uop.exceptionVec.selectByFu(LduCfg)
+  val exception = TriggerAction.isDmode(uop.trigger) || exceptionVec.orR
   exceptionVec(loadAddrMisaligned) := am
   exceptionVec(loadAccessFault) := af
   exceptionVec(hardwareError) := hwe
@@ -1108,7 +1108,7 @@ class LoadUnitS2(param: ExeUnitParams)(
   val stageInfo = Wire(pipeOut.bits.cloneType)
   connectSamePort(stageInfo, in)
   stageInfo.uop.flushPipe := false.B
-  stageInfo.uop.exceptionVec := exceptionVec
+  stageInfo.uop.exceptionVec extendFrom exceptionVec
   stageInfo.uop.vpu.vstart := Mux(
     LoadEntrance.isReplay(entrance) || LoadEntrance.isFastReplay(entrance),
     uop.vpu.vstart,
@@ -1308,7 +1308,7 @@ class LoadUnitS3(param: ExeUnitParams)(
     */
   val s4HeadValid = io.unalignConcat.valid
   val s4Head = io.unalignConcat.bits
-  val s4HeadExceptionVec = s4Head.uop.exceptionVec
+  val s4HeadExceptionVec = s4Head.uop.exceptionVec.selectByFu(LduCfg)
   val s4HeadVAddr = s4Head.vaddr
   val s4HeadMask = s4Head.mask
   val s4HeadPAddr = s4Head.paddr.get
@@ -1334,9 +1334,9 @@ class LoadUnitS3(param: ExeUnitParams)(
     * Noted that exception can affect control signals for wakeup and writeback
     */
   val dcacheError = EnableAccurateLoadError.B && io.csrCtrl.cache_error_enable && troubleMaker && io.dcacheError
-  val s3ExceptionVec = WireInit(uop.exceptionVec)
-  val s3Exception = ExceptionNO.selectByFu(s3ExceptionVec, LduCfg).asUInt.orR || TriggerAction.isDmode(uop.trigger)
-  val exceptionVec = Mux(
+  val s3ExceptionVec = uop.exceptionVec.selectByFu(LduCfg)
+  val s3Exception = s3ExceptionVec.orR || TriggerAction.isDmode(uop.trigger)
+  val exceptionVec = ExceptSparseVec.mux2(
     s4HeadValid && s4HeadHasException,
     s4HeadExceptionVec,
     s3ExceptionVec
@@ -1427,7 +1427,7 @@ class LoadUnitS3(param: ExeUnitParams)(
   }
   ldout.toRob.valid := ldoutValid
   ldout.toRob.bits.robIdx := uop.robIdx
-  ldout.toRob.bits.exceptionVec.get := exceptionVec
+  ldout.toRob.bits.exceptionVec extendFrom exceptionVec
   ldout.toRob.bits.lqIdx.get := uop.lqIdx
   ldout.toRob.bits.trigger.get := uop.trigger
   ldout.toRob.bits.isRVC.get := uop.isRVC
@@ -1449,7 +1449,7 @@ class LoadUnitS3(param: ExeUnitParams)(
   val lqWriteHandledByMSHR = Mux(s4HeadCacheMiss && s4HeadValid, s4HeadHandledByMSHR, in.handledByMSHR.get)
   // TODO: remove useless fields after old LoadUnit is removed
   lqWrite.uop := uop
-  lqWrite.uop.exceptionVec := exceptionVec
+  lqWrite.uop.exceptionVec extendFrom exceptionVec
   lqWrite.vaddr := vaddr
   lqWrite.fullva := exceptionFullva
   lqWrite.vaNeedExt := exceptionVaNeedExt
@@ -1556,7 +1556,7 @@ class LoadUnitS3(param: ExeUnitParams)(
   val exceptionInfoValid = ldoutValid && !in.isMMIOReplay() // MMIO replay sends exceptionInfo independently
   val exceptionInfo = Wire(new MemExceptionInfo)
   exceptionInfo.robIdx := robIdx
-  exceptionInfo.exceptionVec := exceptionVec
+  exceptionInfo.exceptionVec extendFrom exceptionVec
   exceptionInfo.vaddr := exceptionFullva
   exceptionInfo.gpaddr := exceptionGpaddr
   exceptionInfo.isForVSnonLeafPTE := exceptionIsForVSnonLeafPTE
@@ -1578,7 +1578,7 @@ class LoadUnitS3(param: ExeUnitParams)(
   // Consider only unalign head
   val stageInfo = Wire(pipeOut.bits.cloneType)
   connectSamePort(stageInfo, in)
-  stageInfo.uop.exceptionVec := s3ExceptionVec
+  stageInfo.uop.exceptionVec extendFrom s3ExceptionVec
   stageInfo.matchInvalid.get := s3MatchInvalid
   stageInfo.shouldWakeup.get := s3ShouldWakeup
   stageInfo.shouldWriteback.get := s3ShouldWriteback

--- a/src/main/scala/xiangshan/mem/pipeline/NewStoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewStoreUnit.scala
@@ -821,7 +821,7 @@ class StoreUnitS3(param: ExeUnitParams)(
   io.stout.toRob.bits.trigger.foreach(_ := sxData.uop.trigger)
   io.stout.toRob.bits.sqIdx.foreach(_ := sxData.uop.sqIdx)
   io.stout.toRob.bits.lqIdx.foreach(_ := sxData.uop.lqIdx)
-  io.stout.toRob.bits.exceptionVec.foreach(_ := ExceptionNO.selectByFu(sxData.uop.exceptionVec, StaCfg))
+  io.stout.toRob.bits.exceptionVec extendFrom sxData.uop.exceptionVec.selectByFu(StaCfg)
   io.stout.toRob.bits.debugInfo.isMMIO.foreach(_ := sxData.mmio.get)
   io.stout.toRob.bits.debugInfo.isNCIO.foreach(_ := sxData.nc.get && !sxData.memBackTypeMM.get)
   io.stout.toRob.bits.debugInfo.isPerfCnt.foreach(_ := false.B)
@@ -832,7 +832,7 @@ class StoreUnitS3(param: ExeUnitParams)(
 
   io.exceptionInfo.valid := sxValid && !sxVector
   io.exceptionInfo.bits.robIdx := sxData.uop.robIdx
-  io.exceptionInfo.bits.exceptionVec := ExceptionNO.selectByFu(sxData.uop.exceptionVec, StaCfg)
+  io.exceptionInfo.bits.exceptionVec extendFrom sxData.uop.exceptionVec.selectByFu(StaCfg)
   io.exceptionInfo.bits.vaddr := sxData.fullva
   io.exceptionInfo.bits.gpaddr := sxData.gpaddr.get
   io.exceptionInfo.bits.isForVSnonLeafPTE := sxData.isForVSnonLeafPTE.get
@@ -851,7 +851,7 @@ class StoreUnitS3(param: ExeUnitParams)(
   io.vecstout.bits.trigger := sxData.uop.trigger
   io.vecstout.bits.nc := sxData.nc.get
   io.vecstout.bits.mmio := sxData.mmio.get
-  io.vecstout.bits.exceptionVec := ExceptionNO.selectByFu(sxData.uop.exceptionVec, VstuCfg)
+  io.vecstout.bits.exceptionVec := sxData.uop.exceptionVec.selectByFu(VstuCfg)
   io.vecstout.bits.hasException := sxData.hasException.get
   io.vecstout.bits.elemIdx := sxData.elemIdx.get
   io.vecstout.bits.alignedType := sxData.size

--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -81,7 +81,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     sink.data         := source.data
     sink.mask         := source.mask
     sink.flowNum      := source.flowNum
-    sink.exceptionVec.init
+    sink.exceptionVec.zeroInit()
     sink.uop          := source.uop
     sink.sourceType   := 0.U.asTypeOf(VSFQFeedbackType())
     sink.flushState   := false.B

--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -33,11 +33,11 @@ import xiangshan.backend.fu.vector.Bundles.VType
 import xiangshan.mem._
 import xiangshan.mem.Bundles._
 
-class MBufferBundle(implicit p: Parameters) extends VLSUBundle{
+class MBufferBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle{
   val data             = UInt(VLEN.W)
   val mask             = UInt(VLENB.W)
   val flowNum          = UInt(flowIdxBits.W)
-  val exceptionVec     = ExceptionVec()
+  val exceptionVec     = ExceptSparseVec((if (isVStore) VstuCfg else VlduCfg).exceptionOut)
   val uop              = new DynInst
   // val vdOffset         = UInt(vOffsetBits.W)
   val sourceType       = VSFQFeedbackType()
@@ -81,7 +81,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     sink.data         := source.data
     sink.mask         := source.mask
     sink.flowNum      := source.flowNum
-    sink.exceptionVec := ExceptionNO.selectByFu(0.U.asTypeOf(ExceptionVec()), fuCfg)
+    sink.exceptionVec.init
     sink.uop          := source.uop
     sink.sourceType   := 0.U.asTypeOf(VSFQFeedbackType())
     sink.flushState   := false.B
@@ -104,7 +104,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     sink.vecWen.foreach(_ := source.uop.vecWen)
     sink.v0Wen.foreach(_ := source.uop.v0Wen)
     sink.vlWen.foreach(_ := source.uop.vlWen)
-    sink.exceptionVec.foreach(_ := ExceptionNO.selectByFu(source.exceptionVec, fuCfg))
+    sink.exceptionVec extendFrom source.exceptionVec
     sink.flushPipe.foreach(_ := source.uop.flushPipe)
     sink.replay.foreach(_ := source.uop.replayInst)
     sink.lqIdx.foreach(_ := source.uop.lqIdx)
@@ -131,7 +131,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
   }
   def ToLsqConnect(source: MBufferBundle): FeedbackToLsqIO = {
     val sink                                 = WireInit(0.U.asTypeOf(new FeedbackToLsqIO))
-    val hasExp                               = ExceptionNO.selectByFu(source.exceptionVec, fuCfg).asUInt.orR
+    val hasExp                               = source.exceptionVec.orR
     sink.robidx                             := source.uop.robIdx
     sink.uopidx                             := source.uop.uopIdx
     sink.feedback(VecFeedbacks.COMMIT)      := !hasExp
@@ -150,13 +150,13 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     sink.gpaddr                             := source.gpaddr
     sink.isForVSnonLeafPTE                  := source.isForVSnonLeafPTE
     sink.vl                                 := source.vl
-    sink.exceptionVec                       := ExceptionNO.selectByFu(source.exceptionVec, fuCfg)
+    sink.exceptionVec               extendFrom source.exceptionVec
     sink.isHyper                            := false.B
     sink
   }
 
 
-  val entries      = Reg(Vec(uopSize, new MBufferBundle))
+  val entries      = Reg(Vec(uopSize, new MBufferBundle(isVStore)))
   val needCancel   = WireInit(VecInit(Seq.fill(uopSize)(false.B)))
   val allocated    = RegInit(VecInit(Seq.fill(uopSize)(false.B)))
   val freeMaskVec  = WireInit(VecInit(Seq.fill(uopSize)(false.B)))
@@ -257,7 +257,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     val entry               = entries(pipeWbMbIndex)
     val entryVeew           = entry.uop.vpu.veew
     val entryIsUS           = LSUOpType.isAllUS(entry.uop.fuOpType)
-    val entryHasException   = ExceptionNO.selectByFu(entry.exceptionVec, fuCfg).asUInt.orR || TriggerAction.isDmode(entry.uop.trigger)
+    val entryHasException   = entry.exceptionVec.orR || TriggerAction.isDmode(entry.uop.trigger)
     val entryExcp           = entryHasException && entry.mask.orR
     val entryVaddr          = entry.vaddr
     val entryVstart         = entry.vstart
@@ -290,7 +290,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
       when(!entry.fof || vstart === 0.U){
         // For fof loads, if element 0 raises an exception, vl is not modified, and the trap is taken.
         entry.vstart       := vstart
-        entry.exceptionVec := ExceptionNO.selectByFu(selExceptionVec, fuCfg)
+        entry.exceptionVec := selExceptionVec
         entry.uop.trigger  := selPort.trigger
         entry.vaddr        := vaddr
         entry.vaNeedExt    := selPort.vaNeedExt
@@ -307,7 +307,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     val wbIndex          = pipewb.bits.mBIndex
     val flowNumOffset    = PopCount(mergePortMatrix(i))
     val sourceTypeNext   = entries(wbIndex).sourceType | pipewb.bits.sourceType
-    val hasExp           = ExceptionNO.selectByFu(pipewb.bits.exceptionVec, fuCfg).asUInt.orR
+    val hasExp           = pipewb.bits.exceptionVec.orR
 
     // if is VLoad, need latch 1 cycle to merge data. only flowNum and wbIndex need to latch
     val latchWbValid     = if(isVStore) pipewb.valid else RegNext(pipewb.valid)
@@ -339,7 +339,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
    val selPolicy = SelectOne("circ", uopFinish, deqWidth) // select one entry to deq
    private val pipelineOut              = Wire(Vec(deqWidth, DecoupledIO(new ExuOutput(param))))
    private val writeBackOut             = Wire(Vec(deqWidth, DecoupledIO(new ExuOutput(param))))
-   private val writeBackOutExceptionVec = writeBackOut.map(_.bits.exceptionVec.get)
+   private val writeBackOutExceptionVec = writeBackOut.map(_.bits.exceptionVec)
    for(((port, lsqport), i) <- (pipelineOut zip io.toLsq).zipWithIndex){
     val canGo    = port.ready
     val (selValid, selOHVec) = selPolicy.getNthOH(i + 1)
@@ -384,7 +384,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
       Option(s"VMergebufferPipelineConnect${i}")
     )
      io.uopWriteback(i)                  <> writeBackOut(i)
-     io.uopWriteback(i).bits.exceptionVec.foreach(_ := ExceptionNO.selectByFu(writeBackOutExceptionVec(i), fuCfg))
+     io.uopWriteback(i).bits.exceptionVec extendFrom writeBackOutExceptionVec(i).selectByFu(fuCfg)
    }
 
   QueuePerf(uopSize, freeList.io.validCount, freeList.io.validCount === 0.U)
@@ -413,7 +413,7 @@ class VLMergeBufferImp(implicit p: Parameters) extends BaseVMergeBuffer(isVStore
     Mux(
       TriggerAction.isExp(x.bits.trigger) || TriggerAction.isDmode(x.bits.trigger),
       ~x.bits.vecTriggerMask,
-      Fill(x.bits.mask.getWidth, !ExceptionNO.selectByFuAndUnSelect(x.bits.exceptionVec, fuCfg, Seq(breakPoint)).asUInt.orR)
+      Fill(x.bits.mask.getWidth, !x.bits.exceptionVec.unselect(breakPoint).orR)
     ).asUInt & x.bits.mask
   }
 
@@ -488,7 +488,7 @@ class VSMergeBufferImp(implicit p: Parameters) extends BaseVMergeBuffer(isVStore
     sink.vecWen.foreach(_ := source.uop.vecWen)
     sink.v0Wen.foreach(_ := source.uop.v0Wen)
     sink.vlWen.foreach(_ := source.uop.vlWen)
-    sink.exceptionVec.foreach(_ := ExceptionNO.selectByFu(source.exceptionVec, fuCfg))
+    sink.exceptionVec extendFrom source.exceptionVec
     sink.flushPipe.foreach(_ := source.uop.flushPipe)
     sink.replay.foreach(_ := source.uop.replayInst)
     sink.lqIdx.foreach(_ := source.uop.lqIdx)

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -927,7 +927,7 @@ class VSegmentUnit(val param: ExeUnitParams)(implicit p: Parameters) extends VLS
     writebackOut.vecWen.foreach(_ := fofBuffer.vecWen)
     writebackOut.v0Wen.foreach(_ := fofBuffer.v0Wen)
     writebackOut.vlWen.foreach(_ := fofBuffer.vlWen)
-    writebackOut.exceptionVec.foreach(_ := fofBuffer.exceptionVec)
+    writebackOut.exceptionVec := fofBuffer.exceptionVec
     writebackOut.flushPipe.foreach(_ := false.B)
     writebackOut.replay.foreach(_ := false.B)
     writebackOut.trigger.foreach(_ := fofBuffer.trigger)
@@ -954,14 +954,14 @@ class VSegmentUnit(val param: ExeUnitParams)(implicit p: Parameters) extends VLS
     writebackOut.vecWen.foreach(_ := uopq(deqPtr.value).uop.vecWen)
     writebackOut.v0Wen.foreach(_ := uopq(deqPtr.value).uop.v0Wen)
     writebackOut.vlWen.foreach(_ := uopq(deqPtr.value).uop.vlWen)
-    writebackOut.exceptionVec.foreach(_ := instMicroOp.uop.exceptionVec)
+    writebackOut.exceptionVec := instMicroOp.uop.exceptionVec
     writebackOut.flushPipe.foreach(_ := false.B)
     writebackOut.replay.foreach(_ := false.B)
     writebackOut.trigger.foreach(_ := instMicroOp.uop.trigger)
     writebackOut.vls.foreach(vls => {
       vls.vpu := instMicroOp.uop.vpu
       vls.vpu.vl := instMicroOp.vl
-      vls.vpu.vstart := Mux(instMicroOp.uop.exceptionVec.asUInt.orR || TriggerAction.isDmode(instMicroOp.uop.trigger), instMicroOp.exceptionVstart, instMicroOp.vstart)
+      vls.vpu.vstart := Mux(instMicroOp.uop.exceptionVec.orR || TriggerAction.isDmode(instMicroOp.uop.trigger), instMicroOp.exceptionVstart, instMicroOp.vstart)
       vls.vpu.vmask := maskUsed
       vls.vpu.vuopIdx := uopq(deqPtr.value).uop.vpu.vuopIdx
       vls.oldVdPsrc := uopq(deqPtr.value).uop.psrc(2)
@@ -1011,6 +1011,6 @@ class VSegmentUnit(val param: ExeUnitParams)(implicit p: Parameters) extends VLS
   io.exceptionInfo.bits.vl            := instMicroOp.exceptionVl.bits
   io.exceptionInfo.bits.exceptionVec  := instMicroOp.uop.exceptionVec
   io.exceptionInfo.bits.isHyper       := false.B
-  io.exceptionInfo.valid              := (state === s_finish) && instMicroOp.uop.exceptionVec.asUInt.orR && !isEmpty(enqPtr, deqPtr)
+  io.exceptionInfo.valid              := (state === s_finish) && instMicroOp.uop.exceptionVec.orR && !isEmpty(enqPtr, deqPtr)
 }
 

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -386,7 +386,7 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
   io.out.bits match { case x =>
     x.uop                   := issueUop
     x.uop.imm               := 0.U
-    x.uop.exceptionVec      := ExceptionNO.selectByFu(issueUop.exceptionVec, fuCfg)
+    x.uop.exceptionVec extendFrom issueUop.exceptionVec.selectByFu(fuCfg)
     x.vaddr                 := Mux(!issuePreIsSplit, usSplitVaddr, vaddr)
     x.basevaddr             := issueBaseAddr
     x.alignedType           := issueAlignedType

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -25,6 +25,7 @@ import xiangshan._
 import xiangshan.backend.Bundles._
 import xiangshan.backend.fu.NewCSR.CsrTriggerBundle
 import xiangshan.backend.rob.RobPtr
+import xiangshan.backend.fu.FuConfig
 import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.backend.fu.vector.Bundles._
 import xiangshan.backend.exu.ExeUnitParams
@@ -38,7 +39,6 @@ class VLSBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBun
   val data                = UInt(VLEN.W)
   // val fof            = Bool() // fof is only used for vector loads
   val excp_eew_index      = UInt(elemIdxBits.W)
-  // val exceptionVec   = ExceptionVec() // uop has exceptionVec
   val baseAddr            = UInt(XLEN.W)
   val uopAddr             = UInt(XLEN.W)
   val stride              = UInt(VLEN.W)
@@ -102,7 +102,7 @@ class VSFQFeedback (implicit p: Parameters) extends XSBundle {
   val paddr = UInt(PAddrBits.W)
   val mmio = Bool()
   val atomic = Bool()
-  val exceptionVec = ExceptionVec()
+  val exceptionVec = ExceptSparseVec()
 }
 
 class VecPipelineFeedbackIO(isVStore: Boolean=false) (implicit p: Parameters) extends VLSUBundle {
@@ -117,7 +117,7 @@ class VecPipelineFeedbackIO(isVStore: Boolean=false) (implicit p: Parameters) ex
   val nc                   = Bool()
   val mmio                 = Bool()
   //val atomic               = Bool()
-  val exceptionVec         = ExceptionVec()
+  val exceptionVec         = ExceptSparseVec((if (isVStore) FuConfig.VstuCfg else FuConfig.VlduCfg).exceptionOut)
   val hasException         = Bool() // Active
   val vaddr                = UInt(XLEN.W)
   val vaNeedExt            = Bool()

--- a/src/main/scala/xiangshan/mem/vector/VfofBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VfofBuffer.scala
@@ -126,7 +126,7 @@ class VfofBuffer(val param: ExeUnitParams)(implicit p: Parameters) extends VLSUM
   io.uopWriteback.bits.vecWen.foreach(_ := entries.uop.vecWen)
   io.uopWriteback.bits.v0Wen.foreach(_ := entries.uop.v0Wen)
   io.uopWriteback.bits.vlWen.foreach(_ := entries.uop.vlWen)
-  io.uopWriteback.bits.exceptionVec.init
+  io.uopWriteback.bits.exceptionVec.zeroInit()
   io.uopWriteback.bits.lqIdx.foreach(_ := entries.uop.lqIdx)
   io.uopWriteback.bits.sqIdx.foreach(_ := entries.uop.sqIdx)
   io.uopWriteback.bits.vls.foreach(vls => {

--- a/src/main/scala/xiangshan/mem/vector/VfofBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VfofBuffer.scala
@@ -40,7 +40,7 @@ class VfofBuffer(val param: ExeUnitParams)(implicit p: Parameters) extends VLSUM
   val io = IO(new VfofDataBuffIO(param))
 
   private def isOlder(left: DynInst, right: DynInst): Bool = {
-    (right.vpu.vl > left.vpu.vl || left.exceptionVec.asUInt.orR) && !right.exceptionVec.asUInt.orR
+    (right.vpu.vl > left.vpu.vl || left.exceptionVec.orR) && !right.exceptionVec.orR
   }
   implicit val vfofParam: ExeUnitParams = param
 
@@ -105,7 +105,7 @@ class VfofBuffer(val param: ExeUnitParams)(implicit p: Parameters) extends VLSUM
   }
   val wbBits          = selectOldestModule.io.out.bits
   val wbValid         = selectOldestModule.io.out.valid
-  val wbHasException  = wbBits.exceptionVec.asUInt.orR
+  val wbHasException  = wbBits.exceptionVec.orR
   val wbUpdateValid = wbValid && (wbBits.vpu.vl < entries.vl || wbHasException) && valid && !needRedirect && !entries.hasException
 
   XSError(wbValid && wbHasException && valid && entries.hasException, "The same instruction triggers an exception multiple times!\n")
@@ -126,7 +126,7 @@ class VfofBuffer(val param: ExeUnitParams)(implicit p: Parameters) extends VLSUM
   io.uopWriteback.bits.vecWen.foreach(_ := entries.uop.vecWen)
   io.uopWriteback.bits.v0Wen.foreach(_ := entries.uop.v0Wen)
   io.uopWriteback.bits.vlWen.foreach(_ := entries.uop.vlWen)
-  io.uopWriteback.bits.exceptionVec.foreach(_ := 0.U.asTypeOf(ExceptionVec()))
+  io.uopWriteback.bits.exceptionVec.init
   io.uopWriteback.bits.lqIdx.foreach(_ := entries.uop.lqIdx)
   io.uopWriteback.bits.sqIdx.foreach(_ := entries.uop.sqIdx)
   io.uopWriteback.bits.vls.foreach(vls => {

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -253,7 +253,7 @@ package object xiangshan {
      * @param idx the index of element
      * @return the element at [[idx]] if exist, [[false.B]] otherwise
      */
-    def apply(idx: Int) = findOrElse(idx, false.B)
+    def apply(idx: Int): Bool = findOrElse(idx, false.B)
 
     // initialize all existing bits to false
     def init: Unit = {
@@ -323,7 +323,7 @@ package object xiangshan {
       result.asUInt
     }
 
-    override def do_asUInt(implicit sourceInfo: SourceInfo): UInt = asUInt
+    override def do_asUInt(implicit sourceInfo: SourceInfo): UInt = toUInt
 
     /**
      * Or reduction operator
@@ -391,20 +391,6 @@ package object xiangshan {
     }
 
     // connect two exceptionVecs together under different circumstances
-    def connect(sinkVec: ExceptSparseVec, sourceVec: ExceptSparseVec): Unit = {
-      require(sourceVec.indices.toSet.subsetOf(sinkVec.indices.toSet), "ExceptSparseVec connect indices mismatch")
-
-      (0 until sinkVec.length).foreach { idx =>
-        (sinkVec.find(idx), sourceVec.find(idx)) match {
-          case (Some(sink), Some(source)) => sink := source
-          case (Some(sink), None        ) => sink := false.B
-          case _ => // do nothing
-        }
-      }
-    }
-
-    // def connect(destSeq: ExceptSparseVec, sourceSeq: ExceptSparseVec): Unit = connect(destSeq.spVec, sourceSeq.spVec)
-
     def connect(sinkSeq: ExceptSparseVec, sourceVec: Vec[Bool]): Unit = {
       require(sinkSeq.length == sourceVec.length, "ExceptSparseVec connect length mismatch")
 
@@ -419,13 +405,7 @@ package object xiangshan {
     def connect(sinkVec: Vec[Bool], sourceSeq: ExceptSparseVec): Unit = {
       require(sourceSeq.length == sinkVec.length, "ExceptSparseVec connect length mismatch")
 
-      (0 until sourceSeq.length).foreach { idx =>
-        (sinkVec(idx), sourceSeq.find(idx)) match {
-          case (sink, Some(source)) => sink := source
-          case (sink, None        ) => sink := false.B
-          case _ => // do nothing
-        }
-      }
+      (0 until sinkVec.length).foreach { i => sinkVec(i) := sourceSeq(i) }
     }
 
     def connect(none: None.type, sourceSeq: Any): Unit = { /* do nothing */ }

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -1222,7 +1222,7 @@ package object xiangshan {
       instrGuestPageFault,
       virtualInstr, // new
     )
-    def exceptionGenSet(params: BackendParams) = (params.exceptionOut ++ ExceptionNO.decodeSet).distinct.sorted
+    def exceptionGenSet(params: BackendParams) = (params.exceptionOut ++ decodeSet).distinct.sorted
   }
 
   object TopDownCounters extends Enumeration {

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -199,19 +199,6 @@ package object xiangshan {
     }
 
     /**
-     * find the element at [[idx]], and perform function [[f]] on it if exist
-     * @param idx the index of element
-     * @param f the function to perform on the element if exist
-     * @return Unit
-     */
-    // def getAndPerform(idx: Int)(f: T => Unit): Unit = {
-    //   this.find(idx) match {
-    //     case Some(bit) => f(bit)
-    //     case None => /* do nothing */
-    //   }
-    // }
-
-    /**
      * perform function [[f]] on all existing elements, or [[default]] otherwise
      * @param f the function to perform on existing elements
      * @param default the default value if the element does not exist
@@ -255,34 +242,6 @@ package object xiangshan {
       }
       result
     }
-
-    // /**
-    //  * Map all existing bits with function [[f]], and fill non-existing bits with [[default]]
-    //  * @param f the function to map existing bits
-    //  * @param default the default value for non-existing bits
-    //  * @return a Vec after mapping
-    //  */
-    // def mapExist2Seq[T <: Data](f: Bool => T, default: T): Vec[T] = {
-    //   val result = Wire(VecInit(Seq.fill(this.length)(default)))
-    //   this.elements.foreach { case (idx, source) =>
-    //     result(idx.toInt) := f(source)
-    //   }
-    //   result
-    // }
-
-    // /**
-    //  * Get the element at [[idx]], assume it exists
-    //  * @param idx the index of element
-    //  * @return the element at [[idx]]
-    //  */
-    // def getIndex(idx: Int): Bool = this.find(idx).get
-
-    // /**
-    //  * Get the element at [[idx]], assume it exists
-    //  * @param idx the index of element
-    //  * @return the element at [[idx]]
-    //  */
-    // def get: ExceptSparseVec = if (indices.isEmpty) throw new NoSuchElementException("Empty_Exception_Vector.get") else this.map(identity)
 
     /**
      * Convert this SparseVec to a Vec[Bool],
@@ -373,16 +332,6 @@ package object xiangshan {
     def apply(excpList: Seq[Int]): ExceptSparseVec = new ExceptSparseVec(excpList)
     def apply(): ExceptSparseVec = new ExceptSparseVec(ExceptionNO.all)
 
-    // def construct(source: ExceptSparseVec): ExceptSparseVec = {
-    //   val result = Wire(apply(source.indices))
-    //   connect(result, seq)
-    //   result
-    // }
-
-    // def newAs(source: ExceptSparseVec): ExceptSparseVec = {
-    //   Wire(apply(source.indices))
-    // }
-
     @inline private def mergeHelper(operator: (Vec[Bool], Vec[Bool]) => Bool)(oh: Vec[Bool], seqs: Seq[ExceptSparseVec]): ExceptSparseVec = {
       require(seqs.nonEmpty, "ExceptSparseVec merge/select with empty seqs")
       require(oh.length == seqs.length, "ExceptSparseVec merge/select length mismatch")
@@ -418,25 +367,6 @@ package object xiangshan {
     def mux2(cond: Bool, seqTrue: ExceptSparseVec, seqFalse: ExceptSparseVec): ExceptSparseVec = {
       mux1h(VecInit(cond, ~cond), Seq(seqTrue, seqFalse))
     }
-
-    // def connect(sinkVec: ExceptSparseVec, sourceVec: Vec[Bool]): Unit = {
-    //   require(sinkVec.length == sourceVec.length, "ExceptSparseVec connect length mismatch")
-    //
-    //   (0 until sinkVec.length).foreach { idx =>
-    //     (sinkVec.find(idx), sourceVec(idx)) match {
-    //       case (Some(sink), source) => sink := source
-    //       case _ => // do nothing
-    //     }
-    //   }
-    // }
-
-    // def connect(sinkVec: Vec[Bool], sourceVec: ExceptSparseVec): Unit = {
-    //   require(sourceVec.length == sinkVec.length, "ExceptSparseVec connect length mismatch")
-    //
-    //   (0 until sinkVec.length).foreach { i => sinkVec(i) := sourceVec(i) }
-    // }
-
-    // def connect(none: None.type, sourceVec: Any): Unit = { /* do nothing */ }
 
     def fill(excpList: Seq[Int], value: Bool): ExceptSparseVec = {
       val result = Wire(apply(excpList))

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -18,6 +18,7 @@ import chisel3._
 import chisel3.experimental.SourceInfo
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
+import xiangshan.backend.BackendParams
 import xiangshan.backend.fu.FuConfig
 import xiangshan.backend.decode.{Imm, ImmUnion}
 
@@ -164,12 +165,6 @@ package object xiangshan {
     // def isException(level: UInt) = level(1) && level(0)
   }
 
-  object ExceptionVec {
-    val ExceptionVecSize = 24
-    def apply() = Vec(ExceptionVecSize, Bool())
-    def apply(init: Bool) = VecInit(Seq.fill(ExceptionVecSize)(init))
-  }
-
   trait SparseVecHelper[T <: Data] { this: SparseVec[T] =>
     val length: Int
     /**
@@ -196,7 +191,7 @@ package object xiangshan {
      * @tparam R the return type of function [[f]] and default value
      * @return f(element) if exist, [[default]] otherwise
      */
-    def getAndPerformOrElse[R](idx: Int)(f: T => R, default: R): R = {
+    def getAndPerform[R](idx: Int)(f: T => R, default: R={}): R = {
       this.find(idx) match {
         case Some(bit) => f(bit)
         case None => default
@@ -217,35 +212,25 @@ package object xiangshan {
     // }
 
     /**
-     * find the element at [[idx]], and assign singnal [[s]] on it if exist
-     * @param idx the index of element
-     * @param f the function to perform on the element if exist
-     * @return Unit
-     */
-    // def getAndAssign(idx: Int)(s: UInt): Unit = {
-    //   getAndPerform(idx)(_ := s)
-    // }
-
-    /**
      * perform function [[f]] on all existing elements, or [[default]] otherwise
      * @param f the function to perform on existing elements
      * @param default the default value if the element does not exist
      */
     def foreach(f: T => Unit, default: Unit = { /* do nothing */ }): Unit = {
       (0 until this.length).foreach { i =>
-        this.getAndPerformOrElse(i)(f, default)
+        this.getAndPerform(i)(f, default)
       }
     }
   }
 
   // For optional bits in the exception vector
   class ExceptSparseVec(val indices: Seq[Int]) extends SparseVec[Bool](
-    size         = ExceptionVec.ExceptionVecSize,
+    size         = ExceptSparseVec.ExceptionVecSize,
     gen          = Bool(),
     indices      = indices,
     defaultValue = SparseVec.DefaultValueBehavior.UserSpecified(0.U)
   )  with SparseVecHelper[Bool] {
-    override val length = ExceptionVec.ExceptionVecSize
+    override val length: Int = ExceptSparseVec.ExceptionVecSize
 
     /**
      * The apply method can get the element at [[idx]], or return [[false.B]] if not exist because exceptions will be
@@ -256,9 +241,7 @@ package object xiangshan {
     def apply(idx: Int): Bool = findOrElse(idx, false.B)
 
     // initialize all existing bits to false
-    def init: Unit = {
-      this.foreach(_ := false.B)
-    }
+    def zeroInit(): Unit = { this.foreach(_ := false.B) }
 
     /**
      * Map all existing bits with function [[f]]
@@ -273,12 +256,12 @@ package object xiangshan {
       result
     }
 
-    /**
-     * Map all existing bits with function [[f]], and fill non-existing bits with [[default]]
-     * @param f the function to map existing bits
-     * @param default the default value for non-existing bits
-     * @return a Vec after mapping
-     */
+    // /**
+    //  * Map all existing bits with function [[f]], and fill non-existing bits with [[default]]
+    //  * @param f the function to map existing bits
+    //  * @param default the default value for non-existing bits
+    //  * @return a Vec after mapping
+    //  */
     // def mapExist2Seq[T <: Data](f: Bool => T, default: T): Vec[T] = {
     //   val result = Wire(VecInit(Seq.fill(this.length)(default)))
     //   this.elements.foreach { case (idx, source) =>
@@ -287,28 +270,28 @@ package object xiangshan {
     //   result
     // }
 
-    /**
-     * Get the element at [[idx]], assume it exists
-     * @param idx the index of element
-     * @return the element at [[idx]]
-     */
-    def getIndex(idx: Int): Bool = this.find(idx).get
+    // /**
+    //  * Get the element at [[idx]], assume it exists
+    //  * @param idx the index of element
+    //  * @return the element at [[idx]]
+    //  */
+    // def getIndex(idx: Int): Bool = this.find(idx).get
 
-    /**
-     * Get the element at [[idx]], assume it exists
-     * @param idx the index of element
-     * @return the element at [[idx]]
-     */
-    def get: ExceptSparseVec = if (indices.isEmpty) throw new NoSuchElementException("Empty_Exception_Vector.get") else this.map(identity)
+    // /**
+    //  * Get the element at [[idx]], assume it exists
+    //  * @param idx the index of element
+    //  * @return the element at [[idx]]
+    //  */
+    // def get: ExceptSparseVec = if (indices.isEmpty) throw new NoSuchElementException("Empty_Exception_Vector.get") else this.map(identity)
 
     /**
      * Convert this SparseVec to a Vec[Bool],
      * @param default the default value of a non-exist element ([[false.B]] as default)
      * @return a Vec[Bool] after convertion
      */
-    def toVec(default: Bool = false.B): Vec[Bool] = {
+    def toVec: Vec[Bool] = {
       val result = Wire(Vec(length, Bool()))
-      (0 until length).foreach(idx => result(idx) := this(idx))
+      (0 until length).foreach { idx => result(idx) := this(idx) }
       result
     }
 
@@ -318,11 +301,10 @@ package object xiangshan {
      * @return a UInt after convertion
      */
     def toUInt: UInt = {
-      val result = Wire(ExceptionVec())
-      ExceptSparseVec.connect(result, this)
-      result.asUInt
+      this.toVec.asUInt
     }
 
+    // TODO: check whether the override of do_asUInt is done correctly
     override def do_asUInt(implicit sourceInfo: SourceInfo): UInt = toUInt
 
     /**
@@ -333,19 +315,59 @@ package object xiangshan {
 
     def nonEmpty: Boolean = this.indices.nonEmpty
 
-    def select(select: Seq[Int], unselect: Seq[Int] = Seq.empty): ExceptSparseVec = {
+    def select(sel: Seq[Int], unsel: Seq[Int]): ExceptSparseVec = {
       // assert if (select - unselect) is not a subset of this.indices,
       // the result will be wrong but no error will be thrown, so better to avoid this case
-      val newIndices = select.diff(unselect)
+      val newIndices = sel.diff(unsel)
       assert(newIndices.toSet.subsetOf(this.indices.toSet), "ExceptSparseVec select indices mismatch")
 
       val result = Wire(ExceptSparseVec(newIndices))
       newIndices.foreach(i => result(i) := this(i))
       result
     }
+
+    def select(sel: Seq[Int], unsel: Int): ExceptSparseVec          = select(sel, Seq(unsel))
+    def select(sel: Seq[Int]): ExceptSparseVec                      = select(sel, Seq.empty)
+    def selectByFu(cfg: FuConfig, unsel: Seq[Int]): ExceptSparseVec = select(cfg.exceptionOut, unsel)
+    def selectByFu(cfg: FuConfig, unsel: Int): ExceptSparseVec      = select(cfg.exceptionOut, unsel)
+    def selectByFu(cfg: FuConfig): ExceptSparseVec                  = select(cfg.exceptionOut)
+    def unselect(unsel: Seq[Int]): ExceptSparseVec                  = select(this.indices, unsel)
+    def unselect(unsel: Int): ExceptSparseVec                       = select(this.indices, unsel)
+
+    // drive all bits in sink by corresponding bits in source.
+    // if not exist in source, use default value false.B
+    def extendFrom(source: ExceptSparseVec): Unit = {
+      require(this.length == source.length, "ExceptSparseVec extendFrom() length mismatch")
+      require(source.indices.toSet.subsetOf(this.indices.toSet),
+        "ExceptSparseVec extendFrom(): source indices should be subset of sink indices")
+
+      this.indices.foreach { idx => this (idx) := source(idx) }
+    }
+
+    /**
+     * Bitwise OR operator, the resulting ExceptSparseVec will have bits that are the OR of corresponding bits
+     * in this and right. the result has indices of the union of this.indices and right.indices
+     * @param [[that]] the other ExceptSparseVec to OR with
+     * @return OR result
+     */
+    def |(that: ExceptSparseVec): ExceptSparseVec = {
+      ExceptSparseVec.orReduce(Seq(this, that))
+    }
+
+    /**
+     * Bitwise AND operator, the resulting ExceptSparseVec will have bits that are the AND of corresponding bits
+     * in this and right. the result has indices of the union of this.indices and right.indices
+     * @param [[that]] the other ExceptSparseVec to AND with
+     * @return AND result
+     */
+    def &(that: ExceptSparseVec): ExceptSparseVec = {
+      ExceptSparseVec.orReduce(Seq(this, that))
+    }
   }
 
   object ExceptSparseVec {
+    val ExceptionVecSize = 24
+
     // Generate a 24-wide exception vector of Option[Bool], decided by whether the index is given by excpList
     // vec(i).get is a Bool only when i in excpList, otherwise None
     def apply(excpList: Seq[Int]): ExceptSparseVec = new ExceptSparseVec(excpList)
@@ -376,9 +398,16 @@ package object xiangshan {
     }
 
     def orReduce(seqs: Seq[ExceptSparseVec]): ExceptSparseVec = {
-      val oh = Wire(VecInit.fill(seqs.length)(true.B))
-      val mergeOperator = (ors: Vec[Bool], x: Vec[Bool]) => ors.reduce(_ || _)
-      mergeHelper(mergeOperator)(oh, seqs)
+      require(seqs.nonEmpty, "ExceptSparseVec merge with empty seqs")
+
+      val mergeIndices = seqs.flatMap(_.indices).distinct.sorted
+      val result = Wire(ExceptSparseVec(mergeIndices))
+
+      result.indices.foreach { idx =>
+        result(idx) := seqs.map(_(idx)).reduce(_ || _)
+      }
+
+      result
     }
 
     def mux1h(oh: Vec[Bool], seqs: Seq[ExceptSparseVec]): ExceptSparseVec = {
@@ -390,31 +419,32 @@ package object xiangshan {
       mux1h(VecInit(cond, ~cond), Seq(seqTrue, seqFalse))
     }
 
-    // connect two exceptionVecs together under different circumstances
-    def connect(sinkSeq: ExceptSparseVec, sourceVec: Vec[Bool]): Unit = {
-      require(sinkSeq.length == sourceVec.length, "ExceptSparseVec connect length mismatch")
+    // def connect(sinkVec: ExceptSparseVec, sourceVec: Vec[Bool]): Unit = {
+    //   require(sinkVec.length == sourceVec.length, "ExceptSparseVec connect length mismatch")
+    //
+    //   (0 until sinkVec.length).foreach { idx =>
+    //     (sinkVec.find(idx), sourceVec(idx)) match {
+    //       case (Some(sink), source) => sink := source
+    //       case _ => // do nothing
+    //     }
+    //   }
+    // }
 
-      (0 until sinkSeq.length).foreach { idx =>
-        (sinkSeq.find(idx), sourceVec(idx)) match {
-          case (Some(sink), source) => sink := source
-          case _ => // do nothing
-        }
-      }
-    }
+    // def connect(sinkVec: Vec[Bool], sourceVec: ExceptSparseVec): Unit = {
+    //   require(sourceVec.length == sinkVec.length, "ExceptSparseVec connect length mismatch")
+    //
+    //   (0 until sinkVec.length).foreach { i => sinkVec(i) := sourceVec(i) }
+    // }
 
-    def connect(sinkVec: Vec[Bool], sourceSeq: ExceptSparseVec): Unit = {
-      require(sourceSeq.length == sinkVec.length, "ExceptSparseVec connect length mismatch")
+    // def connect(none: None.type, sourceVec: Any): Unit = { /* do nothing */ }
 
-      (0 until sinkVec.length).foreach { i => sinkVec(i) := sourceSeq(i) }
-    }
-
-    def connect(none: None.type, sourceSeq: Any): Unit = { /* do nothing */ }
-
-    def zeros(excpList: Seq[Int]): ExceptSparseVec = {
+    def fill(excpList: Seq[Int], value: Bool): ExceptSparseVec = {
       val result = Wire(apply(excpList))
-      result.init
+      result.foreach(_ := value)
       result
     }
+
+    def zeros(excpList: Seq[Int]): ExceptSparseVec = fill(excpList, false.B)
   }
 
   object PMAMode {
@@ -1176,21 +1206,23 @@ package object xiangshan {
       virtualInstr,
       breakPoint
     )
-    def partialSelect(vec: Vec[Bool], select: Seq[Int], unSelect: Seq[Int] = Seq.empty): Vec[Bool] = {
-      val new_vec = Wire(ExceptionVec())
-      new_vec.foreach(_ := false.B)
-      select.diff(unSelect).foreach(i => new_vec(i) := vec(i))
-      new_vec
-    }
-    def selectFrontend(vec: Vec[Bool]): Vec[Bool] = partialSelect(vec, frontendSet)
-    def selectByFu(vec:Vec[Bool], fuConfig: FuConfig): Vec[Bool] = partialSelect(vec, fuConfig.exceptionOut)
-    def selectByFuAndUnSelect(vec:Vec[Bool], fuConfig: FuConfig, unSelect: Seq[Int]): Vec[Bool] =
-      partialSelect(vec, fuConfig.exceptionOut, unSelect)
-
-    def selectFrontend(vec: ExceptSparseVec): ExceptSparseVec = vec.select(frontendSet)
-    def selectByFu(vec:ExceptSparseVec, fuConfig: FuConfig): ExceptSparseVec = vec.select(fuConfig.exceptionOut)
-    def selectByFuAndUnSelect(vec:ExceptSparseVec, fuConfig: FuConfig, unSelect: Seq[Int]): ExceptSparseVec =
-      vec.select(fuConfig.exceptionOut, unSelect)
+    def fromFrontendSet = Seq(
+      instrAccessFault,
+      illegalInstr,
+      instrPageFault,
+      hardwareError,
+      instrGuestPageFault
+    )
+    def decodeSet = Seq(
+      instrAccessFault,
+      illegalInstr,
+      breakPoint, // new
+      instrPageFault,
+      hardwareError,
+      instrGuestPageFault,
+      virtualInstr, // new
+    )
+    def exceptionGenSet(params: BackendParams) = (params.exceptionOut ++ ExceptionNO.decodeSet).distinct.sorted
   }
 
   object TopDownCounters extends Enumeration {

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -176,6 +176,217 @@ package object xiangshan {
     def apply(init: Bool) = VecInit(Seq.fill(ExceptionVecSize)(init))
   }
 
+  trait SparseVecHelper[T <: Data] { this: SparseVec[T] =>
+    val length: Int
+    /**
+     * get the element at [[idx]] as Option[T]
+     * @param idx the index of element
+     * @return Some(element) if exist, None otherwise
+     */
+    def find(idx: Int): Option[T] = this.elements.get(idx.toString)
+
+    /**
+     * get the element at [[idx]], or return [[default]] if not exist
+     * @param idx the index of element
+     * @param default the default value if the element does not exist
+     * @tparam T1 the super type of T, to allow default value to be of a super type
+     * @return the element at [[idx]] if exist, [[default]] otherwise
+     */
+    def getOrElse[T1 >: T](idx: Int, default: => T1): T1 = this.elements.getOrElse(idx.toString, default)
+
+    /**
+     * find the element at [[idx]], and perform function [[f]] on it if exist, or return [[default]] otherwise
+     * @param idx the index of element
+     * @param f the function to perform on the element if exist
+     * @param default the default value if the element does not exist
+     * @tparam R the return type of function [[f]] and default value
+     * @return f(element) if exist, [[default]] otherwise
+     */
+    def getAndPerformOrElse[R](idx: Int)(f: T => R, default: R): R = {
+      this.find(idx) match {
+        case Some(bit) => f(bit)
+        case None => default
+      }
+    }
+
+    /**
+     * find the element at [[idx]], and perform function [[f]] on it if exist
+     * @param idx the index of element
+     * @param f the function to perform on the element if exist
+     * @return Unit
+     */
+    def getAndPerform(idx: Int)(f: T => Unit): Unit = {
+      this.find(idx) match {
+        case Some(bit) => f(bit)
+        case None => /* do nothing */
+      }
+    }
+
+    /**
+     * find the element at [[idx]], and assign singnal [[s]] on it if exist
+     * @param idx the index of element
+     * @param f the function to perform on the element if exist
+     * @return Unit
+     */
+    def getAndAssign(idx: Int)(s: UInt): Unit = {
+      getAndPerform(idx)(_ := s)
+    }
+
+    /**
+     * perform function [[f]] on all existing elements, or [[default]] otherwise
+     * @param f the function to perform on existing elements
+     * @param default the default value if the element does not exist
+     */
+    def foreachExist(f: T => Unit, default: Unit = { /* do nothing */ }): Unit = {
+      (0 until this.length).foreach { i =>
+        this.getAndPerformOrElse(i)(f, default)
+      }
+    }
+  }
+
+  // For optional bits in the exception vector
+  class ExceptSparseVec(val indices: Seq[Int]) extends SparseVec[Bool](
+    size         = ExceptionVec.ExceptionVecSize,
+    gen          = Bool(),
+    indices      = indices,
+    defaultValue = SparseVec.DefaultValueBehavior.UserSpecified(0.U)
+  )  with SparseVecHelper[Bool] {
+    override val length = ExceptionVec.ExceptionVecSize
+
+    // initialize all existing bits to false
+    def init: Unit = {
+      this.foreachExist(_ := false.B)
+    }
+
+    /**
+     * map all existing bits with function [[f]]
+     * @param f the function to map existing bits
+     * @return a new ExceptSparseVec after mapping
+     */
+    def mapExist(f: Bool => Bool): ExceptSparseVec = {
+      val result = Wire(ExceptSparseVec(indices))
+      this.elements.foreach { case (idx, srcBit) =>
+        result.elements(idx) := f(srcBit)
+      }
+      result
+    }
+
+    /**
+     * map all existing bits with function [[f]], and fill non-existing bits with [[default]]
+     * @param f the function to map existing bits
+     * @param default the default value for non-existing bits
+     * @return a Vec after mapping
+     */
+    def mapExist2Seq[T <: Data](f: Bool => T, default: T): Vec[T] = {
+      val result = Wire(VecInit(Seq.fill(this.length)(default)))
+      this.elements.foreach { case (idx, srcBit) =>
+        result(idx.toInt) := f(srcBit)
+      }
+      result
+    }
+
+    /**
+     * get the element at [[idx]], assume it exists
+     * @param idx the index of element
+     * @return the element at [[idx]]
+     */
+    def get(idx: Int): Bool = this.find(idx).get
+
+    /**
+     * get the element at [[idx]], or return [[default]] if not exist
+     * @param idx the index of element
+     * @param default the default value if the element does not exist
+     * @return the element at [[idx]] if exist, [[default]] otherwise
+     */
+    def getOrElse(idx: Int, default: Bool): Bool = this.find(idx).getOrElse(default)
+  }
+
+  object ExceptSparseVec {
+    // Generate a 24-wide exception vector of Option[Bool], decided by whether the index is given by excpList
+    // vec(i).get is a Bool only when i in excpList, otherwise None
+    def apply(excpList: Seq[Int]): ExceptSparseVec = new ExceptSparseVec(excpList)
+    def apply(): ExceptSparseVec = new ExceptSparseVec(ExceptionNO.all)
+
+    // def construct(src: ExceptSparseVec): ExceptSparseVec = {
+    //   val result = Wire(apply(src.indices))
+    //   connect(result, seq)
+    //   result
+    // }
+
+    // def newAs(src: ExceptSparseVec): ExceptSparseVec = {
+    //   Wire(apply(src.indices))
+    // }
+
+    @inline private def mergeHelper(operator: (Vec[Bool], Vec[Bool]) => Bool)(oh: Vec[Bool], seqs: Seq[ExceptSparseVec]): ExceptSparseVec = {
+      require(seqs.nonEmpty, "ExceptSparseVec merge/select with empty seqs")
+      require(oh.length == seqs.length, "ExceptSparseVec merge/select length mismatch")
+
+      val mergeIndices = seqs.flatMap(_.indices).distinct.sorted
+      val result = Wire(ExceptSparseVec(mergeIndices))
+
+      result.elements.foreach { case (idx, srcBit) =>
+        val optionsAtIdx: Vec[Bool] = VecInit(seqs.map(_.elements.getOrElse(idx, false.B)))
+        srcBit := operator(optionsAtIdx, oh)
+      }
+      result
+    }
+
+    def orReduce(seqs: Seq[ExceptSparseVec]): ExceptSparseVec = {
+      val oh = Wire(VecInit.fill(seqs.length)(true.B))
+      val mergeOperator = (ors: Vec[Bool], _: Vec[Bool]) => ors.reduce(_ || _)
+      mergeHelper(mergeOperator)(oh, seqs)
+    }
+
+    def mux1h(oh: Vec[Bool], seqs: Seq[ExceptSparseVec]): ExceptSparseVec = {
+      val selectOperator = (ors: Vec[Bool], oh: Vec[Bool]) => Mux1H(oh, ors)
+      mergeHelper(selectOperator)(oh, seqs)
+    }
+
+    def mux2(cond: Bool, seqTrue: ExceptSparseVec, seqFalse: ExceptSparseVec): ExceptSparseVec = {
+      mux1h(VecInit(cond, ~cond), Seq(seqTrue, seqFalse))
+    }
+
+    // connect two exceptionVecs together under different circumstances
+    def connect(dstVec: ExceptSparseVec, srcVec: ExceptSparseVec): Unit = {
+      require(srcVec.indices.toSet.subsetOf(dstVec.indices.toSet), "ExceptSparseVec connect indices mismatch")
+
+      (0 until dstVec.length).foreach { idx =>
+        (dstVec.find(idx), srcVec.find(idx)) match {
+          case (Some(dst), Some(src)) => dst := src
+          case (Some(dst), None      ) => dst := false.B
+          case _ => // do nothing
+        }
+      }
+    }
+
+    // def connect(destSeq: ExceptSparseVec, srcSeq: ExceptSparseVec): Unit = connect(destSeq.spVec, srcSeq.spVec)
+
+    def connect(destSeq: ExceptSparseVec, srcVec: Vec[Bool]): Unit = {
+      require(destSeq.length == srcVec.length, "ExceptSparseVec connect length mismatch")
+
+      (0 until destSeq.length).foreach { idx =>
+        (destSeq.find(idx), srcVec(idx)) match {
+          case (Some(dest), srcBit) => dest := srcBit
+          case _ => // do nothing
+        }
+      }
+    }
+
+    def connect(destVec: Vec[Bool], srcSeq: ExceptSparseVec): Unit = {
+      require(srcSeq.length == destVec.length, "ExceptSparseVec connect length mismatch")
+
+      (0 until srcSeq.length).foreach { idx =>
+        (destVec(idx), srcSeq.find(idx)) match {
+          case (destBit, Some(src)) => destBit := src
+          case (destBit, None     ) => destBit := false.B
+          case _ => // do nothing
+        }
+      }
+    }
+
+    def connect(none: None.type, srcSeq: Any): Unit = { /* do nothing */ }
+  }
+
   object PMAMode {
     def R = "b1".U << 0 //readable
     def W = "b1".U << 1 //writeable

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -15,15 +15,9 @@
 ***************************************************************************************/
 
 import chisel3._
+import chisel3.experimental.SourceInfo
 import chisel3.util._
-import utils.NamedUInt
 import org.chipsalliance.cde.config.Parameters
-import freechips.rocketchip.tile.XLen
-import xiangshan.ExceptionNO._
-import xiangshan.backend.fu._
-import xiangshan.backend.fu.fpu._
-import xiangshan.backend.fu.vector._
-import xiangshan.backend.issue._
 import xiangshan.backend.fu.FuConfig
 import xiangshan.backend.decode.{Imm, ImmUnion}
 
@@ -35,7 +29,7 @@ package object xiangshan {
     def fp  = "b0010".U
     def vp  = "b0100".U
     def v0  = "b1000".U
-    def no  = "b0000".U // this src read no reg but cannot be Any value
+    def no  = "b0000".U // this source read no reg but cannot be Any value
 
     // alias
     def reg = this.xp
@@ -192,7 +186,7 @@ package object xiangshan {
      * @tparam T1 the super type of T, to allow default value to be of a super type
      * @return the element at [[idx]] if exist, [[default]] otherwise
      */
-    def getOrElse[T1 >: T](idx: Int, default: => T1): T1 = this.elements.getOrElse(idx.toString, default)
+    def findOrElse[T1 >: T](idx: Int, default: => T1): T1 = this.elements.getOrElse(idx.toString, default)
 
     /**
      * find the element at [[idx]], and perform function [[f]] on it if exist, or return [[default]] otherwise
@@ -215,12 +209,12 @@ package object xiangshan {
      * @param f the function to perform on the element if exist
      * @return Unit
      */
-    def getAndPerform(idx: Int)(f: T => Unit): Unit = {
-      this.find(idx) match {
-        case Some(bit) => f(bit)
-        case None => /* do nothing */
-      }
-    }
+    // def getAndPerform(idx: Int)(f: T => Unit): Unit = {
+    //   this.find(idx) match {
+    //     case Some(bit) => f(bit)
+    //     case None => /* do nothing */
+    //   }
+    // }
 
     /**
      * find the element at [[idx]], and assign singnal [[s]] on it if exist
@@ -228,16 +222,16 @@ package object xiangshan {
      * @param f the function to perform on the element if exist
      * @return Unit
      */
-    def getAndAssign(idx: Int)(s: UInt): Unit = {
-      getAndPerform(idx)(_ := s)
-    }
+    // def getAndAssign(idx: Int)(s: UInt): Unit = {
+    //   getAndPerform(idx)(_ := s)
+    // }
 
     /**
      * perform function [[f]] on all existing elements, or [[default]] otherwise
      * @param f the function to perform on existing elements
      * @param default the default value if the element does not exist
      */
-    def foreachExist(f: T => Unit, default: Unit = { /* do nothing */ }): Unit = {
+    def foreach(f: T => Unit, default: Unit = { /* do nothing */ }): Unit = {
       (0 until this.length).foreach { i =>
         this.getAndPerformOrElse(i)(f, default)
       }
@@ -253,52 +247,102 @@ package object xiangshan {
   )  with SparseVecHelper[Bool] {
     override val length = ExceptionVec.ExceptionVecSize
 
+    /**
+     * The apply method can get the element at [[idx]], or return [[false.B]] if not exist because exceptions will be
+     * ignored by default
+     * @param idx the index of element
+     * @return the element at [[idx]] if exist, [[false.B]] otherwise
+     */
+    def apply(idx: Int) = findOrElse(idx, false.B)
+
     // initialize all existing bits to false
     def init: Unit = {
-      this.foreachExist(_ := false.B)
+      this.foreach(_ := false.B)
     }
 
     /**
-     * map all existing bits with function [[f]]
+     * Map all existing bits with function [[f]]
      * @param f the function to map existing bits
      * @return a new ExceptSparseVec after mapping
      */
-    def mapExist(f: Bool => Bool): ExceptSparseVec = {
+    def map(f: Bool => Bool): ExceptSparseVec = {
       val result = Wire(ExceptSparseVec(indices))
-      this.elements.foreach { case (idx, srcBit) =>
-        result.elements(idx) := f(srcBit)
+      this.elements.foreach { case (idx, source) =>
+        result.elements(idx) := f(source)
       }
       result
     }
 
     /**
-     * map all existing bits with function [[f]], and fill non-existing bits with [[default]]
+     * Map all existing bits with function [[f]], and fill non-existing bits with [[default]]
      * @param f the function to map existing bits
      * @param default the default value for non-existing bits
      * @return a Vec after mapping
      */
-    def mapExist2Seq[T <: Data](f: Bool => T, default: T): Vec[T] = {
-      val result = Wire(VecInit(Seq.fill(this.length)(default)))
-      this.elements.foreach { case (idx, srcBit) =>
-        result(idx.toInt) := f(srcBit)
-      }
+    // def mapExist2Seq[T <: Data](f: Bool => T, default: T): Vec[T] = {
+    //   val result = Wire(VecInit(Seq.fill(this.length)(default)))
+    //   this.elements.foreach { case (idx, source) =>
+    //     result(idx.toInt) := f(source)
+    //   }
+    //   result
+    // }
+
+    /**
+     * Get the element at [[idx]], assume it exists
+     * @param idx the index of element
+     * @return the element at [[idx]]
+     */
+    def getIndex(idx: Int): Bool = this.find(idx).get
+
+    /**
+     * Get the element at [[idx]], assume it exists
+     * @param idx the index of element
+     * @return the element at [[idx]]
+     */
+    def get: ExceptSparseVec = if (indices.isEmpty) throw new NoSuchElementException("Empty_Exception_Vector.get") else this.map(identity)
+
+    /**
+     * Convert this SparseVec to a Vec[Bool],
+     * @param default the default value of a non-exist element ([[false.B]] as default)
+     * @return a Vec[Bool] after convertion
+     */
+    def toVec(default: Bool = false.B): Vec[Bool] = {
+      val result = Wire(Vec(length, Bool()))
+      (0 until length).foreach(idx => result(idx) := this(idx))
       result
     }
 
     /**
-     * get the element at [[idx]], assume it exists
-     * @param idx the index of element
-     * @return the element at [[idx]]
+     * Convert this SparseVec to a UInt of length bits
+     * the bit at idx 0 of the UInt corresponds to the element at idx 0 of this SparseVec
+     * @return a UInt after convertion
      */
-    def get(idx: Int): Bool = this.find(idx).get
+    def toUInt: UInt = {
+      val result = Wire(ExceptionVec())
+      ExceptSparseVec.connect(result, this)
+      result.asUInt
+    }
+
+    override def do_asUInt(implicit sourceInfo: SourceInfo): UInt = asUInt
 
     /**
-     * get the element at [[idx]], or return [[default]] if not exist
-     * @param idx the index of element
-     * @param default the default value if the element does not exist
-     * @return the element at [[idx]] if exist, [[default]] otherwise
+     * Or reduction operator
+     * @return a hardware [[Bool]] resulting from every bit of this vector or'd together
      */
-    def getOrElse(idx: Int, default: Bool): Bool = this.find(idx).getOrElse(default)
+    def orR: Bool = this.toUInt.orR
+
+    def nonEmpty: Boolean = this.indices.nonEmpty
+
+    def select(select: Seq[Int], unselect: Seq[Int] = Seq.empty): ExceptSparseVec = {
+      // assert if (select - unselect) is not a subset of this.indices,
+      // the result will be wrong but no error will be thrown, so better to avoid this case
+      val newIndices = select.diff(unselect)
+      assert(newIndices.toSet.subsetOf(this.indices.toSet), "ExceptSparseVec select indices mismatch")
+
+      val result = Wire(ExceptSparseVec(newIndices))
+      newIndices.foreach(i => result(i) := this(i))
+      result
+    }
   }
 
   object ExceptSparseVec {
@@ -307,14 +351,14 @@ package object xiangshan {
     def apply(excpList: Seq[Int]): ExceptSparseVec = new ExceptSparseVec(excpList)
     def apply(): ExceptSparseVec = new ExceptSparseVec(ExceptionNO.all)
 
-    // def construct(src: ExceptSparseVec): ExceptSparseVec = {
-    //   val result = Wire(apply(src.indices))
+    // def construct(source: ExceptSparseVec): ExceptSparseVec = {
+    //   val result = Wire(apply(source.indices))
     //   connect(result, seq)
     //   result
     // }
 
-    // def newAs(src: ExceptSparseVec): ExceptSparseVec = {
-    //   Wire(apply(src.indices))
+    // def newAs(source: ExceptSparseVec): ExceptSparseVec = {
+    //   Wire(apply(source.indices))
     // }
 
     @inline private def mergeHelper(operator: (Vec[Bool], Vec[Bool]) => Bool)(oh: Vec[Bool], seqs: Seq[ExceptSparseVec]): ExceptSparseVec = {
@@ -324,16 +368,16 @@ package object xiangshan {
       val mergeIndices = seqs.flatMap(_.indices).distinct.sorted
       val result = Wire(ExceptSparseVec(mergeIndices))
 
-      result.elements.foreach { case (idx, srcBit) =>
+      result.elements.foreach { case (idx, source) =>
         val optionsAtIdx: Vec[Bool] = VecInit(seqs.map(_.elements.getOrElse(idx, false.B)))
-        srcBit := operator(optionsAtIdx, oh)
+        source := operator(optionsAtIdx, oh)
       }
       result
     }
 
     def orReduce(seqs: Seq[ExceptSparseVec]): ExceptSparseVec = {
       val oh = Wire(VecInit.fill(seqs.length)(true.B))
-      val mergeOperator = (ors: Vec[Bool], _: Vec[Bool]) => ors.reduce(_ || _)
+      val mergeOperator = (ors: Vec[Bool], x: Vec[Bool]) => ors.reduce(_ || _)
       mergeHelper(mergeOperator)(oh, seqs)
     }
 
@@ -347,44 +391,50 @@ package object xiangshan {
     }
 
     // connect two exceptionVecs together under different circumstances
-    def connect(dstVec: ExceptSparseVec, srcVec: ExceptSparseVec): Unit = {
-      require(srcVec.indices.toSet.subsetOf(dstVec.indices.toSet), "ExceptSparseVec connect indices mismatch")
+    def connect(sinkVec: ExceptSparseVec, sourceVec: ExceptSparseVec): Unit = {
+      require(sourceVec.indices.toSet.subsetOf(sinkVec.indices.toSet), "ExceptSparseVec connect indices mismatch")
 
-      (0 until dstVec.length).foreach { idx =>
-        (dstVec.find(idx), srcVec.find(idx)) match {
-          case (Some(dst), Some(src)) => dst := src
-          case (Some(dst), None      ) => dst := false.B
+      (0 until sinkVec.length).foreach { idx =>
+        (sinkVec.find(idx), sourceVec.find(idx)) match {
+          case (Some(sink), Some(source)) => sink := source
+          case (Some(sink), None        ) => sink := false.B
           case _ => // do nothing
         }
       }
     }
 
-    // def connect(destSeq: ExceptSparseVec, srcSeq: ExceptSparseVec): Unit = connect(destSeq.spVec, srcSeq.spVec)
+    // def connect(destSeq: ExceptSparseVec, sourceSeq: ExceptSparseVec): Unit = connect(destSeq.spVec, sourceSeq.spVec)
 
-    def connect(destSeq: ExceptSparseVec, srcVec: Vec[Bool]): Unit = {
-      require(destSeq.length == srcVec.length, "ExceptSparseVec connect length mismatch")
+    def connect(sinkSeq: ExceptSparseVec, sourceVec: Vec[Bool]): Unit = {
+      require(sinkSeq.length == sourceVec.length, "ExceptSparseVec connect length mismatch")
 
-      (0 until destSeq.length).foreach { idx =>
-        (destSeq.find(idx), srcVec(idx)) match {
-          case (Some(dest), srcBit) => dest := srcBit
+      (0 until sinkSeq.length).foreach { idx =>
+        (sinkSeq.find(idx), sourceVec(idx)) match {
+          case (Some(sink), source) => sink := source
           case _ => // do nothing
         }
       }
     }
 
-    def connect(destVec: Vec[Bool], srcSeq: ExceptSparseVec): Unit = {
-      require(srcSeq.length == destVec.length, "ExceptSparseVec connect length mismatch")
+    def connect(sinkVec: Vec[Bool], sourceSeq: ExceptSparseVec): Unit = {
+      require(sourceSeq.length == sinkVec.length, "ExceptSparseVec connect length mismatch")
 
-      (0 until srcSeq.length).foreach { idx =>
-        (destVec(idx), srcSeq.find(idx)) match {
-          case (destBit, Some(src)) => destBit := src
-          case (destBit, None     ) => destBit := false.B
+      (0 until sourceSeq.length).foreach { idx =>
+        (sinkVec(idx), sourceSeq.find(idx)) match {
+          case (sink, Some(source)) => sink := source
+          case (sink, None        ) => sink := false.B
           case _ => // do nothing
         }
       }
     }
 
-    def connect(none: None.type, srcSeq: Any): Unit = { /* do nothing */ }
+    def connect(none: None.type, sourceSeq: Any): Unit = { /* do nothing */ }
+
+    def zeros(excpList: Seq[Int]): ExceptSparseVec = {
+      val result = Wire(apply(excpList))
+      result.init
+      result
+    }
   }
 
   object PMAMode {
@@ -1146,24 +1196,21 @@ package object xiangshan {
       virtualInstr,
       breakPoint
     )
-    def partialSelect(vec: Vec[Bool], select: Seq[Int]): Vec[Bool] = {
-      val new_vec = Wire(ExceptionVec())
-      new_vec.foreach(_ := false.B)
-      select.foreach(i => new_vec(i) := vec(i))
-      new_vec
-    }
-    def partialSelect(vec: Vec[Bool], select: Seq[Int], unSelect: Seq[Int]): Vec[Bool] = {
+    def partialSelect(vec: Vec[Bool], select: Seq[Int], unSelect: Seq[Int] = Seq.empty): Vec[Bool] = {
       val new_vec = Wire(ExceptionVec())
       new_vec.foreach(_ := false.B)
       select.diff(unSelect).foreach(i => new_vec(i) := vec(i))
       new_vec
     }
     def selectFrontend(vec: Vec[Bool]): Vec[Bool] = partialSelect(vec, frontendSet)
-    def selectAll(vec: Vec[Bool]): Vec[Bool] = partialSelect(vec, ExceptionNO.all)
-    def selectByFu(vec:Vec[Bool], fuConfig: FuConfig): Vec[Bool] =
-      partialSelect(vec, fuConfig.exceptionOut)
+    def selectByFu(vec:Vec[Bool], fuConfig: FuConfig): Vec[Bool] = partialSelect(vec, fuConfig.exceptionOut)
     def selectByFuAndUnSelect(vec:Vec[Bool], fuConfig: FuConfig, unSelect: Seq[Int]): Vec[Bool] =
       partialSelect(vec, fuConfig.exceptionOut, unSelect)
+
+    def selectFrontend(vec: ExceptSparseVec): ExceptSparseVec = vec.select(frontendSet)
+    def selectByFu(vec:ExceptSparseVec, fuConfig: FuConfig): ExceptSparseVec = vec.select(fuConfig.exceptionOut)
+    def selectByFuAndUnSelect(vec:ExceptSparseVec, fuConfig: FuConfig, unSelect: Seq[Int]): ExceptSparseVec =
+      vec.select(fuConfig.exceptionOut, unSelect)
   }
 
   object TopDownCounters extends Enumeration {


### PR DESCRIPTION
Use ExceptSparseVec() to represent exception information instead of ExceptionVec(). ExceptSparseVec() utilizes a sparse matrix to store exception information. It can be instantiated using a specified sequence of indices, enabling it to store only a subset of all possible exception numbers while also allowing for the addition of new custom exception numbers.