### PR TITLE
feat(missQueue, sbuffer): sbuffer releases the entry when miss accepted by mshr, and mshr provides st-ld forwarding

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -31,6 +31,7 @@ import xiangshan._
 import xiangshan.backend.rob.{RobDebugRollingIO, RobPtr}
 import xiangshan.cache.wpu._
 import xiangshan.mem.prefetch._
+import xiangshan.mem.Bundles.SbufferForward
 import xiangshan.mem.{AddPipelineReg, HasL1PrefetchSourceParameter, HasMemBlockParameters, LqPtr, MemorySize}
 
 // DCache specific parameters
@@ -620,6 +621,8 @@ class MissEntryForwardIO(implicit p: Parameters) extends DCacheBundle {
   val inflight = Bool()
   val paddr = UInt(PAddrBits.W)
   val raw_data = Vec(blockRows, UInt(rowBits.W))
+  val isFromStore = Bool()
+  val store_mask = UInt(cfg.blockBytes.W)
   val firstbeat_valid = Bool()
   val lastbeat_valid = Bool()
   val denied = Bool()
@@ -726,6 +729,8 @@ class DCacheToLsuIO(implicit p: Parameters) extends DCacheBundle {
   val release = ValidIO(new Release) // cacheline release hint for ld-ld violation check
   val forward_D = Flipped(Vec(LoadPipelineWidth, new DCacheForward))
   val forward_mshr = Flipped(Vec(LoadPipelineWidth, new DCacheForward))
+  // If a store is miss and accepted by mshr, Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
+  val forward_mshrStData = Flipped(Vec(LoadPipelineWidth, new SbufferForward))
 }
 
 class DCacheTopDownIO(implicit p: Parameters) extends DCacheBundle {
@@ -1512,6 +1517,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   // forward missqueue
   missQueue.io.forward <> io.lsu.forward_mshr
+  // If a store is miss and accepted by mshr, Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
+  missQueue.io.forward_stData <> io.lsu.forward_mshrStData
 
   // refill to load queue
  // io.lsu.lsq <> missQueue.io.refill_to_ldq

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -612,6 +612,8 @@ class DCacheToSbufferIO(implicit p: Parameters) extends DCacheBundle {
   //val refill_hit_resp = ValidIO(new DCacheLineResp)
 
   val replay_resp = ValidIO(new DCacheLineResp)
+  // store replay resp from main pipe S3
+  val replay_resp_s3 = ValidIO(UInt(reqIdWidth.W))
 
   //def hit_resps: Seq[ValidIO[DCacheLineResp]] = Seq(main_pipe_hit_resp, refill_hit_resp)
   def hit_resps: Seq[ValidIO[DCacheLineResp]] = Seq(main_pipe_hit_resp)
@@ -970,7 +972,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   missQueue.io.debugTopDown <> io.debugTopDown
   missQueue.io.l2_hint <> RegNext(io.l2_hint)
   missQueue.io.mainpipe_info := mainPipe.io.mainpipe_info
-  mainPipe.io.mq_merge_grant_store_replay := missQueue.io.mq_merge_grant_store_replay
+  mainPipe.io.store_replay_resp_s3_valid := missQueue.io.store_replay_resp_s3.valid
   missQueue.io.occupy_set.zip(ldu.map(_.io.occupy_set)).foreach { case (l, r) => l <> r }
   missQueue.io.occupy_fail.zip(ldu.map(_.io.occupy_fail)).foreach { case (l, r) => l <> r }
   mainPipe.io.refill_info := missQueue.io.refill_info
@@ -1565,6 +1567,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   io.lsu.store.replay_resp.valid := RegNext(mainPipe.io.store_replay_resp.valid)
   io.lsu.store.replay_resp.bits := RegEnable(mainPipe.io.store_replay_resp.bits, mainPipe.io.store_replay_resp.valid)
   io.lsu.store.main_pipe_hit_resp := mainPipe.io.store_hit_resp
+  io.lsu.store.replay_resp_s3 := missQueue.io.store_replay_resp_s3
 
   mainPipe.io.atomic_req <> io.lsu.atomics.req
 

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -970,6 +970,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   missQueue.io.debugTopDown <> io.debugTopDown
   missQueue.io.l2_hint <> RegNext(io.l2_hint)
   missQueue.io.mainpipe_info := mainPipe.io.mainpipe_info
+  mainPipe.io.mq_merge_grant_store_replay := missQueue.io.mq_merge_grant_store_replay
   missQueue.io.occupy_set.zip(ldu.map(_.io.occupy_set)).foreach { case (l, r) => l <> r }
   missQueue.io.occupy_fail.zip(ldu.map(_.io.occupy_fail)).foreach { case (l, r) => l <> r }
   mainPipe.io.refill_info := missQueue.io.refill_info

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -870,11 +870,17 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.store_replay_resp.bits.replay := true.B // s2_grow_perm_fail
   io.store_replay_resp.bits.id := s2_req.id
 
-  io.store_hit_resp.valid := s3_valid && (s3_store_can_go || (s3_miss_can_go && s3_req.isStore))
+  val mshr_accept_store_miss = s2_valid && s2_can_go_to_mq && s2_req.isStore && !io.store_replay_resp.valid
+  val mshr_accept_store_miss_s3 = RegNext(mshr_accept_store_miss)
+  val mshr_accept_store_miss_id_s3 = RegEnable(s2_req.id, mshr_accept_store_miss)
+  // If a store is miss and accepted by mshr, tell Sbuffer it is a "hit". Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
+  //                                      (1) real hit       (2) store miss and accepted by mshr
+  io.store_hit_resp.valid := s3_valid && s3_store_can_go || mshr_accept_store_miss_s3
   io.store_hit_resp.bits.data := DontCare
   io.store_hit_resp.bits.miss := false.B
   io.store_hit_resp.bits.replay := false.B
-  io.store_hit_resp.bits.id := s3_req.id
+  io.store_hit_resp.bits.id := Mux(mshr_accept_store_miss_s3, mshr_accept_store_miss_id_s3, s3_req.id)
+  // io.store_refill_done_resp.valid := s3_valid && s3_miss_can_go && s3_req.isStore
 
   val atomic_hit_resp = Wire(new MainPipeResp)
   atomic_hit_resp.source := s3_req.source

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -132,6 +132,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     val store_req = Flipped(DecoupledIO(new DCacheLineReq))
     val store_replay_resp = ValidIO(new DCacheLineResp)
     val store_hit_resp = ValidIO(new DCacheLineResp)
+    /** From MissQueue: store merged in pipereg + mem_grant same cycle → Sbuffer via store_hit_resp.replay */
+    val mq_merge_grant_store_replay = Flipped(ValidIO(UInt(reqIdWidth.W)))
     // atmoics
     val atomic_req = Flipped(DecoupledIO(new MainPipeReq))
     val atomic_resp = ValidIO(new MainPipeResp)
@@ -874,12 +876,17 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val mshr_accept_store_miss_s3 = RegNext(mshr_accept_store_miss)
   val mshr_accept_store_miss_id_s3 = RegEnable(s2_req.id, mshr_accept_store_miss)
   // If a store is miss and accepted by mshr, tell Sbuffer it is a "hit". Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
-  //                                      (1) real hit       (2) store miss and accepted by mshr
-  io.store_hit_resp.valid := s3_valid && s3_store_can_go || mshr_accept_store_miss_s3
+  //                                      (1) real hit       (2) store miss and accepted by mshr  (3) MQ merge+grant store replay
+  val mq_merge_grant_store_replay_fire = io.mq_merge_grant_store_replay.valid
+  io.store_hit_resp.valid := s3_valid && s3_store_can_go || mshr_accept_store_miss_s3 || mq_merge_grant_store_replay_fire
   io.store_hit_resp.bits.data := DontCare
   io.store_hit_resp.bits.miss := false.B
-  io.store_hit_resp.bits.replay := false.B
-  io.store_hit_resp.bits.id := Mux(mshr_accept_store_miss_s3, mshr_accept_store_miss_id_s3, s3_req.id)
+  io.store_hit_resp.bits.replay := mq_merge_grant_store_replay_fire
+  io.store_hit_resp.bits.id := Mux(
+    mq_merge_grant_store_replay_fire,
+    io.mq_merge_grant_store_replay.bits,
+    Mux(mshr_accept_store_miss_s3, mshr_accept_store_miss_id_s3, s3_req.id)
+  )
   // io.store_refill_done_resp.valid := s3_valid && s3_miss_can_go && s3_req.isStore
 
   val atomic_hit_resp = Wire(new MainPipeResp)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -132,8 +132,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     val store_req = Flipped(DecoupledIO(new DCacheLineReq))
     val store_replay_resp = ValidIO(new DCacheLineResp)
     val store_hit_resp = ValidIO(new DCacheLineResp)
-    /** From MissQueue: store merged in pipereg + mem_grant same cycle → Sbuffer via store_hit_resp.replay */
-    val mq_merge_grant_store_replay = Flipped(ValidIO(UInt(reqIdWidth.W)))
+    // store replay resp of S3 stage from miss queue
+    val store_replay_resp_s3_valid = Input(Bool())
     // atmoics
     val atomic_req = Flipped(DecoupledIO(new MainPipeReq))
     val atomic_resp = ValidIO(new MainPipeResp)
@@ -876,17 +876,12 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val mshr_accept_store_miss_s3 = RegNext(mshr_accept_store_miss)
   val mshr_accept_store_miss_id_s3 = RegEnable(s2_req.id, mshr_accept_store_miss)
   // If a store is miss and accepted by mshr, tell Sbuffer it is a "hit". Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
-  //                                      (1) real hit       (2) store miss and accepted by mshr  (3) MQ merge+grant store replay
-  val mq_merge_grant_store_replay_fire = io.mq_merge_grant_store_replay.valid
-  io.store_hit_resp.valid := s3_valid && s3_store_can_go || mshr_accept_store_miss_s3 || mq_merge_grant_store_replay_fire
+  //                                      (1) real hit       (2) store miss and accepted by mshr
+  io.store_hit_resp.valid := (s3_valid && s3_store_can_go || mshr_accept_store_miss_s3) && !io.store_replay_resp_s3_valid
   io.store_hit_resp.bits.data := DontCare
   io.store_hit_resp.bits.miss := false.B
-  io.store_hit_resp.bits.replay := mq_merge_grant_store_replay_fire
-  io.store_hit_resp.bits.id := Mux(
-    mq_merge_grant_store_replay_fire,
-    io.mq_merge_grant_store_replay.bits,
-    Mux(mshr_accept_store_miss_s3, mshr_accept_store_miss_id_s3, s3_req.id)
-  )
+  io.store_hit_resp.bits.replay := false.B
+  io.store_hit_resp.bits.id := Mux(mshr_accept_store_miss_s3, mshr_accept_store_miss_id_s3, s3_req.id)
   // io.store_refill_done_resp.valid := s3_valid && s3_miss_can_go && s3_req.isStore
 
   val atomic_hit_resp = Wire(new MainPipeResp)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -872,16 +872,16 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.store_replay_resp.bits.replay := true.B // s2_grow_perm_fail
   io.store_replay_resp.bits.id := s2_req.id
 
-  val mshr_accept_store_miss = s2_valid && s2_can_go_to_mq && s2_req.isStore && !io.store_replay_resp.valid
-  val mshr_accept_store_miss_s3 = RegNext(mshr_accept_store_miss)
-  val mshr_accept_store_miss_id_s3 = RegEnable(s2_req.id, mshr_accept_store_miss)
+  val mshr_handled_store_miss = s2_valid && s2_can_go_to_mq && s2_req.isStore && !io.store_replay_resp.valid
+  val mshr_handled_store_miss_s3 = RegNext(mshr_handled_store_miss)
+  val mshr_handled_store_miss_id_s3 = RegEnable(s2_req.id, mshr_handled_store_miss)
   // If a store is miss and accepted by mshr, tell Sbuffer it is a "hit". Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
   //                                      (1) real hit       (2) store miss and accepted by mshr
-  io.store_hit_resp.valid := (s3_valid && s3_store_can_go || mshr_accept_store_miss_s3) && !io.store_replay_resp_s3_valid
+  io.store_hit_resp.valid := (s3_valid && s3_store_can_go || mshr_handled_store_miss_s3) && !io.store_replay_resp_s3_valid
   io.store_hit_resp.bits.data := DontCare
   io.store_hit_resp.bits.miss := false.B
   io.store_hit_resp.bits.replay := false.B
-  io.store_hit_resp.bits.id := Mux(mshr_accept_store_miss_s3, mshr_accept_store_miss_id_s3, s3_req.id)
+  io.store_hit_resp.bits.id := Mux(mshr_handled_store_miss_s3, mshr_handled_store_miss_id_s3, s3_req.id)
   // io.store_refill_done_resp.valid := s3_valid && s3_miss_can_go && s3_req.isStore
 
   val atomic_hit_resp = Wire(new MainPipeResp)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -879,10 +879,9 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   //                                      (1) real hit       (2) store miss and accepted by mshr
   io.store_hit_resp.valid := (s3_valid && s3_store_can_go || mshr_handled_store_miss_s3) && !io.store_replay_resp_s3_valid
   io.store_hit_resp.bits.data := DontCare
-  io.store_hit_resp.bits.miss := false.B
+  io.store_hit_resp.bits.miss := { if (env.EnableDifftest) mshr_handled_store_miss_s3 else false.B }
   io.store_hit_resp.bits.replay := false.B
   io.store_hit_resp.bits.id := Mux(mshr_handled_store_miss_s3, mshr_handled_store_miss_id_s3, s3_req.id)
-  // io.store_refill_done_resp.valid := s3_valid && s3_miss_can_go && s3_req.isStore
 
   val atomic_hit_resp = Wire(new MainPipeResp)
   atomic_hit_resp.source := s3_req.source

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -36,6 +36,8 @@ import xiangshan._
 import xiangshan.mem.LqPtr
 import xiangshan.mem.prefetch._
 import xiangshan.mem.trace._
+import xiangshan.mem.Bundles.SbufferForward
+import freechips.rocketchip.util.UIntToAugmentedUInt
 
 class MissReqWoStoreData(implicit p: Parameters) extends DCacheBundle {
   val source = UInt(sourceTypeWidth.W)
@@ -833,7 +835,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.refill_to_ldq.bits.error := RegEnable(io.mem_grant.bits.corrupt || io.mem_grant.bits.denied, refill_to_ldq_en)
   io.refill_to_ldq.bits.refill_done := RegEnable(refill_done && io.mem_grant.fire, refill_to_ldq_en)
   io.refill_to_ldq.bits.hasdata := hasData
-  io.refill_to_ldq.bits.data_raw := refill_data_raw.asUInt
+  io.refill_to_ldq.bits.data_raw := refill_and_store_data.asUInt
   io.refill_to_ldq.bits.id := io.id
 
   // if the entry has a pending merge req, wait for it
@@ -958,6 +960,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.forwardInfo.inflight := req_valid
   io.forwardInfo.paddr := req.addr
   io.forwardInfo.raw_data := refill_and_store_data
+  io.forwardInfo.isFromStore := req.isFromStore
+  io.forwardInfo.store_mask := req_store_mask
   io.forwardInfo.firstbeat_valid := w_grantfirst_forward_info
   io.forwardInfo.lastbeat_valid := w_grantlast_forward_info
   io.forwardInfo.denied := denied
@@ -1062,6 +1066,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     // forward missqueue
     val forward = Flipped(Vec(LoadPipelineWidth, new DCacheForward))
     val forwardS1PAddrMatch = Output(Vec(LoadPipelineWidth, Bool()))
+    // If a store is miss and accepted by mshr, Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
+    val forward_stData = Flipped(Vec(LoadPipelineWidth, new SbufferForward))
     val l2_pf_store_only = Input(Bool())
 
     val memSetPattenDetected = Output(Bool())
@@ -1182,6 +1188,51 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     XSError(((s1SelectOH - 1.U) & s1SelectOH).orR && s1RespValid, "multi mshr hit when forward!\n")
   }
 
+  io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
+    val s0ReqValid_stLdForward = forward.s0Req.valid
+    val s0Req_stLdForward = forward.s0Req.bits
+    val s1ReqValid_stLdForward = RegNext(s0ReqValid_stLdForward)
+    val s1Req_stLdForward = RegEnable(s0Req_stLdForward, s0ReqValid_stLdForward)
+    val paddr_stLdForward = forward.s1Req.paddr
+    val s1PaddrMatchVec_stLdForward = VecInit(forwardInfo_vec.map{ case info =>
+      paddr_stLdForward(paddr_stLdForward.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
+      info.inflight})
+    val s1SelectOH_stLdForward = s1PaddrMatchVec_stLdForward.asUInt
+    dontTouch(s1SelectOH_stLdForward)
+    val s1ForwardInfo_stLdForward = Mux1H(s1SelectOH_stLdForward, forwardInfo_vec)
+
+    val VLENB = VLEN / 8
+    val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdForward(blockOffBits - 1, log2Up(VLENB)) === i.U)
+    val s1RespData_stLdForward = Mux1H(paddr_selOH,
+          s1ForwardInfo_stLdForward.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
+    dontTouch(s1RespData_stLdForward)
+    val s1RespMask_stLdForward = Mux1H(paddr_selOH,
+         s1ForwardInfo_stLdForward.store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo_stLdForward.isFromStore, x, 0.U)))
+    dontTouch(s1RespMask_stLdForward)
+    val s1RespValid_stLdForward = s1ReqValid_stLdForward && s1SelectOH_stLdForward.orR
+    
+    forward.s2Resp.valid := RegNext(s1RespValid_stLdForward)
+    for (i <- 0 until VDataBytes) {
+      forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdForward.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdForward) 
+      forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdForward(i), s1RespValid_stLdForward) && forward.s2Resp.valid
+    }
+
+    // val s1RespData_stLdForward = VecInit(
+    //   s1ForwardInfo_stLdForward.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq
+    // )(paddr_stLdForward(blockOffBits - 1, log2Up(VLEN / 8)))
+    // dontTouch(s1RespData_stLdForward)
+    // val s1RespMask_stLdForward = Mux1H(s1SelectOH_stLdForward, forwardInfo_vec.map(x => Mux(x.isFromStore, x.store_mask, 0.U)))
+    // dontTouch(s1RespMask_stLdForward)
+    // val s1RespValid_stLdForward = s1ReqValid_stLdForward && s1SelectOH_stLdForward.orR
+    
+    // forward.s2Resp.valid := RegNext(s1RespValid_stLdForward)
+    // for (i <- 0 until VDataBytes) {
+    //   forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdForward.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdForward) 
+    //   forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdForward(i), s1RespValid_stLdForward) && forward.s2Resp.valid
+    // }
+    forward.s2Resp.bits.matchInvalid := false.B
+  }
+    
   assert(RegNext(PopCount(secondary_ready_vec) <= 1.U || !io.req.valid))
 //  assert(RegNext(PopCount(secondary_reject_vec) <= 1.U))
   // It is possible that one mshr wants to merge a req, while another mshr wants to reject it.

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1190,23 +1190,13 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val s1ReqValid = RegNext(s0ReqValid)
     val s1Req = RegEnable(s0Req, s0ReqValid)
     val mshrIdOH = UIntToOH(s1Req.mshrId)
