### PR TITLE
chore: add uvs support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,16 @@ simv: sim-verilog
 simv-run:
 	$(MAKE) -C ./difftest simv-run NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
 
+# uvs simulation
+uvsim: sim-verilog
+    $(MAKE) -C ./difftest uvsim SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+
+uvsim-run:
+    $(MAKE) -C ./difftest uvsim-run SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+
+uvsim-debug:
+    $(MAKE) -C ./difftest uvsim-debug SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+
 # galaxsim simulation
 xsim: sim-verilog
 	$(MAKE) -C ./difftest xsim NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)

--- a/Makefile
+++ b/Makefile
@@ -360,6 +360,16 @@ simv: sim-verilog
 simv-run:
 	$(MAKE) -C ./difftest simv-run NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
 
+# uvs simulation
+uvsim: sim-verilog
+    $(MAKE) -C ./difftest uvsim SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+
+uvsim-run:
+    $(MAKE) -C ./difftest uvsim-run SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+
+uvsim-debug:
+    $(MAKE) -C ./difftest uvsim-debug SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+
 # galaxsim simulation
 xsim: sim-verilog
 	$(MAKE) -C ./difftest xsim NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)

--- a/Makefile
+++ b/Makefile
@@ -362,13 +362,13 @@ simv-run:
 
 # uvs simulation
 uvsim: sim-verilog
-    $(MAKE) -C ./difftest uvsim SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+	$(MAKE) -C ./difftest uvsim SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
 
 uvsim-run:
-    $(MAKE) -C ./difftest uvsim-run SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+	$(MAKE) -C ./difftest uvsim-run SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
 
 uvsim-debug:
-    $(MAKE) -C ./difftest uvsim-debug SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+	$(MAKE) -C ./difftest uvsim-debug SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
 
 # galaxsim simulation
 xsim: sim-verilog


### PR DESCRIPTION
Add uvs simulation support.
Add UVS (Univista Simulator) build and run support in the top-level Makefile.
- Purely additive changes to the top Makefile, add uvsim / uvsim-run targets
- No modifications to existing VCS / EMU build flow, no regression risk
- Basic test cases (copy_and_run, coremark, flash_recursion_test) passed on UVS
- 0 difftest mismatch with reference model

Link: https://github.com/OpenXiangShan/difftest/pull/877