### PR TITLE
ci: fix occasional CI failures & increase basics parallelism

### DIFF
--- a/.github/workflows/emu-basics.yml
+++ b/.github/workflows/emu-basics.yml
@@ -40,6 +40,9 @@ jobs:
     timeout-minutes: 180
     continue-on-error: false
     steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/emu-basics.yml
+++ b/.github/workflows/emu-basics.yml
@@ -105,7 +105,7 @@ jobs:
           - name: f16_test
           - name: zcb-test
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
     steps:
       - name: Cleanup orphan EMU
         run: |

--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -44,6 +44,9 @@ jobs:
     timeout-minutes: 180
     continue-on-error: false
     steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   NOOP_HOME: ${{ github.workspace }}
+  UNITYCHIP_ENV: /nfs/home/share/ci-workloads/unitychip
 
 jobs:
   build-xsdev-image:
@@ -74,14 +75,14 @@ jobs:
           picker --check || echo "picker not exist"
       - name: build XSPdb 
         run: |
-          source /nfs/share/unitychip/activate
+          source ${{ env.UNITYCHIP_ENV }}/activate
           make pdb
           make package-pdb
-          mv ${{ env.PDB_HOME}}/XSPdb.tar.bz2 "${{ env.PDB_HOME }}/${{ env.FILE_NAME }}"
+          mv ${{ env.PDB_HOME }}/XSPdb.tar.bz2 "${{ env.PDB_HOME }}/${{ env.FILE_NAME }}"
       - name: test run pdb (PR only)
         if: github.event_name == 'pull_request'
         run: |
-          source /nfs/share/unitychip/activate
+          source ${{ env.UNITYCHIP_ENV }}/activate
           cd build/xspdb
           tar -xjf "${FILE_NAME}"
           cd XSPdb


### PR DESCRIPTION
1. We use `builder` tag to run all-in-one misc tests, so there can also be orphan EMU process in builder's workspace, causing checkout to fail. This commit also cleanup orphan EMU in build jobs to prevent failure.
2. `/nfs/share` is actually not mounted to nfs, we've recently re-installed some servers, causing enviroment missing and CI failures. I've manually re-created this environment under `/nfs/home/share/ci-workloads` and this commit uses that.
3. Increase emu-basics max-parallel from 2 to 4.