### PR TITLE
timing(Phr): fix s1 phr timing

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -495,16 +495,32 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val s3_foldedPhr   = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)))
   private val trainFoldedPhr = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)))
 
-  phr.io.train.s0_stall      := s0_stall
-  phr.io.train.stageCtrl     := stageCtrl
-  phr.io.train.redirect      := redirect
-  phr.io.train.s3_override   := s3_override
-  phr.io.train.s3_phrMeta    := s3_phrMeta
-  phr.io.train.s3_prediction := s3_prediction
-  phr.io.train.s3_startPc    := s3_startPc
-  phr.io.train.s1_valid      := s1_fire
-  phr.io.train.s1_prediction := s1_prediction
-  phr.io.train.s1_startPc    := s1_startPc
+  private val s1_ubtbPredWithURas = WireInit(ubtb.io.prediction)
+  when(s1_ubtbPredWithURas.valid && s1_ubtbPredWithURas.bits.attribute.isReturn && uras.io.specOut.isCanUse) {
+    s1_ubtbPredWithURas.bits.target := uras.io.specOut.retTarget
+  }
+
+  private val s1_abtbPredWithURas = WireInit(abtb.io.prediction)
+  s1_abtbPredWithURas.foreach {
+    case p => when(p.valid && p.bits.attribute.isReturn && uras.io.specOut.isCanUse) {
+        p.bits.target := uras.io.specOut.retTarget
+      }
+  }
+
+  phr.io.train.s0_stall             := s0_stall
+  phr.io.train.stageCtrl            := stageCtrl
+  phr.io.train.redirect             := redirect
+  phr.io.train.s3_override          := s3_override
+  phr.io.train.s3_phrMeta           := s3_phrMeta
+  phr.io.train.s3_prediction        := s3_prediction
+  phr.io.train.s3_startPc           := s3_startPc
+  phr.io.s1Train.valid              := s1_fire
+  phr.io.s1Train.taken              := s1_prediction.taken
+  phr.io.s1Train.startPc            := s1_startPc
+  phr.io.s1Train.abtbValid          := s1_abtbValid
+  phr.io.s1Train.abtbFirstTakenBrOH := s1_abtbFirstTakenBrOH
+  phr.io.s1Train.ubtbPrediction     := s1_ubtbPredWithURas
+  phr.io.s1Train.abtbPrediction     := s1_abtbPredWithURas
 
   phr.io.commit.valid := io.fromFtq.train.fire
   phr.io.commit.bits  := train

--- a/src/main/scala/xiangshan/frontend/bpu/history/phr/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/phr/Bundles.scala
@@ -42,13 +42,27 @@ object PhrPtr {
     apply(!ptr.flag, ptr.value)
 }
 
