### PR TITLE
chore(ci,xiangshan.py): drop 'without-numa' & cache numa_info

### DIFF
--- a/.github/workflows/emu-basics.yml
+++ b/.github/workflows/emu-basics.yml
@@ -80,10 +80,8 @@ jobs:
       matrix:
         include:
           - name: cputest
-            without-numa: true # cputest is large number of small tests, numa is not necessary and slow
           - name: riscv-tests
             extra: --rvtest /nfs/home/share/ci-workloads/riscv-tests
-            without-numa: true # similar to cputest
           - name: misc-tests
           - name: rvh-tests
           - name: microbench
@@ -101,9 +99,7 @@ jobs:
             report: true
           - name: rvv-bench
           - name: f16_test
-            without-numa: true # similar to cputest
           - name: zcb-test
-            without-numa: true # similar to cputest
       fail-fast: false
       max-parallel: 2
     steps:
@@ -123,7 +119,7 @@ jobs:
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
             --wave-dump ${WAVE_HOME} \
-            ${{ !matrix.without-numa && '--numa' || '' }} --threads 8 \
+            --numa --threads 8 \
             ${{ matrix.workload || format('--ci {0}', matrix.name) }} \
             ${{ matrix.extra }} \
             2> ${{ matrix.report && 'stderr.log' || '/dev/null' }} | tee stdout.log

--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -219,6 +219,7 @@ class XiangShan(object):
     def __init__(self, args):
         self.args = XSArgs(args)
         self.timeout = args.timeout
+        self.numa_info = None
 
     def show(self):
         self.args.show()
@@ -283,8 +284,9 @@ class XiangShan(object):
             print("workload instr trace: ", instr_trace)
         numa_args = ""
         if self.args.numa:
-            numa_info = get_free_cores(self.args.threads)
-            numa_args = f"numactl -m {numa_info[0]} -C {numa_info[1]}-{numa_info[2]}"
+            if self.numa_info is None:
+                self.numa_info = get_free_cores(self.args.threads)
+            numa_args = f"numactl -m {self.numa_info[0]} -C {self.numa_info[1]}-{self.numa_info[2]}"
         fork_args = "--enable-fork" if self.args.fork else ""
         diff_args = "--no-diff" if self.args.disable_diff else ""
         chiseldb_args = "--dump-db" if self.args.dump_db else ""


### PR DESCRIPTION
for cputest, riscv-test, etc., we used to thought these are 'large number of small tests, numa is not necessary and slow'

though, I've recently noticed that when the server is under heavy load, this can cause tasks to run very slowly and interfere with other tasks, creating a vicious cycle of high load -> slow performance -> sustained high load

thus, this PR drops `without-numa` option and uses numa for every testcase

on the other hand, if we run `get_free_cores` every time we call `run_emu`, it can costs long time simply waiting

see: https://github.com/OpenXiangShan/XiangShan/commit/303c80eaedbd3b5db941336b52a2dd82c3743b2b

now that we have a free core re-check to prevent contention, we should be able to cache the result of get_free_cores and use these result across the whole set of testcases

i.e. before:
1. run test1 ~5s (expectation), ~200s (collide with other emu process)
2. ...

after dropping `without-numa`:
1. get_free_cores ~30s
3. run test1 ~5s
4. get_free_cores ~30s
5. run test2 ~5s
6. ...

after caching numa_info:
1. get_free_cores ~30s
2. run test1, test2, ... ~5s each

Signed-off-by: ngc7331 <ngc7331@outlook.com>