### PR TITLE
fix(backend, ctrlblock): export empty state to ftq when backend drains

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -452,6 +452,7 @@ class FrontendToCtrlIO(implicit p: Parameters) extends XSBundle {
   // from backend
   val toFtq = Flipped(new CtrlToFtqIO)
   val canAccept = Input(Bool())
+  val backendEmpty = Input(Bool())
 
   val wfi = Flipped(new WfiReqBundle)
 }

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -571,8 +571,6 @@ object Bundles {
     val blockBackward   = Bool()
     val flushPipe       = Bool() // This inst will flush all the pipe when commit, like exception but can commit
     val canRobCompress  = Bool()
-    val crossFtqCommit  = UInt(2.W) // use to caculate the ftq idx of ftqentry when commit
-    val crossFtq        = Bool() // use to caculate the ftq idx of brh instructions when pass to exu
     val fusionNum       = UInt(2.W)
     val selImm          = SelImm()
     val imm             = UInt(32.W)

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -50,7 +50,6 @@ class CtrlToFtqIO(implicit p: Parameters) extends XSBundle {
   val resolve = Vec(backendParams.BrhCnt, Valid(new Resolve))
 
   val commit = Valid(new FtqPtr)
-  val backendIsEmpty = Output(Bool())
   val callRetCommit = Vec(CommitWidth, Valid(new CallRetCommit))
 }
 
@@ -370,7 +369,7 @@ class CtrlBlockImp(
     RegNext(VecInit(rename.io.in.map(_.valid))).asUInt.orR ||
     RegNext(VecInit(dispatch.io.enqRob.req.map(_.valid))).asUInt.orR) &&
     RegNext(rob.io.enq.isEmpty)
-  io.frontend.toFtq.backendIsEmpty := RegNext(isEmptyDelay)
+  io.frontend.backendEmpty := RegNext(isEmptyDelay)
 
   io.frontend.toFtq.redirect.valid := s5_flushFromRobValid || s3_redirectGen.valid
   io.frontend.toFtq.redirect.bits := Mux(s5_flushFromRobValid, frontendFlushBits, s3_redirectGen.bits)

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -50,6 +50,7 @@ class CtrlToFtqIO(implicit p: Parameters) extends XSBundle {
   val resolve = Vec(backendParams.BrhCnt, Valid(new Resolve))
 
   val commit = Valid(new FtqPtr)
+  val backendIsEmpty = Output(Bool())
   val callRetCommit = Vec(CommitWidth, Valid(new CallRetCommit))
 }
 
@@ -364,6 +365,12 @@ class CtrlBlockImp(
     ),
     frontendCommit
   )
+
+  val isEmptyDelay = !(RegNext(VecInit(decode.io.in.map(_.valid))).asUInt.orR ||
+    RegNext(VecInit(rename.io.in.map(_.valid))).asUInt.orR ||
+    RegNext(VecInit(dispatch.io.enqRob.req.map(_.valid))).asUInt.orR) &&
+    RegNext(rob.io.enq.isEmpty)
+  io.frontend.toFtq.backendIsEmpty := RegNext(isEmptyDelay)
 
   io.frontend.toFtq.redirect.valid := s5_flushFromRobValid || s3_redirectGen.valid
   io.frontend.toFtq.redirect.bits := Mux(s5_flushFromRobValid, frontendFlushBits, s3_redirectGen.bits)
@@ -949,7 +956,7 @@ class CtrlBlockIO()(implicit p: Parameters, params: BackendParams) extends XSBun
   }
   val fromWB = new Bundle {
     val wbData = Flipped(MixedVec(params.genWrite2RobBundles))
-    val delayedOldestExuRedirect = Flipped(ValidIO(new Redirect)) 
+    val delayedOldestExuRedirect = Flipped(ValidIO(new Redirect))
   }
   val redirect = ValidIO(new Redirect)
   val fromMem = new Bundle {

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -302,7 +302,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   }
   for (i <- 0 until CommitWidth) {
     commitInfo(i).ftqOffset := 0.U
-    commitInfo(i).ftqIdx := rawInfo(i).ftqIdx - 1.U + rawInfo(i).crossFtqCommit
+    commitInfo(i).ftqIdx := rawInfo(i).ftqIdx - 1.U
   }
 
   // data for debug

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -70,7 +70,6 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val realDestSize = UInt(log2Up(MaxUopSize + 1).W)
     val uopNum = UInt(log2Up(MaxUopSize + 1).W)
     val needFlush = Bool()
