### PR TITLE
fix(MMU): exclude NAPOT PTEs from L0 sector entry validity

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -1040,10 +1040,14 @@ class PtwEntries(num: Int, tagLen: Int, level: Int, hasPerm: Boolean, ReservedBi
     ps.prefetch := prefetch
     for (i <- 0 until num) {
       val pte = data((i+1)*XLEN-1, i*XLEN).asTypeOf(new PteBundle)
+      val denyNapotInSector = if (hasPerm && level == 0) pte.isNapot(levelUInt) else false.B
+      val isRefillEntry = pte.canRefill(levelUInt, s2xlate, pbmte, mode) &&
+        (if (hasPerm) pte.isLeaf() else !pte.isLeaf())
+      val onlyPf = (if (hasPerm) pte.onlyPf(levelUInt, s2xlate, pbmte) else false.B)
       ps.pbmts(i) := pte.pbmt
       ps.ppns(i) := pte.getPPN()
-      ps.vs(i)   := (pte.canRefill(levelUInt, s2xlate, pbmte, mode) && (if (hasPerm) pte.isLeaf() else !pte.isLeaf())) || (if (hasPerm) pte.onlyPf(levelUInt, s2xlate, pbmte) else false.B)
-      ps.onlypf(i) := pte.onlyPf(levelUInt, s2xlate, pbmte)
+      ps.vs(i)   := (isRefillEntry || onlyPf) && !denyNapotInSector
+      ps.onlypf(i) := onlyPf && !denyNapotInSector
       ps.perms.map(_(i) := pte.perm)
       when (s2xlate === onlyStage2) {
         // g bit in G-stage PTEs should be ignored by hardware


### PR DESCRIPTION
In PtwEntries.genEntries, when a VPN triggers a full L2->L1->L0 page walk and the resulting L0 sector refill writes the entire 512-bit ptes block, a NAPOT PTE in the same sector is also marked as L0-valid (vs=1). This causes subsequent accesses to the NAPOT VPN to hit L0 instead of the superpage (sp) path. Since L0 does not preserve the NAPOT 'n' bit, genPPN() cannot perform the required 64KB NAPOT expansion, producing an incorrect gvpn.

Add a per-lane check `denyNapotInSector`: when level==0 and hasPerm is true, test pte.isNapot(levelUInt) for each lane. Lanes identified as NAPOT are excluded from both vs(i) and onlypf(i), preventing them from becoming L0-hittable entries.