### PR TITLE
timing(mbtb): fix t1 timing

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -54,14 +54,13 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
 
   io.trainReady := true.B
 
-  private val s0_fire, s1_fire, s2_fire, s3_fire = Wire(Bool())
+  private val s0_fire, s1_fire, s2_fire, s3_fire, t0_fire = Wire(Bool())
   alignBanks.foreach { b =>
     b.io.stageCtrl.s0_fire := s0_fire
     b.io.stageCtrl.s1_fire := s1_fire
     b.io.stageCtrl.s2_fire := s2_fire
     b.io.stageCtrl.s3_fire := s3_fire
-    // alignBank does not care t0, it's using t1 only
-    b.io.stageCtrl.t0_fire := false.B
+    b.io.stageCtrl.t0_fire := t0_fire
   }
 
   /* *** s0 ***
@@ -124,10 +123,21 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   }
 
   /* *** t0 ***
-   * receive training data and latch
+   * receive training data
+   * send startPc to alignBank for replacer state reading
    */
-  private val t0_fire  = io.stageCtrl.t0_fire && io.enable
+  t0_fire := io.stageCtrl.t0_fire && io.enable
   private val t0_train = io.train
+
+  private val t0_startPc = t0_train.startPc
+  private val t0_rotator = VecRotate(getAlignBankIndex(t0_startPc))
+  private val t0_startPcVec = t0_rotator.rotate(
+    VecInit.tabulate(NumAlignBanks)(i => getAlignedPc(t0_startPc + (i << FetchBlockAlignWidth).U))
+  )
+
+  alignBanks.zipWithIndex.foreach { case (b, i) =>
+    b.io.t0_startPc := t0_startPcVec(i)
+  }
 
   /* *** t1 ***
    * calculate write data and write to alignBanks

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -145,11 +145,9 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   private val t1_fire  = RegNext(t0_fire, init = false.B) && io.enable
   private val t1_train = RegEnable(t0_train, t0_fire)
 
-  private val t1_startPc = t1_train.startPc
-  private val t1_rotator = VecRotate(getAlignBankIndex(t1_startPc))
-  private val t1_startPcVec = t1_rotator.rotate(
-    VecInit.tabulate(NumAlignBanks)(i => getAlignedPc(t1_startPc + (i << FetchBlockAlignWidth).U))
-  )
+  private val t1_rotator    = RegEnable(t0_rotator, t0_fire)
+  private val t1_startPcVec = RegEnable(t0_startPcVec, t0_fire)
+
   private val t1_meta           = t1_train.meta.mbtb
   private val t1_mispredictInfo = t1_train.mispredictBranch
 

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
@@ -76,6 +76,9 @@ class MainBtbAlignBank(
 
     // final s3_takenMask (mbtb + tage + sc), used to touch replacer accurately
     val s3_takenMask: Vec[Bool] = Input(Vec(NumWay, Bool()))
+
+    // fast path of train pc, used to read replacer in advance for better timing
+    val t0_startPc: PrunedAddr = Input(new PrunedAddr(VAddrBits))
   }
 
   val io: MainBtbAlignBankIO = IO(new MainBtbAlignBankIO)
@@ -191,6 +194,16 @@ class MainBtbAlignBank(
   replacer.io.predictTouch.bits.setIdx  := s3_replacerSetIdx
   replacer.io.predictTouch.bits.wayMask := s3_takenMask.asUInt
 
+  /* *** t0 ***
+   * read replacer in advance for better timing
+   */
+  private val t0_fire           = io.stageCtrl.t0_fire
+  private val t0_replacerSetIdx = getReplacerSetIndex(io.t0_startPc)
+
+  replacer.io.victim.setIdx := t0_replacerSetIdx
+
+  private val t0_victimMask = replacer.io.victim.wayMask
+
   /* *** t1 ***
    * send write req to internal banks (srams)
    */
