### PR TITLE
fix(NewCSR): vsireg reads from sireg (host→guest IPRIO leak)

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRAIA.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRAIA.scala
@@ -75,7 +75,7 @@ trait CSRAIA { self: NewCSR with HypervisorLevel =>
     .setAddr(CSRs.vsiselect)
 
   val vsireg    = Module(new CSRModule("VSireg") with HasIregSink {
-    rdata := iregRead.sireg
+    rdata := iregRead.vsireg
   })
     .setAddr(CSRs.vsireg)
 


### PR DESCRIPTION

`CSRAIA` wires `vsireg.rdata := iregRead.sireg`, so a VS-mode read of
`vsireg` returns the host's `sireg` data. One-line fix: source from
`iregRead.vsireg`.

(Note: `iregRead.vsireg` is currently tied to 0 by an existing IMSIC
TODO — post-fix the leak is gone but `vsireg` reads 0 until that TODO
lands.)