### PR TITLE
 fix(VLSU): fix vec misalign stuck

### DIFF
--- a/src/main/scala/xiangshan/mem/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/Bundles.scala
@@ -93,7 +93,7 @@ object Bundles {
     val vecBaseVaddr = UInt(VAddrBits.W)
     val vecVaddrOffset = UInt(VAddrBits.W)
     val vecTriggerMask = UInt((VLEN/8).W)
-    val splitIndx = UInt(flowIdxBits.W)
+    val splitIndex = UInt(flowIdxBits.W)
     // 1: vector active element or scala mem operation, 0: vector not active element
     val vecActive = Bool()
     // val flowPtr             = new VlflowPtr() // VLFlowQueue ptr

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1618,7 +1618,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vsSplit(i).io.vstdMisalign.get.storeMisalignBufferRobIdx := storeMisalignBuffer.io.toVecSplit.robIdx
     vsSplit(i).io.vstdMisalign.get.storeMisalignBufferUopIdx := storeMisalignBuffer.io.toVecSplit.uopIdx
     vsSplit(i).io.vstdMisalign.get.storePipeEmpty := !storeUnits.map(_.io.s0_s1_s2_valid).reduce(_||_)
-    storeUnits(i).io.vecMisalignBlockScalaIssue := vsSplit(i).io.vstdMisalign.get.blockScalaIssue
+    storeUnits(i).io.vecMisalignBlockScalaIssue := vsSplit.map(_.io.vstdMisalign.get.blockScalaIssue).reduce(_||_)
 
   }
   (0 until VlduCnt).foreach{i =>

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
@@ -597,7 +597,7 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
   io.vecWriteBack.bits.vstart               := req.uop.vpu.vstart
   io.vecWriteBack.bits.vecTriggerMask       := req.vecTriggerMask
   io.vecWriteBack.bits.nc                   := globalNC
-  io.vecWriteBack.bits.splitIndx            := DontCare
+  io.vecWriteBack.bits.splitIndex            := DontCare
 
 
   val flush = req_valid && req.uop.robIdx.needFlush(io.redirect)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -638,7 +638,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
       wb.bits.vstart            := req.uop.vpu.vstart
       wb.bits.vecTriggerMask    := 0.U
       wb.bits.nc                := globalNC
-      wb.bits.splitIndx         := req.splitIndx
+      wb.bits.splitIndex         := req.splitIndex
     }
   }
 

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1845,7 +1845,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.vecldout.bits.vstart := s3_vecout.vstart
   io.vecldout.bits.vecTriggerMask := s3_vecout.vecTriggerMask
   io.vecldout.bits.nc := DontCare
-  io.vecldout.bits.splitIndx := DontCare
+  io.vecldout.bits.splitIndex := DontCare
 
   io.vecldout.valid := s3_out.valid && !s3_out.bits.uop.robIdx.needFlush(io.redirect) && s3_vecout.isvec && !s3_mis_align && !s3_frm_mabuf //||
   // TODO: check this, why !io.lsq.uncache.bits.isVls before?

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -183,7 +183,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   )) + s0_addr_low
   val s0_rs_corss16Bytes = s0_addr_Up_low(4) =/= s0_addr_low(4)
   val s0_misalignWith16Byte = !s0_rs_corss16Bytes && !s0_addr_aligned && !s0_use_flow_prf
-  val s0_misalignNeedReplay = (s0_use_flow_vec || s0_rs_corss16Bytes) && !(s0_uop.sqIdx === io.sqCommitPtr || s0_uop.robIdx === io.sqCommitRobIdx && s0_uop.uopIdx === io.sqCommitUopIdx)
+  val s0_misalignNeedReplay = s0_rs_corss16Bytes && !(s0_uop.sqIdx === io.sqCommitPtr || s0_uop.robIdx === io.sqCommitRobIdx && s0_uop.uopIdx === io.sqCommitUopIdx)
   s0_is128bit := Mux(s0_use_flow_ma, io.misalign_stin.bits.is128bit, is128Bit(s0_vecstin.alignedType) || s0_misalignWith16Byte)
 
   s0_fullva := Mux(

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -135,7 +135,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s0_alignedType  = s0_vecstin.alignedType
   val s0_mBIndex      = s0_vecstin.mBIndex
   val s0_vecBaseVaddr = s0_vecstin.basevaddr
-  val s0_vecSplitIdx = s0_vecstin.splitIndx
+  val s0_vecSplitIdex = s0_vecstin.splitIndex
   val s0_isFinalSplit = io.misalign_stin.valid && io.misalign_stin.bits.isFinalSplit
 
   // generate addr
@@ -270,7 +270,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   }
   s0_out.isFrmMisAlignBuf := s0_use_flow_ma
   s0_out.isFinalSplit := s0_isFinalSplit
-  s0_out.splitIndx := s0_vecSplitIdx
+  s0_out.splitIndex := s0_vecSplitIdex
 //  s0_out.uop.exceptionVec(storeAddrMisaligned) := Mux(s0_use_non_prf_flow, (!s0_addr_aligned || s0_vecstin.uop.exceptionVec(storeAddrMisaligned) && s0_vecActive), false.B) && !s0_misalignWith16Byte
 
   io.st_mask_out.valid       := s0_use_flow_rs || s0_use_flow_vec
