### PR TITLE
fix(ci): checkout target branch for manually triggered release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,16 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Set test branch or commit
+        id: set_test
+        run: |
+          echo "Using checkout ref: ${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}"
+          echo "commit_sha=${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.test_branch || github.ref }}
+          ref: ${{ steps.set_test.outputs.commit_sha }}
 
       - name: Initialize submodules 
         run: make init-force
@@ -65,9 +72,16 @@ jobs:
       - builder
       - open # use open servers only, keep node servers for emu jobs
     steps:
-      - uses: actions/checkout@v6
+      - name: Set test branch or commit
+        id: set_test
+        run: |
+          echo "Using checkout ref: ${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}"
+          echo "commit_sha=${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.test_branch || github.ref }}
+          ref: ${{ steps.set_test.outputs.commit_sha }}
           fetch-depth: 0
           submodules: true
       - name: set env
@@ -108,9 +122,16 @@ jobs:
     name: Upload Artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Set test branch or commit
+        id: set_test
+        run: |
+          echo "Using checkout ref: ${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}"
+          echo "commit_sha=${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.test_branch || github.ref }}
+          ref: ${{ steps.set_test.outputs.commit_sha }}
       - name: Install deps
         run: |
           sudo apt install python3-psutil

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,9 @@ jobs:
       - name: Set test branch or commit
         id: set_test
         run: |
-          echo "Using checkout ref: ${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}"
-          echo "commit_sha=${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}" >> $GITHUB_OUTPUT
+          REF="${{ inputs.test_branch || github.ref }}"
+          echo "Using checkout ref: ${REF}"
+          echo "commit_sha=${REF}" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -75,8 +76,9 @@ jobs:
       - name: Set test branch or commit
         id: set_test
         run: |
-          echo "Using checkout ref: ${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}"
-          echo "commit_sha=${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}" >> $GITHUB_OUTPUT
+          REF="${{ inputs.test_branch || github.ref }}"
+          echo "Using checkout ref: ${REF}"
+          echo "commit_sha=${REF}" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -125,8 +127,9 @@ jobs:
       - name: Set test branch or commit
         id: set_test
         run: |
-          echo "Using checkout ref: ${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}"
-          echo "commit_sha=${{ inputs.test_branch != '' && inputs.test_branch || github.ref }}" >> $GITHUB_OUTPUT
+          REF="${{ inputs.test_branch || github.ref }}"
+          echo "Using checkout ref: ${REF}"
+          echo "commit_sha=${REF}" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
The manual trigger workflow did not reliably checkout the branch/commit provided by input (test_branch).

Root cause:
- checkout ref selection relied on `github.event_name == 'workflow_call'` inside release.yml.
- In reusable workflow runs, the github context reflects the caller event, results in github.event_name is "workflow_dispatch"passed from release-trigger.yml instead of "workflow_call". So this condition could evaluate unexpectedly and fallback to github.ref.

Fix:
- update release.yml checkout ref resolution to prefer `inputs.test_branch` when non-empty, otherwise fallback to `github.ref`.
- add an explicit "Set test branch or commit" step before checkout in each job to print and export the effective ref, improving CI traceability.