### PR TITLE
fix(MemBlock): fix stuck caused by misalign load filling up LQRAR

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -844,22 +844,11 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vSegmentFlag := false.B
   }
 
-  val misalign_allow_spec = RegInit(true.B)
-  val ldu_rollback_with_misalign_nack = loadUnits.map(ldu =>
-    ldu.io.lsq.ldin.bits.isFrmMisAlignBuf && ldu.io.lsq.ldin.bits.rep_info.rar_nack && ldu.io.rollback.valid
-  ).reduce(_ || _)
-  when (ldu_rollback_with_misalign_nack) {
-    misalign_allow_spec := false.B
-  } .elsewhen(lsq.io.rarValidCount < (LoadQueueRARSize - 4).U) {
-    misalign_allow_spec := true.B
-  }
-
   // LoadUnit
   val correctMissTrain = Constantin.createRecord(s"CorrectMissTrain$hartId", initValue = false)
 
   for (i <- 0 until LduCnt) {
     loadUnits(i).io.redirect <> redirect
-    loadUnits(i).io.misalign_allow_spec := misalign_allow_spec
 
     // get input form dispatch
     loadUnits(i).io.ldin <> io.ooo_to_mem.issueLda(i)
@@ -1198,7 +1187,6 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   loadMisalignBuffer.io.rob.pendingPtrNext      := io.ooo_to_mem.lsqio.pendingPtrNext
 
   lsq.io.loadMisalignFull                       := loadMisalignBuffer.io.loadMisalignFull
-  lsq.io.misalignAllowSpec                      := misalign_allow_spec
 
   storeMisalignBuffer.io.redirect               <> redirect
   storeMisalignBuffer.io.rob.lcommit            := io.ooo_to_mem.lsqio.lcommit

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -120,7 +120,6 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
     val sqCommitRobIdx = Output(new RobPtr)
     val exceptionAddr = new ExceptionAddrIO
     val loadMisalignFull = Input(Bool())
-    val misalignAllowSpec = Input(Bool())
     val issuePtrExt = Output(new SqPtr)
     val l2_hint = Input(Valid(new L2ToL1Hint()))
     val tlb_hint = Flipped(new TlbHintIO)
@@ -129,7 +128,6 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
     val flushSbuffer = new SbufferFlushBundle
     val force_write = Output(Bool())
     val lqEmpty = Output(Bool())
-    val rarValidCount = Output(UInt())
     val wfi = Flipped(new WfiReqBundle)
     // top-down
     val debugTopDown = new LoadQueueTopDownIO
@@ -164,7 +162,6 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   io.sqCommitRobIdx := storeQueue.io.sqCommitRobIdx
   io.sqCommitUopIdx := storeQueue.io.sqCommitUopIdx
   io.sqCommitPtr    := storeQueue.io.sqCommitPtr
-  io.rarValidCount := loadQueue.io.rarValidCount
   for (i <- io.enq.req.indices) {
     loadQueue.io.enq.needAlloc(i)      := io.enq.needAlloc(i)(0)
     loadQueue.io.enq.req(i).valid      := io.enq.needAlloc(i)(0) && io.enq.req(i).valid
@@ -223,7 +220,6 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   loadQueue.io.release             <> io.release
   loadQueue.io.exceptionAddr.isStore := DontCare
   loadQueue.io.loadMisalignFull    := io.loadMisalignFull
-  loadQueue.io.misalignAllowSpec   := io.misalignAllowSpec
   loadQueue.io.lqCancelCnt         <> io.lqCancelCnt
   loadQueue.io.sq.stAddrReadySqPtr <> storeQueue.io.stAddrReadySqPtr
   loadQueue.io.sq.stAddrReadyVec   <> storeQueue.io.stAddrReadyVec

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -193,7 +193,6 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     val uncache = new UncacheWordIO
     val exceptionAddr = new ExceptionAddrIO
     val loadMisalignFull = Input(Bool())
-    val misalignAllowSpec = Input(Bool())
     val lqFull = Output(Bool())
     val lqDeq = Output(UInt(log2Up(CommitWidth + 1).W))
     val lqCancelCnt = Output(UInt(log2Up(VirtualLoadQueueSize+1).W))
@@ -204,8 +203,6 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     val lqEmpty = Output(Bool())
 
     val lqDeqPtr = Output(new LqPtr)
-
-    val rarValidCount = Output(UInt())
 
     val debugTopDown = new LoadQueueTopDownIO
     val noUopsIssed = Input(Bool())
@@ -223,7 +220,6 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   loadQueueRAR.io.redirect  <> io.redirect
   loadQueueRAR.io.release   <> io.release
   loadQueueRAR.io.ldWbPtr   <> virtualLoadQueue.io.ldWbPtr
-  loadQueueRAR.io.validCount<> io.rarValidCount
   for (w <- 0 until LoadPipelineWidth) {
     loadQueueRAR.io.query(w).req    <> io.ldu.ldld_nuke_query(w).req // from load_s1
     loadQueueRAR.io.query(w).resp   <> io.ldu.ldld_nuke_query(w).resp // to load_s2
@@ -284,7 +280,6 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   exceptionBuffer.io.req(LoadPipelineWidth + VecLoadPipelineWidth).bits.vaNeedExt := true.B
 
   loadQueueReplay.io.loadMisalignFull := io.loadMisalignFull
-  loadQueueReplay.io.misalignAllowSpec := io.misalignAllowSpec
 
   io.exceptionAddr <> exceptionBuffer.io.exceptionAddr
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAR.scala
@@ -47,8 +47,6 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
 
     // global
     val lqFull = Output(Bool())
-
-    val validCount = Output(UInt())
   })
 
   private val PartialPAddrStride: Int = 6
@@ -268,7 +266,6 @@ class LoadQueueRAR(implicit p: Parameters) extends XSModule
   })
 
   io.lqFull := freeList.io.empty
