### PR TITLE
feat(abtb): adjust abtb indexing and replacement strategy

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -158,6 +158,9 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val s2_realUtageMeta = Wire(new MicroTageMeta)
   private val s3_utageMeta     = RegEnable(s2_realUtageMeta, s2_fire)
 
+  private val s2_phrMeta = RegEnable(phr.io.phrMeta, s1_fire)
+  private val s3_phrMeta = RegEnable(s2_phrMeta, s2_fire)
+
   /* *** common inputs *** */
   private val stageCtrl = Wire(new StageCtrl)
   stageCtrl.s0_fire := s0_fire
@@ -200,7 +203,13 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   /* *** predictor specific inputs *** */
   abtb.io.redirectValid := redirect.valid
+  // abtb.io.redirectSimpleHist := redirect.bits.meta.simpleHist
+  abtb.io.redirectHash  := redirect.bits.meta.phr.phrLowBits(AheadBtbPerturbWidth - 1, 0)
   abtb.io.overrideValid := s3_override
+  abtb.io.overrideHash  := s3_phrMeta.phrLowBits(AheadBtbPerturbWidth - 1, 0)
+  abtb.io.normalHash    := phr.io.phrMeta.phrLowBits(AheadBtbPerturbWidth - 1, 0)
+  // abtb.io.overridePrevPartPc := s3_abtbMeta.prevPartPc
+  // abtb.io.overrideSimpleHist := s3_abtbMeta.simpleHist
 
   utage.io.foldedPathHist         := phr.io.s0_foldedPhr
   utage.io.foldedPathHistForTrain := phr.io.trainFoldedPhr
@@ -376,9 +385,6 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   s3_override := s3_valid && !(s3_prediction === s3_s1Prediction)
 
-  private val s2_phrMeta = RegEnable(phr.io.phrMeta, s1_fire)
-  private val s3_phrMeta = RegEnable(s2_phrMeta, s2_fire)
-
   private val s3_commonHRMeta = WireInit(0.U.asTypeOf(new CommonHRMeta))
   s3_commonHRMeta.ghr       := commonHR.io.s3ResolveMeta.ghr
   s3_commonHRMeta.bw        := commonHR.io.s3ResolveMeta.bw
@@ -391,6 +397,8 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   s3_redirectMeta.phr          := s3_phrMeta
   s3_redirectMeta.commonHRMeta := s3_commonHRMeta
   s3_redirectMeta.ras          := ras.io.redirectMeta
+  // s3_redirectMeta.prevPartPc   := s3_abtbMeta.prevPartPc
+  // s3_redirectMeta.simpleHist   := s3_abtbMeta.simpleHist
 
   private val s3_resolveMeta = Wire(new BpuResolveMeta)
   s3_resolveMeta.mbtb     := RegEnable(mbtb.io.meta, s2_fire)

--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -203,13 +203,10 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   /* *** predictor specific inputs *** */
   abtb.io.redirectValid := redirect.valid
-  // abtb.io.redirectSimpleHist := redirect.bits.meta.simpleHist
-  abtb.io.redirectHash  := redirect.bits.meta.phr.phrLowBits(AheadBtbPerturbWidth - 1, 0)
+  abtb.io.redirectHash  := redirect.bits.meta.phr.phrLowBits(AheadBtbHashBitWidth - 1, 0)
   abtb.io.overrideValid := s3_override
-  abtb.io.overrideHash  := s3_phrMeta.phrLowBits(AheadBtbPerturbWidth - 1, 0)
-  abtb.io.normalHash    := phr.io.phrMeta.phrLowBits(AheadBtbPerturbWidth - 1, 0)
-  // abtb.io.overridePrevPartPc := s3_abtbMeta.prevPartPc
-  // abtb.io.overrideSimpleHist := s3_abtbMeta.simpleHist
+  abtb.io.overrideHash  := s3_phrMeta.phrLowBits(AheadBtbHashBitWidth - 1, 0)
+  abtb.io.normalHash    := phr.io.phrMeta.phrLowBits(AheadBtbHashBitWidth - 1, 0)
 
   utage.io.foldedPathHist         := phr.io.s0_foldedPhr
   utage.io.foldedPathHistForTrain := phr.io.trainFoldedPhr