-    // val paddr = forward.s1Req.paddr
 
-    // val s1PaddrMatchVec = VecInit(forwardInfo_vec.map{ case info =>
-    //   paddr(paddr.getWidth - 1, blockOffBits) === info.paddr(paddr.getWidth - 1, blockOffBits) &&
-    //   info.inflight})
     val s1BeatMatchVec  = VecInit(forwardInfo_vec.map{ case info =>
       Mux(paddrFwd(i)(log2Up(refillBytes)).asBool,
         info.lastbeat_valid,
         info.firstbeat_valid
     )})
-    // val s1SelectOH     = s1PaddrMatchVec.asUInt & s1BeatMatchVec.asUInt
-    // val s1MshrForwardInfo = Mux1H(s1SelectOH, forwardInfo_vec)
-    // val s1RespData = VecInit(
-    //   s1MshrForwardInfo.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq
-    // )(paddr(blockOffBits - 1, log2Up(VLEN / 8)))
     val s1RespValid = s1ReqValid && (s1SelectOH(i) & s1BeatMatchVec.asUInt).orR
-
 
     forward.s2Resp.valid := RegNext(s1RespValid)
     forward.s2Resp.bits.matchInvalid := false.B
@@ -1219,20 +1209,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
     val s0ReqValid_stLdFwd = forward.s0Req.valid
