### PR TITLE
fix(LSU): fix stuck caused by vector misaligned store

### DIFF
--- a/src/main/scala/xiangshan/mem/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/Bundles.scala
@@ -93,7 +93,7 @@ object Bundles {
     val vecBaseVaddr = UInt(VAddrBits.W)
     val vecVaddrOffset = UInt(VAddrBits.W)
     val vecTriggerMask = UInt((VLEN/8).W)
-    val splitIndx = UInt(flowIdxBits.W)
+    val splitIndex = UInt(flowIdxBits.W)
     // 1: vector active element or scala mem operation, 0: vector not active element
     val vecActive = Bool()
     // val flowPtr             = new VlflowPtr() // VLFlowQueue ptr

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1615,10 +1615,10 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vsSplit(i).io.vstd.get := DontCare // Todo: Discuss how to pass vector store data
 
     vsSplit(i).io.vstdMisalign.get.storeMisalignBufferEmpty  := storeMisalignBuffer.io.toVecSplit.empty
-    vsSplit(i).io.vstdMisalign.get.storeMisalignBufferRobIdx := storeMisalignBuffer.io.toVecSplit.robIdx
-    vsSplit(i).io.vstdMisalign.get.storeMisalignBufferUopIdx := storeMisalignBuffer.io.toVecSplit.uopIdx
-    vsSplit(i).io.vstdMisalign.get.storePipeEmpty := !storeUnits.map(_.io.s0_s1_s2_valid).reduce(_||_)
-    storeUnits(i).io.vecMisalignBlockScalaIssue := vsSplit(i).io.vstdMisalign.get.blockScalaIssue
+    vsSplit(i).io.vstdMisalign.get.scalaIssueValid := storeUnits(i).io.stin.valid
+    vsSplit(i).io.vstdMisalign.get.scalaIssueRobIdx := storeUnits(i).io.stin.bits.uop.robIdx
+    vsSplit(i).io.vstdMisalign.get.storePipeEmpty := !storeUnits.map(_.io.s1_s2_valid).reduce(_||_)
+    storeUnits(i).io.vecMisalignBlockScalaIssue := vsSplit.map(_.io.vstdMisalign.get.blockScalaIssue).reduce(_||_)
 
   }
   (0 until VlduCnt).foreach{i =>

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
@@ -597,7 +597,7 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
   io.vecWriteBack.bits.vstart               := req.uop.vpu.vstart
   io.vecWriteBack.bits.vecTriggerMask       := req.vecTriggerMask
   io.vecWriteBack.bits.nc                   := globalNC
-  io.vecWriteBack.bits.splitIndx            := DontCare
+  io.vecWriteBack.bits.splitIndex            := DontCare
 
 
   val flush = req_valid && req.uop.robIdx.needFlush(io.redirect)

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -638,7 +638,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
       wb.bits.vstart            := req.uop.vpu.vstart
       wb.bits.vecTriggerMask    := 0.U
       wb.bits.nc                := globalNC
-      wb.bits.splitIndx         := req.splitIndx
+      wb.bits.splitIndex         := req.splitIndex
     }
   }
 

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -37,8 +37,6 @@ import xiangshan.cache.wpu.ReplayCarry
 
 class MisBuffertoVecSplitIO(implicit p: Parameters) extends XSBundle {
   val empty  = Bool()
-  val robIdx = new RobPtr
-  val uopIdx = UopIdx()
 }
 class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   with HasCircularQueuePtrHelper
@@ -199,8 +197,6 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
   }
 
   io.toVecSplit.empty  := !req_valid
-  io.toVecSplit.robIdx := req.uop.robIdx
-  io.toVecSplit.uopIdx := req.uop.uopIdx
 
   //logic
   val splitStoreReqs = RegInit(VecInit(List.fill(maxSplitNum)(0.U.asTypeOf(new LsPipelineBundle))))

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1845,7 +1845,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.vecldout.bits.vstart := s3_vecout.vstart
   io.vecldout.bits.vecTriggerMask := s3_vecout.vecTriggerMask
   io.vecldout.bits.nc := DontCare
