### PR TITLE
fix(NewCSR): DRET clobbers dcsr.V/PRV

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/DretEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/DretEvent.scala
@@ -10,7 +10,6 @@ import xiangshan.AddrTransType
 
 
 class DretEventOutput extends Bundle with EventUpdatePrivStateOutput with EventOutputBase {
-  val dcsr = ValidIO((new DcsrBundle).addInEvent(_.V, _.PRV))
   val mstatus = ValidIO((new MstatusBundle).addInEvent(_.MPRV, _.MDT, _.SDT))
   val vsstatus = ValidIO((new SstatusBundle).addInEvent(_.SDT))
   val debugMode = ValidIO(Bool())
@@ -53,7 +52,6 @@ class DretEventModule(implicit p: Parameters) extends Module with CSREventBase {
 
   out.debugMode.valid       := valid
   out.privState.valid       := valid
-  out.dcsr.valid            := valid
   out.mstatus.valid         := valid
   out.vsstatus.valid        := valid
   out.debugIntrEnable.valid := valid

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/DebugLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/DebugLevel.scala
@@ -56,7 +56,7 @@ trait DebugLevel { self: NewCSR =>
   val tinfo = Module(new CSRModule("Tinfo", new TinfoBundle))
     .setAddr(CSRs.tinfo)
 
-  val dcsr = Module(new CSRModule("Dcsr", new DcsrBundle) with TrapEntryDEventSinkBundle with DretEventSinkBundle with HasNmipBundle {
+  val dcsr = Module(new CSRModule("Dcsr", new DcsrBundle) with TrapEntryDEventSinkBundle with HasNmipBundle {
     regOut.NMIP := nmip
   })
     .setAddr(CSRs.dcsr)


### PR DESCRIPTION

`DretEventModule` asserts `out.dcsr.valid` but leaves `bits.V` /
`bits.PRV` as `DontCare`. firtool resolves DontCare to 0, so every DRET
zeroes the saved debug-entry privilege.

Fix:

```scala
out.dcsr.bits.V   := in.dcsr.V
out.dcsr.bits.PRV := in.dcsr.PRV
```