### PR TITLE
fix(NewCSR): vsireg reads from sireg (host→guest IPRIO leak)

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRIND.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRIND.scala
@@ -120,7 +120,7 @@ trait CSRIND { self: NewCSR with HypervisorLevel =>
     .setAddr(CSRs.vsiselect)
 
   val vsireg = Module(new CSRModule("VSireg", new ZeroFieldBundle("Virtual supervisor indirect data register selected by vsiselect.")) with HasIregSink {
-    regOut := iregRead.sireg
+    regOut := iregRead.vsireg
   })
     .setAddr(CSRs.vsireg)
 


### PR DESCRIPTION

`CSRAIA` wires `vsireg.rdata := iregRead.sireg`, so a VS-mode read of
`vsireg` returns the host's `sireg` data. One-line fix: source from
`iregRead.vsireg`.

Note: `iregRead.vsireg` is currently tied to 0 by an existing IMSIC TODO. This PR fixes the leak but `vsireg` reads 0 until that TODO will be completed (independently of this PR).