### PR TITLE
ci(emu-perf): skip comment if from fork

### DIFF
--- a/.github/workflows/emu-performance-comment.yml
+++ b/.github/workflows/emu-performance-comment.yml
@@ -1,0 +1,72 @@
+# Call EMU Performance Summary workflow when a comment is created with the format "/diff <BASE_SHA>" or "/diff" (auto-detect base sha from PR base)
+name: EMU Performance Comment Trigger
+
+on:
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  dispatch-summary:
+    name: Dispatch summary for /diff
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/diff') }}
+    permissions:
+      actions: write
+      pull-requests: read
+      issues: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse /diff command
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          cmd=$(echo "${COMMENT_BODY}" | tr -d '\r' | head -n 1 | xargs)
+          if [[ "${cmd}" =~ ^/diff$ ]]; then
+            echo "use_base_sha=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ ! "${cmd}" =~ ^/diff[[:space:]]+([0-9a-fA-F]{7,40})$ ]]; then
+            echo "Invalid command format. Expected: /diff or /diff {BASE_SHA}" >&2
+            exit 1
+          fi
+          base_sha="${BASH_REMATCH[1]}"
+          echo "use_base_sha=false" >> "$GITHUB_OUTPUT"
+          echo "base_sha=${base_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Get PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          pr_json=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
+          head_sha=$(echo "${pr_json}" | jq -r '.head.sha')
+          base_sha=$(echo "${pr_json}" | jq -r '.base.sha')
+
+          if [ -z "${head_sha}" ] || [ "${head_sha}" = "null" ]; then
+            echo "Failed to get PR head sha" >&2
+            exit 1
+          fi
+          if [ -z "${base_sha}" ] || [ "${base_sha}" = "null" ]; then
+            echo "Failed to get PR base sha" >&2
+            exit 1
+          fi
+
+          echo "head_sha=${head_sha}" >> "$GITHUB_OUTPUT"
+          echo "base_sha=${base_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch emu-performance-summary workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          BASE_SHA: ${{ steps.parse.outputs.use_base_sha == 'true' && steps.pr.outputs.base_sha || steps.parse.outputs.base_sha }}
+          PR: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api repos/${GITHUB_REPOSITORY}/actions/workflows/emu-performance-summary.yml/dispatches \
+            -f ref=${GITHUB_REF_NAME} \
+            -f inputs[HEAD_SHA]="${HEAD_SHA}" \
+            -f inputs[BASE_SHA]="${BASE_SHA}" \
+            -f inputs[PR]="${PR}" \
+            -f inputs[COMMENT_ID]="${COMMENT_ID}"