-    val crossFtqCommit = UInt(2.W) // 59 bit
     // status end
 
     // debug_begin
@@ -121,7 +120,6 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val fpWen = Bool()
     val rfWen = Bool()
     val needFlush = Bool()
-    val crossFtqCommit = UInt(2.W)
     // trace
     val traceBlockInPipe = new TracePipe(IretireWidthEncoded)
     // debug_begin
@@ -151,7 +149,6 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robEntry.dirtyVs := robEnq.dirtyVs
     // flushPipe needFlush but not exception
     robEntry.needFlush := robEnq.hasException || robEnq.flushPipe
-    robEntry.crossFtqCommit := robEnq.crossFtqCommit
     // trace
     robEntry.traceBlockInPipe := robEnq.traceBlockInPipe
     robEntry.debug_ldest.foreach(_ := robEnq.ldest)
@@ -197,7 +194,6 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robCommitEntry.dirtyFs := robEntry.fpWen || robEntry.wflags
     robCommitEntry.dirtyVs := robEntry.dirtyVs
     robCommitEntry.needFlush := robEntry.needFlush
-    robCommitEntry.crossFtqCommit := robEntry.crossFtqCommit
     robCommitEntry.traceBlockInPipe := robEntry.traceBlockInPipe
     robCommitEntry.debug_pc.foreach(_ := robEntry.debug_pc.get)
     robCommitEntry.debug_instr.foreach(_ := robEntry.debug_instr.get)

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -158,12 +158,6 @@ class IfuToFtqIO(implicit p: Parameters) extends FrontendBundle {
   val wbRedirect: Valid[FrontendRedirect] = Valid(new FrontendRedirect)
 }
 
