### PR TITLE
fix(LoadQueueRAR): use RegEnable to avoid X

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
@@ -244,7 +244,7 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
                          robIdxMask(i) &&
                          released(i))
       }
-    val matchMask = GatedValidRegNext(matchMaskReg)
+    val matchMask = RegEnable(matchMaskReg, query.req.valid)
     //  Load-to-Load violation check result
     val ldLdViolationMask = matchMask
     ldLdViolationMask.suggestName("ldLdViolationMask_" + w)


### PR DESCRIPTION
The `query.bits.paddr` is X. Besides, query of `paddrModule` does not have valid,  if we use `GatedValidRegNext` may lead to X (which will use data to clock gate). 

we can use `RegEnable` to clock gate.