### PR TITLE
feat(MissQueue, Sbuffer): enable st-ld forwarding on mshr

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -161,7 +161,7 @@ case class XSCoreParameters
   VecMemUnitStrideMaxFlowNum: Int = 2,
   VecMemLSQEnqIteratorNumberSeq: Seq[Int] = Seq(16, 16, 16, 16, 16, 16),
   StoreBufferSize: Int = 16,
-  StoreBufferThreshold: Int = 7,
+  StoreBufferThreshold: Int = 9,
   EnsbufferWidth: Int = 2,
   LoadDependencyWidth: Int = 2,
   // ============ VLSU ============

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -31,6 +31,7 @@ import xiangshan._
 import xiangshan.backend.rob.{RobDebugRollingIO, RobPtr}
 import xiangshan.cache.wpu._
 import xiangshan.mem.prefetch._
+import xiangshan.mem.Bundles.SbufferForward
 import xiangshan.mem.{AddPipelineReg, HasL1PrefetchSourceParameter, HasMemBlockParameters, LqPtr, MemorySize}
 
 // DCache specific parameters
@@ -620,6 +621,8 @@ class MissEntryForwardIO(implicit p: Parameters) extends DCacheBundle {
   val inflight = Bool()
   val paddr = UInt(PAddrBits.W)
   val raw_data = Vec(blockRows, UInt(rowBits.W))
+  val isFromStore = Bool()
+  val store_mask = UInt(cfg.blockBytes.W)
   val firstbeat_valid = Bool()
   val lastbeat_valid = Bool()
   val denied = Bool()
@@ -726,6 +729,8 @@ class DCacheToLsuIO(implicit p: Parameters) extends DCacheBundle {
   val release = ValidIO(new Release) // cacheline release hint for ld-ld violation check
   val forward_D = Flipped(Vec(LoadPipelineWidth, new DCacheForward))
   val forward_mshr = Flipped(Vec(LoadPipelineWidth, new DCacheForward))
+  // If a store is miss and accepted by mshr, Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
+  val forward_mshrStData = Flipped(Vec(LoadPipelineWidth, new SbufferForward))
 }
 
 class DCacheTopDownIO(implicit p: Parameters) extends DCacheBundle {
@@ -1512,6 +1517,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   // forward missqueue
   missQueue.io.forward <> io.lsu.forward_mshr
+  // If a store is miss and accepted by mshr, Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
+  missQueue.io.forward_stData <> io.lsu.forward_mshrStData
 
   // refill to load queue
  // io.lsu.lsq <> missQueue.io.refill_to_ldq

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -746,6 +746,7 @@ class DCacheIO(implicit p: Parameters) extends DCacheBundle {
   val lsu = new DCacheToLsuIO
   val error = ValidIO(new L1CacheErrorInfo)
   val mshrFull = Output(Bool())
+  val mshr_store_empty = Output(Bool())
   val memSetPattenDetected = Output(Bool())
   val lqEmpty = Input(Bool())
   val pf_ctrl = Output(Vec(L1PrefetcherNum, new PrefetchControlBundle))
@@ -976,6 +977,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   mainPipe.io.refill_info := missQueue.io.refill_info
   mainPipe.io.replace <> missQueue.io.replace
   mainPipe.io.sms_agt_evict_req <> io.sms_agt_evict_req
+  io.mshr_store_empty := missQueue.io.mshr_store_empty
   io.memSetPattenDetected := missQueue.io.memSetPattenDetected
   io.wfi <> missQueue.io.wfi
   io.refillTrain := missQueue.io.refill_train

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -31,7 +31,7 @@ import xiangshan._
 import xiangshan.backend.rob.{RobDebugRollingIO, RobPtr}
 import xiangshan.cache.wpu._
 import xiangshan.mem.prefetch._
-import xiangshan.mem.Bundles.SbufferForward
+import xiangshan.mem.Bundles.SbufferForwardReq
 import xiangshan.mem.{AddPipelineReg, HasL1PrefetchSourceParameter, HasMemBlockParameters, LqPtr, MemorySize}
 
 // DCache specific parameters
@@ -668,6 +668,7 @@ class DCacheForwardReqS1(implicit p: Parameters) extends DCacheBundle {
 class DCacheForwardResp(implicit p: Parameters) extends DCacheBundle {
   val matchInvalid = Bool()
   val forwardData = Vec((VLEN/8), UInt(8.W))
+  val forwardMask = Vec((VLEN/8), Bool())
   // denied and corrupt are only valid when forwarding matches
   val denied = Bool()
   val corrupt = Bool()
@@ -730,7 +731,7 @@ class DCacheToLsuIO(implicit p: Parameters) extends DCacheBundle {
   val forward_D = Flipped(Vec(LoadPipelineWidth, new DCacheForward))
   val forward_mshr = Flipped(Vec(LoadPipelineWidth, new DCacheForward))
   // If a store is miss and accepted by mshr, Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
-  val forward_mshrStData = Flipped(Vec(LoadPipelineWidth, new SbufferForward))
+  val forward_mshrStData = Flipped(Vec(LoadPipelineWidth, new SbufferForwardReq))
 }
 
 class DCacheTopDownIO(implicit p: Parameters) extends DCacheBundle {
@@ -1311,6 +1312,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     s2Resp.valid := RegNext(s1RespValid)
     s2Resp.bits.matchInvalid := false.B
     s2Resp.bits.forwardData := RegEnable(s1RespForwardData.asTypeOf(s2Resp.bits.forwardData), s1ReqValid)
+    s2Resp.bits.forwardMask := VecInit(Seq.fill(VLEN / 8)(RegNext(s1RespValid)))
     s2Resp.bits.denied := RegEnable(bus.d.bits.denied, s1ReqValid)
     s2Resp.bits.corrupt := RegEnable(bus.d.bits.corrupt, s1ReqValid)
   }
@@ -1518,7 +1520,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   // forward missqueue
   missQueue.io.forward <> io.lsu.forward_mshr
   // If a store is miss and accepted by mshr, Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
-  missQueue.io.forward_stData <> io.lsu.forward_mshrStData
+  missQueue.io.forward_stData := io.lsu.forward_mshrStData
 
   // refill to load queue
  // io.lsu.lsq <> missQueue.io.refill_to_ldq

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -877,10 +877,9 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   //                                      (1) real hit       (2) store miss and accepted by mshr
   io.store_hit_resp.valid := s3_valid && s3_store_can_go || mshr_handled_store_miss_s3
   io.store_hit_resp.bits.data := DontCare
-  io.store_hit_resp.bits.miss := false.B
+  io.store_hit_resp.bits.miss := { if (env.EnableDifftest) mshr_handled_store_miss_s3 else false.B }
   io.store_hit_resp.bits.replay := false.B
   io.store_hit_resp.bits.id := Mux(mshr_handled_store_miss_s3, mshr_handled_store_miss_id_s3, s3_req.id)
-  // io.store_refill_done_resp.valid := s3_valid && s3_miss_can_go && s3_req.isStore
 
   val atomic_hit_resp = Wire(new MainPipeResp)
   atomic_hit_resp.source := s3_req.source

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -877,7 +877,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   //                                      (1) real hit       (2) store miss and accepted by mshr
   io.store_hit_resp.valid := s3_valid && s3_store_can_go || mshr_handled_store_miss_s3
   io.store_hit_resp.bits.data := DontCare
-  io.store_hit_resp.bits.miss := { if (env.EnableDifftest) mshr_handled_store_miss_s3 else false.B }
+  io.store_hit_resp.bits.miss := mshr_handled_store_miss_s3
   io.store_hit_resp.bits.replay := false.B
   io.store_hit_resp.bits.id := Mux(mshr_handled_store_miss_s3, mshr_handled_store_miss_id_s3, s3_req.id)
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -870,16 +870,16 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.store_replay_resp.bits.replay := true.B // s2_grow_perm_fail
   io.store_replay_resp.bits.id := s2_req.id
 
-  val mshr_accept_store_miss = s2_valid && s2_can_go_to_mq && s2_req.isStore && !io.store_replay_resp.valid
-  val mshr_accept_store_miss_s3 = RegNext(mshr_accept_store_miss)
-  val mshr_accept_store_miss_id_s3 = RegEnable(s2_req.id, mshr_accept_store_miss)
+  val mshr_handled_store_miss = s2_valid && s2_can_go_to_mq && s2_req.isStore && !io.store_replay_resp.valid
+  val mshr_handled_store_miss_s3 = RegNext(mshr_handled_store_miss)
+  val mshr_handled_store_miss_id_s3 = RegEnable(s2_req.id, mshr_handled_store_miss)
   // If a store is miss and accepted by mshr, tell Sbuffer it is a "hit". Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
   //                                      (1) real hit       (2) store miss and accepted by mshr
-  io.store_hit_resp.valid := s3_valid && s3_store_can_go || mshr_accept_store_miss_s3
+  io.store_hit_resp.valid := s3_valid && s3_store_can_go || mshr_handled_store_miss_s3
   io.store_hit_resp.bits.data := DontCare
   io.store_hit_resp.bits.miss := false.B
   io.store_hit_resp.bits.replay := false.B
-  io.store_hit_resp.bits.id := Mux(mshr_accept_store_miss_s3, mshr_accept_store_miss_id_s3, s3_req.id)
+  io.store_hit_resp.bits.id := Mux(mshr_handled_store_miss_s3, mshr_handled_store_miss_id_s3, s3_req.id)
   // io.store_refill_done_resp.valid := s3_valid && s3_miss_can_go && s3_req.isStore
 
   val atomic_hit_resp = Wire(new MainPipeResp)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -870,11 +870,17 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.store_replay_resp.bits.replay := true.B // s2_grow_perm_fail
   io.store_replay_resp.bits.id := s2_req.id
 
-  io.store_hit_resp.valid := s3_valid && (s3_store_can_go || (s3_miss_can_go && s3_req.isStore))
+  val mshr_accept_store_miss = s2_valid && s2_can_go_to_mq && s2_req.isStore && !io.store_replay_resp.valid
+  val mshr_accept_store_miss_s3 = RegNext(mshr_accept_store_miss)
+  val mshr_accept_store_miss_id_s3 = RegEnable(s2_req.id, mshr_accept_store_miss)
+  // If a store is miss and accepted by mshr, tell Sbuffer it is a "hit". Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
+  //                                      (1) real hit       (2) store miss and accepted by mshr
+  io.store_hit_resp.valid := s3_valid && s3_store_can_go || mshr_accept_store_miss_s3
   io.store_hit_resp.bits.data := DontCare
   io.store_hit_resp.bits.miss := false.B
   io.store_hit_resp.bits.replay := false.B
-  io.store_hit_resp.bits.id := s3_req.id
+  io.store_hit_resp.bits.id := Mux(mshr_accept_store_miss_s3, mshr_accept_store_miss_id_s3, s3_req.id)
+  // io.store_refill_done_resp.valid := s3_valid && s3_miss_can_go && s3_req.isStore
 
   val atomic_hit_resp = Wire(new MainPipeResp)
   atomic_hit_resp.source := s3_req.source

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -601,19 +601,18 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     refill_start_time := GTimer()
   }
 
+  // Wire to hold updated data after refill on grant.fire
   val refill_and_store_data_update = Wire(Vec(blockRows, UInt(rowBits.W)))
-
+  // All the logic of refill_and_store_data. There is a corner case to note: store-merge and grant.fire may happen at the same cycle.
   when (io.miss_req_pipe_reg.alloc && !io.miss_req_pipe_reg.cancel && miss_req_pipe_reg_bits.isFromStore) {
-    for (i <- 0 until blockRows) {
-        refill_and_store_data(i) := miss_req_pipe_reg_bits.store_data(rowBits * (i + 1) - 1, rowBits * i)
-    }
+    refill_and_store_data := VecInit(miss_req_pipe_reg_bits.store_data.grouped(rowBits))
   }.elsewhen (io.miss_req_pipe_reg.merge && !io.miss_req_pipe_reg.cancel && miss_req_pipe_reg_bits.isFromStore) {
-      for (i <- 0 until blockRows) {
-        val store_mask_temp = miss_req_pipe_reg_bits.store_mask.grouped(rowBytes)(i).asBools
-        val store_data_temp = (miss_req_pipe_reg_bits.store_data.grouped(8).grouped(rowBytes).toSeq)(i)
-        refill_and_store_data(i) := VecInit((0 until rowBytes).map(k =>
-          Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data_update(i).grouped(8)(k)))).asUInt
-      }
+    for (i <- 0 until blockRows) {
+      val store_mask_temp = miss_req_pipe_reg_bits.store_mask.grouped(rowBytes)(i).asBools
+      val store_data_temp = (miss_req_pipe_reg_bits.store_data.grouped(8).grouped(rowBytes).toSeq)(i)
+      refill_and_store_data(i) := VecInit((0 until rowBytes).map(k =>
+        Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data_update(i).grouped(8)(k)))).asUInt
+    }
   }.elsewhen (io.mem_grant.fire) {
     refill_and_store_data := refill_and_store_data_update
   }
@@ -656,12 +655,27 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     no_pending := false.B
   }
 
-  // merge data refilled by l2 and store data, update miss queue entry, gen refill_req
-  val new_mask = VecInit(req_store_mask.grouped(rowBytes))
   // merge refilled data and store data (if needed)
   def mergePutData(old_data: UInt, new_data: UInt, wmask: UInt): UInt = {
     val full_wmask = FillInterleaved(8, wmask)
     (~full_wmask & old_data | full_wmask & new_data)
+  }
+  val new_mask = VecInit(req_store_mask.grouped(rowBytes))
+  val grant_data_grouped = io.mem_grant.bits.data.grouped(rowBits)
+  val lowHalf_refill = refill_count === 0.U && !isKeyword || refill_count =/= 0.U && isKeyword
+  //---- refill_and_store_data_update: see definition above ----
+  require(blockRows == 2 * beatRows, "refill_and_store_data_update: so far, only works for blockRows == 2 * beatRows")
+  for (i <- 0 until beatRows) {
+    refill_and_store_data_update(i) := Mux(
+      io.mem_grant.fire && edge.hasData(io.mem_grant.bits) && lowHalf_refill,
+      mergePutData(grant_data_grouped(i), refill_and_store_data(i), new_mask(i)),
+      refill_and_store_data(i)
+    )
+    refill_and_store_data_update(i + beatRows) := Mux(
+      io.mem_grant.fire && edge.hasData(io.mem_grant.bits) && !lowHalf_refill,
+      mergePutData(grant_data_grouped(i), refill_and_store_data(i + beatRows), new_mask(i + beatRows)),
+      refill_and_store_data(i + beatRows)
+    )
   }
 
   val hasData = RegInit(true.B)
@@ -695,38 +709,6 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       val overflow = refill_end_time < refill_start_time || (time_delta >> LATENCY_WIDTH).orR
       refill_latency := Mux(overflow, 0.U, time_delta)
     }
