### PR TITLE
feat(ICache): 2-prefetch

### DIFF
--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -19,6 +19,8 @@ import chisel3._
 import chisel3.util._
 import ftq.BpuFlushInfo
 import ftq.FtqPtr
+import ftq.FtqToMainPipeBundle
+import ftq.FtqToPrefetchBundle
 import org.chipsalliance.cde.config.Parameters
 import utility.InstSeqNum
 import utility.XSError
@@ -37,12 +39,13 @@ import xiangshan.frontend.bpu.BpuRedirect
 import xiangshan.frontend.bpu.BpuTrain
 import xiangshan.frontend.bpu.BranchAttribute
 import xiangshan.frontend.bpu.BranchInfo
-import xiangshan.frontend.bpu.mbtb.MainBtbMeta
 import xiangshan.frontend.ibuffer.IBufPtr
+import xiangshan.frontend.icache.HasICacheParameters
 import xiangshan.frontend.icache.ICacheCacheLineHelper
 import xiangshan.frontend.icache.ICachePerfInfo
 import xiangshan.frontend.icache.ICacheRespBundle
 import xiangshan.frontend.icache.ICacheTopdownInfo
+import xiangshan.frontend.icache.MainPipeToIfuIO
 import xiangshan.frontend.instruncache.InstrUncacheReq
 import xiangshan.frontend.instruncache.InstrUncacheResp
 
