### PR TITLE
chore(scripts/parser): add 'r' prefix to regex expression

### DIFF
--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -400,7 +400,7 @@ def create_filelist(filelist_name, out_dir, file_dirs=None, extra_lines=[]):
 
 
 class SRAMConfiguration(object):
-    ARRAY_NAME = "sram_array_(\d)p(\d+)x(\d+)m(\d+)(_multicycle|)(_repair|)"
+    ARRAY_NAME = r"sram_array_(\d)p(\d+)x(\d+)m(\d+)(_multicycle|)(_repair|)"
 
     SINGLE_PORT = 0
     SINGLE_PORT_MASK = 1


### PR DESCRIPTION
mark it as raw-string to prevent python escaping '\d' and complaining it invalid

```
./scripts/parser.py:403: SyntaxWarning: invalid escape sequence '\d'
  ARRAY_NAME = "sram_array_(\d)p(\d+)x(\d+)m(\d+)(_multicycle|)(_repair|)"
```