@@ -627,7 +627,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
       sx_in(i).gpaddr      := s3_in.gpaddr
       sx_in(i).isForVSnonLeafPTE     := s3_in.isForVSnonLeafPTE
       sx_in(i).vecTriggerMask := s3_in.vecTriggerMask
-      sx_in(i).splitIndx := s3_in.splitIndx
+      sx_in(i).splitIndx := s3_in.splitIndex
       sx_in(i).hasException := s3_exception
       sx_in_vec(i)         := s3_in.isvec
       sx_ready(i) := !s3_valid(i) || sx_in(i).output.uop.robIdx.needFlush(io.redirect) || (if (RAWTotalDelayCycles == 0) io.stout.ready else sx_ready(i+1))
@@ -678,7 +678,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.vecstout.bits.isForVSnonLeafPTE     := sx_last_in.isForVSnonLeafPTE
   io.vecstout.bits.vstart      := sx_last_in.output.uop.vpu.vstart
   io.vecstout.bits.vecTriggerMask := sx_last_in.vecTriggerMask
-  io.vecstout.bits.splitIndx := sx_last_in.splitIndx
+  io.vecstout.bits.splitIndex := sx_last_in.splitIndx
   // io.vecstout.bits.reg_offset.map(_ := DontCare)
   // io.vecstout.bits.elemIdx.map(_ := sx_last_in.elemIdx)
   // io.vecstout.bits.elemIdxInsideVd.map(_ := DontCare)

--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -326,7 +326,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
         when(!io.fromPipeline(i).bits.hit && !isUnitStride) {
           val replayFlowNumOffset = PopCount(mergePortMatrixMiss(i))
           val replayFlowMask = (0 until pipeWidth).map{case i => (0 until pipeWidth).map{case j =>
-            UIntToOH(io.fromPipeline(i).bits.splitIndx, VLENB) & Fill(VLENB, mergePortMatrix(i)(j))
+            UIntToOH(io.fromPipeline(j).bits.splitIndex, VLENB) & Fill(VLENB, mergePortMatrixMiss(i)(j))
           }.reduce(_ | _)}
 
           entries(latchWbIndex).replayFlowNum := entries(latchWbIndex).replayFlowNum + replayFlowNumOffset

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -471,10 +471,7 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
 }
 
 class VSSplitBufferImp(implicit p: Parameters) extends VSplitBuffer(isVStore = true){
-  lazy val canToMisalignBuffer = io.vstdMisalign.get.storeMisalignBufferEmpty ||
-    io.vstdMisalign.get.storeMisalignBufferRobIdx > io.out.bits.uop.robIdx ||
-    io.vstdMisalign.get.storeMisalignBufferRobIdx === io.out.bits.uop.robIdx &&
-      io.vstdMisalign.get.storeMisalignBufferUopIdx > io.out.bits.uop.uopIdx
+  lazy val canToMisalignBuffer = io.vstdMisalign.get.storeMisalignBufferEmpty
 
   override lazy val misalignedCanGo = io.vstdMisalign.get.storePipeEmpty && canToMisalignBuffer
 

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -408,7 +408,7 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
     x.uop_unit_stride_fof   := DontCare
     x.isFirstIssue          := DontCare
     x.mBIndex               := issueMbIndex
-    x.splitIndx             := splitIdx
+    x.splitIndex             := splitIdx
   }
 
   // redirect

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -143,7 +143,7 @@ class VecPipelineFeedbackIO(isVStore: Boolean=false) (implicit p: Parameters) ex
   val reg_offset           = OptionWrapper(!isVStore, UInt(vOffsetBits.W))
   val elemIdxInsideVd      = OptionWrapper(!isVStore, UInt(elemIdxBits.W)) // element index in scope of vd
   val vecdata              = OptionWrapper(!isVStore, UInt(VLEN.W))
-  val splitIndx            = UInt(flowIdxBits.W)
+  val splitIndex            = UInt(flowIdxBits.W)
 }
 
 class VecPipeBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle {
@@ -164,7 +164,7 @@ class VecPipeBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLS
   val mBIndex             = if(isVStore) UInt(vsmBindexBits.W) else UInt(vlmBindexBits.W)
   val elemIdx             = UInt(elemIdxBits.W)
   val elemIdxInsideVd     = UInt(elemIdxBits.W) // only use in unit-stride
-  val splitIndx           = UInt(flowIdxBits.W)
+  val splitIndex           = UInt(flowIdxBits.W)
 }
 
 object VecFeedbacks {


### PR DESCRIPTION
**Bug Symptom:** The system freezes during a misaligned vector store.

**Cause Analysis:** Previously, vector misaligned stores required the pipeline to be empty to ensure that once an element entered the pipeline, it would definitely reach the store misalign buffer and complete execution without being reissued. This is because reissuance of vector stores was previously performed at the UOP granularity. If it could not be guaranteed that a vector misaligned element would complete execution after entering the pipeline, ping-ponging and deadlocks could occur. Therefore, we used the `blockScaleIssue` signal to prevent scalar stores from being issued. However, since there are two store units and one store misalign buffer, we cannot block just one store unit; we must block both store units simultaneously to ensure that misaligned elements entering a store unit will definitely reach the store misalign buffer.
Since we previously implemented support for reissuing vector stores on a per-element basis, this requirement is theoretically no longer necessary. However, we will retain this mechanism, so we have chosen to propagate the `blockScaleIssue` signal to both store units.

**Fix:** Propagate the `blockScaleIssue` signal to both store units.

---

We also addressed some naming issues.