### PR TITLE
adjusting CMO execution and misalign exception

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -834,6 +834,8 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   val cmoOpCode = uncacheUop.fuOpType(1, 0)
   val mmioDoReq = io.uncache.req.fire && !io.uncache.req.bits.nc
   val cboMmioPAddr = Reg(UInt(PAddrBits.W))
+  val cboZeroOffset = RegInit(0.U(log2Ceil(CacheLineSize/XLEN).W))
+  val mmioIsCboZero = LSUOpType.isCboZero(uop(deqPtr).fuOpType) // pbmt mmio/nc
   switch(mmioState) {
     is(s_idle) {
       when(RegNext(io.rob.pendingst && uop(deqPtr).robIdx === io.rob.pendingPtr && pending(deqPtr) && allocated(deqPtr) && datavalid(deqPtr) && addrvalid(deqPtr) && !hasException(deqPtr))) {
@@ -842,7 +844,8 @@ class StoreQueue(implicit p: Parameters) extends XSModule
         uncacheUop.exceptionVec := 0.U.asTypeOf(ExceptionVec())
         uncacheUop.trigger := 0.U.asTypeOf(TriggerAction())
         cboFlushedSb := false.B
-        cboMmioPAddr := paddrModule.io.rdata(0)
+        cboMmioPAddr := get_block_addr(paddrModule.io.rdata(0))
+        cboZeroOffset := 0.U
       }
     }
     is(s_req) {
@@ -853,16 +856,23 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     }
     is(s_resp) {
       when(io.uncache.resp.fire && !io.uncache.resp.bits.nc) {
-        noPending := true.B
-        mmioState := s_wb
+        when (!mmioIsCboZero) {
+          noPending := true.B
+          mmioState := s_wb
+        }.otherwise {
+          cboZeroOffset := cboZeroOffset + 1.U
+          mmioState := Mux(cboZeroOffset.andR, s_wb, s_req)
+        }
 
         when (io.uncache.resp.bits.denied || io.cmoOpResp.bits.denied) {
           uncacheUop.exceptionVec(storeAccessFault) := true.B
+          mmioState := s_wb
         }
 
         when (io.uncache.resp.bits.corrupt && !io.uncache.resp.bits.denied ||
               io.cmoOpResp.bits.corrupt && !io.cmoOpResp.bits.denied) {
           uncacheUop.exceptionVec(hardwareError) := true.B
+          mmioState := s_wb
         }
       }
     }
@@ -886,10 +896,10 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   mmioReq.valid := mmioState === s_req && !LSUOpType.isCbo(uop(deqPtr).fuOpType) && !io.wfi.wfiReq
   mmioReq.bits := DontCare
   mmioReq.bits.cmd  := MemoryOpConstants.M_XWR
-  mmioReq.bits.addr := paddrModule.io.rdata(0) // data(deqPtr) -> rdata(0)
-  mmioReq.bits.vaddr:= vaddrModule.io.rdata(0)
-  mmioReq.bits.data := shiftDataToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).data)
-  mmioReq.bits.mask := shiftMaskToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).mask)
+  mmioReq.bits.addr := Mux(mmioIsCboZero, cboMmioPAddr + (cboZeroOffset << 3), paddrModule.io.rdata(0)) // data(deqPtr) -> rdata(0)
+  mmioReq.bits.vaddr:= Mux(mmioIsCboZero, get_block_addr(vaddrModule.io.rdata(0)).asUInt + (cboZeroOffset << 3), vaddrModule.io.rdata(0))
+  mmioReq.bits.data := Mux(mmioIsCboZero, 0.U, shiftDataToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).data))
+  mmioReq.bits.mask := Mux(mmioIsCboZero, 0xFF.U, shiftMaskToLow(paddrModule.io.rdata(0), dataModule.io.rdata(0).mask))
   mmioReq.bits.robIdx := uop(GatedRegNext(rdataPtrExtNext(0)).value).robIdx
   mmioReq.bits.memBackTypeMM := memBackTypeMM(GatedRegNext(rdataPtrExtNext(0)).value)
   mmioReq.bits.nc := false.B