-    val s0Req_stLdFwd = forward.s0Req.bits
     val s1ReqValid_stLdFwd = RegNext(s0ReqValid_stLdFwd)
-    val s1Req_stLdFwd = RegEnable(s0Req_stLdFwd, s0ReqValid_stLdFwd)
-    // val paddr_stLdFwd = forward.s1Req.paddr
-    // val s1PaddrMatchVec_stLdFwd = VecInit(forwardInfo_vec.map{ case info =>
-    //   paddr_stLdFwd(paddr_stLdFwd.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
-    //   info.inflight})
-    // val s1SelectOH_stLdFwd = s1PaddrMatchVec_stLdFwd.asUInt
-    // val s1ForwardInfo_stLdFwd = Mux1H(s1SelectOH_stLdFwd, forwardInfo_vec)
 
-    // val VLENB = VLEN / 8
-    // val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdFwd(blockOffBits - 1, log2Up(VLENB)) === i.U)
-    // val s1RespData_stLdFwd = Mux1H(paddr_selOH,
-    //       s1ForwardInfo_stLdFwd.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
     val s1RespMask_stLdFwd = Mux1H(paddrFwd_selOH(i),
           s1ForwardInfo(i).store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo(i).isFromStore, x, 0.U)))
     val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH(i).orR

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -476,6 +476,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   val req_valid = RegInit(false.B)
   val set = addr_to_dcache_set(req.vaddr)
   val evict_BtoT_way = RegInit(false.B)
+  val hasStoreAll = Reg(Bool())  // The alloc req is a store req and all merged reqs are store reqs
   // initial keyword
   val isKeyword = RegInit(false.B)
 
@@ -561,6 +562,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
     req_primary_fire := miss_req_pipe_reg_bits.toMissReqWoStoreData()
     evict_BtoT_way := false.B
+    hasStoreAll := miss_req_pipe_reg_bits.isFromStore
     //only  load miss need keyword
     isKeyword := Mux(miss_req_pipe_reg_bits.isFromLoad, miss_req_pipe_reg_bits.vaddr(5).asBool,false.B)
 
@@ -580,6 +582,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       for (i <- 0 until blockRows) {
         refill_and_store_data(i) := miss_req_pipe_reg_bits.store_data(rowBits * (i + 1) - 1, rowBits * i)
       }
+    }.otherwise {
+      req_store_mask := 0.U
     }
     full_overwrite := miss_req_pipe_reg_bits.isFromStore && miss_req_pipe_reg_bits.full_overwrite
 
@@ -610,6 +614,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     // use the most uptodate meta
     req.req_coh := miss_req_pipe_reg_bits.req_coh
 
+    hasStoreAll := hasStoreAll && miss_req_pipe_reg_bits.isFromStore
+
     isKeyword := Mux(
       before_req_sent_can_merge(miss_req_pipe_reg_bits),
       before_req_sent_merge_iskeyword(miss_req_pipe_reg_bits),
@@ -622,9 +628,25 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       req.occupy_way := miss_req_pipe_reg_bits.occupy_way
       evict_BtoT_way := false.B
       req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
-      req_store_mask := miss_req_pipe_reg_bits.store_mask
-      for (i <- 0 until blockRows) {
-        refill_and_store_data(i) := miss_req_pipe_reg_bits.store_data(rowBits * (i + 1) - 1, rowBits * i)
+      req_store_mask := req_store_mask | miss_req_pipe_reg_bits.store_mask
+
+      // for (i <- 0 until blockRows) {
+      //   val store_mask_temp = miss_req_pipe_reg_bits.store_mask.grouped(rowBytes)(i).asBools
+      //   val store_data_temp = (miss_req_pipe_reg_bits.store_data.grouped(8).grouped(rowBytes).toSeq)(i)
+      //   refill_and_store_data(i) := VecInit((0 until rowBytes).map(k => 
+      //     Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data(i).grouped(8)(k)))).asUInt
+      // }
+
+      for (i <- 0 until blockRows) {  //todo: dirty code rewrite
+        val store_data_temp = Wire(Vec(rowBits/8, UInt(8.W)))
+        for (j <- 0 until rowBits/8) {
+          when (miss_req_pipe_reg_bits.store_mask(i * rowBits/8 + j)) {
+            store_data_temp(j) := miss_req_pipe_reg_bits.store_data(i * rowBits + 8 * (j + 1) - 1, i * rowBits + 8 * j)
+          }.otherwise {
+            store_data_temp(j) := refill_and_store_data(i)(8 * (j + 1) - 1, 8 * j)
+          }
+        }
+        refill_and_store_data(i) := store_data_temp.asUInt
       }
       full_overwrite := miss_req_pipe_reg_bits.isFromStore && miss_req_pipe_reg_bits.full_overwrite
       assert(is_alias_match(req.vaddr, miss_req_pipe_reg_bits.vaddr), "alias bits should be the same when merging store")
@@ -750,7 +772,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   }
 
   def before_data_refill_can_merge(new_req: MissReqWoStoreData): Bool = {
-    data_not_refilled && new_req.isFromLoad
+    data_not_refilled && new_req.isFromLoad ||
+    data_not_refilled && new_req.isFromStore && hasStoreAll
   }
 
   // Note that late prefetch will be ignored
@@ -1136,6 +1159,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   miss_req_pipe_reg.merge   := merge && io.req.valid && !io.req.bits.cancel && !io.wbq_block_miss_req
   miss_req_pipe_reg.cancel  := io.wbq_block_miss_req
   miss_req_pipe_reg.mshr_id := io.resp.id
+  assert(!(io.req.bits.isFromStore && io.req.valid && miss_req_pipe_reg.req.isFromStore &&
+          get_block(io.req.bits.addr) === get_block(miss_req_pipe_reg.req.addr)), "Two consecutive store reqs to the same block!")
 
   assert(PopCount(Seq(alloc && io.req.valid, merge && io.req.valid)) <= 1.U, "allocate and merge a mshr in same cycle!")
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1168,6 +1168,7 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   val forwardInfo_vec = VecInit(entries.map(_.io.forwardInfo))
   val VLENB = VLEN / 8
+  // Forwarding paddr CAM, shared by io.forward and io.forward_stData
   val paddrFwd = Wire(Vec(LoadPipelineWidth, UInt(PAddrBits.W)))
   val s1PaddrMatchVec = Wire(Vec(LoadPipelineWidth, Vec(cfg.nMissEntries, Bool())))
   val s1SelectOH = Wire(Vec(LoadPipelineWidth, UInt((cfg.nMissEntries).W)))
@@ -1180,6 +1181,7 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       (paddrFwd(i) >> blockOffBits) === (info.paddr >> blockOffBits) && info.inflight})
     s1SelectOH(i) := s1PaddrMatchVec(i).asUInt
     s1ForwardInfo(i) := Mux1H(s1SelectOH(i), forwardInfo_vec)
