### PR TITLE
fix(LoadUnit): `rfWen` should be false when an exception occurs

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1778,11 +1778,10 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   // io.lsq.uncache.ready := !s3_valid
   val s3_ldout_valid  = s3_mmio_req.valid ||
                         s3_out.valid && RegNext(!s2_out.isvec && !s2_out.isFrmMisAlignBuf)
-  val s3_outexception = ExceptionNO.selectByFu(s3_out.bits.uop.exceptionVec, LduCfg).asUInt.orR && s3_vecActive
   io.ldout.valid       := s3_ldout_valid
   io.ldout.bits        := s3_ld_wb_meta
   io.ldout.bits.data   := Mux(s3_valid, s3_ld_data_frm_pipe(0), s3_ld_data_frm_mmio)
-  io.ldout.bits.uop.rfWen := s3_rfWen
+  io.ldout.bits.uop.rfWen := s3_rfWen && !io.ldout.bits.uop.exceptionVec.asUInt.orR
   io.ldout.bits.uop.fpWen := s3_fpWen
   io.ldout.bits.uop.pdest := s3_pdest
   io.ldout.bits.uop.exceptionVec := ExceptionNO.selectByFu(s3_ld_wb_meta.uop.exceptionVec, LduCfg)


### PR DESCRIPTION
Otherwise, when an exception occurs, an X-state data might be written into the register file, causing X-propagation; moreover, there is a possibility of security vulnerabilities.