-  }
-
-
-      // for (i <- 0 until beatRows) {
-      //   val base_idx = (refill_count << log2Floor(beatRows)) + i.U
-      //   val idx = Mux(isKeyword, base_idx ^ 4.U, base_idx)
-      //   val grant_row = io.mem_grant.bits.data(rowBits * (i + 1) - 1, rowBits * i)
-      //   refill_and_store_data_update(idx) := mergePutData(grant_row, refill_and_store_data(idx), new_mask(idx))
-      // }
-  // when (io.mem_grant.fire && edge.hasData(io.mem_grant.bits)) {
-  //   for (i <- 0 until beatRows) {
-  //     refill_and_store_data_update(i) := mergePutData(grant_data_grouped(i), refill_and_store_data(i),
-  //                                                     new_mask(i) | Fill(rowBytes, isKeyword))
-  //     refill_and_store_data_update(i + beatRows) := mergePutData(grant_data_grouped(i), refill_and_store_data(i + beatRows),
-  //                                                                new_mask(i + beatRows) | Fill(rowBytes, !isKeyword))
-  //   }
-  // }.otherwise {
-  //   refill_and_store_data_update := refill_and_store_data
-  // }
-  val grant_data_grouped = io.mem_grant.bits.data.grouped(rowBits)
-  val lowHalf_refill = refill_count === 0.U && !isKeyword || refill_count =/= 0.U && isKeyword
-  for (i <- 0 until beatRows) {
-    refill_and_store_data_update(i) := Mux(
-      io.mem_grant.fire && edge.hasData(io.mem_grant.bits) && lowHalf_refill,
-      mergePutData(grant_data_grouped(i), refill_and_store_data(i), new_mask(i)),
-      refill_and_store_data(i)
-    )
-    refill_and_store_data_update(i + beatRows) := Mux(
-      io.mem_grant.fire && edge.hasData(io.mem_grant.bits) && !lowHalf_refill,
-      mergePutData(grant_data_grouped(i), refill_and_store_data(i + beatRows), new_mask(i + beatRows)),
-      refill_and_store_data(i + beatRows)
-    )
   }
 
   when (io.mem_finish.fire) {

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -476,7 +476,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   val req_valid = RegInit(false.B)
   val set = addr_to_dcache_set(req.vaddr)
   val evict_BtoT_way = RegInit(false.B)
-  val alloc_is_store = Reg(Bool())  // The alloc (first) req is a store req
+  val alloc_is_store = RegInit(false.B)  // The alloc (first) req is a store req
   // initial keyword
   val isKeyword = RegInit(false.B)
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -839,7 +839,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.refill_to_ldq.bits.error := RegEnable(io.mem_grant.bits.corrupt || io.mem_grant.bits.denied, refill_to_ldq_en)
   io.refill_to_ldq.bits.refill_done := RegEnable(refill_done && io.mem_grant.fire, refill_to_ldq_en)
   io.refill_to_ldq.bits.hasdata := hasData
-  io.refill_to_ldq.bits.data_raw := refill_and_store_data.asUInt
+  io.refill_to_ldq.bits.data_raw := refill_data_raw.asUInt
   io.refill_to_ldq.bits.id := io.id
 
   // if the entry has a pending merge req, wait for it
@@ -1392,11 +1392,25 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val difftest = DifftestModule(new DiffRefillEvent, dontCare = true)
     difftest.coreid := io.hartId
     difftest.index := 1.U
-    // difftest.valid := io.refill_to_ldq.valid && io.refill_to_ldq.bits.hasdata && io.refill_to_ldq.bits.refill_done
-    difftest.valid := false.B
+    difftest.valid := io.refill_to_ldq.valid && io.refill_to_ldq.bits.hasdata && io.refill_to_ldq.bits.refill_done
     difftest.addr := io.refill_to_ldq.bits.addr
     difftest.data := io.refill_to_ldq.bits.data_raw.asTypeOf(difftest.data)
     difftest.mask := VecInit.fill(difftest.mask.getWidth)(true.B).asUInt
+  }
+
+  if (env.EnableDifftest) {
+    // Store-miss refill completed in MainPipe S3: update difftest (DiffSbufferEvent).
+    val mq_s3_sel_info = Mux1H(
+      entries.map(e => (io.mainpipe_info.s3_miss_id === e.io.id) -> e.io.forwardInfo)
+    )
+    val hasStore = mq_s3_sel_info.store_mask.orR
+    val difftest_store = DifftestModule(new DiffSbufferEvent, delay = 1)
+    difftest_store.coreid := io.hartId
+    difftest_store.index := 0.U
+    difftest_store.valid := io.mainpipe_info.s3_valid && io.mainpipe_info.s3_refill_resp && hasStore
+    difftest_store.addr := mq_s3_sel_info.paddr
+    difftest_store.data := mq_s3_sel_info.raw_data.asUInt.asTypeOf(difftest_store.data)
+    difftest_store.mask := mq_s3_sel_info.store_mask
   }
 
   // Perf count

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -754,7 +754,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   def before_data_refill_can_merge(new_req: MissReqWoStoreData): Bool = {
     data_not_refilled && new_req.isFromLoad ||
-    !io.mem_grant.fire && data_not_refilled && new_req.isFromStore && alloc_is_store
+    !io.main_pipe_refill_resp && !w_refill_resp && new_req.isFromStore && alloc_is_store
   }
 
   // Note that late prefetch will be ignored

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -36,6 +36,8 @@ import xiangshan._
 import xiangshan.mem.LqPtr
 import xiangshan.mem.prefetch._
 import xiangshan.mem.trace._
+import xiangshan.mem.Bundles.SbufferForward
+import freechips.rocketchip.util.UIntToAugmentedUInt
 
 class MissReqWoStoreData(implicit p: Parameters) extends DCacheBundle {
   val source = UInt(sourceTypeWidth.W)
@@ -833,7 +835,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.refill_to_ldq.bits.error := RegEnable(io.mem_grant.bits.corrupt || io.mem_grant.bits.denied, refill_to_ldq_en)
   io.refill_to_ldq.bits.refill_done := RegEnable(refill_done && io.mem_grant.fire, refill_to_ldq_en)
   io.refill_to_ldq.bits.hasdata := hasData
-  io.refill_to_ldq.bits.data_raw := refill_data_raw.asUInt
+  io.refill_to_ldq.bits.data_raw := refill_and_store_data.asUInt
   io.refill_to_ldq.bits.id := io.id
 
   // if the entry has a pending merge req, wait for it
@@ -958,6 +960,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.forwardInfo.inflight := req_valid
   io.forwardInfo.paddr := req.addr
   io.forwardInfo.raw_data := refill_and_store_data
+  io.forwardInfo.isFromStore := req.isFromStore
+  io.forwardInfo.store_mask := req_store_mask
   io.forwardInfo.firstbeat_valid := w_grantfirst_forward_info
   io.forwardInfo.lastbeat_valid := w_grantlast_forward_info
   io.forwardInfo.denied := denied
@@ -1062,6 +1066,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     // forward missqueue
     val forward = Flipped(Vec(LoadPipelineWidth, new DCacheForward))
     val forwardS1PAddrMatch = Output(Vec(LoadPipelineWidth, Bool()))
+    // If a store is miss and accepted by mshr, Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
+    val forward_stData = Flipped(Vec(LoadPipelineWidth, new SbufferForward))
     val l2_pf_store_only = Input(Bool())
 
     val memSetPattenDetected = Output(Bool())
@@ -1182,6 +1188,51 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     XSError(((s1SelectOH - 1.U) & s1SelectOH).orR && s1RespValid, "multi mshr hit when forward!\n")
   }
 