+    // Select VLEN (128-bit) data from cacheline data
     paddrFwd_selOH(i) := (0 until (blockBytes / VLENB)).map(k => paddrFwd(i)(blockOffBits - 1, log2Up(VLENB)) === k.U)
     s1RespDataFwd(i) := Mux1H(paddrFwd_selOH(i), s1ForwardInfo(i).raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
   }
@@ -1208,17 +1210,16 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   }
 
   io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
-    val s0ReqValid_stLdFwd = forward.s0Req.valid
-    val s1ReqValid_stLdFwd = RegNext(s0ReqValid_stLdFwd)
+    val s1ReqValid_stLdFwd = RegNext(forward.s0Req.valid)
 
     val s1RespMask_stLdFwd = Mux1H(paddrFwd_selOH(i),
           s1ForwardInfo(i).store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo(i).isFromStore, x, 0.U)))
     val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH(i).orR
     
     forward.s2Resp.valid := RegNext(s1RespValid_stLdFwd)
-    for (j <- 0 until VDataBytes) {
-      forward.s2Resp.bits.forwardData(j) := RegEnable(s1RespDataFwd(i)(8 * j + 7, 8 * j), s1RespValid_stLdFwd) 
-      forward.s2Resp.bits.forwardMask(j) := RegEnable(s1RespMask_stLdFwd(j), s1RespValid_stLdFwd) && forward.s2Resp.valid
+    for (k <- 0 until VLENB) {
+      forward.s2Resp.bits.forwardData(k) := RegEnable(s1RespDataFwd(i)(8 * k + 7, 8 * k), s1RespValid_stLdFwd) 
+      forward.s2Resp.bits.forwardMask(k) := RegEnable(s1RespMask_stLdFwd(k), s1RespValid_stLdFwd) && forward.s2Resp.valid
     }
     forward.s2Resp.bits.matchInvalid := false.B
   }

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1189,47 +1189,30 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   }
 
   io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
-    val s0ReqValid_stLdForward = forward.s0Req.valid
-    val s0Req_stLdForward = forward.s0Req.bits
-    val s1ReqValid_stLdForward = RegNext(s0ReqValid_stLdForward)
-    val s1Req_stLdForward = RegEnable(s0Req_stLdForward, s0ReqValid_stLdForward)
-    val paddr_stLdForward = forward.s1Req.paddr
-    val s1PaddrMatchVec_stLdForward = VecInit(forwardInfo_vec.map{ case info =>
-      paddr_stLdForward(paddr_stLdForward.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
+    val s0ReqValid_stLdFwd = forward.s0Req.valid
+    val s0Req_stLdFwd = forward.s0Req.bits
+    val s1ReqValid_stLdFwd = RegNext(s0ReqValid_stLdFwd)
+    val s1Req_stLdFwd = RegEnable(s0Req_stLdFwd, s0ReqValid_stLdFwd)
+    val paddr_stLdFwd = forward.s1Req.paddr
+    val s1PaddrMatchVec_stLdFwd = VecInit(forwardInfo_vec.map{ case info =>
+      paddr_stLdFwd(paddr_stLdFwd.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
       info.inflight})
-    val s1SelectOH_stLdForward = s1PaddrMatchVec_stLdForward.asUInt
-    dontTouch(s1SelectOH_stLdForward)
-    val s1ForwardInfo_stLdForward = Mux1H(s1SelectOH_stLdForward, forwardInfo_vec)
+    val s1SelectOH_stLdFwd = s1PaddrMatchVec_stLdFwd.asUInt
+    val s1ForwardInfo_stLdFwd = Mux1H(s1SelectOH_stLdFwd, forwardInfo_vec)
 
     val VLENB = VLEN / 8
-    val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdForward(blockOffBits - 1, log2Up(VLENB)) === i.U)
-    val s1RespData_stLdForward = Mux1H(paddr_selOH,
-          s1ForwardInfo_stLdForward.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
-    dontTouch(s1RespData_stLdForward)
-    val s1RespMask_stLdForward = Mux1H(paddr_selOH,
-         s1ForwardInfo_stLdForward.store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo_stLdForward.isFromStore, x, 0.U)))
-    dontTouch(s1RespMask_stLdForward)
-    val s1RespValid_stLdForward = s1ReqValid_stLdForward && s1SelectOH_stLdForward.orR
+    val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdFwd(blockOffBits - 1, log2Up(VLENB)) === i.U)
+    val s1RespData_stLdFwd = Mux1H(paddr_selOH,
+          s1ForwardInfo_stLdFwd.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
+    val s1RespMask_stLdFwd = Mux1H(paddr_selOH,
+          s1ForwardInfo_stLdFwd.store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo_stLdFwd.isFromStore, x, 0.U)))
+    val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH_stLdFwd.orR
     
-    forward.s2Resp.valid := RegNext(s1RespValid_stLdForward)
+    forward.s2Resp.valid := RegNext(s1RespValid_stLdFwd)
     for (i <- 0 until VDataBytes) {
-      forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdForward.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdForward) 
-      forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdForward(i), s1RespValid_stLdForward) && forward.s2Resp.valid
+      forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdFwd.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdFwd) 
+      forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdFwd(i), s1RespValid_stLdFwd) && forward.s2Resp.valid
     }
-
-    // val s1RespData_stLdForward = VecInit(
-    //   s1ForwardInfo_stLdForward.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq
-    // )(paddr_stLdForward(blockOffBits - 1, log2Up(VLEN / 8)))
-    // dontTouch(s1RespData_stLdForward)
-    // val s1RespMask_stLdForward = Mux1H(s1SelectOH_stLdForward, forwardInfo_vec.map(x => Mux(x.isFromStore, x.store_mask, 0.U)))
-    // dontTouch(s1RespMask_stLdForward)
-    // val s1RespValid_stLdForward = s1ReqValid_stLdForward && s1SelectOH_stLdForward.orR
-    
-    // forward.s2Resp.valid := RegNext(s1RespValid_stLdForward)
-    // for (i <- 0 until VDataBytes) {
-    //   forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdForward.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdForward) 
-    //   forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdForward(i), s1RespValid_stLdForward) && forward.s2Resp.valid
-    // }
     forward.s2Resp.bits.matchInvalid := false.B
   }
     

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -476,7 +476,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   val req_valid = RegInit(false.B)
   val set = addr_to_dcache_set(req.vaddr)
   val evict_BtoT_way = RegInit(false.B)
-  val hasStoreAll = Reg(Bool())  // The alloc req is a store req and all merged reqs are store reqs
+  val alloc_is_store = Reg(Bool())  // The alloc (first) req is a store req
   // initial keyword
   val isKeyword = RegInit(false.B)
 
@@ -562,7 +562,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
     req_primary_fire := miss_req_pipe_reg_bits.toMissReqWoStoreData()
     evict_BtoT_way := false.B
-    hasStoreAll := miss_req_pipe_reg_bits.isFromStore
+    alloc_is_store := miss_req_pipe_reg_bits.isFromStore
     //only  load miss need keyword
     isKeyword := Mux(miss_req_pipe_reg_bits.isFromLoad, miss_req_pipe_reg_bits.vaddr(5).asBool,false.B)
 
