### PR TITLE
timing(ifu): replace priority encoder + shift with parallel prefix tree

### DIFF
--- a/src/main/scala/utils/SeqUtils.scala
+++ b/src/main/scala/utils/SeqUtils.scala
@@ -19,4 +19,39 @@ object SeqUtils {
   def mapToMixedVec3[T, A <: Data](in: Seq3[T], f: T => A): MixedVec3[A] = {
     MixedVec(in.map(x => mapToMixedVec2(x, f)))
   }
+
+  /** Computes the prefix OR (cumulative logical OR) of a sequence of Bool signals.
+    *
+    * Example:
+    *   prefixOr([a, b, c, d]) -> [a, a||b, a||b||c, a||b||c||d]
+    *
+    * The implementation uses a divide-and-conquer recursive approach.
+    *
+    * @param in input sequence of Bool
+    * @return   output sequence where each element is the OR of all previous inputs up to that index
+    */
+  // Keep Bool-specific because prefixOr relies on logical OR semantics.
+  def prefixOr(in: Seq[Bool]): Seq[Bool] = {
+    val n = in.length
+    if (n <= 1) {
+      in
+    } else {
+      val half    = n / 2
+      val leftIn  = in.take(half)
+      val rightIn = in.drop(half)
+
+      // Recursively compute prefix OR on left and right halves
+      val leftPrefix  = prefixOr(leftIn)
+      val rightPrefix = prefixOr(rightIn)
+
+      // Overall OR value of the left half (i.e., the last element of leftPrefix)
+      val leftTotalOr = leftPrefix.last
+
+      // Every element in the right half must be ORed with leftTotalOr
+      val rightPrefixAdjusted = rightPrefix.map(_ || leftTotalOr)
+
+      // Concatenate the results
+      leftPrefix ++ rightPrefixAdjusted
+    }
+  }
 }

--- a/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
@@ -40,6 +40,32 @@ trait PreDecodeHelper extends HasIfuParameters {
   }
 }
 