@@ -105,12 +108,10 @@ class FtqFetchRequest(implicit p: Parameters) extends FrontendBundle with ICache
 }
 
 class FtqToICacheIO(implicit p: Parameters) extends FrontendBundle {
-  // NOTE: req.bits must be prepared in T cycle
-  // while req.valid is set true in T + 1 cycle
-  val fetchReq:      DecoupledIO[FtqFetchRequest]    = Decoupled(new FtqFetchRequest)
-  val prefetchReq:   DecoupledIO[FtqPrefetchRequest] = Decoupled(new FtqPrefetchRequest)
-  val flushFromBpu:  BpuFlushInfo                    = new BpuFlushInfo
-  val redirectFlush: Bool                            = Output(Bool())
+  val toPrefetch:    DecoupledIO[FtqToPrefetchBundle] = Decoupled(new FtqToPrefetchBundle)
+  val fetchReq:      DecoupledIO[FtqFetchRequest]     = Decoupled(new FtqFetchRequest)
+  val flushFromBpu:  BpuFlushInfo                     = new BpuFlushInfo
+  val redirectFlush: Bool                             = Output(Bool())
 }
 
 class ICacheToIfuIO(implicit p: Parameters) extends FrontendBundle {

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -216,8 +216,8 @@ class FrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBase(
   // IFU-Ftq
   ifu.io.fromFtq <> ftq.io.toIfu
   ftq.io.toIfu.req.ready := ifu.io.fromFtq.req.ready && icache.io.fromFtq.fetchReq.ready
-
   ftq.io.fromIfu <> ifu.io.toFtq
+
   bpu.io.fromFtq <> ftq.io.toBpu
   ftq.io.fromBpu <> bpu.io.toFtq
 
@@ -225,6 +225,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBase(
   icache.io.fromFtq <> ftq.io.toICache
   // override fetchReq.ready to sync with Ifu
   ftq.io.toICache.fetchReq.ready := ifu.io.fromFtq.req.ready && icache.io.fromFtq.fetchReq.ready
+  ftq.io.fromICache.fromPrefetch := icache.io.toFtq.fromPrefetch
   icache.io.flush                := DontCare
 
   // Ifu-ICache

--- a/src/main/scala/xiangshan/frontend/FrontendParameters.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendParameters.scala
@@ -87,4 +87,9 @@ trait HasFrontendParameters extends HasXSParameter {
   def IBufferEnqueueWidth: Int = FetchBlockInstNum + frontendParameters.ibufferParameters.NumWriteBank
 
   def ResolveEntryBranchNumber: Int = frontendParameters.ResolveEntryBranchNumber
+
+  def MaxPrefetchReqNum: Int = 2
+  def MaxFetchReqNum:    Int = 2
+  def MaxAccessLineNum:  Int = 2
+  def MaxFetchLineNum:   Int = MaxFetchReqNum * MaxAccessLineNum
 }

--- a/src/main/scala/xiangshan/frontend/FrontendParameters.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendParameters.scala
@@ -58,6 +58,7 @@ case class FrontendParameters(
 
   // sanity check
   require(isPow2(FetchBlockSize))
+  require(FetchPorts == 1 || FetchPorts == 2, "Only 1 or 2-fetch is supported")
 }
 
 trait HasFrontendParameters extends HasXSParameter {

--- a/src/main/scala/xiangshan/frontend/TwoFetch.scala
+++ b/src/main/scala/xiangshan/frontend/TwoFetch.scala
@@ -32,7 +32,7 @@ import utils.EnumUInt
 class TwoPrefetchCase extends Bundle {
   val value: UInt = TwoPrefetchCase.Value()
 
-  def valid: Bool = value.orR
+  def valid: Bool = !isConflict
 
   // select 2 vaddr to read ICacheMetaArray
   def selectMetaVAddr(reqVec: Vec[PrefetchReqBundle]): Vec[PrunedAddr] =
@@ -59,6 +59,7 @@ class TwoPrefetchCase extends Bundle {
     )
 
   // NOTE: refer to object TwoPrefetchCase.Value for explanation
+  def isConflict:   Bool = !value.orR
   def isSameLine:   Bool = value(0)
   def isOverlap1:   Bool = value(1)
   def isOverlap2:   Bool = value(2)
@@ -83,7 +84,7 @@ class TwoPrefetchCase extends Bundle {
 }
 
 object TwoPrefetchCase {
-  def Unable: TwoPrefetchCase = apply(Value.Unable)
+  def Conflict: TwoPrefetchCase = apply(Value.Conflict)
 
   def apply(that: UInt, canAssert: Bool = true.B): TwoPrefetchCase = {
     when(canAssert) {
@@ -115,8 +116,8 @@ object TwoPrefetchCase {
     apply(VecInit(sameLine, overlap1, overlap2, interleave).asUInt, canAssert)
 
   private object Value extends EnumUInt(5, useOneHot = true, allowZeroForOneHot = true) {
-    // cannot do 2-prefetch due to SRAM read port conflict
-    def Unable: UInt = 0.U(width.W)
+    // Conflict: cannot do 2-prefetch due to SRAM read port conflict
+    def Conflict: UInt = 0.U(width.W)
 
     /* SameLine: 2 fetch block in the same cacheline(s)
      * |    cacheline0    |    cacheline1    |

--- a/src/main/scala/xiangshan/frontend/TwoFetch.scala
+++ b/src/main/scala/xiangshan/frontend/TwoFetch.scala
@@ -1,0 +1,153 @@
+// Copyright (c) 2024-2026 Beijing Institute of Open Source Chip (BOSC)
+// Copyright (c) 2020-2026 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2020-2021 Peng Cheng Laboratory
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package xiangshan.frontend
+
+import chisel3._
+import chisel3.util._
+import ftq.FtqBundle
+import ftq.FtqPrefetchReq
+import icache.HasICacheParameters
+import icache.MetaInfo
+import icache.PrefetchReqBundle
+import org.chipsalliance.cde.config.Parameters
+import utils.EnumUInt
+
+// As 2-prefetch / 2-fetch support is spread across Ftq/Ifu/ICache,
+// we put these classes / objects in package frontend instead of package icache.
+// Logically, this file is part of Bundles.scala, we split it out for easier management.
+
+class TwoPrefetchCase extends Bundle {
+  val value: UInt = TwoPrefetchCase.Value()
+
+  def valid: Bool = value.orR
+
+  // select 2 vaddr to read ICacheMetaArray
+  def selectMetaVAddr(reqVec: Vec[PrefetchReqBundle]): Vec[PrunedAddr] =
+    MuxCase(
+      // unable to do 2-prefetch, or isSameLine or isOverlap1, both use req1's start and nextLine
+      VecInit(reqVec(0).startVAddr, reqVec(0).nextLineVAddr),
+      Seq(
+        isOverlap2   -> VecInit(reqVec(1).startVAddr, reqVec(1).nextLineVAddr),
+        isInterleave -> VecInit(reqVec(0).startVAddr, reqVec(1).startVAddr)
+      )
+    )
+
+  // select isCrossLine flag to read ICacheMetaArray
+  def selectIsCrossLine(reqVec: Vec[PrefetchReqBundle]): Bool =
+    MuxCase(
+      // unable to do 2-prefetch, use req1.isCrossLine
+      reqVec(0).isCrossLine,
+      Seq(
+        // if 2 fb are in the same line, read 2 if one of them crosses cacheline
+        isSameLine -> (reqVec(0).isCrossLine || reqVec(1).isCrossLine),
+        // otherwise, we must read 2 cacheline
+        (isOverlap1 || isOverlap2 || isInterleave) -> true.B
+      )
+    )
+
+  // NOTE: refer to object TwoPrefetchCase.Value for explanation
+  def isSameLine:   Bool = value(0)
+  def isOverlap1:   Bool = value(1)
+  def isOverlap2:   Bool = value(2)
+  def isInterleave: Bool = value(3)
+
+  // after read 2 (at most) metaInfo from ICacheMetaArray, broadcast to 2 fetch blocks
+  def generateReqMetaInfo(readInfoVec: Vec[MetaInfo]): Vec[Vec[MetaInfo]] =
+    VecInit(
+      VecInit(
+        // if isOverlap2, fb1's first line is fb2's second line and is from port 2, otherwise from port 1
+        Mux(isOverlap2, readInfoVec(1), readInfoVec(0)),
+        // if isOverlap2 or isInterleave, fb1 does not have a second line, otherwise from port 1
+        Mux(isOverlap2 || isInterleave, 0.U.asTypeOf(readInfoVec(0)), readInfoVec(1))
+      ),
+      VecInit(
+        // if isSameLine or isOverlap2, fb2's first line is from port 1, otherwise from port 2
+        Mux(isSameLine || isOverlap2, readInfoVec(0), readInfoVec(1)),
+        // if isOverlap1 or isInterleave, fb2 does not have a second line, otherwise from port 2
+        Mux(isOverlap1 || isInterleave, 0.U.asTypeOf(readInfoVec(0)), readInfoVec(1))
+      )
+    )
+}
+
+object TwoPrefetchCase {
+  def Unable: TwoPrefetchCase = apply(Value.Unable)
+
+  def apply(that: UInt, canAssert: Bool = true.B): TwoPrefetchCase = {
+    when(canAssert) {
+      Value.assertLegal(that)
+    }
+    val twoPrefetchCase = Wire(new TwoPrefetchCase)
+    twoPrefetchCase.value := that
+    twoPrefetchCase
+  }
+
+  def SameLine: TwoPrefetchCase = apply(Value.SameLine)
+
+  def Overlap1: TwoPrefetchCase = apply(Value.Overlap1)
+
+  def Overlap2: TwoPrefetchCase = apply(Value.Overlap2)
+
+  def Interleave: TwoPrefetchCase = apply(Value.Interleave)
+
+  def apply(reqVec: Vec[FtqPrefetchReq], canAssert: Bool): TwoPrefetchCase =
+    TwoPrefetchCase(
+      reqVec(0).vSetIdx(0) === reqVec(1).vSetIdx(0),                                                    // sameLine
+      reqVec(0).isCrossLine && !reqVec(1).isCrossLine && reqVec(0).vSetIdx(1) === reqVec(1).vSetIdx(0), // overlap1
+      !reqVec(0).isCrossLine && reqVec(1).isCrossLine && reqVec(1).vSetIdx(1) === reqVec(0).vSetIdx(0), // overlap2
+      !reqVec(0).isCrossLine && !reqVec(1).isCrossLine && reqVec(0).vSetIdx(0)(0) =/= reqVec(1).vSetIdx(0)(0), // inter
+      canAssert
+    )
+
+  def apply(sameLine: Bool, overlap1: Bool, overlap2: Bool, interleave: Bool, canAssert: Bool): TwoPrefetchCase =
+    apply(VecInit(sameLine, overlap1, overlap2, interleave).asUInt, canAssert)
+
+  private object Value extends EnumUInt(5, useOneHot = true, allowZeroForOneHot = true) {
+    // cannot do 2-prefetch due to SRAM read port conflict
+    def Unable: UInt = 0.U(width.W)
+
+    /* SameLine: 2 fetch block in the same cacheline(s)
+     * |    cacheline0    |    cacheline1    |
+     *      |  fb1             |
+     *          | fb2 |
+     */
+    def SameLine: UInt = 1.U(width.W)
+
+    /* Overlap1: fb2 is in fb1's next line
+     * |    cacheline0    |    cacheline1    |
+     *      |  fb1             |
+     *                       | fb2 |
+     *                       | fb2                | // bad: fb2 cannot cross cacheline
+     */
+    def Overlap1: UInt = 2.U(width.W)
+
+    /* Overlap2: reverse of Overlap1, i.e. fb1 is in fb2's next line
+     */
+    def Overlap2: UInt = 4.U(width.W)
+
+    /* Interleave: 2 fetch block in interleaved cachelines
+     *  |    cacheline(2n)    | ... |    cacheline(2n+1)    |
+     *        | fb1 |
+     *                                   | fb2 |
+     *                                   | fb2                 | // bad: both fb1 and fb2 cannot cross cacheline
+     */
+    def Interleave: UInt = 8.U(width.W)
+  }
+}
+
+class TwoFetchInfo(implicit p: Parameters) extends FtqBundle with HasICacheParameters {
+  val isMmio:  Bool      = Bool()
+  val wayMask: Vec[UInt] = Vec(PortNumber, UInt(nWays.W))
+}

--- a/src/main/scala/xiangshan/frontend/TwoFetch.scala
+++ b/src/main/scala/xiangshan/frontend/TwoFetch.scala
@@ -81,6 +81,8 @@ class TwoPrefetchCase extends Bundle {
         Mux(isOverlap1 || isInterleave, 0.U.asTypeOf(readInfoVec(0)), readInfoVec(1))
       )
     )
+
+  def getValidSeq: Seq[(String, Bool)] = TwoPrefetchCase.Value.getValidSeq(value, exclude = Set("Conflict"))
 }
 
 object TwoPrefetchCase {

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -229,12 +229,12 @@ object TwoPrefetchCase {
 
   def Interleave: TwoPrefetchCase = apply(Value.Interleave)
 
-  def apply(req1: FtqPrefetchReq, req2: FtqPrefetchReq, canAssert: Bool): TwoPrefetchCase =
+  def apply(reqVec: Vec[FtqPrefetchReq], canAssert: Bool): TwoPrefetchCase =
     TwoPrefetchCase(
-      req1.vSetIdx(0) === req2.vSetIdx(0),                                                    // sameLine
-      req1.isCrossLine && !req2.isCrossLine && req1.vSetIdx(1) === req2.vSetIdx(0), // overlap1
-      !req1.isCrossLine && req2.isCrossLine && req2.vSetIdx(1) === req1.vSetIdx(0), // overlap2
-      !req1.isCrossLine && !req2.isCrossLine && req1.vSetIdx(0)(0) =/= req2.vSetIdx(0)(0), // interleave
+      reqVec(0).vSetIdx(0) === reqVec(1).vSetIdx(0),                                                    // sameLine
+      reqVec(0).isCrossLine && !reqVec(1).isCrossLine && reqVec(0).vSetIdx(1) === reqVec(1).vSetIdx(0), // overlap1
+      !reqVec(0).isCrossLine && reqVec(1).isCrossLine && reqVec(1).vSetIdx(1) === reqVec(0).vSetIdx(0), // overlap2
+      !reqVec(0).isCrossLine && !reqVec(1).isCrossLine && reqVec(0).vSetIdx(0)(0) =/= reqVec(1).vSetIdx(0)(0), // inter
       canAssert
     )
 

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -25,13 +25,11 @@ import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.bpu.BpuMeta
 import xiangshan.frontend.bpu.BpuPerfMeta
 import xiangshan.frontend.bpu.BranchInfo
+import xiangshan.frontend.icache.{MetaInfo => ICacheMetaInfo}
 import xiangshan.frontend.icache.HasICacheParameters
-import xiangshan.frontend.icache.ICacheBundle
 import xiangshan.frontend.icache.ICacheCacheLineHelper
 import xiangshan.frontend.icache.ICacheDataHelper
-import xiangshan.frontend.icache.ICacheParameters
 import xiangshan.frontend.icache.PrefetchReqBundle
-import xiangshan.frontend.icache.WayLookupEntry
 
 class FtqEntry(implicit p: Parameters) extends FtqBundle {
   val startPc:        PrunedAddr  = PrunedAddr(VAddrBits)
@@ -158,21 +156,61 @@ class FtqFetchReq(implicit p: Parameters) extends FtqBundle with ICacheDataHelpe
 class TwoPrefetchCase extends Bundle {
   val value: UInt = TwoPrefetchCase.Value()
 
-  def valid:   Bool = value.orR
-  def isCase1: Bool = value(0)
-  def isCase2: Bool = value(1)
-  def isCase3: Bool = value(2)
-  def isCase4: Bool = value(3)
+  def valid: Bool = value.orR
+
+  // select 2 vaddr to read ICacheMetaArray
+  def selectMetaVAddr(reqVec: Vec[PrefetchReqBundle]): Vec[PrunedAddr] =
+    MuxCase(
+      // unable to do 2-prefetch, or isSameLine or isOverlap1, both use req1's start and nextLine
+      VecInit(reqVec(0).startVAddr, reqVec(0).nextLineVAddr),
+      Seq(
+        isOverlap2   -> VecInit(reqVec(1).startVAddr, reqVec(1).nextLineVAddr),
+        isInterleave -> VecInit(reqVec(0).startVAddr, reqVec(1).startVAddr)
+      )
+    )
+
+  // select isCrossLine flag to read ICacheMetaArray
+  def selectIsCrossLine(reqVec: Vec[PrefetchReqBundle]): Bool =
+    MuxCase(
+      // unable to do 2-prefetch, use req1.isCrossLine
+      reqVec(0).isCrossLine,
+      Seq(
+        // if 2 fb are in the same line, read 2 if one of them crosses cacheline
+        isSameLine -> (reqVec(0).isCrossLine || reqVec(1).isCrossLine),
+        // otherwise, we must read 2 cacheline
+        (isOverlap1 || isOverlap2 || isInterleave) -> true.B
+      )
+    )
+
+  // NOTE: refer to object TwoPrefetchCase.Value for explanation
+  def isSameLine: Bool = value(0)
+
+  def isOverlap1: Bool = value(1)
+
+  def isOverlap2: Bool = value(2)
+
+  def isInterleave: Bool = value(3)
+
+  // after read 2 (at most) metaInfo from ICacheMetaArray, broadcast to 2 fetch blocks
+  def generateReqMetaInfo(readInfoVec: Vec[ICacheMetaInfo]): Vec[Vec[ICacheMetaInfo]] =
+    VecInit(
+      VecInit(
+        // if isOverlap2, fb1's first line is fb2's second line and is from port 2, otherwise from port 1
+        Mux(isOverlap2, readInfoVec(1), readInfoVec(0)),
+        // if isOverlap2 or isInterleave, fb1 does not have a second line, otherwise from port 1
+        Mux(isOverlap2 || isInterleave, 0.U.asTypeOf(readInfoVec(0)), readInfoVec(1))
+      ),
+      VecInit(
+        // if isSameLine or isOverlap2, fb2's first line is from port 1, otherwise from port 2
+        Mux(isSameLine || isOverlap2, readInfoVec(0), readInfoVec(1)),
+        // if isOverlap1 or isInterleave, fb2 does not have a second line, otherwise from port 2
+        Mux(isOverlap1 || isInterleave, 0.U.asTypeOf(readInfoVec(0)), readInfoVec(1))
+      )
+    )
 }
 
 object TwoPrefetchCase {
-  private object Value extends EnumUInt(5, useOneHot = true, allowZeroForOneHot = true) {
-    def None:  UInt = 0.U(width.W)
-    def Case1: UInt = 1.U(width.W)
-    def Case2: UInt = 2.U(width.W)
-    def Case3: UInt = 4.U(width.W)
-    def Case4: UInt = 8.U(width.W)
-  }
+  def Unable: TwoPrefetchCase = apply(Value.Unable)
 
   def apply(that: UInt, canAssert: Bool = true.B): TwoPrefetchCase = {
     when(canAssert) {
@@ -183,37 +221,56 @@ object TwoPrefetchCase {
     twoPrefetchCase
   }
 
-  def None:  TwoPrefetchCase = apply(Value.None)
-  def Case1: TwoPrefetchCase = apply(Value.Case1)
-  def Case2: TwoPrefetchCase = apply(Value.Case2)
-  def Case3: TwoPrefetchCase = apply(Value.Case3)
-  def Case4: TwoPrefetchCase = apply(Value.Case4)
+  def SameLine: TwoPrefetchCase = apply(Value.SameLine)
 
-  def apply(firstReq: FtqPrefetchReq, secondReq: FtqPrefetchReq, canAssert: Bool): TwoPrefetchCase = {
-    // case1: two blocks' startPc are in the same cache line
-    val case1 = firstReq.vSetIdx(0) === secondReq.vSetIdx(0)
+  def Overlap1: TwoPrefetchCase = apply(Value.Overlap1)
 
-    // case2: the first block is cross line,
-    // and the second block's startPc is in the same cache line with the first block's second line
-    val case2 = firstReq.isCrossLine && firstReq.vSetIdx(1) === secondReq.vSetIdx(0) && !secondReq.isCrossLine
+  def Overlap2: TwoPrefetchCase = apply(Value.Overlap2)
 
-    // case3: the second block is cross line,
-    // and the first block's startPc is in the same cache line with the second block's second line
-    val case3 = secondReq.isCrossLine && secondReq.vSetIdx(1) === firstReq.vSetIdx(0) && !firstReq.isCrossLine
+  def Interleave: TwoPrefetchCase = apply(Value.Interleave)
 
-    // case4: the two blocks' startPc are in different cache lines (one even, one odd),
-    // and both of them are not cross line
-    val case4 = (firstReq.vSetIdx(0)(0) ^ secondReq.vSetIdx(0)(0)) && !firstReq.isCrossLine && !secondReq.isCrossLine
+  def apply(req1: FtqPrefetchReq, req2: FtqPrefetchReq, canAssert: Bool): TwoPrefetchCase =
+    TwoPrefetchCase(
+      req1.vSetIdx(0) === req2.vSetIdx(0),                                                    // sameLine
+      req1.isCrossLine && !req2.isCrossLine && req1.vSetIdx(1) === req2.vSetIdx(0), // overlap1
+      !req1.isCrossLine && req2.isCrossLine && req2.vSetIdx(1) === req1.vSetIdx(0), // overlap2
+      !req1.isCrossLine && !req2.isCrossLine && req1.vSetIdx(0)(0) =/= req2.vSetIdx(0)(0), // interleave
+      canAssert
+    )
 
-    // TODO: remove them
-    dontTouch(firstReq)
-    dontTouch(secondReq)
-    dontTouch(case1)
-    dontTouch(case2)
-    dontTouch(case3)
-    dontTouch(case4)
+  def apply(sameLine: Bool, overlap1: Bool, overlap2: Bool, interleave: Bool, canAssert: Bool): TwoPrefetchCase =
+    apply(VecInit(sameLine, overlap1, overlap2, interleave).asUInt, canAssert)
 
-    TwoPrefetchCase(VecInit(case1, case2, case3, case4).asUInt, canAssert)
+  private object Value extends EnumUInt(5, useOneHot = true, allowZeroForOneHot = true) {
+    // cannot do 2-prefetch due to SRAM read port conflict
+    def Unable: UInt = 0.U(width.W)
+
+    /* SameLine: 2 fetch block in the same cacheline(s)
+     * |    cacheline0    |    cacheline1    |
+     *      |  fb1             |
+     *          | fb2 |
+     */
+    def SameLine: UInt = 1.U(width.W)
+
+    /* Overlap1: fb2 is in fb1's next line
+     * |    cacheline0    |    cacheline1    |
+     *      |  fb1             |
+     *                       | fb2 |
+     *                       | fb2                | // bad: fb2 cannot cross cacheline
+     */
+    def Overlap1: UInt = 2.U(width.W)
+
+    /* Overlap2: reverse of Overlap1, i.e. fb1 is in fb2's next line
+     */
+    def Overlap2: UInt = 4.U(width.W)
+
+    /* Interleave: 2 fetch block in interleaved cachelines
+     *  |    cacheline(2n)    | ... |    cacheline(2n+1)    |
+     *        | fb1 |
+     *                                   | fb2 |
+     *                                   | fb2                 | // bad: both fb1 and fb2 cannot cross cacheline
+     */
+    def Interleave: UInt = 8.U(width.W)
   }
 }
 

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -19,10 +19,19 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.HasCircularQueuePtrHelper
+import utils.EnumUInt
+import xiangshan.frontend.FtqFetchRequest
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.bpu.BpuMeta
 import xiangshan.frontend.bpu.BpuPerfMeta
 import xiangshan.frontend.bpu.BranchInfo
+import xiangshan.frontend.icache.HasICacheParameters
+import xiangshan.frontend.icache.ICacheBundle
+import xiangshan.frontend.icache.ICacheCacheLineHelper
+import xiangshan.frontend.icache.ICacheDataHelper
+import xiangshan.frontend.icache.ICacheParameters
+import xiangshan.frontend.icache.PrefetchReqBundle
+import xiangshan.frontend.icache.WayLookupEntry
 
 class FtqEntry(implicit p: Parameters) extends FtqBundle {
   val startPc:        PrunedAddr  = PrunedAddr(VAddrBits)
@@ -88,4 +97,127 @@ class PerfMeta(implicit p: Parameters) extends FtqBundle {
   // no matter how many mispredictions happened before, count correct-path only
   val mispredict:           Bool       = Bool()
   val mispredictBranchInfo: BranchInfo = new BranchInfo()
+}
+
+class FtqToPrefetchBundle(implicit p: Parameters) extends FtqBundle {
+  val req:             Vec[PrefetchReqBundle] = Vec(MaxPrefetchReqNum, new PrefetchReqBundle)
+  val twoPrefetchCase: TwoPrefetchCase        = new TwoPrefetchCase
+}
+
+class FtqToMainPipeBundle(implicit p: Parameters) extends FtqBundle {
+  val req: Vec[FtqFetchRequest] = Vec(MaxFetchReqNum, new FtqFetchRequest)
+}
+
+class FtqPrefetchReq(implicit p: Parameters) extends FtqBundle with ICacheCacheLineHelper {
+  val startVAddr:     PrunedAddr = PrunedAddr(VAddrBits)
+  val nextLineVAddr:  PrunedAddr = PrunedAddr(VAddrBits)
+  val takenCfiOffset: UInt       = UInt(CfiPositionWidth.W)
+  val isCrossLine:    Bool       = Bool()
+  val vSetIdx:        Vec[UInt]  = Vec(MaxPrefetchReqNum, UInt(idxBits.W))
+  val vPageNumber:    UInt       = UInt((VAddrBits - PageOffsetWidth).W)
+
+  def fromFtqEntry(entry: FtqEntry): FtqPrefetchReq = {
+    startVAddr     := entry.startPc
+    nextLineVAddr  := entry.startPc + blockBytes.U
+    takenCfiOffset := entry.takenCfiOffset.bits
+    isCrossLine    := isCrossLine(startVAddr, takenCfiOffset)
+    vSetIdx        := VecInit(get_idx(startVAddr), get_idx(nextLineVAddr))
+    vPageNumber    := entry.startPc(VAddrBits - 1, PageOffsetWidth)
+    this
+  }
+}
+
+class FtqFetchReq(implicit p: Parameters) extends FtqBundle with ICacheDataHelper with ICacheCacheLineHelper {
+  val startVAddr:     PrunedAddr = PrunedAddr(VAddrBits)
+  val nextLineVAddr:  PrunedAddr = PrunedAddr(VAddrBits)
+  val takenCfiOffset: UInt       = UInt(CfiPositionWidth.W)
+  val isCrossLine:    Bool       = Bool()
+  val bankSel:        Vec[UInt]  = Vec(PortNumber, UInt(DataBanks.W))
+  val vSetIdx:        Vec[UInt]  = Vec(PortNumber, UInt(idxBits.W))
+  val wayMask:        Vec[UInt]  = Vec(PortNumber, UInt(nWays.W))
+  val isMmio:         Bool       = Bool()
+  val size:           UInt       = UInt((log2Ceil(FetchBlockSize) + 1).W)
+  val vPageNumber:    UInt       = UInt((VAddrBits - PageOffsetWidth).W)
+
+  def fromFtqEntry(entry: FtqEntry, twoFetchInfo: TwoFetchInfo): FtqFetchReq = {
+    val (isCrossLine, bankSel) = getBankSel(startVAddr, takenCfiOffset)
+    startVAddr       := entry.startPc
+    nextLineVAddr    := entry.startPc + blockBytes.U
+    takenCfiOffset   := entry.takenCfiOffset.bits
+    this.isCrossLine := isCrossLine
+    this.bankSel     := bankSel
+    vSetIdx          := VecInit(get_idx(startVAddr), get_idx(nextLineVAddr))
+    wayMask          := twoFetchInfo.wayMask
+    isMmio           := twoFetchInfo.isMmio
+    size             := (entry.takenCfiOffset.bits +& 1.U) << 1
+    vPageNumber      := entry.startPc(VAddrBits - 1, PageOffsetWidth)
+    this
+  }
+}
+
+class TwoPrefetchCase extends Bundle {
+  val value: UInt = TwoPrefetchCase.Value()
+
+  def valid:   Bool = value.orR
+  def isCase1: Bool = value(0)
+  def isCase2: Bool = value(1)
+  def isCase3: Bool = value(2)
+  def isCase4: Bool = value(3)
+}
+
+object TwoPrefetchCase {
+  private object Value extends EnumUInt(5, useOneHot = true, allowZeroForOneHot = true) {
+    def None:  UInt = 0.U(width.W)
+    def Case1: UInt = 1.U(width.W)
+    def Case2: UInt = 2.U(width.W)
+    def Case3: UInt = 4.U(width.W)
+    def Case4: UInt = 8.U(width.W)
+  }
+
+  def apply(that: UInt, canAssert: Bool = true.B): TwoPrefetchCase = {
+    when(canAssert) {
+      Value.assertLegal(that)
+    }
+    val twoPrefetchCase = Wire(new TwoPrefetchCase)
+    twoPrefetchCase.value := that
+    twoPrefetchCase
+  }
+
+  def None:  TwoPrefetchCase = apply(Value.None)
+  def Case1: TwoPrefetchCase = apply(Value.Case1)
+  def Case2: TwoPrefetchCase = apply(Value.Case2)
+  def Case3: TwoPrefetchCase = apply(Value.Case3)
+  def Case4: TwoPrefetchCase = apply(Value.Case4)
+
+  def apply(firstReq: FtqPrefetchReq, secondReq: FtqPrefetchReq, canAssert: Bool): TwoPrefetchCase = {
+    // case1: two blocks' startPc are in the same cache line
+    val case1 = firstReq.vSetIdx(0) === secondReq.vSetIdx(0)
+
+    // case2: the first block is cross line,
+    // and the second block's startPc is in the same cache line with the first block's second line
+    val case2 = firstReq.isCrossLine && firstReq.vSetIdx(1) === secondReq.vSetIdx(0) && !secondReq.isCrossLine
+
+    // case3: the second block is cross line,
+    // and the first block's startPc is in the same cache line with the second block's second line
+    val case3 = secondReq.isCrossLine && secondReq.vSetIdx(1) === firstReq.vSetIdx(0) && !firstReq.isCrossLine
+
+    // case4: the two blocks' startPc are in different cache lines (one even, one odd),
+    // and both of them are not cross line
+    val case4 = (firstReq.vSetIdx(0)(0) ^ secondReq.vSetIdx(0)(0)) && !firstReq.isCrossLine && !secondReq.isCrossLine
+
+    // TODO: remove them
+    dontTouch(firstReq)
+    dontTouch(secondReq)
+    dontTouch(case1)
+    dontTouch(case2)
+    dontTouch(case3)
+    dontTouch(case4)
+
+    TwoPrefetchCase(VecInit(case1, case2, case3, case4).asUInt, canAssert)
+  }
+}
+
+class TwoFetchInfo(implicit p: Parameters) extends FtqBundle with HasICacheParameters {
+  val isMmio:  Bool      = Bool()
+  val wayMask: Vec[UInt] = Vec(PortNumber, UInt(nWays.W))
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -19,14 +19,13 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.HasCircularQueuePtrHelper
-import utils.EnumUInt
 import xiangshan.frontend.FtqFetchRequest
 import xiangshan.frontend.PrunedAddr
+import xiangshan.frontend.TwoFetchInfo
+import xiangshan.frontend.TwoPrefetchCase
 import xiangshan.frontend.bpu.BpuMeta
 import xiangshan.frontend.bpu.BpuPerfMeta
 import xiangshan.frontend.bpu.BranchInfo
-import xiangshan.frontend.icache.{MetaInfo => ICacheMetaInfo}
-import xiangshan.frontend.icache.HasICacheParameters
 import xiangshan.frontend.icache.ICacheCacheLineHelper
 import xiangshan.frontend.icache.ICacheDataHelper
 import xiangshan.frontend.icache.PrefetchReqBundle
@@ -151,130 +150,4 @@ class FtqFetchReq(implicit p: Parameters) extends FtqBundle with ICacheDataHelpe
     vPageNumber      := entry.startPc(VAddrBits - 1, PageOffsetWidth)
     this
   }
-}
-
-class TwoPrefetchCase extends Bundle {
-  val value: UInt = TwoPrefetchCase.Value()
-
-  def valid: Bool = value.orR
-
-  // select 2 vaddr to read ICacheMetaArray
-  def selectMetaVAddr(reqVec: Vec[PrefetchReqBundle]): Vec[PrunedAddr] =
-    MuxCase(
-      // unable to do 2-prefetch, or isSameLine or isOverlap1, both use req1's start and nextLine
-      VecInit(reqVec(0).startVAddr, reqVec(0).nextLineVAddr),
-      Seq(
-        isOverlap2   -> VecInit(reqVec(1).startVAddr, reqVec(1).nextLineVAddr),
-        isInterleave -> VecInit(reqVec(0).startVAddr, reqVec(1).startVAddr)
-      )
-    )
-
-  // select isCrossLine flag to read ICacheMetaArray
-  def selectIsCrossLine(reqVec: Vec[PrefetchReqBundle]): Bool =
-    MuxCase(
-      // unable to do 2-prefetch, use req1.isCrossLine
-      reqVec(0).isCrossLine,
-      Seq(
-        // if 2 fb are in the same line, read 2 if one of them crosses cacheline
-        isSameLine -> (reqVec(0).isCrossLine || reqVec(1).isCrossLine),
-        // otherwise, we must read 2 cacheline
-        (isOverlap1 || isOverlap2 || isInterleave) -> true.B
-      )
-    )
-
-  // NOTE: refer to object TwoPrefetchCase.Value for explanation
-  def isSameLine: Bool = value(0)
-
-  def isOverlap1: Bool = value(1)
-
-  def isOverlap2: Bool = value(2)
-
-  def isInterleave: Bool = value(3)
-
-  // after read 2 (at most) metaInfo from ICacheMetaArray, broadcast to 2 fetch blocks
-  def generateReqMetaInfo(readInfoVec: Vec[ICacheMetaInfo]): Vec[Vec[ICacheMetaInfo]] =
-    VecInit(
-      VecInit(
-        // if isOverlap2, fb1's first line is fb2's second line and is from port 2, otherwise from port 1
-        Mux(isOverlap2, readInfoVec(1), readInfoVec(0)),
-        // if isOverlap2 or isInterleave, fb1 does not have a second line, otherwise from port 1
-        Mux(isOverlap2 || isInterleave, 0.U.asTypeOf(readInfoVec(0)), readInfoVec(1))
-      ),
-      VecInit(
-        // if isSameLine or isOverlap2, fb2's first line is from port 1, otherwise from port 2
-        Mux(isSameLine || isOverlap2, readInfoVec(0), readInfoVec(1)),
-        // if isOverlap1 or isInterleave, fb2 does not have a second line, otherwise from port 2
-        Mux(isOverlap1 || isInterleave, 0.U.asTypeOf(readInfoVec(0)), readInfoVec(1))
-      )
-    )
-}
-
-object TwoPrefetchCase {
-  def Unable: TwoPrefetchCase = apply(Value.Unable)
-
-  def apply(that: UInt, canAssert: Bool = true.B): TwoPrefetchCase = {
-    when(canAssert) {
-      Value.assertLegal(that)
-    }
-    val twoPrefetchCase = Wire(new TwoPrefetchCase)
-    twoPrefetchCase.value := that
-    twoPrefetchCase
-  }
-
-  def SameLine: TwoPrefetchCase = apply(Value.SameLine)
-
-  def Overlap1: TwoPrefetchCase = apply(Value.Overlap1)
-
-  def Overlap2: TwoPrefetchCase = apply(Value.Overlap2)
-
-  def Interleave: TwoPrefetchCase = apply(Value.Interleave)
-
-  def apply(reqVec: Vec[FtqPrefetchReq], canAssert: Bool): TwoPrefetchCase =
-    TwoPrefetchCase(
-      reqVec(0).vSetIdx(0) === reqVec(1).vSetIdx(0),                                                    // sameLine
-      reqVec(0).isCrossLine && !reqVec(1).isCrossLine && reqVec(0).vSetIdx(1) === reqVec(1).vSetIdx(0), // overlap1
-      !reqVec(0).isCrossLine && reqVec(1).isCrossLine && reqVec(1).vSetIdx(1) === reqVec(0).vSetIdx(0), // overlap2
-      !reqVec(0).isCrossLine && !reqVec(1).isCrossLine && reqVec(0).vSetIdx(0)(0) =/= reqVec(1).vSetIdx(0)(0), // inter
-      canAssert
-    )
-
-  def apply(sameLine: Bool, overlap1: Bool, overlap2: Bool, interleave: Bool, canAssert: Bool): TwoPrefetchCase =
-    apply(VecInit(sameLine, overlap1, overlap2, interleave).asUInt, canAssert)
-
-  private object Value extends EnumUInt(5, useOneHot = true, allowZeroForOneHot = true) {
-    // cannot do 2-prefetch due to SRAM read port conflict
-    def Unable: UInt = 0.U(width.W)
-
-    /* SameLine: 2 fetch block in the same cacheline(s)
-     * |    cacheline0    |    cacheline1    |
-     *      |  fb1             |
-     *          | fb2 |
-     */
-    def SameLine: UInt = 1.U(width.W)
-
-    /* Overlap1: fb2 is in fb1's next line
-     * |    cacheline0    |    cacheline1    |
-     *      |  fb1             |
-     *                       | fb2 |
-     *                       | fb2                | // bad: fb2 cannot cross cacheline
-     */
-    def Overlap1: UInt = 2.U(width.W)
-
-    /* Overlap2: reverse of Overlap1, i.e. fb1 is in fb2's next line
-     */
-    def Overlap2: UInt = 4.U(width.W)
-
-    /* Interleave: 2 fetch block in interleaved cachelines
-     *  |    cacheline(2n)    | ... |    cacheline(2n+1)    |
-     *        | fb1 |
-     *                                   | fb2 |
-     *                                   | fb2                 | // bad: both fb1 and fb2 cannot cross cacheline
-     */
-    def Interleave: UInt = 8.U(width.W)
-  }
-}
-
-class TwoFetchInfo(implicit p: Parameters) extends FtqBundle with HasICacheParameters {
-  val isMmio:  Bool      = Bool()
-  val wayMask: Vec[UInt] = Vec(PortNumber, UInt(nWays.W))
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -280,7 +280,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
     req.backendException := Mux(backendExceptionPtr === pfPtr(i), backendException, ExceptionType.None)
     req.isSoftPrefetch   := false.B
   }
-  io.toICache.toPrefetch.bits.twoPrefetchCase := Mux(canTwoPrefetch, twoPrefetchCase, TwoPrefetchCase.Unable)
+  io.toICache.toPrefetch.bits.twoPrefetchCase := Mux(canTwoPrefetch, twoPrefetchCase, TwoPrefetchCase.Conflict)
 
   private val ifuReqValid = bpuPtr(0) > ifuPtr(0) && !redirect.valid &&
     distanceBetween(ifuPtr(0), commitPtr(0)) < (FtqSize - 1).U
@@ -597,5 +597,17 @@ class Ftq(implicit p: Parameters) extends FtqModule
   XSPerfAccumulate(
     "2prefetch",
     io.toICache.toPrefetch.fire && io.toICache.toPrefetch.bits.twoPrefetchCase.valid
+  )
+  XSPerfSeqAccumulate(
+    "2prefetch_fail_reason",
+    io.toICache.toPrefetch.fire && !io.toICache.toPrefetch.bits.twoPrefetchCase.valid,
+    Seq(
+      ("fb_not_enough", distanceBetween(bpuPtr(0), pfPtr(0)) <= 3.U),
+      ("fb1_exception", backendException.hasException && backendExceptionPtr === pfPtr(0)),
+      ("fb2_exception", backendException.hasException && backendExceptionPtr === pfPtr(1)),
+      ("page_conflict", prefetchReq(0).vPageNumber =/= prefetchReq(1).vPageNumber),
+      ("sram_conflict", twoPrefetchCase.isConflict)
+    ),
+    withPriority = true
   )
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -594,9 +594,12 @@ class Ftq(implicit p: Parameters) extends FtqModule
     "total_commits",
     commit
   )
-  XSPerfAccumulate(
+  XSPerfSeqAccumulate(
     "2prefetch",
-    io.toICache.toPrefetch.fire && io.toICache.toPrefetch.bits.twoPrefetchCase.valid
+    io.toICache.toPrefetch.fire && io.toICache.toPrefetch.bits.twoPrefetchCase.valid,
+    Seq(
+      ("total", true.B)
+    ) ++ io.toICache.toPrefetch.bits.twoPrefetchCase.getValidSeq
   )
   XSPerfSeqAccumulate(
     "2prefetch_fail_reason",

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -256,12 +256,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
     ))
 
   // (io.toICache.toPrefetch.fire && canTwoPrefetch) is passed to apply(..., canAssert) to prevent assert(x-state)
-  private val twoPrefetchCase =
-    TwoPrefetchCase(prefetchReq(0), prefetchReq(1), io.toICache.toPrefetch.fire && canTwoPrefetch)
-
-  private val twoPrefetchValid = twoPrefetchCase.valid && canTwoPrefetch
-//
-//  private val twoPrefetchValid = false.B
+  private val twoPrefetchCase = TwoPrefetchCase(prefetchReq, io.toICache.toPrefetch.fire && canTwoPrefetch)
 
   // FIXME: backend redirect delay should be more than ITLB csr delay
   io.toICache.toPrefetch.valid := (bpuPtr(0) > pfPtr(0) || redirectNext.valid) && !redirect.valid
@@ -283,7 +278,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
     req.backendException := Mux(backendExceptionPtr === pfPtr(i), backendException, ExceptionType.None)
     req.isSoftPrefetch   := false.B
   }
-  io.toICache.toPrefetch.bits.twoPrefetchCase := Mux(twoPrefetchValid, twoPrefetchCase, TwoPrefetchCase.Unable)
+  io.toICache.toPrefetch.bits.twoPrefetchCase := Mux(canTwoPrefetch, twoPrefetchCase, TwoPrefetchCase.Unable)
 
   private val ifuReqValid = bpuPtr(0) > ifuPtr(0) && !redirect.valid &&
     distanceBetween(ifuPtr(0), commitPtr(0)) < (FtqSize - 1).U

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -50,13 +50,16 @@ import xiangshan.frontend.bpu.BpuPredictionSource
 import xiangshan.frontend.bpu.BpuRedirectMeta
 import xiangshan.frontend.bpu.BpuResolveMeta
 import xiangshan.frontend.bpu.HalfAlignHelper
+import xiangshan.frontend.icache.ICacheCacheLineHelper
+import xiangshan.frontend.icache.ICacheToFtqIO
 
 class Ftq(implicit p: Parameters) extends FtqModule
     with HalfAlignHelper
     with HasPerfEvents
     with HasCircularQueuePtrHelper
     with IfuRedirectReceiver
-    with BackendRedirectReceiver {
+    with BackendRedirectReceiver
+    with ICacheCacheLineHelper {
 
   class FtqIO extends FtqBundle {
     val fromBpu: BpuToFtqIO = Flipped(new BpuToFtqIO)
@@ -65,7 +68,8 @@ class Ftq(implicit p: Parameters) extends FtqModule
     val fromIfu: IfuToFtqIO = Flipped(new IfuToFtqIO)
     val toIfu:   FtqToIfuIO = new FtqToIfuIO
 
-    val toICache: FtqToICacheIO = new FtqToICacheIO
+    val fromICache: ICacheToFtqIO = Flipped(new ICacheToFtqIO)
+    val toICache:   FtqToICacheIO = new FtqToICacheIO
 
     val fromBackend: CtrlToFtqIO = Flipped(new CtrlToFtqIO)
     val toBackend:   FtqToCtrlIO = new FtqToCtrlIO
@@ -92,6 +96,8 @@ class Ftq(implicit p: Parameters) extends FtqModule
 
   // entryQueue stores predictions made by BPU.
   private val entryQueue = Reg(Vec(FtqSize, new FtqEntry))
+
+  private val twoFetchInfoVec = Reg(Vec(FtqSize, new TwoFetchInfo))
 
   // metaQueueRedirect stores speculation information needed by BPU when redirect happens.
   private val metaQueueRedirect = Reg(Vec(FtqSize, new BpuRedirectMeta))
@@ -177,6 +183,17 @@ class Ftq(implicit p: Parameters) extends FtqModule
     entryQueue(predictionPtr.value).takenCfiOffset := prediction.bits.takenCfiOffset
   }
 
+  when(io.fromICache.fromPrefetch.valid) {
+    val ftqIdx       = io.fromICache.fromPrefetch.bits.ftqIdx
+    val twoFetchInfo = io.fromICache.fromPrefetch.bits.twoFetchInfo
+    twoFetchInfoVec(ftqIdx.value) := twoFetchInfo(0).bits
+    twoFetchInfoVec((ftqIdx + 1.U).value) := Mux(
+      twoFetchInfo(1).valid,
+      twoFetchInfo(1).bits,
+      0.U.asTypeOf(new TwoFetchInfo)
+    )
+  }
+
   when(io.fromBpu.meta.valid) {
     val s3BpuPtr = io.fromBpu.s3FtqPtr.value
     metaQueueRedirect(s3BpuPtr) := io.fromBpu.meta.bits.redirectMeta
@@ -195,8 +212,9 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // Interaction with ICache and IFU
   // --------------------------------------------------------------------------------
 
-  when(io.toICache.prefetchReq.fire) {
-    pfPtr := pfPtr + 1.U
+  when(io.toICache.toPrefetch.fire) {
+    val twoPrefetchValid = io.toICache.toPrefetch.bits.twoPrefetchCase.valid
+    pfPtr := Mux(twoPrefetchValid, pfPtr + 2.U, pfPtr + 1.U)
   }
   when(io.toIfu.req.fire) {
     ifuPtr := ifuPtr + 1.U
@@ -222,32 +240,54 @@ class Ftq(implicit p: Parameters) extends FtqModule
     }
   }
 
+  // --------------------------------------------------------------------------------
+  // 2-prefetch
+  // --------------------------------------------------------------------------------
+
+  private val prefetchReq = VecInit(
+    Wire(new FtqPrefetchReq).fromFtqEntry(entryQueue(pfPtr(0).value)),
+    Wire(new FtqPrefetchReq).fromFtqEntry(entryQueue(pfPtr(1).value))
+  )
+
+  private val canTwoPrefetch = distanceBetween(bpuPtr(0), pfPtr(0)) >= 3.U &&
+    prefetchReq(0).vPageNumber === prefetchReq(1).vPageNumber &&
+    !(backendException.hasException && (
+      backendExceptionPtr === pfPtr(0) || backendExceptionPtr === pfPtr(1)
+    ))
+
+  // (io.toICache.toPrefetch.fire && canTwoPrefetch) is passed to apply(..., canAssert) to prevent assert(x-state)
+  private val twoPrefetchCase =
+    TwoPrefetchCase(prefetchReq(0), prefetchReq(1), io.toICache.toPrefetch.fire && canTwoPrefetch)
+
+  private val twoPrefetchValid = twoPrefetchCase.valid && canTwoPrefetch
+//
+//  private val twoPrefetchValid = false.B
+
   // FIXME: backend redirect delay should be more than ITLB csr delay
-  io.toICache.prefetchReq.valid := (bpuPtr(0) > pfPtr(0) || redirectNext.valid) && !redirect.valid
-  io.toICache.prefetchReq.bits.startVAddr := Mux(
-    redirectNext.valid,
-    PrunedAddrInit(redirectNext.bits.target),
-    entryQueue(pfPtr(0).value).startPc
-  )
-  io.toICache.prefetchReq.bits.nextCachelineVAddr :=
-    io.toICache.prefetchReq.bits.startVAddr + (CacheLineSize / 8).U
-  io.toICache.prefetchReq.bits.ftqIdx := pfPtr(0)
-  // we don't have takenCfiOffset after redirect
-  io.toICache.prefetchReq.bits.takenCfiOffset := Mux(
-    redirectNext.valid,
-    (FetchBlockInstNum - 1).U, // assume maximum fetch block size
-    entryQueue(pfPtr(0).value).takenCfiOffset.bits
-  )
-  io.toICache.prefetchReq.bits.backendException := Mux(
-    backendExceptionPtr === pfPtr(0),
-    backendException,
-    ExceptionType.None
-  )
+  io.toICache.toPrefetch.valid := (bpuPtr(0) > pfPtr(0) || redirectNext.valid) && !redirect.valid
+  io.toICache.toPrefetch.bits.req.zipWithIndex.foreach { case (req, i) =>
+    req.startVAddr := {
+      if (i == 0)
+        Mux(redirectNext.valid, PrunedAddrInit(redirectNext.bits.target), prefetchReq(i).startVAddr)
+      else
+        prefetchReq(i).startVAddr
+    }
+    req.nextLineVAddr := req.startVAddr + blockBytes.U
+    req.isCrossLine := {
+      if (i == 0)
+        Mux(redirectNext.valid, true.B, prefetchReq(i).isCrossLine)
+      else
+        prefetchReq(i).isCrossLine
+    }
+    req.ftqIdx           := pfPtr(i)
+    req.backendException := Mux(backendExceptionPtr === pfPtr(i), backendException, ExceptionType.None)
+    req.isSoftPrefetch   := false.B
+  }
+  io.toICache.toPrefetch.bits.twoPrefetchCase := Mux(twoPrefetchValid, twoPrefetchCase, TwoPrefetchCase.None)
 
   private val ifuReqValid = bpuPtr(0) > ifuPtr(0) && !redirect.valid &&
     distanceBetween(ifuPtr(0), commitPtr(0)) < (FtqSize - 1).U
 
-  // TODO: consider BPU bypass
   io.toICache.fetchReq.valid                   := ifuReqValid
   io.toICache.fetchReq.bits.startVAddr         := entryQueue(ifuPtr(0).value).startPc
   io.toICache.fetchReq.bits.nextCachelineVAddr := entryQueue(ifuPtr(0).value).startPc + (CacheLineSize / 8).U
@@ -556,5 +596,9 @@ class Ftq(implicit p: Parameters) extends FtqModule
   XSPerfAccumulate(
     "total_commits",
     commit
+  )
+  XSPerfAccumulate(
+    "2prefetch",
+    io.toICache.toPrefetch.fire && io.toICache.toPrefetch.bits.twoPrefetchCase.valid
   )
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -249,7 +249,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
     Wire(new FtqPrefetchReq).fromFtqEntry(entryQueue(pfPtr(1).value))
   )
 
-  private val canTwoPrefetch = distanceBetween(bpuPtr(0), pfPtr(0)) >= 3.U &&
+  private val canTwoPrefetch = distanceBetween(bpuPtr(0), pfPtr(0)) > 3.U &&
     prefetchReq(0).vPageNumber === prefetchReq(1).vPageNumber &&
     !(backendException.hasException && (
       backendExceptionPtr === pfPtr(0) || backendExceptionPtr === pfPtr(1)

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -283,7 +283,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
     req.backendException := Mux(backendExceptionPtr === pfPtr(i), backendException, ExceptionType.None)
     req.isSoftPrefetch   := false.B
   }
-  io.toICache.toPrefetch.bits.twoPrefetchCase := Mux(twoPrefetchValid, twoPrefetchCase, TwoPrefetchCase.None)
+  io.toICache.toPrefetch.bits.twoPrefetchCase := Mux(twoPrefetchValid, twoPrefetchCase, TwoPrefetchCase.Unable)
 
   private val ifuReqValid = bpuPtr(0) > ifuPtr(0) && !redirect.valid &&
     distanceBetween(ifuPtr(0), commitPtr(0)) < (FtqSize - 1).U

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -251,11 +251,23 @@ class Ftq(implicit p: Parameters) extends FtqModule
     Wire(new FtqPrefetchReq).fromFtqEntry(entryQueue(pfPtr(1).value))
   )
 
-  private val canTwoPrefetch = distanceBetween(bpuPtr(0), pfPtr(0)) > 3.U &&
-    prefetchReq(0).vPageNumber === prefetchReq(1).vPageNumber &&
-    !(backendException.hasException && (
-      backendExceptionPtr === pfPtr(0) || backendExceptionPtr === pfPtr(1)
-    ))
+  private val canTwoPrefetch =
+    // magic number 3: to simplify ICache/Ifu bpuFlush logic, we ask the second fetch block to be flushed within Ftq,
+    // i.e. the following 2-prefetch (fb0/1) is safe, as fb1 had passed bpu s3 (which is the last chance of override).
+    // bpu -> | fb4 | fb3 | fb2 | fb1 | fb0 | -> prefetch
+    //        bpuPtr                   pfPtr
+    //      bpu s1    s2    s3
+    // and the following is not, we mark canTwoPrefetch=false
+    // bpu -> | fb3 | fb2 | fb1 | fb0 | -> prefetch
+    //        bpuPtr             pfPtr
+    //      bpu s1    s2    s3
+    // Therefore, we check if distanceBetween(bpuPtr(0), pfPtr(0)) (i.e. bpuPtr - pfPtr) > 3
+    // NOTE: this is not portable, if we change the stage count of Bpu, we need to change this too
+    distanceBetween(bpuPtr(0), pfPtr(0)) > 3.U &&
+      // they also need to be on the same page, to prevent extra itlb port
+      prefetchReq(0).vPageNumber === prefetchReq(1).vPageNumber &&
+      // and they cannot have known exception, otherwise we'll prefetch on the wrong path
+      !(backendException.hasException && (backendExceptionPtr === pfPtr(0) || backendExceptionPtr === pfPtr(1)))
 
   // (io.toICache.toPrefetch.fire && canTwoPrefetch) is passed to apply(..., canAssert) to prevent assert(x-state)
   private val twoPrefetchCase = TwoPrefetchCase(prefetchReq, io.toICache.toPrefetch.fire && canTwoPrefetch)

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -45,6 +45,8 @@ import xiangshan.frontend.FtqToICacheIO
 import xiangshan.frontend.FtqToIfuIO
 import xiangshan.frontend.IfuToFtqIO
 import xiangshan.frontend.PrunedAddrInit
+import xiangshan.frontend.TwoFetchInfo
+import xiangshan.frontend.TwoPrefetchCase
 import xiangshan.frontend.bpu.BpuCommitMeta
 import xiangshan.frontend.bpu.BpuPredictionSource
 import xiangshan.frontend.bpu.BpuRedirectMeta

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -267,8 +267,8 @@ class WayLookupExceptionEntry(implicit p: Parameters) extends ICacheBundle {
 }
 
 class WayLookupBundle(implicit p: Parameters) extends ICacheBundle {
-  val entry          = new WayLookupEntry
-  val exceptionEntry = new WayLookupExceptionEntry
+  val entry:          WayLookupEntry          = new WayLookupEntry
+  val exceptionEntry: WayLookupExceptionEntry = new WayLookupExceptionEntry
 
   // for compatibility
   def vSetIdx:           Vec[UInt]     = entry.vSetIdx

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -25,9 +25,11 @@ import xiangshan.backend.fu.PMPReqBundle
 import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.cache.mmu.Pbmt
 import xiangshan.frontend.ExceptionType
-import xiangshan.frontend.FtqPrefetchRequest
+import xiangshan.frontend.FtqFetchRequest
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.ftq.FtqPtr
+import xiangshan.frontend.ftq.TwoFetchInfo
+import xiangshan.frontend.ftq.TwoPrefetchCase
 
 /* ***
  * Naming:
@@ -153,6 +155,7 @@ class DataReadBundle(implicit p: Parameters) extends ICacheBundle {
     val datas: Vec[UInt] = Vec(DataBanks, UInt(ICacheDataBits.W))
     val codes: Vec[UInt] = Vec(DataBanks, UInt(DataEccBits.W))
   }
+
   val req:  DecoupledIO[DataReadReqBundle] = DecoupledIO(new DataReadReqBundle)
   val resp: DataReadRespBundle             = Input(new DataReadRespBundle)
 }
@@ -201,32 +204,26 @@ class ICacheRespBundle(implicit p: Parameters) extends ICacheBundle {
   val isForVSnonLeafPTE: Bool       = Bool()
 }
 
+class MainPipeToIfuIO(implicit p: Parameters) extends ICacheBundle {
+  val req: DecoupledIO[Vec[FtqFetchRequest]] = Decoupled(Vec(MaxFetchReqNum, new FtqFetchRequest))
+}
+
 /* ***** PrefetchPipe ***** */
 class PrefetchReqBundle(implicit p: Parameters) extends ICacheBundle {
-  val startAddr:        PrunedAddr    = PrunedAddr(VAddrBits)
-  val nextlineStart:    PrunedAddr    = PrunedAddr(VAddrBits)
-  val crossCacheline:   Bool          = Bool()
+  val startVAddr:       PrunedAddr    = PrunedAddr(VAddrBits)
+  val nextLineVAddr:    PrunedAddr    = PrunedAddr(VAddrBits)
+  val isCrossLine:      Bool          = Bool()
   val ftqIdx:           FtqPtr        = new FtqPtr
   val backendException: ExceptionType = new ExceptionType
   val isSoftPrefetch:   Bool          = Bool()
 
-  def fromFtqPrefetch(req: FtqPrefetchRequest): PrefetchReqBundle = {
-    this.startAddr        := req.startVAddr
-    this.nextlineStart    := req.nextCachelineVAddr
-    this.crossCacheline   := req.crossCacheline
-    this.ftqIdx           := req.ftqIdx
-    this.backendException := req.backendException
-    this.isSoftPrefetch   := false.B
-    this
-  }
-
   def fromSoftPrefetch(req: SoftIfetchPrefetchBundle): PrefetchReqBundle = {
-    this.startAddr        := req.vaddr
-    this.nextlineStart    := DontCare
-    this.crossCacheline   := false.B // prefetch only one line for a prefetch.i instruction
-    this.ftqIdx           := DontCare
-    this.backendException := ExceptionType.None
-    this.isSoftPrefetch   := true.B
+    startVAddr       := req.vaddr
+    nextLineVAddr    := DontCare
+    isCrossLine      := false.B // prefetch only one line for a prefetch.i instruction
+    ftqIdx           := DontCare
+    backendException := ExceptionType.None
+    isSoftPrefetch   := true.B
     this
   }
 }
@@ -245,6 +242,8 @@ class WayLookupEntry(implicit p: Parameters) extends ICacheBundle {
   val metaCodes:   Vec[UInt] = Vec(PortNumber, UInt(MetaEccBits.W))
   val pTag:        UInt      = UInt(tagBits.W)
   val itlbPbmt:    UInt      = UInt(Pbmt.width.W)
+
+  val debug_startVAddr: PrunedAddr = PrunedAddr(VAddrBits)
 
   def getMetaInfo(i: Int): MetaInfo = {
     val info = Wire(new MetaInfo)
@@ -379,4 +378,13 @@ class PrefetchPipePerfInfo(implicit p: Parameters) extends ICacheBundle {
 // inner WayLookup -> top
 class WayLookupPerfInfo(implicit p: Parameters) extends ICacheBundle {
   val empty: Bool = Bool()
+}
+
+class PrefetchToFtqBundle(implicit p: Parameters) extends ICacheBundle {
+  val ftqIdx:       FtqPtr                   = new FtqPtr
+  val twoFetchInfo: Vec[Valid[TwoFetchInfo]] = Vec(2, Valid(new TwoFetchInfo))
+}
+
+class ICacheToFtqIO(implicit p: Parameters) extends ICacheBundle {
+  val fromPrefetch: Valid[PrefetchToFtqBundle] = Valid(new PrefetchToFtqBundle)
 }

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -27,9 +27,8 @@ import xiangshan.cache.mmu.Pbmt
 import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.FtqFetchRequest
 import xiangshan.frontend.PrunedAddr
+import xiangshan.frontend.TwoFetchInfo
 import xiangshan.frontend.ftq.FtqPtr
-import xiangshan.frontend.ftq.TwoFetchInfo
-import xiangshan.frontend.ftq.TwoPrefetchCase
 
 /* ***
  * Naming:

--- a/src/main/scala/xiangshan/frontend/icache/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Helpers.scala
@@ -131,8 +131,30 @@ trait ICacheDataHelper extends HasICacheParameters {
     )
   }
 
+  def getBankSel(startPc: PrunedAddr, takenCfiOffset: UInt): (Bool, Vec[UInt]) = {
+    val blockOffset        = startPc(blockOffBits - 1, 0)
+    val blockEndOffsetTemp = blockOffset +& Cat(takenCfiOffset, 0.U(instOffsetBits.W))
+    val blockEndOffset     = blockEndOffsetTemp(blockOffBits - 1, 0)
+    val isCrossLine        = blockEndOffsetTemp(blockOffBits)
+    val bankIdxLow         = getBankIdx(blockOffset)
+    val bankIdxHigh        = getBankIdx(blockEndOffset)
+    val bankSel = VecInit(
+      // first line: if in same line, select [low, high], else select [low, end]
+      VecInit((0 until DataBanks).map(i => (i.U >= bankIdxLow) && (isCrossLine || i.U <= bankIdxHigh))).asUInt,
+      // second line: if in same line, select nothing, else select [start, high]
+      VecInit((0 until DataBanks).map(i => (i.U <= bankIdxHigh) && isCrossLine)).asUInt
+    )
+    (isCrossLine, bankSel)
+  }
+
   def getLineSel(blkOffset: UInt): Vec[Bool] = {
     val bankIdxLow = getBankIdx(blkOffset)
+    VecInit((0 until DataBanks).map(i => i.U < bankIdxLow))
+  }
+
+  def getLineSel(startPc: PrunedAddr): Vec[Bool] = {
+    val blockOffset = startPc(blockOffBits - 1, 0)
+    val bankIdxLow  = getBankIdx(blockOffset)
     VecInit((0 until DataBanks).map(i => i.U < bankIdxLow))
   }
 }
@@ -140,6 +162,9 @@ trait ICacheDataHelper extends HasICacheParameters {
 trait ICacheAddrHelper extends HasICacheParameters {
   def getBlkAddrFromPTag(vAddr: PrunedAddr, pTag: UInt): UInt =
     Cat(pTag, vAddr(pgUntagBits - 1, blockOffBits))
+
+  def getGPAddr(gpAddrFromItlb: UInt, vAddr: PrunedAddr): UInt =
+    Cat(gpAddrFromItlb(PAddrBitsMax - 1, PageOffsetWidth), vAddr(PageOffsetWidth - 1, 0))
 
   def getPTagFromBlk(blkAddr: UInt): UInt =
     (blkAddr >> (pgUntagBits - blockOffBits)).asUInt

--- a/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
@@ -200,8 +200,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   wayLookup.io.flush        := io.fromFtq.redirectFlush
   wayLookup.io.flushFromBpu := io.fromFtq.flushFromBpu
   wayLookup.io.write <> prefetcher.io.wayLookupWrite
-  wayLookup.io.secondWriteValid := prefetcher.io.secondWriteValid
-  wayLookup.io.update           := missUnit.io.resp
+  wayLookup.io.update := missUnit.io.resp
 
   replacer.io.touch <> mainPipe.io.replacerTouch
   replacer.io.victim <> missUnit.io.victim

--- a/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
@@ -43,6 +43,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
     val hartId: UInt = Input(UInt(hartIdLen.W))
     // FTQ
     val fromFtq: FtqToICacheIO = Flipped(new FtqToICacheIO)
+    val toFtq:   ICacheToFtqIO = new ICacheToFtqIO
     // memblock
     val softPrefetchReq: Vec[Valid[SoftIfetchPrefetchBundle]] =
       Vec(backendParams.LduCnt, Flipped(Valid(new SoftIfetchPrefetchBundle)))
@@ -167,17 +168,15 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
       0.U.asTypeOf(new SoftIfetchPrefetchBundle),
       io.softPrefetchReq.map(req => req.valid -> req.bits)
     ))
-  }.elsewhen(prefetcher.io.req.fire) {
+  }.elsewhen(prefetcher.io.fromFtq.fire) {
     softPrefetchValid := false.B
   }
-  // pass ftqPrefetch
-  private val ftqPrefetch = WireInit(0.U.asTypeOf(new PrefetchReqBundle))
-  ftqPrefetch.fromFtqPrefetch(io.fromFtq.prefetchReq.bits)
   // software prefetch has higher priority
-  prefetcher.io.req.valid                 := softPrefetchValid || io.fromFtq.prefetchReq.valid
-  prefetcher.io.req.bits                  := Mux(softPrefetchValid, softPrefetch, ftqPrefetch)
-  prefetcher.io.req.bits.backendException := io.fromFtq.prefetchReq.bits.backendException
-  io.fromFtq.prefetchReq.ready            := prefetcher.io.req.ready && !softPrefetchValid
+  prefetcher.io.fromFtq.valid       := softPrefetchValid || io.fromFtq.toPrefetch.valid
+  prefetcher.io.fromFtq.bits        := io.fromFtq.toPrefetch.bits
+  prefetcher.io.fromFtq.bits.req(0) := Mux(softPrefetchValid, softPrefetch, io.fromFtq.toPrefetch.bits.req(0))
+  io.fromFtq.toPrefetch.ready       := prefetcher.io.fromFtq.ready && !softPrefetchValid
+  io.toFtq.fromPrefetch             := prefetcher.io.toFtq
 
   missUnit.io.hartId := io.hartId
   missUnit.io.fencei := io.fencei
@@ -201,7 +200,8 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   wayLookup.io.flush        := io.fromFtq.redirectFlush
   wayLookup.io.flushFromBpu := io.fromFtq.flushFromBpu
   wayLookup.io.write <> prefetcher.io.wayLookupWrite
-  wayLookup.io.update := missUnit.io.resp
+  wayLookup.io.secondWriteValid := prefetcher.io.secondWriteValid
+  wayLookup.io.update           := missUnit.io.resp
 
   replacer.io.touch <> mainPipe.io.replacerTouch
   replacer.io.victim <> missUnit.io.victim
@@ -249,10 +249,10 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
 
   XSPerfAccumulate(
     "softPrefetch_drop_not_ready",
-    io.softPrefetchReq.map(_.valid).reduce(_ || _) && softPrefetchValid && !prefetcher.io.req.fire
+    io.softPrefetchReq.map(_.valid).reduce(_ || _) && softPrefetchValid && !prefetcher.io.fromFtq.fire
   )
   XSPerfAccumulate("softPrefetch_drop_multi_req", PopCount(io.softPrefetchReq.map(_.valid)) > 1.U)
-  XSPerfAccumulate("softPrefetch_block_ftq", softPrefetchValid && io.fromFtq.prefetchReq.valid)
+  XSPerfAccumulate("softPrefetch_block_ftq", softPrefetchValid && io.fromFtq.toPrefetch.valid)
 
   val perfEvents: Seq[(String, Bool)] = Seq(
     (

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -20,7 +20,6 @@ import chisel3.util._
 import difftest.DiffRefillEvent
 import difftest.DifftestModule
 import org.chipsalliance.cde.config.Parameters
-import utility.BoolStopWatch
 import utility.ChiselDB
 import utility.DataHoldBypass
 import utility.ValidHold

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMetaArray.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMetaArray.scala
@@ -38,13 +38,13 @@ class ICacheMetaArray(implicit p: Parameters) extends ICacheModule with ICacheAd
 
   /* *** read *** */
   // vSetIdx(1) must be vSetIdx(0) + 1 if isDoubleLine, it's pre-computed in Ftq for better timing (maybe)
-  assert(
-    !(
-      io.read.req.valid && io.read.req.bits.isDoubleLine &&
-        io.read.req.bits.vSetIdx(0) + 1.U =/= io.read.req.bits.vSetIdx(1)
-    ),
-    "2 read setIdx must be adjacent!"
-  )
+//  assert(
+//    !(
+//      io.read.req.valid && io.read.req.bits.isDoubleLine &&
+//        io.read.req.bits.vSetIdx(0) + 1.U =/= io.read.req.bits.vSetIdx(1)
+//    ),
+//    "2 read setIdx must be adjacent!"
+//  )
 
   // rotate setIdxVec to match interleaved banking
   // e.g. 2-interleaved, if vSetIdx(0) is even (getInterleavedBankIdx == 0), we don't need to rotate

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMetaArray.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMetaArray.scala
@@ -37,6 +37,15 @@ class ICacheMetaArray(implicit p: Parameters) extends ICacheModule with ICacheAd
   private val banks = Seq.tabulate(PortNumber)(i => Module(new ICacheMetaInterleavedBank(i)))
 
   /* *** read *** */
+  // the two setIdx must locate in interleaved banks
+  assert(
+    !(
+      io.read.req.valid && io.read.req.bits.isDoubleLine &&
+        getInterleavedBankIdx(io.read.req.bits.vSetIdx(0)) === getInterleavedBankIdx(io.read.req.bits.vSetIdx(1))
+    ),
+    "2 read setIdx must be in the different interleaved bank!"
+  )
+
   // rotate setIdxVec to match interleaved banking
   // e.g. 2-interleaved, if vSetIdx(0) is even (getInterleavedBankIdx == 0), we don't need to rotate
   //      i.e. vSetIdx(0) goes to bank0, vSetIdx(1) goes to bank1

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMetaArray.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMetaArray.scala
@@ -37,15 +37,6 @@ class ICacheMetaArray(implicit p: Parameters) extends ICacheModule with ICacheAd
   private val banks = Seq.tabulate(PortNumber)(i => Module(new ICacheMetaInterleavedBank(i)))
 
   /* *** read *** */
-  // vSetIdx(1) must be vSetIdx(0) + 1 if isDoubleLine, it's pre-computed in Ftq for better timing (maybe)
-//  assert(
-//    !(
-//      io.read.req.valid && io.read.req.bits.isDoubleLine &&
-//        io.read.req.bits.vSetIdx(0) + 1.U =/= io.read.req.bits.vSetIdx(1)
-//    ),
-//    "2 read setIdx must be adjacent!"
-//  )
-
   // rotate setIdxVec to match interleaved banking
   // e.g. 2-interleaved, if vSetIdx(0) is even (getInterleavedBankIdx == 0), we don't need to rotate
   //      i.e. vSetIdx(0) goes to bank0, vSetIdx(1) goes to bank1

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -19,22 +19,22 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.DataHoldBypass
-import utility.PriorityMuxDefault
 import utility.ValidHold
 import utility.XSPerfAccumulate
 import utils.EnumUInt
 import xiangshan.cache.mmu.Pbmt
 import xiangshan.cache.mmu.TlbCmd
 import xiangshan.cache.mmu.TlbRequestIO
-import xiangshan.cache.mmu.ValidHoldBypass // FIXME: should move this to utility?
+import xiangshan.cache.mmu.ValidHoldBypass
 import xiangshan.frontend.ExceptionType
-import xiangshan.frontend.PrunedAddrInit
 import xiangshan.frontend.ftq.BpuFlushInfo
+import xiangshan.frontend.ftq.FtqToPrefetchBundle
 
 class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     with ICacheAddrHelper
     with ICacheMetaHelper
-    with ICacheMissUpdateHelper {
+    with ICacheMissUpdateHelper
+    with ICacheDataHelper {
 
   class ICachePrefetchPipeIO(implicit p: Parameters) extends ICacheBundle {
     // control
@@ -42,15 +42,17 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     val eccEnable:   Bool = Input(Bool())
     val flush:       Bool = Input(Bool())
 
-    val req:            DecoupledIO[PrefetchReqBundle]    = Flipped(Decoupled(new PrefetchReqBundle))
-    val flushFromBpu:   BpuFlushInfo                      = Flipped(new BpuFlushInfo)
-    val itlb:           TlbRequestIO                      = new TlbRequestIO
-    val itlbFlushPipe:  Bool                              = Output(Bool())
-    val pmp:            PmpCheckBundle                    = new PmpCheckBundle
-    val metaRead:       MetaReadBundle                    = new MetaReadBundle
-    val missReq:        DecoupledIO[MissReqBundle]        = DecoupledIO(new MissReqBundle)
-    val missResp:       Valid[MissRespBundle]             = Flipped(ValidIO(new MissRespBundle))
-    val wayLookupWrite: DecoupledIO[WayLookupWriteBundle] = DecoupledIO(new WayLookupWriteBundle)
+    val fromFtq:          DecoupledIO[FtqToPrefetchBundle]       = Flipped(Decoupled(new FtqToPrefetchBundle))
+    val toFtq:            Valid[PrefetchToFtqBundle]             = Valid(new PrefetchToFtqBundle)
+    val flushFromBpu:     BpuFlushInfo                           = Flipped(new BpuFlushInfo)
+    val itlb:             TlbRequestIO                           = new TlbRequestIO
+    val itlbFlushPipe:    Bool                                   = Output(Bool())
+    val pmp:              PmpCheckBundle                         = new PmpCheckBundle
+    val metaRead:         MetaReadBundle                         = new MetaReadBundle
+    val missReq:          DecoupledIO[MissReqBundle]             = DecoupledIO(new MissReqBundle)
+    val missResp:         Valid[MissRespBundle]                  = Flipped(ValidIO(new MissRespBundle))
+    val wayLookupWrite:   DecoupledIO[Vec[WayLookupWriteBundle]] = DecoupledIO(Vec(2, new WayLookupWriteBundle))
+    val secondWriteValid: Bool                                   = Output(Bool())
 
     val perf: PrefetchPipePerfInfo = Output(new PrefetchPipePerfInfo)
   }
@@ -76,27 +78,41 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     * - 3. send req to Meta SRAM
     ******************************************************************************
     */
-  private val s0_valid = io.req.valid
+  private val s0_valid = io.fromFtq.valid
 
   /**
     ******************************************************************************
     * receive ftq req
     ******************************************************************************
     */
-  private val s0_vAddr            = VecInit(Seq(io.req.bits.startAddr, io.req.bits.nextlineStart))
-  private val s0_ftqIdx           = io.req.bits.ftqIdx
-  private val s0_isSoftPrefetch   = io.req.bits.isSoftPrefetch
-  private val s0_doubleline       = io.req.bits.crossCacheline
-  private val s0_vSetIdx          = VecInit(s0_vAddr.map(get_idx))
-  private val s0_backendException = io.req.bits.backendException
+  private val s0_req              = io.fromFtq.bits.req
+  private val s0_ftqIdx           = s0_req(0).ftqIdx
+  private val s0_isSoftPrefetch   = s0_req(0).isSoftPrefetch
+  private val s0_backendException = s0_req(0).backendException
+  private val s0_twoPrefetchCase  = io.fromFtq.bits.twoPrefetchCase
+
+  private val s0_readMetaVAddr = MuxCase(
+    VecInit(s0_req(0).startVAddr, s0_req(0).nextLineVAddr),
+    Seq(
+      s0_twoPrefetchCase.isCase3 -> VecInit(s0_req(1).startVAddr, s0_req(1).nextLineVAddr),
+      s0_twoPrefetchCase.isCase4 -> VecInit(s0_req(0).startVAddr, s0_req(1).startVAddr)
+    )
+  )
+  private val s0_readMetaSetIdx = VecInit(get_idx(s0_readMetaVAddr(0)), get_idx(s0_readMetaVAddr(1)))
+  private val s0_readDoubleLine = MuxCase(
+    s0_req(0).isCrossLine,
+    Seq(
+      s0_twoPrefetchCase.isCase1 -> (s0_req(0).isCrossLine || s0_req(1).isCrossLine),
+      (s0_twoPrefetchCase.isCase2 || s0_twoPrefetchCase.isCase3 || s0_twoPrefetchCase.isCase4) -> true.B
+    )
+  )
 
   fromBpuS0Flush := !s0_isSoftPrefetch && io.flushFromBpu.shouldFlushByStage3(s0_ftqIdx, s0_valid)
   s0_flush       := io.flush || fromBpuS0Flush || s1_flush
 
-  private val s0_canGo = s1_ready && toItlb.ready && toMeta.ready
-  io.req.ready := s0_canGo
+  io.fromFtq.ready := s1_ready && toItlb.ready && toMeta.ready && !s0_flush
 
-  s0_fire := s0_valid && s0_canGo && !s0_flush
+  s0_fire := io.fromFtq.fire
 
   /**
     ******************************************************************************
@@ -109,12 +125,15 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     */
   private val s1_valid = ValidHold(s0_fire, s1_fire, s1_flush)
 
-  private val s1_vAddr            = RegEnable(s0_vAddr, 0.U.asTypeOf(s0_vAddr), s0_fire)
+  private val s1_req              = RegEnable(s0_req, 0.U.asTypeOf(s0_req), s0_fire)
   private val s1_isSoftPrefetch   = RegEnable(s0_isSoftPrefetch, 0.U.asTypeOf(s0_isSoftPrefetch), s0_fire)
-  private val s1_doubleline       = RegEnable(s0_doubleline, 0.U.asTypeOf(s0_doubleline), s0_fire)
   private val s1_ftqIdx           = RegEnable(s0_ftqIdx, 0.U.asTypeOf(s0_ftqIdx), s0_fire)
-  private val s1_vSetIdx          = VecInit(s1_vAddr.map(get_idx))
   private val s1_backendException = RegEnable(s0_backendException, 0.U.asTypeOf(s0_backendException), s0_fire)
+
+  private val s1_twoPrefetchCase = RegEnable(s0_twoPrefetchCase, s0_fire)
+  private val s1_readMetaVAddr   = RegEnable(s0_readMetaVAddr, s0_fire)
+  private val s1_readMetaSetIdx  = RegEnable(s0_readMetaSetIdx, s0_fire)
+  private val s1_readDoubleLine  = RegEnable(s0_readDoubleLine, s0_fire)
 
   private def nS1FsmState: Int = 5
   private object S1FsmState extends EnumUInt(nS1FsmState) {
@@ -156,8 +175,8 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   toItlb.valid             := s1_needItlb || s0_valid
   toItlb.bits              := DontCare
   toItlb.bits.size         := 3.U
-  toItlb.bits.vaddr        := Mux(s1_needItlb, s1_vAddr.head.toUInt, s0_vAddr.head.toUInt)
-  toItlb.bits.debug.pc     := Mux(s1_needItlb, s1_vAddr.head.toUInt, s0_vAddr.head.toUInt)
+  toItlb.bits.vaddr        := Mux(s1_needItlb, s1_readMetaVAddr(0).toUInt, s0_readMetaVAddr(0).toUInt)
+  toItlb.bits.debug.pc     := Mux(s1_needItlb, s1_readMetaVAddr(0).toUInt, s0_readMetaVAddr(0).toUInt)
   toItlb.bits.cmd          := TlbCmd.exec
   toItlb.bits.no_translate := false.B
   fromItlb.ready           := true.B
@@ -168,8 +187,9 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     * Receive resp from Itlb
     ******************************************************************************
     */
-  private val s1_pTag =
-    DataHoldBypass(get_phy_tag(fromItlb.bits.paddr.head), 0.U(tagBits.W), tlbValidPulse)
+
+  // two blocks use same pTag (Note: untagBits must >= 12)
+  private val s1_pTag = DataHoldBypass(get_phy_tag(fromItlb.bits.paddr.head), 0.U(tagBits.W), tlbValidPulse)
 
   private val s1_itlbExceptionRaw =
     DataHoldBypass(ExceptionType.fromTlbResp(fromItlb.bits), ExceptionType.None, tlbValidPulse)
@@ -177,7 +197,10 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
   // Guest page fault related: save tlb raw response, select later
   // NOTE: we don't use GPAddrBits or XLEN here, refer to ICacheMainPipe.scala L43-48 and PR#3795
-  private val s1_gpAddr = DataHoldBypass(fromItlb.bits.gpaddr.head, 0.U(PAddrBitsMax.W), tlbValidPulse)
+  private val s1_gpAddr = VecInit(
+    DataHoldBypass(getGPAddr(fromItlb.bits.gpaddr.head, s1_req(0).startVAddr), 0.U(PAddrBitsMax.W), tlbValidPulse),
+    DataHoldBypass(getGPAddr(fromItlb.bits.gpaddr.head, s1_req(1).startVAddr), 0.U(PAddrBitsMax.W), tlbValidPulse)
+  )
   private val s1_isForVSnonLeafPTE =
     DataHoldBypass(
       fromItlb.bits.isForVSnonLeafPTE,
@@ -200,8 +223,8 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     */
   private val s1_needMeta = ((s1_state === S1FsmState.ItlbResend) && tlbFinish) || (s1_state === S1FsmState.MetaResend)
   toMeta.valid             := s1_needMeta || s0_valid
-  toMeta.bits.isDoubleLine := Mux(s1_needMeta, s1_doubleline, s0_doubleline)
-  toMeta.bits.vSetIdx      := Mux(s1_needMeta, s1_vSetIdx, s0_vSetIdx)
+  toMeta.bits.isDoubleLine := Mux(s1_needMeta, s1_readDoubleLine, s0_readDoubleLine)
+  toMeta.bits.vSetIdx      := Mux(s1_needMeta, s1_readMetaSetIdx, s0_readMetaSetIdx)
 
   /**
     ******************************************************************************
@@ -238,10 +261,10 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     ******************************************************************************
     */
 
-  private val s1_sramValid = VecInit(Seq(
+  private val s1_sramValid = VecInit(
     s0_fireNext || RegNext(s1_needMeta && toMeta.ready),
-    (s0_fireNext || RegNext(s1_needMeta && toMeta.ready)) && s1_doubleline
-  ))
+    (s0_fireNext || RegNext(s1_needMeta && toMeta.ready)) && s1_readDoubleLine
+  )
   private val s1_mshrValid = fromMiss.valid && !fromMiss.bits.corrupt
 
   private val s1_metaInfo = Wire(Vec(PortNumber, new MetaInfo))
@@ -253,7 +276,7 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   s1_metaInfo.zipWithIndex.foreach { case (info, i) =>
     val (_, newInfo) = updateMetaInfo(
       fromMiss,
-      s1_vSetIdx(i),
+      s1_readMetaSetIdx(i),
       s1_pTag,
       Mux(s1_sramValid(i), s1_sramMetaInfo(i), s1_metaInfoReg(i))
     )
@@ -262,40 +285,82 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
   private val s1_sramHits = VecInit(s1_metaInfo.map(_.waymask.orR))
 
+  private val s1_reqMetaInfo = VecInit(
+    Mux(
+      s1_twoPrefetchCase.isCase3,
+      VecInit(s1_metaInfo(1), 0.U.asTypeOf(new MetaInfo)),
+      s1_metaInfo
+    ),
+    Mux(
+      s1_twoPrefetchCase.isCase2 || s1_twoPrefetchCase.isCase4,
+      VecInit(s1_metaInfo(1), 0.U.asTypeOf(new MetaInfo)),
+      s1_metaInfo
+    )
+  )
+
+  dontTouch(s1_metaInfo)
+  dontTouch(s1_reqMetaInfo)
+
   /**
     ******************************************************************************
     * send enqueue req to ICacheWayLookup
     ******** **********************************************************************
     */
+
+  private val s1_reqSetIdx = VecInit(
+    VecInit(get_idx(s1_req(0).startVAddr), get_idx(s1_req(0).nextLineVAddr)),
+    VecInit(get_idx(s1_req(1).startVAddr), get_idx(s1_req(1).nextLineVAddr))
+  )
+
   // Disallow enqueuing wayLookup when SRAM write occurs.
   toWayLookup.valid := (
     (s1_state === S1FsmState.EnqWay) ||
       ((s1_state === S1FsmState.Idle) && tlbFinish)
   ) && !s1_flush && !fromMiss.valid && !s1_isSoftPrefetch // do not enqueue soft prefetch
-  toWayLookup.bits.ftqIdx            := s1_ftqIdx
-  toWayLookup.bits.vSetIdx           := s1_vSetIdx
-  toWayLookup.bits.waymask           := VecInit(s1_metaInfo.map(_.waymask))
-  toWayLookup.bits.pTag              := s1_pTag
-  toWayLookup.bits.maybeRvcMap       := VecInit(s1_metaInfo.map(_.maybeRvcMap))
-  toWayLookup.bits.gpAddr            := s1_gpAddr(PAddrBitsMax - 1, 0)
-  toWayLookup.bits.isForVSnonLeafPTE := s1_isForVSnonLeafPTE
-  toWayLookup.bits.metaCodes         := VecInit(s1_metaInfo.map(_.metaCodes))
-  toWayLookup.bits.itlbException     := s1_itlbException
-  toWayLookup.bits.itlbPbmt          := s1_itlbPbmt
+  toWayLookup.bits.zipWithIndex.foreach { case (toWayLookup, i) =>
+    toWayLookup.entry.debug_startVAddr := s1_req(i).startVAddr
+    toWayLookup.ftqIdx                 := s1_req(i).ftqIdx
+    toWayLookup.vSetIdx                := VecInit(get_idx(s1_req(i).startVAddr), get_idx(s1_req(i).nextLineVAddr))
+    toWayLookup.waymask                := VecInit(s1_reqMetaInfo(i).map(_.waymask))
+    toWayLookup.pTag                   := s1_pTag
+    toWayLookup.maybeRvcMap            := VecInit(s1_reqMetaInfo(i).map(_.maybeRvcMap))
+    toWayLookup.gpAddr                 := s1_gpAddr(i)(PAddrBitsMax - 1, 0)
+    toWayLookup.isForVSnonLeafPTE      := s1_isForVSnonLeafPTE
+    toWayLookup.metaCodes              := VecInit(s1_reqMetaInfo(i).map(_.metaCodes))
+    toWayLookup.itlbException          := s1_itlbException
+    toWayLookup.itlbPbmt               := s1_itlbPbmt
+  }
+  io.secondWriteValid := s1_twoPrefetchCase.valid
 
   when(toWayLookup.fire) {
-    val waymasksVec = s1_metaInfo.map(_.waymask.asTypeOf(Vec(nWays, Bool())))
+    val waymasksVec = s1_reqMetaInfo(0).map(_.waymask.asTypeOf(Vec(nWays, Bool())))
     assert(
-      PopCount(waymasksVec(0)) <= 1.U && (PopCount(waymasksVec(1)) <= 1.U || !s1_doubleline),
+      PopCount(waymasksVec(0)) <= 1.U && (PopCount(waymasksVec(1)) <= 1.U || !s1_req(0).isCrossLine),
       "Multi-hit:\nport0: count=%d pTag=0x%x vSet=0x%x vAddr=0x%x\nport1: count=%d pTag=0x%x vSet=0x%x vAddr=0x%x",
-      PopCount(waymasksVec(0)) > 1.U,
+      PopCount(waymasksVec(0)),
       s1_pTag,
-      get_idx(s1_vAddr(0)),
-      s1_vAddr(0).toUInt,
-      PopCount(waymasksVec(1)) > 1.U && s1_doubleline,
+      s1_reqSetIdx(0)(0),
+      s1_req(0).startVAddr.toUInt,
+      PopCount(waymasksVec(1)),
       s1_pTag,
-      get_idx(s1_vAddr(1)),
-      s1_vAddr(1).toUInt
+      s1_reqSetIdx(0)(1),
+      s1_req(0).nextLineVAddr.toUInt // FIXME
+    )
+  }
+
+  when(toWayLookup.fire && s1_twoPrefetchCase.valid) {
+    val waymasksVec = s1_reqMetaInfo(1).map(_.waymask.asTypeOf(Vec(nWays, Bool())))
+    assert(
+      PopCount(waymasksVec(0)) <= 1.U && (PopCount(waymasksVec(1)) <= 1.U || !s1_req(1).isCrossLine),
+      "Multi-hit:\nport0: count=%d pTag=0x%x vSet=0x%x vAddr=0x%x\nport1: count=%d pTag=0x%x vSet=0x%x vAddr=0x%x",
+      PopCount(waymasksVec(0)),
+      s1_pTag,
+      s1_reqSetIdx(1)(0),
+      s1_req(1).startVAddr.toUInt,
+      PopCount(waymasksVec(1)),
+      s1_pTag,
+      s1_reqSetIdx(1)(1),
+      s1_req(1).nextLineVAddr.toUInt // FIXME
     )
   }
 
@@ -306,7 +371,7 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     */
   // if itlb has exception, pAddr can be invalid, therefore pmp check can be skipped
   toPmp.valid     := s1_valid // !ExceptionType.hasException(s1_itlbException(i)) // bad for timing
-  toPmp.bits.addr := getPAddrFromPTag(s1_vAddr.head, s1_pTag).toUInt
+  toPmp.bits.addr := getPAddrFromPTag(s1_req(0).startVAddr, s1_pTag).toUInt
   toPmp.bits.size := 3.U
   toPmp.bits.cmd  := TlbCmd.exec
   private val s1_pmpException = ExceptionType.fromPmpResp(fromPmp)
@@ -318,6 +383,15 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
   // merge pmp mmio and itlb pbmt
   private val s1_isMmio = s1_pmpMmio || Pbmt.isUncache(s1_itlbPbmt)
+
+  io.toFtq.valid                             := s1_fire
+  io.toFtq.bits.ftqIdx                       := s1_ftqIdx
+  io.toFtq.bits.twoFetchInfo(0).valid        := true.B
+  io.toFtq.bits.twoFetchInfo(0).bits.isMmio  := s1_isMmio
+  io.toFtq.bits.twoFetchInfo(0).bits.wayMask := VecInit(s1_reqMetaInfo(0).map(_.waymask))
+  io.toFtq.bits.twoFetchInfo(1).valid        := s1_twoPrefetchCase.valid
+  io.toFtq.bits.twoFetchInfo(1).bits.isMmio  := s1_isMmio
+  io.toFtq.bits.twoFetchInfo(1).bits.wayMask := VecInit(s1_reqMetaInfo(1).map(_.waymask))
 
   /**
     ******************************************************************************
@@ -390,16 +464,15 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     */
   private val s2_valid = ValidHold(s1_realFire, s2_fire, s2_flush)
 
-  private val s2_vAddr          = RegEnable(s1_vAddr, 0.U.asTypeOf(s1_vAddr), s1_realFire)
   private val s2_isSoftPrefetch = RegEnable(s1_isSoftPrefetch, 0.U.asTypeOf(s1_isSoftPrefetch), s1_realFire)
-  private val s2_doubleline     = RegEnable(s1_doubleline, 0.U.asTypeOf(s1_doubleline), s1_realFire)
+  private val s2_doubleline     = RegEnable(s1_readDoubleLine, 0.U.asTypeOf(s1_readDoubleLine), s1_realFire)
   private val s2_pTag           = RegEnable(s1_pTag, 0.U.asTypeOf(s1_pTag), s1_realFire)
   private val s2_exception =
     RegEnable(s1_exceptionOut, 0.U.asTypeOf(s1_exceptionOut), s1_realFire) // includes itlb/pmp exception
-  private val s2_isMmio   = RegEnable(s1_isMmio, 0.U.asTypeOf(s1_isMmio), s1_realFire)
-  private val s2_sramHits = RegEnable(s1_sramHits, 0.U.asTypeOf(s1_sramHits), s1_realFire)
-
-  private val s2_vSetIdx = s2_vAddr.map(get_idx)
+  private val s2_isMmio         = RegEnable(s1_isMmio, 0.U.asTypeOf(s1_isMmio), s1_realFire)
+  private val s2_sramHits       = RegEnable(s1_sramHits, 0.U.asTypeOf(s1_sramHits), s1_realFire)
+  private val s2_readMetaVAddr  = RegEnable(s1_readMetaVAddr, 0.U.asTypeOf(s1_readMetaVAddr), s1_realFire)
+  private val s2_readMetaSetIdx = RegEnable(s1_readMetaSetIdx, 0.U.asTypeOf(s1_readMetaSetIdx), s1_realFire)
 
   /**
     ******************************************************************************
@@ -413,7 +486,7 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
    */
   private val s2_mshrHits = (0 until PortNumber).map(i =>
     ValidHoldBypass(
-      checkMshrHit(fromMiss, s2_vSetIdx(i), s2_pTag, s2_valid),
+      checkMshrHit(fromMiss, s2_readMetaSetIdx(i), s2_pTag, s2_valid),
       s2_fire || s2_flush
     )
   )
@@ -445,8 +518,8 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
   (0 until PortNumber).foreach { i =>
     toMissArbiter.io.in(i).valid         := s2_valid && s2_miss(i) && !s2_hasSend(i)
-    toMissArbiter.io.in(i).bits.blkPAddr := getBlkAddrFromPTag(s2_vAddr(i), s2_pTag)
-    toMissArbiter.io.in(i).bits.vSetIdx  := s2_vSetIdx(i)
+    toMissArbiter.io.in(i).bits.blkPAddr := getBlkAddrFromPTag(s2_readMetaVAddr(i), s2_pTag)
+    toMissArbiter.io.in(i).bits.vSetIdx  := s2_readMetaSetIdx(i)
   }
 
   toMiss <> toMissArbiter.io.out
@@ -470,8 +543,8 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   XSPerfAccumulate("bpuS0Flush", fromBpuS0Flush)
   XSPerfAccumulate("bpuS1Flush", fromBpuS1Flush)
   // the number of prefetch request received from ftq or backend (software prefetch)
-  XSPerfAccumulate("hwReq", io.req.fire && !io.req.bits.isSoftPrefetch)
-  XSPerfAccumulate("swReq", io.req.fire && io.req.bits.isSoftPrefetch)
+  XSPerfAccumulate("hwReq", io.fromFtq.fire && !io.fromFtq.bits.req(0).isSoftPrefetch) // FIXME
+  XSPerfAccumulate("swReq", io.fromFtq.fire && io.fromFtq.bits.req(0).isSoftPrefetch)
   // the number of prefetch request sent to missUnit
   XSPerfAccumulate("hwMiss", toMiss.fire && !s2_isSoftPrefetch)
   XSPerfAccumulate("swMiss", toMiss.fire && s2_isSoftPrefetch)

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -354,7 +354,7 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   // merge pmp mmio and itlb pbmt
   private val s1_isMmio = s1_pmpMmio || Pbmt.isUncache(s1_itlbPbmt)
 
-  io.toFtq.valid                             := s1_fire
+  io.toFtq.valid                             := s1_fire && !s1_isSoftPrefetch
   io.toFtq.bits.ftqIdx                       := s1_ftqIdx
   io.toFtq.bits.twoFetchInfo(0).valid        := true.B
   io.toFtq.bits.twoFetchInfo(0).bits.isMmio  := s1_isMmio

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -91,21 +91,9 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   private val s0_backendException = s0_req(0).backendException
   private val s0_twoPrefetchCase  = io.fromFtq.bits.twoPrefetchCase
 
-  private val s0_readMetaVAddr = MuxCase(
-    VecInit(s0_req(0).startVAddr, s0_req(0).nextLineVAddr),
-    Seq(
-      s0_twoPrefetchCase.isCase3 -> VecInit(s0_req(1).startVAddr, s0_req(1).nextLineVAddr),
-      s0_twoPrefetchCase.isCase4 -> VecInit(s0_req(0).startVAddr, s0_req(1).startVAddr)
-    )
-  )
+  private val s0_readMetaVAddr  = s0_twoPrefetchCase.selectMetaVAddr(s0_req)
   private val s0_readMetaSetIdx = VecInit(s0_readMetaVAddr.map(get_idx))
-  private val s0_readDoubleLine = MuxCase(
-    s0_req(0).isCrossLine,
-    Seq(
-      s0_twoPrefetchCase.isCase1 -> (s0_req(0).isCrossLine || s0_req(1).isCrossLine),
-      (s0_twoPrefetchCase.isCase2 || s0_twoPrefetchCase.isCase3 || s0_twoPrefetchCase.isCase4) -> true.B
-    )
-  )
+  private val s0_readDoubleLine = s0_twoPrefetchCase.selectIsCrossLine(s0_req)
 
   fromBpuS0Flush := !s0_isSoftPrefetch && io.flushFromBpu.shouldFlushByStage3(s0_ftqIdx, s0_valid)
   s0_flush       := io.flush || fromBpuS0Flush || s1_flush
@@ -285,18 +273,7 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
   private val s1_sramHits = VecInit(s1_metaInfo.map(_.waymask.orR))
 
-  private val s1_reqMetaInfo = VecInit(
-    Mux(
-      s1_twoPrefetchCase.isCase3,
-      VecInit(s1_metaInfo(1), 0.U.asTypeOf(new MetaInfo)),
-      s1_metaInfo
-    ),
-    Mux(
-      s1_twoPrefetchCase.isCase2 || s1_twoPrefetchCase.isCase4,
-      VecInit(s1_metaInfo(1), 0.U.asTypeOf(new MetaInfo)),
-      s1_metaInfo
-    )
-  )
+  private val s1_reqMetaInfo = s1_twoPrefetchCase.generateReqMetaInfo(s1_metaInfo)
 
   dontTouch(s1_metaInfo)
   dontTouch(s1_reqMetaInfo)

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -42,17 +42,17 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     val eccEnable:   Bool = Input(Bool())
     val flush:       Bool = Input(Bool())
 
-    val fromFtq:          DecoupledIO[FtqToPrefetchBundle]       = Flipped(Decoupled(new FtqToPrefetchBundle))
-    val toFtq:            Valid[PrefetchToFtqBundle]             = Valid(new PrefetchToFtqBundle)
-    val flushFromBpu:     BpuFlushInfo                           = Flipped(new BpuFlushInfo)
-    val itlb:             TlbRequestIO                           = new TlbRequestIO
-    val itlbFlushPipe:    Bool                                   = Output(Bool())
-    val pmp:              PmpCheckBundle                         = new PmpCheckBundle
-    val metaRead:         MetaReadBundle                         = new MetaReadBundle
-    val missReq:          DecoupledIO[MissReqBundle]             = DecoupledIO(new MissReqBundle)
-    val missResp:         Valid[MissRespBundle]                  = Flipped(ValidIO(new MissRespBundle))
-    val wayLookupWrite:   DecoupledIO[Vec[WayLookupWriteBundle]] = DecoupledIO(Vec(2, new WayLookupWriteBundle))
-    val secondWriteValid: Bool                                   = Output(Bool())
+    val fromFtq:       DecoupledIO[FtqToPrefetchBundle] = Flipped(Decoupled(new FtqToPrefetchBundle))
+    val toFtq:         Valid[PrefetchToFtqBundle]       = Valid(new PrefetchToFtqBundle)
+    val flushFromBpu:  BpuFlushInfo                     = Flipped(new BpuFlushInfo)
+    val itlb:          TlbRequestIO                     = new TlbRequestIO
+    val itlbFlushPipe: Bool                             = Output(Bool())
+    val pmp:           PmpCheckBundle                   = new PmpCheckBundle
+    val metaRead:      MetaReadBundle                   = new MetaReadBundle
+    val missReq:       DecoupledIO[MissReqBundle]       = DecoupledIO(new MissReqBundle)
+    val missResp:      Valid[MissRespBundle]            = Flipped(ValidIO(new MissRespBundle))
+
+    val wayLookupWrite: Vec[DecoupledIO[WayLookupWriteBundle]] = Vec(FetchPorts, DecoupledIO(new WayLookupWriteBundle))
 
     val perf: PrefetchPipePerfInfo = Output(new PrefetchPipePerfInfo)
   }
@@ -98,7 +98,7 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
       s0_twoPrefetchCase.isCase4 -> VecInit(s0_req(0).startVAddr, s0_req(1).startVAddr)
     )
   )
-  private val s0_readMetaSetIdx = VecInit(get_idx(s0_readMetaVAddr(0)), get_idx(s0_readMetaVAddr(1)))
+  private val s0_readMetaSetIdx = VecInit(s0_readMetaVAddr.map(get_idx))
   private val s0_readDoubleLine = MuxCase(
     s0_req(0).isCrossLine,
     Seq(
@@ -313,55 +313,48 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   )
 
   // Disallow enqueuing wayLookup when SRAM write occurs.
-  toWayLookup.valid := (
-    (s1_state === S1FsmState.EnqWay) ||
-      ((s1_state === S1FsmState.Idle) && tlbFinish)
-  ) && !s1_flush && !fromMiss.valid && !s1_isSoftPrefetch // do not enqueue soft prefetch
-  toWayLookup.bits.zipWithIndex.foreach { case (toWayLookup, i) =>
-    toWayLookup.entry.debug_startVAddr := s1_req(i).startVAddr
-    toWayLookup.ftqIdx                 := s1_req(i).ftqIdx
-    toWayLookup.vSetIdx                := VecInit(get_idx(s1_req(i).startVAddr), get_idx(s1_req(i).nextLineVAddr))
-    toWayLookup.waymask                := VecInit(s1_reqMetaInfo(i).map(_.waymask))
-    toWayLookup.pTag                   := s1_pTag
-    toWayLookup.maybeRvcMap            := VecInit(s1_reqMetaInfo(i).map(_.maybeRvcMap))
-    toWayLookup.gpAddr                 := s1_gpAddr(i)(PAddrBitsMax - 1, 0)
-    toWayLookup.isForVSnonLeafPTE      := s1_isForVSnonLeafPTE
-    toWayLookup.metaCodes              := VecInit(s1_reqMetaInfo(i).map(_.metaCodes))
-    toWayLookup.itlbException          := s1_itlbException
-    toWayLookup.itlbPbmt               := s1_itlbPbmt
-  }
-  io.secondWriteValid := s1_twoPrefetchCase.valid
+  toWayLookup.zipWithIndex.foreach { case (port, i) =>
+    port.valid :=
+      // tlb/meta ready
+      ((s1_state === S1FsmState.EnqWay) || ((s1_state === S1FsmState.Idle) && tlbFinish)) &&
+        // meta is not being updated
+        !fromMiss.valid &&
+        // pipeline is not being flushed
+        !s1_flush &&
+        // do not send soft prefetch to waylookup/mainpipe, as it does not affect control flow
+        !s1_isSoftPrefetch &&
+        // first port is always valid, the second port is valid only if we can do 2-prefetch
+        (if (i == 0) true.B else s1_twoPrefetchCase.valid)
 
-  when(toWayLookup.fire) {
-    val waymasksVec = s1_reqMetaInfo(0).map(_.waymask.asTypeOf(Vec(nWays, Bool())))
-    assert(
-      PopCount(waymasksVec(0)) <= 1.U && (PopCount(waymasksVec(1)) <= 1.U || !s1_req(0).isCrossLine),
-      "Multi-hit:\nport0: count=%d pTag=0x%x vSet=0x%x vAddr=0x%x\nport1: count=%d pTag=0x%x vSet=0x%x vAddr=0x%x",
-      PopCount(waymasksVec(0)),
-      s1_pTag,
-      s1_reqSetIdx(0)(0),
-      s1_req(0).startVAddr.toUInt,
-      PopCount(waymasksVec(1)),
-      s1_pTag,
-      s1_reqSetIdx(0)(1),
-      s1_req(0).nextLineVAddr.toUInt // FIXME
-    )
-  }
+    port.bits.ftqIdx := s1_req(i).ftqIdx
 
-  when(toWayLookup.fire && s1_twoPrefetchCase.valid) {
-    val waymasksVec = s1_reqMetaInfo(1).map(_.waymask.asTypeOf(Vec(nWays, Bool())))
-    assert(
-      PopCount(waymasksVec(0)) <= 1.U && (PopCount(waymasksVec(1)) <= 1.U || !s1_req(1).isCrossLine),
-      "Multi-hit:\nport0: count=%d pTag=0x%x vSet=0x%x vAddr=0x%x\nport1: count=%d pTag=0x%x vSet=0x%x vAddr=0x%x",
-      PopCount(waymasksVec(0)),
-      s1_pTag,
-      s1_reqSetIdx(1)(0),
-      s1_req(1).startVAddr.toUInt,
-      PopCount(waymasksVec(1)),
-      s1_pTag,
-      s1_reqSetIdx(1)(1),
-      s1_req(1).nextLineVAddr.toUInt // FIXME
-    )
+    port.bits.entry.vSetIdx     := VecInit(get_idx(s1_req(i).startVAddr), get_idx(s1_req(i).nextLineVAddr))
+    port.bits.entry.waymask     := VecInit(s1_reqMetaInfo(i).map(_.waymask))
+    port.bits.entry.pTag        := s1_pTag
+    port.bits.entry.maybeRvcMap := VecInit(s1_reqMetaInfo(i).map(_.maybeRvcMap))
+    port.bits.entry.metaCodes   := VecInit(s1_reqMetaInfo(i).map(_.metaCodes))
+    port.bits.entry.itlbPbmt    := s1_itlbPbmt
+
+    port.bits.exceptionEntry.itlbException     := s1_itlbException
+    port.bits.exceptionEntry.gpAddr            := s1_gpAddr(i)(PAddrBitsMax - 1, 0)
+    port.bits.exceptionEntry.isForVSnonLeafPTE := s1_isForVSnonLeafPTE
+
+    port.bits.entry.debug_startVAddr := s1_req(i).startVAddr
+
+    when(port.fire) {
+      val waymasksVec = s1_reqMetaInfo(i).map(_.waymask.asTypeOf(Vec(nWays, Bool())))
+      assert(
+        PopCount(waymasksVec(0)) <= 1.U && (PopCount(waymasksVec(1)) <= 1.U || !s1_req(i).isCrossLine),
+        s"Block $i multi-hit:\npTag: 0x%x\nport0: count=%d vSet=0x%x vAddr=0x%x\nport1: count=%d vSet=0x%x vAddr=0x%x",
+        s1_pTag,
+        PopCount(waymasksVec(0)),
+        s1_reqSetIdx(i)(0),
+        s1_req(i).startVAddr.toUInt,
+        PopCount(waymasksVec(1)),
+        s1_reqSetIdx(i)(1),
+        s1_req(i).nextLineVAddr.toUInt
+      )
+    }
   }
 
   /**
@@ -404,9 +397,9 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
       when(s1_valid) {
         when(!tlbFinish) {
           s1_nextState := S1FsmState.ItlbResend
-        }.elsewhen(!toWayLookup.fire) { // tlbFinish
+        }.elsewhen(!toWayLookup.head.fire) { // tlbFinish
           s1_nextState := S1FsmState.EnqWay
-        }.elsewhen(!s2_ready) { // tlbFinish && toWayLookup.fire
+        }.elsewhen(!s2_ready) { // tlbFinish && toWayLookup.head.fire
           s1_nextState := S1FsmState.EnterS2
         } // .otherwise { s1_nextState := S1FsmState.Idle }
       }   // .otherwise { s1_nextState := S1FsmState.Idle }  // !s1_valid
@@ -426,7 +419,7 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
       } // .otherwise { s1_nextState := S1FsmState.metaResend }  // !toMeta.ready
     }
     is(S1FsmState.EnqWay) {
-      when(toWayLookup.fire || s1_isSoftPrefetch) {
+      when(toWayLookup.head.fire || s1_isSoftPrefetch) {
         when(!s2_ready) {
           s1_nextState := S1FsmState.EnterS2
         }.otherwise { // s2_ready

--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -20,6 +20,7 @@ import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.CircularQueuePtr
 import utility.HasCircularQueuePtrHelper
+import utility.XSError
 import utility.XSPerfAccumulate
 import utility.XSPerfHistogram
 import xiangshan.frontend.ftq.BpuFlushInfo
@@ -27,16 +28,17 @@ import xiangshan.frontend.ftq.FtqPtr
 
 class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     with ICacheMissUpdateHelper
-    with HasCircularQueuePtrHelper
-    with ICacheDataHelper {
+    with HasCircularQueuePtrHelper {
 
   class ICacheWayLookupIO(implicit p: Parameters) extends ICacheBundle {
-    val flush:        Bool                                   = Input(Bool())
-    val flushFromBpu: BpuFlushInfo                           = Input(new BpuFlushInfo)
-    val read:         DecoupledIO[WayLookupBundle]           = DecoupledIO(new WayLookupBundle)
-    val write:        DecoupledIO[Vec[WayLookupWriteBundle]] = Flipped(DecoupledIO(Vec(2, new WayLookupWriteBundle)))
-    val secondWriteValid: Bool                  = Input(Bool())
-    val update:           Valid[MissRespBundle] = Flipped(ValidIO(new MissRespBundle))
+    val flush:        Bool         = Input(Bool())
+    val flushFromBpu: BpuFlushInfo = Input(new BpuFlushInfo)
+
+    val read: DecoupledIO[WayLookupBundle] = DecoupledIO(new WayLookupBundle)
+
+    val write: Vec[DecoupledIO[WayLookupWriteBundle]] = Vec(FetchPorts, Flipped(DecoupledIO(new WayLookupWriteBundle)))
+
+    val update: Valid[MissRespBundle] = Flipped(ValidIO(new MissRespBundle))
 
     val perf: WayLookupPerfInfo = Output(new WayLookupPerfInfo)
   }
@@ -78,8 +80,9 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     writePtr.flag  := false.B
   }.elsewhen(bpuS3FlushValid && !empty) {
     writePtr := bpuS3FlushPtr
-  }.elsewhen(io.write.fire) {
-    val enqCnt = Mux(io.secondWriteValid, 2.U, 1.U)
+  }.elsewhen(io.write.head.fire) {
+    // FetchPorts must be 1 or 2, and last.fire is depend on head.fire
+    val enqCnt = Mux(io.write.last.fire, FetchPorts.U, 1.U)
     writePtr := writePtr + enqCnt
   }
 
@@ -93,8 +96,8 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
   when(io.flush) {
     tailFtqIdx.value := 0.U
     tailFtqIdx.flag  := false.B
-  }.elsewhen(io.write.fire) {
-    tailFtqIdx := Mux(io.secondWriteValid, io.write.bits(1).ftqIdx, io.write.bits(0).ftqIdx)
+  }.elsewhen(io.write.head.fire) {
+    tailFtqIdx := Mux(io.write.last.fire, io.write.last.bits.ftqIdx, io.write.head.bits.ftqIdx)
   }
 
   // we can store only the first exception encountered, as exceptions must trigger a redirection (and thus a flush)
@@ -128,11 +131,11 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
 
   /* *** read *** */
   // if the entry is empty, but there is a valid write, we can bypass it to read port (maybe timing critical)
-  private val canBypass = empty && io.write.valid && !exceptionEntry.valid
+  private val canBypass = empty && io.write.head.valid && !exceptionEntry.valid
   private val canRead   = !empty && !updateStall
   io.read.valid := canRead || canBypass
   when(canBypass) {
-    io.read.bits := io.write.bits(0)
+    io.read.bits := io.write.head.bits
   }.otherwise {
     io.read.bits.entry          := entries(readPtr.value)
     io.read.bits.exceptionEntry := Mux(exceptionHit, exceptionEntry.bits, 0.U.asTypeOf(new WayLookupExceptionEntry))
@@ -145,19 +148,24 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     */
   // stall write if there is an exceptions to save power (i.e. wait for flush)
   // this will stall the prefetch pipe
-  io.write.ready := numFreeEntries >= 2.U && !exceptionEntry.valid
-  when(io.write.fire) {
-    entries(writePtr.value) := io.write.bits(0).entry
-    when(io.secondWriteValid) {
-      entries(writePtr.value + 1.U) := io.write.bits(1).entry
+  // also we disallow only 1 ready, to simplify PrefetchPipe
+  io.write.foreach(_.ready := numFreeEntries >= FetchPorts.U && !exceptionEntry.valid)
+  when(io.write.head.fire) {
+    entries(writePtr.value) := io.write.head.bits.entry
+    if (FetchPorts > 1) {
+      when(io.write.last.fire) {
+        entries(writePtr.value + 1.U) := io.write.last.bits.entry
+      }
     }
-    // do not allow 2-prefetch when has backend exception
-    when(io.write.bits(0).itlbException.hasException) {
+    // ftq/prefetchPipe ensure fetch blocks has the same exception, here we can consider only .head
+    when(io.write.head.bits.itlbException.hasException) {
       exceptionEntry.valid := true.B
-      exceptionEntry.bits  := io.write.bits(0).exceptionEntry
+      exceptionEntry.bits  := io.write.head.bits.exceptionEntry
       exceptionPtr         := writePtr
     }
   }
+  // the second port (if FetchPorts == 2) must fire together with the first port
+  XSError(io.write.last.fire && !io.write.head.fire, "2-prefetch port fire without first port fire")
 
   /* *** perf *** */
   // tell ICache top if queue is empty
@@ -172,8 +180,8 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     0,
     WayLookupSize
   )
-  XSPerfAccumulate("emptyHasBypass", empty && io.write.valid)
-  XSPerfAccumulate("emptyNoBypass", empty && !io.write.valid)
+  XSPerfAccumulate("emptyHasBypass", empty && io.write.head.valid)
+  XSPerfAccumulate("emptyNoBypass", empty && !io.write.head.valid)
   // exception stall cycles
   XSPerfAccumulate("waitingForExceptionRead", exceptionEntry.valid && !empty)
   XSPerfAccumulate("waitingForExceptionFlush", exceptionEntry.valid && empty)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -22,20 +22,21 @@ import utility.CircularQueuePtr
 import utility.HasCircularQueuePtrHelper
 import utility.XSPerfAccumulate
 import utility.XSPerfHistogram
-import utils.EnumUInt
 import xiangshan.frontend.ftq.BpuFlushInfo
 import xiangshan.frontend.ftq.FtqPtr
 
 class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     with ICacheMissUpdateHelper
-    with HasCircularQueuePtrHelper {
+    with HasCircularQueuePtrHelper
+    with ICacheDataHelper {
 
   class ICacheWayLookupIO(implicit p: Parameters) extends ICacheBundle {
-    val flush:        Bool                              = Input(Bool())
-    val flushFromBpu: BpuFlushInfo                      = Input(new BpuFlushInfo)
-    val read:         DecoupledIO[WayLookupBundle]      = DecoupledIO(new WayLookupBundle)
-    val write:        DecoupledIO[WayLookupWriteBundle] = Flipped(DecoupledIO(new WayLookupWriteBundle))
-    val update:       Valid[MissRespBundle]             = Flipped(ValidIO(new MissRespBundle))
+    val flush:        Bool                                   = Input(Bool())
+    val flushFromBpu: BpuFlushInfo                           = Input(new BpuFlushInfo)
+    val read:         DecoupledIO[WayLookupBundle]           = DecoupledIO(new WayLookupBundle)
+    val write:        DecoupledIO[Vec[WayLookupWriteBundle]] = Flipped(DecoupledIO(Vec(2, new WayLookupWriteBundle)))
+    val secondWriteValid: Bool                  = Input(Bool())
+    val update:           Valid[MissRespBundle] = Flipped(ValidIO(new MissRespBundle))
 
     val perf: WayLookupPerfInfo = Output(new WayLookupPerfInfo)
   }
@@ -59,7 +60,11 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
   private val tailFtqIdx = RegInit(0.U.asTypeOf(new FtqPtr))
 
   private val empty = readPtr === writePtr
-  private val full  = (readPtr.value === writePtr.value) && (readPtr.flag ^ writePtr.flag)
+
+  private val numValidEntries = distanceBetween(writePtr, readPtr)
+  private val numFreeEntries  = WayLookupSize.U - numValidEntries
+  dontTouch(numValidEntries)
+  dontTouch(numFreeEntries)
 
   // NOTE: May be unportable, we have bp3 == pf2 now, and WayLookup is written in pf1,
   // so the tailing 0 (already bypassed to if1) or 1 (if1 stall, stored here) entries might be flushed by bp3,
@@ -74,7 +79,8 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
   }.elsewhen(bpuS3FlushValid && !empty) {
     writePtr := bpuS3FlushPtr
   }.elsewhen(io.write.fire) {
-    writePtr := writePtr + 1.U
+    val enqCnt = Mux(io.secondWriteValid, 2.U, 1.U)
+    writePtr := writePtr + enqCnt
   }
 
   when(io.flush) {
@@ -88,7 +94,7 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     tailFtqIdx.value := 0.U
     tailFtqIdx.flag  := false.B
   }.elsewhen(io.write.fire) {
-    tailFtqIdx := io.write.bits.ftqIdx
+    tailFtqIdx := Mux(io.secondWriteValid, io.write.bits(1).ftqIdx, io.write.bits(0).ftqIdx)
   }
 
   // we can store only the first exception encountered, as exceptions must trigger a redirection (and thus a flush)
@@ -126,7 +132,7 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
   private val canRead   = !empty && !updateStall
   io.read.valid := canRead || canBypass
   when(canBypass) {
-    io.read.bits := io.write.bits
+    io.read.bits := io.write.bits(0)
   }.otherwise {
     io.read.bits.entry          := entries(readPtr.value)
     io.read.bits.exceptionEntry := Mux(exceptionHit, exceptionEntry.bits, 0.U.asTypeOf(new WayLookupExceptionEntry))
@@ -139,12 +145,16 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     */
   // stall write if there is an exceptions to save power (i.e. wait for flush)
   // this will stall the prefetch pipe
-  io.write.ready := !full && !exceptionEntry.valid
+  io.write.ready := numFreeEntries >= 2.U && !exceptionEntry.valid
   when(io.write.fire) {
-    entries(writePtr.value) := io.write.bits.entry
-    when(io.write.bits.itlbException.hasException) {
+    entries(writePtr.value) := io.write.bits(0).entry
+    when(io.secondWriteValid) {
+      entries(writePtr.value + 1.U) := io.write.bits(1).entry
+    }
+    // do not allow 2-prefetch when has backend exception
+    when(io.write.bits(0).itlbException.hasException) {
       exceptionEntry.valid := true.B
-      exceptionEntry.bits  := io.write.bits.exceptionEntry
+      exceptionEntry.bits  := io.write.bits(0).exceptionEntry
       exceptionPtr         := writePtr
     }
   }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -72,6 +72,8 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
   // so the tailing 0 (already bypassed to if1) or 1 (if1 stall, stored here) entries might be flushed by bp3,
   // therefore, when shouldFlushByStage3, we need to move back writePtr by 0 (empty) or 1.
   // If in future we have bp4 (or even more) flush, this might not be enough.
+  // NOTE: With 2-prefetch, writePtr - 2.U still does not need to be flushed,
+  // as we ask the second fetch block to be flushed within Ftq. Refer to `canTwoPrefetch` condition in `class Ftq`
   private val bpuS3FlushValid = io.flushFromBpu.shouldFlushByStage3(tailFtqIdx, true.B)
   private val bpuS3FlushPtr   = writePtr - 1.U
 


### PR DESCRIPTION
Add initial 2-prefetch support in ICache/Ftq, 2-prefetch and 2-fetch are decoupled with WayLookup.

To prevent extra read ports in ICacheMetaArray, ITLB etc., also to prevent complex bpu override logic, 2-prefetch is limited to the following scenario:
- 2 fetch block (fb in short) are in the same page (so only 1 ITLB port is needed for translating vpn to ppn), and
- `bpPtr` is >= 4 entries ahead of `pfPtr` (so all Bpu override is resolved in Ftq, before sending to prefetchPipe), and
- no backend exception (i.e. pc upper bits pre-check for af/pf/gpf) occurred, and
- is one of the following cases:
  - 2 fb are in the same cache line (so they share the same read port of MetaArray), don't care if they crossline
  - fb1 is crossline, fb2 is not, and fb2 is in fb1's second cache line
  - or the reverse, i.e. fb1 is in fb2's second line
  - 2 fb are both not crossline, and they are interleaved (i.e. `vSetIdx % 2` differs)
  - Refer to this for implementation detail: https://github.com/OpenXiangShan/XiangShan/blob/798a9c2edc7d8b56954cedc4c2539e4234b6bbed/src/main/scala/xiangshan/frontend/TwoFetch.scala

Without 2-taken and 2-fetch, this is expected to have only minor performance changes, the performance may improve due to more timely prefetching, or it may be negatively impacted by cache pollution caused by extra wrong prefetches.

Anyway, lets get this merged once to prevent conflict with future icache / ftq modifications. Performance tuning will be carried out after the initial implementation of 2-taken and 2-fetch.