@@ -614,8 +614,6 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     // use the most uptodate meta
     req.req_coh := miss_req_pipe_reg_bits.req_coh
 
-    hasStoreAll := hasStoreAll && miss_req_pipe_reg_bits.isFromStore
-
     isKeyword := Mux(
       before_req_sent_can_merge(miss_req_pipe_reg_bits),
       before_req_sent_merge_iskeyword(miss_req_pipe_reg_bits),
@@ -629,24 +627,11 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       evict_BtoT_way := false.B
       req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
       req_store_mask := req_store_mask | miss_req_pipe_reg_bits.store_mask
-
-      // for (i <- 0 until blockRows) {
-      //   val store_mask_temp = miss_req_pipe_reg_bits.store_mask.grouped(rowBytes)(i).asBools
-      //   val store_data_temp = (miss_req_pipe_reg_bits.store_data.grouped(8).grouped(rowBytes).toSeq)(i)
-      //   refill_and_store_data(i) := VecInit((0 until rowBytes).map(k => 
-      //     Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data(i).grouped(8)(k)))).asUInt
-      // }
-
-      for (i <- 0 until blockRows) {  //todo: dirty code rewrite
-        val store_data_temp = Wire(Vec(rowBits/8, UInt(8.W)))
-        for (j <- 0 until rowBits/8) {
-          when (miss_req_pipe_reg_bits.store_mask(i * rowBits/8 + j)) {
-            store_data_temp(j) := miss_req_pipe_reg_bits.store_data(i * rowBits + 8 * (j + 1) - 1, i * rowBits + 8 * j)
-          }.otherwise {
-            store_data_temp(j) := refill_and_store_data(i)(8 * (j + 1) - 1, 8 * j)
-          }
-        }
-        refill_and_store_data(i) := store_data_temp.asUInt
+      for (i <- 0 until blockRows) {
+        val store_mask_temp = miss_req_pipe_reg_bits.store_mask.grouped(rowBytes)(i).asBools
+        val store_data_temp = (miss_req_pipe_reg_bits.store_data.grouped(8).grouped(rowBytes).toSeq)(i)
+        refill_and_store_data(i) := VecInit((0 until rowBytes).map(k => 
+          Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data(i).grouped(8)(k)))).asUInt
       }
       full_overwrite := miss_req_pipe_reg_bits.isFromStore && miss_req_pipe_reg_bits.full_overwrite
       assert(is_alias_match(req.vaddr, miss_req_pipe_reg_bits.vaddr), "alias bits should be the same when merging store")
@@ -773,7 +758,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   def before_data_refill_can_merge(new_req: MissReqWoStoreData): Bool = {
     data_not_refilled && new_req.isFromLoad ||
-    data_not_refilled && new_req.isFromStore && hasStoreAll
+    data_not_refilled && new_req.isFromStore && alloc_is_store
   }
 
   // Note that late prefetch will be ignored
@@ -1159,7 +1144,7 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   miss_req_pipe_reg.merge   := merge && io.req.valid && !io.req.bits.cancel && !io.wbq_block_miss_req
   miss_req_pipe_reg.cancel  := io.wbq_block_miss_req
   miss_req_pipe_reg.mshr_id := io.resp.id
-  assert(!(io.req.bits.isFromStore && io.req.valid && miss_req_pipe_reg.req.isFromStore &&
+  assert(!(io.req.bits.isFromStore && io.req.valid && miss_req_pipe_reg.req.isFromStore && (miss_req_pipe_reg.alloc || miss_req_pipe_reg.merge) &&
           get_block(io.req.bits.addr) === get_block(miss_req_pipe_reg.req.addr)), "Two consecutive store reqs to the same block!")
 
   assert(PopCount(Seq(alloc && io.req.valid, merge && io.req.valid)) <= 1.U, "allocate and merge a mshr in same cycle!")

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -636,7 +636,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
         refill_and_store_data(i) := VecInit((0 until rowBytes).map(k => 
           Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data(i).grouped(8)(k)))).asUInt
       }
-      full_overwrite := miss_req_pipe_reg_bits.isFromStore && miss_req_pipe_reg_bits.full_overwrite
+      full_overwrite := full_overwrite || miss_req_pipe_reg_bits.full_overwrite
       assert(is_alias_match(req.vaddr, miss_req_pipe_reg_bits.vaddr), "alias bits should be the same when merging store")
     }
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -413,6 +413,9 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     // for main pipe s2
     val refill_info = ValidIO(new MissQueueRefillInfo)
     val refill_train = ValidIO(new TrainReqBundle)
+    // store replay to main pipe s3 (finally to sbuffer)
+    //   only triggerd when a store req is being merged to an entry but the grant.fire comes at the same time
+    val store_replay_resp = Output(Bool())
 
     val occupy_way = Output(UInt(nWays.W))
 
@@ -607,7 +610,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     refill_start_time := GTimer()
   }
 
-  when (io.miss_req_pipe_reg.merge && !io.miss_req_pipe_reg.cancel) {
+  when (io.miss_req_pipe_reg.merge && !io.miss_req_pipe_reg.cancel && !(io.mem_grant.fire && miss_req_pipe_reg_bits.isFromStore)) {
     assert(RegNext(secondary_fire) || RegNext(RegNext(primary_fire)), "after 1 cycle of secondary_fire or 2 cycle of primary_fire, entry will be merged")
     assert(miss_req_pipe_reg_bits.req_coh.state <= req.req_coh.state || (prefetch && !access))
     assert(!(miss_req_pipe_reg_bits.isFromAMO || req.isFromAMO))
@@ -644,6 +647,9 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     }
     secondary_fired := true.B
   }
+
+  io.store_replay_resp := io.mem_grant.fire && io.miss_req_pipe_reg.merge && !io.miss_req_pipe_reg.cancel &&
+                          miss_req_pipe_reg_bits.isFromStore
 
   when (io.mem_acquire.fire) {
     s_acquire := true.B
@@ -758,7 +764,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   def before_data_refill_can_merge(new_req: MissReqWoStoreData): Bool = {
     data_not_refilled && new_req.isFromLoad ||
-    data_not_refilled && new_req.isFromStore && alloc_is_store
+    !io.mem_grant.fire && data_not_refilled && new_req.isFromStore && alloc_is_store
   }
 
   // Note that late prefetch will be ignored
@@ -1087,6 +1093,9 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
     val debugTopDown = new DCacheTopDownIO
     val l1Miss = Output(Bool())
+
+    /** Store merged in pipereg gets grant same cycle: pulse to MainPipe → Sbuffer main_pipe_hit_resp.replay */
+    val mq_merge_grant_store_replay = ValidIO(UInt(reqIdWidth.W))
   })
 
   // 128KBL1: FIXME: provide vaddr for l2
@@ -1309,6 +1318,9 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
       e.io.wfi.wfiReq := io.wfi.wfiReq
   }
+
+  io.mq_merge_grant_store_replay.valid := VecInit(entries.map(_.io.store_replay_resp)).asUInt.orR
+  io.mq_merge_grant_store_replay.bits := miss_req_pipe_reg.req.id
 
   cmo_unit.io.wfi.wfiReq := io.wfi.wfiReq
   cmo_unit.io.req <> io.cmo_req

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1401,7 +1401,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val difftest = DifftestModule(new DiffRefillEvent, dontCare = true)
     difftest.coreid := io.hartId
     difftest.index := 1.U
-    difftest.valid := io.refill_to_ldq.valid && io.refill_to_ldq.bits.hasdata && io.refill_to_ldq.bits.refill_done
+    // difftest.valid := io.refill_to_ldq.valid && io.refill_to_ldq.bits.hasdata && io.refill_to_ldq.bits.refill_done
+    difftest.valid := false.B
     difftest.addr := io.refill_to_ldq.bits.addr
     difftest.data := io.refill_to_ldq.bits.data_raw.asTypeOf(difftest.data)
     difftest.mask := VecInit.fill(difftest.mask.getWidth)(true.B).asUInt

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1167,37 +1167,54 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.memSetPattenDetected := memSetPattenDetected
 
   val forwardInfo_vec = VecInit(entries.map(_.io.forwardInfo))
