### PR TITLE
area(sc): SC train data changed from meta to re-read

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/sc/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/sc/Bundles.scala
@@ -70,18 +70,13 @@ class ScMeta(implicit p: Parameters) extends ScBundle with HasScParameters {
   // NOTE: Seems ChiselDB has problem dealing with SInt, so we do not use ScEntry for scResp here
   // FIXME: is there a better way to do this?
   private def ScEntryWidth = (new ScEntry).getWidth
-  val scPathResp:      Vec[Vec[UInt]] = Vec(NumPathTables, Vec(NumWays, UInt(ScEntryWidth.W)))
-  val scGlobalResp:    Vec[Vec[UInt]] = Vec(NumGlobalTables, Vec(NumWays, UInt(ScEntryWidth.W)))
-  val scBWResp:        Vec[Vec[UInt]] = Vec(NumBWTables, Vec(NumWays, UInt(ScEntryWidth.W)))
-  val scImliResp:      Vec[UInt]      = Vec(NumWays, UInt(ScEntryWidth.W))
-  val scBiasResp:      Vec[UInt]      = Vec(BiasTableNumWays, UInt(ScEntryWidth.W))
-  val scBiasLowerBits: Vec[UInt]      = Vec(NumWays, UInt(BiasUseTageBitWidth.W))
-  val scPred:          Vec[Bool]      = Vec(NumWays, Bool())
-  val tagePred:        Vec[Bool]      = Vec(NumBtbResultEntries, Bool())
-  val tageCtr:         Vec[UInt]      = Vec(NumBtbResultEntries, UInt(TageTakenCtrWidth.W))
-  val tagePredValid:   Vec[Bool]      = Vec(NumBtbResultEntries, Bool())
-  val useScPred:       Vec[Bool]      = Vec(NumWays, Bool())
-  val sumAboveThres:   Vec[Bool]      = Vec(NumWays, Bool())
+  val scBiasLowerBits: Vec[UInt] = Vec(NumWays, UInt(BiasUseTageBitWidth.W))
+  val scPred:          Vec[Bool] = Vec(NumWays, Bool())
+  val tagePred:        Vec[Bool] = Vec(NumBtbResultEntries, Bool())
+  val tageCtr:         Vec[UInt] = Vec(NumBtbResultEntries, UInt(TageTakenCtrWidth.W))
+  val tagePredValid:   Vec[Bool] = Vec(NumBtbResultEntries, Bool())
+  val useScPred:       Vec[Bool] = Vec(NumWays, Bool())
+  val sumAboveThres:   Vec[Bool] = Vec(NumWays, Bool())
 
   // for debug
   val debug_scPathTakenVec:   Option[Vec[Bool]] = Some(Vec(NumWays, Bool()))

--- a/src/main/scala/xiangshan/frontend/bpu/sc/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/sc/Helpers.scala
@@ -33,8 +33,9 @@ trait Helpers extends HasScParameters with PhrHelper {
 
   protected def generateAddrField(setIdxWidth: Option[Int] = None): AddrField = AddrField(
     Seq(
-      ("shiftBit", FetchBlockAlignWidth),
-      ("bankIdx", BankWidth)
+      ("instOffset", instOffsetBits),
+      ("bankIdx", BankWidth),
+      ("shiftBits", ShiftBits)
     ) ++ (if (setIdxWidth.isDefined) Seq(("setIdx", setIdxWidth.get)) else Seq()),
     maxWidth = Option(VAddrBits)
   )

--- a/src/main/scala/xiangshan/frontend/bpu/sc/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/sc/Parameters.scala
@@ -46,7 +46,7 @@ case class ScParameters(
     ThresholdInit:       Int = 1130, // magic number,greater than min and less than max
     NumBanks:            Int = 2,
     WriteBufferSize:     Int = 4,
-    EnableScTrace:       Boolean = true
+    EnableScTrace:       Boolean = false
 ) {}
 
 trait HasScParameters extends HasBpuParameters {
@@ -94,6 +94,7 @@ trait HasScParameters extends HasBpuParameters {
     s"ThresholdInit($ThresholdInit) should be in [$MinThreshold, $MaxThreshold]"
   )
 
+  def ShiftBits:       Int = FetchBlockAlignWidth - BankWidth - instOffsetBits
   def WriteBufferSize: Int = scParameters.WriteBufferSize
 
   def EnableScTrace: Boolean = scParameters.EnableScTrace

--- a/src/main/scala/xiangshan/frontend/bpu/sc/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/sc/Parameters.scala
@@ -46,7 +46,7 @@ case class ScParameters(
     ThresholdInit:       Int = 1130, // magic number,greater than min and less than max
     NumBanks:            Int = 2,
     WriteBufferSize:     Int = 4,
-    EnableScTrace:       Boolean = false
+    EnableScTrace:       Boolean = true
 ) {}
 
 trait HasScParameters extends HasBpuParameters {

--- a/src/main/scala/xiangshan/frontend/bpu/sc/Sc.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/sc/Sc.scala
@@ -99,8 +99,6 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
       biasTable.io.sramResetDone
   ).reduce(_ && _)
 
-  io.trainReady := true.B
-
   /*
    * ghr stage ctrl signals
    */
@@ -145,30 +143,30 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
   private val s2_bwIdx = s1_bwIdx.map(RegEnable(_, s1_fire)) // for debug
 
   pathTable.zip(s0_pathIdx).foreach { case (table, idx) =>
-    table.io.req.valid         := s0_fire && PathEnable.B
-    table.io.req.bits.setIdx   := idx
-    table.io.req.bits.bankMask := s0_bankMask
+    table.io.predictReadReq.valid         := s0_fire && PathEnable.B
+    table.io.predictReadReq.bits.setIdx   := idx
+    table.io.predictReadReq.bits.bankMask := s0_bankMask
   }
 
   globalTable.zip(s0_globalIdx).foreach { case (table, idx) =>
-    table.io.req.valid := s0_fire && s0_commonHR.valid && GlobalEnable.B // if ghr invalid not request global table
-    table.io.req.bits.setIdx   := idx
-    table.io.req.bits.bankMask := s0_bankMask
+    table.io.predictReadReq.valid := s0_fire && s0_commonHR.valid && GlobalEnable.B // if ghr invalid not request global table
+    table.io.predictReadReq.bits.setIdx   := idx
+    table.io.predictReadReq.bits.bankMask := s0_bankMask
   }
 
   bwTable.zip(s0_bwIdx).foreach { case (table, idx) =>
-    table.io.req.valid         := s0_fire && s0_commonHR.valid && BWEnable.B
-    table.io.req.bits.setIdx   := idx
-    table.io.req.bits.bankMask := s0_bankMask
+    table.io.predictReadReq.valid         := s0_fire && s0_commonHR.valid && BWEnable.B
+    table.io.predictReadReq.bits.setIdx   := idx
+    table.io.predictReadReq.bits.bankMask := s0_bankMask
   }
 
-  imliTable.io.req.valid         := s0_fire && ImliEnable.B
-  imliTable.io.req.bits.setIdx   := s0_imliIdx
-  imliTable.io.req.bits.bankMask := s0_bankMask
+  imliTable.io.predictReadReq.valid         := s0_fire && ImliEnable.B
+  imliTable.io.predictReadReq.bits.setIdx   := s0_imliIdx
+  imliTable.io.predictReadReq.bits.bankMask := s0_bankMask
 
-  biasTable.io.req.valid         := s0_fire && BiasEnable.B
-  biasTable.io.req.bits.setIdx   := s0_biasIdx
-  biasTable.io.req.bits.bankMask := s0_bankMask
+  biasTable.io.predictReadReq.valid         := s0_fire && BiasEnable.B
+  biasTable.io.predictReadReq.bits.setIdx   := s0_biasIdx
+  biasTable.io.predictReadReq.bits.bankMask := s0_bankMask
 
   /*
    *  predict pipeline stage 1
@@ -177,31 +175,31 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
   private val s1_startPc = RegEnable(io.startPc, s0_fire)
   private val s1_pathResp = Mux(
     PathEnable.B,
-    VecInit(pathTable.map(_.io.resp)),
+    VecInit(pathTable.map(_.io.predictReadResp)),
     VecInit.fill(NumPathTables)(VecInit.fill(NumWays)(0.U.asTypeOf(new ScEntry())))
   )
   // if s0_commonHR invalid, global table resp is also invalid
   private val s1_globalResp = Mux(
     s1_commonHRValid && GlobalEnable.B,
-    VecInit(globalTable.map(_.io.resp)),
+    VecInit(globalTable.map(_.io.predictReadResp)),
     VecInit.fill(NumGlobalTables)(VecInit.fill(NumWays)(0.U.asTypeOf(new ScEntry())))
   )
 
   private val s1_bwResp = Mux(
     s1_commonHRValid && BWEnable.B,
-    VecInit(bwTable.map(_.io.resp)),
+    VecInit(bwTable.map(_.io.predictReadResp)),
     VecInit.fill(NumBWTables)(VecInit.fill(NumWays)(0.U.asTypeOf(new ScEntry())))
   )
 
   private val s1_imliResp = Mux(
     ImliEnable.B,
-    imliTable.io.resp,
+    imliTable.io.predictReadResp,
     VecInit.fill(NumWays)(0.U.asTypeOf(new ScEntry()))
   )
 
   private val s1_biasResp = Mux(
     BiasEnable.B,
-    biasTable.io.resp,
+    biasTable.io.predictReadResp,
     VecInit.fill(BiasTableNumWays)(0.U.asTypeOf(new ScEntry()))
   )
 
@@ -239,12 +237,7 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
    *  predict pipeline stage 2
    *  match entries and calculate final percSum
    */
-  private val s2_startPc    = RegEnable(s1_startPc, s1_fire)
-  private val s2_pathResp   = s1_pathResp.map(entries => VecInit(entries.map(RegEnable(_, s1_fire))))
-  private val s2_globalResp = s1_globalResp.map(entries => VecInit(entries.map(RegEnable(_, s1_fire))))
-  private val s2_bwResp     = s1_bwResp.map(entries => VecInit(entries.map(RegEnable(_, s1_fire))))
-  private val s2_imliResp   = VecInit(s1_imliResp.map(RegEnable(_, s1_fire)))
-  private val s2_biasResp   = VecInit(s1_biasResp.map(RegEnable(_, s1_fire)))
+  private val s2_startPc = RegEnable(s1_startPc, s1_fire)
 
   private val s2_biasPercsum = VecInit(s1_biasPercsum.map(RegEnable(_, s1_fire)))
   private val s2_sumPercsum  = VecInit(s1_sumPercsum.map(RegEnable(_, s1_fire)))
@@ -321,11 +314,6 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
     XSError(s2_fire && use && !valid, "SC useScPred is true but tage provider is invalid!\n")
   }
 
-  io.meta.scPathResp      := VecInit(s2_pathResp.map(v => VecInit(v.map(s => RegEnable(s.asUInt, s2_fire)))))
-  io.meta.scGlobalResp    := VecInit(s2_globalResp.map(v => VecInit(v.map(s => RegEnable(s.asUInt, s2_fire)))))
-  io.meta.scBWResp        := VecInit(s2_bwResp.map(v => VecInit(v.map(s => RegEnable(s.asUInt, s2_fire)))))
-  io.meta.scImliResp      := VecInit(s2_imliResp.map(v => RegEnable(v.asUInt, s2_fire)))
-  io.meta.scBiasResp      := VecInit(s2_biasResp.map(v => RegEnable(v.asUInt, s2_fire)))
   io.meta.scBiasLowerBits := RegEnable(s2_biasIdxLowBits, s2_fire)
 
   io.meta.scPred        := RegEnable(s2_scPred, s2_fire)
@@ -350,67 +338,130 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
   /*
    *  train pipeline stage 0
    */
-  private val t0_fire = io.stageCtrl.t0_fire && io.enable
+  private val t0_fire     = io.stageCtrl.t0_fire && io.enable
+  private val t0_meta     = io.train.meta.sc
+  private val t0_commonHR = io.train.meta.commonHR
+  private val t0_bankMask = getBankMask(io.train.startPc)
+  private val t0_pathIdx = PathTableInfos.zip(pathTable).map { case (info, table) =>
+    table.getPathTableIdx(
+      io.train.startPc,
+      new FoldedHistoryInfo(info.HistoryLength, min(info.HistoryLength, log2Ceil(info.NumSets))),
+      io.trainFoldedPathHist
+    )
+  }
+  private val t0_globalIdx = GlobalTableInfos.zip(globalTable).map { case (info, table) =>
+    table.getTableIdx(io.train.startPc, t0_commonHR.ghr(info.HistoryLength - 1, 0))
+  }
+  private val t0_bwIdx = BackwardTableInfos.zip(bwTable).map { case (info, table) =>
+    table.getTableIdx(io.train.startPc, t0_commonHR.bw(info.HistoryLength - 1, 0))
+  }
+  private val t0_imliIdx     = imliTable.getTableIdx(io.train.startPc, t0_commonHR.imli)
+  private val t0_biasIdx     = biasTable.getBiasTableIdx(io.train.startPc)
+  private val t0_branches    = io.train.branches
+  private val t0_mbtbEntries = io.train.meta.mbtb.entries.flatten
+  // if the branch cfi not in mbtbResult, do not train
+  // During training, find the predicted scPred and lowBits values in the order of the predicted mbtbResult
+  // MBTB may invalidate entry with larger idx during multihit, and the order needs to be reversed
+  private val t0_branchesScIdxHitVec = WireInit(VecInit.fill(ResolveEntryBranchNumber)(false.B))
+  private val t0_branchesScIdxVec    = WireInit(VecInit.fill(ResolveEntryBranchNumber)(0.U(log2Ceil(NumWays).W)))
+  t0_branches.zipWithIndex.foreach { case (branch, branchIdx) =>
+    for (i <- (0 until NumWays).reverse) {
+      when(branch.valid && t0_mbtbEntries(i).hit(branch.bits)) {
+        t0_branchesScIdxHitVec(branchIdx) := true.B
+        t0_branchesScIdxVec(branchIdx)    := i.U
+      }
+    }
+  }
+  private val t0_writeTakenVec =
+    VecInit(t0_branches.map(b => b.valid && b.bits.taken && b.bits.attribute.isConditional))
+  private val t0_writeValidVec =
+    VecInit(t0_branches.zip(t0_branchesScIdxHitVec).zip(t0_branchesScIdxVec).zip(t0_writeTakenVec).map {
+      case (((b, hit), predIdx), taken) =>
+        b.valid && b.bits.attribute.isConditional && hit && t0_meta.tagePredValid(predIdx) &&
+        (!(t0_meta.useScPred(predIdx) && t0_meta.scPred(predIdx) === taken) || !(t0_meta.useScPred(predIdx) &&
+          t0_meta.tagePredValid(predIdx) && t0_meta.scPred(predIdx) === t0_meta.tagePred(predIdx)))
+    })
+  private val t0_needWrite    = t0_writeValidVec.reduce(_ || _)
+  private val t0_bankConflict = t0_needWrite && s0_fire && t0_bankMask === s0_bankMask
+  io.trainReady := !t0_bankConflict
+  pathTable.zip(t0_pathIdx).foreach { case (table, idx) =>
+    table.io.trainReadReq.valid         := t0_fire && t0_needWrite && PathEnable.B
+    table.io.trainReadReq.bits.setIdx   := idx
+    table.io.trainReadReq.bits.bankMask := t0_bankMask
+  }
+  globalTable.zip(t0_globalIdx).foreach { case (table, idx) =>
+    table.io.trainReadReq.valid         := t0_fire && t0_needWrite && t0_commonHR.valid && GlobalEnable.B
+    table.io.trainReadReq.bits.setIdx   := idx
+    table.io.trainReadReq.bits.bankMask := t0_bankMask
+  }
+  bwTable.zip(t0_bwIdx).foreach { case (table, idx) =>
+    table.io.trainReadReq.valid         := t0_fire && t0_needWrite && t0_commonHR.valid && BWEnable.B
+    table.io.trainReadReq.bits.setIdx   := idx
+    table.io.trainReadReq.bits.bankMask := t0_bankMask
+  }
+  imliTable.io.trainReadReq.valid         := t0_fire && t0_needWrite && ImliEnable.B
+  imliTable.io.trainReadReq.bits.setIdx   := t0_imliIdx
+  imliTable.io.trainReadReq.bits.bankMask := t0_bankMask
+
+  biasTable.io.trainReadReq.valid         := t0_fire && t0_needWrite && BiasEnable.B
+  biasTable.io.trainReadReq.bits.setIdx   := t0_biasIdx
+  biasTable.io.trainReadReq.bits.bankMask := t0_bankMask
+
+  dontTouch(t0_bankConflict)
+  XSPerfAccumulate("t0_writeConflict", t0_bankConflict)
 
   /*
    *  train pipeline stage 1
    */
   private val t1_fire     = RegNext(t0_fire, false.B)
-  private val t1_train    = RegEnable(io.train, t0_fire)
-  private val t1_branches = t1_train.branches
-  private val t1_meta     = t1_train.meta.sc
-  private val t1_commonHR = t1_train.meta.commonHR
+  private val t1_branches = RegEnable(io.train.branches, t0_fire)
+  private val t1_meta     = RegEnable(t0_meta, 0.U.asTypeOf(t0_meta), t0_fire)
+  private val t1_commonHR = RegEnable(t0_commonHR, t0_fire)
+  private val t1_startPc  = RegEnable(io.train.startPc, t0_fire)
 
-  private val t1_bankMask = getBankMask(t1_train.startPc)
+  private val t1_bankMask     = RegEnable(t0_bankMask, t0_fire)
+  private val t1_pathSetIdx   = RegEnable(VecInit(t0_pathIdx), t0_fire)
+  private val t1_globalSetIdx = RegEnable(VecInit(t0_globalIdx), t0_fire)
 
-  private val t1_pathSetIdx = PathTableInfos.zip(pathTable).map { case (info, table) =>
-    table.getPathTableIdx(
-      t1_train.startPc,
-      new FoldedHistoryInfo(info.HistoryLength, min(info.HistoryLength, log2Ceil(info.NumSets))),
-      RegEnable(io.trainFoldedPathHist, t0_fire)
-    )
-  }
-  private val t1_globalSetIdx = GlobalTableInfos.zip(globalTable).map { case (info, table) =>
-    table.getTableIdx(t1_train.startPc, t1_commonHR.ghr(info.HistoryLength - 1, 0))
-  }
+  private val t1_bwSetIdx   = RegEnable(VecInit(t0_bwIdx), t0_fire)
+  private val t1_imliSetIdx = RegEnable(t0_imliIdx, t0_fire)
+  private val t1_biasSetIdx = RegEnable(t0_biasIdx, t0_fire)
 
-  private val t1_bwSetIdx = BackwardTableInfos.zip(bwTable).map { case (info, table) =>
-    table.getTableIdx(t1_train.startPc, t1_commonHR.bw(info.HistoryLength - 1, 0))
-  }
-  private val t1_imliSetIdx = imliTable.getTableIdx(t1_train.startPc, t1_commonHR.imli)
-  private val t1_biasSetIdx = biasTable.getBiasTableIdx(t1_train.startPc)
+  private val t1_oldPathEntries = Mux(
+    PathEnable.B,
+    VecInit(pathTable.map(_.io.trainReadResp)),
+    VecInit.fill(NumPathTables)(VecInit.fill(NumWays)(0.U.asTypeOf(new ScEntry())))
+  )
+  private val t1_oldGlobalEntries = Mux(
+    t1_commonHR.valid && GlobalEnable.B,
+    VecInit(globalTable.map(_.io.trainReadResp)),
+    VecInit.fill(NumGlobalTables)(VecInit.fill(NumWays)(0.U.asTypeOf(new ScEntry())))
+  )
+  private val t1_oldBWEntries = Mux(
+    t1_commonHR.valid && BWEnable.B,
+    VecInit(bwTable.map(_.io.trainReadResp)),
+    VecInit.fill(NumBWTables)(VecInit.fill(NumWays)(0.U.asTypeOf(new ScEntry())))
+  )
+  private val t1_oldImliEntries = Mux(
+    ImliEnable.B,
+    imliTable.io.trainReadResp,
+    VecInit.fill(NumWays)(0.U.asTypeOf(new ScEntry()))
+  )
+  private val t1_oldBiasEntries = Mux(
+    BiasEnable.B,
+    biasTable.io.trainReadResp,
+    VecInit.fill(BiasTableNumWays)(0.U.asTypeOf(new ScEntry()))
+  )
+  private val t1_oldBiasLowBits = RegEnable(t0_meta.scBiasLowerBits, t0_fire)
 
-  private val t1_oldPathEntries = VecInit(t1_meta.scPathResp.map(v => VecInit(v.map(r => r.asTypeOf(new ScEntry())))))
-  private val t1_oldGlobalEntries =
-    VecInit(t1_meta.scGlobalResp.map(v => VecInit(v.map(r => r.asTypeOf(new ScEntry())))))
-  private val t1_oldBWEntries   = VecInit(t1_meta.scBWResp.map(v => VecInit(v.map(r => r.asTypeOf(new ScEntry())))))
-  private val t1_oldImliEntries = VecInit(t1_meta.scImliResp.map(v => v.asTypeOf(new ScEntry())))
-  private val t1_oldBiasEntries = VecInit(t1_meta.scBiasResp.map(v => v.asTypeOf(new ScEntry())))
-  private val t1_oldBiasLowBits = t1_meta.scBiasLowerBits
-  private val t1_mbtbEntries    = t1_train.meta.mbtb.entries.flatten
+  private val t1_branchesWayIdxVec   = VecInit(t1_branches.map(b => getWayIdx(b.bits.cfiPosition)))
+  private val t1_branchesScIdxHitVec = RegEnable(t0_branchesScIdxHitVec, t0_fire)
+  private val t1_branchesScIdxVec    = RegEnable(t0_branchesScIdxVec, t0_fire)
 
-  private val t1_branchesWayIdxVec = VecInit(t1_branches.map(b => getWayIdx(b.bits.cfiPosition)))
-  private val t1_branchesScIdxVec  = WireInit(VecInit.fill(ResolveEntryBranchNumber)(0.U(log2Ceil(NumWays).W)))
-  private val t1_branchesScIdxHitVec =
-    WireInit(VecInit.fill(ResolveEntryBranchNumber)(false.B)) // if the branch cfi not in mbtbResult, do not train
-  private val t1_writeValidVec =
-    VecInit(t1_branches.zip(t1_branchesScIdxHitVec).map { case (b, hit) =>
-      b.valid && b.bits.attribute.isConditional && t1_fire && hit
-    })
-  private val t1_writeValid = t1_writeValidVec.reduce(_ || _)
-  private val t1_writeTakenVec =
-    VecInit(t1_branches.map(b => b.valid && b.bits.taken && b.bits.attribute.isConditional))
-
-  // During training, find the predicted scPred and lowBits values in the order of the predicted mbtbResult
-  // MBTB may invalidate entry with larger idx during multihit, and the order needs to be reversed
-  t1_branches.zipWithIndex.foreach { case (branch, branchIdx) =>
-    for (i <- (0 until NumWays).reverse) {
-      when(branch.valid && t1_mbtbEntries(i).hit(branch.bits)) { // branch.valid may have been recalculated on t1_writeValidVec
-        t1_branchesScIdxHitVec(branchIdx) := true.B
-        t1_branchesScIdxVec(branchIdx)    := i.U
-      }
-    }
-  }
+  private val t1_writeTakenVec    = RegEnable(t0_writeTakenVec, t0_fire)
+  private val t1_writeValidVecReg = RegEnable(t0_writeValidVec, t0_fire)
+  private val t1_writeValidVec    = VecInit(t1_writeValidVecReg.map(_ && t1_fire))
+  private val t1_writeValid       = t1_writeValidVec.reduce(_ || _)
 
   require(
     t1_branchesWayIdxVec(0).getWidth == log2Ceil(NumWays),
@@ -558,6 +609,8 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
 
     newEntry.ctr := Mux(inc >= dec, oldEntry.ctr.getIncrease(inc - dec), oldEntry.ctr.getDecrease(dec - inc))
   }
+  dontTouch(t1_startPc)
+  dontTouch(t1_branchesScIdxHitVec)
   dontTouch(writeBiasWayMask)
   dontTouch(writeBiasDirMask)
   dontTouch(t1_writeBiasEntryVec)
@@ -569,11 +622,11 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
   /*
    *  train pipeline stage 2
    */
-  private val t2_writeValid                 = RegNext(t1_writeValid, init = false.B)
+  private val t2_writeValid                 = RegNext(t1_writeValid, false.B)
   private val t2_bankMask                   = RegEnable(t1_bankMask, t1_fire)
-  private val t2_pathSetIdx                 = RegEnable(VecInit(t1_pathSetIdx), t1_fire)
-  private val t2_globalSetIdx               = RegEnable(VecInit(t1_globalSetIdx), t1_fire)
-  private val t2_bwSetIdx                   = RegEnable(VecInit(t1_bwSetIdx), t1_fire)
+  private val t2_pathSetIdx                 = RegEnable(t1_pathSetIdx, t1_fire)
+  private val t2_globalSetIdx               = RegEnable(t1_globalSetIdx, t1_fire)
+  private val t2_bwSetIdx                   = RegEnable(t1_bwSetIdx, t1_fire)
   private val t2_imliSetIdx                 = RegEnable(t1_imliSetIdx, t1_fire)
   private val t2_biasSetIdx                 = RegEnable(t1_biasSetIdx, t1_fire)
   private val t2_commonHR                   = RegEnable(t1_commonHR, t1_fire)
@@ -801,8 +854,8 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
   private val scTraceVec = Wire(Vec(ResolveEntryBranchNumber, Valid(new ScConditionalBranchTrace)))
   scTraceVec.zipWithIndex.foreach { case (trace, i) =>
     val predWayIdx = t1_branchesScIdxVec(i)
-    trace.valid        := t1_branches(i).valid && t1_branches(i).bits.attribute.isConditional && t1_fire
-    trace.bits.startPc := t1_train.startPc
+    trace.valid        := t1_writeValidVec(i)
+    trace.bits.startPc := t1_startPc
     trace.bits.cfiPc   := t1_branches(i).bits.debug_realCfiPc.getOrElse(0.U(VAddrBits.W))
 
     trace.bits.providerValid := t1_meta.tagePredValid(predWayIdx)
@@ -836,7 +889,7 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
   scTraceDBTables.zip(scTraceVec).foreach { case (dbTable, condTrace) =>
     dbTable.log(
       data = condTrace.bits,
-      en = t1_writeValid && condTrace.valid,
+      en = condTrace.valid,
       clock = clock,
       reset = reset
     )

--- a/src/main/scala/xiangshan/frontend/bpu/sc/ScTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/sc/ScTable.scala
@@ -33,10 +33,12 @@ class ScTable(
 )(implicit p: Parameters)
     extends ScModule with HasScParameters with Helpers {
   class ScTableIO extends ScBundle {
-    val req:           Valid[ScTableReq] = Flipped(Valid(new ScTableReq(numSets, numWays)))
-    val resp:          Vec[ScEntry]      = Output(Vec(numWays, new ScEntry()))
-    val update:        ScTableTrain      = Input(new ScTableTrain(numSets, numWays))
-    val sramResetDone: Bool              = Output(Bool())
+    val predictReadReq:  Valid[ScTableReq] = Flipped(Valid(new ScTableReq(numSets, numWays)))
+    val predictReadResp: Vec[ScEntry]      = Output(Vec(numWays, new ScEntry()))
+    val trainReadReq:    Valid[ScTableReq] = Flipped(Valid(new ScTableReq(numSets, numWays)))
+    val trainReadResp:   Vec[ScEntry]      = Output(Vec(numWays, new ScEntry()))
+    val update:          ScTableTrain      = Input(new ScTableTrain(numSets, numWays))
+    val sramResetDone:   Bool              = Output(Bool())
   }
 
   val io = IO(new ScTableIO())
@@ -75,18 +77,21 @@ class ScTable(
   )
 
   // read path table by setIndex
-  private val reqSetIdx   = io.req.bits.setIdx
-  private val reqBankMask = io.req.bits.bankMask
-  sram.zip(reqBankMask.asBools).foreach {
-    case (bank, bankEnable) =>
-      bank.io.r.req.valid       := io.req.valid && bankEnable
-      bank.io.r.req.bits.setIdx := reqSetIdx
+  sram.zipWithIndex.foreach { case (bank, bankIdx) =>
+    val predictReadValid = io.predictReadReq.valid && io.predictReadReq.bits.bankMask(bankIdx)
+    val trainReadValid   = io.trainReadReq.valid && io.trainReadReq.bits.bankMask(bankIdx)
+    bank.io.r.req.valid       := predictReadValid || trainReadValid
+    bank.io.r.req.bits.setIdx := Mux(predictReadValid, io.predictReadReq.bits.setIdx, io.trainReadReq.bits.setIdx)
+    assert(!(predictReadValid && trainReadValid), s"read conflict in sc${tableType}${tableIdx}_${bankIdx}")
   }
 
   io.sramResetDone := sram.map(_.io.resetDone).reduce(_ && _)
 
-  private val respBankMask = RegEnable(reqBankMask, io.req.valid)
-  io.resp := Mux1H(respBankMask.asBools, sram.map(_.io.r.resp.data))
+  private val predictReadBankMaskNext = RegEnable(io.predictReadReq.bits.bankMask, io.predictReadReq.valid)
+  io.predictReadResp := Mux1H(predictReadBankMaskNext, sram.map(_.io.r.resp.data))
+
+  private val trainReadBankMaskNext = RegEnable(io.trainReadReq.bits.bankMask, io.trainReadReq.valid)
+  io.trainReadResp := Mux1H(trainReadBankMaskNext, sram.map(_.io.r.resp.data))
 
   // update path table
   private val updateValid    = io.update.valid && io.update.wayMask.reduce(_ || _)
@@ -120,5 +125,4 @@ class ScTable(
       buffer.io.read.head.ready      := bank.io.w.req.ready && !bank.io.r.req.valid
       buffer.io.read.head.ready      := bank.io.w.req.ready && !bank.io.r.req.valid
   }
-
 }


### PR DESCRIPTION
- SC training data source changed from meta to re-reading SC tables
- To reduce read-read conflicts during updates, SC bank selection uses a subset of the PC bits used by TAGE; SC setIdx still uses aligned PC bits

log:
```
[749] TageTable[0]:
[749]   Size(set, bank, way): 512 * 4 * 2 = 4096
[749]   History length: 4
[749]   Address fields:
[749]     50| 49..25 | 24..12 | 11...3 | 2.....1 | .........0 |
[749]       | unused |    tag | setIdx | bankIdx | instOffset |
....
[749] ScbiasTable[0]:
[749]   Size(set, bank, way): 128 * 2 * 32
[749]   Address fields:
[749]     50| 49..12 | 11...5 | 4.......2 | ......1 | .........0 |
[749]       | unused | setIdx | shiftBits | bankIdx | instOffset |
```