### PR TITLE
style(ittage): simplify table parameter helpers

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
@@ -67,7 +67,7 @@ class Ittage(implicit p: Parameters) extends BasePredictor with HasIttageParamet
   // Each ITTAGE table manages its own banking (NumBanks parameter); top-level only supplies PC/history.
   private val tables = TableInfos.zipWithIndex.map {
     case (info, i) =>
-      val t = Module(new IttageTable(info.Size, info.HistoryLength, TagWidth, i))
+      val t = Module(new IttageTable(i, info))
       t
   }
 

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/IttageTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/IttageTable.scala
@@ -26,16 +26,19 @@ import utility.mbist.MbistPipeline
 import utility.sram.FoldedSRAMTemplate
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.bpu.FoldedHistoryInfo
+import xiangshan.frontend.bpu.IttageTableInfo
 import xiangshan.frontend.bpu.SaturateCounter
 import xiangshan.frontend.bpu.WriteBuffer
 import xiangshan.frontend.bpu.history.phr.PhrAllFoldedHistories
 
 class IttageTable(
-    val nRows:    Int,
-    val histLen:  Int,
-    val tagLen:   Int,
-    val tableIdx: Int
+    val tableIdx:      Int,
+    implicit val info: IttageTableInfo
 )(implicit p: Parameters) extends IttageModule {
+  private val nRows   = info.Size
+  private val histLen = info.HistoryLength
+  private val tagLen  = TagWidth
+
   class IttageTableIO extends IttageBundle {
     class Req extends Bundle {
       val startPc:    PrunedAddr            = PrunedAddr(VAddrBits)
@@ -75,21 +78,15 @@ class IttageTable(
   val io: IttageTableIO = IO(new IttageTableIO)
 
   // Banked organization: split rows evenly across banks to allow predict/read and update on different banks.
-  private val bankIdxWidth = IttageBankIdxWidth
-  private val numBanks     = IttageNumBanks
-  require(nRows % numBanks == 0, "ITTAGE table rows must be divisible by number of banks")
-  private val setsPerBank  = nRows / numBanks
-  private val setIdxWidth  = log2Ceil(setsPerBank)
-  private val idxFullWidth = setIdxWidth + bankIdxWidth
-  private val foldedWidth  = if (setsPerBank >= TableSramSize) setsPerBank / TableSramSize else 1
-  private val dataSplit    = if (setsPerBank <= 2 * TableSramSize) 1 else 2
+  private val foldedWidth = if (NumSetsPerBank >= TableSramSize) NumSetsPerBank / TableSramSize else 1
+  private val dataSplit   = if (NumSetsPerBank <= 2 * TableSramSize) 1 else 2
 
   if (nRows < TableSramSize) {
     println(f"warning: ittage table $tableIdx has small sram depth of $nRows")
   }
 
   require(histLen == 0 && tagLen == 0 || histLen != 0 && tagLen != 0)
-  private val idxFhInfo    = new FoldedHistoryInfo(histLen, min(histLen, setIdxWidth))
+  private val idxFhInfo    = new FoldedHistoryInfo(histLen, min(histLen, SetIdxWidth))
   private val tagFhInfo    = new FoldedHistoryInfo(histLen, min(histLen, tagLen))
   private val altTagFhInfo = new FoldedHistoryInfo(histLen, min(histLen, tagLen - 1))
 
@@ -98,16 +95,16 @@ class IttageTable(
       val idxFh      = allFh.getHistWithInfo(idxFhInfo).foldedHist
       val tagFh      = allFh.getHistWithInfo(tagFhInfo).foldedHist
       val altTagFh   = allFh.getHistWithInfo(altTagFhInfo).foldedHist
-      val bankIdx    = if (bankIdxWidth == 0) 0.U else unhashedIdx(bankIdxWidth - 1, 0)
-      val setIdxBase = unhashedIdx(bankIdxWidth + setIdxWidth - 1, bankIdxWidth)
-      val setIdx     = (setIdxBase ^ idxFh)(setIdxWidth - 1, 0)
-      val tagBase    = (unhashedIdx >> idxFullWidth).asUInt
+      val bankIdx    = if (BankIdxWidth == 0) 0.U else unhashedIdx(BankIdxWidth - 1, 0)
+      val setIdxBase = unhashedIdx(BankIdxWidth + SetIdxWidth - 1, BankIdxWidth)
+      val setIdx     = (setIdxBase ^ idxFh)(SetIdxWidth - 1, 0)
+      val tagBase    = (unhashedIdx >> FullIdxWidth).asUInt
       val tag        = (tagBase ^ tagFh ^ (altTagFh << 1).asUInt)(tagLen - 1, 0)
       (bankIdx, setIdx, tag)
     } else {
       require(tagLen == 0)
-      val bankIdx = if (bankIdxWidth == 0) 0.U else unhashedIdx(bankIdxWidth - 1, 0)
-      val setIdx  = unhashedIdx(bankIdxWidth + setIdxWidth - 1, bankIdxWidth)
+      val bankIdx = if (BankIdxWidth == 0) 0.U else unhashedIdx(BankIdxWidth - 1, 0)
+      val setIdx  = unhashedIdx(BankIdxWidth + SetIdxWidth - 1, BankIdxWidth)
       (bankIdx, setIdx, 0.U)
     }
 
@@ -126,20 +123,20 @@ class IttageTable(
   private val (s0_bankIdx, s0_setIdx, s0_tag) =
     computeTagAndHash(s0_unhashedIdx, io.req.bits.foldedHist)
 
-  private val s0_bankMask = UIntToOH(s0_bankIdx, numBanks)
+  private val s0_bankMask = UIntToOH(s0_bankIdx, NumBanks)
 
   private val (s1_setIdx, s1_tag) = (RegEnable(s0_setIdx, io.req.fire), RegEnable(s0_tag, io.req.fire))
   private val s1_bankMask         = RegEnable(s0_bankMask, io.req.fire)
   private val s1_valid            = RegNext(s0_valid)
 
   // Each bank is a single-port SRAM slice; banking lets predict/read and commit/update touch different banks concurrently.
-  private val tables = Seq.tabulate(numBanks) { bankIdx =>
+  private val tables = Seq.tabulate(NumBanks) { bankIdx =>
     Module(new FoldedSRAMTemplate(
       new IttageEntry(tagLen),
       setSplit = 1,
       waySplit = 1,
       dataSplit = dataSplit,
-      set = setsPerBank,
+      set = NumSetsPerBank,
       width = foldedWidth,
       shouldReset = true,
       holdRead = true,
@@ -174,7 +171,7 @@ class IttageTable(
   private val updateFoldedHist                      = io.update.foldedHist
   private val updateUnhashedIdx                     = getUnhashedIdx(io.update.startPc)
   private val (updateBankIdx, updateIdx, updateTag) = computeTagAndHash(updateUnhashedIdx, updateFoldedHist)
-  private val updateBankMask                        = UIntToOH(updateBankIdx, numBanks)
+  private val updateBankMask                        = UIntToOH(updateBankIdx, NumBanks)
   private val updateWdata                           = Wire(new IttageEntry(tagLen))
 
   private val updateAllBitmask = VecInit.fill(ittageEntrySz)(1.U).asUInt // update all entry
@@ -185,8 +182,8 @@ class IttageTable(
 
   private val needReset      = RegInit(false.B)
   private val usefulCanReset = !(io.req.fire || io.update.valid) && needReset
-  // Sweep one set index per cycle; all banks reuse resetSet so the full table resets in setsPerBank cycles.
-  private val (resetSet, resetFinish) = Counter(usefulCanReset, setsPerBank)
+  // Sweep one set index per cycle; all banks reuse resetSet so the full table resets in NumSetsPerBank cycles.
+  private val (resetSet, resetFinish) = Counter(usefulCanReset, NumSetsPerBank)
   when(io.update.resetUsefulCnt) {
     needReset := true.B
   }.elsewhen(resetFinish) {
@@ -202,9 +199,9 @@ class IttageTable(
     Bypass write data from per-bank WriteBuffer to SRAM when that bank's read port is idle.
     Each bank owns its own buffer so an update to bank A can proceed while bank B is serving a read.
   */
-  private val writeBuffers = Seq.tabulate(numBanks) { bankIdx =>
+  private val writeBuffers = Seq.tabulate(NumBanks) { bankIdx =>
     Module(new WriteBuffer(
-      gen = new IttageWriteReq(tagLen, setsPerBank, ittageEntrySz),
+      gen = new IttageWriteReq(tagLen, NumSetsPerBank, ittageEntrySz),
       numEntries = TableWriteBufferSize,
       numPorts = 1,
       nameSuffix = s"ittageTable${tableIdx}_bank$bankIdx"
@@ -309,7 +306,7 @@ class IttageTable(
     XSDebug(RegNext(io.req.fire) && !s1_reqReadHit, "TageTableResp: no hits!\n")
 
     // ------------------------------Debug-------------------------------------
-    val valids = RegInit(VecInit.fill(numBanks)(VecInit.fill(setsPerBank)(false.B)))
+    val valids = RegInit(VecInit.fill(NumBanks)(VecInit.fill(NumSetsPerBank)(false.B)))
     when(io.update.valid)(valids(updateBankIdx)(updateIdx) := true.B)
     XSDebug("ITTAGE Table usage:------------------------\n")
     val totalValid = valids.map(bankVec => PopCount(bankVec)).reduce(_ +& _)

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Parameters.scala
@@ -43,6 +43,10 @@ case class IttageParameters(
     RegionReplacer: String = "plru" // "random", "plru", "lru"
 ) {
   require(isPow2(TableSramSize), "TableSramSize must be a power of 2")
+  require(isPow2(NumBanks), "NumBanks must be a power of 2")
+  TableInfos.foreach { info =>
+    require(info.Size % NumBanks == 0, "ITTAGE table rows must be divisible by number of banks")
+  }
 }
 
 // TODO: expose this to Parameters.scala / XSCore.scala
@@ -54,12 +58,8 @@ trait HasIttageParameters extends HasBpuParameters {
 
   def NumBanks:     Int = ittageParameters.NumBanks
   def BankIdxWidth: Int = log2Ceil(NumBanks)
-  require(isPow2(NumBanks), "NumBanks must be a power of 2")
 
-  def NumSetsPerBank(implicit info: IttageTableInfo): Int = {
-    require(info.Size % NumBanks == 0, "ITTAGE table rows must be divisible by number of banks")
-    info.Size / NumBanks
-  }
+  def NumSetsPerBank(implicit info: IttageTableInfo): Int = info.Size / NumBanks
 
   def SetIdxWidth(implicit info:  IttageTableInfo): Int = log2Ceil(NumSetsPerBank)
   def FullIdxWidth(implicit info: IttageTableInfo): Int = SetIdxWidth + BankIdxWidth

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Parameters.scala
@@ -52,9 +52,17 @@ trait HasIttageParameters extends HasBpuParameters {
   def TableInfos: Seq[IttageTableInfo] = ittageParameters.TableInfos
   def NumTables:  Int                  = TableInfos.length
 
-  def IttageNumBanks:     Int = ittageParameters.NumBanks
-  def IttageBankIdxWidth: Int = log2Ceil(IttageNumBanks)
-  require(isPow2(IttageNumBanks), "IttageNumBanks must be a power of 2")
+  def NumBanks:     Int = ittageParameters.NumBanks
+  def BankIdxWidth: Int = log2Ceil(NumBanks)
+  require(isPow2(NumBanks), "NumBanks must be a power of 2")
+
+  def NumSetsPerBank(implicit info: IttageTableInfo): Int = {
+    require(info.Size % NumBanks == 0, "ITTAGE table rows must be divisible by number of banks")
+    info.Size / NumBanks
+  }
+
+  def SetIdxWidth(implicit info:  IttageTableInfo): Int = log2Ceil(NumSetsPerBank)
+  def FullIdxWidth(implicit info: IttageTableInfo): Int = SetIdxWidth + BankIdxWidth
 
   def TagWidth:           Int = ittageParameters.TagWidth
   def ConfidenceCntWidth: Int = ittageParameters.ConfidenceCntWidth


### PR DESCRIPTION
- Address PR #5430 style review on ITTAGE parameter helpers.
- Derive per-table set/index widths from implicit IttageTableInfo.
- Match the existing TAGE table parameter-passing pattern.
- No intended RTL behavior change.

Refs: #5430