+class S1Train(implicit p: Parameters) extends PhrBundle with HasPhrParameters {
+  val valid:              Bool                   = Bool()
+  val taken:              Bool                   = Bool() // actual s1_taken
+  val startPc:            PrunedAddr             = PrunedAddr(VAddrBits)
+  val abtbValid:          Bool                   = Bool()
+  val abtbFirstTakenBrOH: Vec[Bool]              = Vec(NumAheadBtbPredictionEntries, Bool())
+  val ubtbPrediction:     Valid[Prediction]      = Valid(new Prediction)
+  val abtbPrediction:     Vec[Valid[Prediction]] = Vec(NumAheadBtbPredictionEntries, Valid(new Prediction))
+}
+
 class PhrUpdateData(implicit p: Parameters) extends PhrBundle with HasPhrParameters {
-  val valid:     Bool                  = Bool()
-  val taken:     Bool                  = Bool()
-  val cfiPc:     PrunedAddr            = PrunedAddr(VAddrBits)
-  val target:    PrunedAddr            = PrunedAddr(VAddrBits)
-  val phrMeta:   PhrMeta               = new PhrMeta()
-  val foldedPhr: PhrAllFoldedHistories = new PhrAllFoldedHistories(AllFoldedHistoryInfo)
+  val valid:   Bool       = Bool()
+  val taken:   Bool       = Bool()
+  val cfiPc:   PrunedAddr = PrunedAddr(VAddrBits)
+  val target:  PrunedAddr = PrunedAddr(VAddrBits)
+  val phrMeta: PhrMeta    = new PhrMeta()
+}
+
+class PhrUpdateResult(implicit p: Parameters) extends PhrBundle with HasPhrParameters {
+  val phrPtr:     PhrPtr = new PhrPtr
+  val phrLowBits: UInt   = UInt(PathHashHighWidth.W)
 }
 
 class PhrUpdate(implicit p: Parameters) extends PhrBundle {
@@ -57,10 +71,6 @@ class PhrUpdate(implicit p: Parameters) extends PhrBundle {
   val stageCtrl: StageCtrl = new StageCtrl
 
   val redirect: Valid[BpuRedirect] = Valid(new BpuRedirect)
-
-  val s1_valid:      Bool       = Bool()
-  val s1_prediction: Prediction = new Prediction()
-  val s1_startPc:    PrunedAddr = PrunedAddr(VAddrBits)
 
   val s3_override:   Bool       = Bool()
   val s3_phrMeta:    PhrMeta    = new PhrMeta()

--- a/src/main/scala/xiangshan/frontend/bpu/history/phr/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/phr/Helpers.scala
@@ -62,6 +62,13 @@ trait Helpers extends HasPhrParameters with HalfAlignHelper with PhrHelper {
     hash(PathHashWidth - 1, 0)
   }
 
+  def getPathHashComponents(pc: PrunedAddr, target: PrunedAddr): (UInt, UInt) = {
+    val hash      = pathHash(pc, target)
+    val shiftBits = hash(Shamt - 1, 0)
+    val hashHigh  = hash(PathHashWidth - 1, Shamt)
+    (shiftBits, hashHigh)
+  }
+
   def computeFoldedHash(hashBits: UInt, compLen: Int)(histLen: Int): UInt =
     if (histLen > 0 && PathHashWidth >= histLen) {
       val effectiveBit = hashBits(histLen - 1, 0)
@@ -73,4 +80,47 @@ trait Helpers extends HasPhrParameters with HalfAlignHelper with PhrHelper {
       val histChunks = (0 until nChunks) map { i => hashBits(min((i + 1) * compLen, PathHashWidth) - 1, i * compLen) }
       ParallelXOR(histChunks)
     } else 0.U
+
+  def getUpdatePtrs(data: PhrUpdateData, hashHigh: UInt): PhrUpdateResult = {
+    val updateResult = WireInit(0.U.asTypeOf(new PhrUpdateResult))
+    when(data.valid) {
+      updateResult.phrPtr     := data.phrMeta.phrPtr
+      updateResult.phrLowBits := data.phrMeta.phrLowBits
+      when(data.taken) {
+        updateResult.phrPtr     := data.phrMeta.phrPtr - Shamt.U
+        updateResult.phrLowBits := hashHigh ^ data.phrMeta.phrLowBits
+      }
+    }
+    updateResult
+  }
+
+  def computeAllFoldedPhr(hist: UInt): PhrAllFoldedHistories = {
+    val foldedPhr = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)))
+    AllFoldedHistoryInfo.foreach { info =>
+      foldedPhr.getHistWithInfo(info).foldedHist :=
+        computeFoldedHist(hist, info.FoldedLength)(info.HistoryLength)
+    }
+    foldedPhr
+  }
+
+  def getNextFoldedPhr(
+      data:          PhrUpdateData,
+      baseFoldedPhr: PhrAllFoldedHistories,
+      basePhr:       UInt,
+      hashHigh:      UInt,
+      shiftBits:     UInt
+  ): PhrAllFoldedHistories = {
+    val nextFoldedPhr = WireInit(baseFoldedPhr)
+
+    when(data.taken) {
+      nextFoldedPhr := baseFoldedPhr.update(
+        VecInit(basePhr.asBools),
+        data.phrMeta.phrPtr,
+        hashHigh,
+        Shamt,
+        shiftBits
+      )
+    }
+    nextFoldedPhr
+  }
 }