-  io.validCount := freeList.io.validCount
 
   // perf cnt
   val canEnqCount = PopCount(io.query.map(_.req.fire))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -206,7 +206,6 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val rarFull = Input(Bool())
     val rawFull = Input(Bool())
     val loadMisalignFull = Input(Bool())
-    val misalignAllowSpec = Input(Bool())
     val l2_hint  = Input(Valid(new L2ToL1Hint()))
     val tlb_hint = Flipped(new TlbHintIO)
     val tlbReplayDelayCycleCtrl = Vec(4, Input(UInt(ReSelectLen.W)))
@@ -364,7 +363,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     }
     // case C_MF
     when (cause(i)(LoadReplayCauses.C_MF)) {
-      blocking(i) := Mux(!io.loadMisalignFull && (io.misalignAllowSpec || !isAfter(uop(i).lqIdx, io.ldWbPtr)), false.B, blocking(i))
+      blocking(i) := Mux(!isAfter(uop(i).lqIdx, io.ldWbPtr), false.B, blocking(i))
     }
   })
 

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -202,7 +202,6 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
     // to misalign buffer
     val misalign_enq = new MisalignBufferEnqIO
-    val misalign_allow_spec = Input(Bool())
 
     // Load RAR rollback
     val rollback = Valid(new Redirect)
@@ -1561,7 +1560,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s3_safe_writeback = RegEnable(s2_safe_writeback, s2_fire) || s3_hw_err
   val s3_exception = RegEnable(s2_real_exception, s2_fire)
   val s3_mis_align = RegEnable(s2_mis_align, s2_fire) && !s3_exception
-  val s3_misalign_can_go = RegEnable(!isAfter(s2_out.uop.lqIdx, io.lsq.lqDeqPtr) || io.misalign_allow_spec, s2_fire)
+  val s3_misalign_can_go = RegEnable(!isAfter(s2_out.uop.lqIdx, io.lsq.lqDeqPtr), s2_fire)
   val s3_trigger_debug_mode = RegEnable(s2_trigger_debug_mode, false.B, s2_fire)
 
   // TODO: Fix vector load merge buffer nack


### PR DESCRIPTION
**Bug Symptom:** 
When there are a large number of out-of-order loads, the processor may freeze because the RARqueue is full.

**Cause Analysis:** 
Because 128-bit misaligned loads must be split, a single load instruction occupies two slots in the rarqueue and one slot in the loadqueue. Consequently, even though the loadqueue and rarqueue are the same size, a situation may arise where the loadqueue is not full but the rarqueue is. In this case, the oldest load instruction may be unable to enter the rarqueue, causing the processor to hang.

**Fix:** 
In the end, we opted for the most conservative approach, **allowing only the oldest `load` instructions to be split across cache lines. Although, in theory**, a split that spans multiple cache lines could occupy only a single entry in the rarequeue, there is no need to distinguish this in v2.