### PR TITLE
feat(dispatch): optimize dispatch policy to improve performance

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -152,6 +152,14 @@ class CtrlBlockImp(
   }
 
   val wbData = io.fromWB.wbData
+  val needPerfCounterExuName = Seq("ALU", "BJU", "LDU", "FEX", "STA", "STD")
+  needPerfCounterExuName.map { name =>
+    val exuWBValid = params.allExuParams.zip(delayedWriteBack).filter(_._1.name.contains(name)).map(_._2).map(_.valid)
+    val exuNum = exuWBValid.size
+    for (i <- 0 to exuNum) {
+      XSPerfAccumulate(s"${name}_SameWBNum_$i", PopCount(exuWBValid) === i.U)
+    }
+  }
   val intScheWbData = io.fromWB.wbData.filter(_.bits.params.schdType.isInstanceOf[IntScheduler])
   val fpScheWbData = io.fromWB.wbData.filter(_.bits.params.schdType.isInstanceOf[FpScheduler])
   val vfScheWbData = io.fromWB.wbData.filter(_.bits.params.schdType.isInstanceOf[VecScheduler])

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -728,8 +728,20 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
     io.wbDataPathToCtrlBlock.delayedOldestExuRedirect.get.valid := RegNext(oldestExuRedirect.valid)
     io.wbDataPathToCtrlBlock.delayedOldestExuRedirect.get.bits  := RegEnable(oldestExuRedirect.bits, oldestExuRedirect.valid)
   }
-
-  io.IQValidNumVec := issueQueues.filter(_.param.StdCnt == 0).map(_.io.validCntDeqVec).flatten
+  var staIQIdx = 0
+  val staIssueQueue = issueQueues.filter(_.param.StaCnt > 0)
+  val stdIssueQueue = issueQueues.filter(_.param.StdCnt > 0)
+  val IQValidNumVecWire = VecInit(issueQueues.filter(_.param.StdCnt == 0).map { case iq =>
+    if (iq.param.StaCnt > 0) {
+      // sta and std iq has 1 deq
+      val staCnt = staIssueQueue(staIQIdx).io.validCntDeqVec.head
+      val stdCnt = stdIssueQueue(staIQIdx).io.validCntDeqVec.head
+      staIQIdx = staIQIdx + 1
+      VecInit(Mux(stdCnt > staCnt, stdCnt, staCnt))
+    }
+    else iq.io.validCntDeqVec
+  }.flatten)
+  io.IQValidNumVec := IQValidNumVecWire
   io.og0Cancel := dataPath.io.og0Cancel
   io.diffVl.foreach(_ := dataPath.io.diffVl.get)
   io.lduWriteback.foreach(_.flatten.foreach(_.ready := true.B))

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -728,20 +728,7 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
     io.wbDataPathToCtrlBlock.delayedOldestExuRedirect.get.valid := RegNext(oldestExuRedirect.valid)
     io.wbDataPathToCtrlBlock.delayedOldestExuRedirect.get.bits  := RegEnable(oldestExuRedirect.bits, oldestExuRedirect.valid)
   }
-  var staIQIdx = 0
-  val staIssueQueue = issueQueues.filter(_.param.StaCnt > 0)
-  val stdIssueQueue = issueQueues.filter(_.param.StdCnt > 0)
-  val IQValidNumVecWire = VecInit(issueQueues.filter(_.param.StdCnt == 0).map { case iq =>
-    if (iq.param.StaCnt > 0) {
-      // sta and std iq has 1 deq
-      val staCnt = staIssueQueue(staIQIdx).io.validCntDeqVec.head
-      val stdCnt = stdIssueQueue(staIQIdx).io.validCntDeqVec.head
-      staIQIdx = staIQIdx + 1
-      VecInit(Mux(stdCnt > staCnt, stdCnt, staCnt))
-    }
-    else iq.io.validCntDeqVec
-  }.flatten)
-  io.IQValidNumVec := IQValidNumVecWire
+  io.IQValidNumVec := issueQueues.filter(_.param.StdCnt == 0).map(_.io.validCntDeqVec).flatten
   io.og0Cancel := dataPath.io.og0Cancel
   io.diffVl.foreach(_ := dataPath.io.diffVl.get)
   io.lduWriteback.foreach(_.flatten.foreach(_.ready := true.B))

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -94,7 +94,8 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   }
 
   val exuNum = allExuParams.size
