### PR TITLE
ci(emu): dirty fix for kunminghu-v2 & bump action version

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -482,7 +482,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' }}
     continue-on-error: false
-    timeout-minutes: 40
+    timeout-minutes: 60
     name: Upload Artifacts
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -18,8 +18,8 @@ jobs:
     outputs:
       core: ${{ steps.filter.outputs.core }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: actions/checkout@v6
+    - uses: dorny/paths-filter@v4
       id: filter
       with:
         predicate-quantifier: 'every'
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 900
     name: Generate Verilog
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: set env
@@ -120,7 +120,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - Basics
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: set env
@@ -217,7 +217,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - CHI
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: set env
@@ -256,7 +256,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build docker image
         run: make image
@@ -272,7 +272,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - Performance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: set env
@@ -385,7 +385,7 @@ jobs:
     timeout-minutes: 900
     name: EMU - MC
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: set env
@@ -428,7 +428,7 @@ jobs:
     timeout-minutes: 900
     name: SIMV - Basics
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: set env
@@ -485,7 +485,7 @@ jobs:
     timeout-minutes: 40
     name: Upload Artifacts
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: set env
         run: echo "NOOP_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
       - name: psutil
@@ -523,7 +523,7 @@ jobs:
           rm `find $GITHUB_WORKSPACE/build -name "*.fir"`
           cd $GITHUB_WORKSPACE/build/rtl && find . -name "*.*v" > filelist.f
       - name: acrhive issue B verilog artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: xs-issue-b-difftest-verilog
           path: build
@@ -541,7 +541,7 @@ jobs:
           rm `find $GITHUB_WORKSPACE/build -name "*.fir"`
           cd $GITHUB_WORKSPACE/build/rtl && find . -name "*.*v" > filelist.f
       - name: acrhive issue E.b verilog artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: xs-issue-e-b-difftest-verilog
           path: build
@@ -559,7 +559,7 @@ jobs:
           rm `find $GITHUB_WORKSPACE/build -name "*.fir"`
           cd $GITHUB_WORKSPACE/build/rtl && find . -name "*.*v" > filelist.f
       - name: acrhive issue E.b lowpower verilog artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: xs-issue-e-b-lowpower-difftest-verilog
           path: build
@@ -568,7 +568,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
           make test-jar
       - name: acrhive test jar artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: xsgen
           path: out/xiangshan/test/assembly.dest/out.jar
@@ -581,7 +581,7 @@ jobs:
     timeout-minutes: 5
     name: Check Submodules
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: 'true'
           fetch-depth: '0'
@@ -614,10 +614,10 @@ jobs:
     timeout-minutes: 900
     name: Check Format
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -36,7 +36,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -45,7 +44,10 @@ jobs:
           echo "WAVE_HOME=/nfs/home/ci-runner/xs-wave/${HEAD_SHA}" >> $GITHUB_ENV
           mkdir -p /nfs/home/ci-runner/xs-wave/${HEAD_SHA}
       - name: Initialize submodules
-        run: make init-force
+        run: |
+          make init-force || {
+            cd rocket-chip && git fetch --unshallow && cd .. && make init-force
+          }
       - name: clean up
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
@@ -121,7 +123,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -134,7 +135,10 @@ jobs:
           mkdir -p /nfs/home/ci-runner/xs-perf/${HEAD_SHA}
           mkdir -p /nfs/home/ci-runner/xs-wave/${HEAD_SHA}
       - name: Initialize submodules
-        run: make init-force
+        run: |
+          make init-force || {
+            cd rocket-chip && git fetch --unshallow && cd .. && make init-force
+          }
       - name: clean up
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
@@ -216,7 +220,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -225,7 +228,10 @@ jobs:
           echo "WAVE_HOME=/nfs/home/ci-runner/xs-wave/${HEAD_SHA}" >> $GITHUB_ENV
           mkdir -p /nfs/home/ci-runner/xs-wave/${HEAD_SHA}
       - name: Initialize submodules
-        run: make init-force
+        run: |
+          make init-force || {
+            cd rocket-chip && git fetch --unshallow && cd .. && make init-force
+          }
       - name: clean up
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
@@ -269,7 +275,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -282,7 +287,10 @@ jobs:
           mkdir -p /nfs/home/ci-runner/xs-perf/${HEAD_SHA}
           mkdir -p /nfs/home/ci-runner/xs-wave/${HEAD_SHA}
       - name: Initialize submodules
-        run: make init-force
+        run: |
+          make init-force || {
+            cd rocket-chip && git fetch --unshallow && cd .. && make init-force
+          }
       - name: clean up
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
@@ -380,7 +388,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -392,7 +399,10 @@ jobs:
           mkdir -p /nfs/home/ci-runner/xs-perf/${HEAD_SHA}
           mkdir -p /nfs/home/ci-runner/xs-wave/${HEAD_SHA}
       - name: Initialize submodules
-        run: make init-force
+        run: |
+          make init-force || {
+            cd rocket-chip && git fetch --unshallow && cd .. && make init-force
+          }
       - name: clean up
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
@@ -421,7 +431,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: true
       - name: set env
         run: |
           export HEAD_SHA=${{ github.run_number }}
@@ -433,7 +442,10 @@ jobs:
           mkdir -p /nfs/home/ci-runner/xs-perf/${HEAD_SHA}
           mkdir -p /nfs/home/ci-runner/xs-wave/${HEAD_SHA}
       - name: Initialize submodules
-        run: make init-force
+        run: |
+          make init-force || {
+            cd rocket-chip && git fetch --unshallow && cd .. && make init-force
+          }
       - name: clean up
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
@@ -479,7 +491,10 @@ jobs:
       - name: psutil
         run: sudo apt install python3-psutil
       - name: Initialize submodules
-        run: make init-force
+        run: |
+          make init-force || {
+            cd rocket-chip && git fetch --unshallow && cd .. && make init-force
+          }
       - name: mill
         uses: jodersky/setup-mill@v0.3.0
         with:


### PR DESCRIPTION
Fix this (hopefully):

```
  warning: 9114012def7a730a5e9d334e5122d800825dca11:.gitmodules, multiple configurations found for 'submodule.riscv-rocket.url'. Skipping second one!
  warning: 9114012def7a730a5e9d334e5122d800825dca11:.gitmodules, multiple configurations found for 'submodule.uncore.path'. Skipping second one!
  warning: 9114012def7a730a5e9d334e5122d800825dca11:.gitmodules, multiple configurations found for 'submodule.uncore.url'. Skipping second one!
  warning: 9114012def7a730a5e9d334e5122d800825dca11:.gitmodules, multiple configurations found for 'submodule.dramsim2.path'. Skipping second one!
  warning: 9114012def7a730a5e9d334e5122d800825dca11:.gitmodules, multiple configurations found for 'submodule.dramsim2.url'. Skipping second one!
  Fetching submodule hardfloat
  Error: fatal: remote error: upload-pack: not our ref 1c8a6e6815eadebc1592c65e10a2ba87ecabb3c6
  Errors during submodule fetch:
  	hardfloat
  Error: fatal: Fetched in submodule path 'rocket-chip', but it did not contain 46f1efefa1ff431bffe3262e4830bc50316842f4. Direct fetching of that commit failed.
  Error: The process '/usr/bin/git' failed with exit code 128
```

1. Drop `submodules: true` in `actions/checkout`, let `make init-force` do this.
2. If `make init-force` failed, assume it's caused by this 'not our ref' and try fixing by running `git fetch --unshallow` in `rocket-chip` and retry `make init-force`.

Also:
- bump action versions, as node20 is deprecated.
- relax timeout of `artifacts-uploading` to 60min.

**NOTE: Do not pick this to kunminghu-v3**