-  io.vecldout.bits.splitIndx := DontCare
+  io.vecldout.bits.splitIndex := DontCare
 
   io.vecldout.valid := s3_out.valid && !s3_out.bits.uop.robIdx.needFlush(io.redirect) && s3_vecout.isvec && !s3_mis_align && !s3_frm_mabuf //||
   // TODO: check this, why !io.lsq.uncache.bits.isVls before?

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -181,9 +181,9 @@ class StoreUnit(implicit p: Parameters) extends XSModule
     "b10".U -> 3.U,
     "b11".U -> 7.U
   )) + s0_addr_low
-  val s0_rs_corss16Bytes = s0_addr_Up_low(4) =/= s0_addr_low(4)
-  val s0_misalignWith16Byte = !s0_rs_corss16Bytes && !s0_addr_aligned && !s0_use_flow_prf
-  val s0_misalignNeedReplay = s0_rs_corss16Bytes && !(s0_uop.sqIdx === io.sqCommitPtr || s0_uop.robIdx === io.sqCommitRobIdx && s0_uop.uopIdx === io.sqCommitUopIdx)
+  val s0_rs_cross16Bytes = s0_addr_Up_low(4) =/= s0_addr_low(4)
+  val s0_misalignWith16Byte = !s0_rs_cross16Bytes && !s0_addr_aligned && !s0_use_flow_prf
+  val s0_misalignNeedReplay = s0_rs_cross16Bytes && !(s0_uop.sqIdx === io.sqCommitPtr || s0_uop.robIdx === io.sqCommitRobIdx && s0_uop.uopIdx === io.sqCommitUopIdx)
   s0_is128bit := Mux(s0_use_flow_ma, io.misalign_stin.bits.is128bit, is128Bit(s0_vecstin.alignedType) || s0_misalignWith16Byte)
 
   s0_fullva := Mux(
@@ -251,7 +251,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   s0_out.uop          := s0_uop
   s0_out.miss         := false.B
   // For unaligned, we need to generate a base-aligned mask in storeunit and then do a shift split in StoreQueue.
-  s0_out.mask         := Mux(s0_rs_corss16Bytes && !s0_addr_aligned, genBasemask(s0_saddr,s0_alignType(1,0)), s0_mask)
+  s0_out.mask         := Mux(s0_rs_cross16Bytes && !s0_addr_aligned, genBasemask(s0_saddr,s0_alignType(1,0)), s0_mask)
   s0_out.isFirstIssue := s0_isFirstIssue
   s0_out.isHWPrefetch := s0_use_flow_prf
   s0_out.wlineflag    := s0_wlineflag

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -75,7 +75,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
     val sqCommitUopIdx = Input(UopIdx())
     val sqCommitRobIdx = Input(new RobPtr)
 
-    val s0_s1_s2_valid = Output(Bool())
+    val s1_s2_valid = Output(Bool())
     val vecMisalignBlockScalaIssue = Input(Bool())
 
   })
@@ -89,7 +89,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   // stage 0
   // --------------------------------------------------------------------------------
   // generate addr, use addr to query DCache and DTLB
-  val s0_iss_valid        = io.stin.valid && !io.vecMisalignBlockScalaIssue
+  val s0_iss_valid        = io.stin.valid
   val s0_prf_valid        = io.prefetch_req.valid && io.dcache.req.ready
   val s0_vec_valid        = io.vecstin.valid
   val s0_ma_st_valid      = io.misalign_stin.valid
@@ -183,7 +183,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   )) + s0_addr_low
   val s0_rs_corss16Bytes = s0_addr_Up_low(4) =/= s0_addr_low(4)
   val s0_misalignWith16Byte = !s0_rs_corss16Bytes && !s0_addr_aligned && !s0_use_flow_prf