+  io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
+    val s0ReqValid_stLdForward = forward.s0Req.valid
+    val s0Req_stLdForward = forward.s0Req.bits
+    val s1ReqValid_stLdForward = RegNext(s0ReqValid_stLdForward)
+    val s1Req_stLdForward = RegEnable(s0Req_stLdForward, s0ReqValid_stLdForward)
+    val paddr_stLdForward = forward.s1Req.paddr
+    val s1PaddrMatchVec_stLdForward = VecInit(forwardInfo_vec.map{ case info =>
+      paddr_stLdForward(paddr_stLdForward.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
+      info.inflight})
+    val s1SelectOH_stLdForward = s1PaddrMatchVec_stLdForward.asUInt
+    dontTouch(s1SelectOH_stLdForward)
+    val s1ForwardInfo_stLdForward = Mux1H(s1SelectOH_stLdForward, forwardInfo_vec)
+
+    val VLENB = VLEN / 8
+    val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdForward(blockOffBits - 1, log2Up(VLENB)) === i.U)
+    val s1RespData_stLdForward = Mux1H(paddr_selOH,
+          s1ForwardInfo_stLdForward.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
+    dontTouch(s1RespData_stLdForward)
+    val s1RespMask_stLdForward = Mux1H(paddr_selOH,
+         s1ForwardInfo_stLdForward.store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo_stLdForward.isFromStore, x, 0.U)))
+    dontTouch(s1RespMask_stLdForward)
+    val s1RespValid_stLdForward = s1ReqValid_stLdForward && s1SelectOH_stLdForward.orR
+    
+    forward.s2Resp.valid := RegNext(s1RespValid_stLdForward)
+    for (i <- 0 until VDataBytes) {
+      forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdForward.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdForward) 
+      forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdForward(i), s1RespValid_stLdForward) && forward.s2Resp.valid
+    }
+
+    // val s1RespData_stLdForward = VecInit(
+    //   s1ForwardInfo_stLdForward.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq
+    // )(paddr_stLdForward(blockOffBits - 1, log2Up(VLEN / 8)))
+    // dontTouch(s1RespData_stLdForward)
+    // val s1RespMask_stLdForward = Mux1H(s1SelectOH_stLdForward, forwardInfo_vec.map(x => Mux(x.isFromStore, x.store_mask, 0.U)))
+    // dontTouch(s1RespMask_stLdForward)
+    // val s1RespValid_stLdForward = s1ReqValid_stLdForward && s1SelectOH_stLdForward.orR
+    
+    // forward.s2Resp.valid := RegNext(s1RespValid_stLdForward)
+    // for (i <- 0 until VDataBytes) {
+    //   forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdForward.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdForward) 
+    //   forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdForward(i), s1RespValid_stLdForward) && forward.s2Resp.valid
+    // }
+    forward.s2Resp.bits.matchInvalid := false.B
+  }
+    
   assert(RegNext(PopCount(secondary_ready_vec) <= 1.U || !io.req.valid))
 //  assert(RegNext(PopCount(secondary_reject_vec) <= 1.U))
   // It is possible that one mshr wants to merge a req, while another mshr wants to reject it.

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1392,7 +1392,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val difftest = DifftestModule(new DiffRefillEvent, dontCare = true)
     difftest.coreid := io.hartId
     difftest.index := 1.U
-    difftest.valid := io.refill_to_ldq.valid && io.refill_to_ldq.bits.hasdata && io.refill_to_ldq.bits.refill_done
+    // difftest.valid := io.refill_to_ldq.valid && io.refill_to_ldq.bits.hasdata && io.refill_to_ldq.bits.refill_done
+    difftest.valid := false.B
     difftest.addr := io.refill_to_ldq.bits.addr
     difftest.data := io.refill_to_ldq.bits.data_raw.asTypeOf(difftest.data)
     difftest.mask := VecInit.fill(difftest.mask.getWidth)(true.B).asUInt

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -62,8 +62,9 @@ class MissReqWoStoreData(implicit p: Parameters) extends DCacheBundle {
 
   /**
     * isBtoT is used to mark whether the current request requires BtoT permission.
-    * If so, other requests for BtoT in the same set are blocked. Otherwise,
-    * they are not blocked.
+    * When the number of BtoT-occupied ways in the same set exceeds nWays-2,
+    * new BtoT requests for that set are blocked (via occupy_fail -> LoadPipe cancel).
+    * Non-BtoT requests are not affected.
     */
   val isBtoT = Bool()
   /**
@@ -71,15 +72,14 @@ class MissReqWoStoreData(implicit p: Parameters) extends DCacheBundle {
     */
   val occupy_way = UInt(nWays.W)
 
-  // For now, miss queue entry req is actually valid when req.valid && !cancel
-  // * req.valid is fast to generate
-  // * cancel is slow to generate, it will not be used until the last moment
+  // Enqueue logic uses req.valid && !cancel && !wbq_block_miss_req
   //
-  // cancel may come from the following sources:
-  // 1. miss req blocked by writeback queue:
-  //      a writeback req of the same address is in progress
-  // 2. pmp check failed
-  val cancel = Bool() // cancel is slow to generate, it will cancel missreq.valid
+  // cancel is usually ready later than req.valid and is driven by whoever builds the MissReq:
+  // - LoadPipe: io.lsu.s2_kill (dcacheKill: flush, exceptions incl. PMP-related faults, uncache, ...),
+  //   plus s2_tag_error and s2_btot_occupy_fail
+  // - StorePipe: io.lsu.s2_kill
+  // - MainPipe (miss): s2_grow_perm_fail
+  val cancel = Bool()
 
   // Req source decode
   // Note that req source is NOT cmd type
@@ -783,12 +783,9 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       )
   }
 
-  // store can be merged before io.mem_acquire.fire
-  // store can not be merged the cycle that io.mem_acquire.fire
   // load can be merged before io.mem_grant.fire
-  //
-  // TODO: merge store if possible? mem_acquire may need to be re-issued,
-  // but sbuffer entry can be freed
+  // Now the store-store merge is supported: if this entry is allocated by store req,
+  // the following same-block store can be merged before refill done.
   def should_reject(new_req: MissReqWoStoreData): Bool = {
     val block_match = get_block(req.addr) === get_block(new_req.addr)
     val set_match = set === addr_to_dcache_set(new_req.vaddr)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1210,8 +1210,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     forward.s2Resp.bits.forwardMask := VecInit((0 until VLENB).map(k =>
       Mux(s2Resp_Valid, true.B, RegEnable(s1RespMask_stLdFwd(k), s1RespValid_stLdFwd) && s2Resp_stLdFwd_Valid)
     ))
-    forward.s2Resp.bits.denied := RegEnable(s1ForwardInfo(i).denied, s1ReqValid)
-    forward.s2Resp.bits.corrupt := RegEnable(s1ForwardInfo(i).corrupt, s1ReqValid)
+    forward.s2Resp.bits.denied := RegEnable(s1ForwardInfo(i).denied, s1ReqValid) && s2Resp_Valid
+    forward.s2Resp.bits.corrupt := RegEnable(s1ForwardInfo(i).corrupt, s1ReqValid) && s2Resp_Valid
     io.forwardS1PAddrMatch(i) := s1ReqValid && (mshrIdOH & s1PaddrMatchVec(i).asUInt).orR
     XSError(((s1SelectOH(i) - 1.U) & s1SelectOH(i)).orR && s1RespValid, "multi mshr hit when forward!\n")
   }

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -36,7 +36,7 @@ import xiangshan._
 import xiangshan.mem.LqPtr
 import xiangshan.mem.prefetch._
 import xiangshan.mem.trace._
-import xiangshan.mem.Bundles.SbufferForward
+import xiangshan.mem.Bundles.SbufferForwardReq
 import freechips.rocketchip.util.UIntToAugmentedUInt
 
 class MissReqWoStoreData(implicit p: Parameters) extends DCacheBundle {
@@ -1071,7 +1071,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val forward = Flipped(Vec(LoadPipelineWidth, new DCacheForward))
     val forwardS1PAddrMatch = Output(Vec(LoadPipelineWidth, Bool()))
     // If a store is miss and accepted by mshr, Sbuffer releases the entry and mshr provides corresponding st-ld forwarding data.
-    val forward_stData = Flipped(Vec(LoadPipelineWidth, new SbufferForward))
+    // Note: the resp of this st-ld forwarding is merged into io.forward.S2Resp interface
+    val forward_stData = Flipped(Vec(LoadPipelineWidth, new SbufferForwardReq))
     val l2_pf_store_only = Input(Bool())
 
     val memSetPattenDetected = Output(Bool())
@@ -1186,7 +1187,6 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val s1ReqValid = RegNext(s0ReqValid)
     val s1Req = RegEnable(s0Req, s0ReqValid)
     val mshrIdOH = UIntToOH(s1Req.mshrId)
-
     val s1BeatMatchVec  = VecInit(forwardInfo_vec.map{ case info =>
       Mux(paddrFwd(i)(log2Up(refillBytes)).asBool,
         info.lastbeat_valid,
@@ -1194,28 +1194,26 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     )})
     val s1RespValid = s1ReqValid && (s1SelectOH(i) & s1BeatMatchVec.asUInt).orR
 
-    forward.s2Resp.valid := RegNext(s1RespValid)
+    // store-load forwarding (from io.forward_stData)
+    val s1ReqValid_stLdFwd = RegNext(io.forward_stData(i).s0Req.valid)
+    val s1RespMask_stLdFwd = Mux1H(paddrFwd_selOH(i),
+          s1ForwardInfo(i).store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo(i).isFromStore, x, 0.U)))
+    val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH(i).orR
+
+    val s2Resp_Valid = RegNext(s1RespValid)
+    val s2Resp_stLdFwd_Valid = RegNext(s1RespValid_stLdFwd)
+
+    forward.s2Resp.valid := s2Resp_Valid || s2Resp_stLdFwd_Valid
     forward.s2Resp.bits.matchInvalid := false.B
-    forward.s2Resp.bits.forwardData := RegEnable(s1RespDataFwd(i).asTypeOf(forward.s2Resp.bits.forwardData), s1ReqValid)
+    forward.s2Resp.bits.forwardData := RegEnable(s1RespDataFwd(i).asTypeOf(forward.s2Resp.bits.forwardData),
+                                                 s1ReqValid || s1ReqValid_stLdFwd)
+    forward.s2Resp.bits.forwardMask := VecInit((0 until VLENB).map(k =>
+      Mux(s2Resp_Valid, true.B, RegEnable(s1RespMask_stLdFwd(k), s1RespValid_stLdFwd) && s2Resp_stLdFwd_Valid)
+    ))
     forward.s2Resp.bits.denied := RegEnable(s1ForwardInfo(i).denied, s1ReqValid)
     forward.s2Resp.bits.corrupt := RegEnable(s1ForwardInfo(i).corrupt, s1ReqValid)
     io.forwardS1PAddrMatch(i) := s1ReqValid && (mshrIdOH & s1PaddrMatchVec(i).asUInt).orR
     XSError(((s1SelectOH(i) - 1.U) & s1SelectOH(i)).orR && s1RespValid, "multi mshr hit when forward!\n")
