### PR TITLE
fix(VSSplitBuffer): fix misalign robIdx age comparison

### DIFF
--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -472,7 +472,7 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
 
 class VSSplitBufferImp(implicit p: Parameters) extends VSplitBuffer(isVStore = true){
   lazy val canToMisalignBuffer = io.vstdMisalign.get.storeMisalignBufferEmpty &&
-    (!io.vstdMisalign.get.scalaIssueValid || io.vstdMisalign.get.scalaIssueRobIdx < issueUop.robIdx)
+    (!io.vstdMisalign.get.scalaIssueValid || issueUop.robIdx < io.vstdMisalign.get.scalaIssueRobIdx)
 
   override lazy val misalignedCanGo = io.vstdMisalign.get.storePipeEmpty && canToMisalignBuffer
 


### PR DESCRIPTION
Correct the robIdx comparison when checking whether a vector store split can enter StoreMisalignBuffer. The split should wait when an older scalar store issue exists, preventing incorrect ordering in misaligned store handling.