-  val s0_misalignNeedReplay = (s0_use_flow_vec || s0_rs_corss16Bytes) && !(s0_uop.sqIdx === io.sqCommitPtr || s0_uop.robIdx === io.sqCommitRobIdx && s0_uop.uopIdx === io.sqCommitUopIdx)
+  val s0_misalignNeedReplay = s0_rs_corss16Bytes && !(s0_uop.sqIdx === io.sqCommitPtr || s0_uop.robIdx === io.sqCommitRobIdx && s0_uop.uopIdx === io.sqCommitUopIdx)
   s0_is128bit := Mux(s0_use_flow_ma, io.misalign_stin.bits.is128bit, is128Bit(s0_vecstin.alignedType) || s0_misalignWith16Byte)
 
   s0_fullva := Mux(
@@ -566,7 +566,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.prefetch_train.bits.hasException := false.B
 
   // for misalign in vsMergeBuffer
-  io.s0_s1_s2_valid := s0_valid || s1_valid || s2_valid
+  io.s1_s2_valid := s1_valid || s2_valid
 
   // Pipeline
   // --------------------------------------------------------------------------------

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -135,7 +135,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s0_alignedType  = s0_vecstin.alignedType
   val s0_mBIndex      = s0_vecstin.mBIndex
   val s0_vecBaseVaddr = s0_vecstin.basevaddr
-  val s0_vecSplitIdx = s0_vecstin.splitIndx
+  val s0_vecSplitIdex = s0_vecstin.splitIndex
   val s0_isFinalSplit = io.misalign_stin.valid && io.misalign_stin.bits.isFinalSplit
 
   // generate addr
@@ -270,7 +270,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   }
   s0_out.isFrmMisAlignBuf := s0_use_flow_ma
   s0_out.isFinalSplit := s0_isFinalSplit
-  s0_out.splitIndx := s0_vecSplitIdx
+  s0_out.splitIndex := s0_vecSplitIdex
 //  s0_out.uop.exceptionVec(storeAddrMisaligned) := Mux(s0_use_non_prf_flow, (!s0_addr_aligned || s0_vecstin.uop.exceptionVec(storeAddrMisaligned) && s0_vecActive), false.B) && !s0_misalignWith16Byte
 
   io.st_mask_out.valid       := s0_use_flow_rs || s0_use_flow_vec
@@ -627,7 +627,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
       sx_in(i).gpaddr      := s3_in.gpaddr
       sx_in(i).isForVSnonLeafPTE     := s3_in.isForVSnonLeafPTE
       sx_in(i).vecTriggerMask := s3_in.vecTriggerMask
-      sx_in(i).splitIndx := s3_in.splitIndx
+      sx_in(i).splitIndx := s3_in.splitIndex
       sx_in(i).hasException := s3_exception
       sx_in_vec(i)         := s3_in.isvec
       sx_ready(i) := !s3_valid(i) || sx_in(i).output.uop.robIdx.needFlush(io.redirect) || (if (RAWTotalDelayCycles == 0) io.stout.ready else sx_ready(i+1))
@@ -678,7 +678,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.vecstout.bits.isForVSnonLeafPTE     := sx_last_in.isForVSnonLeafPTE
   io.vecstout.bits.vstart      := sx_last_in.output.uop.vpu.vstart
   io.vecstout.bits.vecTriggerMask := sx_last_in.vecTriggerMask
-  io.vecstout.bits.splitIndx := sx_last_in.splitIndx
+  io.vecstout.bits.splitIndex := sx_last_in.splitIndx
   // io.vecstout.bits.reg_offset.map(_ := DontCare)
   // io.vecstout.bits.elemIdx.map(_ := sx_last_in.elemIdx)
   // io.vecstout.bits.elemIdxInsideVd.map(_ := DontCare)

