### PR TITLE
fix(Bitmap): cfs indexed with wrong truncated PPN in L2TLB (#5858)

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -754,7 +754,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
       val isAf = pte_in.isAf() && (s2xlate === noS2xlate || s2xlate === onlyStage1) && !isPf
       ptw_resp.pf := (if (af_first) !af else true.B) && isPf
       ptw_resp.af := (if (af_first) true.B else !isPf) && (af || isAf)
-      ptw_resp.cf := cfs(ptw_resp.ppn(sectortlbwidth - 1, 0))
+      ptw_resp.cf := cfs(ptw_resp.ppn_low)
       ptw_resp.v := !ptw_resp.pf
       ptw_resp.prefetch := DontCare
       ptw_resp.asid := Mux(hasS2xlate, vsatp.asid, satp.asid)


### PR DESCRIPTION
As describe in https://github.com/OpenXiangShan/XiangShan/issues/5854 , in L2TLB(function contiguous_pte_to_merge_ptwResp), when assigning the bitmap check result (cf) to each of the 8 PTEs packed into the same TLB entry, the code uses the wrong bits to index into the cfs vector.