+  val VLENB = VLEN / 8
+  val paddrFwd = Wire(Vec(LoadPipelineWidth, UInt(PAddrBits.W)))
+  val s1PaddrMatchVec = Wire(Vec(LoadPipelineWidth, Vec(cfg.nMissEntries, Bool())))
+  val s1SelectOH = Wire(Vec(LoadPipelineWidth, UInt((cfg.nMissEntries).W)))
+  val s1ForwardInfo = Wire(Vec(LoadPipelineWidth, new MissEntryForwardIO))
+  val paddrFwd_selOH = Wire(Vec(LoadPipelineWidth, Vec(blockBytes / VLENB, Bool())))
+  val s1RespDataFwd = Wire(Vec(LoadPipelineWidth, UInt(VLEN.W)))
+  for (i <- 0 until LoadPipelineWidth) {
+    paddrFwd(i) := Mux(RegNext(io.forward_stData(i).s0Req.valid), io.forward_stData(i).s1Req.paddr, io.forward(i).s1Req.paddr)
+    s1PaddrMatchVec(i) := VecInit(forwardInfo_vec.map{ case info =>
+      (paddrFwd(i) >> blockOffBits) === (info.paddr >> blockOffBits) && info.inflight})
+    s1SelectOH(i) := s1PaddrMatchVec(i).asUInt
+    s1ForwardInfo(i) := Mux1H(s1SelectOH(i), forwardInfo_vec)
+    paddrFwd_selOH(i) := (0 until (blockBytes / VLENB)).map(k => paddrFwd(i)(blockOffBits - 1, log2Up(VLENB)) === k.U)
+    s1RespDataFwd(i) := Mux1H(paddrFwd_selOH(i), s1ForwardInfo(i).raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
+  }
+
   io.forward.zipWithIndex.foreach { case (forward, i) =>
     val s0ReqValid = forward.s0Req.valid
     val s0Req = forward.s0Req.bits
     val s1ReqValid = RegNext(s0ReqValid)
     val s1Req = RegEnable(s0Req, s0ReqValid)
     val mshrIdOH = UIntToOH(s1Req.mshrId)
-    val paddr = forward.s1Req.paddr
+    // val paddr = forward.s1Req.paddr
 
-    val s1PaddrMatchVec = VecInit(forwardInfo_vec.map{ case info =>
-      paddr(paddr.getWidth - 1, blockOffBits) === info.paddr(paddr.getWidth - 1, blockOffBits) &&
-      info.inflight})
+    // val s1PaddrMatchVec = VecInit(forwardInfo_vec.map{ case info =>
+    //   paddr(paddr.getWidth - 1, blockOffBits) === info.paddr(paddr.getWidth - 1, blockOffBits) &&
+    //   info.inflight})
     val s1BeatMatchVec  = VecInit(forwardInfo_vec.map{ case info =>
-      Mux(paddr(log2Up(refillBytes)).asBool,
+      Mux(paddrFwd(i)(log2Up(refillBytes)).asBool,
         info.lastbeat_valid,
         info.firstbeat_valid
     )})
-    val s1SelectOH     = s1PaddrMatchVec.asUInt & s1BeatMatchVec.asUInt
-    val s1MshrForwardInfo = Mux1H(s1SelectOH, forwardInfo_vec)
-    val s1RespData = VecInit(
-      s1MshrForwardInfo.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq
-    )(paddr(blockOffBits - 1, log2Up(VLEN / 8)))
-    val s1RespValid = s1ReqValid && s1SelectOH.orR
+    // val s1SelectOH     = s1PaddrMatchVec.asUInt & s1BeatMatchVec.asUInt
+    // val s1MshrForwardInfo = Mux1H(s1SelectOH, forwardInfo_vec)
+    // val s1RespData = VecInit(
+    //   s1MshrForwardInfo.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq
+    // )(paddr(blockOffBits - 1, log2Up(VLEN / 8)))
+    val s1RespValid = s1ReqValid && (s1SelectOH(i) & s1BeatMatchVec.asUInt).orR
 
 
     forward.s2Resp.valid := RegNext(s1RespValid)
     forward.s2Resp.bits.matchInvalid := false.B
-    forward.s2Resp.bits.forwardData := RegEnable(s1RespData.asTypeOf(forward.s2Resp.bits.forwardData), s1ReqValid)
-    forward.s2Resp.bits.denied := RegEnable(s1MshrForwardInfo.denied, s1ReqValid)
-    forward.s2Resp.bits.corrupt := RegEnable(s1MshrForwardInfo.corrupt, s1ReqValid)
-    io.forwardS1PAddrMatch(i) := s1ReqValid && (mshrIdOH & s1PaddrMatchVec.asUInt).orR
-    XSError(((s1SelectOH - 1.U) & s1SelectOH).orR && s1RespValid, "multi mshr hit when forward!\n")
+    forward.s2Resp.bits.forwardData := RegEnable(s1RespDataFwd(i).asTypeOf(forward.s2Resp.bits.forwardData), s1ReqValid)
+    forward.s2Resp.bits.denied := RegEnable(s1ForwardInfo(i).denied, s1ReqValid)
+    forward.s2Resp.bits.corrupt := RegEnable(s1ForwardInfo(i).corrupt, s1ReqValid)
+    io.forwardS1PAddrMatch(i) := s1ReqValid && (mshrIdOH & s1PaddrMatchVec(i).asUInt).orR
+    XSError(((s1SelectOH(i) - 1.U) & s1SelectOH(i)).orR && s1RespValid, "multi mshr hit when forward!\n")
   }
 
   io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
@@ -1205,25 +1222,25 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val s0Req_stLdFwd = forward.s0Req.bits
     val s1ReqValid_stLdFwd = RegNext(s0ReqValid_stLdFwd)
     val s1Req_stLdFwd = RegEnable(s0Req_stLdFwd, s0ReqValid_stLdFwd)
-    val paddr_stLdFwd = forward.s1Req.paddr
-    val s1PaddrMatchVec_stLdFwd = VecInit(forwardInfo_vec.map{ case info =>
-      paddr_stLdFwd(paddr_stLdFwd.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
-      info.inflight})
-    val s1SelectOH_stLdFwd = s1PaddrMatchVec_stLdFwd.asUInt
-    val s1ForwardInfo_stLdFwd = Mux1H(s1SelectOH_stLdFwd, forwardInfo_vec)
+    // val paddr_stLdFwd = forward.s1Req.paddr
+    // val s1PaddrMatchVec_stLdFwd = VecInit(forwardInfo_vec.map{ case info =>
+    //   paddr_stLdFwd(paddr_stLdFwd.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
+    //   info.inflight})
+    // val s1SelectOH_stLdFwd = s1PaddrMatchVec_stLdFwd.asUInt
+    // val s1ForwardInfo_stLdFwd = Mux1H(s1SelectOH_stLdFwd, forwardInfo_vec)
 
-    val VLENB = VLEN / 8
-    val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdFwd(blockOffBits - 1, log2Up(VLENB)) === i.U)
-    val s1RespData_stLdFwd = Mux1H(paddr_selOH,
-          s1ForwardInfo_stLdFwd.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
-    val s1RespMask_stLdFwd = Mux1H(paddr_selOH,
-          s1ForwardInfo_stLdFwd.store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo_stLdFwd.isFromStore, x, 0.U)))
-    val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH_stLdFwd.orR
+    // val VLENB = VLEN / 8
+    // val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdFwd(blockOffBits - 1, log2Up(VLENB)) === i.U)
+    // val s1RespData_stLdFwd = Mux1H(paddr_selOH,
+    //       s1ForwardInfo_stLdFwd.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
+    val s1RespMask_stLdFwd = Mux1H(paddrFwd_selOH(i),
+          s1ForwardInfo(i).store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo(i).isFromStore, x, 0.U)))
+    val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH(i).orR
     
     forward.s2Resp.valid := RegNext(s1RespValid_stLdFwd)
-    for (i <- 0 until VDataBytes) {
-      forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdFwd.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdFwd) 
-      forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdFwd(i), s1RespValid_stLdFwd) && forward.s2Resp.valid
+    for (j <- 0 until VDataBytes) {
+      forward.s2Resp.bits.forwardData(j) := RegEnable(s1RespDataFwd(i)(8 * j + 7, 8 * j), s1RespValid_stLdFwd) 
+      forward.s2Resp.bits.forwardMask(j) := RegEnable(s1RespMask_stLdFwd(j), s1RespValid_stLdFwd) && forward.s2Resp.valid
     }
     forward.s2Resp.bits.matchInvalid := false.B
   }

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -841,7 +841,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.refill_to_ldq.bits.error := RegEnable(io.mem_grant.bits.corrupt || io.mem_grant.bits.denied, refill_to_ldq_en)
   io.refill_to_ldq.bits.refill_done := RegEnable(refill_done && io.mem_grant.fire, refill_to_ldq_en)
   io.refill_to_ldq.bits.hasdata := hasData
-  io.refill_to_ldq.bits.data_raw := refill_and_store_data.asUInt
+  io.refill_to_ldq.bits.data_raw := refill_data_raw.asUInt
   io.refill_to_ldq.bits.id := io.id
 
   // if the entry has a pending merge req, wait for it