-  }
-
-  io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
-    val s1ReqValid_stLdFwd = RegNext(forward.s0Req.valid)
-
-    val s1RespMask_stLdFwd = Mux1H(paddrFwd_selOH(i),
-          s1ForwardInfo(i).store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo(i).isFromStore, x, 0.U)))
-    val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH(i).orR
-    
-    forward.s2Resp.valid := RegNext(s1RespValid_stLdFwd)
-    for (k <- 0 until VLENB) {
-      forward.s2Resp.bits.forwardData(k) := RegEnable(s1RespDataFwd(i)(8 * k + 7, 8 * k), s1RespValid_stLdFwd) 
-      forward.s2Resp.bits.forwardMask(k) := RegEnable(s1RespMask_stLdFwd(k), s1RespValid_stLdFwd) && forward.s2Resp.valid
-    }
-    forward.s2Resp.bits.matchInvalid := false.B
   }
     
   assert(RegNext(PopCount(secondary_ready_vec) <= 1.U || !io.req.valid))

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1184,23 +1184,13 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val s1ReqValid = RegNext(s0ReqValid)
     val s1Req = RegEnable(s0Req, s0ReqValid)
     val mshrIdOH = UIntToOH(s1Req.mshrId)
-    // val paddr = forward.s1Req.paddr
 
-    // val s1PaddrMatchVec = VecInit(forwardInfo_vec.map{ case info =>
-    //   paddr(paddr.getWidth - 1, blockOffBits) === info.paddr(paddr.getWidth - 1, blockOffBits) &&
-    //   info.inflight})
     val s1BeatMatchVec  = VecInit(forwardInfo_vec.map{ case info =>
       Mux(paddrFwd(i)(log2Up(refillBytes)).asBool,
         info.lastbeat_valid,
         info.firstbeat_valid
     )})
-    // val s1SelectOH     = s1PaddrMatchVec.asUInt & s1BeatMatchVec.asUInt
-    // val s1MshrForwardInfo = Mux1H(s1SelectOH, forwardInfo_vec)
-    // val s1RespData = VecInit(
-    //   s1MshrForwardInfo.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq
-    // )(paddr(blockOffBits - 1, log2Up(VLEN / 8)))
     val s1RespValid = s1ReqValid && (s1SelectOH(i) & s1BeatMatchVec.asUInt).orR
-
 
     forward.s2Resp.valid := RegNext(s1RespValid)
     forward.s2Resp.bits.matchInvalid := false.B
@@ -1213,20 +1203,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
     val s0ReqValid_stLdFwd = forward.s0Req.valid
-    val s0Req_stLdFwd = forward.s0Req.bits
     val s1ReqValid_stLdFwd = RegNext(s0ReqValid_stLdFwd)
-    val s1Req_stLdFwd = RegEnable(s0Req_stLdFwd, s0ReqValid_stLdFwd)
-    // val paddr_stLdFwd = forward.s1Req.paddr
-    // val s1PaddrMatchVec_stLdFwd = VecInit(forwardInfo_vec.map{ case info =>
-    //   paddr_stLdFwd(paddr_stLdFwd.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
-    //   info.inflight})
-    // val s1SelectOH_stLdFwd = s1PaddrMatchVec_stLdFwd.asUInt
-    // val s1ForwardInfo_stLdFwd = Mux1H(s1SelectOH_stLdFwd, forwardInfo_vec)
 
-    // val VLENB = VLEN / 8
-    // val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdFwd(blockOffBits - 1, log2Up(VLENB)) === i.U)
-    // val s1RespData_stLdFwd = Mux1H(paddr_selOH,
-    //       s1ForwardInfo_stLdFwd.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
     val s1RespMask_stLdFwd = Mux1H(paddrFwd_selOH(i),
           s1ForwardInfo(i).store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo(i).isFromStore, x, 0.U)))
     val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH(i).orR

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -476,6 +476,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   val req_valid = RegInit(false.B)
   val set = addr_to_dcache_set(req.vaddr)
   val evict_BtoT_way = RegInit(false.B)
+  val hasStoreAll = Reg(Bool())  // The alloc req is a store req and all merged reqs are store reqs
   // initial keyword
   val isKeyword = RegInit(false.B)
 
@@ -561,6 +562,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
     req_primary_fire := miss_req_pipe_reg_bits.toMissReqWoStoreData()
     evict_BtoT_way := false.B
+    hasStoreAll := miss_req_pipe_reg_bits.isFromStore
     //only  load miss need keyword
     isKeyword := Mux(miss_req_pipe_reg_bits.isFromLoad, miss_req_pipe_reg_bits.vaddr(5).asBool,false.B)
 
@@ -580,6 +582,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       for (i <- 0 until blockRows) {
         refill_and_store_data(i) := miss_req_pipe_reg_bits.store_data(rowBits * (i + 1) - 1, rowBits * i)
       }
+    }.otherwise {
+      req_store_mask := 0.U
     }
     full_overwrite := miss_req_pipe_reg_bits.isFromStore && miss_req_pipe_reg_bits.full_overwrite
 
@@ -610,6 +614,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     // use the most uptodate meta
     req.req_coh := miss_req_pipe_reg_bits.req_coh
 
+    hasStoreAll := hasStoreAll && miss_req_pipe_reg_bits.isFromStore
+
     isKeyword := Mux(
       before_req_sent_can_merge(miss_req_pipe_reg_bits),
       before_req_sent_merge_iskeyword(miss_req_pipe_reg_bits),
@@ -622,9 +628,25 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       req.occupy_way := miss_req_pipe_reg_bits.occupy_way
       evict_BtoT_way := false.B
       req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
-      req_store_mask := miss_req_pipe_reg_bits.store_mask
-      for (i <- 0 until blockRows) {
-        refill_and_store_data(i) := miss_req_pipe_reg_bits.store_data(rowBits * (i + 1) - 1, rowBits * i)
+      req_store_mask := req_store_mask | miss_req_pipe_reg_bits.store_mask
+
+      // for (i <- 0 until blockRows) {
+      //   val store_mask_temp = miss_req_pipe_reg_bits.store_mask.grouped(rowBytes)(i).asBools
+      //   val store_data_temp = (miss_req_pipe_reg_bits.store_data.grouped(8).grouped(rowBytes).toSeq)(i)
+      //   refill_and_store_data(i) := VecInit((0 until rowBytes).map(k => 
+      //     Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data(i).grouped(8)(k)))).asUInt
+      // }
+
+      for (i <- 0 until blockRows) {  //todo: dirty code rewrite
+        val store_data_temp = Wire(Vec(rowBits/8, UInt(8.W)))
+        for (j <- 0 until rowBits/8) {
+          when (miss_req_pipe_reg_bits.store_mask(i * rowBits/8 + j)) {
+            store_data_temp(j) := miss_req_pipe_reg_bits.store_data(i * rowBits + 8 * (j + 1) - 1, i * rowBits + 8 * j)
+          }.otherwise {
+            store_data_temp(j) := refill_and_store_data(i)(8 * (j + 1) - 1, 8 * j)
+          }
+        }
+        refill_and_store_data(i) := store_data_temp.asUInt
       }
       full_overwrite := miss_req_pipe_reg_bits.isFromStore && miss_req_pipe_reg_bits.full_overwrite
       assert(is_alias_match(req.vaddr, miss_req_pipe_reg_bits.vaddr), "alias bits should be the same when merging store")
@@ -750,7 +772,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   }
 
   def before_data_refill_can_merge(new_req: MissReqWoStoreData): Bool = {
-    data_not_refilled && new_req.isFromLoad
+    data_not_refilled && new_req.isFromLoad ||
+    data_not_refilled && new_req.isFromStore && hasStoreAll
   }
 
   // Note that late prefetch will be ignored
@@ -1136,6 +1159,8 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   miss_req_pipe_reg.merge   := merge && io.req.valid && !io.req.bits.cancel && !io.wbq_block_miss_req
   miss_req_pipe_reg.cancel  := io.wbq_block_miss_req
   miss_req_pipe_reg.mshr_id := io.resp.id
+  assert(!(io.req.bits.isFromStore && io.req.valid && miss_req_pipe_reg.req.isFromStore &&
+          get_block(io.req.bits.addr) === get_block(miss_req_pipe_reg.req.addr)), "Two consecutive store reqs to the same block!")
 
   assert(PopCount(Seq(alloc && io.req.valid, merge && io.req.valid)) <= 1.U, "allocate and merge a mshr in same cycle!")
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1161,37 +1161,54 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.memSetPattenDetected := memSetPattenDetected
 
   val forwardInfo_vec = VecInit(entries.map(_.io.forwardInfo))
+  val VLENB = VLEN / 8
+  val paddrFwd = Wire(Vec(LoadPipelineWidth, UInt(PAddrBits.W)))
+  val s1PaddrMatchVec = Wire(Vec(LoadPipelineWidth, Vec(cfg.nMissEntries, Bool())))
+  val s1SelectOH = Wire(Vec(LoadPipelineWidth, UInt((cfg.nMissEntries).W)))
+  val s1ForwardInfo = Wire(Vec(LoadPipelineWidth, new MissEntryForwardIO))
+  val paddrFwd_selOH = Wire(Vec(LoadPipelineWidth, Vec(blockBytes / VLENB, Bool())))
+  val s1RespDataFwd = Wire(Vec(LoadPipelineWidth, UInt(VLEN.W)))
+  for (i <- 0 until LoadPipelineWidth) {
+    paddrFwd(i) := Mux(RegNext(io.forward_stData(i).s0Req.valid), io.forward_stData(i).s1Req.paddr, io.forward(i).s1Req.paddr)
+    s1PaddrMatchVec(i) := VecInit(forwardInfo_vec.map{ case info =>
+      (paddrFwd(i) >> blockOffBits) === (info.paddr >> blockOffBits) && info.inflight})
+    s1SelectOH(i) := s1PaddrMatchVec(i).asUInt
+    s1ForwardInfo(i) := Mux1H(s1SelectOH(i), forwardInfo_vec)
+    paddrFwd_selOH(i) := (0 until (blockBytes / VLENB)).map(k => paddrFwd(i)(blockOffBits - 1, log2Up(VLENB)) === k.U)
+    s1RespDataFwd(i) := Mux1H(paddrFwd_selOH(i), s1ForwardInfo(i).raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
+  }
+
   io.forward.zipWithIndex.foreach { case (forward, i) =>
     val s0ReqValid = forward.s0Req.valid
     val s0Req = forward.s0Req.bits
     val s1ReqValid = RegNext(s0ReqValid)
     val s1Req = RegEnable(s0Req, s0ReqValid)
     val mshrIdOH = UIntToOH(s1Req.mshrId)
-    val paddr = forward.s1Req.paddr
+    // val paddr = forward.s1Req.paddr
 
-    val s1PaddrMatchVec = VecInit(forwardInfo_vec.map{ case info =>
-      paddr(paddr.getWidth - 1, blockOffBits) === info.paddr(paddr.getWidth - 1, blockOffBits) &&
-      info.inflight})
+    // val s1PaddrMatchVec = VecInit(forwardInfo_vec.map{ case info =>
+    //   paddr(paddr.getWidth - 1, blockOffBits) === info.paddr(paddr.getWidth - 1, blockOffBits) &&
+    //   info.inflight})
     val s1BeatMatchVec  = VecInit(forwardInfo_vec.map{ case info =>
-      Mux(paddr(log2Up(refillBytes)).asBool,
+      Mux(paddrFwd(i)(log2Up(refillBytes)).asBool,
         info.lastbeat_valid,
         info.firstbeat_valid
     )})
-    val s1SelectOH     = s1PaddrMatchVec.asUInt & s1BeatMatchVec.asUInt
-    val s1MshrForwardInfo = Mux1H(s1SelectOH, forwardInfo_vec)
-    val s1RespData = VecInit(
-      s1MshrForwardInfo.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq
-    )(paddr(blockOffBits - 1, log2Up(VLEN / 8)))
-    val s1RespValid = s1ReqValid && s1SelectOH.orR
+    // val s1SelectOH     = s1PaddrMatchVec.asUInt & s1BeatMatchVec.asUInt
+    // val s1MshrForwardInfo = Mux1H(s1SelectOH, forwardInfo_vec)
+    // val s1RespData = VecInit(
+    //   s1MshrForwardInfo.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq
+    // )(paddr(blockOffBits - 1, log2Up(VLEN / 8)))
+    val s1RespValid = s1ReqValid && (s1SelectOH(i) & s1BeatMatchVec.asUInt).orR
 
 
     forward.s2Resp.valid := RegNext(s1RespValid)
     forward.s2Resp.bits.matchInvalid := false.B
-    forward.s2Resp.bits.forwardData := RegEnable(s1RespData.asTypeOf(forward.s2Resp.bits.forwardData), s1ReqValid)
-    forward.s2Resp.bits.denied := RegEnable(s1MshrForwardInfo.denied, s1ReqValid)
-    forward.s2Resp.bits.corrupt := RegEnable(s1MshrForwardInfo.corrupt, s1ReqValid)
-    io.forwardS1PAddrMatch(i) := s1ReqValid && (mshrIdOH & s1PaddrMatchVec.asUInt).orR
-    XSError(((s1SelectOH - 1.U) & s1SelectOH).orR && s1RespValid, "multi mshr hit when forward!\n")
+    forward.s2Resp.bits.forwardData := RegEnable(s1RespDataFwd(i).asTypeOf(forward.s2Resp.bits.forwardData), s1ReqValid)
+    forward.s2Resp.bits.denied := RegEnable(s1ForwardInfo(i).denied, s1ReqValid)
+    forward.s2Resp.bits.corrupt := RegEnable(s1ForwardInfo(i).corrupt, s1ReqValid)
+    io.forwardS1PAddrMatch(i) := s1ReqValid && (mshrIdOH & s1PaddrMatchVec(i).asUInt).orR
+    XSError(((s1SelectOH(i) - 1.U) & s1SelectOH(i)).orR && s1RespValid, "multi mshr hit when forward!\n")
   }
 
   io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
@@ -1199,25 +1216,25 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val s0Req_stLdFwd = forward.s0Req.bits
     val s1ReqValid_stLdFwd = RegNext(s0ReqValid_stLdFwd)
     val s1Req_stLdFwd = RegEnable(s0Req_stLdFwd, s0ReqValid_stLdFwd)
-    val paddr_stLdFwd = forward.s1Req.paddr
-    val s1PaddrMatchVec_stLdFwd = VecInit(forwardInfo_vec.map{ case info =>
-      paddr_stLdFwd(paddr_stLdFwd.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
-      info.inflight})
-    val s1SelectOH_stLdFwd = s1PaddrMatchVec_stLdFwd.asUInt
-    val s1ForwardInfo_stLdFwd = Mux1H(s1SelectOH_stLdFwd, forwardInfo_vec)
+    // val paddr_stLdFwd = forward.s1Req.paddr
+    // val s1PaddrMatchVec_stLdFwd = VecInit(forwardInfo_vec.map{ case info =>
+    //   paddr_stLdFwd(paddr_stLdFwd.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
+    //   info.inflight})
+    // val s1SelectOH_stLdFwd = s1PaddrMatchVec_stLdFwd.asUInt
+    // val s1ForwardInfo_stLdFwd = Mux1H(s1SelectOH_stLdFwd, forwardInfo_vec)
 
-    val VLENB = VLEN / 8
-    val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdFwd(blockOffBits - 1, log2Up(VLENB)) === i.U)
-    val s1RespData_stLdFwd = Mux1H(paddr_selOH,
-          s1ForwardInfo_stLdFwd.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
-    val s1RespMask_stLdFwd = Mux1H(paddr_selOH,
-          s1ForwardInfo_stLdFwd.store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo_stLdFwd.isFromStore, x, 0.U)))
-    val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH_stLdFwd.orR
+    // val VLENB = VLEN / 8
+    // val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdFwd(blockOffBits - 1, log2Up(VLENB)) === i.U)
+    // val s1RespData_stLdFwd = Mux1H(paddr_selOH,
+    //       s1ForwardInfo_stLdFwd.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
+    val s1RespMask_stLdFwd = Mux1H(paddrFwd_selOH(i),
+          s1ForwardInfo(i).store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo(i).isFromStore, x, 0.U)))
+    val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH(i).orR
     
     forward.s2Resp.valid := RegNext(s1RespValid_stLdFwd)
