### PR TITLE
fix(LoadUnit): clear replay cause on matchInvalid writeback

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -1440,7 +1440,8 @@ class LoadUnitS3(param: ExeUnitParams)(
   // Writeback to LQ
   val lqWriteValid = pipeIn.valid && !doFastReplay && endPipe
   val lqWriteReady = io.lqWrite.ready
-  val lqWriteCause = Mux(s4HeadValid && s4HeadShouldReplay, s4HeadReplayCause, cause)
+  // matchInvalid is a terminal poisoned-load path: it redirects the backend and must not establish replay state in LRQ.
+  val lqWriteCause = Mux(matchInvalid, 0.U.asTypeOf(cause), Mux(s4HeadValid && s4HeadShouldReplay, s4HeadReplayCause, cause))
   val lqWriteCauseOH = PriorityEncoderOH(lqWriteCause)
   val lqWrite = Wire(new LqWriteBundle)
   val lqWriteMshrId = Mux(s4HeadCacheMiss && s4HeadValid, s4HeadMshrId, in.mshrId.get)
@@ -1521,6 +1522,11 @@ class LoadUnitS3(param: ExeUnitParams)(
   lqWrite.rep_info.tlb_full := in.tlbFull.get
   lqWrite.nc_with_data := in.isNCReplay() && !cause(C_UNCACHE)
   lqWrite.data_wen_dup := DontCare // TODO: remove this
+
+  assert(
+    !(lqWriteValid && matchInvalid && lqWriteCause.asUInt.orR),
+    "matchInvalid load should not carry replay causes into LQ/LRQ"
+  )
 
   // Writeback to VLMergeBuffer
   val vecldoutValid = pipeIn.valid && !kill && shouldWriteback && isVector && endPipe


### PR DESCRIPTION
 ## Background

  When a load hits the `matchInvalid` path in `NewLoadUnit`, it should be
  treated as a terminal poisoned-load case:
  - redirect backend
  - write back the load state
  - avoid establishing replay state in LQ/LRQ

  Before this change, `lqWriteCause` could still inherit replay cause bits from
  the current stage or S4 head state during `matchInvalid` writeback. That may
  incorrectly leave replay metadata in LQ/LRQ for an operation that should only
  trigger rollback/flush handling.

  ## Change

  This PR updates `NewLoadUnit` so that:
  - `lqWriteCause` is forced to zero when `matchInvalid` is true
  - `matchInvalid` writeback no longer carries replay causes into LQ/LRQ
  - an assertion is added to guard this invariant

  ## Expected Result

  After the fix, a `matchInvalid` load:
  - still performs the required redirect/rollback handling
  - does not leave stale replay cause state in LQ/LRQ
  - avoids follow-up incorrect replay behavior caused by poisoned replay
  metadata