@@ -1401,11 +1401,25 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val difftest = DifftestModule(new DiffRefillEvent, dontCare = true)
     difftest.coreid := io.hartId
     difftest.index := 1.U
-    // difftest.valid := io.refill_to_ldq.valid && io.refill_to_ldq.bits.hasdata && io.refill_to_ldq.bits.refill_done
-    difftest.valid := false.B
+    difftest.valid := io.refill_to_ldq.valid && io.refill_to_ldq.bits.hasdata && io.refill_to_ldq.bits.refill_done
     difftest.addr := io.refill_to_ldq.bits.addr
     difftest.data := io.refill_to_ldq.bits.data_raw.asTypeOf(difftest.data)
     difftest.mask := VecInit.fill(difftest.mask.getWidth)(true.B).asUInt
+  }
+
+  if (env.EnableDifftest) {
+    // Store-miss refill completed in MainPipe S3: update difftest (DiffSbufferEvent).
+    val mq_s3_sel_info = Mux1H(
+      entries.map(e => (io.mainpipe_info.s3_miss_id === e.io.id) -> e.io.forwardInfo)
+    )
+    val hasStore = mq_s3_sel_info.store_mask.orR
+    val difftest_store = DifftestModule(new DiffSbufferEvent, delay = 1)
+    difftest_store.coreid := io.hartId
+    difftest_store.index := 0.U
+    difftest_store.valid := io.mainpipe_info.s3_valid && io.mainpipe_info.s3_refill_resp && hasStore
+    difftest_store.addr := mq_s3_sel_info.paddr
+    difftest_store.data := mq_s3_sel_info.raw_data.asUInt.asTypeOf(difftest_store.data)
+    difftest_store.mask := mq_s3_sel_info.store_mask
   }
 
   // Perf count

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -414,7 +414,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val refill_info = ValidIO(new MissQueueRefillInfo)
     val refill_train = ValidIO(new TrainReqBundle)
     // store replay to main pipe s3 (finally to sbuffer)
-    //   only triggerd when a store req is being merged to an entry but the grant.fire comes at the same time
+    // -- only triggered when a store req is being merged to an entry but the grant.fire comes at the same time
     val store_replay_resp = Output(Bool())
 
     val occupy_way = Output(UInt(nWays.W))
@@ -610,7 +610,10 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     refill_start_time := GTimer()
   }
 