--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -326,7 +326,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
         when(!io.fromPipeline(i).bits.hit && !isUnitStride) {
           val replayFlowNumOffset = PopCount(mergePortMatrixMiss(i))
           val replayFlowMask = (0 until pipeWidth).map{case i => (0 until pipeWidth).map{case j =>
-            UIntToOH(io.fromPipeline(i).bits.splitIndx, VLENB) & Fill(VLENB, mergePortMatrix(i)(j))
+            UIntToOH(io.fromPipeline(j).bits.splitIndex, VLENB) & Fill(VLENB, mergePortMatrixMiss(i)(j))
           }.reduce(_ | _)}
 
           entries(latchWbIndex).replayFlowNum := entries(latchWbIndex).replayFlowNum + replayFlowNumOffset

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -471,13 +471,10 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
 }
 
 class VSSplitBufferImp(implicit p: Parameters) extends VSplitBuffer(isVStore = true){
-  lazy val canToMisalignBuffer = io.vstdMisalign.get.storeMisalignBufferEmpty ||
-    io.vstdMisalign.get.storeMisalignBufferRobIdx > io.out.bits.uop.robIdx ||
-    io.vstdMisalign.get.storeMisalignBufferRobIdx === io.out.bits.uop.robIdx &&
-      io.vstdMisalign.get.storeMisalignBufferUopIdx > io.out.bits.uop.uopIdx
+  lazy val canToMisalignBuffer = io.vstdMisalign.get.storeMisalignBufferEmpty &&
+    (!io.vstdMisalign.get.scalaIssueValid || io.vstdMisalign.get.scalaIssueRobIdx < issueUop.robIdx)
 
   override lazy val misalignedCanGo = io.vstdMisalign.get.storePipeEmpty && canToMisalignBuffer
-
 
   // split data
   val splitData = genVSData(

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -408,7 +408,7 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
     x.uop_unit_stride_fof   := DontCare
     x.isFirstIssue          := DontCare
     x.mBIndex               := issueMbIndex
-    x.splitIndx             := splitIdx
+    x.splitIndex             := splitIdx
   }
 
   // redirect

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -143,7 +143,7 @@ class VecPipelineFeedbackIO(isVStore: Boolean=false) (implicit p: Parameters) ex
   val reg_offset           = OptionWrapper(!isVStore, UInt(vOffsetBits.W))
   val elemIdxInsideVd      = OptionWrapper(!isVStore, UInt(elemIdxBits.W)) // element index in scope of vd
   val vecdata              = OptionWrapper(!isVStore, UInt(VLEN.W))
-  val splitIndx            = UInt(flowIdxBits.W)
+  val splitIndex            = UInt(flowIdxBits.W)
 }
 
 class VecPipeBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle {
@@ -164,7 +164,7 @@ class VecPipeBundle(isVStore: Boolean=false)(implicit p: Parameters) extends VLS
   val mBIndex             = if(isVStore) UInt(vsmBindexBits.W) else UInt(vlmBindexBits.W)
   val elemIdx             = UInt(elemIdxBits.W)
   val elemIdxInsideVd     = UInt(elemIdxBits.W) // only use in unit-stride
-  val splitIndx           = UInt(flowIdxBits.W)
+  val splitIndex           = UInt(flowIdxBits.W)
 }
 
 object VecFeedbacks {

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -233,8 +233,8 @@ class FeedbackToLsqIO(implicit p: Parameters) extends VLSUBundle{
 class storeMisaignIO(implicit p: Parameters) extends Bundle{
   val storePipeEmpty            = Input(Bool())
   val storeMisalignBufferEmpty  = Input(Bool())
-  val storeMisalignBufferRobIdx = Input(new RobPtr)
-  val storeMisalignBufferUopIdx = Input(UopIdx())
+  val scalaIssueValid           = Input(Bool())
+  val scalaIssueRobIdx          = Input(new RobPtr)
   val blockScalaIssue           = Output(Bool())
 
 }


### PR DESCRIPTION
**Bug Symptom:** The system freezes during a misaligned vector store.

**Cause Analysis:** Previously, vector misaligned stores required the pipeline to be empty to ensure that once an element entered the pipeline, it would definitely reach the store misalign buffer and complete execution without being reissued. This is because reissuance of vector stores was previously performed at the UOP granularity. If it could not be guaranteed that a vector misaligned element would complete execution after entering the pipeline, ping-ponging and deadlocks could occur. Therefore, we used the `blockScaleIssue` signal to prevent scalar stores from being issued. However, since there are two store units and one store misalign buffer, we cannot block just one store unit; we must block both store units simultaneously to ensure that misaligned elements entering a store unit will definitely reach the store misalign buffer.

**Fix:** Propagate the `blockScaleIssue` signal to both store units.

---

We also addressed some naming issues.