-class MmioCommitRead(implicit p: Parameters) extends FrontendBundle {
-  val valid:          Bool   = Output(Bool())
-  val mmioFtqPtr:     FtqPtr = Output(new FtqPtr)
-  val mmioLastCommit: Bool   = Input(Bool())
-}
-
 class ExceptionType extends Bundle {
   val value: UInt = ExceptionType.Value()
 

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -155,8 +155,7 @@ class FrontendRedirect(implicit p: Parameters) extends FrontendBundle {
 }
 
 class IfuToFtqIO(implicit p: Parameters) extends FrontendBundle {
-  val mmioCommitRead: MmioCommitRead          = new MmioCommitRead
-  val wbRedirect:     Valid[FrontendRedirect] = Valid(new FrontendRedirect)
+  val wbRedirect: Valid[FrontendRedirect] = Valid(new FrontendRedirect)
 }
 
 class MmioCommitRead(implicit p: Parameters) extends FrontendBundle {

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -238,10 +238,13 @@ class FrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBase(
 
   // IFU-Ibuffer
   ifu.io.toIBuffer <> ibuffer.io.in
+  ifu.io.ibufferEmpty := ibuffer.io.empty
 
   ftq.io.fromBackend <> io.backend.toFtq
   io.backend.fromFtq := ftq.io.toBackend
-  io.backend.fromIfu := ifu.io.toBackend
+
+  ifu.io.backendEmpty := io.backend.backendEmpty
+  io.backend.fromIfu  := ifu.io.toBackend
 
   ibuffer.io.flush           := needFlush
   ibuffer.io.decodeCanAccept := io.backend.canAccept

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -422,15 +422,6 @@ class Ftq(implicit p: Parameters) extends FtqModule
   io.toBpu.commit.bits.attribute.rasAction  := commitQueue.io.bpuTrain.bits.rasAction
 
   // --------------------------------------------------------------------------------
-  // MMIO fetch
-  // --------------------------------------------------------------------------------
-  private val mmioPtr   = io.fromIfu.mmioCommitRead.mmioFtqPtr
-  private val mmioValid = io.fromIfu.mmioCommitRead.valid
-  private val lastMmioCommitted =
-    commitPtr > mmioPtr || commitPtr === mmioPtr && commit || io.fromBackend.backendIsEmpty
-  io.fromIfu.mmioCommitRead.mmioLastCommit := RegNext(lastMmioCommitted && mmioValid)
-
-  // --------------------------------------------------------------------------------
   // Performance monitoring
   // --------------------------------------------------------------------------------
 

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -424,9 +424,10 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // --------------------------------------------------------------------------------
   // MMIO fetch
   // --------------------------------------------------------------------------------
-  private val mmioPtr           = io.fromIfu.mmioCommitRead.mmioFtqPtr
-  private val mmioValid         = io.fromIfu.mmioCommitRead.valid
-  private val lastMmioCommitted = commitPtr > mmioPtr || commitPtr === mmioPtr && commit
+  private val mmioPtr   = io.fromIfu.mmioCommitRead.mmioFtqPtr
+  private val mmioValid = io.fromIfu.mmioCommitRead.valid
+  private val lastMmioCommitted =
+    commitPtr > mmioPtr || commitPtr === mmioPtr && commit || io.fromBackend.backendIsEmpty
   io.fromIfu.mmioCommitRead.mmioLastCommit := RegNext(lastMmioCommitted && mmioValid)
 
   // --------------------------------------------------------------------------------

--- a/src/main/scala/xiangshan/frontend/ibuffer/IBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/ibuffer/IBuffer.scala
@@ -35,11 +35,15 @@ import xiangshan.frontend.FrontendTopDownBundle
 
 class IBuffer(implicit p: Parameters) extends IBufferModule with HasCircularQueuePtrHelper with HasPerfEvents {
   class IBufferIO extends Bundle {
-    val flush:           Bool                        = Input(Bool())
-    val in:              DecoupledIO[FetchToIBuffer] = Flipped(DecoupledIO(new FetchToIBuffer))
-    val out:             Vec[DecoupledIO[CtrlFlow]]  = Vec(DecodeWidth, DecoupledIO(new CtrlFlow))
-    val full:            Bool                        = Output(Bool())
-    val decodeCanAccept: Bool                        = Input(Bool())
+    val in:  DecoupledIO[FetchToIBuffer] = Flipped(DecoupledIO(new FetchToIBuffer))
+    val out: Vec[DecoupledIO[CtrlFlow]]  = Vec(DecodeWidth, DecoupledIO(new CtrlFlow))
+
+    val flush: Bool = Input(Bool())
+
+    val full:  Bool = Output(Bool())
+    val empty: Bool = Output(Bool())
+
+    val decodeCanAccept: Bool = Input(Bool())
 
     // top-down
     val backendRedirectTopdown: BackendRedirectTopdown = Input(new BackendRedirectTopdown)
@@ -99,6 +103,13 @@ class IBuffer(implicit p: Parameters) extends IBufferModule with HasCircularQueu
 
   private val enqPtrVec = RegInit(VecInit.tabulate(EnqueueWidth)(_.U.asTypeOf(new IBufPtr)))
   private val enqPtr    = enqPtrVec(0)
+
+  // No bubble for ibuffer.out, so head.valid is enough
+  io.empty := enqPtr === deqPtr && !io.out.head.valid
+  XSError(
+    !io.out.head.valid && io.out.tail.map(_.valid).reduce(_ || _),
+    "Bubble in ibuffer.out"
+  )
 
   XSError(
     io.in.valid && io.in.bits.prevIBufEnqPtr =/= enqPtr,

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -544,7 +544,6 @@ class Ifu(implicit p: Parameters) extends IfuModule
   }
 
   uncacheUnit.io.req.valid       := s3_valid && s3_useUncacheFetch && !uncacheBusy
-  uncacheUnit.io.req.bits.ftqIdx := s3_alignFetchBlock(0).ftqIdx
   uncacheUnit.io.req.bits.pbmt   := s3_icacheMeta(0).itlbPbmt
   uncacheUnit.io.req.bits.isMmio := s3_icacheMeta(0).pmpMmio
   uncacheUnit.io.req.bits.paddr  := s3_icacheMeta(0).pAddr

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -67,10 +67,12 @@ class Ifu(implicit p: Parameters) extends IfuModule
     val fromUncache: InstrUncacheToIfuIO = Flipped(new InstrUncacheToIfuIO)
 
     // IBuffer: enqueue
-    val toIBuffer: DecoupledIO[FetchToIBuffer] = DecoupledIO(new FetchToIBuffer)
+    val toIBuffer:    DecoupledIO[FetchToIBuffer] = DecoupledIO(new FetchToIBuffer)
+    val ibufferEmpty: Bool                        = Input(Bool())
 
     // Backend: gpaMem
-    val toBackend: IfuToBackendIO = new IfuToBackendIO
+    val toBackend:    IfuToBackendIO = new IfuToBackendIO
+    val backendEmpty: Bool           = Input(Bool())
 
     // debug extension: frontend trigger
     val frontendTrigger: FrontendTdataDistributeIO = Flipped(new FrontendTdataDistributeIO)
@@ -549,7 +551,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   uncacheUnit.io.flush           := s3_flush
   uncacheUnit.io.isFirstInstr    := isFirstInstr
   uncacheUnit.io.ifuStall        := !io.toIBuffer.ready
-  io.toFtq.mmioCommitRead <> uncacheUnit.io.mmioCommitRead
+  uncacheUnit.io.emptyAfter      := io.backendEmpty && io.ibufferEmpty
   io.toUncache <> uncacheUnit.io.toUncache
   uncacheUnit.io.fromUncache <> io.fromUncache
 

--- a/src/main/scala/xiangshan/frontend/ifu/IfuUncacheUnit.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/IfuUncacheUnit.scala
@@ -40,12 +40,12 @@ class IfuUncacheUnit(implicit p: Parameters) extends IfuModule with IfuHelper {
       val exception:   ExceptionType = new ExceptionType
       val crossPage:   Bool          = Bool()
     }
-    val req            = Flipped(DecoupledIO(new IfuUncacheReq))
-    val resp           = Output(ValidIO(new IfuUncacheResp))
-    val isFirstInstr   = Input(Bool())
-    val ifuStall       = Input(Bool())
-    val flush          = Input(Bool())
-    val mmioCommitRead = new MmioCommitRead
+    val req          = Flipped(DecoupledIO(new IfuUncacheReq))
+    val resp         = Output(ValidIO(new IfuUncacheResp))
+    val isFirstInstr = Input(Bool())
+    val ifuStall     = Input(Bool())
+    val flush        = Input(Bool())
+    val emptyAfter   = Input(Bool())
     // Uncache: mmio request / response
     val toUncache   = new IfuToInstrUncacheIO
     val fromUncache = Flipped(new InstrUncacheToIfuIO)
@@ -102,7 +102,7 @@ class IfuUncacheUnit(implicit p: Parameters) extends IfuModule with IfuHelper {
       when(isFirstInstr) {
         uncacheState := UncacheFsmState.SendReq
       }.otherwise {
-        uncacheState := Mux(io.mmioCommitRead.mmioLastCommit, UncacheFsmState.SendReq, UncacheFsmState.WaitLastCommit)
+        uncacheState := Mux(io.emptyAfter, UncacheFsmState.SendReq, UncacheFsmState.WaitLastCommit)
       }
     }
 
@@ -147,8 +147,6 @@ class IfuUncacheUnit(implicit p: Parameters) extends IfuModule with IfuHelper {
 
   // When a single MMIO instruction spans pages,
   // should the second send for confirming the oldest instruction be blocked?
-  io.mmioCommitRead.valid      := uncacheValid && isMmio
-  io.mmioCommitRead.mmioFtqPtr := RegEnable(io.req.bits.ftqIdx - 1.U, io.req.valid)
   when(io.flush) {
     uncacheReset()
   }

--- a/src/main/scala/xiangshan/frontend/ifu/IfuUncacheUnit.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/IfuUncacheUnit.scala
@@ -145,8 +145,6 @@ class IfuUncacheUnit(implicit p: Parameters) extends IfuModule with IfuHelper {
   io.resp.bits.uncacheData := uncacheData
   io.resp.bits.crossPage   := uncacheCrossPage
 
-  // When a single MMIO instruction spans pages,
-  // should the second send for confirming the oldest instruction be blocked?
   when(io.flush) {
     uncacheReset()
   }

--- a/src/main/scala/xiangshan/frontend/ifu/IfuUncacheUnit.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/IfuUncacheUnit.scala
@@ -22,15 +22,12 @@ import xiangshan.cache.mmu.Pbmt
 import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.IfuToInstrUncacheIO
 import xiangshan.frontend.InstrUncacheToIfuIO
-import xiangshan.frontend.MmioCommitRead
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
-import xiangshan.frontend.ftq.FtqPtr
 
 class IfuUncacheUnit(implicit p: Parameters) extends IfuModule with IfuHelper {
   class IfuUncacheIO extends IfuBundle {
     class IfuUncacheReq(implicit p: Parameters) extends IfuBundle {
-      val ftqIdx: FtqPtr     = new FtqPtr
       val pbmt:   UInt       = UInt(Pbmt.width.W)
       val isMmio: Bool       = Bool()
       val paddr:  PrunedAddr = PrunedAddr(PAddrBits)


### PR DESCRIPTION
 * Export backend empty state from CtrlBlock so FTQ treat last instruction as retired.
 * Use the direct commit ftqIdx selection in CtrlBlock and remove redundant ROB crossFtqCommit propagation in the commit path.