+trait PredCheckerHelper extends HasIfuParameters {
+  def prefixOr(in: Seq[Bool]): Seq[Bool] = {
+    val n = in.length
+    if (n <= 1) {
+      in
+    } else {
+      val half    = n / 2
+      val leftIn  = in.take(half)
+      val rightIn = in.drop(half)
+
+      // Recursively compute prefix OR on left and right halves
+      val leftPrefix  = prefixOr(leftIn)
+      val rightPrefix = prefixOr(rightIn)
+
+      // Overall OR value of the left half (i.e., the last element of leftPrefix)
+      val leftTotalOr = leftPrefix.last
+
+      // Every element in the right half must be ORed with leftTotalOr
+      val rightPrefixAdjusted = rightPrefix.map(_ || leftTotalOr)
+
+      // Concatenate the results
+      leftPrefix ++ rightPrefixAdjusted
+    }
+  }
+}
+
 trait IfuHelper extends HasIfuParameters {
   private object ShiftType {
     val NoShift     = 0.U(2.W)

--- a/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
@@ -40,32 +40,6 @@ trait PreDecodeHelper extends HasIfuParameters {
   }
 }
 
-trait PredCheckerHelper extends HasIfuParameters {
-  def prefixOr(in: Seq[Bool]): Seq[Bool] = {
-    val n = in.length
-    if (n <= 1) {
-      in
-    } else {
-      val half    = n / 2
-      val leftIn  = in.take(half)
-      val rightIn = in.drop(half)
-
-      // Recursively compute prefix OR on left and right halves
-      val leftPrefix  = prefixOr(leftIn)
-      val rightPrefix = prefixOr(rightIn)
-
-      // Overall OR value of the left half (i.e., the last element of leftPrefix)
-      val leftTotalOr = leftPrefix.last
-
-      // Every element in the right half must be ORed with leftTotalOr
-      val rightPrefixAdjusted = rightPrefix.map(_ || leftTotalOr)
-
-      // Concatenate the results
-      leftPrefix ++ rightPrefixAdjusted
-    }
-  }
-}
-
 trait IfuHelper extends HasIfuParameters {
   private object ShiftType {
     val NoShift     = 0.U(2.W)

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -27,7 +27,7 @@ import xiangshan.frontend.PreDecodeInfo
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.bpu.BranchAttribute
 
-class PredChecker(implicit p: Parameters) extends IfuModule {
+class PredChecker(implicit p: Parameters) extends IfuModule with PredCheckerHelper {
   class PredCheckerIO extends IfuBundle {
     class PredCheckerReq(implicit p: Parameters) extends IfuBundle {
       // Input data is offset-adjusted for IBuffer enqueue.
@@ -130,20 +130,15 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
     VecInit((0 until IBufferEnqueueWidth).map(i =>
       jalFaultVec(i) || jalrFaultVec(i) || retFaultVec(i) || invalidTaken(i) || notCfiTaken(i)
     ))
-  private val remaskIdx  = ParallelPriorityEncoder(remaskFault.asUInt)
-  private val needRemask = ParallelOR(remaskFault)
-  // NOTE: we need a minimal pow2 that greater than IBufferEnqueueWidth, so we do a log2Up then pow(2)
-  private val fixedRange =
-    instrValid.asUInt & (
-      Fill(IBufferEnqueueWidth, !needRemask) |
-        (Fill(pow(2, log2Up(IBufferEnqueueWidth)).toInt, 1.U(1.W)) >> (~remaskIdx).asUInt).asUInt
-    )
-  // Adjust this if one IBuffer input entry is later removed
-  // require(
-  //   isPow2(IBufferEnqueueWidth),
-  //   "If IBufferEnqueueWidth does not satisfy the power of 2," +
-  //     "expression: Fill(IBufferEnqueueWidth, 1.U(1.W)) >> ~remaskIdx is not right !!"
-  // )
+
+  // Timing optimization: prefixOr is implemented as a parallel prefix tree (recursive bisection),
+  // which retains all valid instruction entries before the first fault occurs (including the fault position itself).
+  private val maskFaultOrBefore = false.B +: prefixOr(remaskFault)
+
+  // keep entries before and including the first remask fault
+  private val fixedRange = VecInit((0 until IBufferEnqueueWidth).map {
+    i => instrValid(i) && !maskFaultOrBefore(i)
+  }).asUInt
 
   io.resp.stage1Out.fixedTwoFetchRange := fixedRange.asTypeOf(Vec(IBufferEnqueueWidth, Bool()))
 

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -22,12 +22,13 @@ import org.chipsalliance.cde.config.Parameters
 import utility.ParallelOR
 import utility.ParallelPriorityEncoder
 import utility.XSPerfAccumulate
+import utils.SeqUtils.prefixOr
 import xiangshan.ValidUndirectioned
 import xiangshan.frontend.PreDecodeInfo
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.bpu.BranchAttribute
 
-class PredChecker(implicit p: Parameters) extends IfuModule with PredCheckerHelper {
+class PredChecker(implicit p: Parameters) extends IfuModule {
   class PredCheckerIO extends IfuBundle {
     class PredCheckerReq(implicit p: Parameters) extends IfuBundle {
       // Input data is offset-adjusted for IBuffer enqueue.


### PR DESCRIPTION
Objective: Modify the calculation method for narrowing the instruction fetch range to optimize timing.

Retention Logic: Based on the error location, retain all instructions preceding the fault point, including the instruction at the fault location itself. (For example, if a branch instruction predicts the wrong target address, the branch instruction itself remains within the fetch range.)

Validity Check: To determine whether a valid instruction exists at position i, simply perform a bitwise OR operation on the remaskFault signals of all preceding positions.

Optimization: Since the bitwise OR logic involves repetitive patterns, a recursive approach is adopted to simplify the code structure and enhance reusability.