--- a/src/main/scala/xiangshan/frontend/bpu/history/phr/Phr.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/phr/Phr.scala
@@ -34,7 +34,8 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
     val phr:            Vec[Bool]             = Output(Vec(PhrHistoryLength, Bool()))
     val phrMeta:        PhrMeta               = Output(new PhrMeta)
     val train:          PhrUpdate             = Input(new PhrUpdate)       // redirect from backend
-    val commit:         Valid[BpuTrain]       = Input(Valid(new BpuTrain)) // update from commit
+    val s1Train:        S1Train               = Input(new S1Train)
+    val commit:         Valid[BpuTrain]       = Input(Valid(new BpuTrain)) // trian bp data from reslove
     val trainFoldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
   }
   val io: PhrIO = IO(new PhrIO)
@@ -55,11 +56,10 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
    */
 
   private val s0_stall = io.train.s0_stall
-  private val s1_valid = io.train.s1_valid
+  private val s1_valid = io.s1Train.valid
   private val s0_fire  = io.train.stageCtrl.s0_fire
   private val s1_fire  = io.train.stageCtrl.s1_fire
   private val s2_fire  = io.train.stageCtrl.s2_fire
-  private val s3_fire  = io.train.stageCtrl.s3_fire
 
   private val histFoldedPhr = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo))) // for diff
   private val s0_foldedPhr  = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)))
@@ -72,24 +72,34 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
   private val s3_foldedPhrReg =
     RegEnable(s2_foldedPhrReg, 0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)), s2_fire)
 
-  private val s0_phrPtr    = WireInit(0.U.asTypeOf(new PhrPtr))
-  private val s0_phrPtrReg = RegEnable(s0_phrPtr, 0.U.asTypeOf(new PhrPtr), !s0_stall)
-  private val s1_phrPtr    = RegEnable(s0_phrPtr, 0.U.asTypeOf(new PhrPtr), s0_fire)
+  private val s0_phrPtr = WireInit(0.U.asTypeOf(new PhrPtr))
+  private val s1_phrPtr = RegEnable(s0_phrPtr, 0.U.asTypeOf(new PhrPtr), s0_fire)
 
-  private val s0_phrValue    = getPhr(s0_phrPtr)                       // debug use it
-  private val s0_phrRegValue = getPhr(RegEnable(s0_phrPtr, !s0_stall)) // debug use it
-  private val s1_phrValue    = getPhr(s1_phrPtr)
-  private val phrValue       = getPhr(phrPtr)
+  private val s1_phrValue = getPhr(s1_phrPtr)
+  private val phrValue    = getPhr(phrPtr)
 
-  private val redirectData    = WireInit(0.U.asTypeOf(new PhrUpdateData))
-  private val s1_overrideData = WireInit(0.U.asTypeOf(new PhrUpdateData))
-  private val s3_override     = WireInit(false.B)
-  private val s3_overrideData = WireInit(0.U.asTypeOf(new PhrUpdateData))
+  private val s1AbtbUpdateData = VecInit.fill(NumAheadBtbPredictionEntries)(0.U.asTypeOf(new PhrUpdateData))
+  private val s1UbtbUpdateData = WireInit(0.U.asTypeOf(new PhrUpdateData))
+  private val redirectData     = WireInit(0.U.asTypeOf(new PhrUpdateData))
+  private val s3_override      = WireInit(false.B)
+  private val s3_overrideData  = WireInit(0.U.asTypeOf(new PhrUpdateData))
 
