### PR TITLE
fix(NewCSR): csrIsUCustom predicate is inverted

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRPermitModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRPermitModule.scala
@@ -212,7 +212,7 @@ class CSRPermitModule extends Module {
   // [0x5c0, 0x5ff], [0x9c0, 0x9ff], [0xdc0, 0xdff]
   private val csrIsSCustom   = (addr(11, 10) =/= "b00".U) && (addr(9, 8) === "b01".U) && (addr(7, 6) === "b11".U)
   // [0x800, 0x8ff], [0xcc0, 0xcff]
-  private val csrIsUCustom   = (addr(11, 8) =/= "b1000".U) || (addr(11, 6) =/= "b100011".U)
+  private val csrIsUCustom   = (addr(11, 8) === "b1000".U) || (addr(11, 6) === "b110011".U)
   private val allCustom      = csrIsHVSCustom || csrIsSCustom || csrIsUCustom
   private val accessCustom_EX_II = allCustom && (
     !privState.isModeM && !mstateen0.C.asBool ||


### PR DESCRIPTION

In `CSRPermitModule`:

```scala
val csrIsUCustom = (addr(11,8) =/= 0x8.U) || (addr(11,6) =/= 0x23.U)
```

This is the De Morgan flip — true for nearly every CSR address, false
only on `0x8C0..0x8FF`. The custom range stays ungated and most
standard CSRs get gated by `mstateen0.C` instead.

Fix:

```scala
val csrIsUCustom = (addr(11,8) === 0x8.U) || (addr(11,6) === 0x33.U)
```