-    for (i <- 0 until VDataBytes) {
-      forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdFwd.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdFwd) 
-      forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdFwd(i), s1RespValid_stLdFwd) && forward.s2Resp.valid
+    for (j <- 0 until VDataBytes) {
+      forward.s2Resp.bits.forwardData(j) := RegEnable(s1RespDataFwd(i)(8 * j + 7, 8 * j), s1RespValid_stLdFwd) 
+      forward.s2Resp.bits.forwardMask(j) := RegEnable(s1RespMask_stLdFwd(j), s1RespValid_stLdFwd) && forward.s2Resp.valid
     }
     forward.s2Resp.bits.matchInvalid := false.B
   }

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1189,47 +1189,30 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   }
 
   io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
-    val s0ReqValid_stLdForward = forward.s0Req.valid
-    val s0Req_stLdForward = forward.s0Req.bits
-    val s1ReqValid_stLdForward = RegNext(s0ReqValid_stLdForward)
-    val s1Req_stLdForward = RegEnable(s0Req_stLdForward, s0ReqValid_stLdForward)
-    val paddr_stLdForward = forward.s1Req.paddr
-    val s1PaddrMatchVec_stLdForward = VecInit(forwardInfo_vec.map{ case info =>
-      paddr_stLdForward(paddr_stLdForward.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
+    val s0ReqValid_stLdFwd = forward.s0Req.valid
+    val s0Req_stLdFwd = forward.s0Req.bits
+    val s1ReqValid_stLdFwd = RegNext(s0ReqValid_stLdFwd)
+    val s1Req_stLdFwd = RegEnable(s0Req_stLdFwd, s0ReqValid_stLdFwd)
+    val paddr_stLdFwd = forward.s1Req.paddr
+    val s1PaddrMatchVec_stLdFwd = VecInit(forwardInfo_vec.map{ case info =>
+      paddr_stLdFwd(paddr_stLdFwd.getWidth - 1, blockOffBits) === info.paddr(info.paddr.getWidth - 1, blockOffBits) &&
       info.inflight})
-    val s1SelectOH_stLdForward = s1PaddrMatchVec_stLdForward.asUInt
-    dontTouch(s1SelectOH_stLdForward)
-    val s1ForwardInfo_stLdForward = Mux1H(s1SelectOH_stLdForward, forwardInfo_vec)
+    val s1SelectOH_stLdFwd = s1PaddrMatchVec_stLdFwd.asUInt
+    val s1ForwardInfo_stLdFwd = Mux1H(s1SelectOH_stLdFwd, forwardInfo_vec)
 
     val VLENB = VLEN / 8
-    val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdForward(blockOffBits - 1, log2Up(VLENB)) === i.U)
-    val s1RespData_stLdForward = Mux1H(paddr_selOH,
-          s1ForwardInfo_stLdForward.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
-    dontTouch(s1RespData_stLdForward)
-    val s1RespMask_stLdForward = Mux1H(paddr_selOH,
-         s1ForwardInfo_stLdForward.store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo_stLdForward.isFromStore, x, 0.U)))
-    dontTouch(s1RespMask_stLdForward)
-    val s1RespValid_stLdForward = s1ReqValid_stLdForward && s1SelectOH_stLdForward.orR
+    val paddr_selOH = (0 until (blockBytes / VLENB)).map(i => paddr_stLdFwd(blockOffBits - 1, log2Up(VLENB)) === i.U)
+    val s1RespData_stLdFwd = Mux1H(paddr_selOH,
+          s1ForwardInfo_stLdFwd.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
+    val s1RespMask_stLdFwd = Mux1H(paddr_selOH,
+          s1ForwardInfo_stLdFwd.store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo_stLdFwd.isFromStore, x, 0.U)))
+    val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH_stLdFwd.orR
     
-    forward.s2Resp.valid := RegNext(s1RespValid_stLdForward)
+    forward.s2Resp.valid := RegNext(s1RespValid_stLdFwd)
     for (i <- 0 until VDataBytes) {
-      forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdForward.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdForward) 
-      forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdForward(i), s1RespValid_stLdForward) && forward.s2Resp.valid
+      forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdFwd.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdFwd) 
+      forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdFwd(i), s1RespValid_stLdFwd) && forward.s2Resp.valid
     }
-
-    // val s1RespData_stLdForward = VecInit(
-    //   s1ForwardInfo_stLdForward.raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq
-    // )(paddr_stLdForward(blockOffBits - 1, log2Up(VLEN / 8)))
-    // dontTouch(s1RespData_stLdForward)
-    // val s1RespMask_stLdForward = Mux1H(s1SelectOH_stLdForward, forwardInfo_vec.map(x => Mux(x.isFromStore, x.store_mask, 0.U)))
-    // dontTouch(s1RespMask_stLdForward)
-    // val s1RespValid_stLdForward = s1ReqValid_stLdForward && s1SelectOH_stLdForward.orR
-    
-    // forward.s2Resp.valid := RegNext(s1RespValid_stLdForward)
-    // for (i <- 0 until VDataBytes) {
-    //   forward.s2Resp.bits.forwardData(i) := RegEnable(s1RespData_stLdForward.asUInt(8 * i + 7, 8 * i), s1RespValid_stLdForward) 
-    //   forward.s2Resp.bits.forwardMask(i) := RegEnable(s1RespMask_stLdForward(i), s1RespValid_stLdForward) && forward.s2Resp.valid
-    // }
     forward.s2Resp.bits.matchInvalid := false.B
   }
     

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -476,7 +476,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   val req_valid = RegInit(false.B)
   val set = addr_to_dcache_set(req.vaddr)
   val evict_BtoT_way = RegInit(false.B)
-  val hasStoreAll = Reg(Bool())  // The alloc req is a store req and all merged reqs are store reqs
+  val alloc_is_store = Reg(Bool())  // The alloc (first) req is a store req
   // initial keyword
   val isKeyword = RegInit(false.B)
 
@@ -562,7 +562,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
     req_primary_fire := miss_req_pipe_reg_bits.toMissReqWoStoreData()
     evict_BtoT_way := false.B