-  private val updateData   = WireInit(0.U.asTypeOf(new PhrUpdateData))
-  private val updateCfiPc  = WireInit(0.U.asTypeOf(PrunedAddr(VAddrBits)))
-  private val updateTarget = WireInit(0.U.asTypeOf(PrunedAddr(VAddrBits)))
-  private val redirectPhr  = WireInit(0.U(PhrHistoryLength.W))
+  private val redirectS0PhrPtr     = WireInit(0.U.asTypeOf(new PhrPtr))
+  private val redirectS0PhrLowBits = WireInit(0.U(PathHashHighWidth.W))
+  private val redirectS0FoldedPhr  = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)))
+  private val redirectUpdate       = WireInit(0.U.asTypeOf(new PhrUpdateResult))
+  private val s3S0PhrPtr           = WireInit(0.U.asTypeOf(new PhrPtr))
+  private val s3S0PhrLowBits       = WireInit(0.U(PathHashHighWidth.W))
+  private val s3S0FoldedPhr        = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)))
+  private val s3Update             = WireInit(0.U.asTypeOf(new PhrUpdateResult))
+  private val s1S0PhrPtr           = WireInit(0.U.asTypeOf(new PhrPtr))
+  private val s1S0PhrLowBits       = WireInit(0.U(PathHashHighWidth.W))
+  private val s1S0FoldedPhr        = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)))
+  private val s1Update             = WireInit(0.U.asTypeOf(new PhrUpdateResult))
+  private val updatePhrLowBits     = WireInit(0.U(PathHashHighWidth.W))
+  private val redirectPhr          = WireInit(0.U(PhrHistoryLength.W))
+
+  // Organize the input data into the structure required for PHR updates
 
   redirectData.valid   := io.train.redirect.valid
   redirectData.taken   := io.train.redirect.bits.taken
@@ -97,110 +107,164 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
   redirectData.target  := io.train.redirect.bits.target
   redirectData.phrMeta := io.train.redirect.bits.meta.phr
 
-  s3_override               := io.train.s3_override
-  s3_overrideData.valid     := s3_override
-  s3_overrideData.taken     := io.train.s3_prediction.taken
-  s3_overrideData.cfiPc     := getCfiPcFromPosition(io.train.s3_startPc, io.train.s3_prediction.cfiPosition)
-  s3_overrideData.target    := io.train.s3_prediction.target
-  s3_overrideData.phrMeta   := io.train.s3_phrMeta
-  s3_overrideData.foldedPhr := s3_foldedPhrReg
+  s3_override             := io.train.s3_override
+  s3_overrideData.valid   := s3_override
+  s3_overrideData.taken   := io.train.s3_prediction.taken
+  s3_overrideData.cfiPc   := getCfiPcFromPosition(io.train.s3_startPc, io.train.s3_prediction.cfiPosition)
+  s3_overrideData.target  := io.train.s3_prediction.target
+  s3_overrideData.phrMeta := io.train.s3_phrMeta
 
-  s1_overrideData.valid              := s1_valid
-  s1_overrideData.taken              := io.train.s1_prediction.taken
-  s1_overrideData.cfiPc              := getCfiPcFromPosition(io.train.s1_startPc, io.train.s1_prediction.cfiPosition)
-  s1_overrideData.target             := io.train.s1_prediction.target
-  s1_overrideData.foldedPhr          := s1_foldedPhrReg
-  s1_overrideData.phrMeta.phrPtr     := s1_phrPtr
-  s1_overrideData.phrMeta.phrLowBits := s1_phrValue(PathHashHighWidth - 1, 0)
+  s1AbtbUpdateData.zip(io.s1Train.abtbPrediction).foreach { case (data, pred) =>
+    data.valid := s1_valid && pred.valid
+    // Since S1 does not require recovery, and because the "taken" signal provided by abtbPrediction may not reflect the actual branch outcome,
+    // we always assume "taken" when computing s1NextPhr and s1NextFoldedPhr.
+    // If the branch is actually not taken, we simply leave Phr unchanged
+    data.taken              := s1_valid && pred.valid
+    data.cfiPc              := getCfiPcFromPosition(io.s1Train.startPc, pred.bits.cfiPosition)
+    data.target             := pred.bits.target
+    data.phrMeta.phrPtr     := s1_phrPtr
+    data.phrMeta.phrLowBits := s1_phrValue(PathHashHighWidth - 1, 0)
+  }
 
