### PR TITLE
fix(Rob): vsetvl zero, zero should not respond to interrupts

### DIFF
--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1146,7 +1146,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       val allow_interrupts = !CommitType.isLoadStore(io.enq.req(i).bits.commitType) &&
                              !FuType.isFence(io.enq.req(i).bits.fuType) &&
                              !FuType.isCsr(io.enq.req(i).bits.fuType) &&
-                             !FuType.isVset(io.enq.req(i).bits.fuType) &&
+                             !io.enq.req(i).bits.isVset &&
                              !FuType.isAMO(io.enq.req(i).bits.fuType)
       robEntries(allocatePtrVec(i).value).interrupt_safe := allow_interrupts
     }


### PR DESCRIPTION
vset should not respond to interrupts. If an interrupt occurs during the execution of a vset, it will first trigger a flushAfter, and then trigger a flushSelf upon dequeueing (commit). This causes the enqPtr to overtake the deqPtr, ultimately leading to a pipeline hang on the FPGA. I have written a test case to prove this.

Although it appears that vset is explicitly excluded here, the instruction vsetvl zero, zero is actually cracked into two uops. The fuType of the first uop is i2v, which causes it to be mistakenly marked as interrupt_safe in the ROB:

https://github.com/OpenXiangShan/XiangShan/blob/54944b0202f43034465e3609872cbd7f971eba96/src/main/scala/xiangshan/backend/decode/DecodeUnitComp.scala#L307-L321