@@ -397,8 +394,6 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   s3_redirectMeta.phr          := s3_phrMeta
   s3_redirectMeta.commonHRMeta := s3_commonHRMeta
   s3_redirectMeta.ras          := ras.io.redirectMeta
-  // s3_redirectMeta.prevPartPc   := s3_abtbMeta.prevPartPc
-  // s3_redirectMeta.simpleHist   := s3_abtbMeta.simpleHist
 
   private val s3_resolveMeta = Wire(new BpuResolveMeta)
   s3_resolveMeta.mbtb     := RegEnable(mbtb.io.meta, s2_fire)

--- a/src/main/scala/xiangshan/frontend/bpu/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Parameters.scala
@@ -64,7 +64,8 @@ trait HasBpuParameters extends HasFrontendParameters {
   def PhrHistoryLength: Int = frontendParameters.getPhrHistoryLength
 
   def NumAheadBtbPredictionEntries: Int = bpuParameters.abtbParameters.NumWays
-  def AheadBtbPerturbWidth:         Int = 4
+  // Bit width participating in the index hash, used to disperse hot branches and bias bank conflicts.
+  def AheadBtbHashBitWidth: Int = 4
 
   def NumBtbResultEntries: Int = bpuParameters.mbtbParameters.NumWay * bpuParameters.mbtbParameters.NumAlignBanks
 

--- a/src/main/scala/xiangshan/frontend/bpu/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Parameters.scala
@@ -64,6 +64,7 @@ trait HasBpuParameters extends HasFrontendParameters {
   def PhrHistoryLength: Int = frontendParameters.getPhrHistoryLength
 
   def NumAheadBtbPredictionEntries: Int = bpuParameters.abtbParameters.NumWays
+  def AheadBtbPerturbWidth:         Int = 4
 
   def NumBtbResultEntries: Int = bpuParameters.mbtbParameters.NumWay * bpuParameters.mbtbParameters.NumAlignBanks
 

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
@@ -31,10 +31,10 @@ import xiangshan.frontend.bpu.Prediction
 class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
   class AheadBtbIO(implicit p: Parameters) extends BasePredictorIO with HasFastTrainIO {
     val redirectValid: Bool                       = Input(Bool())
-    val redirectHash:  UInt                       = Input(UInt(AheadBtbPerturbWidth.W))
+    val redirectHash:  UInt                       = Input(UInt(AheadBtbHashBitWidth.W))
     val overrideValid: Bool                       = Input(Bool())
-    val overrideHash:  UInt                       = Input(UInt(AheadBtbPerturbWidth.W))
-    val normalHash:    UInt                       = Input(UInt(AheadBtbPerturbWidth.W))
+    val overrideHash:  UInt                       = Input(UInt(AheadBtbHashBitWidth.W))
+    val normalHash:    UInt                       = Input(UInt(AheadBtbHashBitWidth.W))
     val prediction:    Vec[Valid[Prediction]]     = Output(Vec(NumAheadBtbPredictionEntries, Valid(new Prediction)))
     val abtbResult:    Vec[Valid[AheadBtbResult]] = Output(Vec(NumAheadBtbPredictionEntries, Valid(new AheadBtbResult)))
     val abtbResultPos: Vec[UInt]                  = Output(Vec(NumAheadBtbPredictionEntries, UInt(CfiPositionWidth.W)))

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
@@ -31,7 +31,10 @@ import xiangshan.frontend.bpu.Prediction
 class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
   class AheadBtbIO(implicit p: Parameters) extends BasePredictorIO with HasFastTrainIO {
     val redirectValid: Bool                       = Input(Bool())
+    val redirectHash:  UInt                       = Input(UInt(AheadBtbPerturbWidth.W))
     val overrideValid: Bool                       = Input(Bool())
+    val overrideHash:  UInt                       = Input(UInt(AheadBtbPerturbWidth.W))
+    val normalHash:    UInt                       = Input(UInt(AheadBtbPerturbWidth.W))
     val prediction:    Vec[Valid[Prediction]]     = Output(Vec(NumAheadBtbPredictionEntries, Valid(new Prediction)))
     val abtbResult:    Vec[Valid[AheadBtbResult]] = Output(Vec(NumAheadBtbPredictionEntries, Valid(new AheadBtbResult)))
     val abtbResultPos: Vec[UInt]                  = Output(Vec(NumAheadBtbPredictionEntries, UInt(CfiPositionWidth.W)))
@@ -81,7 +84,10 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
   private val predictReqValid = io.stageCtrl.s0_fire
   private val predictionSent  = io.stageCtrl.s1_fire
   private val redirectValid   = io.redirectValid
+  private val redirectHash    = io.redirectHash
   private val overrideValid   = io.overrideValid
+  private val overrideHash    = io.overrideHash
+  private val normalHash      = io.normalHash
 
   s0_fire := io.enable && predictReqValid
   s1_fire := io.enable && s1_valid && s2_ready && predictReqValid
@@ -108,9 +114,18 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
      -------------------------------------------------------------------------------------------------------------- */
 
   private val s0_previousStartPc = io.startPc
-
-  private val s0_setIdx   = getSetIndex(s0_previousStartPc)
-  private val s0_bankIdx  = getBankIndex(s0_previousStartPc)
+  private val s0_simpleHash = MuxCase(
+    normalHash,
+    Seq(
+      redirectValid -> redirectHash,
+      overrideValid -> overrideHash
+    )
+  )
+  private val s0_hashIndex = s0_previousStartPc(log2Ceil(NumEntries / NumWays) - 1, 0) ^ s0_simpleHash
+  private val s0_setIdx    = s0_hashIndex(log2Ceil(NumEntries / NumWays) - 1, log2Ceil(NumBanks))
+  private val s0_bankIdx   = s0_hashIndex(log2Ceil(NumBanks) - 1, 0)
+  // private val s0_setIdx   = getSetIndex(s0_previousStartPc)
+  // private val s0_bankIdx  = getBankIndex(s0_previousStartPc)
   private val s0_bankMask = UIntToOH(s0_bankIdx)
 
   banks.zipWithIndex.foreach { case (b, i) =>
@@ -209,12 +224,6 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
 
   // used for check abtb output
   io.debug_startPc := s2_startPc
-
-  replacers.zipWithIndex.foreach { case (r, i) =>
-    r.io.readValid   := s2_valid && s2_hit && s2_bankMask(i)
-    r.io.readSetIdx  := s2_setIdx
-    r.io.readWayMask := s2_hitMask
-  }
 
   /* --------------------------------------------------------------------------------------------------------------
      train pipeline stage 0
@@ -321,6 +330,12 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
       b.io.writeReq.valid := false.B
       b.io.writeReq.bits  := 0.U.asTypeOf(new BankWriteReq)
     }
+  }
+
+  replacers.zipWithIndex.foreach { case (r, i) =>
+    r.io.readValid   := t1_fire && t1_bankMask(i)
+    r.io.readSetIdx  := t1_setIdx
+    r.io.readWayMask := t1_hitMaskOH
   }
 
   replacers.zip(banks).foreach { case (r, b) =>


### PR DESCRIPTION
1. The introduction of a small amount of hashing can, to some extent, mitigate the problem of hot branches concentrating on the same set, as history can serve as a partial filter.
2. Hashing may, to some degree, disperse the read/write bias across banks.
3. Hashing can improve the accuracy of indirect jump branch addresses to a certain extent.
4. The downside is that hashing reduces the effective capacity of the ABTB (to some extent).  (In SPEC06, under 0.3 coverage, we observe a performance gain of 0.02 points; floating-point gain is 0.04 points, while integer sees a slight improvement.)