### PR TITLE
feat(DCache, CoupledL2): add PC field for L2 NextLine prefetcher

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -332,6 +332,8 @@ case class L2CacheConfig
   inclusive: Boolean = true,
   banks: Int = 1,
   tp: Boolean = true,
+  nl: Boolean = false, 
+  enablePC: Boolean = false, // Enable PC field for L1Param
   enableFlush: Boolean = false
 ) extends Config((site, here, up) => {
   case XSTileKey =>
@@ -353,6 +355,7 @@ case class L2CacheConfig
           ways = p.dcacheParametersOpt.get.nWays + 2,
           aliasBitsOpt = p.dcacheParametersOpt.get.aliasBitsOpt,
           vaddrBitsOpt = Some(p.GPAddrBitsSv48x4 - log2Up(p.dcacheParametersOpt.get.blockBytes)),
+          pcBitOpt = if (enablePC) Some(p.GPAddrBitsSv48x4) else None, // Enable PC field if needed
           isKeywordBitsOpt = p.dcacheParametersOpt.get.isKeywordBitsOpt
         )),
         reqField = Seq(utility.ReqSourceField()),
@@ -365,6 +368,7 @@ case class L2CacheConfig
         enablePoison = true,
         prefetch = Seq(BOPParameters()) ++
           (if (tp) Seq(TPParameters()) else Nil) ++
+          (if (nl) Seq(NLParameters()) else Nil) ++
           (if (p.prefetcher.nonEmpty) Seq(PrefetchReceiverParams()) else Nil),
         enableL2Flush = enableFlush,
         enablePerf = !site(DebugOptionsKey).FPGAPlatform && site(DebugOptionsKey).EnablePerfDebug,
@@ -599,7 +603,6 @@ class TLConfig(n: Int = 1) extends Config(
     ++ new BaseConfig(n)
 )
 class DefaultConfig(n: Int = 1) extends TLConfig(n) with DeprecatedConfigWarning
-
 class TLCVMConfig(n: Int = 1) extends Config(
   new CVMCompile
     ++ new TLConfig(n)

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -603,6 +603,7 @@ class TLConfig(n: Int = 1) extends Config(
     ++ new BaseConfig(n)
 )
 class DefaultConfig(n: Int = 1) extends TLConfig(n) with DeprecatedConfigWarning
+
 class TLCVMConfig(n: Int = 1) extends Config(
   new CVMCompile
     ++ new TLConfig(n)

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -19,7 +19,7 @@ package xiangshan.cache
 import chisel3._
 import chisel3.experimental.ExtModule
 import chisel3.util._
-import coupledL2.{IsKeywordKey, IsKeywordField, MemBackTypeMMField, MemPageTypeNCField, PCKey, PCField, VaddrField}
+import coupledL2.{IsKeywordKey, IsKeywordField, MemBackTypeMMField, MemPageTypeNCField, PCField, VaddrField}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util.BundleFieldBase

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -19,7 +19,7 @@ package xiangshan.cache
 import chisel3._
 import chisel3.experimental.ExtModule
 import chisel3.util._
-import coupledL2.{IsKeywordKey, IsKeywordField, MemBackTypeMMField, MemPageTypeNCField, VaddrField}
+import coupledL2.{IsKeywordKey, IsKeywordField, MemBackTypeMMField, MemPageTypeNCField, PCKey, PCField, VaddrField}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util.BundleFieldBase
@@ -94,6 +94,9 @@ trait HasDCacheParameters
   with HasL1CacheParameters {
   val cacheParams = dcacheParameters
   val cfg = cacheParams
+  def l2ClientPcBitsOpt: Option[Int] = p(XSCoreParamsKey).L2CacheParamsOpt
+    .flatMap(_.clientCaches.find(_.name == "dcache"))
+    .flatMap(_.pcBitOpt)
 
   def GenLatencyArray: Boolean = hasBerti
 
@@ -849,9 +852,9 @@ class DCache()(implicit p: Parameters) extends LazyModule with HasDCacheParamete
     ReqSourceField(),
     VaddrField(VAddrBits - blockOffBits),
     MemBackTypeMMField(),
-    MemPageTypeNCField(),
+    MemPageTypeNCField()
   //  IsKeywordField()
-  ) ++ cacheParams.aliasBitsOpt.map(AliasField)
+  ) ++ l2ClientPcBitsOpt.map(PCField(_)).toSeq ++ cacheParams.aliasBitsOpt.map(AliasField)
   val echoFields: Seq[BundleFieldBase] = Seq(
     IsKeywordField()
   )

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -849,7 +849,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   miss_req.req_coh := s2_hit_coh
   miss_req.id := s2_req.id
   miss_req.cancel := s2_grow_perm_fail
-  miss_req.pc := DontCare
+  miss_req.pc := 0.U // MainPipe requests (Store Buffer writeback) don't have a single corresponding PC
   miss_req.full_overwrite := s2_req.isStore && s2_req.store_mask.andR
   miss_req.isBtoT := s2_grow_perm
   miss_req.occupy_way := s2_tag_ecc_match_way

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -26,7 +26,7 @@ package xiangshan.cache
 import chisel3._
 import chisel3.experimental.dataview._
 import chisel3.util._
-import coupledL2.{IsKeywordKey, MemBackTypeMM, MemPageTypeNC, VaddrKey}
+import coupledL2.{IsKeywordKey, MemBackTypeMM, MemPageTypeNC, PCKey, VaddrKey}
 import difftest._
 import freechips.rocketchip.tilelink._
 import huancun.{AliasKey, DirtyKey, PrefetchKey}
@@ -262,6 +262,8 @@ class MissReqPipeRegBundle(edge: TLEdgeOut)(implicit p: Parameters) extends DCac
     acquire.user.lift(AliasKey).foreach(_ := req.vaddr(13, 12))
     // pass vaddr to l2
     acquire.user.lift(VaddrKey).foreach(_ := req.vaddr(VAddrBits - 1, blockOffBits))
+    // pass pc to l2
+    acquire.user.lift(PCKey).foreach(_ := req.pc) 
 
     // miss req pipe reg pass keyword to L2, is priority
     acquire.echo.lift(IsKeywordKey).foreach(_ := isKeyword())
@@ -859,6 +861,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.mem_acquire.bits.user.lift(AliasKey).foreach( _ := req.vaddr(13, 12))
   // pass vaddr to l2
   io.mem_acquire.bits.user.lift(VaddrKey).foreach( _ := req.vaddr(VAddrBits-1, blockOffBits))
+  // pass pc to l2
+  io.mem_acquire.bits.user.lift(PCKey).foreach(_ := req.pc)
   // pass keyword to L2
   io.mem_acquire.bits.echo.lift(IsKeywordKey).foreach(_ := isKeyword)
   // trigger prefetch


### PR DESCRIPTION
+ Add a `PC` field to the L1-to-L2 TileLink path so coupledL2 can
use request PC information to drive the L2 nextline prefetcher.

+ Propagate the field through DCacheWrapper, MainPipe and
MissQueue, and forward it to coupledL2.

+ Add `enablePC` to control whether the dcache client exports
PC information to L2. This option is disabled by default.

+ Add `nl` to control whether the L2 nextline prefetcher is
enabled. This option is disabled by default.

+ Bump the `coupledL2` submodule to include the corresponding
support for the PC field and the L2 NextLine prefetcher.