-  val maxIQSize = allIssueParams.map(_.numEntries).max
+  // + 6 because that need add 3 cycle enqNum
+  val maxIQSize = allIssueParams.map(_.numEntries).max + 6
   val IQEnqSum = allIssueParams.map(_.numEnq).sum
   val issueQueueNum = allIssueParams.size
 
@@ -426,6 +427,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     needAppendIQValidNumVec(iqDeqIdx) := selIQNum
   }}
   val issueQueueCount = VecInit(io.IQValidNumVec.zip(needAppendIQValidNumVec).map(x => RegNext(x._1 + x._2)))
+  val issueQueueCountAddEnq = VecInit(issueQueueCount.zip(needAppendIQValidNumVec).map(x => x._1 + x._2))
   val minIQSelAll = Wire(Vec(needMultiExu.size, Vec(renameWidth, Vec(issueQueueNum, Bool()))))
   needMultiExu.zipWithIndex.map{ case ((fus, exuidx), needMultiExuidx) => {
     val suffix = fus.map(_.name).mkString("_")
@@ -436,18 +438,49 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     for (i <- 0 until iqNum) {
       for (j <- 0 until iqNum) {
         if (i == j) compareMatrix(i)(j) := false.B
-        else if (i < j) compareMatrix(i)(j) := (issueQueueCount(exuidx(i)) + needAppendIQValidNumVec(exuidx(i))) < (issueQueueCount(exuidx(j)) + needAppendIQValidNumVec(exuidx(j)))
+        else if (i < j) compareMatrix(i)(j) := issueQueueCountAddEnq(exuidx(i)) < issueQueueCountAddEnq(exuidx(j))
         else compareMatrix(i)(j) := !compareMatrix(j)(i)
       }
     }
     val IQSort = Reg(Vec(iqNum, Vec(iqNum, Bool()))).suggestName(s"IQSort_$suffix}")
+    val IQSortWire = Wire(Vec(iqNum, Vec(iqNum, Bool()))).suggestName(s"IQSortWire_$suffix}")
+    IQSort := IQSortWire
+    val IQSortValidCnt = Reg(Vec(iqNum, UInt(maxIQSize.U.getWidth.W))).suggestName(s"IQSortValidCnt_$suffix}")
+    val IQSortValidCntAddEnq = Wire(Vec(iqNum, UInt(maxIQSize.U.getWidth.W))).suggestName(s"IQSortValidCntAddEnq_$suffix}")
     for (i <- 0 until iqNum){
       // i = 0 minimum iq, i = iqNum - 1 -> maximum iq
-      IQSort(i) := compareMatrix.map(x => PopCount(x) === (iqNum - 1 - i).U)
+      IQSortWire(i) := compareMatrix.map(x => PopCount(x) === (iqNum - 1 - i).U)
+      IQSortValidCnt(i) := Mux1H(IQSortWire(i), exuidx.map(x => issueQueueCountAddEnq(x)))
+      IQSortValidCntAddEnq(i) := Mux1H(IQSort(i), exuidx.map(x => needAppendIQValidNumVec(x)))
     }
+    // update IQSort
+    val IQSortUpdate = Wire(Vec(iqNum, Vec(iqNum, Bool()))).suggestName(s"IQSortUpdate_$suffix}")
+    val updateInterval = 3
+    val segmentNum = (iqNum - 1) / updateInterval + 1
+    for (segIdx <- 0 until segmentNum) {
+      val realNum = Seq(iqNum - segIdx * updateInterval, updateInterval).min
+      val compareMatrixNew = Wire(Vec(realNum, Vec(realNum, Bool())))
+      val startNum = segIdx * updateInterval
+      val endNum   = startNum + realNum
+      for (i <- 0 until realNum) {
+        for (j <- 0 until realNum) {
+          if (i == j) compareMatrixNew(i)(j) := false.B
+          else if (i < j) compareMatrixNew(i)(j) := IQSortValidCnt(startNum+i) + IQSortValidCntAddEnq(startNum+i) <
+                                                 IQSortValidCnt(startNum+j) + IQSortValidCntAddEnq(startNum+j)
+          else compareMatrixNew(i)(j) := !compareMatrixNew(j)(i)
+        }
+      }
+      val newIQSort = Wire(Vec(realNum, Vec(realNum, Bool())))
+      for (i <- 0 until realNum) {
+        // i = 0 minimum iq, i = realNum - 1 -> maximum iq
+        newIQSort(i) := compareMatrixNew.map(x => PopCount(x) === (realNum - 1 - i).U)
+        IQSortUpdate(startNum + i) := Mux1H(newIQSort(i), IQSort.drop(startNum).take(realNum))
+      }
+    }
+
     val minIQSel = Wire(Vec(renameWidth, Vec(issueQueueNum, Bool()))).suggestName(s"minIQSel_$suffix")
     for (i <- 0 until renameWidth){
-      val minIQSel_ith = IQSort(i % iqNum)
+      val minIQSel_ith = IQSortUpdate(i % iqNum)
       for (j <- 0 until issueQueueNum){
         minIQSel(i)(j) := false.B
         if (iqidx.contains(j)){

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -188,7 +188,6 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   }
 
   val renameWidth = io.fromRename.size
-  val issueQueueCount = RegNext(io.IQValidNumVec)
   // int fp vec v0
   val numRegType = 4
   val idxRegTypeInt = allFuConfigs.map(x => {
@@ -414,6 +413,19 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     }
   }
 
+  val uopSelIQ = Reg(Vec(renameWidth, Vec(issueQueueNum, Bool())))
+  val needAppendIQValidNumVec = Wire(Vec(exuNum, UInt(RenameWidth.U.getWidth.W)))
+  allExuParams.zipWithIndex.map { case (exuParams, iqDeqIdx) => {
+    val iqidx = allIssueParams.indexWhere(_.exuBlockParams.contains(exuParams))
+    val selIQNumReg = PopCount(uopSelIQ.zipWithIndex.map { case (u, i) =>
+      RegNext(u(iqidx) && FuType.FuTypeOrR(fromRename(i).bits.fuType, exuParams.fuConfigs.map(_.fuType)) && fromRename(i).fire)
+    })
+    val selIQNum = PopCount(uopSelIQ.zipWithIndex.map { case (u, i) =>
+      u(iqidx) && FuType.FuTypeOrR(fromRename(i).bits.fuType, exuParams.fuConfigs.map(_.fuType))
+    })
+    needAppendIQValidNumVec(iqDeqIdx) := selIQNum
+  }}
+  val issueQueueCount = VecInit(io.IQValidNumVec.zip(needAppendIQValidNumVec).map(x => RegNext(x._1 + x._2)))
   val minIQSelAll = Wire(Vec(needMultiExu.size, Vec(renameWidth, Vec(issueQueueNum, Bool()))))
   needMultiExu.zipWithIndex.map{ case ((fus, exuidx), needMultiExuidx) => {
     val suffix = fus.map(_.name).mkString("_")
@@ -448,6 +460,8 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
       dontTouch(compareMatrix)
       dontTouch(IQSort)
       dontTouch(minIQSel)
+      dontTouch(issueQueueCount)
+      dontTouch(needAppendIQValidNumVec)
     }
   }
   }
@@ -470,7 +484,6 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
       }
     }
   }}