--- a/.github/workflows/emu-performance-summary.yml
+++ b/.github/workflows/emu-performance-summary.yml
@@ -1,0 +1,160 @@
+# Generate performance summary report from EMU Performance Test workflow runs and post as a comment on the PR. Can be triggered manually or by EMU Performance Comment Trigger workflow.
+name: EMU Performance Summary
+
+on:
+  workflow_dispatch:
+    inputs:
+      HEAD_SHA:
+        description: Head commit SHA
+        required: true
+        type: string
+      BASE_SHA:
+        description: Base commit SHA
+        required: false
+        type: string
+      PR:
+        description: Pull request number
+        required: false
+        type: string
+      COMMENT_ID:
+        description: Existing issue comment id to update
+        required: false
+        type: string
+
+jobs:
+  summary:
+    name: EMU - Performance - Summary
+    permissions:
+      actions: read
+      pull-requests: write
+      issues: write
+    runs-on: ubuntu-latest
+    env:
+      HEAD_SHA: ${{ inputs.HEAD_SHA }}
+      BASE_SHA: ${{ inputs.BASE_SHA }}
+      PR: ${{ inputs.PR }}
+      COMMENT_ID: ${{ inputs.COMMENT_ID }}
+    steps:
+      - name: Find run ids
+        id: runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          head_run_id=$(gh run list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --workflow "EMU Performance Test" \
+            --commit "${HEAD_SHA}" \
+            --json databaseId \
+            --limit 1 | jq -r '.[0].databaseId')
+
+          if [ -z "${head_run_id}" ] || [ "${head_run_id}" = "null" ]; then
+            echo "Failed to find head run for ${HEAD_SHA}" >&2
+            exit 1
+          fi
+
+          echo "head_run_id=${head_run_id}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${BASE_SHA}" ]; then
+            base_run_id=$(gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow "EMU Performance Test" \
+              --commit "${BASE_SHA}" \
+              --json databaseId \
+              --limit 1 | jq -r '.[0].databaseId')
+            if [ -n "${base_run_id}" ] && [ "${base_run_id}" != "null" ]; then
+              echo "base_found=true" >> "$GITHUB_OUTPUT"
+              echo "base_run_id=${base_run_id}" >> "$GITHUB_OUTPUT"
+            else
+              echo "base_found=false" >> "$GITHUB_OUTPUT"
+              echo "base_error=Failed to find base run (commit ${BASE_SHA})" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "base_found=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Download head reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ipc-*
+          path: current
+          merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.runs.outputs.head_run_id }}
+      - name: Download base reports
+        if: ${{ steps.runs.outputs.base_found == 'true' }}
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ipc-*
+          path: base
+          merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.runs.outputs.base_run_id }}
+      - name: Generate summary
+        run: |
+          geomean() {
+            python3 -c "import sys, math; print(math.exp(sum(math.log(float(x)) for x in sys.argv[1:]) / len(sys.argv[1:])))" "$@"
+          }
+
+          diff() {
+            python3 -c "print(f'{(float($1) - float($2)) / float($2) * 100:.2f}')" "$@"
+          }
+
+          {
+            echo "## Emu - Performance Summary"
+            echo
+            if [ -n "${{ steps.runs.outputs.base_error }}" ]; then
+              echo "Error: ${{ steps.runs.outputs.base_error }}"
+              echo "Please check workflow logs for details."
+              echo
+            fi
+            echo "### Metadata"
+            echo "| - | SHA | Run ID |"
+            echo "| - | --- | ------ |"
+            if [ -n "${BASE_SHA}" ]; then
+              echo "| Base | ${BASE_SHA} | ${{ steps.runs.outputs.base_run_id || 'N/A' }} |"
+            fi
+            echo "| Current | ${HEAD_SHA} | ${{ steps.runs.outputs.head_run_id }} |"
+            echo
+            echo "### IPC Report"
+            echo "| Testcase | Current | Base | Diff |"
+            echo "| -------- | ------- | ---- | ---- |"
+
+            has_na=false
+            for file in current/ipc-*; do
+              name=$(basename "${file}" | cut -d '-' -f 2-)
+              ipc=$(cat "${file}")
+              if [ -f "base/ipc-${name}" ]; then
+                base_ipc=$(cat "base/ipc-${name}")
+                echo "| ${name} | ${ipc} | ${base_ipc} | $(diff "${ipc}" "${base_ipc}")% |"
+              else
+                echo "| ${name} | ${ipc} | N/A | N/A |"
+                has_na=true
+              fi
+            done
+
+            current_geomean=$(geomean $(cat current/ipc-* | xargs))
+            base_geomean=$(geomean $(cat base/ipc-* | xargs) 2>/dev/null || echo "N/A")
+            geomean_diff=$(diff "${current_geomean}" "${base_geomean}" 2>/dev/null || echo "N/A")
+            echo "| **GEOMEAN** | **${current_geomean}** | **${base_geomean}** | **${geomean_diff}%** |"
+            echo
+            if [ "${has_na}" = true ]; then
+              echo "**NOTE**: Some testcases do not have base data, diff is shown as N/A and GEOMEAN diff may not be accurate."
+            fi
+          } > report.md
+
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Create or Update Comment from Bot
+        if: ${{ inputs.PR != '' && inputs.COMMENT_ID == '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${PR}" --repo "${GITHUB_REPOSITORY}" --body-file report.md --edit-last --create-if-none
+      - name: Update Comment from Specified ID
+        if: ${{ inputs.COMMENT_ID != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          body=$(cat report.md)
+          gh api \
+            -X PATCH \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+            -f body="${body}"

--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -249,104 +249,53 @@ jobs:
           name: ipc-reports
           path: ${{ env.PERF_HOME }}/ipc-*
 
-  summary:
-    name: EMU - Performance - Summary
+  dispatch-summary:
+    name: EMU - Performance - Dispatch Summary
     permissions:
-      actions: read # to download upstream artifact
-      pull-requests: write # to post PR comment
+      actions: write
     needs: upload
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - name: Download reports
-        uses: actions/download-artifact@v8
-        with:
-          pattern: ipc-*
-          path: current
-          merge-multiple: true
-      - name: Find upstream run_id
-        if: ${{ github.event_name == 'pull_request' }}
-        id: find_upstream
+      - name: Dispatch emu-performance-summary workflow
+        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISPATCH_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+          PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          COMMENT_ID: ""
         run: |
-          echo "Upstream commit sha: ${{ github.event.pull_request.base.sha }}"
-          run_id=$(gh run list --commit "${{ github.event.pull_request.base.sha }}" --workflow "${{ github.workflow }}" --json databaseId --limit 1 | jq -r '.[0].databaseId')
-          if [ -z "${run_id}" ] || [ "${run_id}" == "null" ]; then
-            echo "Failed to find upstream run"
-            echo "error=Failed to find upstream run (commit ${{ github.event.pull_request.base.sha }})" >> $GITHUB_OUTPUT
-            echo "run_id=N/A" >> $GITHUB_OUTPUT
-            echo "found=false" >> $GITHUB_OUTPUT
-            exit 0
+          dispatch_ts=$(date -u +%s)
+          gh api repos/${GITHUB_REPOSITORY}/actions/workflows/emu-performance-summary.yml/dispatches \
+            -f ref="${DISPATCH_REF}" \
+            -f inputs[HEAD_SHA]="${HEAD_SHA}" \
+            -f inputs[BASE_SHA]="${BASE_SHA}" \
+            -f inputs[PR]="${PR}" \
+            -f inputs[COMMENT_ID]="${COMMENT_ID}"
+
+          summary_url=""
+          for _ in {1..20}; do
+            summary_url=$(gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow "EMU Performance Summary" \
+              --event workflow_dispatch \
+              --branch "${DISPATCH_REF}" \
+              --limit 20 \
+              --json url,createdAt \
+              | jq -r --argjson ts "${dispatch_ts}" '[.[] | select((.createdAt | fromdateiso8601) >= $ts)] | first | .url // empty')
+            if [ -n "${summary_url}" ]; then
+              break
+            fi
+            sleep 3
+          done
+
+          if [ -n "${summary_url}" ]; then
+            echo "Summary workflow dispatched: ${summary_url}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Summary workflow dispatched, but run URL not found yet. Please check workflow list manually." >> "$GITHUB_STEP_SUMMARY"
           fi
-
-          echo "Upstream run_id: ${run_id}"
-          echo "run_id=${run_id}" >> $GITHUB_OUTPUT
-          echo "found=true" >> $GITHUB_OUTPUT
-      - name: Download upstream reports
-        if: ${{ steps.find_upstream.outputs.found == 'true' }}
-        uses: actions/download-artifact@v8
-        with:
-          pattern: ipc-*
-          path: upstream
-          merge-multiple: true
-          github-token: ${{ secrets.GITHUB_TOKEN }} # we need this to download artifact from another run
-          run-id: ${{ steps.find_upstream.outputs.run_id }}
-      - name: Generate summary
+      - name: Skip dispatch for fork PR
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
         run: |
-          function geomean() {
-            python3 -c "import sys, math; print(math.exp(sum(math.log(float(x)) for x in sys.argv[1:]) / len(sys.argv[1:])))" "$@"
-          }
-
-          function diff() {
-            python3 -c "print(f'{(float($1) - float($2)) / float($2) * 100:.2f}')" "$@"
-          }
-
-          {
-            echo "## Emu - Performance Summary"
-            echo ""
-            if [ -n "${{ steps.find_upstream.outputs.error }}" ]; then
-              echo "Error: ${{ steps.find_upstream.outputs.error }}"
-              echo "Please checkout workflow logs for details."
-              echo ""
-            fi
-            echo "### Metadata"
-            echo "| - | Branch | SHA | Run ID |"
-            echo "| - | ------ | --- | ------ |"
-            if [ "${{ github.event_name }}" == "pull_request" ]; then
-              echo "| Upstream | ${{ github.base_ref }} | ${{ github.event.pull_request.base.sha }} | ${{ steps.find_upstream.outputs.run_id }} |"
-            fi
-            echo "| Current | ${{ github.head_ref }} | ${{ github.event.pull_request.head.sha || github.sha }} | ${{ github.run_id }} |"
-            echo ""
-            echo "### IPC Report"
-            echo "| Testcase | Current | Upstream | Diff |"
-            echo "| -------- | ------- | -------- | ---- |"
-            for file in current/ipc-*; do
-              name=$(basename ${file} | cut -d '-' -f 2-)
-              ipc=$(cat "${file}")
-              has_na=false
-              if [ -f "upstream/ipc-${name}" ]; then
-                upstream_ipc=$(cat "upstream/ipc-${name}")
-                echo "| ${name} | ${ipc} | ${upstream_ipc} | $(diff ${ipc} ${upstream_ipc})% |"
-              else
-                echo "| ${name} | ${ipc} | N/A | N/A |"
-                has_na=true
-              fi
-            done
-
-            current_geomean=$(geomean $(cat current/ipc-* | xargs))
-            upstream_geomean=$(geomean $(cat upstream/ipc-* | xargs) 2>/dev/null || echo "N/A")
-            geomean_diff=$(diff ${current_geomean} ${upstream_geomean} 2>/dev/null || echo "N/A")
-            echo "| **GEOMEAN** | **${current_geomean}** | **${upstream_geomean}** | **${geomean_diff}%** |"
-            echo
-            if [ "${has_na}" = true ]; then
-              echo "**NOTE**: Some testcases do not have upstream data, diff is shown as N/A and GEOMEAN diff may not be accurate."
-            fi
-          } > report.md
-          cat report.md >> $GITHUB_STEP_SUMMARY
-      - name: Post PR comment
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body-file report.md
+          echo "Fork PR detected, skip summary workflow dispatch because GITHUB_TOKEN cannot dispatch workflows in pull_request from fork." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
GITHUB_TOKEN has read-only permissions in PR from forked repo, see https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories. It cannot create PR comments nor dispatch workflows.

In this PR I splitted summary into a separate `on: workflow_dispatch` workflow, it will be called if the PR is **NOT** from forked repo.

As alternative, I added `/diff` command, anyone can simply comment `/diff` or `/diff <UPSTREAM_SHA>` to trigger the summary workflow, it will edit the comment with the actual summary, thereby bypass the permission issue.

Showcase in my test repo:
<img width="1900" height="1383" alt="image" src="https://github.com/user-attachments/assets/b1414711-8598-482d-b9a9-64f692e2a598" />

Signed-off-by: ngc7331 <ngc7331@outlook.com>