### PR TITLE
timing(bpu): pc-related path fixes

### DIFF
--- a/src/main/scala/utils/Duplicate.scala
+++ b/src/main/scala/utils/Duplicate.scala
@@ -133,7 +133,7 @@ class Duplicate[T <: Data](
     DuplicateInit(names, dups)
   }
 
-  def getNext: T = {
+  def get: T = {
     val ret = this.dup(this.next)
     this.next = (this.next + 1) % this.num
     ret
@@ -165,6 +165,20 @@ class Duplicate[T <: Data](
   def toVec: Vec[T] = this.dup
 
   def :=(source: T): Unit = this.dup.foreach(_ := source)
+
+  def :=(source: Duplicate[T]): Unit = this.dup.foreach(_ := source.get)
+
+  def foreach(f: T => Unit): Unit = this.dup.foreach(f)
+
+  def map[TT <: Data](f: T => TT): Duplicate[TT] = {
+    val mapped = this.dup.map(f)
+    DuplicateInit(this.names, mapped)
+  }
+
+  def generateAssertion(valid: Bool = true.B): Unit =
+    this.dup.tail.zipWithIndex.foreach { case (dup, idx) =>
+      assert(!valid || dup === this.head, s"Duplicate assertion failed for ${idx}")
+    }
 }
 
 object Duplicate {

--- a/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
@@ -38,16 +38,16 @@ abstract class BasePredictorIO(implicit p: Parameters) extends BpuBundle {
   // predict request
   val startPc: PrunedAddr = Input(PrunedAddr(VAddrBits))
   // resolve train
-  val trainReady: Bool     = Output(Bool())
-  val train:      BpuTrain = Input(new BpuTrain)
+  val trainReady: Bool  = Output(Bool())
+  val train:      Train = Input(new Train)
   // fast train for s1 predictors
-  val fastTrain: Option[Valid[BpuFastTrain]] = None
+  val fastTrain: Option[Valid[FastTrain]] = None
 
   val sramResetDone: Bool = Output(Bool())
 }
 
 trait HasFastTrainIO extends BasePredictorIO {
-  override val fastTrain: Option[Valid[BpuFastTrain]] = Option(Input(Valid(new BpuFastTrain)))
+  override val fastTrain: Option[Valid[FastTrain]] = Option(Input(Valid(new FastTrain)))
 }
 
 // The abstract class is used to abstract the setIdx and tag from write requests for updating write buffer entries

--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -25,10 +25,12 @@ import utility.XSError
 import utility.XSPerfAccumulate
 import utility.XSPerfHistogram
 import utility.XSPerfSeqAccumulate
+import utils.DuplicateInit
 import xiangshan.frontend.BpuToFtqIO
 import xiangshan.frontend.FrontendTopDownBundle
 import xiangshan.frontend.FtqToBpuIO
 import xiangshan.frontend.PrunedAddr
+import xiangshan.frontend.PrunedAddrInit
 import xiangshan.frontend.bpu.abtb.AheadBtb
 import xiangshan.frontend.bpu.history.commonhr.CommonHR
 import xiangshan.frontend.bpu.history.commonhr.CommonHRMeta
@@ -138,7 +140,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   private val debug_bpId = RegInit(0.U(XLEN.W))
 
-  private val s0_startPc    = WireDefault(0.U.asTypeOf(PrunedAddr(VAddrBits)))
+  private val s0_startPc    = DuplicateInit(NumStartPcDuplicate, PrunedAddrInit(0.U(VAddrBits.W)))
   private val s0_startPcReg = RegEnable(s0_startPc, !s0_stall)
 
   when(RegNext(RegNext(reset.asBool)) && !reset.asBool) {
@@ -181,20 +183,26 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     b.valid := io.fromFtq.train.bits.branches(i).valid && t0_firstMispredictMask(i)
   }
 
-  private val fastTrain = Wire(Valid(new BpuFastTrain))
+  private val fastTrain = Wire(Valid(new FastTrain))
   fastTrain.valid                := s3_valid
-  fastTrain.bits.startPc         := s3_startPc
+  fastTrain.bits.startPc         := s3_startPc.get
   fastTrain.bits.finalPrediction := s3_prediction
   fastTrain.bits.abtbMeta        := s3_abtbMeta
   fastTrain.bits.utageMeta       := s3_utageMeta
   fastTrain.bits.hasOverride     := s3_override
 
   predictors.foreach { p =>
-    // TODO: duplicate pc and fire to solve high fan-out issue
-    p.io.startPc   := s0_startPc
+    p.io.startPc   := s0_startPc.get
     p.io.stageCtrl := stageCtrl
-    p.io.train     := train
-    p.io.fastTrain.foreach(_ := fastTrain) // fastTrain is an Option[Valid[BpuFastTrain]]
+    // in this fromBpuTrain, we get a duplicated startPcVec, so this cannot be moved outside "predictors.foreach"
+    // i.e. this is wrong: ```
+    //   private val train = Wire(new Train)
+    //   train.fromBpuTrain(io.fromFtq.train.bits)
+    //   predictors.foreach { p => p.io.train := train }
+    // ```
+    p.io.train.fromBpuTrain(train)
+    // fastTrain is an Option[Valid[BpuFastTrain]], we need .foreach
+    p.io.fastTrain.foreach(_ := fastTrain)
   }
   io.fromFtq.train.ready := predictors.map(_.io.trainReady).reduce(_ && _)
 
@@ -218,12 +226,12 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   utage.io.overrideStartPc := s3_prediction.target
 
   // uras
-  uras.io.specIn.startPc                := s1_startPc
+  uras.io.specIn.startPc                := s1_startPc.get
   uras.io.specIn.cfiPosition            := s1_prediction.cfiPosition
   uras.io.specIn.attribute              := s1_prediction.attribute
   uras.io.hasRedirect                   := redirect.valid
   uras.io.overrideData.valid            := s3_override
-  uras.io.overrideData.bits.startPc     := s3_startPc.toUInt
+  uras.io.overrideData.bits.startPc     := s3_startPc.get.toUInt
   uras.io.overrideData.bits.attribute   := s3_prediction.attribute
   uras.io.overrideData.bits.cfiPosition := s3_prediction.cfiPosition
   uras.io.fullRetAddr                   := ras.io.topRetAddr
@@ -231,7 +239,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   ras.io.redirect                := redirect
   ras.io.commit                  := commit
   ras.io.specIn.valid            := s3_fire
-  ras.io.specIn.bits.startPc     := s3_startPc.toUInt
+  ras.io.specIn.bits.startPc     := s3_startPc.get.toUInt
   ras.io.specIn.bits.attribute   := s3_prediction.attribute
   ras.io.specIn.bits.cfiPosition := s3_prediction.cfiPosition
 
@@ -470,9 +478,9 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   /* *** bpu to ftq io *** */
   io.toFtq.prediction.valid := s1_valid && s2_ready || s3_override
   when(s3_override) {
-    io.toFtq.prediction.bits.fromStage(s3_startPc, s3_prediction)
+    io.toFtq.prediction.bits.fromStage(s3_startPc.get, s3_prediction)
   }.otherwise {
-    io.toFtq.prediction.bits.fromStage(s1_startPc, s1_prediction)
+    io.toFtq.prediction.bits.fromStage(s1_startPc.get, s1_prediction)
   }
   io.toFtq.prediction.bits.s3Override := s3_override
 
@@ -488,7 +496,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   /* *** s0_startPc selection *** */
   s0_startPc := MuxCase(
-    s0_startPcReg,
+    s0_startPcReg.get,
     Seq(
       redirect.valid -> redirect.bits.target,
       s3_override    -> s3_prediction.target,
@@ -521,17 +529,17 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   phr.io.train.s3_override          := s3_override
   phr.io.train.s3_phrMeta           := s3_phrMeta
   phr.io.train.s3_prediction        := s3_prediction
-  phr.io.train.s3_startPc           := s3_startPc
+  phr.io.train.s3_startPc           := s3_startPc.get
   phr.io.s1Train.valid              := s1_fire
   phr.io.s1Train.taken              := s1_prediction.taken
-  phr.io.s1Train.startPc            := s1_startPc
+  phr.io.s1Train.startPc            := s1_startPc.get
   phr.io.s1Train.abtbValid          := s1_abtbValid
   phr.io.s1Train.abtbFirstTakenBrOH := s1_abtbFirstTakenBrOH
   phr.io.s1Train.ubtbPrediction     := s1_ubtbPredWithURas
   phr.io.s1Train.abtbPrediction     := s1_abtbPredWithURas
 
   phr.io.commit.valid := io.fromFtq.train.fire
-  phr.io.commit.bits  := train
+  phr.io.commit.bits.fromBpuTrain(train)
 
   s0_foldedPhr   := phr.io.s0_foldedPhr
   s1_foldedPhr   := phr.io.s1_foldedPhr
@@ -543,19 +551,19 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   dontTouch(phrBits)
 
   // ghr update
-  private val s1_cfiPc = getCfiPcFromPosition(s1_startPc, s1_prediction.cfiPosition)
+  private val s1_cfiPc = getCfiPcFromPosition(s1_startPc.get, s1_prediction.cfiPosition)
   private val s1_imliTaken =
     s1_prediction.taken && s1_prediction.attribute.isConditional &&
       (s1_cfiPc.addr(CompareAddrLowWidth - 1, 0) > s1_prediction.target.addr(CompareAddrLowWidth - 1, 0))
 
   commonHR.io.stageCtrl                 := stageCtrl
-  commonHR.io.s0_startPc.get            := s0_startPc
+  commonHR.io.s0_startPc.get            := s0_startPc.get
   commonHR.io.s1_imliTaken              := s1_imliTaken
-  commonHR.io.s2StartPc                 := s2_startPc
+  commonHR.io.s2StartPc                 := s2_startPc.get
   commonHR.io.s2CondHitMask             := VecInit(mbtb.io.result.map(e => e.valid && e.bits.attribute.isConditional))
   commonHR.io.s2CfiPositions            := VecInit(mbtb.io.result.map(_.bits.cfiPosition))
   commonHR.io.s2CfiTargets              := VecInit(mbtb.io.result.map(_.bits.target))
-  commonHR.io.update.startPc            := s3_startPc
+  commonHR.io.update.startPc            := s3_startPc.get
   commonHR.io.update.target             := s3_prediction.target
   commonHR.io.update.taken              := s3_taken
   commonHR.io.update.s3Override         := s3_override
@@ -579,13 +587,13 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     powerOnResetState := false.B
   }
   XSError(
-    !powerOnResetState && s0_stall && s0_startPc =/= s0_startPcReg,
+    !powerOnResetState && s0_stall && s0_startPc.head =/= s0_startPcReg.head,
     "s0_stall but s0_startPc is different from s0_startPcReg"
   )
 
   /* *** check abtb output *** */
   when(io.toFtq.prediction.fire && abtb.io.prediction.map(_.valid).reduce(_ || _)) {
-    assert(abtb.io.debug_startPc === s1_startPc)
+    assert(abtb.io.debug_startPc === s1_startPc.head)
   }
 
   /* *** Debug Meta *** */
@@ -615,7 +623,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val s3_s1PredictionSource = RegEnable(s2_s1PredictionSource, s2_fire)
 
   private val s3_perfMeta = Wire(new BpuPerfMeta)
-  s3_perfMeta.startPc             := s3_startPc
+  s3_perfMeta.startPc             := s3_startPc.head
   s3_perfMeta.bpId                := debug_bpId
   s3_perfMeta.s1Prediction        := s3_s1Prediction
   s3_perfMeta.s3Prediction        := s3_prediction

--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -25,10 +25,12 @@ import utility.XSError
 import utility.XSPerfAccumulate
 import utility.XSPerfHistogram
 import utility.XSPerfSeqAccumulate
+import utils.DuplicateInit
 import xiangshan.frontend.BpuToFtqIO
 import xiangshan.frontend.FrontendTopDownBundle
 import xiangshan.frontend.FtqToBpuIO
 import xiangshan.frontend.PrunedAddr
+import xiangshan.frontend.PrunedAddrInit
 import xiangshan.frontend.bpu.abtb.AheadBtb
 import xiangshan.frontend.bpu.history.commonhr.CommonHR
 import xiangshan.frontend.bpu.history.commonhr.CommonHRMeta
@@ -138,7 +140,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   private val debug_bpId = RegInit(0.U(XLEN.W))
 
-  private val s0_startPc    = WireDefault(0.U.asTypeOf(PrunedAddr(VAddrBits)))
+  private val s0_startPc    = DuplicateInit(NumStartPcDuplicate, PrunedAddrInit(0.U(VAddrBits.W)))
   private val s0_startPcReg = RegEnable(s0_startPc, !s0_stall)
 
   when(RegNext(RegNext(reset.asBool)) && !reset.asBool) {
@@ -181,20 +183,26 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     b.valid := io.fromFtq.train.bits.branches(i).valid && t0_firstMispredictMask(i)
   }
 
-  private val fastTrain = Wire(Valid(new BpuFastTrain))
+  private val fastTrain = Wire(Valid(new FastTrain))
   fastTrain.valid                := s3_valid
-  fastTrain.bits.startPc         := s3_startPc
+  fastTrain.bits.startPc         := s3_startPc.get
   fastTrain.bits.finalPrediction := s3_prediction
   fastTrain.bits.abtbMeta        := s3_abtbMeta
   fastTrain.bits.utageMeta       := s3_utageMeta
   fastTrain.bits.hasOverride     := s3_override
 
   predictors.foreach { p =>
-    // TODO: duplicate pc and fire to solve high fan-out issue
-    p.io.startPc   := s0_startPc
+    p.io.startPc   := s0_startPc.get
     p.io.stageCtrl := stageCtrl
-    p.io.train     := train
-    p.io.fastTrain.foreach(_ := fastTrain) // fastTrain is an Option[Valid[BpuFastTrain]]
+    // in this fromBpuTrain, we get a duplicated startPcVec, so this cannot be moved outside "predictors.foreach"
+    // i.e. this is wrong: ```
+    //   private val train = Wire(new Train)
+    //   train.fromBpuTrain(io.fromFtq.train.bits)
+    //   predictors.foreach { p => p.io.train := train }
+    // ```
+    p.io.train.fromBpuTrain(train)
+    // fastTrain is an Option[Valid[BpuFastTrain]], we need .foreach
+    p.io.fastTrain.foreach(_ := fastTrain)
   }
   io.fromFtq.train.ready := predictors.map(_.io.trainReady).reduce(_ && _)
 
@@ -210,12 +218,12 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   utage.io.redirectValid          := redirect.valid
 
   // uras
-  uras.io.specIn.startPc                := s1_startPc
+  uras.io.specIn.startPc                := s1_startPc.get
   uras.io.specIn.cfiPosition            := s1_prediction.cfiPosition
   uras.io.specIn.attribute              := s1_prediction.attribute
   uras.io.hasRedirect                   := redirect.valid
   uras.io.overrideData.valid            := s3_override
-  uras.io.overrideData.bits.startPc     := s3_startPc.toUInt
+  uras.io.overrideData.bits.startPc     := s3_startPc.get.toUInt
   uras.io.overrideData.bits.attribute   := s3_prediction.attribute
   uras.io.overrideData.bits.cfiPosition := s3_prediction.cfiPosition
   uras.io.fullRetAddr                   := ras.io.topRetAddr
@@ -223,7 +231,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   ras.io.redirect                := redirect
   ras.io.commit                  := commit
   ras.io.specIn.valid            := s3_fire
-  ras.io.specIn.bits.startPc     := s3_startPc.toUInt
+  ras.io.specIn.bits.startPc     := s3_startPc.get.toUInt
   ras.io.specIn.bits.attribute   := s3_prediction.attribute
   ras.io.specIn.bits.cfiPosition := s3_prediction.cfiPosition
 
@@ -462,9 +470,9 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   /* *** bpu to ftq io *** */
   io.toFtq.prediction.valid := s1_valid && s2_ready || s3_override
   when(s3_override) {
-    io.toFtq.prediction.bits.fromStage(s3_startPc, s3_prediction)
+    io.toFtq.prediction.bits.fromStage(s3_startPc.get, s3_prediction)
   }.otherwise {
-    io.toFtq.prediction.bits.fromStage(s1_startPc, s1_prediction)
+    io.toFtq.prediction.bits.fromStage(s1_startPc.get, s1_prediction)
   }
   io.toFtq.prediction.bits.s3Override := s3_override
 
@@ -480,7 +488,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   /* *** s0_startPc selection *** */
   s0_startPc := MuxCase(
-    s0_startPcReg,
+    s0_startPcReg.get,
     Seq(
       redirect.valid -> redirect.bits.target,
       s3_override    -> s3_prediction.target,
@@ -513,17 +521,17 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   phr.io.train.s3_override          := s3_override
   phr.io.train.s3_phrMeta           := s3_phrMeta
   phr.io.train.s3_prediction        := s3_prediction
-  phr.io.train.s3_startPc           := s3_startPc
+  phr.io.train.s3_startPc           := s3_startPc.get
   phr.io.s1Train.valid              := s1_fire
   phr.io.s1Train.taken              := s1_prediction.taken
-  phr.io.s1Train.startPc            := s1_startPc
+  phr.io.s1Train.startPc            := s1_startPc.get
   phr.io.s1Train.abtbValid          := s1_abtbValid
   phr.io.s1Train.abtbFirstTakenBrOH := s1_abtbFirstTakenBrOH
   phr.io.s1Train.ubtbPrediction     := s1_ubtbPredWithURas
   phr.io.s1Train.abtbPrediction     := s1_abtbPredWithURas
 
   phr.io.commit.valid := io.fromFtq.train.fire
-  phr.io.commit.bits  := train
+  phr.io.commit.bits.fromBpuTrain(train)
 
   s0_foldedPhr   := phr.io.s0_foldedPhr
   s1_foldedPhr   := phr.io.s1_foldedPhr
@@ -535,15 +543,15 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   dontTouch(phrBits)
 
   // ghr update
-  private val s1_cfiPc = getCfiPcFromPosition(s1_startPc, s1_prediction.cfiPosition)
+  private val s1_cfiPc = getCfiPcFromPosition(s1_startPc.get, s1_prediction.cfiPosition)
   private val s1_imliTaken =
     s1_prediction.taken && s1_prediction.attribute.isConditional &&
       (s1_cfiPc.addr(CompareAddrLowWidth - 1, 0) > s1_prediction.target.addr(CompareAddrLowWidth - 1, 0))
 
   commonHR.io.stageCtrl               := stageCtrl
-  commonHR.io.s0_startPc.get          := s0_startPc
+  commonHR.io.s0_startPc.get          := s0_startPc.get
   commonHR.io.s1_imliTaken            := s1_imliTaken
-  commonHR.io.update.startPc          := s3_startPc
+  commonHR.io.update.startPc          := s3_startPc.get
   commonHR.io.update.target           := s3_prediction.target
   commonHR.io.update.taken            := s3_taken
   commonHR.io.update.s3Override       := s3_override
@@ -564,13 +572,13 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     powerOnResetState := false.B
   }
   XSError(
-    !powerOnResetState && s0_stall && s0_startPc =/= s0_startPcReg,
+    !powerOnResetState && s0_stall && s0_startPc.head =/= s0_startPcReg.head,
     "s0_stall but s0_startPc is different from s0_startPcReg"
   )
 
   /* *** check abtb output *** */
   when(io.toFtq.prediction.fire && abtb.io.prediction.map(_.valid).reduce(_ || _)) {
-    assert(abtb.io.debug_startPc === s1_startPc)
+    assert(abtb.io.debug_startPc === s1_startPc.head)
   }
 
   /* *** Debug Meta *** */
@@ -600,7 +608,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val s3_s1PredictionSource = RegEnable(s2_s1PredictionSource, s2_fire)
 
   private val s3_perfMeta = Wire(new BpuPerfMeta)
-  s3_perfMeta.startPc             := s3_startPc
+  s3_perfMeta.startPc             := s3_startPc.head
   s3_perfMeta.bpId                := debug_bpId
   s3_perfMeta.s1Prediction        := s3_s1Prediction
   s3_perfMeta.s3Prediction        := s3_prediction

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -18,6 +18,7 @@ package xiangshan.frontend.bpu
 import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
+import utils.Duplicate
 import utils.EnumUInt
 import xiangshan.Resolve
 import xiangshan.backend.decode.isa.predecode.PreDecodeInst
@@ -238,12 +239,13 @@ class BranchInfo(implicit p: Parameters) extends BpuBundle with HalfAlignHelper 
 
 // Backend & Ftq -> Bpu
 class BpuTrain(implicit p: Parameters) extends BpuBundle with HalfAlignHelper {
-  val startPcVec: Vec[PrunedAddr]        = Vec(NumBtbAlignBanks, PrunedAddr(VAddrBits))
-  val branches:   Vec[Valid[BranchInfo]] = Vec(ResolveEntryBranchNumber, Valid(new BranchInfo))
-  val meta:       BpuResolveMeta         = new BpuResolveMeta
-  val perfMeta:   BpuPerfMeta            = new BpuPerfMeta
+  val startPcVec: Duplicate[Vec[PrunedAddr]] =
+    Duplicate(NumStartPcDuplicate, Vec(NumBtbAlignBanks, PrunedAddr(VAddrBits)))
+  val branches: Vec[Valid[BranchInfo]] = Vec(ResolveEntryBranchNumber, Valid(new BranchInfo))
+  val meta:     BpuResolveMeta         = new BpuResolveMeta
+  val perfMeta: BpuPerfMeta            = new BpuPerfMeta
 
-  def startPc: PrunedAddr = startPcVec.head
+  def startPc: PrunedAddr = startPcVec.get.head // get one duplicate and use its head (startPc for first alignBank)
 
   // we masked out all branches after the first mispredict branch in Bpu top (refer to Bpu.scala t0_firstMispredictMask)
   // so, we can assert that branches.map(b => b.valid && b.bits.mispredict) is at-most-one-hot
@@ -252,8 +254,21 @@ class BpuTrain(implicit p: Parameters) extends BpuBundle with HalfAlignHelper {
     Mux1H(branches.map(b => (b.valid && b.bits.mispredict, b)))
 }
 
+// Bpu top -> predictors
+class Train(NumStartPcVecDup: Int = 1)(implicit p: Parameters) extends BpuTrain {
+  override val startPcVec: Duplicate[Vec[PrunedAddr]] =
+    Duplicate(NumStartPcVecDup, Vec(NumBtbAlignBanks, PrunedAddr(VAddrBits)))
+
+  def fromBpuTrain(that: BpuTrain): Unit = {
+    this.startPcVec := that.startPcVec // NOTE this ':=' is overloaded for fan-out balancing
+    this.branches   := that.branches
+    this.meta       := that.meta
+    this.perfMeta   := that.perfMeta
+  }
+}
+
 // use s3 prediction to train s1 predictors
-class BpuFastTrain(implicit p: Parameters) extends BpuBundle {
+class FastTrain(implicit p: Parameters) extends BpuBundle {
   val startPc:         PrunedAddr    = PrunedAddr(VAddrBits)
   val finalPrediction: Prediction    = new Prediction
   val hasOverride:     Bool          = Bool()

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -238,10 +238,12 @@ class BranchInfo(implicit p: Parameters) extends BpuBundle with HalfAlignHelper 
 
 // Backend & Ftq -> Bpu
 class BpuTrain(implicit p: Parameters) extends BpuBundle with HalfAlignHelper {
-  val startPc:  PrunedAddr             = PrunedAddr(VAddrBits)
-  val branches: Vec[Valid[BranchInfo]] = Vec(ResolveEntryBranchNumber, Valid(new BranchInfo))
-  val meta:     BpuResolveMeta         = new BpuResolveMeta
-  val perfMeta: BpuPerfMeta            = new BpuPerfMeta
+  val startPcVec: Vec[PrunedAddr]        = Vec(NumBtbAlignBanks, PrunedAddr(VAddrBits))
+  val branches:   Vec[Valid[BranchInfo]] = Vec(ResolveEntryBranchNumber, Valid(new BranchInfo))
+  val meta:       BpuResolveMeta         = new BpuResolveMeta
+  val perfMeta:   BpuPerfMeta            = new BpuPerfMeta
+
+  def startPc: PrunedAddr = startPcVec.head
 
   // we masked out all branches after the first mispredict branch in Bpu top (refer to Bpu.scala t0_firstMispredictMask)
   // so, we can assert that branches.map(b => b.valid && b.bits.mispredict) is at-most-one-hot

--- a/src/main/scala/xiangshan/frontend/bpu/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Parameters.scala
@@ -34,6 +34,8 @@ import xiangshan.frontend.bpu.utage.MicroTageParameters
 case class BpuParameters(
     // general
     FetchBlockAlignSize: Option[Int] = None, // bytes, if None, use half-align (FetchBLockSize / 2) by default
+    // ppa
+    NumStartPcDuplicate: Int = 3, // duplicate pc-related register to control fan-out
     // debug
     EnableBpTrace: Boolean = false,
     // history
@@ -60,6 +62,9 @@ trait HasBpuParameters extends HasFrontendParameters {
   def FetchBlockAlignSize:    Int = bpuParameters.FetchBlockAlignSize.getOrElse(FetchBlockSize / 2)
   def FetchBlockAlignWidth:   Int = log2Ceil(FetchBlockAlignSize)
   def FetchBlockAlignInstNum: Int = FetchBlockAlignSize / instBytes
+
+  // ppa
+  def NumStartPcDuplicate: Int = bpuParameters.NumStartPcDuplicate
 
   def PhrHistoryLength: Int = frontendParameters.getPhrHistoryLength
 

--- a/src/main/scala/xiangshan/frontend/bpu/history/phr/Phr.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/phr/Phr.scala
@@ -22,7 +22,7 @@ import utility.XSPerfAccumulate
 import utility.XSWarn
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
-import xiangshan.frontend.bpu.BpuTrain
+import xiangshan.frontend.bpu.Train
 
 // PHR: Predicted History Register
 class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with Helpers {
@@ -33,9 +33,9 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
     val s3_foldedPhr:   PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
     val phr:            Vec[Bool]             = Output(Vec(PhrHistoryLength, Bool()))
     val phrMeta:        PhrMeta               = Output(new PhrMeta)
-    val train:          PhrUpdate             = Input(new PhrUpdate)       // redirect from backend
+    val train:          PhrUpdate             = Input(new PhrUpdate)    // redirect from backend
     val s1Train:        S1Train               = Input(new S1Train)
-    val commit:         Valid[BpuTrain]       = Input(Valid(new BpuTrain)) // trian bp data from reslove
+    val commit:         Valid[Train]          = Input(Valid(new Train)) // trian bp data from reslove
     val oldFoldedPhr:   PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
     val trainFoldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
   }

--- a/src/main/scala/xiangshan/frontend/bpu/history/phr/Phr.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/phr/Phr.scala
@@ -22,7 +22,7 @@ import utility.XSPerfAccumulate
 import utility.XSWarn
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
-import xiangshan.frontend.bpu.BpuTrain
+import xiangshan.frontend.bpu.Train
 
 // PHR: Predicted History Register
 class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with Helpers {
@@ -33,9 +33,9 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
     val s3_foldedPhr:   PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
     val phr:            Vec[Bool]             = Output(Vec(PhrHistoryLength, Bool()))
     val phrMeta:        PhrMeta               = Output(new PhrMeta)
-    val train:          PhrUpdate             = Input(new PhrUpdate)       // redirect from backend
+    val train:          PhrUpdate             = Input(new PhrUpdate)    // redirect from backend
     val s1Train:        S1Train               = Input(new S1Train)
-    val commit:         Valid[BpuTrain]       = Input(Valid(new BpuTrain)) // trian bp data from reslove
+    val commit:         Valid[Train]          = Input(Valid(new Train)) // trian bp data from reslove
     val trainFoldedPhr: PhrAllFoldedHistories = Output(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
   }
   val io: PhrIO = IO(new PhrIO)

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
@@ -36,8 +36,8 @@ import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
 import xiangshan.frontend.bpu.BasePredictor
 import xiangshan.frontend.bpu.BasePredictorIO
-import xiangshan.frontend.bpu.BpuTrain
 import xiangshan.frontend.bpu.SaturateCounter
+import xiangshan.frontend.bpu.Train
 import xiangshan.frontend.bpu.WriteBuffer
 import xiangshan.frontend.bpu.history.phr.PhrAllFoldedHistories
 
@@ -115,8 +115,8 @@ class Ittage(implicit p: Parameters) extends BasePredictor with HasIttageParamet
 
   private val t0_fire = io.enable && io.stageCtrl.t0_fire
 
-  private val t1_train = Wire(new BpuTrain)
-  t1_train := RegEnable(io.train, 0.U.asTypeOf(new BpuTrain), t0_fire)
+  private val t1_train = Wire(new Train)
+  t1_train := RegEnable(io.train, 0.U.asTypeOf(new Train), t0_fire)
 
   private val t1_meta = Wire(new IttageMeta)
   t1_train.meta.ittage := t1_meta

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -129,11 +129,9 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   t0_fire := io.stageCtrl.t0_fire && io.enable
   private val t0_train = io.train
 
-  private val t0_startPc = t0_train.startPc
-  private val t0_rotator = VecRotate(getAlignBankIndex(t0_startPc))
-  private val t0_startPcVec = t0_rotator.rotate(
-    VecInit.tabulate(NumAlignBanks)(i => getAlignedPc(t0_startPc + (i << FetchBlockAlignWidth).U))
-  )
+  private val t0_startPc    = t0_train.startPc
+  private val t0_rotator    = VecRotate(getAlignBankIndex(t0_startPc))
+  private val t0_startPcVec = t0_rotator.rotate(t0_train.startPcVec)
 
   alignBanks.zipWithIndex.foreach { case (b, i) =>
     b.io.t0_startPc := t0_startPcVec(i)

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -131,7 +131,7 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
 
   private val t0_startPc    = t0_train.startPc
   private val t0_rotator    = VecRotate(getAlignBankIndex(t0_startPc))
-  private val t0_startPcVec = t0_rotator.rotate(t0_train.startPcVec)
+  private val t0_startPcVec = t0_rotator.rotate(t0_train.startPcVec.get)
 
   alignBanks.zipWithIndex.foreach { case (b, i) =>
     b.io.t0_startPc := t0_startPcVec(i)

--- a/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
@@ -26,9 +26,8 @@ import utility.XSPerfSeqAccumulate
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.bpu.BasePredictor
 import xiangshan.frontend.bpu.BasePredictorIO
-import xiangshan.frontend.bpu.BpuFastTrain
-import xiangshan.frontend.bpu.BpuTrain
 import xiangshan.frontend.bpu.CompareMatrix
+import xiangshan.frontend.bpu.FastTrain
 import xiangshan.frontend.bpu.FoldedHistoryInfo
 import xiangshan.frontend.bpu.HasFastTrainIO
 import xiangshan.frontend.bpu.Prediction
@@ -243,7 +242,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
   }
 
   // ------------ MicroTage is only concerned with conditional branches ---------- //
-  private val t0_train                  = RegNext(io.fastTrain.get.bits, 0.U.asTypeOf(new BpuFastTrain))
+  private val t0_train                  = RegNext(io.fastTrain.get.bits, 0.U.asTypeOf(new FastTrain))
   private val t0_fire                   = RegNext(io.fastTrain.get.valid, false.B)
   private val t0_trainMeta              = t0_train.utageMeta
   private val t0_abtbResult             = t0_trainMeta.abtbResult

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -376,11 +376,13 @@ class Ftq(implicit p: Parameters) extends FtqModule
     trainCache.valid := false.B
   }.elsewhen(resolveQueue.io.bpuTrain.fire) {
     trainCache.bits.meta := metaQueueResolve(resolveQueue.io.bpuTrain.bits.ftqIdx.value)
-    trainCache.bits.startPcVec.zipWithIndex.foreach { case (startPc, i) =>
-      if (i == 0)
-        startPc := resolveQueue.io.bpuTrain.bits.startPc // do not align startPcVec.head
-      else
-        startPc := getAlignedPc(resolveQueue.io.bpuTrain.bits.startPc + (i << FetchBlockAlignWidth).U)
+    trainCache.bits.startPcVec.foreach { dup =>
+      dup.zipWithIndex.foreach { case (startPc, i) =>
+        if (i == 0)
+          startPc := resolveQueue.io.bpuTrain.bits.startPc // do not align startPcVec.head
+        else
+          startPc := getAlignedPc(resolveQueue.io.bpuTrain.bits.startPc + (i << FetchBlockAlignWidth).U)
+      }
     }
     trainCache.bits.branches := resolveQueue.io.bpuTrain.bits.branches
     trainCache.bits.perfMeta := perfQueue(resolveQueue.io.bpuTrain.bits.ftqIdx.value).bpuPerf

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -375,8 +375,13 @@ class Ftq(implicit p: Parameters) extends FtqModule
   when(flushTrain) {
     trainCache.valid := false.B
   }.elsewhen(resolveQueue.io.bpuTrain.fire) {
-    trainCache.bits.meta     := metaQueueResolve(resolveQueue.io.bpuTrain.bits.ftqIdx.value)
-    trainCache.bits.startPc  := resolveQueue.io.bpuTrain.bits.startPc
+    trainCache.bits.meta := metaQueueResolve(resolveQueue.io.bpuTrain.bits.ftqIdx.value)
+    trainCache.bits.startPcVec.zipWithIndex.foreach { case (startPc, i) =>
+      if (i == 0)
+        startPc := resolveQueue.io.bpuTrain.bits.startPc // do not align startPcVec.head
+      else
+        startPc := getAlignedPc(resolveQueue.io.bpuTrain.bits.startPc + (i << FetchBlockAlignWidth).U)
+    }
     trainCache.bits.branches := resolveQueue.io.bpuTrain.bits.branches
     trainCache.bits.perfMeta := perfQueue(resolveQueue.io.bpuTrain.bits.ftqIdx.value).bpuPerf
     trainCache.valid         := true.B

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -371,8 +371,13 @@ class Ftq(implicit p: Parameters) extends FtqModule
   resolveQueue.io.bpuTrain.ready := !trainCache.valid || io.toBpu.train.fire
 
   when(resolveQueue.io.bpuTrain.fire) {
-    trainCache.bits.meta     := metaQueueResolve(resolveQueue.io.bpuTrain.bits.ftqIdx.value)
-    trainCache.bits.startPc  := resolveQueue.io.bpuTrain.bits.startPc
+    trainCache.bits.meta := metaQueueResolve(resolveQueue.io.bpuTrain.bits.ftqIdx.value)
+    trainCache.bits.startPcVec.zipWithIndex.foreach { case (startPc, i) =>
+      if (i == 0)
+        startPc := resolveQueue.io.bpuTrain.bits.startPc // do not align startPcVec.head
+      else
+        startPc := getAlignedPc(resolveQueue.io.bpuTrain.bits.startPc + (i << FetchBlockAlignWidth).U)
+    }
     trainCache.bits.branches := resolveQueue.io.bpuTrain.bits.branches
     trainCache.bits.perfMeta := perfQueue(resolveQueue.io.bpuTrain.bits.ftqIdx.value).bpuPerf
     trainCache.valid         := true.B

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -372,11 +372,13 @@ class Ftq(implicit p: Parameters) extends FtqModule
 
   when(resolveQueue.io.bpuTrain.fire) {
     trainCache.bits.meta := metaQueueResolve(resolveQueue.io.bpuTrain.bits.ftqIdx.value)
-    trainCache.bits.startPcVec.zipWithIndex.foreach { case (startPc, i) =>
-      if (i == 0)
-        startPc := resolveQueue.io.bpuTrain.bits.startPc // do not align startPcVec.head
-      else
-        startPc := getAlignedPc(resolveQueue.io.bpuTrain.bits.startPc + (i << FetchBlockAlignWidth).U)
+    trainCache.bits.startPcVec.foreach { dup =>
+      dup.zipWithIndex.foreach { case (startPc, i) =>
+        if (i == 0)
+          startPc := resolveQueue.io.bpuTrain.bits.startPc // do not align startPcVec.head
+        else
+          startPc := getAlignedPc(resolveQueue.io.bpuTrain.bits.startPc + (i << FetchBlockAlignWidth).U)
+      }
     }
     trainCache.bits.branches := resolveQueue.io.bpuTrain.bits.branches
     trainCache.bits.perfMeta := perfQueue(resolveQueue.io.bpuTrain.bits.ftqIdx.value).bpuPerf


### PR DESCRIPTION
- pre-generate startPcVec in Ftq resolveCache
- duplicate startPc in both prediction & training path to reduce fan-out

Also some enhancement in class Duplicate, including:
- `:= Duplicate` for auto connection
- `.foreach` and `.map` for Vec-like operation