### PR TITLE
submodule(CoupledL2): bump CoupledL2

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -283,7 +283,7 @@ case class L2CacheConfig
   banks: Int = 1,
   tp: Boolean = true,
   enableFlush: Boolean = false,
-  enableCHIAsyncBridge: Option[Boolean] = None
+  txSourceReady: Boolean = false
 ) extends Config((site, here, up) => {
   case XSTileKey =>
     require(inclusive, "L2 must be inclusive")
@@ -318,7 +318,7 @@ case class L2CacheConfig
           (if (tp) Seq(TPParameters()) else Nil) ++
           (if (p.prefetcher.nonEmpty) Seq(PrefetchReceiverParams()) else Nil),
         enableL2Flush = enableFlush,
-        enableCHIAsyncBridge = enableCHIAsyncBridge,
+        txSourceReady = txSourceReady,
         enablePerf = !site(DebugOptionsKey).FPGAPlatform && site(DebugOptionsKey).EnablePerfDebug,
         enableRollingDB = site(DebugOptionsKey).EnableRollingDB,
         enableMonitor = site(DebugOptionsKey).AlwaysBasicDB,

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -366,6 +366,12 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
       core.module.io.dft_reset.foreach(dontTouch(_) := DontCare)
       core.module.io.reset_vector := io.riscv_rst_vec(i)
       core.module.io.reset_mtvec.foreach(_ := io.riscv_rst_mtvec.get(i))
+      core.module.io.lcrdy.foreach { lcrdy =>
+        lcrdy.req.rdy := true.B
+        lcrdy.dat.rdy := true.B
+        lcrdy.rsp.rdy := true.B
+        lcrdy.empty := true.B
+      }
     }
 
     withClockAndReset(io.clock, io.reset) {

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -118,8 +118,11 @@ trait HasCoreLowPowerImp[+L <: HasXSTile] { this: BaseXSSocImp with HasXSTileCHI
     }
     val exitco = withClockAndReset(clock, cpuReset_sync) {
       AsyncResetSynchronizerShiftReg((!io_chi.syscoreq & !sync_chi_syscoack),3, 0)}
-    val QACTIVE = WireInit(false.B)
-    val QACCEPTn = WireInit(false.B)
+    val QACTIVE = withClockAndReset(clock, cpuReset_sync) {
+      AsyncResetSynchronizerShiftReg(io_power.QACTIVE,3, 0)}
+    val QACCEPTn = withClockAndReset(clock, cpuReset_sync) {
+      AsyncResetSynchronizerShiftReg(io_power.QACCEPTn,3, 0)}
+    io_power.QREQ := exitco
     cpu_no_op := lpState === sPOFFREQ
     lpState := lpStateNext(lpState, l2_flush_en, l2_flush_done, isWFI, exitco, QACTIVE, QACCEPTn)
     io.lp.foreach { lp => lp.o_cpu_no_op := cpu_no_op} // inform SoC core+l2 want to power off
@@ -270,6 +273,11 @@ trait HasXSTileCHIImp[+L <: HasXSTile] extends HasXSTileImp[L] {
   this: BaseXSSocImp with HasAsyncClockImp =>
 
   val io_chi = IO(new PortIO)
+  val io_power = Wire(new Bundle {
+    val QACTIVE = Output(Bool())
+    val QACCEPTn = Output(Bool())
+    val QREQ = Input(Bool())
+  })
 
   require(socParams.enableCHI)
 
@@ -279,10 +287,15 @@ trait HasXSTileCHIImp[+L <: HasXSTile] extends HasXSTileImp[L] {
         val time_sink = Module(new CHIAsyncBridgeSink(param))
         time_sink.io.async <> core_with_l2.module.io.chi
         io_chi <> time_sink.io.deq
+        io_power.QACTIVE := time_sink.io.powerAck.QACTIVE
+        io_power.QACCEPTn := time_sink.io.powerAck.QACCEPTn
+        time_sink.io.powerAck.QREQ := withClockAndReset(noc_clock.get, noc_reset_sync.get) { AsyncResetSynchronizerShiftReg(io_power.QREQ, 3, 0) }
       }
     case None =>
       io_chi <> core_with_l2.module.io.chi
-  }
+      io_power.QACTIVE := false.B
+      io_power.QACCEPTn := false.B
+   }
 }
 
 object SeperatedBusType extends Enumeration {

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -31,6 +31,7 @@ import freechips.rocketchip.diplomacy.AddressSet
 import freechips.rocketchip.tile.MaxHartIdBits
 import freechips.rocketchip.util.AsyncQueueParams
 import device.IMSICBusType
+import coupledL2.L2ParamKey
 
 case class YamlConfig(
   Config: Option[String],
@@ -96,17 +97,16 @@ object YamlParser {
         case SoCParamsKey => up(SoCParamsKey).copy(PMAConfigs = pmaConfigs)
       })
     }