-  val uopSelIQ = Reg(Vec(renameWidth, Vec(issueQueueNum, Bool())))
   val fuTypeOHSingle = Wire(Vec(renameWidth, Vec(needSingleIQ.size, Bool())))
   fuTypeOHSingle.zip(renameIn).map{ case (oh, in) => {
     oh := needSingleIQ.map(_._1).map(x => x.map(xx => in.valid && in.bits.fuType(xx.fuType.id)).reduce(_ || _))

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -188,7 +188,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   }
 
   val renameWidth = io.fromRename.size
-  val issueQueueCount = io.IQValidNumVec
+  val issueQueueCount = RegNext(io.IQValidNumVec)
   // int fp vec v0
   val numRegType = 4
   val idxRegTypeInt = allFuConfigs.map(x => {

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -504,6 +504,11 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     oh := fuConfigSeq.map(x => x.map(xx => in.bits.fuType(xx.fuType.id)).reduce(_ || _) && in.valid)
   }
   }
+  val fuTypeOHFromRename = Wire(Vec(renameWidth, Vec(needMultiExu.size, Bool())))
+  fuTypeOHFromRename.zip(fromRename).map{ case(oh, in) => {
+    oh := fuConfigSeq.map(x => x.map(xx => in.bits.fuType(xx.fuType.id)).reduce(_ || _) && in.valid)
+  }
+  }
   // not count itself
   val popFuTypeOH = Wire(Vec(renameWidth, Vec(needMultiExu.size, UInt((renameWidth-1).U.getWidth.W))))
   popFuTypeOH.zipWithIndex.map{ case (pop, idx) => {
@@ -517,8 +522,24 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
       }
     }
   }}