@@ -204,6 +217,7 @@ class MainBtbAlignBank(
   private val t1_internalBankIdx  = getInternalBankIndex(t1_startPc)
   private val t1_internalBankMask = UIntToOH(t1_internalBankIdx, NumInternalBanks)
   private val t1_alignBankIdx     = getAlignBankIndex(t1_startPc)
+  private val t1_victimMask       = RegEnable(t0_victimMask, t0_fire)
 
   /* *** update entry *** */
   // NOTE: the original rawHit result can be multi-hit (i.e. multiple rawHit && position match), so PriorityEncoderOH
@@ -221,7 +235,7 @@ class MainBtbAlignBank(
       !(t1_mispredictInfo.bits.attribute === Mux1H(t1_hitMask, t1_meta.map(_.attribute)))
   )
   // Use hit wayMask if hit, else use replacer's victim way
-  private val t1_entryWayMask = Mux(t1_hit, t1_hitMask, replacer.io.victim.wayMask)
+  private val t1_entryWayMask = Mux(t1_hit, t1_hitMask, t1_victimMask)
 
   private val t1_entry = Wire(new MainBtbEntry)
   t1_entry.valid           := true.B

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbReplacer.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbReplacer.scala
@@ -29,10 +29,11 @@ class MainBtbReplacer(implicit p: Parameters) extends MainBtbModule {
     }
 
     class Victim extends Bundle {
-      val wayMask: UInt = UInt(NumWay.W)
+      val setIdx:  UInt = Input(UInt(SetIdxLen.W))
+      val wayMask: UInt = Output(UInt(NumWay.W))
     }
 
-    val victim: Victim            = Output(new Victim)
+    val victim: Victim            = new Victim
     val touch:  Vec[Valid[Touch]] = Vec(2, Flipped(Valid(new Touch))) // magic number 2: predict and train
 
     def predictTouch: Valid[Touch] = touch(0)
@@ -42,8 +43,9 @@ class MainBtbReplacer(implicit p: Parameters) extends MainBtbModule {
   val io: MainBtbReplacerIO = IO(new MainBtbReplacerIO)
 
   private val predictStateGen = Module(ReplacerStateGen(Replacer, NumWay, accessSize = NumWay))
-  private val trainStateGen   = Module(ReplacerStateGen(Replacer, NumWay, accessSize = 1))
-  private val stateBank       = Module(new ReplacerState(NumSets, predictStateGen.StateWidth))
+  private val trainStateGen   = Module(ReplacerStateGen(Replacer, NumWay))
+  private val victimStateGen  = Module(ReplacerStateGen(Replacer, NumWay))
+  private val stateBank       = Module(new ReplacerState(NumSets, predictStateGen.StateWidth, HasExtraReadPort = true))
 
   /* *** predict *** */
   // read current state
@@ -93,5 +95,14 @@ class MainBtbReplacer(implicit p: Parameters) extends MainBtbModule {
   stateBank.io.trainWriteState  := trainNextState
 
   /* *** victim *** */
-  io.victim.wayMask := UIntToOH(trainStateGen.io.victim)
+  stateBank.io.readSetIdx.get := io.victim.setIdx
+  private val victimState = stateBank.io.readState.get
+
+  // NOTE: io.trainTouch is on t1, io.victim.setIdx is on t0,
+  //       if they are accessing the same set, we use the updated state to select victim
+  private val trainVictimConflict = io.trainTouch.valid && (io.trainTouch.bits.setIdx === io.victim.setIdx)
+  victimStateGen.io.state   := Mux(trainVictimConflict, trainNextState, victimState)
+  victimStateGen.io.touches := DontCare // we use victimStateGen just to select victim, don't care touch & nextState
+
+  io.victim.wayMask := UIntToOH(victimStateGen.io.victim)
 }


### PR DESCRIPTION
mainBtb does not have read-on-train (it saves all metadata in ftq), so its t0 stage is cleaner than other predictors who have. Thus we can move some calculation and state read from t1 to t0 for better timing.

This PR:
- move replacer victim selection to t0
- move startPcVec adder (`startPc for alignBank(1)` = `aligned(startPc + 64)`) to t0

A slight performance change is expected as victim selection is 1 cycle ahead.

Rebased to 6708290b9a6b0c0e2b432982501f4029049ced6e and ran DC, report shows mbtb t1 120ps violation + t0 clean -> t0 40ps violation + t1 clean(on startPc-related path).