-  when (io.miss_req_pipe_reg.merge && !io.miss_req_pipe_reg.cancel && !(io.mem_grant.fire && miss_req_pipe_reg_bits.isFromStore)) {
+  val store_at_grant = io.mem_grant.fire && miss_req_pipe_reg_bits.isFromStore
+  io.store_replay_resp := io.miss_req_pipe_reg.merge && !io.miss_req_pipe_reg.cancel && store_at_grant
+
+  when (io.miss_req_pipe_reg.merge && !io.miss_req_pipe_reg.cancel && !store_at_grant) {
     assert(RegNext(secondary_fire) || RegNext(RegNext(primary_fire)), "after 1 cycle of secondary_fire or 2 cycle of primary_fire, entry will be merged")
     assert(miss_req_pipe_reg_bits.req_coh.state <= req.req_coh.state || (prefetch && !access))
     assert(!(miss_req_pipe_reg_bits.isFromAMO || req.isFromAMO))
@@ -648,9 +651,6 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     secondary_fired := true.B
   }
 
-  io.store_replay_resp := io.mem_grant.fire && io.miss_req_pipe_reg.merge && !io.miss_req_pipe_reg.cancel &&
-                          miss_req_pipe_reg_bits.isFromStore
-
   when (io.mem_acquire.fire) {
     s_acquire := true.B
     no_pending := false.B
@@ -678,20 +678,12 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     w_grantfirst := true.B
     grant_param := io.mem_grant.bits.param
     when (edge.hasData(io.mem_grant.bits)) {
-      // GrantData
-      when (isKeyword) {
-       for (i <- 0 until beatRows) {
-         val idx = ((refill_count << log2Floor(beatRows)) + i.U) ^ 4.U
-         val grant_row = io.mem_grant.bits.data(rowBits * (i + 1) - 1, rowBits * i)
-         refill_and_store_data(idx) := mergePutData(grant_row, new_data(idx), new_mask(idx))
-        }
-      }
-      .otherwise{
-       for (i <- 0 until beatRows) {
-         val idx = (refill_count << log2Floor(beatRows)) + i.U
-         val grant_row = io.mem_grant.bits.data(rowBits * (i + 1) - 1, rowBits * i)
-         refill_and_store_data(idx) := mergePutData(grant_row, new_data(idx), new_mask(idx))
-        }
+      // GrantData: keyword load swaps beat-to-row mapping (^4 rows for 8-row line, 4 rows/beat)
+      for (i <- 0 until beatRows) {
+        val base_idx = (refill_count << log2Floor(beatRows)) + i.U
+        val idx = Mux(isKeyword, base_idx ^ 4.U, base_idx)
+        val grant_row = io.mem_grant.bits.data(rowBits * (i + 1) - 1, rowBits * i)
+        refill_and_store_data(idx) := mergePutData(grant_row, new_data(idx), new_mask(idx))
       }
       w_grantlast := w_grantlast || refill_done
       no_pending := no_pending || refill_done
@@ -1094,8 +1086,9 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val debugTopDown = new DCacheTopDownIO
     val l1Miss = Output(Bool())
 
-    /** Store merged in pipereg gets grant same cycle: pulse to MainPipe → Sbuffer main_pipe_hit_resp.replay */
-    val mq_merge_grant_store_replay = ValidIO(UInt(reqIdWidth.W))
+    // store replay to main pipe S3 (finally to sbuffer)
+    // -- only triggered when a store req is being merged to an entry but the grant.fire comes at the same time
+    val store_replay_resp_s3 = ValidIO(UInt(reqIdWidth.W))
   })
 
   // 128KBL1: FIXME: provide vaddr for l2
@@ -1319,8 +1312,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       e.io.wfi.wfiReq := io.wfi.wfiReq
   }
 
-  io.mq_merge_grant_store_replay.valid := VecInit(entries.map(_.io.store_replay_resp)).asUInt.orR
-  io.mq_merge_grant_store_replay.bits := miss_req_pipe_reg.req.id
+  io.store_replay_resp_s3.valid := entries.map(_.io.store_replay_resp).reduce(_||_)
+  io.store_replay_resp_s3.bits := miss_req_pipe_reg.req.id
 
   cmo_unit.io.wfi.wfiReq := io.wfi.wfiReq
   cmo_unit.io.req <> io.cmo_req

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -896,6 +896,19 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     // forward & NC bypass
     lsq.io.forward(i) <> newLoadUnits(i).io.sqForward
     sbuffer.io.forward(i) <> newLoadUnits(i).io.sbufferForward
+    dcache.io.lsu.forward_mshrStData(i) <> newLoadUnits(i).io.sbufferForward
+    // Rewrite newLoadUnits(i).io.sbufferForward.s2Resp to merge sbuffer and mshr st-ld forwarding data
+    newLoadUnits(i).io.sbufferForward.s2Resp.valid := sbuffer.io.forward(i).s2Resp.valid || dcache.io.lsu.forward_mshrStData(i).s2Resp.valid
+    newLoadUnits(i).io.sbufferForward.s2Resp.bits.matchInvalid := sbuffer.io.forward(i).s2Resp.valid && sbuffer.io.forward(i).s2Resp.bits.matchInvalid
+    for (k <- 0 until VDataBytes) {
+      when (sbuffer.io.forward(i).s2Resp.valid && sbuffer.io.forward(i).s2Resp.bits.forwardMask(k)) {
+        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardData(k) := sbuffer.io.forward(i).s2Resp.bits.forwardData(k)
+        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardMask(k) := true.B
+      } otherwise {
+        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardData(k) := dcache.io.lsu.forward_mshrStData(i).s2Resp.bits.forwardData(k)
+        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardMask(k) := dcache.io.lsu.forward_mshrStData(i).s2Resp.bits.forwardMask(k)
+      }
+    }
     uncache.io.forward(i) <> newLoadUnits(i).io.uncacheForward
     dcache.io.lsu.forward_D(i) <> newLoadUnits(i).io.tldForward
     dcache.io.lsu.forward_mshr(i) <> newLoadUnits(i).io.mshrForward

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -711,10 +711,10 @@ class Sbuffer(implicit p: Parameters)
   // hit resp
   io.dcache.hit_resps.map(resp => {
     val dcache_resp_id = resp.bits.id
-    when (resp.fire) {
+    when (resp.fire && !resp.bits.replay) {
       stateVec(dcache_resp_id).state_inflight := false.B
       stateVec(dcache_resp_id).state_valid := false.B
-      assert(!resp.bits.replay)
+      // assert(!resp.bits.replay)
       assert(!resp.bits.miss) // not need to resp if miss, to be opted
       assert(stateVec(dcache_resp_id).state_inflight === true.B)
     }
@@ -728,8 +728,8 @@ class Sbuffer(implicit p: Parameters)
       when(
         stateVec(i).w_sameblock_inflight &&
         stateVec(i).state_valid &&
-        GatedValidRegNext(resp.fire) &&
-        waitInflightMask(i) === UIntToOH(RegEnable(id_to_sbuffer_id(dcache_resp_id), resp.fire))
+        GatedValidRegNext(resp.fire && !resp.bits.replay) &&
+        waitInflightMask(i) === UIntToOH(RegEnable(id_to_sbuffer_id(dcache_resp_id), resp.fire && !resp.bits.replay))
       ){
         stateVec(i).w_sameblock_inflight := false.B
       }
@@ -737,17 +737,21 @@ class Sbuffer(implicit p: Parameters)
   })
 
   io.dcache.hit_resps.zip(dataModule.io.maskFlushReq).map{case (resp, maskFlush) => {
-    maskFlush.valid := resp.fire
+    maskFlush.valid := resp.fire && !resp.bits.replay
     maskFlush.bits.wvec := UIntToOH(resp.bits.id)
   }}
 
-  // replay resp
-  val replay_resp_id = io.dcache.replay_resp.bits.id
-  when (io.dcache.replay_resp.fire) {
+  // replay resp (id from replay channel or main_pipe hit with replay bit)
+  val replay_resp_id = Mux(
+    io.dcache.replay_resp.fire,
+    io.dcache.replay_resp.bits.id,
+    io.dcache.main_pipe_hit_resp.bits.id
+  )
+  when (io.dcache.replay_resp.fire || io.dcache.main_pipe_hit_resp.fire && io.dcache.main_pipe_hit_resp.bits.replay) {
     missqReplayCount(replay_resp_id) := 0.U
     stateVec(replay_resp_id).w_timeout := true.B
     // waiting for timeout
-    assert(io.dcache.replay_resp.bits.replay)
+    assert(io.dcache.replay_resp.bits.replay || io.dcache.main_pipe_hit_resp.bits.replay)
     assert(stateVec(replay_resp_id).state_inflight === true.B)
   }
 
@@ -768,7 +772,7 @@ class Sbuffer(implicit p: Parameters)
       val dcache_resp_id = resp.bits.id
       difftest.coreid := io.hartId
       difftest.index  := index.U
-      difftest.valid  := resp.fire
+      difftest.valid  := resp.fire && !resp.bits.replay
       difftest.addr   := getAddr(ptag(dcache_resp_id))
       difftest.data   := data(dcache_resp_id).asTypeOf(Vec(CacheLineBytes, UInt(8.W)))
       difftest.mask   := mask(dcache_resp_id).asUInt

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -711,10 +711,10 @@ class Sbuffer(implicit p: Parameters)
   // hit resp
   io.dcache.hit_resps.map(resp => {
     val dcache_resp_id = resp.bits.id
-    when (resp.fire && !resp.bits.replay) {
+    when (resp.fire) {
       stateVec(dcache_resp_id).state_inflight := false.B
       stateVec(dcache_resp_id).state_valid := false.B
-      // assert(!resp.bits.replay)
+      assert(!resp.bits.replay)
       assert(!resp.bits.miss) // not need to resp if miss, to be opted
       assert(stateVec(dcache_resp_id).state_inflight === true.B)
     }
@@ -728,8 +728,8 @@ class Sbuffer(implicit p: Parameters)
       when(
         stateVec(i).w_sameblock_inflight &&
         stateVec(i).state_valid &&
-        GatedValidRegNext(resp.fire && !resp.bits.replay) &&
-        waitInflightMask(i) === UIntToOH(RegEnable(id_to_sbuffer_id(dcache_resp_id), resp.fire && !resp.bits.replay))
+        GatedValidRegNext(resp.fire) &&
+        waitInflightMask(i) === UIntToOH(RegEnable(id_to_sbuffer_id(dcache_resp_id), resp.fire))
       ){
         stateVec(i).w_sameblock_inflight := false.B
       }
@@ -737,22 +737,29 @@ class Sbuffer(implicit p: Parameters)
   })
 
   io.dcache.hit_resps.zip(dataModule.io.maskFlushReq).map{case (resp, maskFlush) => {
-    maskFlush.valid := resp.fire && !resp.bits.replay
+    maskFlush.valid := resp.fire
     maskFlush.bits.wvec := UIntToOH(resp.bits.id)
   }}
 
-  // replay resp (id from replay channel or main_pipe hit with replay bit)
-  val replay_resp_id = Mux(
-    io.dcache.replay_resp.fire,
-    io.dcache.replay_resp.bits.id,
-    io.dcache.main_pipe_hit_resp.bits.id
-  )
-  when (io.dcache.replay_resp.fire || io.dcache.main_pipe_hit_resp.fire && io.dcache.main_pipe_hit_resp.bits.replay) {
-    missqReplayCount(replay_resp_id) := 0.U
-    stateVec(replay_resp_id).w_timeout := true.B
-    // waiting for timeout
-    assert(io.dcache.replay_resp.bits.replay || io.dcache.main_pipe_hit_resp.bits.replay)
-    assert(stateVec(replay_resp_id).state_inflight === true.B)
+  // replay resp
+  val replay_resp_id = io.dcache.replay_resp.bits.id
+  val replay_resp_id_s3 = io.dcache.replay_resp_s3.bits
+  
+  for (i <- 0 until StoreBufferSize) {
+    when (io.dcache.replay_resp.fire && replay_resp_id === i.U || io.dcache.replay_resp_s3.valid && replay_resp_id_s3 === i.U) {
+      missqReplayCount(i) := 0.U
+      stateVec(i).w_timeout := true.B
+    }
+  }
+  when (io.dcache.replay_resp.fire) {
+    assert(io.dcache.replay_resp.bits.replay)
+    assert(stateVec(replay_resp_id).state_inflight === true.B, "(Sbuffer): replay s2 id is not inflight")
+  }
+  when (io.dcache.replay_resp_s3.valid) {
+    assert(stateVec(replay_resp_id_s3).state_inflight === true.B, "(Sbuffer): replay s3 id is not inflight")
+  }
+  when (io.dcache.replay_resp.fire && io.dcache.replay_resp_s3.valid) {
+    assert(replay_resp_id =/= replay_resp_id_s3, "(Sbuffer): replay s2 and replay s3 have the same id")
   }
 
   // TODO: reuse cohCount
@@ -772,7 +779,7 @@ class Sbuffer(implicit p: Parameters)
       val dcache_resp_id = resp.bits.id
       difftest.coreid := io.hartId
       difftest.index  := index.U
-      difftest.valid  := resp.fire && !resp.bits.replay
+      difftest.valid  := resp.fire
       difftest.addr   := getAddr(ptag(dcache_resp_id))
       difftest.data   := data(dcache_resp_id).asTypeOf(Vec(CacheLineBytes, UInt(8.W)))
       difftest.mask   := mask(dcache_resp_id).asUInt

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -715,7 +715,7 @@ class Sbuffer(implicit p: Parameters)
       stateVec(dcache_resp_id).state_inflight := false.B
       stateVec(dcache_resp_id).state_valid := false.B
       assert(!resp.bits.replay)
-      assert(!resp.bits.miss) // not need to resp if miss, to be opted
+      // assert(!resp.bits.miss)
       assert(stateVec(dcache_resp_id).state_inflight === true.B)
     }
 
@@ -778,8 +778,8 @@ class Sbuffer(implicit p: Parameters)
       val difftest = DifftestModule(new DiffSbufferEvent, delay = 1)
       val dcache_resp_id = resp.bits.id
       difftest.coreid := io.hartId
-      difftest.index  := index.U
-      difftest.valid  := resp.fire
+      difftest.index  := 1.U + index.U
+      difftest.valid  := resp.fire && !resp.bits.miss
       difftest.addr   := getAddr(ptag(dcache_resp_id))
       difftest.data   := data(dcache_resp_id).asTypeOf(Vec(CacheLineBytes, UInt(8.W)))
       difftest.mask   := mask(dcache_resp_id).asUInt


### PR DESCRIPTION
Sbuffer releases the entry when store-miss is accepted by mshr, and mshr provides corresponding st-ld forwarding.

MissQueue supports store-store merge.

Add a replay resp (mainpipe S3) to sbuffer when store-merge-to-missQ and grant-fire happen at the same time. (which means the store-merge-to-missQ fails)

In missQueue, the paddr-CAM and data-select logic are shared by mshr forwarding and st-ld forwarding paths