@@ -913,7 +923,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     is(nc_idle) {
       when(
         nc(rptr0) && allocated(rptr0) && !completed(rptr0) && committed(rptr0) &&
-        allvalid(rptr0) && !isVec(rptr0) && !hasException(rptr0) && !mmio(rptr0)
+        allvalid(rptr0) && !isVec(rptr0) && !hasException(rptr0) && !mmio(rptr0) && !LSUOpType.isCboAll(uop(rptr0).fuOpType)
       ) {
         ncState := nc_req
         ncWaitRespPtrReg := rptr0
@@ -972,11 +982,11 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
   // CBO op type check can be delayed for 1 cycle,
   // as uncache op will not start in s_idle
-  val cboMmioAddr = get_block_addr(cboMmioPAddr)
-  val deqCanDoCbo = GatedRegNext(LSUOpType.isCbo(uop(deqPtr).fuOpType) && allocated(deqPtr) && addrvalid(deqPtr) && !hasException(deqPtr))
+  val deqCanDoCbo = GatedRegNext(LSUOpType.isCbo(uop(deqPtr).fuOpType) && allocated(deqPtr) && addrvalid(deqPtr) && !hasException(deqPtr)) && memBackTypeMM(deqPtr)
 
   val isCboZeroToSbVec = (0 until EnsbufferWidth).map{ i =>
-    io.sbuffer(i).fire && io.sbuffer(i).bits.vecValid && io.sbuffer(i).bits.wline && allocated(dataBuffer.io.deq(i).bits.sqPtr.value)
+    io.sbuffer(i).fire && io.sbuffer(i).bits.vecValid && io.sbuffer(i).bits.wline &&
+    allocated(dataBuffer.io.deq(i).bits.sqPtr.value) && memBackTypeMM(dataBuffer.io.deq(i).bits.sqPtr.value)
   }
   val cboZeroToSb        = isCboZeroToSbVec.reduce(_ || _)
   val cboZeroFlushSb     = GatedRegNext(cboZeroToSb)
@@ -1012,7 +1022,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
   io.cmoOpReq.valid := deqCanDoCbo && cboFlushedSb && (mmioState === s_req) && !io.wfi.wfiReq
   io.cmoOpReq.bits.opcode  := cmoOpCode
-  io.cmoOpReq.bits.address := cboMmioAddr
+  io.cmoOpReq.bits.address := cboMmioPAddr
 
   io.cmoOpResp.ready := deqCanDoCbo && (mmioState === s_resp)
 
@@ -1398,7 +1408,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     val cmoInvalEvent = DifftestModule(new DiffCMOInvalEvent)
     cmoInvalEvent.coreid := io.hartId
     cmoInvalEvent.valid := io.mmioStout.fire && deqCanDoCbo && LSUOpType.isCboInval(uop(deqPtr).fuOpType)
-    cmoInvalEvent.addr := cboMmioAddr
+    cmoInvalEvent.addr := cboMmioPAddr
 
     // DiffStoreEvent happens when rdataPtr moves.
     // That is, pmsStore enter dataBuffer or ncStore enter Ubuffer

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1173,6 +1173,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s2_trigger_debug_mode = RegEnable(s1_trigger_debug_mode, false.B, s1_fire)
   val s2_nc_with_data = RegNext(s1_nc_with_data)
   val s2_mmio_req = Wire(Valid(new MemExuOutput))
+  val s2_tlb_hit = RegNext(s1_tlb_hit)
   s2_mmio_req.valid := RegNextN(io.lsq.uncache.fire, 2, Some(false.B))
   s2_mmio_req.bits  := RegNextN(io.lsq.uncache.bits, 2)
 
@@ -1209,6 +1210,10 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   )
   // This real physical address is located in uncache space.
   val s2_actually_uncache = !s2_in.tlbMiss && !s2_un_access_exception && Pbmt.isPMA(s2_pbmt) && (s2_pmp.mmio && !s2_pmp.ld) || s2_in.nc || s2_in.mmio
+  val s2_actually_mmio = !s2_in.tlbMiss && !s2_un_access_exception && Pbmt.isPMA(s2_pbmt) && !s2_pmp.st && s2_pmp.mmio
+  val s2_actually_all_mmio = !s2_in.tlbMiss && !s2_un_access_exception && (Pbmt.isPMA(s2_pbmt) && !s2_pmp.st && s2_pmp.mmio || s2_in.mmio)
+  val s2_actually_pbmt_nc = !s2_in.tlbMiss && !s2_un_access_exception && s2_in.nc
+  val s2_actually_pbmt_mmio = !s2_in.tlbMiss && !s2_un_access_exception && s2_in.mmio
   val s2_uncache = !s2_prf && s2_actually_uncache
   val s2_memBackTypeMM = !s2_pmp.mmio
   when (!s2_in.delayedLoadError) {
@@ -1239,7 +1244,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   // * ecc data error is slow to generate, so we will not use it until load stage 3
   // * in load stage 3, an extra signal io.load_error will be used to
   // * if pbmt =/= 0, mmio is up to pbmt; otherwise, it's up to pmp
-  val s2_tlb_hit = RegNext(s1_tlb_hit)
   val s2_mmio = !s2_prf &&
     !s2_exception && !s2_in.tlbMiss &&
     Mux(Pbmt.isUncache(s2_pbmt), s2_in.mmio, s2_tlb_hit && s2_pmp.mmio)
@@ -1334,11 +1338,12 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   // Here a judgement is made as to whether a misaligned exception needs to actually be generated.
   // We will generate misaligned exceptions at mmio.
   val s2_real_exceptionVec = WireInit(s2_exception_vec)
-  s2_real_exceptionVec(loadAddrMisaligned) := (s2_out.isMisalign || s2_out.isFrmMisAlignBuf) && s2_uncache && !s2_isvec && !s2_prf
+  s2_real_exceptionVec(loadAddrMisaligned) := (s2_out.isMisalign || s2_out.isFrmMisAlignBuf) && s2_actually_pbmt_nc && !s2_isvec && !s2_prf
   s2_real_exceptionVec(loadAccessFault) := (s2_exception_vec(loadAccessFault) ||
     s2_fwd_frm_d_chan && s2_d_denied ||
-    s2_fwd_data_valid && s2_fwd_frm_mshr && s2_mshr_denied) && !s2_prf
-  s2_real_exceptionVec(hardwareError) := (s2_exception_vec(hardwareError) ||
+    s2_fwd_data_valid && s2_fwd_frm_mshr && s2_mshr_denied) && !s2_prf ||
+    (s2_out.isMisalign || s2_out.isFrmMisAlignBuf) && s2_actually_all_mmio
+    s2_real_exceptionVec(hardwareError) := (s2_exception_vec(hardwareError) ||
     s2_fwd_frm_d_chan && s2_d_corrupt && !s2_d_denied ||
     s2_fwd_data_valid && s2_fwd_frm_mshr && s2_mshr_corrupt && !s2_mshr_denied) && !s2_prf
 

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -493,9 +493,10 @@ class StoreUnit(implicit p: Parameters) extends XSModule
                                                 s2_pmp.st ||
                                                 s2_pmp.ld && s2_isCbo_noZero || // cmo need read permission but produce store exception
                                                 (s2_in.isvec && s2_actually_uncache) ||
+                                                s2_actually_all_mmio && (s2_in.isMisalign || s2_in.isFrmMisAlignBuf) ||
                                                 s2_actually_mmio && s2_isCbo
                                                 ) && s2_vecActive
-  s2_out.uop.exceptionVec(storeAddrMisaligned) := s2_actually_uncache && !s2_in.isvec && (s2_in.isMisalign || s2_in.isFrmMisAlignBuf) && !s2_un_misalign_exception
+  s2_out.uop.exceptionVec(storeAddrMisaligned) := s2_actually_pbmt_nc && !s2_in.isvec && (s2_in.isMisalign || s2_in.isFrmMisAlignBuf) && !s2_un_misalign_exception
   s2_out.uop.vpu.vstart     := s2_in.vecVaddrOffset >> s2_in.uop.vpu.veew
 
   // kill dcache write intent request when mmio or exception

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -474,7 +474,12 @@ class StoreUnit(implicit p: Parameters) extends XSModule
     s2_in.uop.exceptionVec(storeGuestPageFault)
   )
   // This real physical address is located in uncache space.
