### PR TITLE
ci(perf): append emulator type to emu binary name

### DIFF
--- a/.github/workflows/perf-template.yml
+++ b/.github/workflows/perf-template.yml
@@ -7,11 +7,6 @@ on:
         description: Branch or commit to run performance test on
         required: true
         type: string
-      recompile:
-        description: Recompile the emu
-        required: false
-        type: string
-        default: false
       emulator:
         description: emulator to use
         required: false
@@ -205,7 +200,7 @@ jobs:
 
       - name: Build EMU with DRAMsim3
         run: |
-          if [ ! -e "$SPEC_DIR/emu" ] || [ "${{ inputs.recompile }}" = "true" ]; then
+          if [ ! -e "$SPEC_DIR/emu-${{ inputs.emulator }}" ]; then
             python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
               --config "${{ inputs.xs_config }}" \
               --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 \
@@ -215,7 +210,7 @@ jobs:
               --emulator ${{ inputs.emulator }} \
               $CST_COMPILE_OPT
             mkdir -p $SPEC_DIR
-            cp $GITHUB_WORKSPACE/build/emu $SPEC_DIR/emu
+            cp $GITHUB_WORKSPACE/build/emu "$SPEC_DIR/emu-${{ inputs.emulator }}"
           fi
           if [ ! -e "$SPEC_DIR/riscv64-nemu-interpreter-so" ]; then
             cp $GITHUB_WORKSPACE/ready-to-run/riscv64-nemu-interpreter-so $SPEC_DIR/riscv64-nemu-interpreter-so
@@ -225,7 +220,7 @@ jobs:
         run: |
           cd $SCRIPTS_HOME/perf_trigger
           python3 main.py --gcpt-path $CKPT_HOME --json-path $CKPT_JSON_PATH \
-            --emu-path $SPEC_DIR/emu --result-path $SPEC_DIR \
+            --emu-path "$SPEC_DIR/emu-${{ inputs.emulator }}" --result-path $SPEC_DIR \
             --threads $([ "${{ inputs.emulator }}" = "gsim" ] && echo 1 || echo 8) \
             --benchmarks "${{ inputs.benchmarks }}" \
             --server-list "$SERVER_LIST" \

--- a/.github/workflows/perf-trigger.yml
+++ b/.github/workflows/perf-trigger.yml
@@ -15,14 +15,6 @@ on:
         required: false
         type: string
         default: kunminghu-v3
-      recompile:
-        description: Recompile the emu
-        required: false
-        type: choice
-        options:
-          - false
-          - true
-        default: false
       emulator:
         description: emulator to use
         required: false
@@ -83,7 +75,6 @@ jobs:
     uses: ./.github/workflows/perf-template.yml
     with:
         test_branch: ${{ github.event.inputs.test_branch }}
-        recompile: ${{ github.event.inputs.recompile }}
         emulator: ${{ github.event.inputs.emulator }}
         xs_config: ${{ github.event.inputs.xs_config }}
         benchmark_type: ${{ github.event.inputs.benchmark_type }}


### PR DESCRIPTION
In the following scenario:

1. run perf trigger with gsim (default)
2. failed due a gsim bug
3. want to re-run with verilator

we used to trigger a new run with recompile flag, this caused 3 problems:

1. if it failed due to an internet connection issue, it will compile again after clicking re-run, which is unnecessary
2. if the old emu (gsim) binary is copied to open servers, the manager script will skip copying again (emu already exists in target directory)
3. after recompile, the old emu (gsim) binary is gone and we need to compile it again if we want to debug it.

So, in this PR and https://github.com/OpenXiangShan/env-scripts/pull/127, we append emulator type to emu binary name, so `emu-gsim` and `emu-verilator` can exists together.

Then, the `recompile` flag should be not useful, as we stored emu with different commit(in #3533), config(in #5468), or emulator(in this PR) in completely different path, so this PR also remove it.