### PR TITLE
fix(NewCSR): DRET clobbers dcsr.V/PRV

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/DretEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/DretEvent.scala
@@ -58,6 +58,11 @@ class DretEventModule(implicit p: Parameters) extends Module with CSREventBase {
 
   out.privState.bits.PRVM     := in.dcsr.PRV.asUInt
   out.privState.bits.V        := in.dcsr.V
+  // DRET must preserve dcsr.V and dcsr.PRV (they record the saved debug-entry
+  // privilege).  Pass the input through so the framework's per-field Mux1H
+  // writes the same value back instead of a DontCare.
+  out.dcsr.bits.V             := in.dcsr.V
+  out.dcsr.bits.PRV           := in.dcsr.PRV.asUInt
   out.mstatus.bits.MPRV       := Mux(!out.privState.bits.isModeM, 0.U, in.mstatus.MPRV.asUInt)
   out.debugMode.bits          := false.B
   out.debugIntrEnable.bits    := true.B


### PR DESCRIPTION

`DretEventModule` asserts `out.dcsr.valid` but leaves `bits.V` /
`bits.PRV` as `DontCare`. firtool resolves DontCare to 0, so every DRET
zeroes the saved debug-entry privilege.

Fix:

```scala
out.dcsr.bits.V   := in.dcsr.V
out.dcsr.bits.PRV := in.dcsr.PRV
```