-  val s2_actually_uncache = s2_tlb_hit && !s2_un_access_exception && (Pbmt.isPMA(s2_pbmt) && !s2_pmp.st && s2_pmp.mmio || s2_in.nc || s2_in.mmio) && RegNext(s1_feedback.bits.hit)
+  val s2_actually_uncache = s2_tlb_hit && !s2_un_access_exception && (Pbmt.isPMA(s2_pbmt) && !s2_pmp.st && s2_pmp.mmio || s2_in.nc || s2_in.mmio)
+  val s2_actually_mmio = s2_tlb_hit && !s2_un_access_exception && Pbmt.isPMA(s2_pbmt) && !s2_pmp.st && s2_pmp.mmio
+  val s2_actually_all_mmio = s2_tlb_hit && !s2_un_access_exception && (Pbmt.isPMA(s2_pbmt) && !s2_pmp.st && s2_pmp.mmio || s2_in.mmio)
+  val s2_actually_pbmt_nc = s2_tlb_hit && !s2_un_access_exception && s2_in.nc
+  val s2_is_actually_pbmt_mmio = s2_tlb_hit && !s2_un_access_exception && s2_in.mmio
+
   val s2_isCbo  = RegEnable(s1_isCbo, s1_fire) // all cbo instr
   val s2_isCbo_noZero = LSUOpType.isCbo(s2_in.uop.fuOpType)
 