+    yamlConfig.L2CacheConfig.foreach(l2 => newConfig = newConfig.alter(l2))
     yamlConfig.EnableCHIAsyncBridge.foreach { enable =>
       newConfig = newConfig.alter((site, here, up) => {
         case SoCParamsKey => up(SoCParamsKey).copy(
           EnableCHIAsyncBridge = Option.when(enable)(AsyncQueueParams(depth = 4, sync = 3, safe = true))
         )
+        case L2ParamKey => up(L2ParamKey).copy(
+          txSourceReady = enable
+        )
       })
-    }
-    yamlConfig.L2CacheConfig.foreach(l2 => newConfig = newConfig.alter(l2))
-    yamlConfig.L2CacheConfig.foreach { l2 =>
-      val updatedL2 = l2.copy( enableCHIAsyncBridge = yamlConfig.EnableCHIAsyncBridge)
-      newConfig = newConfig.alter(updatedL2)
     }
     yamlConfig.L3CacheConfig.foreach(l3 => newConfig = newConfig.alter(l3))
     yamlConfig.DebugAttachProtocals.foreach { protocols =>

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -27,7 +27,7 @@ import freechips.rocketchip.tile.{BusErrorUnit, BusErrorUnitParams, BusErrors, M
 import freechips.rocketchip.tilelink._
 import coupledL2.{EnableCHI, EnableL2ClockGate, L2ParamKey, PrefetchCtrlFromCore}
 import coupledL2.tl2tl.TL2TLCoupledL2
-import coupledL2.tl2chi.{CHIIssue, PortIO, TL2CHICoupledL2, CHIAddrWidthKey, NonSecureKey}
+import coupledL2.tl2chi.{CHIIssue, PortIO, TL2CHICoupledL2, CHIAddrWidthKey, NonSecureKey, LCrdyIn}
 import huancun.BankBitsKey
 import system.HasSoCParameter
 import top.BusPerfMonitor
@@ -74,7 +74,8 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
     (buffers, node)
   }
   val enableL2 = coreParams.L2CacheParamsOpt.isDefined
-  // =========== Components ============
+  val txSourceReady = p(L2ParamKey).txSourceReady
+   // =========== Components ============
   val l1_xbar = TLXbar()
   val mmio_xbar = TLXbar()
   val mmio_port = TLIdentityNode() // to L3
@@ -241,6 +242,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       val perfEvents = Output(Vec(numPCntHc * coreParams.L2NBanks + 1, new PerfEvent))
       val l2_flush_en = Option.when(EnablePowerDown) (Input(Bool()))
       val l2_flush_done = Option.when(EnablePowerDown) (Output(Bool()))
+      val lcrdy = Option.when(txSourceReady) (new LCrdyIn)
       val dft = Option.when(hasDFT)(Input(new SramBroadcastBundle))
       val dft_reset = Option.when(hasMbist)(Input(new DFTResetSignals()))
       val dft_out = Option.when(hasDFT)(Output(new SramBroadcastBundle))
@@ -369,6 +371,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
           l2.io_nodeID := io.nodeID.get
           io.chi.get <> l2.io_chi
           l2.io_cpu_halt.foreach { _:= io.cpu_halt.fromCore }
+          io.lcrdy.foreach { in => l2.io_lcrdy.foreach(out => out := in) }
         case l2cache: TL2TLCoupledL2 =>
       }
 
@@ -384,6 +387,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       io.l2_tlb_req.req_kill := DontCare
       io.l2_tlb_req.resp.ready := true.B
       io.perfEvents := DontCare
+      io.lcrdy.foreach { _ := DontCare }
 
       beu.module.io.errors.l2 := 0.U.asTypeOf(beu.module.io.errors.l2)
     }

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -28,8 +28,8 @@ import system.HasSoCParameter
 import top.{ArgParser, BusPerfMonitor, Generator}
 import utility._
 import utility.sram.SramBroadcastBundle
-import coupledL2.EnableCHI
-import coupledL2.tl2chi.PortIO
+import coupledL2.{EnableCHI, L2ParamKey}
+import coupledL2.tl2chi.{PortIO, LCrdyIn}
 import xiangshan.backend.trace.TraceCoreInterface
 
 class XSTile()(implicit p: Parameters) extends LazyModule
