### PR TITLE
feat(difftest): support FullBasicDiff with pc/instr/trap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ endif
 RELEASE_ARGS += --fpga-platform --disable-all --remove-assert --reset-gen --firtool-opt --ignore-read-enable-mem
 ifeq ($(FPGA), 1)
 override DEBUG_ARGS	+= --fpga-platform --disable-all --remove-assert --disable-clockgate
+override DEBUG_ARGS	+= --full-basicdiff
 else
 override DEBUG_ARGS	+= --enable-difftest
 endif

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -43,6 +43,7 @@ object ArgParser {
       |--fpga-platform
       |--reset-gen
       |--enable-difftest
+      |--full-basicdiff
       |--enable-log
       |--with-chiseldb
       |--with-rollingdb
@@ -126,6 +127,10 @@ object ArgParser {
         case "--enable-difftest" :: tail =>
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(EnableDifftest = true)
+          }), tail)
+        case "--full-basicdiff" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(FullBasicDiff = true)
           }), tail)
         case "--disable-always-basic-diff" :: tail =>
           nextOption(config.alter((site, here, up) => {

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -554,6 +554,7 @@ case class DebugOptions
   ResetGen: Boolean = false,
   EnableDifftest: Boolean = false,
   AlwaysBasicDiff: Boolean = true,
+  FullBasicDiff: Boolean = false,
   EnableDebug: Boolean = false,
   EnablePerfDebug: Boolean = true,
   PerfLevel: String = "VERBOSE",

--- a/src/main/scala/xiangshan/backend/BackendParams.scala
+++ b/src/main/scala/xiangshan/backend/BackendParams.scala
@@ -38,7 +38,10 @@ case class BackendParams(
   iqWakeUpParams : Seq[WakeUpConfig],
 ) {
 
-  def debugEn(implicit p: Parameters): Boolean = p(DebugOptionsKey).EnableDifftest
+  def debugEn(implicit p: Parameters): Boolean = {
+    val debugOpts = p(DebugOptionsKey)
+    debugOpts.EnableDifftest || debugOpts.FullBasicDiff
+  }
 
   def basicDebugEn(implicit p: Parameters): Boolean = p(DebugOptionsKey).AlwaysBasicDiff || debugEn
 

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -1570,7 +1570,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
     difftest.interrupt   := Mux(hasIntr, causeNO, 0.U)
     difftest.exception   := Mux(hasException, causeNO, 0.U)
     difftest.exceptionPC := dexceptionPC
-    if (env.EnableDifftest) {
+    if (env.EnableDifftest || env.FullBasicDiff) {
       difftest.exceptionInst := csrio.exception.bits.instr
     }
   }

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -1559,7 +1559,7 @@ class NewCSR(implicit val p: Parameters) extends Module
     diffArchEvent.virtualInterruptIsHvictlInject := RegNext(virtualInterruptIsHvictlInject && hasTrap)
     diffArchEvent.irToHS := RegEnable(irToHS, hasTrap)
     diffArchEvent.irToVS := RegEnable(irToVS, hasTrap)
-    if (env.EnableDifftest) {
+    if (env.EnableDifftest || env.FullBasicDiff) {
       diffArchEvent.exceptionInst := RegEnable(io.fromRob.trap.bits.instr, hasTrap)
     }
 

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1498,7 +1498,8 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     // These are the structures used by difftest only and should be optimized after synthesis.
     val dt_eliminatedMove = Mem(RobSize, Bool())
     val dt_isRVC = Mem(RobSize, Bool())
-    val dt_pcTransType = Option.when(env.EnableDifftest)(Mem(RobSize, new AddrTransType))
+    val fullBasicDiff = env.EnableDifftest || env.FullBasicDiff
+    val dt_pcTransType = Option.when(fullBasicDiff)(Mem(RobSize, new AddrTransType))
     val dt_exuDebug = Reg(Vec(RobSize, new DebugBundle))
     for (i <- 0 until RenameWidth) {
       when(canEnqueue(i)) {
@@ -1553,7 +1554,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       when(difftest.valid) {
         assert(CommitType.isFused(commitInfo.commitType).asUInt + commitInfo.instrSize >= 1.U)
       }
-      if (env.EnableDifftest) {
+      if (fullBasicDiff) {
         val pcTransType = dt_pcTransType.get(deqPtrVec(i).value)
         difftest.pc := Mux(pcTransType.shouldBeSext, SignExt(uop.pc, XLEN), uop.pc)
         difftest.instr := uop.instr
@@ -1562,6 +1563,8 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
         difftest.sqIdx := ZeroExt(uop.sqIdx.value, 7)
         difftest.isLoad := io.commits.info(i).commitType === CommitType.LOAD
         difftest.isStore := io.commits.info(i).commitType === CommitType.STORE
+      }
+      if (env.EnableDifftest) {
         // Check LoadEvent only when isAmo or isLoad and skip MMIO
         val difftestLoadEvent = DifftestModule(new DiffLoadEvent, delay = 3)
         difftestLoadEvent.coreid := io.hartId
@@ -1595,7 +1598,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     difftest.instrCnt := instrCnt
     difftest.hasWFI := hasWFI
 
-    if (env.EnableDifftest) {
+    if (env.EnableDifftest || env.FullBasicDiff) {
       val trapCode = PriorityMux(wdata.zip(trapVec).map(x => x._2 -> x._1))
       val trapPC = SignExt(PriorityMux(wpc.zip(trapVec).map(x => x._2 -> x._1)), XLEN)
       difftest.code := trapCode
@@ -1605,7 +1608,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
 
   //store evetn difftest information
   io.storeDebugInfo := DontCare
-  if (env.EnableDifftest) {
+  if (env.EnableDifftest || env.FullBasicDiff) {
     io.storeDebugInfo.map{port =>
       port.pc := debug_microOp(port.robidx.value).pc
     }
@@ -1649,7 +1652,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val commitStuck = (!io.commits.commitValid.reduce(_ || _) || !io.commits.isCommit) && !deqismmio
   val commitStuckCounter = Module(new CommitStuckCounter(
     width = log2Up(maxCommitStuck),
-    forceEnable = env.EnableDifftest.B
+    forceEnable = (env.EnableDifftest || env.FullBasicDiff).B
   ))
   val commitStuckOverflowEnabled = if (wfiResume) true.B else !hasWFI
   commitStuckCounter.io.stuck := commitStuck
@@ -1706,7 +1709,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     dontTouch(walkFinished)
     dontTouch(changeBankAddrToDeqPtr)
   }
-  if (env.EnableDifftest) {
+  if (env.EnableDifftest || env.FullBasicDiff) {
     io.commits.info.map(info => dontTouch(info.debug_pc.get))
   }
 }


### PR DESCRIPTION
Previously, the FPGA release used a simplified BasicDiff for baseline 
correctness checking. PC/INSTR comparison was intentionally disabled
to avoid introducing extra modules and area overhead. Other unused 
BasicDiff logic would be automatically optimized away during synthesis.

For enhancing FpgaDiff Debuggability and keep origin BasicDiff clean, 
this change introduces FullBasicDiff with PC/INSTR/TrapCode checking,
enabled via `--full-basicdiff`. Software no longer relies on RELEASE=1 to 
bypass PC comparison.