### PR TITLE
power(tage): separate tage write ctr and write useful

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/tage/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Bundles.scala
@@ -90,17 +90,21 @@ class TableReadResp(implicit p: Parameters, info: TageTableInfo) extends TageBun
 
 class EntrySramWriteReq(implicit p: Parameters, info: TageTableInfo) extends WriteReqBundle
     with HasTageParameters {
-  val setIdx:       UInt                    = UInt(SetIdxWidth.W)
-  val entry:        TageEntry               = new TageEntry
-  val usefulCtr:    SaturateCounter         = UsefulCounter()
-  override def tag: Option[UInt]            = Some(entry.tag)
-  override def cnt: Option[SaturateCounter] = Some(entry.takenCtr)
+  val setIdx:        UInt                    = UInt(SetIdxWidth.W)
+  val entry:         TageEntry               = new TageEntry
+  val writeEntryEn:  Bool                    = Bool()
+  val writeUsefulEn: Bool                    = Bool()
+  val usefulCtr:     SaturateCounter         = UsefulCounter()
+  override def tag:  Option[UInt]            = Some(entry.tag)
+  override def cnt:  Option[SaturateCounter] = Some(entry.takenCtr)
 }
 
 class TableWriteReq(implicit p: Parameters, info: TageTableInfo) extends TageBundle {
   val setIdx:          UInt                 = UInt(SetIdxWidth.W)
   val bankMask:        UInt                 = UInt(NumBanks.W)
   val wayMask:         UInt                 = UInt(NumWays.W)
+  val writeEntryEn:    Vec[Bool]            = Vec(NumWays, Bool())
+  val writeUsefulEn:   Vec[Bool]            = Vec(NumWays, Bool())
   val actualTakenMask: Vec[Bool]            = Vec(NumWays, Bool())
   val entries:         Vec[TageEntry]       = Vec(NumWays, new TageEntry)
   val usefulCtrs:      Vec[SaturateCounter] = Vec(NumWays, UsefulCounter())
@@ -159,9 +163,10 @@ class TrainInfo(implicit p: Parameters) extends TageBundle {
   val altEntry:        TageEntry       = new TageEntry
   val altOldUsefulCtr: SaturateCounter = UsefulCounter()
 
-  val needAllocate:       Bool = Bool()
-  val needUpdateProvider: Bool = Bool()
-  val needUpdateAlt:      Bool = Bool()
+  val needAllocate:             Bool = Bool()
+  val needUpdateProviderCtr:    Bool = Bool()
+  val needUpdateProviderUseful: Bool = Bool()
+  val needUpdateAltCtr:         Bool = Bool()
 
   val incUseAltOnNa: Bool = Bool()
   val decUseAltOnNa: Bool = Bool()

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
@@ -398,11 +398,10 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
       !(hasProvider && providerTableOH(NumTables - 1)) &&
       !(hasProvider && !useProvider && providerPred === actualTaken && provider.takenCtr.isWeak)
 
-    val notNeedUpdate = hasProvider && provider.takenCtr.shouldHold(actualTaken) &&
-      provider.usefulCtr.isSaturatePositive && incProviderUsefulCtr &&
-      (useProvider || !hasAlt || alt.takenCtr.shouldHold(actualTaken))
-    val needUpdateProvider = !notNeedUpdate && hasProvider
-    val needUpdateAlt      = !notNeedUpdate && useAlt
+    val needUpdateProviderCtr    = !provider.takenCtr.shouldHold(actualTaken) && hasProvider
+    val needUpdateProviderUseful = !provider.usefulCtr.isSaturatePositive && incProviderUsefulCtr && hasProvider
+
+    val needUpdateAltCtr = !alt.takenCtr.shouldHold(actualTaken) && useAlt
 
     val incUseAltOnNa = hasProvider && provider.takenCtr.isWeak && altOrBasePred === actualTaken
     val decUseAltOnNa = hasProvider && provider.takenCtr.isWeak && altOrBasePred =/= actualTaken
@@ -429,9 +428,10 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     trainInfo.altEntry.takenCtr := altNewTakenCtr
     trainInfo.altOldUsefulCtr   := alt.usefulCtr
 
-    trainInfo.needAllocate       := needAllocate
-    trainInfo.needUpdateProvider := needUpdateProvider
-    trainInfo.needUpdateAlt      := needUpdateAlt
+    trainInfo.needAllocate             := needAllocate
+    trainInfo.needUpdateProviderCtr    := needUpdateProviderCtr
+    trainInfo.needUpdateProviderUseful := needUpdateProviderUseful
+    trainInfo.needUpdateAltCtr         := needUpdateAltCtr
 
     trainInfo.incUseAltOnNa := incUseAltOnNa
     trainInfo.decUseAltOnNa := decUseAltOnNa
@@ -508,6 +508,8 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     implicit val info: TageTableInfo = TableInfos(tableIdx) // used by NumWays
 
     val writeWayMask    = Wire(Vec(NumWays, Bool()))
+    val writeEntryEn    = Wire(Vec(NumWays, Bool()))
+    val writeUsefulEn   = Wire(Vec(NumWays, Bool()))
     val writeEntries    = Wire(Vec(NumWays, new TageEntry))
     val writeUsefulCtrs = Wire(Vec(NumWays, UsefulCounter()))
 
@@ -515,22 +517,29 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     val actualTakenMask = Wire(Vec(NumWays, Bool()))
 
     (0 until NumWays).foreach { wayIdx =>
-      val (hitProviderMask, hitAltMask) = t2_trainInfoVec.map { info =>
-        val hitProvider =
-          info.valid && info.needUpdateProvider && info.providerTableOH(tableIdx) && info.providerWayOH(wayIdx)
-        val hitAlt = info.valid && info.needUpdateAlt && info.altTableOH(tableIdx) && info.altWayOH(wayIdx)
-        (hitProvider, hitAlt)
-      }.unzip
-      val hitProvider = hitProviderMask.reduce(_ || _)
-      val hitAlt      = hitAltMask.reduce(_ || _)
+      val (providerWriteCtr, providerWriteUseful, altWriteCtr) = t2_trainInfoVec.map { info =>
+        val providerNeedUpdateCtr =
+          info.valid && info.needUpdateProviderCtr && info.providerTableOH(tableIdx) && info.providerWayOH(wayIdx)
+        val providerNeedUpdateUseful =
+          info.valid && info.needUpdateProviderUseful && info.providerTableOH(tableIdx) && info.providerWayOH(wayIdx)
+        val altNeedUpdateCtr = info.valid && info.needUpdateAltCtr && info.altTableOH(tableIdx) && info.altWayOH(wayIdx)
+        (providerNeedUpdateCtr, providerNeedUpdateUseful, altNeedUpdateCtr)
+      }.unzip3
+
+      val hitProvider = providerWriteCtr.reduce(_ || _) || providerWriteUseful.reduce(_ || _)
+      val hitProviderMask = (providerWriteCtr zip providerWriteUseful).map {
+        case (writeCtr, writeUseful) =>
+          writeCtr || writeUseful
+      }
+      val hitAlt = altWriteCtr.reduce(_ || _)
       when(t2_fire) {
         assert(PopCount(hitProviderMask) <= 1.U)
-        assert(PopCount(hitAltMask) <= 1.U)
+        assert(PopCount(altWriteCtr) <= 1.U)
         assert(!(hitProvider && hitAlt))
       }
 
       val providerInfo = Mux1H(hitProviderMask, t2_trainInfoVec)
-      val altInfo      = Mux1H(hitAltMask, t2_trainInfoVec)
+      val altInfo      = Mux1H(altWriteCtr, t2_trainInfoVec)
 
       val updateEn                = hitProvider || hitAlt
       val updateEntry             = Mux(hitProvider, providerInfo.providerEntry, altInfo.altEntry)
@@ -540,6 +549,8 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
       val allocateEn = t2_allocate && t2_allocateTableOH(tableIdx) && t2_allocateWayOH(wayIdx)
 
       writeWayMask(wayIdx)    := updateEn || allocateEn
+      writeEntryEn(wayIdx)    := providerWriteCtr.reduce(_ || _) || hitAlt || allocateEn
+      writeUsefulEn(wayIdx)   := providerWriteUseful.reduce(_ || _) || allocateEn
       writeEntries(wayIdx)    := Mux(allocateEn, t2_allocateEntry, updateEntry)
       writeUsefulCtrs(wayIdx) := Mux(allocateEn, UsefulCounter.Init, updateUsefulCtr)
       actualTakenMask(wayIdx) := Mux(allocateEn, t2_allocateBranch.bits.taken, updateBranchActualTaken)
@@ -549,11 +560,12 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     table.io.writeReq.bits.setIdx          := t2_setIdx(tableIdx)
     table.io.writeReq.bits.bankMask        := t2_bankMask
     table.io.writeReq.bits.wayMask         := writeWayMask.asUInt
+    table.io.writeReq.bits.writeEntryEn    := writeEntryEn
+    table.io.writeReq.bits.writeUsefulEn   := writeUsefulEn
     table.io.writeReq.bits.entries         := writeEntries
     table.io.writeReq.bits.usefulCtrs      := writeUsefulCtrs
     table.io.writeReq.bits.actualTakenMask := actualTakenMask
-
-    table.io.resetUseful := t2_fire && usefulResetCtr.isSaturatePositive
+    table.io.resetUseful                   := t2_fire && usefulResetCtr.isSaturatePositive
   }
 
   when(t2_fire) {

--- a/src/main/scala/xiangshan/frontend/bpu/tage/TageTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/TageTable.scala
@@ -103,10 +103,12 @@ class TageTable(
   // write to write buffer
   entryWriteBuffers.zipWithIndex.foreach { case (buffer, bankIdx) =>
     buffer.io.write.zipWithIndex.foreach { case (writePort, wayIdx) =>
-      writePort.valid          := writeReqValid && writeReq.bankMask(bankIdx) && writeReq.wayMask(wayIdx)
-      writePort.bits.setIdx    := writeReq.setIdx
-      writePort.bits.entry     := writeReq.entries(wayIdx)
-      writePort.bits.usefulCtr := writeReq.usefulCtrs(wayIdx)
+      writePort.valid              := writeReqValid && writeReq.bankMask(bankIdx) && writeReq.wayMask(wayIdx)
+      writePort.bits.setIdx        := writeReq.setIdx
+      writePort.bits.entry         := writeReq.entries(wayIdx)
+      writePort.bits.usefulCtr     := writeReq.usefulCtrs(wayIdx)
+      writePort.bits.writeEntryEn  := writeReq.writeEntryEn(wayIdx)
+      writePort.bits.writeUsefulEn := writeReq.writeUsefulEn(wayIdx)
     }
     buffer.io.takenMask.get := writeReq.actualTakenMask
   }
@@ -114,15 +116,15 @@ class TageTable(
   // write to sram from write buffer
   entrySram.zip(usefulCtrs).zip(entryWriteBuffers) foreach { case ((bank, ctrsPerBank), buffer) =>
     bank.zip(ctrsPerBank).zip(buffer.io.read).foreach { case ((way, ctrsPerWay), readPort) =>
-      val valid  = readPort.valid && !way.io.r.req.valid
+      val valid  = readPort.valid && !way.io.r.req.valid && readPort.bits.writeEntryEn
       val setIdx = readPort.bits.setIdx
       val entry  = readPort.bits.entry
       way.io.w.apply(valid, entry, setIdx, 1.U(1.W))
       readPort.ready := way.io.w.req.ready && !way.io.r.req.valid
-
+      val writeUseful = readPort.fire && readPort.bits.writeUsefulEn
       when(io.resetUseful) {
         ctrsPerWay.foreach(_.resetZero())
-      }.elsewhen(readPort.fire) {
+      }.elsewhen(writeUseful) {
         ctrsPerWay(setIdx) := readPort.bits.usefulCtr
       }
     }
@@ -159,6 +161,15 @@ class TageTable(
   XSPerfAccumulate("predict_read", io.predictReadReq.valid)
   XSPerfAccumulate("train_read", io.trainReadReq.valid)
   XSPerfAccumulate("write", io.writeReq.valid)
+  XSPerfAccumulate(
+    s"tage_write_entry_${tableIdx}",
+    Mux(io.writeReq.valid, PopCount(io.writeReq.bits.writeEntryEn), 0.U)
+  )
+  XSPerfAccumulate(
+    s"tage_write_useful_${tableIdx}",
+    Mux(io.writeReq.valid, PopCount(io.writeReq.bits.writeUsefulEn), 0.U)
+  )
+  XSPerfAccumulate(s"tage_write_total_${tableIdx}", Mux(io.writeReq.valid, PopCount(io.writeReq.bits.wayMask), 0.U))
   XSPerfAccumulate(
     "drop_write",
     PopCount(entryWriteBuffers.flatMap(writePorts => writePorts.io.write.map(p => p.valid && !p.ready)))


### PR DESCRIPTION
Previous tage write entry and write useful was done together. If CTR was saturated, but the useful was not saturated,it would still choose to write an entry again,which is unnecessary. This Pr separates writing CTR from writing useful.reducing unnecessary sram write. Also fix useful need update cond(found by copilot).