-  updateData := MuxCase(
-    0.U.asTypeOf(new PhrUpdateData),
+  s1UbtbUpdateData.valid  := s1_valid
+  s1UbtbUpdateData.taken  := io.s1Train.ubtbPrediction.bits.taken
+  s1UbtbUpdateData.cfiPc  := getCfiPcFromPosition(io.s1Train.startPc, io.s1Train.ubtbPrediction.bits.cfiPosition)
+  s1UbtbUpdateData.target := io.s1Train.ubtbPrediction.bits.target
+  s1UbtbUpdateData.phrMeta.phrPtr     := s1_phrPtr
+  s1UbtbUpdateData.phrMeta.phrLowBits := s1_phrValue(PathHashHighWidth - 1, 0)
+
+  // Compute all ShiftBits values and the high bits of the hash
+  private val redirectHashComponents = getPathHashComponents(redirectData.cfiPc, redirectData.target)
+  private val s3HashComponents       = getPathHashComponents(s3_overrideData.cfiPc, s3_overrideData.target)
+  private val s1UbtbHashComponents   = getPathHashComponents(s1UbtbUpdateData.cfiPc, s1UbtbUpdateData.target)
+  private val s1AbtbHashComponents   = s1AbtbUpdateData.map(data => getPathHashComponents(data.cfiPc, data.target))
+
+  private val redirectShiftBits = redirectHashComponents._1
+  private val redirectHashHigh  = redirectHashComponents._2
+  private val s3ShiftBits       = s3HashComponents._1
+  private val s3HashHigh        = s3HashComponents._2
+
+  // Compute all phrPtr and phrLowBits for updates
+  redirectUpdate := getUpdatePtrs(redirectData, redirectHashHigh)
+  s3Update       := getUpdatePtrs(s3_overrideData, s3HashHigh)
+  private val s1UbtbUpdate = getUpdatePtrs(s1UbtbUpdateData, s1UbtbHashComponents._2)
+  private val s1AbtbUpdateCandidates = s1AbtbUpdateData.zip(s1AbtbHashComponents).map { case (data, hash) =>
+    getUpdatePtrs(data, hash._2)
+  }
+  private val s1AbtbUpdateOH = Mux1H(io.s1Train.abtbFirstTakenBrOH, s1AbtbUpdateCandidates)
+
+  s1Update := Mux(io.s1Train.abtbValid, s1AbtbUpdateOH, s1UbtbUpdate)
+  private val s1AbtbShiftBits = Mux1H(io.s1Train.abtbFirstTakenBrOH, s1AbtbHashComponents.map(_._1))
+  private val s1ShiftBits     = Mux(io.s1Train.abtbValid, s1AbtbShiftBits, s1UbtbHashComponents._1)
+
+  redirectS0PhrPtr     := redirectUpdate.phrPtr
+  redirectS0PhrLowBits := redirectUpdate.phrLowBits
+  s3S0PhrPtr           := s3Update.phrPtr
+  s3S0PhrLowBits       := s3Update.phrLowBits
+  s1S0PhrPtr           := Mux(io.s1Train.taken, s1Update.phrPtr, s1_phrPtr)
+  s1S0PhrLowBits       := Mux(io.s1Train.taken, s1Update.phrLowBits, s1_phrValue(PathHashHighWidth - 1, 0))
+
+  private val shiftBits = MuxCase(
+    0.U(Shamt.W),
     Seq(
-      redirectData.valid -> redirectData,
-      s3_override        -> s3_overrideData,
-      s1_valid           -> s1_overrideData
+      redirectData.valid -> redirectShiftBits,
+      s3_override        -> s3ShiftBits,
+      s1_valid           -> s1ShiftBits
     )
   )
 
-  updateCfiPc  := updateData.cfiPc
-  updateTarget := updateData.target
+  phrPtr := MuxCase(
+    phrPtr,
+    Seq(
+      redirectData.valid -> redirectS0PhrPtr,
+      s3_override        -> s3S0PhrPtr,
+      s1_valid           -> s1S0PhrPtr
+    )
+  )
+  s0_phrPtr := MuxCase(
+    phrPtr,
+    Seq(
+      redirectData.valid -> redirectS0PhrPtr,
+      s3_override        -> s3S0PhrPtr,
+      s1_valid           -> s1S0PhrPtr
+    )
+  )
+  updatePhrLowBits := MuxCase(
+    0.U(PathHashHighWidth.W),
+    Seq(
+      redirectData.valid -> redirectS0PhrLowBits,
+      s3_override        -> s3S0PhrLowBits,
+      s1_valid           -> s1S0PhrLowBits
+    )
+  )
 
-  /*
-   * phr := (phr<<Shamt) ^ hash
-   */
-  private val hash      = pathHash(updateCfiPc, updateTarget)
-  private val shiftBits = hash(Shamt - 1, 0)
-  private val hashHigh  = hash(PathHashWidth - 1, Shamt)
+  redirectPhr := getRedirectPhr(redirectData.phrMeta)
+  redirectS0FoldedPhr := getNextFoldedPhr(
+    redirectData,
+    computeAllFoldedPhr(redirectPhr),
+    redirectPhr,
+    redirectHashHigh,
+    redirectShiftBits
+  )
+  s3S0FoldedPhr := getNextFoldedPhr(
+    s3_overrideData,
+    s3_foldedPhrReg,
+    getRedirectPhr(s3_overrideData.phrMeta),
+    s3HashHigh,
+    s3ShiftBits
+  )
+  private val s1UbtbS0FoldedPhr = getNextFoldedPhr(
+    s1UbtbUpdateData,
+    s1_foldedPhrReg,
+    getRedirectPhr(s1UbtbUpdateData.phrMeta),
+    s1UbtbHashComponents._2,
+    s1UbtbHashComponents._1
+  )
+  private val s1AbtbS0FoldedPhrCandidates = s1AbtbUpdateData.zip(s1AbtbHashComponents).map { case (data, hash) =>
+    getNextFoldedPhr(
+      data,
+      s1_foldedPhrReg,
+      getRedirectPhr(data.phrMeta),
+      hash._2,
+      hash._1
+    )
+  }
+  private val s1AbtbS0FoldedPhr = Mux1H(io.s1Train.abtbFirstTakenBrOH, s1AbtbS0FoldedPhrCandidates)
+  s1S0FoldedPhr := Mux(io.s1Train.abtbValid, s1AbtbS0FoldedPhr, s1UbtbS0FoldedPhr)
 
-  when(updateData.valid) {
-    phrPtr    := updateData.phrMeta.phrPtr
-    s0_phrPtr := updateData.phrMeta.phrPtr
+  private val updateValid = redirectData.valid || s3_overrideData.valid || io.s1Train.valid
+  private val updateTaken = MuxCase(
+    false.B,
+    Seq(
+      redirectData.valid -> redirectData.taken,
+      s3_override        -> s3_overrideData.taken,
+      s1_valid           -> io.s1Train.taken
+    )
+  )
+  // If this update includes a taken branch, updatePtr should be s0_phrPtr + Shamt.U; otherwise, it should be s0_phrPtr.
+  private val updatePtr = Mux(updateTaken, s0_phrPtr + Shamt.U, s0_phrPtr)
+  when(updateValid) {
     for (i <- 1 to PathHashHighWidth) {
-      phr((updateData.phrMeta.phrPtr + i.U).value) := updateData.phrMeta.phrLowBits(i - 1)
+      phr((updatePtr + i.U).value) := updatePhrLowBits(i - 1)
     }
-    when(updateData.taken) {
+    when(updateTaken) {
       for (i <- 0 until Shamt) {
-        phr((updateData.phrMeta.phrPtr - i.U).value) := shiftBits(Shamt - 1 - i)
+        phr((updatePtr - i.U).value) := shiftBits(Shamt - 1 - i)
       }
-      for (i <- 1 to PathHashHighWidth) {
-        phr((updateData.phrMeta.phrPtr + i.U).value) := hashHigh(i - 1) ^ updateData.phrMeta.phrLowBits(i - 1)
-      }
-      phrPtr    := updateData.phrMeta.phrPtr - Shamt.U
-      s0_phrPtr := updateData.phrMeta.phrPtr - Shamt.U
     }
-  }.otherwise {
-    s0_phrPtr := phrPtr
   }
 
   /*
-   * PHR folded history compute & maintenance
+   * PHR folded history select
    */
-  AllFoldedHistoryInfo.foreach { info =>
-    s0_foldedPhr.getHistWithInfo(info).foldedHist :=
-      computeFoldedHist(phrValue, info.FoldedLength)(info.HistoryLength)
-  }
-
-  when(redirectData.valid) {
-    redirectPhr := getRedirectPhr(redirectData.phrMeta)
-    AllFoldedHistoryInfo.foreach { info =>
-      redirectData.foldedPhr.getHistWithInfo(info).foldedHist :=
-        computeFoldedHist(redirectPhr, info.FoldedLength)(info.HistoryLength)
-    }
-    s0_foldedPhr := redirectData.foldedPhr
-    when(redirectData.taken) {
-      s0_foldedPhr := redirectData.foldedPhr.update(
-        VecInit(redirectPhr.asBools),
-        redirectData.phrMeta.phrPtr,
-        hashHigh,
-        Shamt,
-        shiftBits
-      )
-    }
-  }.elsewhen(s3_override) {
-    s0_foldedPhr := s3_foldedPhrReg
-    when(s3_overrideData.taken) {
-      s0_foldedPhr := s3_foldedPhrReg.update(
-        VecInit(getRedirectPhr(s3_overrideData.phrMeta).asBools),
-        s3_overrideData.phrMeta.phrPtr,
-        hashHigh,
-        Shamt,
-        shiftBits
-      )
-    }
-  }.elsewhen(s1_valid) {
-    s0_foldedPhr := s1_foldedPhrReg
-    when(s1_overrideData.taken) {
-      s0_foldedPhr := s1_foldedPhrReg.update(
-        VecInit(getRedirectPhr(s1_overrideData.phrMeta).asBools),
-        s1_overrideData.phrMeta.phrPtr,
-        hashHigh,
-        Shamt,
-        shiftBits
-      )
-    }
-  }.otherwise {
-    s0_foldedPhr := s0_foldedPhrReg
-  }
+  s0_foldedPhr := MuxCase(
+    s0_foldedPhrReg,
+    Seq(
+      redirectData.valid             -> redirectS0FoldedPhr,
+      s3_override                    -> s3S0FoldedPhr,
+      (s1_valid && io.s1Train.taken) -> s1S0FoldedPhr
+    )
+  )
 
   AllFoldedHistoryInfo.foreach { info =>
     histFoldedPhr.getHistWithInfo(info).foldedHist :=
@@ -309,8 +373,6 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
   dontTouch(s0_foldedPhr)
   dontTouch(s1_foldedPhrReg)
   dontTouch(s2_foldedPhrReg)
-  dontTouch(s0_phrValue)
-  dontTouch(s0_phrRegValue)
   dontTouch(phrValue)
   dontTouch(histFoldedPhr)
   dontTouch(redirectPhr)


### PR DESCRIPTION
Changed the PHR update logic from using the final S1-level prediction to calculating the states to be updated based on the prediction results of ABTB, UTAGE, URAS, and UBTB respectively, and then using the final S1-level prediction for selection.

- Combined with other changes and run PR, this fix resolves the S1 timing issue of the PHR. 
- There is no performance regression on spec2006 0.3cov.