-    hasStoreAll := miss_req_pipe_reg_bits.isFromStore
+    alloc_is_store := miss_req_pipe_reg_bits.isFromStore
     //only  load miss need keyword
     isKeyword := Mux(miss_req_pipe_reg_bits.isFromLoad, miss_req_pipe_reg_bits.vaddr(5).asBool,false.B)
 
@@ -614,8 +614,6 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     // use the most uptodate meta
     req.req_coh := miss_req_pipe_reg_bits.req_coh
 
-    hasStoreAll := hasStoreAll && miss_req_pipe_reg_bits.isFromStore
-
     isKeyword := Mux(
       before_req_sent_can_merge(miss_req_pipe_reg_bits),
       before_req_sent_merge_iskeyword(miss_req_pipe_reg_bits),
@@ -629,24 +627,11 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       evict_BtoT_way := false.B
       req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
       req_store_mask := req_store_mask | miss_req_pipe_reg_bits.store_mask
-
-      // for (i <- 0 until blockRows) {
-      //   val store_mask_temp = miss_req_pipe_reg_bits.store_mask.grouped(rowBytes)(i).asBools
-      //   val store_data_temp = (miss_req_pipe_reg_bits.store_data.grouped(8).grouped(rowBytes).toSeq)(i)
-      //   refill_and_store_data(i) := VecInit((0 until rowBytes).map(k => 
-      //     Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data(i).grouped(8)(k)))).asUInt
-      // }
-
-      for (i <- 0 until blockRows) {  //todo: dirty code rewrite
-        val store_data_temp = Wire(Vec(rowBits/8, UInt(8.W)))
-        for (j <- 0 until rowBits/8) {
-          when (miss_req_pipe_reg_bits.store_mask(i * rowBits/8 + j)) {
-            store_data_temp(j) := miss_req_pipe_reg_bits.store_data(i * rowBits + 8 * (j + 1) - 1, i * rowBits + 8 * j)
-          }.otherwise {
-            store_data_temp(j) := refill_and_store_data(i)(8 * (j + 1) - 1, 8 * j)
-          }
-        }
-        refill_and_store_data(i) := store_data_temp.asUInt
+      for (i <- 0 until blockRows) {
+        val store_mask_temp = miss_req_pipe_reg_bits.store_mask.grouped(rowBytes)(i).asBools
+        val store_data_temp = (miss_req_pipe_reg_bits.store_data.grouped(8).grouped(rowBytes).toSeq)(i)
+        refill_and_store_data(i) := VecInit((0 until rowBytes).map(k => 
+          Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data(i).grouped(8)(k)))).asUInt
       }
       full_overwrite := miss_req_pipe_reg_bits.isFromStore && miss_req_pipe_reg_bits.full_overwrite
       assert(is_alias_match(req.vaddr, miss_req_pipe_reg_bits.vaddr), "alias bits should be the same when merging store")
@@ -773,7 +758,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   def before_data_refill_can_merge(new_req: MissReqWoStoreData): Bool = {
     data_not_refilled && new_req.isFromLoad ||
-    data_not_refilled && new_req.isFromStore && hasStoreAll
+    data_not_refilled && new_req.isFromStore && alloc_is_store
   }
 
   // Note that late prefetch will be ignored
@@ -1159,7 +1144,7 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   miss_req_pipe_reg.merge   := merge && io.req.valid && !io.req.bits.cancel && !io.wbq_block_miss_req
   miss_req_pipe_reg.cancel  := io.wbq_block_miss_req
   miss_req_pipe_reg.mshr_id := io.resp.id
-  assert(!(io.req.bits.isFromStore && io.req.valid && miss_req_pipe_reg.req.isFromStore &&
+  assert(!(io.req.bits.isFromStore && io.req.valid && miss_req_pipe_reg.req.isFromStore && (miss_req_pipe_reg.alloc || miss_req_pipe_reg.merge) &&
           get_block(io.req.bits.addr) === get_block(miss_req_pipe_reg.req.addr)), "Two consecutive store reqs to the same block!")
 
   assert(PopCount(Seq(alloc && io.req.valid, merge && io.req.valid)) <= 1.U, "allocate and merge a mshr in same cycle!")

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -577,14 +577,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
     no_pending := !io.acquire_fired_by_pipe_reg
 
-    when(miss_req_pipe_reg_bits.isFromStore) {
-      req_store_mask := miss_req_pipe_reg_bits.store_mask
-      for (i <- 0 until blockRows) {
-        refill_and_store_data(i) := miss_req_pipe_reg_bits.store_data(rowBits * (i + 1) - 1, rowBits * i)
-      }
-    }.otherwise {
-      req_store_mask := 0.U
-    }
+    req_store_mask := Mux(miss_req_pipe_reg_bits.isFromStore, miss_req_pipe_reg_bits.store_mask, 0.U)
+
     full_overwrite := miss_req_pipe_reg_bits.isFromStore && miss_req_pipe_reg_bits.full_overwrite
 
     when (!miss_req_pipe_reg_bits.isFromAMO) {
@@ -607,6 +601,23 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     refill_start_time := GTimer()
   }
 
+  val refill_and_store_data_update = Wire(Vec(blockRows, UInt(rowBits.W)))
+
+  when (io.miss_req_pipe_reg.alloc && !io.miss_req_pipe_reg.cancel && miss_req_pipe_reg_bits.isFromStore) {
+    for (i <- 0 until blockRows) {
+        refill_and_store_data(i) := miss_req_pipe_reg_bits.store_data(rowBits * (i + 1) - 1, rowBits * i)
+    }
+  }.elsewhen (io.miss_req_pipe_reg.merge && !io.miss_req_pipe_reg.cancel && miss_req_pipe_reg_bits.isFromStore) {
+      for (i <- 0 until blockRows) {
+        val store_mask_temp = miss_req_pipe_reg_bits.store_mask.grouped(rowBytes)(i).asBools
+        val store_data_temp = (miss_req_pipe_reg_bits.store_data.grouped(8).grouped(rowBytes).toSeq)(i)
+        refill_and_store_data(i) := VecInit((0 until rowBytes).map(k =>
+          Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data_update(i).grouped(8)(k)))).asUInt
+      }
+  }.elsewhen (io.mem_grant.fire) {
+    refill_and_store_data := refill_and_store_data_update
+  }
+
   when (io.miss_req_pipe_reg.merge && !io.miss_req_pipe_reg.cancel) {
     assert(RegNext(secondary_fire) || RegNext(RegNext(primary_fire)), "after 1 cycle of secondary_fire or 2 cycle of primary_fire, entry will be merged")
     assert(miss_req_pipe_reg_bits.req_coh.state <= req.req_coh.state || (prefetch && !access))
@@ -627,13 +638,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       evict_BtoT_way := false.B
       req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
       req_store_mask := req_store_mask | miss_req_pipe_reg_bits.store_mask
-      for (i <- 0 until blockRows) {
-        val store_mask_temp = miss_req_pipe_reg_bits.store_mask.grouped(rowBytes)(i).asBools
-        val store_data_temp = (miss_req_pipe_reg_bits.store_data.grouped(8).grouped(rowBytes).toSeq)(i)
-        refill_and_store_data(i) := VecInit((0 until rowBytes).map(k => 
-          Mux(store_mask_temp(k), store_data_temp(k), refill_and_store_data(i).grouped(8)(k)))).asUInt
-      }
-      full_overwrite := miss_req_pipe_reg_bits.isFromStore && miss_req_pipe_reg_bits.full_overwrite
+
+      full_overwrite := full_overwrite || miss_req_pipe_reg_bits.full_overwrite
       assert(is_alias_match(req.vaddr, miss_req_pipe_reg_bits.vaddr), "alias bits should be the same when merging store")
     }
 
@@ -651,51 +657,27 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   }
 
   // merge data refilled by l2 and store data, update miss queue entry, gen refill_req
-  val new_data = Wire(Vec(blockRows, UInt(rowBits.W)))
-  val new_mask = Wire(Vec(blockRows, UInt(rowBytes.W)))
+  val new_mask = VecInit(req_store_mask.grouped(rowBytes))
   // merge refilled data and store data (if needed)
   def mergePutData(old_data: UInt, new_data: UInt, wmask: UInt): UInt = {
     val full_wmask = FillInterleaved(8, wmask)
     (~full_wmask & old_data | full_wmask & new_data)
   }
-  for (i <- 0 until blockRows) {
-    // new_data(i) := req.store_data(rowBits * (i + 1) - 1, rowBits * i)
-    new_data(i) := refill_and_store_data(i)
-    // we only need to merge data for Store
-    new_mask(i) := Mux(req.isFromStore, req_store_mask(rowBytes * (i + 1) - 1, rowBytes * i), 0.U)
-  }
 
   val hasData = RegInit(true.B)
   val isDirty = RegInit(false.B)
   io.wfi.wfiSafe := GatedValidRegNext(no_pending && io.wfi.wfiReq)
+
   when (io.mem_grant.fire) {
     w_grantfirst := true.B
     grant_param := io.mem_grant.bits.param
     when (edge.hasData(io.mem_grant.bits)) {
-      // GrantData
-      when (isKeyword) {
-       for (i <- 0 until beatRows) {
-         val idx = ((refill_count << log2Floor(beatRows)) + i.U) ^ 4.U
-         val grant_row = io.mem_grant.bits.data(rowBits * (i + 1) - 1, rowBits * i)
-         refill_and_store_data(idx) := mergePutData(grant_row, new_data(idx), new_mask(idx))
-        }
-      }
-      .otherwise{
-       for (i <- 0 until beatRows) {
-         val idx = (refill_count << log2Floor(beatRows)) + i.U
-         val grant_row = io.mem_grant.bits.data(rowBits * (i + 1) - 1, rowBits * i)
-         refill_and_store_data(idx) := mergePutData(grant_row, new_data(idx), new_mask(idx))
-        }
-      }
       w_grantlast := w_grantlast || refill_done
       no_pending := no_pending || refill_done
       hasData := true.B
     }.otherwise {
       // Grant
       assert(full_overwrite)
-      for (i <- 0 until blockRows) {
-        refill_and_store_data(i) := new_data(i)
-      }
       w_grantlast := true.B
       no_pending := true.B
       hasData := false.B
@@ -713,6 +695,38 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       val overflow = refill_end_time < refill_start_time || (time_delta >> LATENCY_WIDTH).orR
       refill_latency := Mux(overflow, 0.U, time_delta)
     }
+  }
+
+
+      // for (i <- 0 until beatRows) {
+      //   val base_idx = (refill_count << log2Floor(beatRows)) + i.U
+      //   val idx = Mux(isKeyword, base_idx ^ 4.U, base_idx)
+      //   val grant_row = io.mem_grant.bits.data(rowBits * (i + 1) - 1, rowBits * i)
+      //   refill_and_store_data_update(idx) := mergePutData(grant_row, refill_and_store_data(idx), new_mask(idx))
+      // }
+  // when (io.mem_grant.fire && edge.hasData(io.mem_grant.bits)) {
+  //   for (i <- 0 until beatRows) {
+  //     refill_and_store_data_update(i) := mergePutData(grant_data_grouped(i), refill_and_store_data(i),
+  //                                                     new_mask(i) | Fill(rowBytes, isKeyword))
+  //     refill_and_store_data_update(i + beatRows) := mergePutData(grant_data_grouped(i), refill_and_store_data(i + beatRows),
+  //                                                                new_mask(i + beatRows) | Fill(rowBytes, !isKeyword))
+  //   }
+  // }.otherwise {
+  //   refill_and_store_data_update := refill_and_store_data
+  // }
+  val grant_data_grouped = io.mem_grant.bits.data.grouped(rowBits)
+  val lowHalf_refill = refill_count === 0.U && !isKeyword || refill_count =/= 0.U && isKeyword
+  for (i <- 0 until beatRows) {
+    refill_and_store_data_update(i) := Mux(
+      io.mem_grant.fire && edge.hasData(io.mem_grant.bits) && lowHalf_refill,
+      mergePutData(grant_data_grouped(i), refill_and_store_data(i), new_mask(i)),
+      refill_and_store_data(i)
+    )
+    refill_and_store_data_update(i + beatRows) := Mux(
+      io.mem_grant.fire && edge.hasData(io.mem_grant.bits) && !lowHalf_refill,
+      mergePutData(grant_data_grouped(i), refill_and_store_data(i + beatRows), new_mask(i + beatRows)),
+      refill_and_store_data(i + beatRows)
+    )
   }
 
   when (io.mem_finish.fire) {
@@ -758,7 +772,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   def before_data_refill_can_merge(new_req: MissReqWoStoreData): Bool = {
     data_not_refilled && new_req.isFromLoad ||
-    data_not_refilled && new_req.isFromStore && alloc_is_store
+    !io.mem_grant.fire && data_not_refilled && new_req.isFromStore && alloc_is_store
   }
 
   // Note that late prefetch will be ignored

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -426,6 +426,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val req_vaddr = ValidIO(UInt(VAddrBits.W))
     val req_isBtoT = Output(Bool())
 
+    val req_hasStore = Output(Bool())
+
     val req_handled_by_this_entry = Output(Bool())
 
     val forwardInfo = Output(new MissEntryForwardIO)
@@ -477,6 +479,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   val set = addr_to_dcache_set(req.vaddr)
   val evict_BtoT_way = RegInit(false.B)
   val alloc_is_store = RegInit(false.B)  // The alloc (first) req is a store req
+  val hasStore = RegInit(false.B)
   // initial keyword
   val isKeyword = RegInit(false.B)
 
@@ -563,6 +566,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     req_primary_fire := miss_req_pipe_reg_bits.toMissReqWoStoreData()
     evict_BtoT_way := false.B
     alloc_is_store := miss_req_pipe_reg_bits.isFromStore
+    hasStore := miss_req_pipe_reg_bits.isFromStore
     //only  load miss need keyword
     isKeyword := Mux(miss_req_pipe_reg_bits.isFromLoad, miss_req_pipe_reg_bits.vaddr(5).asBool,false.B)
 
@@ -601,7 +605,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     refill_start_time := GTimer()
   }
 
-  // Wire to hold updated data after refill on grant.fire
+  // Wire to hold updated data that has merged grant data (on grant.fire)
   val refill_and_store_data_update = Wire(Vec(blockRows, UInt(rowBits.W)))
   // All the logic of refill_and_store_data. There is a corner case to note: store-merge and grant.fire may happen at the same cycle.
   when (io.miss_req_pipe_reg.alloc && !io.miss_req_pipe_reg.cancel && miss_req_pipe_reg_bits.isFromStore) {
@@ -637,7 +641,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       evict_BtoT_way := false.B
       req.addr := get_block_addr(miss_req_pipe_reg_bits.addr)
       req_store_mask := req_store_mask | miss_req_pipe_reg_bits.store_mask
-
+      hasStore := true.B
       full_overwrite := full_overwrite || miss_req_pipe_reg_bits.full_overwrite
       assert(is_alias_match(req.vaddr, miss_req_pipe_reg_bits.vaddr), "alias bits should be the same when merging store")
     }
@@ -927,6 +931,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   io.req_vaddr.bits := req.vaddr
   io.req_isBtoT := req.isBtoT
 
+  io.req_hasStore := hasStore && req_valid
+
   io.occupy_way := req.occupy_way
 
   io.refill_info.valid := req_valid && w_grantlast
@@ -1075,6 +1081,9 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     val memSetPattenDetected = Output(Bool())
     val lqEmpty = Input(Bool())
 
+    // sbuffer-flush must flush all store entries in mshr as well
+    val mshr_store_empty = Output(Bool())
+
     val prefetch_stat = Output(new MissPrefetchStatBundle)
 
     val wfi = Flipped(new WfiReqBundle)
@@ -1090,6 +1099,11 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   val miss_req_pipe_reg = RegInit(0.U.asTypeOf(new MissReqPipeRegBundle(edge)))
   val acquire_from_pipereg = Wire(chiselTypeOf(io.mem_acquire))
+
+  // Store misses may reside either in MSHR entries or in the miss_req_pipe_reg.
+  // sbuffer-flush should wait until both places are clear.
+  val mshr_has_store = Cat(entries.map(_.io.req_hasStore) :+ (miss_req_pipe_reg.reg_valid() && miss_req_pipe_reg.req.isFromStore)).orR
+  io.mshr_store_empty := !mshr_has_store
 
   val primary_ready_vec = entries.map(_.io.primary_ready)
   val secondary_ready_vec = entries.map(_.io.secondary_ready)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1162,6 +1162,7 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   val forwardInfo_vec = VecInit(entries.map(_.io.forwardInfo))
   val VLENB = VLEN / 8
+  // Forwarding paddr CAM, shared by io.forward and io.forward_stData
   val paddrFwd = Wire(Vec(LoadPipelineWidth, UInt(PAddrBits.W)))
   val s1PaddrMatchVec = Wire(Vec(LoadPipelineWidth, Vec(cfg.nMissEntries, Bool())))
   val s1SelectOH = Wire(Vec(LoadPipelineWidth, UInt((cfg.nMissEntries).W)))
@@ -1174,6 +1175,7 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
       (paddrFwd(i) >> blockOffBits) === (info.paddr >> blockOffBits) && info.inflight})
     s1SelectOH(i) := s1PaddrMatchVec(i).asUInt
     s1ForwardInfo(i) := Mux1H(s1SelectOH(i), forwardInfo_vec)
