### PR TITLE
docs(Makefile): correct typos in build scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ COMMON_EXTRA_ARGS += --dfx false
 endif
 endif
 
-# enable or disable sram ctl maunally
+# enable or disable sram ctl manually
 ifeq ($(SRAM_WITH_CTL),1)
 COMMON_EXTRA_ARGS += --sram-with-ctl
 endif

--- a/scripts/Makefile.docker
+++ b/scripts/Makefile.docker
@@ -76,14 +76,14 @@ sh:
 .PHONY: image __prep_proxy sh
 
 #
-# docker envrionment switch helper
+# docker environment switch helper
 #
 __switch_docker_env:
 	@mkdir -p out $(MILL_OUTPUT_DIR) $(BUILD_DIR)
 	@if [ -z "$(IN_XSDEV_DOCKER)" ]; then \
 		echo "\e[32mSwitching to Docker environment...\e[0m"; \
 		$(call DOCKER_RUN, -c "make $(DOCKER_TARGET)"); \
-		echo "\e[32mLeaving Docker envrionment...\e[0m"; \
+		echo "\e[32mLeaving Docker environment...\e[0m"; \
 	fi
 .PHONY: __switch_docker_env
 
@@ -93,6 +93,6 @@ __$(1): DOCKER_TARGET=$(1)
 __$(1): __switch_docker_env
 endef
 
-# run selected target in docker envrionment
+# run selected target in docker environment
 docker-deps = $(if $(NO_XSDEV_IMAGE)$(IN_XSDEV_DOCKER),$(1),__$(1) \
 		   $(eval $(rule_docker_target)))


### PR DESCRIPTION
This is a small cleanup PR for a couple of typos in build-related files.

Changes:
- `envrionment` -> `environment` in `scripts/Makefile.docker`
- `maunally` -> `manually` in the top-level `Makefile`

No behavior change.