### PR TITLE
feat(ftq): read the queue with redirect FTQ index one cycle ahead of real redirect

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -44,8 +44,7 @@ import xiangshan.TopDownCounters._
 
 class CtrlToFtqIO(implicit p: Parameters) extends XSBundle {
   val redirect = Valid(new Redirect)
-  val ftqIdxAhead = Vec(BackendRedirectNum, Valid(new FtqPtr))
-  val ftqIdxSelOH = Valid(UInt((BackendRedirectNum).W))
+  val ftqIdxAhead = Valid(new FtqPtr)
 
   val resolve = Vec(backendParams.BrhCnt, Valid(new Resolve))
 
@@ -373,18 +372,10 @@ class CtrlBlockImp(
 
   io.frontend.toFtq.redirect.valid := s5_flushFromRobValid || s3_redirectGen.valid
   io.frontend.toFtq.redirect.bits := Mux(s5_flushFromRobValid, frontendFlushBits, s3_redirectGen.bits)
-  io.frontend.toFtq.ftqIdxSelOH.valid := s5_flushFromRobValid || redirectGen.io.stage2Redirect.valid
-  io.frontend.toFtq.ftqIdxSelOH.bits := Cat(s5_flushFromRobValid, redirectGen.io.stage2oldestOH & Fill(NumRedirect + 1, !s5_flushFromRobValid))
 
-  //jmp/brh, sel oldest first, only use one read port
-  io.frontend.toFtq.ftqIdxAhead(0).valid := oldestExuRedirect.valid && !s1_robFlushRedirect.valid && !s4_flushFromRobValidAhead
-  io.frontend.toFtq.ftqIdxAhead(0).bits := oldestExuRedirect.bits.ftqIdx
-  //loadreplay
-  io.frontend.toFtq.ftqIdxAhead(NumRedirect).valid := loadReplay.valid && !s1_robFlushRedirect.valid && !s4_flushFromRobValidAhead
-  io.frontend.toFtq.ftqIdxAhead(NumRedirect).bits := loadReplay.bits.ftqIdx
-  //exception
-  io.frontend.toFtq.ftqIdxAhead.last.valid := s4_flushFromRobValidAhead
-  io.frontend.toFtq.ftqIdxAhead.last.bits := frontendFlushBits.ftqIdx
+  // jmp/brh, sel oldest first
+  io.frontend.toFtq.ftqIdxAhead.valid := oldestExuRedirect.valid && !s1_robFlushRedirect.valid && !s4_flushFromRobValidAhead
+  io.frontend.toFtq.ftqIdxAhead.bits := oldestExuRedirect.bits.ftqIdx
 
   for (i <- 0 until CommitWidth) {
     val crc = io.frontend.toFtq.callRetCommit(i)

--- a/src/main/scala/xiangshan/frontend/ftq/BackendRedirectReceiver.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/BackendRedirectReceiver.scala
@@ -26,35 +26,30 @@ trait BackendRedirectReceiver extends HasFtqParameters {
       fromBackend: CtrlToFtqIO
   ): (Valid[FtqPtr], Valid[Redirect]) = {
     // Backend sends the redirect index from bju to FTQ one cycle in advance, and FTQ uses this index to read queues.
-    // Other redirect indexes are sent to FTQ when the real redirect happens. If ftqIdxInAdvance is sent in advance,
-    // FTQ can process the redirect when it comes. Otherwise, FTQ has to delay the redirect for one cycle.
+    // Other redirect indexes are sent to FTQ when the real redirect happens. If ftqIdxAhead is sent in advance, FTQ can
+    // process the redirect when it comes. Otherwise, FTQ has to delay the redirect for one cycle.
 
-    // TODO: Now only channel 0 is used. Will change to single valid bundle and remove ftqIdxSelOH in the future.
-    val ftqIdxInAdvance = Wire(Valid(new FtqPtr))
-    ftqIdxInAdvance.valid := fromBackend.ftqIdxAhead(0).valid && !fromBackend.redirect.valid
-    ftqIdxInAdvance.bits  := fromBackend.ftqIdxAhead(0).bits
-    val ftqIdxInAdvanceValidNext = RegNext(ftqIdxInAdvance.valid)
-    // TODO: why this is not designed as folloing two assertions?
-//    XSError(
-//      ftqIdxInAdvanceValidNext && !fromBackend.redirect.valid,
-//      "FTQ index sent in advance, but no redirect comes in the next cycle\n"
-//    )
-//    XSError(
-//      ftqIdxInAdvanceValidNext && fromBackend.redirect.bits.ftqIdx =/= RegNext(ftqIdxInAdvance.bits),
-//      "FTQ index sent in advance, but it is not the same with redirect FTQ index\n"
-//    )
+    val redirect = fromBackend.redirect
 
-    val redirect    = fromBackend.redirect
+    // ftqIdxAhead has lower priority than real redirect
+    // Magic! Do not touch!!!
+    val ftqIdxAhead = Wire(Valid(new FtqPtr))
+    ftqIdxAhead.valid := fromBackend.ftqIdxAhead.valid && !redirect.valid
+    ftqIdxAhead.bits  := fromBackend.ftqIdxAhead.bits
+    val ftqIdxAheadNext = RegNext(ftqIdxAhead)
+
+    val aheadIdxMatch = ftqIdxAheadNext.valid && redirect.bits.ftqIdx === ftqIdxAheadNext.bits
+
     val redirectReg = RegNext(redirect)
-    redirectReg.valid := redirect.valid && !ftqIdxInAdvanceValidNext
+    redirectReg.valid := redirect.valid && !aheadIdxMatch
 
     val ftqIdx = Wire(Valid(new FtqPtr))
-    ftqIdx.valid := redirect.valid
+    ftqIdx.valid := redirect.valid && !aheadIdxMatch
     ftqIdx.bits  := redirect.bits.ftqIdx
 
     (
-      Mux(ftqIdxInAdvance.valid, ftqIdxInAdvance, ftqIdx),
-      Mux(ftqIdxInAdvanceValidNext, redirect, redirectReg)
+      Mux(redirect.valid, ftqIdx, ftqIdxAhead),
+      Mux(aheadIdxMatch, redirect, redirectReg)
     )
   }
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -365,21 +365,27 @@ class Ftq(implicit p: Parameters) extends FtqModule
 
   resolveQueue.io.backendResolve := io.fromBackend.resolve
 
-  private val trainCache = RegInit(0.U.asTypeOf(Valid(new BpuTrain)))
+  private val trainCache      = RegInit(0.U.asTypeOf(Valid(new BpuTrain)))
+  private val trainIndexCache = RegInit(0.U.asTypeOf(new FtqPtr))
 
   resolveQueue.io.bpuTrain.ready := !trainCache.valid || io.toBpu.train.fire
 
-  when(resolveQueue.io.bpuTrain.fire) {
+  private val flushTrain = backendRedirect.valid && trainIndexCache > backendRedirect.bits.ftqIdx
+
+  when(flushTrain) {
+    trainCache.valid := false.B
+  }.elsewhen(resolveQueue.io.bpuTrain.fire) {
     trainCache.bits.meta     := metaQueueResolve(resolveQueue.io.bpuTrain.bits.ftqIdx.value)
     trainCache.bits.startPc  := resolveQueue.io.bpuTrain.bits.startPc
     trainCache.bits.branches := resolveQueue.io.bpuTrain.bits.branches
     trainCache.bits.perfMeta := perfQueue(resolveQueue.io.bpuTrain.bits.ftqIdx.value).bpuPerf
     trainCache.valid         := true.B
+    trainIndexCache          := resolveQueue.io.bpuTrain.bits.ftqIdx
   }.elsewhen(io.toBpu.train.fire) {
     trainCache.valid := false.B
   }
 
-  io.toBpu.train.valid := trainCache.valid
+  io.toBpu.train.valid := trainCache.valid && !flushTrain
   io.toBpu.train.bits  := trainCache.bits
 
   io.fromBackend.resolve.foreach { branch =>

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -134,8 +134,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
     ifuRedirectFtqIdxInAdvance.bits
   )
 
-  private val redirect     = Mux(backendRedirect.valid, backendRedirect, ifuRedirect)
-  private val redirectNext = RegNext(redirect)
+  private val redirect = Mux(backendRedirect.valid, backendRedirect, ifuRedirect)
 
   // Instruction page fault and instruction access fault are sent from backend with redirect requests.
   // When IPF and IAF are sent, backendPcFaultIfuPtr points to the FTQ entry whose first instruction
@@ -285,21 +284,11 @@ class Ftq(implicit p: Parameters) extends FtqModule
   private val twoPrefetchCase = TwoPrefetchCase(prefetchReq, io.toICache.toPrefetch.fire && canTwoPrefetch)
 
   // FIXME: backend redirect delay should be more than ITLB csr delay
-  io.toICache.toPrefetch.valid := (bpuPtr(0) > pfPtr(0) || redirectNext.valid) && !redirect.valid
+  io.toICache.toPrefetch.valid := bpuPtr(0) > pfPtr(0) && !redirect.valid
   io.toICache.toPrefetch.bits.req.zipWithIndex.foreach { case (req, i) =>
-    req.startVAddr := {
-      if (i == 0)
-        Mux(redirectNext.valid, PrunedAddrInit(redirectNext.bits.target), prefetchReq(i).startVAddr)
-      else
-        prefetchReq(i).startVAddr
-    }
-    req.nextLineVAddr := req.startVAddr + blockBytes.U
-    req.isCrossLine := {
-      if (i == 0)
-        Mux(redirectNext.valid, true.B, prefetchReq(i).isCrossLine)
-      else
-        prefetchReq(i).isCrossLine
-    }
+    req.startVAddr       := prefetchReq(i).startVAddr
+    req.nextLineVAddr    := req.startVAddr + blockBytes.U
+    req.isCrossLine      := prefetchReq(i).isCrossLine
     req.ftqIdx           := pfPtr(i)
     req.backendException := Mux(backendExceptionPtr === pfPtr(i), backendException, ExceptionType.None)
     req.isSoftPrefetch   := false.B

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -118,13 +118,23 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // perfQueue stores information for performance monitoring. These queues should not exist in hardware
   private val perfQueue = Reg(Vec(FtqSize, new PerfMeta))
 
+  private val (backendRedirectFtqIdxInAdvance, backendRedirect) = receiveBackendRedirect(io.fromBackend)
+
   private val specTopAddr = metaQueueRedirect(io.fromIfu.wbRedirect.bits.ftqIdx.value).ras.topRetAddr.toUInt
-  private val ifuRedirect = receiveIfuRedirect(io.fromIfu.wbRedirect, specTopAddr)
+  private val (ifuRedirectFtqIdxInAdvance, ifuRedirect) = receiveIfuRedirect(
+    io.fromIfu.wbRedirect,
+    specTopAddr,
+    backendRedirect.valid
+  )
 
-  private val (backendRedirectFtqIdx, backendRedirect) = receiveBackendRedirect(io.fromBackend)
+  // redirectFtqIdxInAdvance is always one cycle ahead of redirect
+  private val redirectFtqIdxInAdvance = Mux(
+    backendRedirectFtqIdxInAdvance.valid,
+    backendRedirectFtqIdxInAdvance.bits,
+    ifuRedirectFtqIdxInAdvance.bits
+  )
 
-  // Delay one cycle for timing considerations
-  private val redirect     = RegNext(Mux(backendRedirect.valid, backendRedirect, ifuRedirect))
+  private val redirect     = Mux(backendRedirect.valid, backendRedirect, ifuRedirect)
   private val redirectNext = RegNext(redirect)
 
   // Instruction page fault and instruction access fault are sent from backend with redirect requests.
@@ -354,7 +364,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
   io.toBpu.redirect.bits.target    := redirect.bits.target
   io.toBpu.redirect.bits.taken     := redirect.bits.taken
   io.toBpu.redirect.bits.attribute := redirect.bits.attribute
-  io.toBpu.redirect.bits.meta      := metaQueueRedirect(redirect.bits.ftqIdx.value)
+  io.toBpu.redirect.bits.meta      := RegNext(metaQueueRedirect(redirectFtqIdxInAdvance.value))
   io.toBpu.redirectFromIFU         := ifuRedirect.valid
 
   resolveQueue.io.backendRedirect    := backendRedirect.valid
@@ -457,7 +467,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
     PrunedAddrInit(redirect.bits.pc),
     redirect.bits.ftqOffset
   )._1
-  private val redirectPerfMeta = perfQueue(backendRedirectFtqIdx.bits.value).bpuPerf
+  private val redirectPerfMeta = perfQueue(backendRedirect.bits.ftqIdx.value).bpuPerf
   private val commitPerfMeta   = perfQueue(commitPtr(0).value)
 
   XSPerfSeqAccumulate(

--- a/src/main/scala/xiangshan/frontend/ftq/IfuRedirectReceiver.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/IfuRedirectReceiver.scala
@@ -23,12 +23,13 @@ import xiangshan.frontend.FrontendRedirect
 
 trait IfuRedirectReceiver extends HasFtqParameters {
   def receiveIfuRedirect(
-      wbRedirect:  Valid[FrontendRedirect],
-      specTopAddr: UInt
-  ): Valid[Redirect] = {
+      wbRedirect:      Valid[FrontendRedirect],
+      specTopAddr:     UInt,
+      backendRedirect: Bool
+  ): (Valid[FtqPtr], Valid[Redirect]) = {
     val redirect = WireInit(0.U.asTypeOf(Valid(new Redirect)))
 
-    redirect.valid          := wbRedirect.valid
+    redirect.valid          := wbRedirect.valid && !backendRedirect
     redirect.bits.ftqIdx    := wbRedirect.bits.ftqIdx
     redirect.bits.ftqOffset := wbRedirect.bits.ftqOffset
     redirect.bits.level     := RedirectLevel.flushAfter
@@ -37,6 +38,12 @@ trait IfuRedirectReceiver extends HasFtqParameters {
     redirect.bits.pc        := wbRedirect.bits.pc
     redirect.bits.target    := Mux(wbRedirect.bits.attribute.isReturn, specTopAddr, wbRedirect.bits.target)
     redirect.bits.taken     := wbRedirect.bits.taken
-    redirect
+    redirect.bits.isMisPred := true.B
+
+    val ftqIdx = Wire(Valid(new FtqPtr))
+    ftqIdx.valid := redirect.valid
+    ftqIdx.bits  := redirect.bits.ftqIdx
+
+    (ftqIdx, RegNext(redirect))
   }
 }


### PR DESCRIPTION
If FTQ index is not sent one cycle in advance, the redirect is delayed for one cycle

This should also optimize the port timing between FTQ and BPU