### PR TITLE
timing(mbtb): reuse t0 read state

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
@@ -190,19 +190,20 @@ class MainBtbAlignBank(
   private val s3_takenMask      = io.s3_takenMask
 
   // touch taken entries only: not-taken conditional entries are considered not very useful and should be killed first
-  replacer.io.predictTouch.valid        := s3_fire && s3_takenMask.reduce(_ || _)
-  replacer.io.predictTouch.bits.setIdx  := s3_replacerSetIdx
-  replacer.io.predictTouch.bits.wayMask := s3_takenMask.asUInt
+  replacer.io.predict.touch.valid        := s3_fire && s3_takenMask.reduce(_ || _)
+  replacer.io.predict.touch.bits.setIdx  := s3_replacerSetIdx
+  replacer.io.predict.touch.bits.wayMask := s3_takenMask.asUInt
 
   /* *** t0 ***
    * read replacer in advance for better timing
    */
-  private val t0_fire           = io.stageCtrl.t0_fire
-  private val t0_replacerSetIdx = getReplacerSetIndex(io.t0_startPc)
+  private val t0_fire    = io.stageCtrl.t0_fire
+  private val t0_startPc = io.t0_startPc
 
-  replacer.io.victim.setIdx := t0_replacerSetIdx
+  replacer.io.train.t0_setIdx := getReplacerSetIndex(t0_startPc)
+  replacer.io.train.t0_fire   := t0_fire
 
-  private val t0_victimMask = replacer.io.victim.wayMask
+  private val t0_victimMask = replacer.io.train.t0_victim
 
   /* *** t1 ***
    * send write req to internal banks (srams)
@@ -256,9 +257,9 @@ class MainBtbAlignBank(
   }
 
   // update replacer
-  replacer.io.trainTouch.valid        := t1_fire && t1_entryNeedWrite
-  replacer.io.trainTouch.bits.setIdx  := getReplacerSetIndex(t1_startPc)
-  replacer.io.trainTouch.bits.wayMask := t1_entryWayMask
+  replacer.io.train.t1_touch.valid        := t1_fire && t1_entryNeedWrite
+  replacer.io.train.t1_touch.bits.setIdx  := getReplacerSetIndex(t1_startPc)
+  replacer.io.train.t1_touch.bits.wayMask := t1_entryWayMask
 
   /* *** update counter *** */
   private val t1_newCounters    = Wire(Vec(NumWay, TakenCounter()))

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbReplacer.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbReplacer.scala
@@ -28,16 +28,19 @@ class MainBtbReplacer(implicit p: Parameters) extends MainBtbModule {
       val wayMask: UInt = UInt(NumWay.W)
     }
 
-    class Victim extends Bundle {
-      val setIdx:  UInt = Input(UInt(SetIdxLen.W))
-      val wayMask: UInt = Output(UInt(NumWay.W))
+    class Predict extends Bundle {
+      val touch: Valid[Touch] = Flipped(Valid(new Touch))
     }
 
-    val victim: Victim            = new Victim
-    val touch:  Vec[Valid[Touch]] = Vec(2, Flipped(Valid(new Touch))) // magic number 2: predict and train
+    class Train extends Bundle {
+      val t0_setIdx: UInt         = Input(UInt(SetIdxLen.W))
+      val t0_fire:   Bool         = Input(Bool())
+      val t0_victim: UInt         = Output(UInt(NumWay.W))
+      val t1_touch:  Valid[Touch] = Flipped(Valid(new Touch))
+    }
 
-    def predictTouch: Valid[Touch] = touch(0)
-    def trainTouch:   Valid[Touch] = touch(1)
+    val predict: Predict = new Predict
+    val train:   Train   = new Train
   }
 
   val io: MainBtbReplacerIO = IO(new MainBtbReplacerIO)
@@ -45,17 +48,17 @@ class MainBtbReplacer(implicit p: Parameters) extends MainBtbModule {
   private val predictStateGen = Module(ReplacerStateGen(Replacer, NumWay, accessSize = NumWay))
   private val trainStateGen   = Module(ReplacerStateGen(Replacer, NumWay))
   private val victimStateGen  = Module(ReplacerStateGen(Replacer, NumWay))
-  private val stateBank       = Module(new ReplacerState(NumSets, predictStateGen.StateWidth, HasExtraReadPort = true))
+  private val stateBank       = Module(new ReplacerState(NumSets, predictStateGen.StateWidth))
 
   /* *** predict *** */
   // read current state
-  stateBank.io.predictReadSetIdx := io.predictTouch.bits.setIdx
+  stateBank.io.predictReadSetIdx := io.predict.touch.bits.setIdx
   private val predictState = stateBank.io.predictReadState
 
   // compose touch way vec
   private val predictTouchWay = VecInit((0 until NumWay).map { i =>
     val wayValid = Wire(Valid(UInt(log2Up(NumWay).W)))
-    wayValid.valid := io.predictTouch.valid && io.predictTouch.bits.wayMask(i)
+    wayValid.valid := io.predict.touch.valid && io.predict.touch.bits.wayMask(i)
     wayValid.bits  := i.U
     wayValid
   })
@@ -63,46 +66,61 @@ class MainBtbReplacer(implicit p: Parameters) extends MainBtbModule {
   // generate next state
   predictStateGen.io.state   := predictState
   predictStateGen.io.touches := predictTouchWay
-  private val predictNextState = Mux(io.predictTouch.valid, predictStateGen.io.nextState, predictState)
+  private val predictNextState = predictStateGen.io.nextState
 
   // write back next state
-  stateBank.io.predictWriteValid  := io.predictTouch.valid
-  stateBank.io.predictWriteSetIdx := io.predictTouch.bits.setIdx
+  stateBank.io.predictWriteValid  := io.predict.touch.valid
+  stateBank.io.predictWriteSetIdx := io.predict.touch.bits.setIdx
   stateBank.io.predictWriteState  := predictNextState
 
-  /* *** train *** */
+  /* *** train t0 *** */
   // read current state
-  stateBank.io.trainReadSetIdx := io.trainTouch.bits.setIdx
-  private val trainState = stateBank.io.trainReadState
+  stateBank.io.trainReadSetIdx := io.train.t0_setIdx
 
+  // if t1 is about to write the same set as t0 read, we need to use the updated state (trainStateGen.io.nextState)
+  private val trainNextState = trainStateGen.io.nextState
+  private val trainSameSet   = io.train.t1_touch.valid && (io.train.t1_touch.bits.setIdx === io.train.t0_setIdx)
+  private val predictSameSet = io.predict.touch.valid && (io.predict.touch.bits.setIdx === io.train.t0_setIdx)
+  private val trainState = MuxCase(
+    stateBank.io.trainReadState,
+    Seq(
+      trainSameSet   -> trainNextState, // trainNextState has higher priority, see ReplacerState.scala
+      predictSameSet -> predictNextState
+    )
+  )
+
+  // generate victim
+  victimStateGen.io.state   := trainState
+  victimStateGen.io.touches := DontCare // we use victimStateGen just to select victim, don't care touch & nextState
+
+  // send back to MainBtbAlignBank
+  io.train.t0_victim := UIntToOH(victimStateGen.io.victim)
+
+  /* *** train t1 *** */
   // compose touch way vec
   private val trainTouchWay = Wire(Valid(UInt(log2Up(NumWay).W)))
-  trainTouchWay.valid := io.trainTouch.valid
-  trainTouchWay.bits  := OHToUInt(io.trainTouch.bits.wayMask) // MainBtbAlignBank ensures this is one-hot
+  trainTouchWay.valid := io.train.t1_touch.valid
+  trainTouchWay.bits  := OHToUInt(io.train.t1_touch.bits.wayMask) // MainBtbAlignBank ensures this is one-hot
   assert(
-    !io.trainTouch.valid || PopCount(io.trainTouch.bits.wayMask) <= 1.U,
+    !io.train.t1_touch.valid || PopCount(io.train.t1_touch.bits.wayMask) <= 1.U,
     "victim wayMask should be at-most-one-hot"
   )
 
   // generate next state
-  trainStateGen.io.state   := trainState
+  trainStateGen.io.state   := RegEnable(trainState, io.train.t0_fire) // RegEnable to sync with t1
   trainStateGen.io.touches := VecInit(Seq(trainTouchWay))
-  private val trainNextState = Mux(io.trainTouch.valid, trainStateGen.io.nextState, trainState)
 
   // write back next state
-  stateBank.io.trainWriteValid  := io.trainTouch.valid
-  stateBank.io.trainWriteSetIdx := io.trainTouch.bits.setIdx
+  stateBank.io.trainWriteValid  := io.train.t1_touch.valid
+  stateBank.io.trainWriteSetIdx := io.train.t1_touch.bits.setIdx
   stateBank.io.trainWriteState  := trainNextState
 
-  /* *** victim *** */
-  stateBank.io.readSetIdx.get := io.victim.setIdx
-  private val victimState = stateBank.io.readState.get
-
-  // NOTE: io.trainTouch is on t1, io.victim.setIdx is on t0,
-  //       if they are accessing the same set, we use the updated state to select victim
-  private val trainVictimConflict = io.trainTouch.valid && (io.trainTouch.bits.setIdx === io.victim.setIdx)
-  victimStateGen.io.state   := Mux(trainVictimConflict, trainNextState, victimState)
-  victimStateGen.io.touches := DontCare // we use victimStateGen just to select victim, don't care touch & nextState
-
-  io.victim.wayMask := UIntToOH(victimStateGen.io.victim)
+  // we use t0_setIdx to pre-read stateBank for better timing, it's a tightly-coupled design,
+  // so we require t1 to touch the same set
+  assert(
+    !(
+      io.train.t1_touch.valid && RegEnable(io.train.t0_setIdx, io.train.t0_fire) =/= io.train.t1_touch.bits.setIdx
+    ),
+    "pipeline mismatch: t1 touch should be for the same set as t0 train"
+  )
 }

--- a/src/main/scala/xiangshan/frontend/bpu/replacer/ReplacerState.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/replacer/ReplacerState.scala
@@ -59,7 +59,7 @@ class ReplacerState(NumSets: Int, StateBits: Int, HasExtraReadPort: Boolean = fa
       states(io.predictWriteSetIdx) := io.predictWriteState
     }
     when(io.trainWriteValid) {
-      states(io.trainReadSetIdx) := io.trainWriteState
+      states(io.trainWriteSetIdx) := io.trainWriteState
     }
   }
   io.predictReadState := states(io.predictReadSetIdx)


### PR DESCRIPTION
Further improve #5897

original t1 path: trainTouch.setIdx -> stateBank -> trainStateGen -> stateBank

new t1 path: RegEnable(trainState) -> trainStateGen -> stateBank

This also reduced 1 read port of ReplacerStateBank, saving some area (comb. logic)

Also:
1. fix victim selection: if predict s3 touches the same set in t0 stage, use the updated state to select victim.
    <img width="2632" height="438" alt="image" src="https://github.com/user-attachments/assets/ec5df784-4ab5-4b23-90e5-8cdea50691a9" />
    After fix (left) newState is calculated with currentState=0x3f (3 > 2 > 1 > 0), after touching way1, newState should be 0x38 (1 > 3 > 2 > 0). While before (right) calculating with currentState=0x3E (3 > 2 > 0 > 1), and got newState=0x27 (1 > 3 > 2 > 0)
2. fix a typo in ReplacerState, which does not affect performance since trainRead and trainWrite are in the same cycle. After this PR, read is 1 cycle ahead write, causing problem.

A slight performance change is expected due to victim selection fix.

DC report show mbtb t1 (replacer update-related path) ~30ps violation -> clean.