### PR TITLE
fix: Add a parameter "txSourceReady" to control the Option IO LCrdy

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -283,7 +283,7 @@ case class L2CacheConfig
   banks: Int = 1,
   tp: Boolean = true,
   enableFlush: Boolean = false,
-  enableCHIAsyncBridge: Option[Boolean] = None
+  txSourceReady: Boolean = false 
 ) extends Config((site, here, up) => {
   case XSTileKey =>
     require(inclusive, "L2 must be inclusive")
@@ -318,7 +318,7 @@ case class L2CacheConfig
           (if (tp) Seq(TPParameters()) else Nil) ++
           (if (p.prefetcher.nonEmpty) Seq(PrefetchReceiverParams()) else Nil),
         enableL2Flush = enableFlush,
-        enableCHIAsyncBridge = enableCHIAsyncBridge,
+        txSourceReady = txSourceReady,
         enablePerf = !site(DebugOptionsKey).FPGAPlatform && site(DebugOptionsKey).EnablePerfDebug,
         enableRollingDB = site(DebugOptionsKey).EnableRollingDB,
         enableMonitor = site(DebugOptionsKey).AlwaysBasicDB,

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -118,8 +118,11 @@ trait HasCoreLowPowerImp[+L <: HasXSTile] { this: BaseXSSocImp with HasXSTileCHI
     }
     val exitco = withClockAndReset(clock, cpuReset_sync) {
       AsyncResetSynchronizerShiftReg((!io_chi.syscoreq & !sync_chi_syscoack),3, 0)}
-    val QACTIVE = WireInit(false.B)
-    val QACCEPTn = WireInit(false.B)
+    val QACTIVE = withClockAndReset(clock, cpuReset_sync) {
+      AsyncResetSynchronizerShiftReg(io_power.QACTIVE,3, 0)}
+    val QACCEPTn = withClockAndReset(clock, cpuReset_sync) {
+      AsyncResetSynchronizerShiftReg(io_power.QACCEPTn,3, 0)}
+    io_power.QREQ := exitco
     cpu_no_op := lpState === sPOFFREQ
     lpState := lpStateNext(lpState, l2_flush_en, l2_flush_done, isWFI, exitco, QACTIVE, QACCEPTn)
     io.lp.foreach { lp => lp.o_cpu_no_op := cpu_no_op} // inform SoC core+l2 want to power off
@@ -268,6 +271,11 @@ trait HasXSTileCHIImp[+L <: HasXSTile] extends HasXSTileImp[L] {
   this: BaseXSSocImp with HasAsyncClockImp =>
 
   val io_chi = IO(new PortIO)
+  val io_power = Wire(new Bundle {
+    val QACTIVE = Output(Bool())
+    val QACCEPTn = Output(Bool())
+    val QREQ = Input(Bool())
+  })
 
   require(socParams.enableCHI)
 
@@ -277,9 +285,14 @@ trait HasXSTileCHIImp[+L <: HasXSTile] extends HasXSTileImp[L] {
         val time_sink = Module(new CHIAsyncBridgeSink(param))
         time_sink.io.async <> core_with_l2.module.io.chi
         io_chi <> time_sink.io.deq
+        io_power.QACTIVE := time_sink.io.powerAck.QACTIVE
+        io_power.QACCEPTn := time_sink.io.powerAck.QACCEPTn
+        time_sink.io.powerAck.QREQ := withClockAndReset(noc_clock.get, noc_reset_sync.get) { AsyncResetSynchronizerShiftReg(io_power.QREQ, 3, 0) }
       }
     case None =>
       io_chi <> core_with_l2.module.io.chi
+      io_power.QACTIVE := false.B
+      io_power.QACCEPTn := false.B
   }
 }
 

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -31,6 +31,7 @@ import freechips.rocketchip.diplomacy.AddressSet
 import freechips.rocketchip.tile.MaxHartIdBits
 import freechips.rocketchip.util.AsyncQueueParams
 import device.IMSICBusType
+import coupledL2.L2ParamKey
 
 case class YamlConfig(
   Config: Option[String],
@@ -95,17 +96,16 @@ object YamlParser {
         case SoCParamsKey => up(SoCParamsKey).copy(PMAConfigs = pmaConfigs)
       })
     }