@@ -41,7 +41,8 @@ class XSTile()(implicit p: Parameters) extends LazyModule
   val l2top = LazyModule(new L2Top())
 
   val enableL2 = coreParams.L2CacheParamsOpt.isDefined
-  // =========== Public Ports ============
+  val txSourceReady = p(L2ParamKey).txSourceReady
+// =========== Public Ports ============
   val memBlock = core.memBlock.inner
   val core_l3_pf_port = memBlock.l3_pf_sender_opt
   val memory_port = if (enableCHI && enableL2) None else Some(l2top.inner.memory_port.get)
@@ -123,6 +124,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
       val dft_reset = Option.when(hasMbist)(Input(new DFTResetSignals()))
       val l2_flush_en = Option.when(EnablePowerDown) (Output(Bool()))
       val l2_flush_done = Option.when(EnablePowerDown) (Output(Bool()))
+      val lcrdy = Option.when(txSourceReady) (new LCrdyIn)
     })
 
     dontTouch(io.hartId)
@@ -174,6 +176,7 @@ class XSTile()(implicit p: Parameters) extends LazyModule
     io.l2_flush_en.foreach { _ := core.module.io.l2_flush_en }
     core.module.io.l2_flush_done := l2top.module.io.l2_flush_done.getOrElse(false.B)
     io.l2_flush_done.foreach { _ := l2top.module.io.l2_flush_done.getOrElse(false.B) }
+    io.lcrdy.foreach { in => l2top.module.io.lcrdy.foreach( out => out := in ) }
 
     l2top.module.io.dft.zip(io.dft).foreach({ case (a, b) => a := b })
     l2top.module.io.dft_reset.zip(io.dft_reset).foreach({ case (a, b) => a := b })

--- a/src/main/scala/xiangshan/XSTileWrap.scala
+++ b/src/main/scala/xiangshan/XSTileWrap.scala
@@ -189,7 +189,10 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
       case Some(param) =>
         val source = withClockAndReset(clock, reset_sync)(Module(new CHIAsyncBridgeSource(param)))
         source.io.enq <> tile.module.io.chi.get
-        io.chi <> source.io.async
+        tile.module.io.lcrdy.foreach { out =>
+          out := source.io.lcrdy
+        }
+         io.chi <> source.io.async
       case None =>
         require(enableCHI)
         io.chi <> tile.module.io.chi.get

--- a/src/main/scala/xiangshan/XSTileWrap.scala
+++ b/src/main/scala/xiangshan/XSTileWrap.scala
@@ -196,7 +196,12 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
       case None =>
         require(enableCHI)
         io.chi <> tile.module.io.chi.get
-        tile.module.io.lcrdy.foreach { out => out := true.B }
+        tile.module.io.lcrdy.foreach { lcrdy =>
+          lcrdy.req.rdy := true.B
+          lcrdy.dat.rdy := true.B
+          lcrdy.rsp.rdy := true.B
+          lcrdy.empty := true.B
+        }
     }
 
     withClockAndReset(clock, reset_sync) {

--- a/src/main/scala/xiangshan/XSTileWrap.scala
+++ b/src/main/scala/xiangshan/XSTileWrap.scala
@@ -190,7 +190,7 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
         val source = withClockAndReset(clock, reset_sync)(Module(new CHIAsyncBridgeSource(param)))
         source.io.enq <> tile.module.io.chi.get
         tile.module.io.lcrdy.foreach { out =>
-          out := source.io.lcrdy
+          out <> source.io.lcrdy
         }
          io.chi <> source.io.async
       case None =>

--- a/src/main/scala/xiangshan/XSTileWrap.scala
+++ b/src/main/scala/xiangshan/XSTileWrap.scala
@@ -196,6 +196,7 @@ class XSTileWrap()(implicit p: Parameters) extends LazyModule
       case None =>
         require(enableCHI)
         io.chi <> tile.module.io.chi.get
+        tile.module.io.lcrdy.foreach { out => out := true.B }
     }
 
     withClockAndReset(clock, reset_sync) {


### PR DESCRIPTION
This PR includes following changes:
- https://github.com/OpenXiangShan/CoupledL2/pull/508
- https://github.com/OpenXiangShan/CoupledL2/pull/510
- https://github.com/OpenXiangShan/CoupledL2/pull/512

Add a parameter "txSourceReady" to control the Option IO LCrdy which allows AsyncBridge to correctly propagate back-pressure while maintaining copatibility with existing design

Add low power handshake signals with Sink: QREQ/QACTIVE/QACCEPTn