### PR TITLE
refactor(prefetch): replace LsPrefetchTrainBundle with TrainReqBundle

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -960,6 +960,9 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   // FIXME lyq: when mshr entry merges, req.pf_source may be cleaned.
   io.refill_train.bits.metaSource := req.pf_source
   io.refill_train.bits.refillLatency := refill_latency
+  io.refill_train.bits.robIdx := DontCare
+  io.refill_train.bits.isFirstIssue := DontCare
+  io.refill_train.bits.isHwPrefetch := DontCare
 
   XSPerfAccumulate("miss_refill_mainpipe_req", io.main_pipe_req.fire)
   XSPerfAccumulate("miss_refill_without_hint", io.main_pipe_req.fire && !mainpipe_req_fired && !w_l2hint)

--- a/src/main/scala/xiangshan/mem/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/Bundles.scala
@@ -28,7 +28,7 @@ import xiangshan.cache._
 import xiangshan.cache.wpu.ReplayCarry
 import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.frontend.PreDecodeInfo
-import xiangshan.mem.prefetch.{PrefetchReqBundle, TrainReqBundle}
+import xiangshan.mem.prefetch._
 import xiangshan.backend.exu.ExeUnitParams
 
 import scala.math._
@@ -178,16 +178,6 @@ object Bundles {
       }
       connectSamePort(this, inputReg)
       // The remaining variables must be assigned outside the function to ensure correctness
-    }
-
-    def toPrefetchReqBundle(): PrefetchReqBundle = {
-      val res = Wire(new PrefetchReqBundle)
-      res.vaddr := this.vaddr
-      res.paddr := this.paddr
-      res.pc := this.uop.pc
-      res.miss := this.miss
-      res.pfHitStream := isFromStream(this.meta_prefetch)
-      res
     }
 
     def toTrainReqBundle(): TrainReqBundle = {

--- a/src/main/scala/xiangshan/mem/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/Bundles.scala
@@ -165,33 +165,6 @@ object Bundles {
     }
   }
 