+  val popFuTypeOHFromRename = Wire(Vec(renameWidth, Vec(needMultiExu.size, UInt((renameWidth-1).U.getWidth.W))))
+  popFuTypeOHFromRename.zipWithIndex.map{ case (pop, idx) => {
+    if (idx == 0){
+      pop := 0.U.asTypeOf(pop)
+    }
+    else {
+      pop.zipWithIndex.map{ case (p, i) => {
+        p := PopCount(fuTypeOHFromRename.take(idx).map(x => x(i)))
+        }
+      }
+    }
+  }}
   val fuTypeOHSingle = Wire(Vec(renameWidth, Vec(needSingleIQ.size, Bool())))
   fuTypeOHSingle.zip(renameIn).map{ case (oh, in) => {
+    oh := needSingleIQ.map(_._1).map(x => x.map(xx => in.valid && in.bits.fuType(xx.fuType.id)).reduce(_ || _))
+  }}
+  val fuTypeOHSingleFromRename = Wire(Vec(renameWidth, Vec(needSingleIQ.size, Bool())))
+  fuTypeOHSingleFromRename.zip(fromRename).map{ case (oh, in) => {
     oh := needSingleIQ.map(_._1).map(x => x.map(xx => in.valid && in.bits.fuType(xx.fuType.id)).reduce(_ || _))
   }}
   val uopSelIQSingle = Wire(Vec(needSingleIQ.size, Vec(issueQueueNum, Bool())))
@@ -529,6 +550,13 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
                 Mux(fuTypeOH(i).asUInt.orR,
                   Mux1H(fuTypeOH(i), minIQSelAll)(Mux1H(fuTypeOH(i), popFuTypeOH(i))),
                   Mux1H(fuTypeOHSingle(i), uopSelIQSingle)),