+    // Select VLEN (128-bit) data from cacheline data
     paddrFwd_selOH(i) := (0 until (blockBytes / VLENB)).map(k => paddrFwd(i)(blockOffBits - 1, log2Up(VLENB)) === k.U)
     s1RespDataFwd(i) := Mux1H(paddrFwd_selOH(i), s1ForwardInfo(i).raw_data.grouped(VLEN / rowBits).map(VecInit(_).asUInt).toSeq)
   }
@@ -1202,17 +1204,16 @@ class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   }
 
   io.forward_stData.zipWithIndex.foreach { case (forward, i) =>
-    val s0ReqValid_stLdFwd = forward.s0Req.valid
-    val s1ReqValid_stLdFwd = RegNext(s0ReqValid_stLdFwd)
+    val s1ReqValid_stLdFwd = RegNext(forward.s0Req.valid)
 
     val s1RespMask_stLdFwd = Mux1H(paddrFwd_selOH(i),
           s1ForwardInfo(i).store_mask.grouped(VLENB).map(x => Mux(s1ForwardInfo(i).isFromStore, x, 0.U)))
     val s1RespValid_stLdFwd = s1ReqValid_stLdFwd && s1SelectOH(i).orR
     
     forward.s2Resp.valid := RegNext(s1RespValid_stLdFwd)
-    for (j <- 0 until VDataBytes) {
-      forward.s2Resp.bits.forwardData(j) := RegEnable(s1RespDataFwd(i)(8 * j + 7, 8 * j), s1RespValid_stLdFwd) 
-      forward.s2Resp.bits.forwardMask(j) := RegEnable(s1RespMask_stLdFwd(j), s1RespValid_stLdFwd) && forward.s2Resp.valid
+    for (k <- 0 until VLENB) {
+      forward.s2Resp.bits.forwardData(k) := RegEnable(s1RespDataFwd(i)(8 * k + 7, 8 * k), s1RespValid_stLdFwd) 
+      forward.s2Resp.bits.forwardMask(k) := RegEnable(s1RespMask_stLdFwd(k), s1RespValid_stLdFwd) && forward.s2Resp.valid
     }
     forward.s2Resp.bits.matchInvalid := false.B
   }

--- a/src/main/scala/xiangshan/mem/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/Bundles.scala
@@ -275,6 +275,11 @@ object Bundles {
     val s2Resp = Flipped(ValidIO(new SbufferForwardResp))
   }
 
+  class SbufferForwardReq(implicit p: Parameters) extends XSBundle {
+    val s0Req = ValidIO(new StoreForwardReqS0)
+    val s1Req = Output(new StoreForwardReqS1)
+  }
+
   class SQForward(implicit p: Parameters) extends XSBundle {
     val s0Req = ValidIO(new StoreForwardReqS0)
     val s1Req = Output(new StoreForwardReqS1)

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -897,6 +897,19 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     // forward & NC bypass
     lsq.io.forward(i) <> newLoadUnits(i).io.sqForward
     sbuffer.io.forward(i) <> newLoadUnits(i).io.sbufferForward
+    dcache.io.lsu.forward_mshrStData(i) <> newLoadUnits(i).io.sbufferForward
+    // Rewrite newLoadUnits(i).io.sbufferForward.s2Resp to merge sbuffer and mshr st-ld forwarding data
+    newLoadUnits(i).io.sbufferForward.s2Resp.valid := sbuffer.io.forward(i).s2Resp.valid || dcache.io.lsu.forward_mshrStData(i).s2Resp.valid
+    newLoadUnits(i).io.sbufferForward.s2Resp.bits.matchInvalid := sbuffer.io.forward(i).s2Resp.valid && sbuffer.io.forward(i).s2Resp.bits.matchInvalid
+    for (k <- 0 until VDataBytes) {
+      when (sbuffer.io.forward(i).s2Resp.valid && sbuffer.io.forward(i).s2Resp.bits.forwardMask(k)) {
+        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardData(k) := sbuffer.io.forward(i).s2Resp.bits.forwardData(k)
+        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardMask(k) := true.B
+      } otherwise {
+        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardData(k) := dcache.io.lsu.forward_mshrStData(i).s2Resp.bits.forwardData(k)
+        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardMask(k) := dcache.io.lsu.forward_mshrStData(i).s2Resp.bits.forwardMask(k)
+      }
+    }
     uncache.io.forward(i) <> newLoadUnits(i).io.uncacheForward
     dcache.io.lsu.forward_D(i) <> newLoadUnits(i).io.tldForward
     dcache.io.lsu.forward_mshr(i) <> newLoadUnits(i).io.mshrForward

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1360,6 +1360,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   // Sbuffer
   sbuffer.io.csrCtrl    <> csrCtrl
   sbuffer.io.dcache     <> dcache.io.lsu.store
+  sbuffer.io.mshr_store_empty := dcache.io.mshr_store_empty
   sbuffer.io.memSetPattenDetected := dcache.io.memSetPattenDetected
   sbuffer.io.force_write <> lsq.io.force_write
   // flush sbuffer

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -897,19 +897,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     // forward & NC bypass
     lsq.io.forward(i) <> newLoadUnits(i).io.sqForward
     sbuffer.io.forward(i) <> newLoadUnits(i).io.sbufferForward
-    dcache.io.lsu.forward_mshrStData(i) <> newLoadUnits(i).io.sbufferForward
-    // Rewrite newLoadUnits(i).io.sbufferForward.s2Resp to merge sbuffer and mshr st-ld forwarding data
-    newLoadUnits(i).io.sbufferForward.s2Resp.valid := sbuffer.io.forward(i).s2Resp.valid || dcache.io.lsu.forward_mshrStData(i).s2Resp.valid
-    newLoadUnits(i).io.sbufferForward.s2Resp.bits.matchInvalid := sbuffer.io.forward(i).s2Resp.valid && sbuffer.io.forward(i).s2Resp.bits.matchInvalid
-    for (k <- 0 until VDataBytes) {
-      when (sbuffer.io.forward(i).s2Resp.valid && sbuffer.io.forward(i).s2Resp.bits.forwardMask(k)) {
-        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardData(k) := sbuffer.io.forward(i).s2Resp.bits.forwardData(k)
-        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardMask(k) := true.B
-      } otherwise {
-        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardData(k) := dcache.io.lsu.forward_mshrStData(i).s2Resp.bits.forwardData(k)
-        newLoadUnits(i).io.sbufferForward.s2Resp.bits.forwardMask(k) := dcache.io.lsu.forward_mshrStData(i).s2Resp.bits.forwardMask(k)
-      }
-    }
+    connectSamePort(dcache.io.lsu.forward_mshrStData(i), newLoadUnits(i).io.sbufferForward)
     uncache.io.forward(i) <> newLoadUnits(i).io.uncacheForward
     dcache.io.lsu.forward_D(i) <> newLoadUnits(i).io.tldForward
     dcache.io.lsu.forward_mshr(i) <> newLoadUnits(i).io.mshrForward

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -1757,15 +1757,15 @@ class LoadUnitDataPath(val param: ExeUnitParams)(implicit p: Parameters) extends
   val sbufferForwardData = io.s2SbufferForwardResp.bits.forwardData.asUInt
   val tldMask = Fill(VLEN / 8, io.s2TLDForwardResp.valid)
   val tldData = io.s2TLDForwardResp.bits.forwardData.asUInt
-  val mshrMask = Fill(VLEN / 8, io.s2MSHRForwardResp.valid)
+  val mshrMask = io.s2MSHRForwardResp.bits.forwardMask.asUInt
   val mshrData = io.s2MSHRForwardResp.bits.forwardData.asUInt
   val (masks, datas) = Seq(
     // DO NOT change the priority here
     (sqForwardMask, sqForwardData),
     (ncForwardMask, ncForwardData),
     (sbufferForwardMask, sbufferForwardData),
-    (tldMask, tldData),
-    (mshrMask, mshrData)
+    (mshrMask, mshrData),
+    (tldMask, tldData)
   ).unzip
 
   val s2Data = mergeData(rawData, datas, masks)

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -962,7 +962,8 @@ class LoadUnitS2(param: ExeUnitParams)(
   afForwardDenied := mshrForwardDenied || tldForwardDenied
   hweForwardCorrupt := mshrForwardCorrupt || tldForwardCorrupt
 
-  val dcacheFullForward = io.mshrForwardResp.valid || io.tldForwardResp.valid
+  val dcacheFullForward = (~(io.mshrForwardResp.bits.forwardMask.asUInt) & in.mask) === 0.U ||
+                          io.tldForwardResp.valid
   val uncacheFullForward = (~io.uncacheForwardResp.bits.forwardMask.asUInt & in.mask) === 0.U && !sqDataInvalid
   val storeFullForward = (~storeForwardMask & in.mask) === 0.U && !sqDataInvalid
   val fullForward = storeFullForward || dcacheFullForward

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -715,7 +715,7 @@ class Sbuffer(implicit p: Parameters)
       stateVec(dcache_resp_id).state_inflight := false.B
       stateVec(dcache_resp_id).state_valid := false.B
       assert(!resp.bits.replay)
-      assert(!resp.bits.miss) // not need to resp if miss, to be opted
+      // assert(!resp.bits.miss)
       assert(stateVec(dcache_resp_id).state_inflight === true.B)
     }
 
@@ -767,8 +767,8 @@ class Sbuffer(implicit p: Parameters)
       val difftest = DifftestModule(new DiffSbufferEvent, delay = 1)
       val dcache_resp_id = resp.bits.id
       difftest.coreid := io.hartId
-      difftest.index  := index.U
-      difftest.valid  := resp.fire
+      difftest.index  := 1.U + index.U
+      difftest.valid  := resp.fire && !resp.bits.miss
       difftest.addr   := getAddr(ptag(dcache_resp_id))
       difftest.data   := data(dcache_resp_id).asTypeOf(Vec(CacheLineBytes, UInt(8.W)))
       difftest.mask   := mask(dcache_resp_id).asUInt

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -715,7 +715,6 @@ class Sbuffer(implicit p: Parameters)
       stateVec(dcache_resp_id).state_inflight := false.B
       stateVec(dcache_resp_id).state_valid := false.B
       assert(!resp.bits.replay)
-      // assert(!resp.bits.miss)
       assert(stateVec(dcache_resp_id).state_inflight === true.B)
     }
 

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -532,11 +532,10 @@ class Sbuffer(implicit p: Parameters)
 
   // ---------------------- Send Dcache Req ---------------------
 
-  val sbuffer_empty = Cat(invalidMask).andR
+  // Flush completion must also wait until store misses in MSHR are drained.
+  val sbuffer_empty = Cat(invalidMask).andR && io.mshr_store_empty
   val sq_empty = !Cat(io.in.req.map(_.valid)).orR
   val empty = sbuffer_empty && sq_empty
-  // Flush completion must also wait until store misses in MSHR are drained.
-  val flush_empty = empty && io.mshr_store_empty
   val threshold = Wire(UInt(5.W)) // RegNext(io.csrCtrl.sbuffer_threshold +& 1.U)
   threshold := Constantin.createRecord(s"StoreBufferThreshold_${p(XSCoreParamsKey).HartId}", initValue = 9)
   val base = Wire(UInt(5.W))
@@ -549,8 +548,8 @@ class Sbuffer(implicit p: Parameters)
 
   XSDebug(p"ActiveCount[$ActiveCount]\n")
 
-  io.sbempty := GatedValidRegNext(flush_empty)
-  io.flush.empty := GatedValidRegNext(flush_empty && io.sqempty)
+  io.sbempty := GatedValidRegNext(empty)
+  io.flush.empty := GatedValidRegNext(empty && io.sqempty)
   // lru.io.flush := sbuffer_state === x_drain_all && empty
   switch(sbuffer_state){
     is(x_idle){

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -681,8 +681,8 @@ class Sbuffer(implicit p: Parameters)
   XSDebug(p"sbuffer_out_s0_valid:$sbuffer_out_s0_valid evictIdx:$sbuffer_out_s0_evictionIdx dcache ready:${io.dcache.req.ready}\n")
   // Note: if other dcache req in the same block are inflight,
   // the lru update may not accurate
-  accessIdx(EnsbufferWidth).valid := invalidMask(replaceIdx) || (
-    need_replace && !need_drain && !cohHasTimeOut && !missqReplayHasTimeOut && sbuffer_out_s0_cango && activeMask(replaceIdx))
+  accessIdx(EnsbufferWidth).valid :=
+    need_replace && !need_drain && !cohHasTimeOut && !missqReplayHasTimeOut && sbuffer_out_s0_cango && activeMask(replaceIdx)
   accessIdx(EnsbufferWidth).bits := replaceIdx
   val sbuffer_out_s1_evictionIdx = RegEnable(sbuffer_out_s0_evictionIdx, sbuffer_out_s0_fire)
   val sbuffer_out_s1_evictionPTag = RegEnable(ptag(sbuffer_out_s0_evictionIdx), sbuffer_out_s0_fire)

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -535,7 +535,7 @@ class Sbuffer(implicit p: Parameters)
   val sq_empty = !Cat(io.in.req.map(_.valid)).orR
   val empty = sbuffer_empty && sq_empty
   val threshold = Wire(UInt(5.W)) // RegNext(io.csrCtrl.sbuffer_threshold +& 1.U)
-  threshold := Constantin.createRecord(s"StoreBufferThreshold_${p(XSCoreParamsKey).HartId}", initValue = 7)
+  threshold := Constantin.createRecord(s"StoreBufferThreshold_${p(XSCoreParamsKey).HartId}", initValue = 9)
   val base = Wire(UInt(5.W))
   base := Constantin.createRecord(s"StoreBufferBase_${p(XSCoreParamsKey).HartId}", initValue = 4)
   val ActiveCount = PopCount(activeMask)

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -198,6 +198,7 @@ class Sbuffer(implicit p: Parameters)
     val forward = Vec(LoadPipelineWidth, Flipped(new SbufferForward))
     val sqempty = Input(Bool())
     val sbempty = Output(Bool())
+    val mshr_store_empty = Input(Bool()) // sbuffer-flush must flush all store entries in mshr as well
     val flush = Flipped(new SbufferFlushBundle)
     val csrCtrl = Flipped(new CustomCSRCtrlIO)
     val store_prefetch = Vec(StorePipelineWidth, DecoupledIO(new StorePrefetchReq)) // to dcache
@@ -534,6 +535,8 @@ class Sbuffer(implicit p: Parameters)
   val sbuffer_empty = Cat(invalidMask).andR
   val sq_empty = !Cat(io.in.req.map(_.valid)).orR
   val empty = sbuffer_empty && sq_empty
+  // Flush completion must also wait until store misses in MSHR are drained.
+  val flush_empty = empty && io.mshr_store_empty
   val threshold = Wire(UInt(5.W)) // RegNext(io.csrCtrl.sbuffer_threshold +& 1.U)
   threshold := Constantin.createRecord(s"StoreBufferThreshold_${p(XSCoreParamsKey).HartId}", initValue = 9)
   val base = Wire(UInt(5.W))
@@ -546,8 +549,8 @@ class Sbuffer(implicit p: Parameters)
 
   XSDebug(p"ActiveCount[$ActiveCount]\n")
 
-  io.sbempty := GatedValidRegNext(empty)
-  io.flush.empty := GatedValidRegNext(empty && io.sqempty)
+  io.sbempty := GatedValidRegNext(flush_empty)
+  io.flush.empty := GatedValidRegNext(flush_empty && io.sqempty)
   // lru.io.flush := sbuffer_state === x_drain_all && empty
   switch(sbuffer_state){
     is(x_idle){


### PR DESCRIPTION
Sbuffer releases the entry when store-miss is accepted by mshr, and mshr provides corresponding st-ld forwarding.

MissQueue supports store-store merge. Store can be merged until refill to dataArray is done

In missQueue, the paddr-CAM and data-select logic are shared by mshr forwarding and st-ld forwarding paths. The missQueue st-ld forwarding uses the same interface to loadUnit as mshr forwarding.

Add one DiffSbufferEvent in missQueue to solve the 'refill test failed' in dual-core test

Change StoreBufferThreshold 7 -> 9

The SPEC06 1.0c score got 0.25% improvement.