-  class LsPrefetchTrainBundle(implicit p: Parameters) extends LsPipelineBundle {
-    val meta_prefetch = UInt(L1PfSourceBits.W)
-    val meta_access = Bool()
-    val is_from_hw_pf = Bool() // s0 source is from prefetch
-    val refillLatency = UInt(LATENCY_WIDTH.W)
-
-    def fromLsPipelineBundle(input: LsPipelineBundle, latch: Boolean = false, enable: Bool = true.B) = {
-      val inputReg = latch match {
-        case true   => RegEnable(input, enable)
-        case false  => input
-      }
-      connectSamePort(this, inputReg)
-      // The remaining variables must be assigned outside the function to ensure correctness
-    }
-
-    def toTrainReqBundle(): TrainReqBundle = {
-      val res = Wire(new TrainReqBundle)
-      res.vaddr := this.vaddr
-      res.paddr := this.paddr
-      res.pc := this.uop.pc
-      res.miss := this.miss
-      res.metaSource := this.meta_prefetch
-      res.refillLatency := this.refillLatency
-      res
-    }
-  }
-
   class LqWriteBundle(implicit p: Parameters) extends LsPipelineBundle {
     // load inst replay informations
     val rep_info = new LoadToLsqReplayIO

--- a/src/main/scala/xiangshan/mem/MemCommon.scala
+++ b/src/main/scala/xiangshan/mem/MemCommon.scala
@@ -29,7 +29,6 @@ import xiangshan.backend.rob.RobPtr
 import xiangshan.cache._
 import xiangshan.backend.fu.FenceToSbuffer
 import xiangshan.cache.wpu.ReplayCarry
-import xiangshan.mem.prefetch.PrefetchReqBundle
 import math._
 
 object genWmask {

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -33,6 +33,7 @@ import xiangshan.backend.exu.ExeUnitParams
 import xiangshan.mem.Bundles._
 import xiangshan.mem.LoadReplayCauses._
 import xiangshan.mem.LoadStage._
+import xiangshan.mem.prefetch._
 import xiangshan.cache._
 import xiangshan.cache.mmu._
 
@@ -838,7 +839,7 @@ class LoadUnitS2(param: ExeUnitParams)(
 
     // Prefetch train
     // TODO: this bundle is tooooooo big, define a smaller one
-    val prefetchTrain = ValidIO(new LsPrefetchTrainBundle)
+    val prefetchTrain = ValidIO(new TrainReqBundle)
 
     // CSR control signals
     val csrCtrl = Flipped(new CustomCSRCtrlIO)
@@ -1151,17 +1152,17 @@ class LoadUnitS2(param: ExeUnitParams)(
   io.rawNukeQueryReq.bits := nukeQueryReq
 
   // TODO: Currently, we don't train prefetcher on vector request, because vector instruction PC is incorrect.
+  // TODO: `isFirstIssue` is Fake First Issue according to prefetcher !!!
   io.prefetchTrain.valid := pipeIn.valid && tlbHit && !exception && !isUncache && !isUncacheReplay &&
     in.isFirstIssue() && !isVector
-  io.prefetchTrain.bits := DontCare
-  io.prefetchTrain.bits.uop := uop
+  io.prefetchTrain.bits.robIdx := uop.robIdx
+  io.prefetchTrain.bits.pc := uop.pc
   io.prefetchTrain.bits.vaddr := in.vaddr
   io.prefetchTrain.bits.paddr := paddr
   io.prefetchTrain.bits.miss := io.dcacheResp.bits.miss
   io.prefetchTrain.bits.isFirstIssue := in.isFirstIssue()
-  io.prefetchTrain.bits.meta_prefetch := io.dcacheResp.bits.meta_prefetch
-  io.prefetchTrain.bits.meta_access := io.dcacheResp.bits.meta_access
-  io.prefetchTrain.bits.is_from_hw_pf := accessType.isHwPrefetch()
+  io.prefetchTrain.bits.metaSource := io.dcacheResp.bits.meta_prefetch
+  io.prefetchTrain.bits.isHwPrefetch := accessType.isHwPrefetch()
   io.prefetchTrain.bits.refillLatency := io.dcacheResp.bits.refill_latency
 
   io.debugInfo.isBankConflict := pipeIn.valid && !kill && cause(C_BC)
@@ -1859,7 +1860,7 @@ class LoadUnitIO(val param: ExeUnitParams)(implicit p: Parameters) extends XSBun
   // Prefetch Train
   val prefetchTrainHintS1 = Output(Bool())
   val prefetchTrainHintS2 = Output(Bool())
-  val prefetchTrain = ValidIO(new LsPrefetchTrainBundle)
+  val prefetchTrain = ValidIO(new TrainReqBundle)
   // Software instruction prefetch
   val swInstrPrefetch = ValidIO(new SoftIfetchPrefetchBundle)
   // CSR control signals and load trigger

--- a/src/main/scala/xiangshan/mem/pipeline/NewStoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewStoreUnit.scala
@@ -32,6 +32,7 @@ import xiangshan.cache.mmu._
 import xiangshan.ExceptionNO._
 import xiangshan.mem.Bundles._
 import xiangshan.mem.StoreStage._
+import xiangshan.mem.prefetch._
 
 class StoreUnitS0(param: ExeUnitParams)(
   implicit p: Parameters,
@@ -574,7 +575,7 @@ class StoreUnitS2(param: ExeUnitParams)(
 
     // Prefetch Train
     val prefetchTrainHint = Output(Bool())
-    val prefetchTrain = ValidIO(new LsPrefetchTrainBundle())
+    val prefetchTrain = ValidIO(new TrainReqBundle())
   })
 
   val pipeIn = io_pipeIn.get
@@ -694,15 +695,14 @@ class StoreUnitS2(param: ExeUnitParams)(
   val prefetchTrainValid = fire && io.dcacheResp.fire && tlbHit && tlbAccessible && !hasException && !isUncache
   io.prefetchTrainHint := prefetchTrainValid
   io.prefetchTrain.valid := prefetchTrainValid
-  io.prefetchTrain.bits := DontCare
-  io.prefetchTrain.bits.uop := uop
+  io.prefetchTrain.bits.robIdx := uop.robIdx
+  io.prefetchTrain.bits.pc := uop.pc
   io.prefetchTrain.bits.vaddr := in.vaddr
   io.prefetchTrain.bits.paddr := in.paddr.get
   io.prefetchTrain.bits.miss := cacheMiss
   io.prefetchTrain.bits.isFirstIssue := in.isFirstIssue
-  io.prefetchTrain.bits.meta_prefetch := false.B
-  io.prefetchTrain.bits.meta_access := false.B
-  io.prefetchTrain.bits.is_from_hw_pf := isHWPrefetch
+  io.prefetchTrain.bits.metaSource := L1_HW_PREFETCH_NULL
+  io.prefetchTrain.bits.isHwPrefetch := isHWPrefetch
   io.prefetchTrain.bits.refillLatency := 0.U // TODO: store not for berti, so there is no refillLatency
 
   io.unalignHeadTlbHit := fire && isUnalignHead && tlbHit
@@ -905,7 +905,7 @@ class StoreUnitIO(val param: ExeUnitParams)(implicit p: Parameters) extends XSBu
   // Prefetch Train
   val prefetchTrainHintS1 = Output(Bool())
   val prefetchTrainHintS2 = Output(Bool())
-  val prefetchTrain = ValidIO(new LsPrefetchTrainBundle())
+  val prefetchTrain = ValidIO(new TrainReqBundle())
   // Feedback to RS in s2, for store issue control
   val feedBackSlow = ValidIO(new RSFeedback)
   // Writeback

--- a/src/main/scala/xiangshan/mem/prefetch/BasePrefecher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/BasePrefecher.scala
@@ -23,9 +23,9 @@ import org.chipsalliance.cde.config.Parameters
 import utility.MemReqSource
 import xiangshan._
 import xiangshan.backend.fu.PMPRespBundle
+import xiangshan.backend.rob.RobPtr
 import xiangshan.cache._
 import xiangshan.cache.mmu.TlbRequestIO
-import xiangshan.mem.Bundles.LsPrefetchTrainBundle
 import xiangshan.mem.L1PrefetchReq
 
 object PrefetchTarget extends Enumeration{
@@ -75,11 +75,14 @@ class L2PrefetchReq(implicit p: Parameters) extends XSBundle {
 class L3PrefetchReq(implicit p: Parameters) extends L2PrefetchReq
 
 class TrainReqBundle()(implicit p: Parameters) extends DCacheBundle {
+  val robIdx = new RobPtr
   val vaddr = UInt(VAddrBits.W)
   val paddr = UInt(PAddrBits.W)
   val pc = UInt(VAddrBits.W)
   val miss = Bool()
   val metaSource = UInt(L1PfSourceBits.W)
+  val isFirstIssue = Bool()
+  val isHwPrefetch = Bool()
   val refillLatency = UInt(LATENCY_WIDTH.W)
 }
 
@@ -92,8 +95,8 @@ class SourcePrefetchReq()(implicit p: Parameters) extends DCacheBundle {
 
 class PrefetcherIO()(implicit p: Parameters) extends XSBundle {
   val enable = Input(Bool())
-  val ld_in = Flipped(Vec(backendParams.LdExuCnt, ValidIO(new LsPrefetchTrainBundle())))
-  val st_in = Flipped(Vec(backendParams.StaExuCnt, ValidIO(new LsPrefetchTrainBundle())))
+  val ld_in = Flipped(Vec(backendParams.LdExuCnt, ValidIO(new TrainReqBundle())))
+  val st_in = Flipped(Vec(backendParams.StaExuCnt, ValidIO(new TrainReqBundle())))
   val tlb_req = new TlbRequestIO(nRespDups = 2)
   val pmp_resp = Flipped(new PMPRespBundle())
   val l1_req = DecoupledIO(new L1PrefetchReq())

--- a/src/main/scala/xiangshan/mem/prefetch/BasePrefecher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/BasePrefecher.scala
@@ -105,14 +105,6 @@ class BertiPrefetcherIO()(implicit p: Parameters) extends PrefetcherIO {
   val refillTrain = Flipped(ValidIO(new TrainReqBundle()))
 }
 
-class PrefetchReqBundle()(implicit p: Parameters) extends XSBundle {
-  val vaddr       = UInt(VAddrBits.W)
-  val paddr       = UInt(PAddrBits.W)
-  val pc          = UInt(VAddrBits.W)
-  val miss        = Bool()
-  val pfHitStream = Bool()
-}
-
 abstract class BasePrefecher()(implicit p: Parameters) extends XSModule
   with PrefetcherParams
   with HasDCacheParameters

--- a/src/main/scala/xiangshan/mem/prefetch/Berti.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/Berti.scala
@@ -937,7 +937,7 @@ class DeltaPrefetchBuffer(size: Int, name: String)(implicit p: Parameters) exten
 class BertiPrefetcher()(implicit p: Parameters) extends BasePrefecher with HasBertiHelper {
   override lazy val io = IO(new BertiPrefetcherIO)
 
-  val trainFilter = Module(new NewTrainFilter(TRAIN_FILTER_SIZE, name, true, true))
+  val trainFilter = Module(new TrainFilter(TRAIN_FILTER_SIZE, name, true, true))
   val historyTable = Module(new HistoryTable())
   val detlaTable = Module(new DeltaTable())
   val prefetchBuffer = Module(new DeltaPrefetchBuffer(PREFETCH_FILTER_SIZE, name))

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -104,157 +104,9 @@ trait HasL1PrefetchHelper extends HasCircularQueuePtrHelper with HasDCacheParame
   }
 }
 
-trait HasTrainFilterHelper extends HasCircularQueuePtrHelper {
-  def reorder[T <: LsPrefetchTrainBundle](source: Vec[ValidIO[T]]): Vec[ValidIO[T]] = {
-    if(source.length == 1) {
-      source
-    }else if(source.length == 2) {
-      val source_v = source.map(_.valid)
-      val res = Wire(source.cloneType)
-      // source 1 is older than source 0 (only when source0/1 are both valid)
-      val source_1_older = Mux(Cat(source_v).andR,
-        isBefore(source(1).bits.uop.robIdx, source(0).bits.uop.robIdx),
-        false.B
-      )
-      when(source_1_older) {
-        res(0) := source(1)
-        res(1) := source(0)
-      }.otherwise {
-        res := source
-      }
-
-      res
-    }else if(source.length == 3) {
-      // TODO: generalize
-      val res_0_1 = Reg(source.cloneType)
-      val res_1_2 = Reg(source.cloneType)
-      val res = Reg(source.cloneType)
-
-      val tmp = reorder(VecInit(source.slice(0, 2)))
-      res_0_1(0) := tmp(0)
-      res_0_1(1) := tmp(1)
-      res_0_1(2) := source(2)
-      val tmp_1 = reorder(VecInit(res_0_1.slice(1, 3)))
-      res_1_2(0) := res_0_1(0)
-      res_1_2(1) := tmp_1(0)
-      res_1_2(2) := tmp_1(1)
-      val tmp_2 = reorder(VecInit(res_1_2.slice(0, 2)))
-      res(0) := tmp_2(0)
-      res(1) := tmp_2(1)
-      res(2) := res_1_2(2)
-
-      res
-    }else {
-      require(false, "for now, 4 or more sources are invalid")
-      source
-    }
-  }
-}
-
-// get prefetch train reqs from `exuParameters.LduCnt` load pipelines (up to `exuParameters.LduCnt`/cycle)
-// filter by cache line address, send out train req to stride (up to 1 req/cycle)
-class TrainFilter(size: Int, name: String)(implicit p: Parameters) extends XSModule with HasL1PrefetchHelper with HasTrainFilterHelper {
-  val io = IO(new Bundle() {
-    val enable = Input(Bool())
-    val flush = Input(Bool())
-    // train input, only from load for now
-    val ld_in = Flipped(Vec(backendParams.LduCnt, ValidIO(new LsPrefetchTrainBundle())))
-    // filter out
-    val train_req = DecoupledIO(new PrefetchReqBundle())
-  })
-
-  class Ptr(implicit p: Parameters) extends CircularQueuePtr[Ptr]( p => size ){}
-  object Ptr {
-    def apply(f: Bool, v: UInt)(implicit p: Parameters): Ptr = {
-      val ptr = Wire(new Ptr)
-      ptr.flag := f
-      ptr.value := v
-      ptr
-    }
-  }
-
-  val entries = Reg(Vec(size, new PrefetchReqBundle))
-  val valids = RegInit(VecInit(Seq.fill(size){ (false.B) }))
-
-  // enq
-  val enqLen = backendParams.LduCnt
-  val enqPtrExt = RegInit(VecInit((0 until enqLen).map(_.U.asTypeOf(new Ptr))))
-  val deqPtrExt = RegInit(0.U.asTypeOf(new Ptr))
-
-  val deqPtr = WireInit(deqPtrExt.value)
-
-  require(size >= enqLen)
-
-  val ld_in_reordered = reorder(io.ld_in)
-  val reqs_l = ld_in_reordered.map(_.bits.toPrefetchReqBundle())
-  val reqs_vl = ld_in_reordered.map(_.valid)
-  val needAlloc = Wire(Vec(enqLen, Bool()))
-  val canAlloc = Wire(Vec(enqLen, Bool()))
-
-  for(i <- (0 until enqLen)) {
-    val req = reqs_l(i)
-    val req_v = reqs_vl(i)
-    val index = PopCount(needAlloc.take(i))
-    val allocPtr = enqPtrExt(index)
-    val entry_match = Cat(entries.zip(valids).map {
-      case(e, v) => v && block_hash_tag(e.vaddr) === block_hash_tag(req.vaddr)
-    }).orR
-    val prev_enq_match = if(i == 0) false.B else Cat(reqs_l.zip(reqs_vl).take(i).map {
-      case(pre, pre_v) => pre_v && block_hash_tag(pre.vaddr) === block_hash_tag(req.vaddr)
-    }).orR
-
-    needAlloc(i) := req_v && !entry_match && !prev_enq_match
-    canAlloc(i) := needAlloc(i) && allocPtr >= deqPtrExt && io.enable
-
-    when(canAlloc(i)) {
-      valids(allocPtr.value) := true.B
-      entries(allocPtr.value) := req
-    }
-  }
-  val allocNum = PopCount(canAlloc)
-
-  enqPtrExt.foreach{case x => when(canAlloc.asUInt.orR) {x := x + allocNum} }
-
-  // deq
-  io.train_req.valid := false.B
-  io.train_req.bits := DontCare
-  valids.zip(entries).zipWithIndex.foreach {
-    case((valid, entry), i) => {
-      when(deqPtr === i.U) {
-        io.train_req.valid := valid && io.enable
-        io.train_req.bits := entry
-      }
-    }
-  }
-
-  when(io.train_req.fire) {
-    valids(deqPtr) := false.B
-    deqPtrExt := deqPtrExt + 1.U
-  }
-
-  when(RegNext(io.flush)) {
-    valids.foreach {case valid => valid := false.B}
-    (0 until enqLen).map {case i => enqPtrExt(i) := i.U.asTypeOf(new Ptr)}
-    deqPtrExt := 0.U.asTypeOf(new Ptr)
-  }
-
-  XSPerfAccumulate(s"${name}_train_filter_full", PopCount(valids) === size.U)
-  XSPerfAccumulate(s"${name}_train_filter_half", PopCount(valids) >= (size / 2).U)
-  XSPerfAccumulate(s"${name}_train_filter_empty", PopCount(valids) === 0.U)
-
-  val raw_enq_pattern = Cat(reqs_vl)
-  val filtered_enq_pattern = Cat(needAlloc)
-  val actual_enq_pattern = Cat(canAlloc)
-  XSPerfAccumulate(s"${name}_train_filter_enq", allocNum > 0.U)
-  XSPerfAccumulate(s"${name}_train_filter_deq", io.train_req.fire)
-  for(i <- 0 until (1 << enqLen)) {
-    XSPerfAccumulate(s"${name}_train_filter_raw_enq_pattern_${toBinary(i)}", raw_enq_pattern === i.U)
-    XSPerfAccumulate(s"${name}_train_filter_filtered_enq_pattern_${toBinary(i)}", filtered_enq_pattern === i.U)
-    XSPerfAccumulate(s"${name}_train_filter_actual_enq_pattern_${toBinary(i)}", actual_enq_pattern === i.U)
-  }
-}
-
-class NewTrainFilter(size: Int, name: String, hasLoadTrain: Boolean=true, hasStoreTrain: Boolean=false)(implicit p: Parameters) extends XSModule with HasL1PrefetchHelper {
+// get prefetch train reqs from pipelines
+// filter by cache line address, send out train req up to 1 req/cycle
+class TrainFilter(size: Int, name: String, hasLoadTrain: Boolean=true, hasStoreTrain: Boolean=false)(implicit p: Parameters) extends XSModule with HasL1PrefetchHelper {
   val io = IO(new Bundle() {
     // control
     val enable = Input(Bool()) // FIXME lyq: some doubts about the functionality of enable
@@ -948,7 +800,7 @@ class L1Prefetcher(implicit p: Parameters) extends BasePrefecher with HasStreamP
   val stream_pf_ctrl = pf_ctrl(0)
   val stride_pf_ctrl = pf_ctrl(1)
 
-  stream_train_filter.io.ld_in.zipWithIndex.foreach {
+  stream_train_filter.io.ldTrainOpt.get.zipWithIndex.foreach {
     case (ld_in, i) => {
       ld_in.valid := io.ld_in(i).valid && enable
       ld_in.bits := io.ld_in(i).bits
@@ -957,7 +809,7 @@ class L1Prefetcher(implicit p: Parameters) extends BasePrefecher with HasStreamP
   stream_train_filter.io.enable := enable
   stream_train_filter.io.flush := stream_pf_ctrl.flush
 
-  stride_train_filter.io.ld_in.zipWithIndex.foreach {
+  stride_train_filter.io.ldTrainOpt.get.zipWithIndex.foreach {
     case (ld_in, i) => {
       ld_in.valid := stride_train(i).valid && enable
       ld_in.bits := stride_train(i).bits
@@ -970,13 +822,13 @@ class L1Prefetcher(implicit p: Parameters) extends BasePrefecher with HasStreamP
   stream_bit_vec_array.io.flush := stream_pf_ctrl.flush
   stream_bit_vec_array.io.dynamic_depth := stream_pf_ctrl.dynamic_depth
   stream_bit_vec_array.io.confidence := stream_pf_ctrl.confidence
-  stream_bit_vec_array.io.train_req <> stream_train_filter.io.train_req
+  stream_bit_vec_array.io.train_req <> stream_train_filter.io.trainReq
 
   stride_meta_array.io.enable := enable && strideEnable
   stride_meta_array.io.flush := stride_pf_ctrl.flush
   stride_meta_array.io.dynamic_depth := 0.U
   stride_meta_array.io.confidence := stride_pf_ctrl.confidence
-  stride_meta_array.io.train_req <> stride_train_filter.io.train_req
+  stride_meta_array.io.train_req <> stride_train_filter.io.trainReq
   stride_meta_array.io.stream_lookup_req <> stream_bit_vec_array.io.stream_lookup_req
   stride_meta_array.io.stream_lookup_resp <> stream_bit_vec_array.io.stream_lookup_resp
 

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -9,7 +9,6 @@ import xiangshan._
 import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.cache.HasDCacheParameters
 import xiangshan.cache.mmu._
-import xiangshan.mem.Bundles.LsPrefetchTrainBundle
 import xiangshan.mem.{L1PrefetchReq, L1PrefetchSource}
 
 case class StreamStrideParams() extends PrefetcherParams{
@@ -114,10 +113,10 @@ class TrainFilter(size: Int, name: String, hasLoadTrain: Boolean=true, hasStoreT
     // train input: from ldu, stu
 
     val ldTrainOpt = if (hasLoadTrain) {
-      Some(Flipped(Vec(backendParams.LdExuCnt, ValidIO(new LsPrefetchTrainBundle()))))
+      Some(Flipped(Vec(backendParams.LdExuCnt, ValidIO(new TrainReqBundle()))))
     } else None
     val stTrainOpt = if (hasStoreTrain) {
-       Some(Flipped(Vec(backendParams.StaExuCnt, ValidIO(new LsPrefetchTrainBundle()))))
+       Some(Flipped(Vec(backendParams.StaExuCnt, ValidIO(new TrainReqBundle()))))
     } else None
     // filter output
     val trainReq = DecoupledIO(new TrainReqBundle())
@@ -137,13 +136,13 @@ class TrainFilter(size: Int, name: String, hasLoadTrain: Boolean=true, hasStoreT
   val deqPtr = WireInit(deqPtrExt.value)
 
   val ldReorderOpt = io.ldTrainOpt.map { ldTrain =>
-    HwSort(VecInit(ldTrain.map { case x => DataWithPtr(x.valid, x.bits, x.bits.uop.robIdx) }))
+    HwSort(VecInit(ldTrain.map { case x => DataWithPtr(x.valid, x.bits, x.bits.robIdx) }))
   }
   val stReorderOpt = io.stTrainOpt.map { stTrain =>
-    HwSort(VecInit(stTrain.map { case x => DataWithPtr(x.valid, x.bits, x.bits.uop.robIdx) }))
+    HwSort(VecInit(stTrain.map { case x => DataWithPtr(x.valid, x.bits, x.bits.robIdx) }))
   }
-  val reqs = ldReorderOpt.map(_.map(_.bits.toTrainReqBundle())).getOrElse(Seq.empty) ++
-    stReorderOpt.map(_.map(_.bits.toTrainReqBundle())).getOrElse(Seq.empty)
+  val reqs = ldReorderOpt.map(_.map(_.bits)).getOrElse(Seq.empty) ++
+    stReorderOpt.map(_.map(_.bits)).getOrElse(Seq.empty)
   val reqsValid = ldReorderOpt.map(_.map(_.valid)).getOrElse(Seq.empty) ++
     stReorderOpt.map(_.map(_.valid)).getOrElse(Seq.empty)
 
@@ -784,7 +783,7 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
 
 class L1Prefetcher(implicit p: Parameters) extends BasePrefecher with HasStreamPrefetchHelper with HasStridePrefetchHelper {
   val pf_ctrl = IO(Input(Vec(L1PrefetcherNum, new PrefetchControlBundle)))
-  val stride_train = IO(Flipped(Vec(backendParams.LduCnt + backendParams.HyuCnt, ValidIO(new LsPrefetchTrainBundle()))))
+  val stride_train = IO(Flipped(Vec(backendParams.LduCnt + backendParams.HyuCnt, ValidIO(new TrainReqBundle()))))
   val l2PfqBusy = IO(Input(Bool()))
   val strideEnable = IO(Input(Bool()))
 

--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -174,12 +174,12 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
     val flush = Input(Bool())
     val dynamic_depth = Input(UInt(DEPTH_BITS.W))
     val confidence = Input(UInt(1.W))
-    val train_req = Flipped(DecoupledIO(new PrefetchReqBundle))
+    val train_req = Flipped(DecoupledIO(new TrainReqBundle))
     val l1_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
     val l2_l3_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
 
     // Stride send lookup req here
-    val stream_lookup_req  = Flipped(ValidIO(new PrefetchReqBundle))
+    val stream_lookup_req  = Flipped(ValidIO(UInt(VAddrBits.W)))
     val stream_lookup_resp = Output(Bool())
   })
 
@@ -200,7 +200,7 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
   val s0_pc    = io.train_req.bits.pc
   val s0_vaddr = io.train_req.bits.vaddr
   val s0_miss  = io.train_req.bits.miss
-  val s0_pfHit = io.train_req.bits.pfHitStream
+  val s0_pfHit = isFromStream(io.train_req.bits.metaSource)
   val s0_valid = s0_fire && (s0_miss || s0_pfHit)
   val s0_region_bits = get_region_bits(s0_vaddr)
   val s0_region_tag = get_region_tag(s0_vaddr)
@@ -448,7 +448,7 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
   // Stride lookup starts here
   // S0: Stride send req
   val s0_lookup_valid = io.stream_lookup_req.valid
-  val s0_lookup_vaddr = io.stream_lookup_req.bits.vaddr
+  val s0_lookup_vaddr = io.stream_lookup_req.bits
   val s0_lookup_tag = get_region_tag(s0_lookup_vaddr)
   // S1: match
   val s1_lookup_valid = GatedValidRegNext(s0_lookup_valid)

--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -7,7 +7,6 @@ import utils._
 import utility._
 import xiangshan._
 import xiangshan.mem.L1PrefetchReq
-import xiangshan.mem.Bundles.LsPrefetchTrainBundle
 import xiangshan.mem.trace._
 import xiangshan.mem.L1PrefetchSource
 import xiangshan.cache.HasDCacheParameters

--- a/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
@@ -116,11 +116,11 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
     val flush = Input(Bool())
     val dynamic_depth = Input(UInt(32.W)) // TODO: enable dynamic stride depth
     val confidence = Input(UInt(1.W))
-    val train_req = Flipped(DecoupledIO(new PrefetchReqBundle))
+    val train_req = Flipped(DecoupledIO(new TrainReqBundle))
     val l1_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
     val l2_l3_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
     // query Stream component to see if a stream pattern has already been detected
-    val stream_lookup_req  = ValidIO(new PrefetchReqBundle)
+    val stream_lookup_req  = ValidIO(UInt(VAddrBits.W))
     val stream_lookup_resp = Input(Bool())
   })
 
@@ -146,7 +146,7 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
   val s0_index = Mux(s0_hit, OHToUInt(s0_pc_match_vec), replacement.way)
   io.train_req.ready := s0_can_accept
   io.stream_lookup_req.valid := s0_valid
-  io.stream_lookup_req.bits  := io.train_req.bits
+  io.stream_lookup_req.bits := io.train_req.bits.vaddr
 
   when(s0_valid) {
     replacement.access(s0_index)

--- a/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
@@ -31,7 +31,6 @@ import utils._
 import utility._
 import xiangshan._
 import xiangshan.mem.L1PrefetchReq
-import xiangshan.mem.Bundles.LsPrefetchTrainBundle
 import xiangshan.mem.trace._
 import xiangshan.cache.HasDCacheParameters
 import xiangshan.cache.mmu._

--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherMonitor.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherMonitor.scala
@@ -7,7 +7,6 @@ import utils._
 import utility._
 import xiangshan._
 import xiangshan.mem.L1PrefetchReq
-import xiangshan.mem.Bundles.LsPrefetchTrainBundle
 import xiangshan.mem.HasL1PrefetchSourceParameter
 import xiangshan.backend.rob.RobDebugRollingIO
 

--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
@@ -11,7 +11,6 @@ import xiangshan.backend.Bundles.DynInst
 import xiangshan.backend.fu.{FuType, PMPRespBundle}
 import xiangshan.cache.mmu._
 import xiangshan.cache.{HasDCacheParameters, LoadPfDbBundle}
-import xiangshan.mem.Bundles.LsPrefetchTrainBundle
 import xiangshan.mem._
 import xiangshan.mem.trace._
 
@@ -69,13 +68,13 @@ class TrainSourceIO(implicit p: Parameters) extends PrefetchBundle {
   // load: ldu + hyu
   val s1_loadFireHint = Output(Vec(LD_TRAIN_WIDTH, Bool()))
   val s2_loadFireHint = Output(Vec(LD_TRAIN_WIDTH, Bool()))
-  val s3_load = Output(Vec(LD_TRAIN_WIDTH, ValidIO(new LsPrefetchTrainBundle())))
+  val s3_load = Output(Vec(LD_TRAIN_WIDTH, ValidIO(new TrainReqBundle())))
   val s3_ptrChasing = Output(Vec(LD_TRAIN_WIDTH, Bool()))
 
   // store: stu + hyu
   val s1_storeFireHint = Output(Vec(ST_TRAIN_WIDTH, Bool()))
   val s2_storeFireHint = Output(Vec(ST_TRAIN_WIDTH, Bool()))
-  val s3_store = Output(Vec(ST_TRAIN_WIDTH, ValidIO(new LsPrefetchTrainBundle())))
+  val s3_store = Output(Vec(ST_TRAIN_WIDTH, ValidIO(new TrainReqBundle())))
 }
 
 class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
@@ -181,14 +180,14 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
 
     for (i <- 0 until LD_TRAIN_WIDTH) {
       val source = io.trainSource.s3_load(i)
-      val primaryValid = source.valid && !source.bits.tlbMiss && !source.bits.is_from_hw_pf
+      val primaryValid = source.valid && !source.bits.isHwPrefetch
       pf.io.ld_in(i).valid := Mux(
         pf_train_on_hit,
         primaryValid,
         primaryValid && source.bits.isFirstIssue && source.bits.miss
       ) // && isLoadAccess(source.bits.uop)
       pf.io.ld_in(i).bits := source.bits
-      pf.io.ld_in(i).bits.uop.pc := Mux(
+      pf.io.ld_in(i).bits.pc := Mux(
         io.trainSource.s3_ptrChasing(i),
         s2_loadPcVec(i),
         s3_loadPcVec(i)
@@ -197,14 +196,14 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
 
     for (i <- 0 until ST_TRAIN_WIDTH) {
       val source = io.trainSource.s3_store(i)
-      val primaryValid = source.valid && !source.bits.tlbMiss && !source.bits.is_from_hw_pf
+      val primaryValid = source.valid && !source.bits.isHwPrefetch
       pf.io.st_in(i).valid := Mux(
         pf_train_on_hit,
         primaryValid,
         primaryValid && source.bits.isFirstIssue && source.bits.miss
       ) // && isStoreAccess(source.bits.uop)
       pf.io.st_in(i).bits := source.bits
-      pf.io.st_in(i).bits.uop.pc := s3_storePcVec(i)
+      pf.io.st_in(i).bits.pc := s3_storePcVec(i)
     }
 
     io.tlb_req(IdxSMS) <> pf.io.tlb_req
@@ -230,15 +229,15 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
     for(i <- 0 until LD_TRAIN_WIDTH){
       val source = io.trainSource.s3_load(i)
       pf.stride_train(i).valid := source.valid && source.bits.isFirstIssue && (
-        source.bits.miss || isFromStride(source.bits.meta_prefetch)
-      ) && !source.bits.is_from_hw_pf // && isLoadAccess(source.bits.uop)
+        source.bits.miss || isFromStride(source.bits.metaSource)
+      ) && !source.bits.isHwPrefetch // && isLoadAccess(source.bits.uop)
       pf.stride_train(i).bits := source.bits
-      pf.stride_train(i).bits.uop.pc := Mux(
+      pf.stride_train(i).bits.pc := Mux(
         io.trainSource.s3_ptrChasing(i),
         s2_loadPcVec(i),
         s3_loadPcVec(i)
       )
-      pf.io.ld_in(i).valid := source.valid && source.bits.isFirstIssue && !source.bits.is_from_hw_pf
+      pf.io.ld_in(i).valid := source.valid && source.bits.isFirstIssue && !source.bits.isHwPrefetch
       // && isLoadAccess(source.bits.uop)
       pf.io.ld_in(i).bits := source.bits
     }
@@ -267,10 +266,10 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
     for(i <- 0 until LD_TRAIN_WIDTH){
       val source = io.trainSource.s3_load(i)
       pf.io.ld_in(i).valid := source.valid && source.bits.isFirstIssue && (
-        source.bits.miss || isFromBerti(source.bits.meta_prefetch)
-      ) && !source.bits.is_from_hw_pf // && isLoadAccess(source.bits.uop)
+        source.bits.miss || isFromBerti(source.bits.metaSource)
+      ) && !source.bits.isHwPrefetch // && isLoadAccess(source.bits.uop)
       pf.io.ld_in(i).bits := source.bits
-      pf.io.ld_in(i).bits.uop.pc := Mux(
+      pf.io.ld_in(i).bits.pc := Mux(
         io.trainSource.s3_ptrChasing(i),
         s2_loadPcVec(i),
         s3_loadPcVec(i)
@@ -282,7 +281,7 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
       pf.io.st_in(i).bits := DontCare
       // val source = io.trainSource.s3_store(i)
       // pf.io.st_in(i).valid := source.valid && source.bits.isFirstIssue && (
-      //  source.bits.miss || isFromBerti(source.bits.meta_prefetch)
+      //  source.bits.miss || isFromBerti(source.bits.metaSource)
       // )
       // pf.io.st_in(i).bits := source.bits
       // pf.io.st_in(i).bits.uop.pc := s3_storePcVec(i)

--- a/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
@@ -1120,108 +1120,6 @@ class PrefetchFilter()(implicit p: Parameters) extends XSModule with HasSMSModul
   XSPerfAccumulate("sms_pf_filter_l2_req", io.l2_pf_addr.valid)
 }
 
-class SMSTrainFilter()(implicit p: Parameters) extends XSModule with HasSMSModuleHelper with HasTrainFilterHelper {
-  val io = IO(new Bundle() {
-    // train input
-    // hybrid load store
-    val ld_in = Flipped(Vec(backendParams.LdExuCnt, ValidIO(new LsPrefetchTrainBundle())))
-    val st_in = Flipped(Vec(backendParams.StaExuCnt, ValidIO(new LsPrefetchTrainBundle())))
-    // filter out
-    val train_req = ValidIO(new PrefetchReqBundle())
-  })
-
-  class Ptr(implicit p: Parameters) extends CircularQueuePtr[Ptr](
-    p => smsParams.train_filter_size
-  ){
-  }
-
-  object Ptr {
-    def apply(f: Bool, v: UInt)(implicit p: Parameters): Ptr = {
-      val ptr = Wire(new Ptr)
-      ptr.flag := f
-      ptr.value := v
-      ptr
-    }
-  }
-
-  val entries = RegInit(VecInit(Seq.fill(smsParams.train_filter_size){ (0.U.asTypeOf(new PrefetchReqBundle())) }))
-  val valids = RegInit(VecInit(Seq.fill(smsParams.train_filter_size){ (false.B) }))
-
-  val enqLen = backendParams.LduCnt + backendParams.StaCnt
-  val enqPtrExt = RegInit(VecInit((0 until enqLen).map(_.U.asTypeOf(new Ptr))))
-  val deqPtrExt = RegInit(0.U.asTypeOf(new Ptr))
-
-  val deqPtr = WireInit(deqPtrExt.value)
-
-  require(smsParams.train_filter_size >= enqLen)
-
-  val ld_reorder = reorder(io.ld_in)
-  val st_reorder = reorder(io.st_in)
-  val reqs_ls = ld_reorder.map(_.bits.toPrefetchReqBundle()) ++ st_reorder.map(_.bits.toPrefetchReqBundle())
-  val reqs_vls = ld_reorder.map(_.valid) ++ st_reorder.map(_.valid)
-  val needAlloc = Wire(Vec(enqLen, Bool()))
-  val canAlloc = Wire(Vec(enqLen, Bool()))
-
-  for(i <- (0 until enqLen)) {
-    val req = reqs_ls(i)
-    val req_v = reqs_vls(i)
-    val index = PopCount(needAlloc.take(i))
-    val allocPtr = enqPtrExt(index)
-    val entry_match = Cat(entries.zip(valids).map {
-      case(e, v) => v && block_hash_tag(e.vaddr) === block_hash_tag(req.vaddr)
-    }).orR
-    val prev_enq_match = if(i == 0) false.B else Cat(reqs_ls.zip(reqs_vls).take(i).map {
-      case(pre, pre_v) => pre_v && block_hash_tag(pre.vaddr) === block_hash_tag(req.vaddr)
-    }).orR
-
-    needAlloc(i) := req_v && !entry_match && !prev_enq_match
-    canAlloc(i) := needAlloc(i) && allocPtr >= deqPtrExt
-
-    when(canAlloc(i)) {
-      valids(allocPtr.value) := true.B
-      entries(allocPtr.value) := req
-    }
-  }
-  val allocNum = PopCount(canAlloc)
-
-  enqPtrExt.foreach{case x => when(canAlloc.asUInt.orR) {x := x + allocNum} }
-
-  io.train_req.valid := false.B
-  io.train_req.bits := DontCare
-  valids.zip(entries).zipWithIndex.foreach {
-    case((valid, entry), i) => {
-      when(deqPtr === i.U) {
-        io.train_req.valid := valid
-        io.train_req.bits := entry
-      }
-    }
-  }
-
-  when(io.train_req.valid) {
-    valids(deqPtr) := false.B
-    deqPtrExt := deqPtrExt + 1.U
-  }
-
-  XSPerfAccumulate("sms_train_filter_full", PopCount(valids) === (smsParams.train_filter_size).U)
-  XSPerfAccumulate("sms_train_filter_half", PopCount(valids) >= (smsParams.train_filter_size / 2).U)
-  XSPerfAccumulate("sms_train_filter_empty", PopCount(valids) === 0.U)
-
-  val raw_enq_pattern = Cat(reqs_vls)
-  val filtered_enq_pattern = Cat(needAlloc)
-  val actual_enq_pattern = Cat(canAlloc)
-  XSPerfAccumulate("sms_train_filter_enq", allocNum > 0.U)
-  XSPerfAccumulate("sms_train_filter_deq", io.train_req.fire)
-  def toBinary(n: Int): String = n match {
-    case 0|1 => s"$n"
-    case _   => s"${toBinary(n/2)}${n%2}"
-  }
-  for(i <- 0 until (1 << enqLen)) {
-    XSPerfAccumulate(s"sms_train_filter_raw_enq_pattern_${toBinary(i)}", raw_enq_pattern === i.U)
-    XSPerfAccumulate(s"sms_train_filter_filtered_enq_pattern_${toBinary(i)}", filtered_enq_pattern === i.U)
-    XSPerfAccumulate(s"sms_train_filter_actual_enq_pattern_${toBinary(i)}", actual_enq_pattern === i.U)
-  }
-}
-
 class SMSPrefetcher()(implicit p: Parameters) extends BasePrefecher with HasSMSModuleHelper with HasL1PrefetchSourceParameter {
   import freechips.rocketchip.util._
 
@@ -1232,12 +1130,15 @@ class SMSPrefetcher()(implicit p: Parameters) extends BasePrefecher with HasSMSM
   val io_act_stride = IO(Input(UInt(6.W)))
   val io_dcache_evict = IO(Flipped(DecoupledIO(new AGTEvictReq)))
 
-  val train_filter = Module(new SMSTrainFilter)
+  val train_filter = Module(new TrainFilter(smsParams.train_filter_size, "SMS", true, true))
 
-  train_filter.io.ld_in <> io.ld_in
-  train_filter.io.st_in <> io.st_in
+  train_filter.io.enable := true.B
+  train_filter.io.flush := false.B
+  train_filter.io.ldTrainOpt.map(_ := io.ld_in)
+  train_filter.io.stTrainOpt.map(_ := io.st_in)
+  train_filter.io.trainReq.ready := true.B
 
-  val train_ld = train_filter.io.train_req.bits
+  val train_ld = train_filter.io.trainReq.bits
 
   val train_block_tag = block_hash_tag(train_ld.vaddr)
   val train_region_tag = train_block_tag.head(REGION_TAG_WIDTH)
@@ -1258,7 +1159,7 @@ class SMSPrefetcher()(implicit p: Parameters) extends BasePrefecher with HasSMSM
   val train_region_paddr = region_addr(train_ld.paddr)
   val train_region_vaddr = region_addr(train_ld.vaddr)
   val train_region_offset = train_block_tag(REGION_OFFSET - 1, 0)
-  val train_vld = train_filter.io.train_req.valid
+  val train_vld = train_filter.io.trainReq.valid
 
 
   // prefetch stage0

--- a/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
@@ -34,7 +34,6 @@ import utility._
 import xiangshan._
 import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.mem.L1PrefetchReq
-import xiangshan.mem.Bundles.LsPrefetchTrainBundle
 import xiangshan.mem.trace._
 import xiangshan.mem.HasL1PrefetchSourceParameter
 import xiangshan.cache.HasDCacheParameters
@@ -1247,7 +1246,7 @@ class SMSPrefetcher()(implicit p: Parameters) extends BasePrefecher with HasSMSM
 
   for((train, i) <- io.ld_in.zipWithIndex){
     XSPerfAccumulate(s"pf_train_miss_${i}", train.valid && train.bits.miss)
-    XSPerfAccumulate(s"pf_train_prefetched_${i}", train.valid && isFromL1Prefetch(train.bits.meta_prefetch))
+    XSPerfAccumulate(s"pf_train_prefetched_${i}", train.valid && isFromL1Prefetch(train.bits.metaSource))
   }
   val trace = Wire(new L1MissTrace)
   trace.vaddr := 0.U


### PR DESCRIPTION
The main changes are as follows

* Use TrainReqBundle for load/store/refill prefetch training paths and remove the local LsPrefetchTrainBundle conversion logic.
* Unify SMS, stride, stream, and Berti train filters on the shared TrainFilter interface, and update related field names such as metaSource, isFirstIssue, and isHwPrefetch.
* Bump utility for fix HwSort.

The above changes have no impact on performance (base spec 2006 0.3cov)
<img width="1072" height="1638" alt="image" src="https://github.com/user-attachments/assets/c813f3f7-691a-4524-94da-c552d0170504" />