+                0.U.asTypeOf(u)
+              )
+    }.elsewhen(io.fromRename(i).valid && !io.fromRename(i).ready) {
+      u := Mux(fromRename(i).valid,
+                Mux(fuTypeOHFromRename(i).asUInt.orR,
+                  Mux1H(fuTypeOHFromRename(i), minIQSelAll)(Mux1H(fuTypeOHFromRename(i), popFuTypeOHFromRename(i))),
+                  Mux1H(fuTypeOHSingleFromRename(i), uopSelIQSingle)),
                 0.U.asTypeOf(u)
               )
     }.elsewhen(io.fromRename(i).fire){

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -436,7 +436,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     for (i <- 0 until iqNum) {
       for (j <- 0 until iqNum) {
         if (i == j) compareMatrix(i)(j) := false.B
-        else if (i < j) compareMatrix(i)(j) := issueQueueCount(exuidx(i)) < issueQueueCount(exuidx(j))
+        else if (i < j) compareMatrix(i)(j) := (issueQueueCount(exuidx(i)) + needAppendIQValidNumVec(exuidx(i))) < (issueQueueCount(exuidx(j)) + needAppendIQValidNumVec(exuidx(j)))
         else compareMatrix(i)(j) := !compareMatrix(j)(i)
       }
     }

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -988,26 +988,35 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
   private val enqHasIssuedRegNext = validVecRegNext.zip(issuedVecRegNext).take(params.numEnq).map(x => x._1 & x._2).reduce(_ | _)
   private val enqEntryValidCnt = PopCount(validVec.take(params.numEnq))
   private val othersValidCnt = PopCount(validVec.drop(params.numEnq))
-  private val enqEntryValidCntDeq0 = PopCount(
-    validVec.take(params.numEnq).zip(deqCanAcceptVec(0).take(params.numEnq)).map { case (a, b) => a && b }
+  private val entryValidCntDeq0 = PopCount(
+    validVec.zip(deqCanAcceptVec(0)).map { case (a, b) => a && b }
   )
-  private val othersValidCntDeq0 = PopCount(
-    validVec.drop(params.numEnq).zip(deqCanAcceptVec(0).drop(params.numEnq)).map { case (a, b) => a && b }
+  private val entryValidCntDeq1 = PopCount(
+    validVec.zip(deqCanAcceptVec.last).map { case (a, b) => a && b }
   )
-  private val enqEntryValidCntDeq1 = PopCount(
-    validVec.take(params.numEnq).zip(deqCanAcceptVec.last.take(params.numEnq)).map { case (a, b) => a && b }
+  private val entryIssuedCntDeq0 = PopCount(
+    validVec.zip(issuedVec).zip(deqCanAcceptVec(0)).map { case ((a, b), c) => a && b && c }
   )
-  private val othersValidCntDeq1 = PopCount(
-    validVec.drop(params.numEnq).zip(deqCanAcceptVec.last.drop(params.numEnq)).map { case (a, b) => a && b }
+  private val entryIssuedCntDeq1 = PopCount(
+    validVec.zip(issuedVec).zip(deqCanAcceptVec.last).map { case ((a, b), c) => a && b && c }
   )
   protected val deqCanAcceptVecEnq: Seq[IndexedSeq[Bool]] = deqFuCfgs.map { fuCfgs: Seq[FuConfig] =>
     io.enq.map(_.bits.fuType).map(fuType =>
       FuType.FuTypeOrR(fuType, fuCfgs.map(_.fuType)))
   }
-  protected val enqValidCntDeq0 = PopCount(io.enq.map(_.fire).zip(deqCanAcceptVecEnq(0)).map { case (a, b) => a && b })
-  protected val enqValidCntDeq1 = PopCount(io.enq.map(_.fire).zip(deqCanAcceptVecEnq.last).map { case (a, b) => a && b })
-  io.validCntDeqVec.head := RegNext(enqEntryValidCntDeq0 +& othersValidCntDeq0 - io.deqDelay.head.fire) // validCntDeqVec(0)
-  io.validCntDeqVec.last := RegNext(enqEntryValidCntDeq1 +& othersValidCntDeq1 - io.deqDelay.last.fire) // validCntDeqVec(1)
+  val finalSuccess = if (param.needSnResp) io.snResp.get.map(_.finalSuccess)
+                     else if (param.needS2Resp) io.s2Resp.get.map(_.finalSuccess)
+                     else if (param.needS0Resp) io.s0Resp.get.map(_.finalSuccess)
+                     else if (param.needOg2Resp) io.og2Resp.get.map(_.finalSuccess)
+                     else io.og1Resp.map(_.finalSuccess)
+  val og1RespIsFinal = !param.needSnResp && !param.needS2Resp && !param.needS0Resp && !param.needOg2Resp
+  val issuedCnt0 = Mux(entryIssuedCntDeq0 > 3.U, 3.U, entryIssuedCntDeq0)
+  val issuedCnt1 = Mux(entryIssuedCntDeq1 > 3.U, 3.U, entryIssuedCntDeq1)
+  val finalResp0 = og1RespIsFinal.B & deqBeforeDly.head.valid
+  val finalResp1 = og1RespIsFinal.B & deqBeforeDly.last.valid
+  // valid counter -> uopSelIQ has 3 pipe latancy, sub deq
+  io.validCntDeqVec.head := entryValidCntDeq0 - issuedCnt0 - finalResp0
+  io.validCntDeqVec.last := entryValidCntDeq1 - issuedCnt1 - finalResp1
   private val othersLeftOneCaseVec = Wire(Vec(params.numEntries - params.numEnq, UInt((params.numEntries - params.numEnq).W)))
   othersLeftOneCaseVec.zipWithIndex.foreach { case (leftone, i) =>
     leftone := ~(1.U((params.numEntries - params.numEnq).W) << i)

--- a/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
@@ -1872,20 +1872,6 @@ class NewStoreQueue(implicit p: Parameters) extends NewStoreQueueBase with HasPe
       ctrlEntries(i).allocated
   })
 
-  when (io.redirect.valid) {
-    addrReadyPtrExt := Mux(
-      isAfter(cmtPtrExt(0), deqPtrExt(0)),
-      cmtPtrExt(0),
-      deqPtrExtNext(0) // for mmio insts, deqPtr may be ahead of cmtPtr
-    )
-
-    dataReadyPtrExt := Mux(
-      isAfter(cmtPtrExt(0), deqPtrExt(0)),
-      cmtPtrExt(0),
-      deqPtrExtNext(0) // for mmio insts, deqPtr may be ahead of cmtPtr
-    )
-  }
-
     // enqPtr update
   val dataReadyLookupVec = (0 until IssuePtrMoveStride).map(dataReadyPtrExt + _.U)
   val dataReadyLookup = dataReadyLookupVec.map(ptr =>
@@ -1905,6 +1891,20 @@ class NewStoreQueue(implicit p: Parameters) extends NewStoreQueueBase with HasPe
       ctrlEntries(i).vecMbCommit) &&
       ctrlEntries(i).allocated
   })
+
+  when (io.redirect.valid) {
+    addrReadyPtrExt := Mux(
+      isAfter(cmtPtrExt(0), deqPtrExt(0)),
+      cmtPtrExt(0),
+      deqPtrExtNext(0) // for mmio insts, deqPtr may be ahead of cmtPtr
+    )
+
+    dataReadyPtrExt := Mux(
+      isAfter(cmtPtrExt(0), deqPtrExt(0)),
+      cmtPtrExt(0),
+      deqPtrExtNext(0) // for mmio insts, deqPtr may be ahead of cmtPtr
+    )
+  }
 
   // deqPtr logic
   deqPtrExt := deqPtrExtNext


### PR DESCRIPTION
## Background

The main issues before this change were:

- Dispatch relies on `IQValidNumVec`, which has pipeline latency and cannot reflect the uops already selected in the current cycle or the uops that are about to be enqueued into the IQs.
- When rename is blocked by downstream backpressure, `uopSelIQ` may keep the previous selection result instead of recomputing the target IQ based on the actual stalled uops in `fromRename`.
- When multiple duplicated EXUs share multiple IQs, sorting only by the current valid count can bias several consecutive dispatch slots toward the same IQ.

## What This PR Does

1. Add predicted enqueue information to the Dispatch-side IQ accounting.

- `issueQueueCount` is extended from a pure `IQValidNumVec` view to a view that also includes selected but not yet enqueued uops.
- IQ comparison now considers same-cycle predicted enqueue pressure, which helps distribute traffic more evenly across duplicated IQs.

2. Refine the `IQSort` update behavior.

- After the initial ordering is built, the ordering is updated with the enqueue decisions that have already been made in the current cycle.
- This allows later rename slots to observe an IQ order that is closer to the real runtime state and reduces short-term clustering.

3. Recompute `uopSelIQ` when dispatch is blocked.

- When `fromRename.valid && !fromRename.ready`, Dispatch recalculates the target IQ using the actual stalled uops in `fromRename`.
- This avoids reusing stale selection results under backpressure and improves routing accuracy.

4. Adjust the `IssueQueue` valid counter behavior.

- `validCntDeqVec` is changed from the old partition-based count with `deqDelay` subtraction to a model that subtracts the uops expected to leave the queue three cycles later.
- This gives Dispatch a more realistic view of effective IQ availability.

## Additional Fix In This Commit Range

This commit range also includes an independent fix:

- It corrects `NewStoreQueue` pointer handling after redirect so that `addrReadyPtr` and `dataReadyPtr` do not move past the enqueue pointer.

This is a functional bug fix and is not part of the main dispatch/IQ balancing optimization.

## Expected Benefit

- Better load distribution across duplicated IQs.
- More accurate IQ selection when rename/dispatch is blocked by backpressure.
- A more realistic Dispatch-side view of IQ occupancy, which helps reduce local congestion and ineffective retries.