### PR TITLE
perf(Stride): add decr mode and big stride support

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -973,6 +973,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   when(io.prefetch_info.hit_prefetch) {
     prefetch := false.B
+    req.pf_source := L1_HW_PREFETCH_CLEAR
   }
 
   io.l1Miss := req_valid

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -984,6 +984,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   when(io.prefetch_info.hit_prefetch) {
     prefetch := false.B
+    req.pf_source := L1_HW_PREFETCH_CLEAR
   }
 
   io.l1Miss := req_valid

--- a/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
@@ -39,7 +39,7 @@ import scala.collection.SeqLike
 
 trait HasStridePrefetchHelper extends HasL1PrefetchHelper {
   val STRIDE_FILTER_SIZE = 6
-  val STRIDE_ENTRY_NUM = 10
+  val STRIDE_ENTRY_NUM = 16
   val STRIDE_BITS = 10 + BLOCK_OFFSET
   val STRIDE_VADDR_BITS = 10 + BLOCK_OFFSET
   val STRIDE_CONF_BITS = 2

--- a/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
@@ -58,6 +58,7 @@ trait HasStridePrefetchHelper extends HasL1PrefetchHelper {
 class StrideMetaBundle(implicit p: Parameters) extends XSBundle with HasStridePrefetchHelper {
   val pre_vaddr = UInt(STRIDE_VADDR_BITS.W)
   val stride = UInt(STRIDE_BITS.W)
+  val decr_mode = Bool()
   val confidence = UInt(STRIDE_CONF_BITS.W)
   val hash_pc = UInt(HASH_TAG_WIDTH.W)
 
@@ -66,6 +67,7 @@ class StrideMetaBundle(implicit p: Parameters) extends XSBundle with HasStridePr
     stride := 0.U
     confidence := 0.U
     hash_pc := index.U
+    decr_mode := false.B
   }
 
   def tag_match(valid1: Bool, valid2: Bool, new_hash_pc: UInt): Bool = {
@@ -81,11 +83,13 @@ class StrideMetaBundle(implicit p: Parameters) extends XSBundle with HasStridePr
 
   def update(vaddr: UInt, always_update_pre_vaddr: Bool) = {
     val new_vaddr = vaddr(STRIDE_VADDR_BITS - 1, 0)
-    val new_stride = new_vaddr - pre_vaddr
+    val new_stride_plus = new_vaddr -& pre_vaddr
+    val new_stride_minus = pre_vaddr - new_vaddr
+    val isDecrMode = new_stride_plus(STRIDE_VADDR_BITS)
+    val new_stride = Mux(isDecrMode, new_stride_minus(STRIDE_VADDR_BITS - 1, 0), new_stride_plus(STRIDE_VADDR_BITS - 1, 0))
     val new_stride_blk = block_addr(new_stride)
-    // NOTE: for now, disable negtive stride
-    val stride_valid = new_stride_blk =/= 0.U && new_stride_blk =/= 1.U && new_stride(STRIDE_VADDR_BITS - 1) === 0.U
-    val stride_match = new_stride === stride
+    val stride_valid = new_stride_blk =/= 0.U && new_stride_blk =/= 1.U
+    val stride_match = new_stride === stride && isDecrMode === decr_mode
     val low_confidence = confidence <= 1.U
     val can_send_pf = stride_valid && stride_match && confidence === MAX_CONF.U
 
@@ -96,6 +100,7 @@ class StrideMetaBundle(implicit p: Parameters) extends XSBundle with HasStridePr
         confidence := Mux(confidence === 0.U, confidence, confidence - 1.U)
         when(low_confidence) {
           stride := new_stride
+          decr_mode := isDecrMode
         }
       }
       pre_vaddr := new_vaddr
@@ -166,6 +171,7 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
   val s1_alloc = s1_valid && !s1_hit
   val s1_update = s1_valid && s1_hit
   val s1_stride = array(s1_index).stride
+  val s1_decr_mode = array(s1_index).decr_mode
   val s1_new_stride = WireInit(0.U(STRIDE_BITS.W))
   val s1_can_send_pf = WireInit(false.B)
   s0_can_accept := !(s1_valid && s1_pc_hash === s0_pc_hash)
@@ -192,15 +198,20 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
   val s2_valid = GatedValidRegNext(s1_valid && s1_can_send_pf)
   val s2_vaddr = RegEnable(s1_vaddr, s1_valid && s1_can_send_pf)
   val s2_stride = RegEnable(s1_stride, s1_valid && s1_can_send_pf)
+  val s2_decr_mode = RegEnable(s1_decr_mode, s1_valid && s1_can_send_pf)
   val s2_l1_depth = s2_stride << l1_stride_ratio
-  val s2_l1_pf_vaddr = (s2_vaddr + s2_l1_depth)(VAddrBits - 1, 0)
+  val s2_l1_pf_incr_vaddr = (s2_vaddr + s2_l1_depth)(VAddrBits - 1, 0)
+  val s2_l1_pf_decr_vaddr = (s2_vaddr - s2_l1_depth)(VAddrBits - 1, 0)
+  val s2_l1_pf_vaddr = Mux(s2_decr_mode, s2_l1_pf_decr_vaddr, s2_l1_pf_incr_vaddr)
   val s2_l2_depth = s2_stride << l2_stride_ratio
-  val s2_l2_pf_vaddr = (s2_vaddr + s2_l2_depth)(VAddrBits - 1, 0)
+  val s2_l2_pf_incr_vaddr = (s2_vaddr + s2_l2_depth)(VAddrBits - 1, 0)
+  val s2_l2_pf_decr_vaddr = (s2_vaddr - s2_l2_depth)(VAddrBits - 1, 0)
+  val s2_l2_pf_vaddr = Mux(s2_decr_mode, s2_l2_pf_decr_vaddr, s2_l2_pf_incr_vaddr)
   val s2_l1_pf_req_bits = (new StreamPrefetchReqBundle).getStreamPrefetchReqBundle(
     valid = s2_valid,
     vaddr = s2_l1_pf_vaddr,
     width = STRIDE_WIDTH_BLOCKS,
-    decr_mode = false.B,
+    decr_mode = s2_decr_mode,
     sink = SINK_L1,
     source = L1_HW_PREFETCH_STRIDE,
     confidence = io.confidence,
@@ -212,7 +223,7 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
     valid = s2_valid,
     vaddr = s2_l2_pf_vaddr,
     width = STRIDE_WIDTH_BLOCKS,
-    decr_mode = false.B,
+    decr_mode = s2_decr_mode,
     sink = SINK_L2,
     source = L1_HW_PREFETCH_STRIDE,
     confidence = io.confidence,

--- a/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
@@ -42,7 +42,7 @@ trait HasStridePrefetchHelper extends HasL1PrefetchHelper {
   val STRIDE_ENTRY_NUM = 16
   val STRIDE_BITS = 10 + BLOCK_OFFSET
   val STRIDE_VADDR_BITS = 10 + BLOCK_OFFSET
-  val STRIDE_CONF_BITS = 2
+  val STRIDE_CONF_BITS = 3
 
   // detail control
   val ALWAYS_UPDATE_PRE_VADDR = true
@@ -53,6 +53,7 @@ trait HasStridePrefetchHelper extends HasL1PrefetchHelper {
   val STRIDE_WIDTH_BLOCKS = if(AGGRESIVE_POLICY) STRIDE_LOOK_AHEAD_BLOCKS else 1
 
   def MAX_CONF = (1 << STRIDE_CONF_BITS) - 1
+  def CONF_THRESHOLD = (1 << (STRIDE_CONF_BITS-1)) - 1
 }
 
 class StrideMetaBundle(implicit p: Parameters) extends XSBundle with HasStridePrefetchHelper {
@@ -91,7 +92,7 @@ class StrideMetaBundle(implicit p: Parameters) extends XSBundle with HasStridePr
     val stride_valid = new_stride_blk =/= 0.U && new_stride_blk =/= 1.U
     val stride_match = new_stride === stride && isDecrMode === decr_mode
     val low_confidence = confidence <= 1.U
-    val can_send_pf = stride_valid && stride_match && confidence === MAX_CONF.U
+    val can_send_pf = stride_valid && stride_match && confidence >= CONF_THRESHOLD.U
 
     when(stride_valid) {
       when(stride_match) {

--- a/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
@@ -40,8 +40,8 @@ import scala.collection.SeqLike
 trait HasStridePrefetchHelper extends HasL1PrefetchHelper {
   val STRIDE_FILTER_SIZE = 6
   val STRIDE_ENTRY_NUM = 16
-  val STRIDE_BITS = 10 + BLOCK_OFFSET
-  val STRIDE_VADDR_BITS = 10 + BLOCK_OFFSET
+  val STRIDE_BITS = 19 + BLOCK_OFFSET
+  val STRIDE_VADDR_BITS = 19 + BLOCK_OFFSET
   val STRIDE_CONF_BITS = 3
 
   // detail control

--- a/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
@@ -110,7 +110,7 @@ class StrideMetaBundle(implicit p: Parameters) extends XSBundle with HasStridePr
       pre_vaddr := new_vaddr
     }
 
-    (can_send_pf, new_stride)
+    (can_send_pf, new_stride, isDecrMode =/= decr_mode, stride_valid)
   }
 
 }
@@ -175,6 +175,8 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
   val s1_decr_mode = array(s1_index).decr_mode
   val s1_new_stride = WireInit(0.U(STRIDE_BITS.W))
   val s1_can_send_pf = WireInit(false.B)
+  val s1_mode_changed = WireInit(false.B)
+  val s1_stride_valid = WireInit(false.B)
   s0_can_accept := !(s1_valid && s1_pc_hash === s0_pc_hash)
 
   val always_update = Constantin.createRecord(s"always_update${p(XSCoreParamsKey).HartId}", initValue = ALWAYS_UPDATE_PRE_VADDR)
@@ -189,6 +191,8 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
     val res = array(s1_index).update(s1_vaddr, always_update)
     s1_can_send_pf := res._1
     s1_new_stride := res._2
+    s1_mode_changed := res._3
+    s1_stride_valid := res._4
   }
 
   val l1_stride_ratio_const = Constantin.createRecord(s"l1_stride_ratio${p(XSCoreParamsKey).HartId}", initValue = 2)
@@ -251,17 +255,23 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
   XSPerfAccumulate("l1_pf_valid", s3_valid)
   XSPerfAccumulate("l2_pf_valid", s4_valid)
   XSPerfAccumulate("detect_stream", io.stream_lookup_resp)
-  XSPerfHistogram("high_conf_num", PopCount(VecInit(array.map(_.confidence === MAX_CONF.U))).asUInt, true.B, 0, STRIDE_ENTRY_NUM, 1)
+  XSPerfHistogram("high_conf_num", PopCount(VecInit(array.zipWithIndex.map { case (entry, idx) => valids(idx) && entry.confidence >= CONF_THRESHOLD.U })).asUInt, true.B, 0, STRIDE_ENTRY_NUM, 1)
   for(i <- 0 until STRIDE_ENTRY_NUM) {
     XSPerfAccumulate(s"entry_${i}_update", i.U === s1_index && s1_update)
-    for(j <- 0 until 4) {
-      XSPerfAccumulate(s"entry_${i}_disturb_${j}", i.U === s1_index && s1_update &&
-                                                   j.U === s1_new_stride &&
-                                                   array(s1_index).confidence === MAX_CONF.U &&
-                                                   array(s1_index).stride =/= s1_new_stride
-      )
-    }
+    XSPerfAccumulate(s"entry_${i}_alloc", i.U === s1_index && s1_alloc)
+    val active_entry = valids(s1_index) && array(s1_index).confidence >= CONF_THRESHOLD.U
+    XSPerfAccumulate(s"entry_${i}_evict", i.U === s1_index && active_entry && s1_alloc)
+    XSPerfAccumulate(s"entry_${i}_decr", i.U === s1_index && active_entry && array(s1_index).decr_mode)
+    XSPerfAccumulate(s"entry_${i}_incr", i.U === s1_index && active_entry && !array(s1_index).decr_mode)
   }
+  for (j <- 0 until STRIDE_VADDR_BITS) {
+    val highestOne = Reverse(PriorityEncoderOH(Reverse(array(s1_index).stride)))
+    val is_stride_j = highestOne === (1 << j).U
+    XSPerfAccumulate(s"stride_${j}", s1_can_send_pf && array(s1_index).confidence >= CONF_THRESHOLD.U && !array(s1_index).decr_mode && is_stride_j)
+    XSPerfAccumulate(s"negstride_${j}", s1_can_send_pf && array(s1_index).confidence >= CONF_THRESHOLD.U && array(s1_index).decr_mode && is_stride_j)
+  }
+  XSPerfAccumulate("stride_mode_changed", s1_update && s1_mode_changed)
+  XSPerfAccumulate("always_update", s1_update && s1_stride_valid)
 
   for(i <- 0 until STRIDE_ENTRY_NUM) {
     when(GatedValidRegNext(io.flush)) {

--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherMonitor.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherMonitor.scala
@@ -87,9 +87,10 @@ class PrefetcherMonitor()(implicit p: Parameters) extends XSModule with HasStrea
 
   // ldu 0, 1, 2 can only have one prefetch request at a time
   val total_prefetch = io.loadinfo.map(t => t.total_prefetch).reduce(_ || _)
-  val nack_prefetch = io.loadinfo.map(t => t.nack_prefetch).reduce(_ || _)
+  val nack_prefetch_raw = io.loadinfo.map(t => t.nack_prefetch).reduce(_ || _)
   val pf_late_in_cache = io.loadinfo.map(t => t.pf_late_in_cache).reduce(_ || _)
   val pf_late_in_mshr = io.missinfo.pf_late_in_mshr
+  val nack_prefetch = nack_prefetch_raw && !pf_late_in_mshr
   val pf_late = pf_late_in_cache.asUInt + pf_late_in_mshr.asUInt
   // demand accesses from different ldu may hit different prefetch blocks
   val hit_pf_in_cache = PopCount(prefetch_info.loadinfo.map(t => t.hit_pf_in_cache) ++ Seq(prefetch_info.maininfo.hit_pf_in_cache))
@@ -191,8 +192,9 @@ class L1PrefetchMonitor(param : PrefetcherMonitorParam)(implicit p: Parameters) 
 
   val total_prefetch = io.prefetch_info.loadinfo.map(t => t.total_prefetch && param.isMyType(t.pf_source)).reduce(_ || _)
   val pf_late_in_cache = io.prefetch_info.loadinfo.map(t => t.pf_late_in_cache && param.isMyType(t.pf_source)).reduce(_ || _)
-  val nack_prefetch = io.prefetch_info.loadinfo.map(t => t.nack_prefetch && param.isMyType(t.pf_source)).reduce(_ || _)
+  val nack_prefetch_raw = io.prefetch_info.loadinfo.map(t => t.nack_prefetch && param.isMyType(t.pf_source)).reduce(_ || _)
   val pf_late_in_mshr = io.prefetch_info.missinfo.pf_late_in_mshr && param.isMyType(io.prefetch_info.missinfo.pf_source)
+  val nack_prefetch = nack_prefetch_raw && !pf_late_in_mshr
   val hit_pf_in_cache = PopCount(io.prefetch_info.loadinfo.map(t => t.hit_pf_in_cache && param.isMyType(t.hit_source)) ++ Seq(io.prefetch_info.maininfo.hit_pf_in_cache && param.isMyType(io.prefetch_info.maininfo.hit_pf_source_in_cache)))
   val pf_useless = io.prefetch_info.maininfo.pf_useless && param.isMyType(io.prefetch_info.maininfo.pf_source_useless)
   val prefetch_miss = io.prefetch_info.missinfo.prefetch_miss && param.isMyType(io.prefetch_info.missinfo.pf_source)

--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherMonitor.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherMonitor.scala
@@ -91,9 +91,10 @@ class PrefetcherMonitor()(implicit p: Parameters) extends XSModule with HasStrea
 
   // ldu 0, 1, 2 can only have one prefetch request at a time
   val total_prefetch = io.loadinfo.map(t => t.total_prefetch).reduce(_ || _)
-  val nack_prefetch = io.loadinfo.map(t => t.nack_prefetch).reduce(_ || _)
+  val nack_prefetch_raw = io.loadinfo.map(t => t.nack_prefetch).reduce(_ || _)
   val pf_late_in_cache = io.loadinfo.map(t => t.pf_late_in_cache).reduce(_ || _)
   val pf_late_in_mshr = io.missinfo.pf_late_in_mshr
+  val nack_prefetch = nack_prefetch_raw && !pf_late_in_mshr
   val pf_late = pf_late_in_cache.asUInt + pf_late_in_mshr.asUInt
   // demand accesses from different ldu may hit different prefetch blocks
   val hit_pf_in_cache = PopCount(prefetch_info.loadinfo.map(t => t.hit_pf_in_cache) ++ Seq(prefetch_info.maininfo.hit_pf_in_cache))
@@ -195,8 +196,9 @@ class L1PrefetchMonitor(param : PrefetcherMonitorParam)(implicit p: Parameters) 
 
   val total_prefetch = io.prefetch_info.loadinfo.map(t => t.total_prefetch && param.isMyType(t.pf_source)).reduce(_ || _)
   val pf_late_in_cache = io.prefetch_info.loadinfo.map(t => t.pf_late_in_cache && param.isMyType(t.pf_source)).reduce(_ || _)
-  val nack_prefetch = io.prefetch_info.loadinfo.map(t => t.nack_prefetch && param.isMyType(t.pf_source)).reduce(_ || _)
+  val nack_prefetch_raw = io.prefetch_info.loadinfo.map(t => t.nack_prefetch && param.isMyType(t.pf_source)).reduce(_ || _)
   val pf_late_in_mshr = io.prefetch_info.missinfo.pf_late_in_mshr && param.isMyType(io.prefetch_info.missinfo.pf_source)
+  val nack_prefetch = nack_prefetch_raw && !pf_late_in_mshr
   val hit_pf_in_cache = PopCount(io.prefetch_info.loadinfo.map(t => t.hit_pf_in_cache && param.isMyType(t.hit_source)) ++ Seq(io.prefetch_info.maininfo.hit_pf_in_cache && param.isMyType(io.prefetch_info.maininfo.hit_pf_source_in_cache)))
   val pf_useless = io.prefetch_info.maininfo.pf_useless && param.isMyType(io.prefetch_info.maininfo.pf_source_useless)
   val prefetch_miss = io.prefetch_info.missinfo.prefetch_miss && param.isMyType(io.prefetch_info.missinfo.pf_source)
@@ -341,3 +343,4 @@ class BertiMonitorParam extends PrefetcherMonitorParam with HasL1PrefetchSourceP
   override val name: String = "Berti"
   override def isMyType(value: UInt) = value === L1_HW_PREFETCH_BERTI
 }
+


### PR DESCRIPTION
This pull request primarily aligns with the implementation of the gem5 stride prefetcher, with the following modifications:

* In the miss queue, when a prefetch MSHR is matched by a demand miss, the prefetch flag is cleared to avoid duplicate counting in the load pipe.
* When a prefetch request miss and match an MSHR in the miss queue, nack_prefetch and pf_late_in_mshr are counted redundantly.  Since nack_prefetch and pf_late_in_mshr occur in the same cycle, nack_prefetch is not counted when both are active in the prefetch monitor. 
* STRIDE_ENTRY_NUM is increased from 10 to 16, and STRIDE_BITS and STRIDE_VADDR_BITS are increased to 25 to enhance the performance of the stride prefetcher on mcf. The total number of registers is increased from 500 bits to 1120 bits.
* STRIDE_ENTRY_CONF is modified to a saturating counter-like mechanism, where the threshold is not equal to the confidence upper limit, and continuous matches can continuously increase the confidence value, improving tolerance to out-of-order memory accesses.

Performance improved by 0.2% on spec2006 1.0cov.
<img width="2668" height="1920" alt="116617" src="https://github.com/user-attachments/assets/f2d05679-5506-4a32-a17b-e0cdcc270740" />