### PR TITLE
build: add unused warning

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -36,7 +36,7 @@ val pwd = os.Path(sys.env("MILL_WORKSPACE_ROOT"))
 trait ChiselModule extends SbtModule with ScalafmtModule {
   def scalaVersion: T[String] = defaultScalaVersion
 
-  def scalacOptions = Seq("-language:reflectiveCalls", "-Ymacro-annotations", "-Ytasty-reader")
+  def scalacOptions = Seq("-language:reflectiveCalls", "-Ymacro-annotations", "-Ytasty-reader", "-Wunused")
 
   def ivyDeps: T[Agg[Dep]] = Agg(ivy"org.chipsalliance::chisel:7.3.0")
 


### PR DESCRIPTION
IntelliJ IDEA has built-in hints for unused variables, but the Metals plugin in VS Code does not. Therefore, this PR adds warnings for unused variables so that developers using VS Code can also easily spot unused variables.