### PR TITLE
chore: fix java19+ `new Locale` deprecation warning

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -158,6 +158,7 @@ object xiangshan extends ChiselModule {
 
   def scalacOptions: T[Seq[String]] = super.scalacOptions() ++ Agg("-deprecation", "-feature")
 
+  private def publishLocale: Locale = new Locale.Builder().setLanguage("en").build()
   private def publishVersion: T[String] = VcsVersion.vcsState().format(
     revHashDigits = 8,
     dirtyHashDigits = 0,
@@ -166,7 +167,7 @@ object xiangshan extends ChiselModule {
     tagModifier = (tag: String) =>
       "[Rr]elease.*".r.findFirstMatchIn(tag) match {
         case Some(_) => "KunminghuV3-Release-" + LocalDateTime.now().format(
-            DateTimeFormatter.ofPattern("MMM-dd-yyyy").withLocale(new Locale("en"))
+            DateTimeFormatter.ofPattern("MMM-dd-yyyy").withLocale(publishLocale)
           )
         case None => "KunminghuV3-dev"
       },
@@ -174,7 +175,7 @@ object xiangshan extends ChiselModule {
     untaggedSuffix = " (%s@%s) # %s".format(
       System.getProperty("user.name"),
       java.net.InetAddress.getLocalHost.getHostName,
-      LocalDateTime.now().format(DateTimeFormatter.ofPattern("MMM dd hh:mm:ss yyyy").withLocale(new Locale("en")))
+      LocalDateTime.now().format(DateTimeFormatter.ofPattern("MMM dd hh:mm:ss yyyy").withLocale(publishLocale))
     )
   )
 


### PR DESCRIPTION
`new Locale` is deprecated after java 19, we need factory method `Locale.of("en")` or predefined `Locale.ENGLISH` or builder `new Locale.Builder().setLanguage("en").build()`

The former 2 methods requires java19+, so here we use builder for java7+