### PR TITLE
fix(difftest): split backend debug enable from difftest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ ifeq ($(FPGA), 1)
 override DEBUG_ARGS	+= --fpga-platform --disable-all --remove-assert --disable-clockgate
 override DEBUG_ARGS	+= --full-basicdiff
 else
-override DEBUG_ARGS	+= --enable-difftest
+override DEBUG_ARGS	+= --enable-difftest --enable-backend-debug
 endif
 ifeq ($(RELEASE),1)
 override SIM_ARGS += $(RELEASE_ARGS)

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -43,6 +43,7 @@ object ArgParser {
       |--fpga-platform
       |--reset-gen
       |--enable-difftest
+      |--enable-backend-debug
       |--full-basicdiff
       |--enable-log
       |--with-chiseldb
@@ -131,6 +132,10 @@ object ArgParser {
         case "--enable-difftest" :: tail =>
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(EnableDifftest = true)
+          }), tail)
+        case "--enable-backend-debug" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case DebugOptionsKey => up(DebugOptionsKey).copy(EnableBackendDebug = true)
           }), tail)
         case "--full-basicdiff" :: tail =>
           nextOption(config.alter((site, here, up) => {

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -557,6 +557,7 @@ case class DebugOptions
   AlwaysBasicDiff: Boolean = true,
   FullBasicDiff: Boolean = false,
   EnableDebug: Boolean = false,
+  EnableBackendDebug: Boolean = false,
   EnablePerfDebug: Boolean = true,
   PerfLevel: String = "VERBOSE",
   EnableXMR: Boolean = true,

--- a/src/main/scala/xiangshan/backend/BackendParams.scala
+++ b/src/main/scala/xiangshan/backend/BackendParams.scala
@@ -38,12 +38,11 @@ case class BackendParams(
   iqWakeUpParams : Seq[WakeUpConfig],
 ) {
 
-  def debugEn(implicit p: Parameters): Boolean = {
-    val debugOpts = p(DebugOptionsKey)
-    debugOpts.EnableDifftest || debugOpts.FullBasicDiff
-  }
+  def debugEn(implicit p: Parameters): Boolean = p(DebugOptionsKey).EnableBackendDebug
 
-  def basicDebugEn(implicit p: Parameters): Boolean = p(DebugOptionsKey).AlwaysBasicDiff || debugEn
+  def difftestDebugEn(implicit p: Parameters): Boolean = p(DebugOptionsKey).FullBasicDiff || p(DebugOptionsKey).EnableDifftest || debugEn
+
+  def basicDebugEn(implicit p: Parameters): Boolean = p(DebugOptionsKey).AlwaysBasicDiff || difftestDebugEn
 
   val copyPdestInfo = mutable.HashMap[Int, (Int, Int)]()
 

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -78,8 +78,8 @@ object RobBundles extends HasCircularQueuePtrHelper {
     // status end
 
     // debug_begin
-    val debug_pc = OptionWrapper(backendParams.debugEn, UInt(VAddrBits.W))
-    val debug_instr = OptionWrapper(backendParams.debugEn, UInt(32.W))
+    val debug_pc = OptionWrapper(backendParams.difftestDebugEn, UInt(VAddrBits.W))
+    val debug_instr = OptionWrapper(backendParams.difftestDebugEn, UInt(32.W))
     val debug_ldest = OptionWrapper(backendParams.basicDebugEn, UInt(LogicRegsWidth.W))
     val debug_pdest = OptionWrapper(backendParams.basicDebugEn, UInt(PhyRegIdxWidth.W))
     val debug_fuType = OptionWrapper(backendParams.debugEn, FuType())
@@ -115,8 +115,8 @@ object RobBundles extends HasCircularQueuePtrHelper {
     // trace
     val traceBlockInPipe = new TracePipe(IretireWidthInPipe)
     // debug_begin
-    val debug_pc = OptionWrapper(backendParams.debugEn, UInt(VAddrBits.W))
-    val debug_instr = OptionWrapper(backendParams.debugEn, UInt(32.W))
+    val debug_pc = OptionWrapper(backendParams.difftestDebugEn, UInt(VAddrBits.W))
+    val debug_instr = OptionWrapper(backendParams.difftestDebugEn, UInt(32.W))
     val debug_ldest = OptionWrapper(backendParams.basicDebugEn, UInt(LogicRegsWidth.W))
     val debug_pdest = OptionWrapper(backendParams.basicDebugEn, UInt(PhyRegIdxWidth.W))
     val debug_otherPdest = OptionWrapper(backendParams.basicDebugEn, Vec(7, UInt(PhyRegIdxWidth.W)))


### PR DESCRIPTION
PR #5874 enabled backend debugEn when FullBasicDiff is enabled, so difftest can collect extra commit information. However, debugEn also keeps many RTL internal debug signals unrelated to difftest, such as TopDown and other backend debug paths, causing significant area growth.

This change separates difftestDebugEn from the original backend debugEn. Difftest-only signals are enabled by FullBasicDiff or EnableDifftest, while backend debug signals stay behind a dedicated backend debug switch.

The original --enable-difftest flow still passes --enable-backend-debug to preserve the existing full difftest debug behavior.