+    yamlConfig.L2CacheConfig.foreach(l2 => newConfig = newConfig.alter(l2))
     yamlConfig.EnableCHIAsyncBridge.foreach { enable =>
       newConfig = newConfig.alter((site, here, up) => {
         case SoCParamsKey => up(SoCParamsKey).copy(
-          EnableCHIAsyncBridge = Option.when(enable)(AsyncQueueParams(depth = 16, sync = 3, safe = true))
+          EnableCHIAsyncBridge = Option.when(enable)(AsyncQueueParams(depth = 4, sync = 3, safe = true))
+        )
+        case L2ParamKey => up(L2ParamKey).copy(
+          txSourceReady = enable
         )
       })
-    }
-    yamlConfig.L2CacheConfig.foreach(l2 => newConfig = newConfig.alter(l2))
-    yamlConfig.L2CacheConfig.foreach { l2 =>
-      val updatedL2 = l2.copy( enableCHIAsyncBridge = yamlConfig.EnableCHIAsyncBridge)
-      newConfig = newConfig.alter(updatedL2)
     }
     yamlConfig.L3CacheConfig.foreach(l3 => newConfig = newConfig.alter(l3))
     yamlConfig.DebugAttachProtocals.foreach { protocols =>
@@ -151,7 +151,7 @@ object YamlParser {
     yamlConfig.DCacheCtrlRange.foreach { range =>
       newConfig = newConfig.alter((site, here, up) => {
         case SoCParamsKey => up(SoCParamsKey).copy(DCacheCtrlRange = range)
-      })  
+      })
     }
     yamlConfig.EnableICacheCtrl.foreach { enable =>
       newConfig = newConfig.alter((site, here, up) => {
@@ -161,7 +161,7 @@ object YamlParser {
     yamlConfig.ICacheCtrlRange.foreach { range =>
       newConfig = newConfig.alter((site, here, up) => {
         case SoCParamsKey => up(SoCParamsKey).copy(ICacheCtrlRange = range)
-      })  
+      })
     }
     yamlConfig.SeperateDM.foreach { enable =>
       newConfig = newConfig.alter((site, here, up) => {

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -27,7 +27,7 @@ import freechips.rocketchip.tile.{BusErrorUnit, BusErrorUnitParams, BusErrors, M
 import freechips.rocketchip.tilelink._
 import coupledL2.{EnableCHI, EnableL2ClockGate, L2ParamKey, PrefetchCtrlFromCore}
 import coupledL2.tl2tl.TL2TLCoupledL2
-import coupledL2.tl2chi.{CHIIssue, PortIO, TL2CHICoupledL2, CHIAddrWidthKey, NonSecureKey}
+import coupledL2.tl2chi.{CHIIssue, PortIO, TL2CHICoupledL2, CHIAddrWidthKey, NonSecureKey, LCrdyIn}
 import huancun.BankBitsKey
 import system.HasSoCParameter
 import top.BusPerfMonitor
@@ -74,6 +74,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
     (buffers, node)
   }
   val enableL2 = coreParams.L2CacheParamsOpt.isDefined
+  val txSourceReady = p(L2ParamKey).txSourceReady
   // =========== Components ============
   val l1_xbar = TLXbar()
   val mmio_xbar = TLXbar()
@@ -237,6 +238,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       val perfEvents = Output(Vec(numPCntHc * coreParams.L2NBanks + 1, new PerfEvent))
       val l2_flush_en = Option.when(EnablePowerDown) (Input(Bool()))
       val l2_flush_done = Option.when(EnablePowerDown) (Output(Bool()))
+      val lcrdy = Option.when(txSourceReady) (new LCrdyIn) 
       val dft = Option.when(hasDFT)(Input(new SramBroadcastBundle))
       val dft_reset = Option.when(hasMbist)(Input(new DFTResetSignals()))
       val dft_out = Option.when(hasDFT)(Output(new SramBroadcastBundle))
@@ -361,6 +363,10 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
           l2.io_nodeID := io.nodeID.get
           io.chi.get <> l2.io_chi
           l2.io_cpu_halt.foreach { _:= io.cpu_halt.fromCore }
+          io.lcrdy.foreach { in =>
+            l2.io_lcrdy.foreach(out => out := in)
+          }
+
         case l2cache: TL2TLCoupledL2 =>
       }
 
@@ -376,6 +382,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       io.l2_tlb_req.req_kill := DontCare
       io.l2_tlb_req.resp.ready := true.B
       io.perfEvents := DontCare
+      io.lcrdy.foreach { _ := DontCare }
 
       beu.module.io.errors.l2 := 0.U.asTypeOf(beu.module.io.errors.l2)
     }

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -28,8 +28,8 @@ import system.HasSoCParameter
 import top.{ArgParser, BusPerfMonitor, Generator}
 import utility._
 import utility.sram.SramBroadcastBundle
-import coupledL2.EnableCHI
-import coupledL2.tl2chi.PortIO
+import coupledL2.{EnableCHI, HasCoupledL2Parameters, L2ParamKey}
+import coupledL2.tl2chi.{PortIO, LCrdyIn}
 import xiangshan.backend.trace.TraceCoreInterface
 
 class XSTile()(implicit p: Parameters) extends LazyModule
@@ -41,6 +41,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
   val l2top = LazyModule(new L2Top())
 
   val enableL2 = coreParams.L2CacheParamsOpt.isDefined
+  val txSourceReady = p(L2ParamKey).txSourceReady
   // =========== Public Ports ============
   val memBlock = core.memBlock.inner
   val core_l3_pf_port = memBlock.l3_pf_sender_opt
@@ -122,6 +123,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
       val dft_reset = Option.when(hasMbist)(Input(new DFTResetSignals()))
       val l2_flush_en = Option.when(EnablePowerDown) (Output(Bool()))
       val l2_flush_done = Option.when(EnablePowerDown) (Output(Bool()))
+      val lcrdy = Option.when(txSourceReady) (new LCrdyIn)
     })
 
     dontTouch(io.hartId)
@@ -171,6 +173,9 @@ class XSTile()(implicit p: Parameters) extends LazyModule
     io.l2_flush_en.foreach { _ := core.module.io.l2_flush_en }
     core.module.io.l2_flush_done := l2top.module.io.l2_flush_done.getOrElse(false.B)
     io.l2_flush_done.foreach { _ := l2top.module.io.l2_flush_done.getOrElse(false.B) }
+    io.lcrdy.foreach { in =>
+      l2top.module.io.lcrdy.foreach( out => out := in )
+    }
 
     l2top.module.io.dft.zip(io.dft).foreach({ case (a, b) => a := b })
     l2top.module.io.dft_reset.zip(io.dft_reset).foreach({ case (a, b) => a := b })

--- a/src/main/scala/xiangshan/XSTileWrap.scala
+++ b/src/main/scala/xiangshan/XSTileWrap.scala
@@ -187,6 +187,9 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
       case Some(param) =>
         val source = withClockAndReset(clock, reset_sync)(Module(new CHIAsyncBridgeSource(param)))
         source.io.enq <> tile.module.io.chi.get
+        tile.module.io.lcrdy.foreach { out =>
+          out := source.io.lcrdy
+        }
         io.chi <> source.io.async
       case None =>
         require(enableCHI)


### PR DESCRIPTION
Add a parameter "txSourceReady" to control the Option IO LCrdy which allows AsyncBridge to correctly propagate back-pressure while maintaining copatibility with existing design

Add low power handshake signals with Sink: QREQ/QACTIVE/QACCEPTn