### PR TITLE
fix(AtomicsUnit): cache error no longer persisted

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -387,11 +387,11 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
       ))
     )
 
-    when (dcache_resp_tl_error.asUInt.orR && io.csrCtrl.cache_error_enable) {
-      exceptionVec(loadAccessFault)  := isLr && dcache_resp_tl_error.tl_denied
-      exceptionVec(storeAccessFault) := !isLr && dcache_resp_tl_error.tl_denied
-      exceptionVec(hardwareError)    := dcache_resp_tl_error.tl_corrupt && !dcache_resp_tl_error.tl_denied
-    }
+    val canTriggerCacheError = dcache_resp_tl_error.asUInt.orR && io.csrCtrl.cache_error_enable
+
+    exceptionVec(loadAccessFault)  := canTriggerCacheError && isLr && dcache_resp_tl_error.tl_denied
+    exceptionVec(storeAccessFault) := canTriggerCacheError && !isLr && dcache_resp_tl_error.tl_denied
+    exceptionVec(hardwareError)    := canTriggerCacheError && dcache_resp_tl_error.tl_corrupt && !dcache_resp_tl_error.tl_denied
 
     resp_data := resp_data_wire
     state := s_finish


### PR DESCRIPTION
**Bug Symptom:** 
The cache error is incorrectly cached in the `amounit`, which causes subsequent normal amo instructions to trigger a cache error as well.

**Cause Analysis:** 
This was caused by an incorrect implementation. In `amounit`, the exception message is stored in a register. 
We do not clear this register during state machine initialization, so we always need to update it, regardless of whether a cache error occurs. The previous incorrect implementation would only set this register when a cache error occurred, but would not clear it when no error occurred, which led to the issue.

**Fix:** 
Instead of using `when` to set the bit, we directly use combinational logic for the assignment; if a cache error occurs, the bit is set; otherwise, it is cleared.