### PR TITLE
fix(ICache): explicitly set `s1_itlbPbmt`'s init width

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -181,7 +181,7 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
   private val s1_itlbExceptionRaw =
     DataHoldBypass(ExceptionType.fromTlbResp(fromItlb.bits), ExceptionType.None, tlbValidPulse)
-  private val s1_itlbPbmt = DataHoldBypass(fromItlb.bits.pbmt.head, Pbmt.pma, tlbValidPulse)
+  private val s1_itlbPbmt = DataHoldBypass(fromItlb.bits.pbmt.head, 0.U(Pbmt.width.W), tlbValidPulse)
 
   // Guest page fault related: save tlb raw response, select later
   // NOTE: we don't use GPAddrBits or XLEN here, refer to ICacheMainPipe.scala L43-48 and PR#3795


### PR DESCRIPTION
Pbmt.pma does not have an explicit width, chisel inferred width is 1, so if we do `RegEnable(..., init = Pbmt.pma, ...)` (same for RegNext/DataHoldBypass), we'll get a 1-bit register.

Bug introduced in #4909, does not affect v2

Tested with https://github.com/OpenXiangShan/nexus-am/pull/68