### PR TITLE
fix(jump, perf): fix redirect valid

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/wrapper/JumpUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/JumpUnit.scala
@@ -35,7 +35,7 @@ class JumpUnit(cfg: FuConfig)(implicit p: Parameters) extends PipedFuncUnit(cfg)
 
   val redirect = io.out.bits.res.redirect.get.bits
   val redirectValid = io.out.bits.res.redirect.get.valid
-  redirectValid := io.in.valid && !jumpDataModule.io.isAuipc
+  redirectValid := io.in.valid && !jumpDataModule.io.isAuipc && (redirect.cfiUpdate.isMisPred || redirect.cfiUpdate.hasBackendFault)
   redirect := 0.U.asTypeOf(redirect)
   redirect.level := RedirectLevel.flushAfter
   redirect.robIdx := io.in.bits.ctrl.robIdx


### PR DESCRIPTION
This PR is a performance fix patch for PR #5762.

The purpose of #5762:
The purpose of #5762 is to fix the performance counters `mis_pred` and `total_flush`.
The performance counter `mis_pred` only counts when the `Branch` and `Jump` instructions experience `misPred`, removing the impact of `CSR`.
The performance counter `total_flush` only counts the oldest redirect.

The impact caused:
When modifying the `redirect valid` signal written back by the functional unit, the `redirect Valid` of `Branch` and `Jump` instructions were generated and placed inside the functional unit. However, #5762 missed the `Jump` instruction, causing each `Jump` instruction except `Auipc` to redirect and causing `IPC` to crash.

How to fix it:
The current PR has fixed the correct logic for the `Jump` instruction 'redirectValid'. For the `Jump` instruction, only when `misPred` or `backendFault` occurs will a redirect be initiated.

`IPC` returns to normal values.