### PR TITLE
ci(emu): set -o pipefail

### DIFF
--- a/.github/workflows/emu-basics.yml
+++ b/.github/workflows/emu-basics.yml
@@ -117,6 +117,7 @@ jobs:
           echo "Getting EMU binary from ${PERF_HOME}/emu"
           cp -L ${PERF_HOME}/emu ${GITHUB_WORKSPACE}/build/emu
       - name: Run Basic Test - ${{ matrix.name }}
+        shell: bash
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
             --wave-dump ${WAVE_HOME} \

--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -117,6 +117,7 @@ jobs:
           echo "Getting EMU binary from ${PERF_HOME}/emu"
           cp -L ${PERF_HOME}/emu ${GITHUB_WORKSPACE}/build/emu
       - name: Run Legacy CI Test - ${{ matrix.name }}
+        shell: bash
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
             --wave-dump ${WAVE_HOME} \
@@ -218,6 +219,7 @@ jobs:
           echo "Getting EMU binary from ${PERF_HOME}/emu"
           cp -L ${PERF_HOME}/emu ${GITHUB_WORKSPACE}/build/emu
       - name: Run SPEC06 Test - ${{ matrix.name }}
+        shell: bash
         run: |
           export CKPT=$(find "${CKPT_HOME}/${{ matrix.name }}/${{ matrix.ckpt }}" -type f \( -name "*.gz" -o -name "*.zstd" \) | head -n 1)
           echo "Running checkpoint: ${CKPT}"

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -156,6 +156,7 @@ jobs:
             --trace-fst
       - name: Simfrontend Test - SPEC06 astar
         id: astar_simfrontend
+        shell: bash
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
             --wave-dump ${WAVE_HOME} \
@@ -169,6 +170,7 @@ jobs:
           echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
       - name: Simfrontend Test - SPEC06 milc
         id: milc_simfrontend
+        shell: bash
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
             --wave-dump ${WAVE_HOME} \
@@ -182,6 +184,7 @@ jobs:
           echo "IPC=$(grep -oP 'IPC = \K\d+\.\d+' stdout.log)" >> $GITHUB_OUTPUT
       - name: Simfrontend Test - SPEC06 xalancbmk
         id: xalancbmk_simfrontend
+        shell: bash
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
             --wave-dump ${WAVE_HOME} \


### PR DESCRIPTION
The default behavior does `set -e` but not `set -o pipefail`. Refer to https://github.com/actions/runner-images/issues/4459

In #5635 and #5667 we have been using matrix for emu-performace and emu-basics, in which I added `| tee stdout.log` to each run job.

But without `-o pipefail`, `python3 -c 'import sys; sys.exit(1)' | tee stdout.log` will succeed, as `tee`'s return code is 0.

This causes some storequeue assertion failure gets into mainline, apologize.

This PR adds `shell: bash` to run jobs, which is translated to `bash --noprofile --norc -eo pipefail {0}`, refer to https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsshell.

See:
- https://github.com/OpenXiangShan/XiangShan/pull/5698#issuecomment-4140254625
- https://github.com/OpenXiangShan/XiangShan/actions/runs/23728582717/job/69145800226?pr=5698
- E.g. this is aborted but step reported as succeed: 
<img width="3748" height="1912" alt="98070ae176ae83090a39141cd468c034" src="https://github.com/user-attachments/assets/2f77f6ea-26cc-4857-b829-41ad77ee2357" />