@@ -487,7 +492,8 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   s2_out.uop.exceptionVec(storeAccessFault) := (s2_in.uop.exceptionVec(storeAccessFault) ||
                                                 s2_pmp.st ||
                                                 s2_pmp.ld && s2_isCbo_noZero || // cmo need read permission but produce store exception
-                                                ((s2_in.isvec || s2_isCbo) && s2_actually_uncache && RegNext(s1_feedback.bits.hit))
+                                                (s2_in.isvec && s2_actually_uncache) ||
+                                                s2_actually_mmio && s2_isCbo
                                                 ) && s2_vecActive
   s2_out.uop.exceptionVec(storeAddrMisaligned) := s2_actually_uncache && !s2_in.isvec && (s2_in.isMisalign || s2_in.isFrmMisAlignBuf) && !s2_un_misalign_exception
   s2_out.uop.vpu.vstart     := s2_in.vecVaddrOffset >> s2_in.uop.vpu.veew

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -594,6 +594,7 @@ package object xiangshan {
     def isCboClean(op: UInt): Bool = isCbo(op) && (op(3, 0) === cbo_clean)
     def isCboFlush(op: UInt): Bool = isCbo(op) && (op(3, 0) === cbo_flush)
     def isCboInval(op: UInt): Bool = isCbo(op) && (op(3, 0) === cbo_inval)
+    def isCboZero(op:UInt): Bool = op(3,0) === cbo_zero
 
     // atomics
     // bit(1, 0) are size


### PR DESCRIPTION
**Since these two commits are related in terms of the code, I’ve included them in the same pull request, but they represent two separate changes.**

---

### 1.
**Bug Symptom:** 
The cache-block management instructions do not conform to the definition in the manual.

**Cause Analysis:** 
The manual was updated in January 2026, explicitly stating that cache-block management instructions should ignore the PBMT attribute:
> Cache-block management instructions ignore cacheability attributes and operate on the cache block irrespective of the PMA cacheable attribute and any Page-Based Memory Type (PBMT) downgrade from cacheable to non-cacheable.

This requires us to update our implementation. Previously, when executing cache-block management instructions, encountering a `pbmt nc/io` condition would trigger a SAF. 

**Fix:** 
Following the update, we will no longer trigger a SAF in such situations; instead, the instructions will execute normally.
Additionally, the `cbo.zero` instruction will be executed when the `pmp` attribute is set to `memory` (cacheable), even if its memory attribute is overridden by PBMT.

---

### 2.
**Bug Symptom:** 
Exceptions caused by misaligned accesses in uncacheable regions do not match the manual.

**Cause Analysis:** 
I had overlooked that description in the manual earlier:
> Non-idempotent regions might not support misaligned accesses. Misaligned accesses to such regions should raise access-fault exceptions rather than address-misaligned exceptions, indicating that software should not emulate the misaligned access using multiple smaller accesses, which could cause unexpected side effects.

**Fix:** 
Performing misaligned memory accesses in non-idempotent regions will result in an AF exception, whereas doing so in idempotent regions will result in an AM exception.