### PR TITLE
refactor: remove TL version of XiangShan

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,7 +15,6 @@
     - src/main/scala/xiangshan/cache/**
     - src/main/scala/xiangshan/mem/**
     - XSCache
-    - huancun
 
 "module: top":
 - changed-files:
@@ -72,7 +71,6 @@
     - ChiselIOPMP
     - XSCache
     - difftest
-    - huancun
     - ready-to-run
     - rocket-chip
     - utility

--- a/.github/workflows/emu-basics.yml
+++ b/.github/workflows/emu-basics.yml
@@ -94,6 +94,8 @@ jobs:
             report: true
           - name: linux-hello-opensbi
             report: true
+          - name: iopmp-test
+            extra: --no-diff
           - name: povray
             extra: --max-instr 5000000 --gcpt-restore-bin /nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin
             report: true

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -82,51 +82,6 @@ jobs:
             2> stderr.log
           cat stderr.log | sort
 
-  # CHI Release config test
-  emu-basics:
-    name: EMU - Basics
-    needs: changes
-    if: ${{ needs.changes.outputs.core == 'true' }}
-    runs-on: builder
-    timeout-minutes: 900
-    continue-on-error: false
-    steps:
-      - name: Cleanup orphan EMU
-        run: |
-          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: true
-      - name: Init
-        run: |
-          mkdir -p ${WAVE_HOME} ${PERF_HOME}
-          make init-force
-          python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py --clean
-      - name: Build DefaultConfig Release EMU
-        run: |
-          python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py --build \
-            --emulator verilator --threads 8 \
-            --config DefaultConfig --release \
-            --trace-fst
-      - name: DefaultConfig Test - Linux
-        run: |
-          python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
-            --wave-dump ${WAVE_HOME} \
-            --threads 8 --numa \
-            --ci linux-hello-opensbi \
-            2> stderr.log
-          cat stderr.log | sort
-      - name: DefaultConfig Test - Iopmp
-        run: |
-          python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
-            --wave-dump ${WAVE_HOME} \
-            --threads 8 --numa \
-            --no-diff \
-            --ci iopmp-test \
-          2> stderr.log
-          cat stderr.log | sort
-
   # Simfrontend test
   emu-simfrontend:
     name: EMU - SimFrontend

--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -83,8 +83,8 @@ jobs:
           cat stderr.log | sort
 
   # CHI Release config test
-  emu-chi:
-    name: EMU - CHI
+  emu-basics:
+    name: EMU - Basics
     needs: changes
     if: ${{ needs.changes.outputs.core == 'true' }}
     runs-on: builder
@@ -103,13 +103,13 @@ jobs:
           mkdir -p ${WAVE_HOME} ${PERF_HOME}
           make init-force
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py --clean
-      - name: Build CHIConfig Release EMU
+      - name: Build DefaultConfig Release EMU
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py --build \
             --emulator verilator --threads 8 \
-            --config CHIConfig --release \
+            --config DefaultConfig --release \
             --trace-fst
-      - name: CHIConfig Test - Linux
+      - name: DefaultConfig Test - Linux
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
             --wave-dump ${WAVE_HOME} \
@@ -117,7 +117,7 @@ jobs:
             --ci linux-hello-opensbi \
             2> stderr.log
           cat stderr.log | sort
-      - name: CHIConfig Test - Iopmp
+      - name: DefaultConfig Test - Iopmp
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
             --wave-dump ${WAVE_HOME} \
@@ -371,11 +371,11 @@ jobs:
         run: |
           make sim-verilog CHISEL_TARGET=chirrtl
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --clean
-      - name: Build TLMinimalConfig Release EMU
+      - name: Build MinimalConfig Release EMU
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
-            --threads 8 --config TLMinimalConfig --release --trace-fst
-      - name: Run TLMinimalConfig - Linux
+            --threads 8 --config MinimalConfig --release --trace-fst
+      - name: Run MinimalConfig - Linux
         run: |
           python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --wave-dump $WAVE_HOME --threads 8 --numa --ci linux-hello-opensbi 2> perf.log
           cat perf.log | sort
@@ -416,8 +416,6 @@ jobs:
         run: cd difftest && git fetch --all && git merge-base --is-ancestor `git rev-parse HEAD` origin/master
       - name: Check ready-to-run
         run: cd ready-to-run && git fetch --all && git merge-base --is-ancestor `git rev-parse HEAD` origin/master
-      - name: Check huancun
-        run: cd huancun && git fetch --all && git merge-base --is-ancestor `git rev-parse HEAD` origin/master
       - name: Check utility
         run: cd utility && git fetch --all && git merge-base --is-ancestor `git rev-parse HEAD` origin/master
       - name: Check yunsuan

--- a/.github/workflows/perf-template.yml
+++ b/.github/workflows/perf-template.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: gsim
-      xs_config:
-        description: Config for XiangShan core
-        required: false
-        type: string
-        default: CHIConfig
       benchmark_type:
         required: false
         type: string
@@ -61,7 +56,7 @@ on:
         value: ${{ jobs.run.outputs.SPEC_DIR }}
       CONFIG:
         description: XiangShan config used in this run
-        value: ${{ inputs.xs_config }}
+        value: DefaultConfig
       SCORE_FILE:
         description: Path to the score.txt generated in this run
         value: ${{ jobs.run.outputs.SCORE_FILE }}
@@ -111,7 +106,7 @@ jobs:
             echo "SERVER_LIST=${{ inputs.servers }}" >> $GITHUB_ENV
           fi
 
-          SPEC_TAG="-${{ inputs.xs_config }}"
+          SPEC_TAG="-DefaultConfig"
           # Set CST_COMPILE_OPT and CST_RUN_OPT based on cst_file
           if [[ -n "${{ inputs.cst_file }}" ]]; then
             if [[ ! -f "${{ inputs.cst_file }}" ]]; then
@@ -209,7 +204,7 @@ jobs:
         run: |
           if [ ! -e "$SPEC_DIR/emu-${{ inputs.emulator }}" ]; then
             python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
-              --config "${{ inputs.xs_config }}" \
+              --config "DefaultConfig" \
               --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 \
               --threads $([ "${{ inputs.emulator }}" = "gsim" ] && echo 1 || echo 8) \
               --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin \

--- a/.github/workflows/perf-template.yml
+++ b/.github/workflows/perf-template.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: gsim
+      xs_config:
+        description: Config for XiangShan core
+        required: false
+        type: string
+        default: DefaultConfig
       benchmark_type:
         required: false
         type: string
@@ -56,7 +61,7 @@ on:
         value: ${{ jobs.run.outputs.SPEC_DIR }}
       CONFIG:
         description: XiangShan config used in this run
-        value: DefaultConfig
+        value: ${{ inputs.xs_config }}
       SCORE_FILE:
         description: Path to the score.txt generated in this run
         value: ${{ jobs.run.outputs.SCORE_FILE }}
@@ -106,7 +111,7 @@ jobs:
             echo "SERVER_LIST=${{ inputs.servers }}" >> $GITHUB_ENV
           fi
 
-          SPEC_TAG="-DefaultConfig"
+          SPEC_TAG="-${{ inputs.xs_config }}"
           # Set CST_COMPILE_OPT and CST_RUN_OPT based on cst_file
           if [[ -n "${{ inputs.cst_file }}" ]]; then
             if [[ ! -f "${{ inputs.cst_file }}" ]]; then
@@ -204,7 +209,7 @@ jobs:
         run: |
           if [ ! -e "$SPEC_DIR/emu-${{ inputs.emulator }}" ]; then
             python3 $GITHUB_WORKSPACE/scripts/xiangshan.py --build \
-              --config "DefaultConfig" \
+              --config "${{ inputs.xs_config }}" \
               --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 --with-dramsim3 \
               --threads $([ "${{ inputs.emulator }}" = "gsim" ] && echo 1 || echo 8) \
               --pgo $GITHUB_WORKSPACE/ready-to-run/coremark-2-iteration.bin \

--- a/.github/workflows/perf-trigger.yml
+++ b/.github/workflows/perf-trigger.yml
@@ -1,6 +1,6 @@
 name: Performance Regression Trigger
 
-run-name: "${{ github.event.inputs.note }} - ${{ github.event.inputs.test_branch }} - ${{ github.event.inputs.benchmark_type }}"
+run-name: "${{ github.event.inputs.note }} - ${{ github.event.inputs.test_branch }} - ${{ github.event.inputs.benchmark_type }} - ${{ github.event.inputs.xs_config }}"
 
 on:
   workflow_dispatch:
@@ -23,6 +23,14 @@ on:
           - gsim
           - verilator
         default: gsim
+      xs_config:
+        description: Config for XiangShan core
+        required: false
+        type: choice
+        options:
+          - DefaultConfig
+          - BackendV2Config
+        default: DefaultConfig
       benchmark_type:
         description: Benchmark type
         required: false
@@ -67,6 +75,7 @@ jobs:
     with:
         test_branch: ${{ github.event.inputs.test_branch }}
         emulator: ${{ github.event.inputs.emulator }}
+        xs_config: ${{ github.event.inputs.xs_config }}
         benchmark_type: ${{ github.event.inputs.benchmark_type }}
         benchmarks: ${{ github.event.inputs.benchmarks }}
         cst_file: ${{ github.event.inputs.cst_file }}

--- a/.github/workflows/perf-trigger.yml
+++ b/.github/workflows/perf-trigger.yml
@@ -1,6 +1,6 @@
 name: Performance Regression Trigger
 
-run-name: "${{ github.event.inputs.note }} - ${{ github.event.inputs.test_branch }} - ${{ github.event.inputs.benchmark_type }} - ${{ github.event.inputs.xs_config }}"
+run-name: "${{ github.event.inputs.note }} - ${{ github.event.inputs.test_branch }} - ${{ github.event.inputs.benchmark_type }}"
 
 on:
   workflow_dispatch:
@@ -23,15 +23,6 @@ on:
           - gsim
           - verilator
         default: gsim
-      xs_config:
-        description: Config for XiangShan core
-        required: false
-        type: choice
-        options:
-          - CHIConfig
-          - TLConfig
-          - TLBackendV2Config
-        default: CHIConfig
       benchmark_type:
         description: Benchmark type
         required: false
@@ -76,7 +67,6 @@ jobs:
     with:
         test_branch: ${{ github.event.inputs.test_branch }}
         emulator: ${{ github.event.inputs.emulator }}
-        xs_config: ${{ github.event.inputs.xs_config }}
         benchmark_type: ${{ github.event.inputs.benchmark_type }}
         benchmarks: ${{ github.event.inputs.benchmarks }}
         cst_file: ${{ github.event.inputs.cst_file }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "ready-to-run"]
 	path = ready-to-run
 	url = https://github.com/OpenXiangShan/ready-to-run.git
-[submodule "huancun"]
-	path = huancun
-	url = https://github.com/OpenXiangShan/HuanCun.git
 [submodule "utility"]
 	path = utility
 	url = https://github.com/OpenXiangShan/Utility.git

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ JAR = $(BUILD_DIR)/xsgen.jar
 SCALA_FILE = $(shell find ./src/main/scala -name '*.scala')
 TEST_FILE = $(shell find ./src/test/scala -name '*.scala')
 
-CONFIG ?= TLConfig
+CONFIG ?= DefaultConfig
 NUM_CORES ?= 1
 ISSUE ?= E.b
 CHISEL_TARGET ?= systemverilog

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Some of the key directories are shown below.
 │           └── transforms # some useful firrtl transforms
 ├── scripts                # scripts for agile development
 ├── yunsuan                # yunsuan submodule of XiangShan
-├── huancun                # L2/L3 cache submodule of XiangShan
+├── XSCache                # cache subsystem of XiangShan
 ├── difftest               # difftest co-simulation framework
 └── ready-to-run           # pre-built simulation images
 ```
@@ -117,7 +117,7 @@ make idea
 Example:
 
 ```bash
-make emu CONFIG=TLMinimalConfig EMU_THREADS=2 -j10
+make emu CONFIG=MinimalConfig EMU_THREADS=2 -j10
 ./build/emu -b 0 -e 0 -i ./ready-to-run/coremark-2-iteration.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so
 ```
 ### Run with xspdb

--- a/build.mill
+++ b/build.mill
@@ -87,14 +87,10 @@ object utility extends ChiselModule {
 
 object yunsuan extends ChiselModule {}
 
-object huancun extends ChiselModule {
-  def moduleDeps = Seq(`rocket-chip`, utility)
-}
-
 object XSCache extends ChiselModule {
   def millSourcePath = pwd / "XSCache"
 
-  def moduleDeps = Seq(`rocket-chip`, utility, huancun, openNCB)
+  def moduleDeps = Seq(`rocket-chip`, utility, openNCB)
 }
 
 object openNCB extends ChiselModule {
@@ -131,7 +127,6 @@ object xiangshan extends ChiselModule {
   def moduleDeps = Seq(
     `rocket-chip`,
     difftest,
-    huancun,
     XSCache,
     yunsuan,
     utility,

--- a/readme.zh-cn.md
+++ b/readme.zh-cn.md
@@ -68,7 +68,7 @@ Weibo/微博：[香山开源处理器](https://weibo.com/u/7706264932)
 │           └── transforms # 一些实用的 firrtl 变换代码
 ├── scripts                # 用于敏捷开发的脚本文件
 ├── yunsuan                # 香山运算子模块
-├── huancun                # 香山 L2/L3 缓存子模块
+├── XSCache                # 香山缓存子系统子模块
 ├── difftest               # 香山协同仿真框架
 └── read-to-run            # 预建的仿真镜像文件
 ```
@@ -111,7 +111,7 @@ make idea
 运行示例：
 
 ```bash
-make emu CONFIG=TLMinimalConfig EMU_THREADS=2 -j10
+make emu CONFIG=MinimalConfig EMU_THREADS=2 -j10
 ./build/emu -b 0 -e 0 -i ./ready-to-run/coremark-2-iteration.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so
 ```
 

--- a/scripts/generate_all.sh
+++ b/scripts/generate_all.sh
@@ -5,7 +5,6 @@ cd $NOOP_HOME
 
 for module in Frontend Backend MemBlock L2Top XSTile XSTop
 do
-  python3 scripts/parser.py $module --config TLConfig --prefix bosc_ --sram-replace --xs-home $(pwd) > generate_$module.log
+  python3 scripts/parser.py $module --config DefaultConfig --prefix bosc_ --sram-replace --xs-home $(pwd) > generate_$module.log
   mv generate_$module.log bosc_${module}-Release*
 done
-

--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -17,9 +17,9 @@ PMAConfigs:
 
 EnableCHIAsyncBridge: true
 
-L2CacheConfig: { size: 2 MB, ways: 8, inclusive: true, banks: 4, tp: true, enableFlush: false }
+L2CacheConfig: { size: 2 MB, ways: 8, inclusive: true, banks: 4, tp: false, enableFlush: false }
 
-L3CacheConfig: { size: 16 MB, ways: 16, inclusive: false, banks: 4 }
+OpenLLCConfig: { size: 16 MB, ways: 16, banks: 4 }
 
 HartIDBits: 6
 

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -20,11 +20,10 @@ import org.chipsalliance.cde.config.{Field, Parameters}
 import chisel3._
 import chisel3.util._
 import device.{AXI4MemEncrypt, DebugModule, DebugModuleIO, SYSCNT, SYSCNTConsts, SYSCNTParams, TIMER, TIMERConsts, TIMERParams, TLPMA, TLPMAIO}
-import huancun._
 import utility.{ReqSourceKey, TLClientsMerger, TLEdgeBuffer, TLLogger}
-import coupledL2.{EnableCHI, L2Param}
-import coupledL2.tl2chi.CHIIssue
-import openLLC.OpenLLCParam
+import xscache.coupledL2.L2Param
+import xscache.chi.CHIIssue
+import xscache.openLLC.OpenLLCParam
 import freechips.rocketchip.amba.axi4._
 import freechips.rocketchip.devices.debug.DebugModuleKey
 import freechips.rocketchip.devices.tilelink._
@@ -79,12 +78,6 @@ case class SoCParameters
   UARTLiteForDTS: Boolean = true, // should be false in SimMMIO
   extIntrs: Int = 64,
   L3NBanks: Int = 4,
-  L3CacheParamsOpt: Option[HCCacheParameters] = Some(HCCacheParameters(
-    name = "L3",
-    level = 3,
-    ways = 8,
-    sets = 2048 // 1MB per bank
-  )),
   OpenLLCParamsOpt: Option[OpenLLCParam] = None,
   XSTopPrefix: Option[String] = None,
   NodeIDWidthList: Map[String, Int] = Map(
@@ -127,10 +120,6 @@ case class SoCParameters
     "HasTEEIMSIC only can be set true with IMSICBusType == AXI"
   )
   require(
-    L3CacheParamsOpt.isDefined ^ OpenLLCParamsOpt.isDefined || L3CacheParamsOpt.isEmpty && OpenLLCParamsOpt.isEmpty,
-    "Atmost one of L3CacheParamsOpt and OpenLLCParamsOpt should be defined"
-  )
-  require(
     !UsePrivateClint || (SeperateBus != top.SeperatedBusType.NONE),
     "SeperateBus should not be None when UsePrivateClint is true"
   )
@@ -150,7 +139,7 @@ trait HasSoCParameter {
   val cvm = p(CVMParamsKey)
   val debugOpts = p(DebugOptionsKey)
   val tiles = p(XSTileKey)
-  val enableCHI = p(EnableCHI)
+  val enableCHI = true
   val issue = p(CHIIssue)
 
   val NumCores = tiles.size
@@ -207,6 +196,7 @@ trait HasPeripheralRanges {
 
   private def cvm = p(CVMParamsKey)
   private def soc = p(SoCParamsKey)
+  private def enableCHI = true
   private def dm = p(DebugModuleKey)
   private def pmParams = p(PMParameKey)
 
@@ -222,11 +212,6 @@ trait HasPeripheralRanges {
     "UART16550" -> soc.UART16550Range,
     "DEBUG" -> dm.get.address,
     "MMPMA" -> AddressSet(mmpma.address, mmpma.mask)
-  ) ++ (
-    if (soc.L3CacheParamsOpt.map(_.ctrl.isDefined).getOrElse(false))
-      Map("L3CTL" -> AddressSet(soc.L3CacheParamsOpt.get.ctrl.get.address, 0xffff))
-    else
-      Map()
   ) ++ (
     if (cvm.HasMEMencryption)
       Map("MEMENC"  -> cvm.MEMENCRange)
@@ -472,7 +457,7 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
     case None =>
   }
 
-  if(soc.L3CacheParamsOpt.isEmpty){
+  if(!enableCHI){
     l3_out :*= l3_in
   }
 

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -62,7 +62,7 @@ object ArgParser {
     c.newInstance(1.asInstanceOf[Object]).asInstanceOf[Parameters]
   }
   def parse(args: Array[String]): (Parameters, Array[String], Array[String]) = {
-    val default = new TLConfig(1)
+    val default = new DefaultConfig(1)
     var firrtlOpts = Array[String]()
     var firtoolOpts = Array[String]()
     @tailrec
@@ -81,7 +81,7 @@ object ArgParser {
           nextOption(getConfigByName(confString), tail)
         case "--issue" :: issueString :: tail =>
           nextOption(config.alter((site, here, up) => {
-            case coupledL2.tl2chi.CHIIssue => issueString
+            case xscache.chi.CHIIssue => issueString
           }), tail)
         case "--num-cores" :: value :: tail =>
           nextOption(config.alter((site, here, up) => {
@@ -157,7 +157,7 @@ object ArgParser {
           }), tail)
         case "--enable-ns" :: tail =>
           nextOption(config.alter((site, here, up) => {
-            case coupledL2.tl2chi.NonSecureKey => true
+            case xscache.chi.NonSecureKey => true
           }), tail)
         case "--firtool-opt" :: option :: tail =>
           firtoolOpts ++= option.split(" ").filter(_.nonEmpty)
@@ -185,20 +185,10 @@ object ArgParser {
             case SoCParamsKey =>
               val socParam = up(SoCParamsKey)
               val banks = socParam.L3NBanks
-              val l3Ways = socParam.L3CacheParamsOpt.map(_.ways)
-              val l3Sets = l3Ways.map(value.toInt * 1024 / banks / _ / 64)
-              val openLLCWays = socParam.OpenLLCParamsOpt.map(_.ways)
-              val openLLCSets = openLLCWays.map(value.toInt * 1024 / banks / _ / 64)
-              val newL3Param = socParam.L3CacheParamsOpt.map(_.copy(
-                sets = l3Sets.get
-              ))
-              val openLLCParam = socParam.OpenLLCParamsOpt.map(_.copy(
-                sets = openLLCSets.get
-              ))
-              socParam.copy(
-                L3CacheParamsOpt = newL3Param,
-                OpenLLCParamsOpt = openLLCParam
-              )
+              val openLLCParam = socParam.OpenLLCParamsOpt.map { llc =>
+                llc.copy(sets = value.toInt * 1024 / banks / llc.ways / 64)
+              }
+              socParam.copy(OpenLLCParamsOpt = openLLCParam)
           }), tail)
         case "--sim-mem-size" :: value :: tail =>
           nextOption(config.alter((site, here, up) => {
@@ -226,7 +216,7 @@ object ArgParser {
           }), tail)
         case "--chi-addr-width" :: value :: tail =>
           nextOption(config.alter((site, here, up) => {
-            case coupledL2.tl2chi.CHIAddrWidthKey => value.toInt
+            case xscache.chi.CHIAddrWidthKey => value.toInt
           }), tail)
         case "--wfi-resume" :: value :: tail =>
           nextOption(config.alter((site, here, up) => {

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -40,15 +40,15 @@ import xiangshan.frontend.ftq.FtqParameters
 import xiangshan.frontend.icache.ICacheParameters
 import xiangshan.frontend.ibuffer.IBufferParameters
 import freechips.rocketchip.devices.debug._
-import openLLC.OpenLLCParam
+import xscache.openLLC.OpenLLCParam
 import freechips.rocketchip.diplomacy._
 import xiangshan.backend.regfile._
 import xiangshan.cache.DCacheParameters
 import xiangshan.cache.mmu.{L2TLBParameters, TLBParameters}
 import device.EnableJtag
-import huancun._
-import coupledL2._
-import coupledL2.prefetch._
+import xscache.coupledL2._
+import xscache.coupledL2.prefetch._
+import xscache.common.DirtyField
 
 class BaseConfig(n: Int) extends Config((site, here, up) => {
   case XLen => 64
@@ -73,236 +73,204 @@ class BaseConfig(n: Int) extends Config((site, here, up) => {
   case DFTOptionsKey => DFTOptions()
 })
 
-// Synthesizable minimal XiangShan
-// * It is still an out-of-order, super-scalaer arch
-// * L1 cache included
-// * L2 cache NOT included
-// * L3 cache included
-class TLMinimalConfig(n: Int = 1) extends Config(
-  new BaseConfig(n).alter((site, here, up) => {
-    case XSTileKey => up(XSTileKey).map(
-      p => p.copy(
-        DecodeWidth = 8,
-        RenameWidth = 8,
-        RobCommitWidth = 8,
-        // FetchWidth = 4, // NOTE: make sure that FTQ SRAM width is not a prime number bigger than 256.
-        VirtualLoadQueueSize = 24,
-        LoadQueueRARSize = 24,
-        LoadQueueRAWSize = 12,
-        LoadQueueReplaySize = 24,
-        LoadUncacheBufferSize = 8,
-        LoadQueueNWriteBanks = 4, // NOTE: make sure that LoadQueue{RAR, RAW, Replay}Size is divided by LoadQueueNWriteBanks.
-        RollbackGroupSize = 8,
-        StoreQueueSize = 20,
-        StoreQueueNWriteBanks = 4, // NOTE: make sure that StoreQueueSize is divided by StoreQueueNWriteBanks
-        StoreQueueForwardWithMask = true,
-        // ============ VLSU ============
-        VlMergeBufferSize = 16,
-        VsMergeBufferSize = 8,
-        UopWritebackWidth = 2,
-        // ==============================
-        RobSize = 48,
-        RabSize = 96,
-        frontendParameters = FrontendParameters(
-          FetchBlockSize = 32, // in bytes
-          bpuParameters = BpuParameters(
-            // FIXME: these are from V2 Ftb(Size=512, Way=2), may not correct
-            mbtbParameters = MainBtbParameters(
-              // NumEntries = 512,
-              // NumWay = 2
-            ),
-            tageParameters = TageParameters(
-              TableInfos = Seq(
-                // Size, NumWays, HistoryLength
-                new TageTableInfo(1024, 2, 6),
-                new TageTableInfo(1024, 2, 9),
-                new TageTableInfo(1024, 2, 17),
-                new TageTableInfo(1024, 2, 31)
+class MinimalConfig(n: Int = 1) extends Config(
+  OpenLLCConfig("4MB", ways = 8, banks = 4)
+    ++ L2CacheConfig("128KB", inclusive = true, banks = 1, tp = false)
+    ++ WithNKBL1D(32, ways = 4)
+    ++ new BaseConfig(n).alter((site, here, up) => {
+      case XSTileKey => up(XSTileKey).map(
+        p => p.copy(
+          DecodeWidth = 8,
+          RenameWidth = 8,
+          RobCommitWidth = 8,
+          // FetchWidth = 4, // NOTE: make sure that FTQ SRAM width is not a prime number bigger than 256.
+          VirtualLoadQueueSize = 24,
+          LoadQueueRARSize = 24,
+          LoadQueueRAWSize = 12,
+          LoadQueueReplaySize = 24,
+          LoadUncacheBufferSize = 8,
+          LoadQueueNWriteBanks = 4, // NOTE: make sure that LoadQueue{RAR, RAW, Replay}Size is divided by LoadQueueNWriteBanks.
+          RollbackGroupSize = 8,
+          StoreQueueSize = 20,
+          StoreQueueNWriteBanks = 4, // NOTE: make sure that StoreQueueSize is divided by StoreQueueNWriteBanks
+          StoreQueueForwardWithMask = true,
+          // ============ VLSU ============
+          VlMergeBufferSize = 16,
+          VsMergeBufferSize = 8,
+          UopWritebackWidth = 2,
+          // ==============================
+          RobSize = 48,
+          RabSize = 96,
+          frontendParameters = FrontendParameters(
+            FetchBlockSize = 32, // in bytes
+            bpuParameters = BpuParameters(
+              // FIXME: these are from V2 Ftb(Size=512, Way=2), may not correct
+              mbtbParameters = MainBtbParameters(
+                // NumEntries = 512,
+                // NumWay = 2
+              ),
+              tageParameters = TageParameters(
+                TableInfos = Seq(
+                  // Size, NumWays, HistoryLength
+                  new TageTableInfo(1024, 2, 6),
+                  new TageTableInfo(1024, 2, 9),
+                  new TageTableInfo(1024, 2, 17),
+                  new TageTableInfo(1024, 2, 31)
+                ),
+              ),
+              utageParameters = MicroTageParameters(
+                TableInfos = Seq(
+                  new MicroTageInfo(512, 6, 6, 15),
+                  new MicroTageInfo(512, 12, 6, 15)
+                ),
+              ),
+              // FIXME: these are from V2 SC, we don't have equivalent parameters now
+              scParameters = ScParameters(
+                // NumRows = 128,
+                // NumTables = 2,
+                // HistLens = Seq(0, 5),
+              ),
+              ittageParameters = IttageParameters(
+                TableInfos = Seq(
+                  new IttageTableInfo(256, 4),
+                  new IttageTableInfo(256, 8),
+                  new IttageTableInfo(512, 16)
+                ),
+                TagWidth = 7
+              ),
+              rasParameters = RasParameters(
+                CommitStackSize = 8,
+                SpecQueueSize = 16
               ),
             ),
-            utageParameters = MicroTageParameters(
-              TableInfos = Seq(
-                new MicroTageInfo(512, 6, 6, 15),
-                new MicroTageInfo(512, 12, 6, 15)
-              ),
+            ftqParameters = FtqParameters(
+              FtqSize = 8,
             ),
-            // FIXME: these are from V2 SC, we don't have equivalent parameters now
-            scParameters = ScParameters(
-              // NumRows = 128,
-              // NumTables = 2,
-              // HistLens = Seq(0, 5),
+            icacheParameters = ICacheParameters( // default 64B blockBytes, 4way, 256set (64KB ICache)
+              nSets = 64, // override to 64set in MinimalConfig (16KB ICache)
             ),
-            ittageParameters = IttageParameters(
-              TableInfos = Seq(
-                new IttageTableInfo(256, 4),
-                new IttageTableInfo(256, 8),
-                new IttageTableInfo(512, 16)
-              ),
-              TagWidth = 7
-            ),
-            rasParameters = RasParameters(
-              CommitStackSize = 8,
-              SpecQueueSize = 16
+            ibufferParameters = IBufferParameters(
+              Size = 24,
             ),
           ),
-          ftqParameters = FtqParameters(
-            FtqSize = 8,
+          StoreBufferSize = 4,
+          StoreBufferThreshold = 3,
+          IssueQueueSize = 10,
+          IssueQueueCompEntrySize = 4,
+          intPreg = IntPregParams(
+            numEntries = 64,
+            numBank = 4,
+            numRead = None,
+            numWrite = None,
           ),
-          icacheParameters = ICacheParameters( // default 64B blockBytes, 4way, 256set (64KB ICache)
-            nSets = 64, // override to 64set in MinimalConfig (16KB ICache)
+          fpPreg = FpPregParams(
+            numEntries = 64,
+            numBank = 1,
+            numRead = None,
+            numWrite = None,
           ),
-          ibufferParameters = IBufferParameters(
-            Size = 24,
+          vfPreg = VfPregParams(
+            numEntries = 160,
+            numBank = 1,
+            numRead = None,
+            numWrite = None,
           ),
-        ),
-        StoreBufferSize = 4,
-        StoreBufferThreshold = 3,
-        IssueQueueSize = 10,
-        IssueQueueCompEntrySize = 4,
-        intPreg = IntPregParams(
-          numEntries = 64,
-          numBank = 4,
-          numRead = None,
-          numWrite = None,
-        ),
-        fpPreg = FpPregParams(
-          numEntries = 64,
-          numBank = 1,
-          numRead = None,
-          numWrite = None,
-        ),
-        vfPreg = VfPregParams(
-          numEntries = 160,
-          numBank = 1,
-          numRead = None,
-          numWrite = None,
-        ),
-        dcacheParametersOpt = Some(DCacheParameters(
-          nSets = 64, // 32KB DCache
-          nWays = 8,
-          tagECC = Some("secded"),
-          dataECC = Some("secded"),
-          replacer = Some("setplru"),
-          nMissEntries = 4,
-          nProbeEntries = 4,
-          nReleaseEntries = 8,
-          nMaxPrefetchEntry = 2,
-          enableTagEcc = true,
-          enableDataEcc = true,
-          cacheCtrlAddressOpt = Some(AddressSet(0x38022000, 0x7f))
-        )),
-        itlbParameters = TLBParameters(
-          name = "itlb",
-          fetchi = true,
-          useDmode = false,
-          NWays = 4,
-        ),
-        ldtlbParameters = TLBParameters(
-          name = "ldtlb",
-          NWays = 4,
-          partialStaticPMP = true,
-          outsideRecvFlush = true,
-          outReplace = false,
-          lgMaxSize = 4
-        ),
-        sttlbParameters = TLBParameters(
-          name = "sttlb",
-          NWays = 4,
-          partialStaticPMP = true,
-          outsideRecvFlush = true,
-          outReplace = false,
-          lgMaxSize = 4
-        ),
-        hytlbParameters = TLBParameters(
-          name = "hytlb",
-          NWays = 4,
-          partialStaticPMP = true,
-          outsideRecvFlush = true,
-          outReplace = false,
-          lgMaxSize = 4
-        ),
-        pftlbParameters = TLBParameters(
-          name = "pftlb",
-          NWays = 4,
-          partialStaticPMP = true,
-          outsideRecvFlush = true,
-          outReplace = false,
-          lgMaxSize = 4
-        ),
-        btlbParameters = TLBParameters(
-          name = "btlb",
-          NWays = 4,
-        ),
-        l2tlbParameters = L2TLBParameters(
-          l3Size = 4,
-          l2Size = 4,
-          l1nSets = 4,
-          l1nWays = 4,
-          l1ReservedBits = 1,
-          l0nSets = 4,
-          l0nWays = 8,
-          l0ReservedBits = 0,
-          spSize = 4,
-        ),
-        L2CacheParamsOpt = Some(L2Param(
-          name = "L2",
-          ways = 8,
-          sets = 128,
-          echoField = Seq(huancun.DirtyField()),
-          prefetch = Nil,
-          clientCaches = Seq(L1Param(
-            "dcache",
-            isKeywordBitsOpt = p.dcacheParametersOpt.get.isKeywordBitsOpt
+          dcacheParametersOpt = Some(DCacheParameters(
+            nSets = 64, // 32KB DCache
+            nWays = 8,
+            tagECC = Some("secded"),
+            dataECC = Some("secded"),
+            replacer = Some("setplru"),
+            nMissEntries = 4,
+            nProbeEntries = 4,
+            nReleaseEntries = 8,
+            nMaxPrefetchEntry = 2,
+            enableTagEcc = true,
+            enableDataEcc = true,
+            cacheCtrlAddressOpt = Some(AddressSet(0x38022000, 0x7f))
           )),
-        )),
-        L2NBanks = 2,
-        prefetcher = Nil // if L2 pf_recv_node does not exist, disable SMS prefetcher
+          itlbParameters = TLBParameters(
+            name = "itlb",
+            fetchi = true,
+            useDmode = false,
+            NWays = 4,
+          ),
+          ldtlbParameters = TLBParameters(
+            name = "ldtlb",
+            NWays = 4,
+            partialStaticPMP = true,
+            outsideRecvFlush = true,
+            outReplace = false,
+            lgMaxSize = 4
+          ),
+          sttlbParameters = TLBParameters(
+            name = "sttlb",
+            NWays = 4,
+            partialStaticPMP = true,
+            outsideRecvFlush = true,
+            outReplace = false,
+            lgMaxSize = 4
+          ),
+          hytlbParameters = TLBParameters(
+            name = "hytlb",
+            NWays = 4,
+            partialStaticPMP = true,
+            outsideRecvFlush = true,
+            outReplace = false,
+            lgMaxSize = 4
+          ),
+          pftlbParameters = TLBParameters(
+            name = "pftlb",
+            NWays = 4,
+            partialStaticPMP = true,
+            outsideRecvFlush = true,
+            outReplace = false,
+            lgMaxSize = 4
+          ),
+          btlbParameters = TLBParameters(
+            name = "btlb",
+            NWays = 4,
+          ),
+          l2tlbParameters = L2TLBParameters(
+            l3Size = 4,
+            l2Size = 4,
+            l1nSets = 4,
+            l1nWays = 4,
+            l1ReservedBits = 1,
+            l0nSets = 4,
+            l0nWays = 8,
+            l0ReservedBits = 0,
+            spSize = 4,
+          ),
+          L2CacheParamsOpt = Some(L2Param(
+            name = "L2",
+            ways = 8,
+            sets = 128,
+            echoField = Seq(DirtyField()),
+            prefetch = Nil,
+            clientCaches = Seq(L1Param(
+              "dcache",
+              isKeywordBitsOpt = p.dcacheParametersOpt.get.isKeywordBitsOpt
+            )),
+          )),
+          L2NBanks = 2,
+          prefetcher = Nil // if L2 pf_recv_node does not exist, disable SMS prefetcher
+        )
       )
-    )
-    case SoCParamsKey =>
-      val tiles = site(XSTileKey)
-      up(SoCParamsKey).copy(
-        L3CacheParamsOpt = Option.when(!up(EnableCHI))(up(SoCParamsKey).L3CacheParamsOpt.get.copy(
-          sets = 1024,
-          inclusive = false,
-          clientCaches = tiles.map{ core =>
-            val clientDirBytes = tiles.map{ t =>
-              t.L2NBanks * t.L2CacheParamsOpt.map(_.toCacheParams.capacity).getOrElse(0)
-            }.sum
-            val l2params = core.L2CacheParamsOpt.get.toCacheParams
-            l2params.copy(sets = 2 * clientDirBytes / core.L2NBanks / l2params.ways / 64)
-          },
-          simulation = !site(DebugOptionsKey).FPGAPlatform,
-          prefetch = None
-        )),
-        OpenLLCParamsOpt = Option.when(up(EnableCHI))(OpenLLCParam(
-          name = "LLC",
-          ways = 8,
-          sets = 2048,
-          banks = 4,
-          fullAddressBits = 48,
-          clientCaches = Seq(L2Param())
-        )),
-        L3NBanks = 1
-      )
-  })
+      case SoCParamsKey =>
+        up(SoCParamsKey).copy(
+          OpenLLCParamsOpt = Some(OpenLLCParam(
+            name = "LLC",
+            ways = 8,
+            sets = 2048,
+            banks = 4,
+            fullAddressBits = 48,
+            clientCaches = Seq(L2Param())
+          )),
+          L3NBanks = 1
+        )
+    })
 )
-class MinimalConfig(n: Int = 1) extends TLMinimalConfig(n) with DeprecatedConfigWarning
-
-// Non-synthesizable MinimalConfig, for fast simulation only
-class TLMinimalSimConfig(n: Int = 1) extends Config(
-  new TLMinimalConfig(n).alter((site, here, up) => {
-    case XSTileKey => up(XSTileKey).map(_.copy(
-      dcacheParametersOpt = None,
-      softPTW = true
-    ))
-    case SoCParamsKey => up(SoCParamsKey).copy(
-      L3CacheParamsOpt = None,
-      OpenLLCParamsOpt = None
-    )
-  })
-)
-class MinimalSimConfig(n: Int = 1) extends TLMinimalSimConfig(n) with DeprecatedConfigWarning
 
 case class WithNKBL1D(n: Int, ways: Int = 8) extends Config((site, here, up) => {
   case XSTileKey =>
@@ -359,7 +327,7 @@ case class L2CacheConfig
           isKeywordBitsOpt = p.dcacheParametersOpt.get.isKeywordBitsOpt
         )),
         reqField = Seq(utility.ReqSourceField()),
-        echoField = Seq(huancun.DirtyField()),
+        echoField = Seq(DirtyField()),
         tagECC = Some("secded"),
         dataECC = Some("secded"),
         enableTagECC = true,
@@ -382,7 +350,7 @@ case class L2CacheConfig
     ))
 })
 
-case class L3CacheConfig(size: String, ways: Int = 8, inclusive: Boolean = true, banks: Int = 1) extends Config((site, here, up) => {
+case class OpenLLCConfig(size: String, ways: Int = 8, banks: Int = 1) extends Config((site, here, up) => {
   case SoCParamsKey =>
     val nKB = size.toUpperCase() match {
       case s"${k}KB" => k.trim().toInt
@@ -390,36 +358,12 @@ case class L3CacheConfig(size: String, ways: Int = 8, inclusive: Boolean = true,
     }
     val sets = nKB * 1024 / banks / ways / 64
     val tiles = site(XSTileKey)
-    val clientDirBytes = tiles.map{ t =>
+    val clientDirBytes = tiles.map { t =>
       t.L2NBanks * t.L2CacheParamsOpt.map(_.toCacheParams.capacity).getOrElse(0)
     }.sum
     up(SoCParamsKey).copy(
       L3NBanks = banks,
-      L3CacheParamsOpt = Option.when(!up(EnableCHI))(HCCacheParameters(
-        name = "L3",
-        level = 3,
-        ways = ways,
-        sets = sets,
-        inclusive = inclusive,
-        clientCaches = tiles.map{ core =>
-          val l2params = core.L2CacheParamsOpt.get.toCacheParams
-          l2params.copy(sets = 2 * clientDirBytes / core.L2NBanks / l2params.ways / 64, ways = l2params.ways + 2)
-        },
-        enablePerf = !site(DebugOptionsKey).FPGAPlatform && site(DebugOptionsKey).EnablePerfDebug,
-        ctrl = Some(CacheCtrl(
-          address = 0x39000000,
-          numCores = tiles.size
-        )),
-        reqField = Seq(utility.ReqSourceField()),
-        sramClkDivBy2 = true,
-        sramDepthDiv = 4,
-        tagECC = Some("secded"),
-        dataECC = Some("secded"),
-        simulation = !site(DebugOptionsKey).FPGAPlatform,
-        prefetch = Some(huancun.prefetch.L3PrefetchReceiverParams()),
-        tpmeta = Some(huancun.prefetch.DefaultTPmetaParameters())
-      )),
-      OpenLLCParamsOpt = Option.when(up(EnableCHI))(OpenLLCParam(
+      OpenLLCParamsOpt = Some(OpenLLCParam(
         name = "LLC",
         ways = ways,
         sets = sets,
@@ -427,7 +371,10 @@ case class L3CacheConfig(size: String, ways: Int = 8, inclusive: Boolean = true,
         fullAddressBits = 48,
         clientCaches = tiles.map { core =>
           val l2params = core.L2CacheParamsOpt.get
-          l2params.copy(sets = 2 * clientDirBytes / core.L2NBanks / l2params.ways / 64, ways = l2params.ways + 2)
+          l2params.copy(
+            sets = 2 * clientDirBytes / core.L2NBanks / l2params.ways / 64,
+            ways = l2params.ways + 2
+          )
         },
         enablePerf = !site(DebugOptionsKey).FPGAPlatform && site(DebugOptionsKey).EnablePerfDebug,
         elaboratedTopDown = !site(DebugOptionsKey).FPGAPlatform
@@ -436,27 +383,22 @@ case class L3CacheConfig(size: String, ways: Int = 8, inclusive: Boolean = true,
 })
 
 class WithL3DebugConfig extends Config(
-  L3CacheConfig("256KB", inclusive = false) ++ L2CacheConfig("64KB")
+  OpenLLCConfig("256KB") ++ L2CacheConfig("64KB")
 )
 
-class TLMinimalL3DebugConfig(n: Int = 1) extends Config(
-  new WithL3DebugConfig ++ new TLMinimalConfig(n)
-)
-class MinimalL3DebugConfig(n: Int = 1) extends TLMinimalL3DebugConfig(n) with DeprecatedConfigWarning
+class MinimalL3DebugConfig(n: Int = 1) extends Config(
+  new WithL3DebugConfig ++ new MinimalConfig(n)
+) with DeprecatedConfigWarning
 
-class TLDefaultL3DebugConfig(n: Int = 1) extends Config(
-  new WithL3DebugConfig ++ new BaseConfig(n)
-)
-class DefaultL3DebugConfig(n: Int = 1) extends TLDefaultL3DebugConfig(n) with DeprecatedConfigWarning
+class DefaultL3DebugConfig(n: Int = 1) extends Config(
+  new WithL3DebugConfig ++ new DefaultConfig(n)
+) with DeprecatedConfigWarning
 
 class WithFuzzer extends Config((site, here, up) => {
   case DebugOptionsKey => up(DebugOptionsKey).copy(
     EnablePerfDebug = false,
   )
   case SoCParamsKey => up(SoCParamsKey).copy(
-    L3CacheParamsOpt = up(SoCParamsKey).L3CacheParamsOpt.map(_.copy(
-      enablePerf = false,
-    )),
     OpenLLCParamsOpt = up(SoCParamsKey).OpenLLCParamsOpt.map(_.copy(
       enablePerf = false,
     )),
@@ -470,8 +412,8 @@ class WithFuzzer extends Config((site, here, up) => {
   }
 })
 
-class CHIFrontendDebugConfig(n: Int = 1) extends Config(
-  (new CHIConfig(n)).alter((site, here, up) => {
+class FrontendDebugConfig(n: Int = 1) extends Config(
+  (new DefaultConfig(n)).alter((site, here, up) => {
     case XSTileKey => up(XSTileKey).map{ p => p.copy(
       frontendParameters = p.frontendParameters.copy(
         bpuParameters = p.frontendParameters.bpuParameters.copy(
@@ -501,8 +443,8 @@ class CHIFrontendDebugConfig(n: Int = 1) extends Config(
   })
 )
 
-class CHIBackendV2Config(n: Int = 1) extends Config(
-  new CHIConfig(n).alter((site, here, up) => {
+class BackendV2Config(n: Int = 1) extends Config(
+  new DefaultConfig(n).alter((site, here, up) => {
     case XSTileKey => up(XSTileKey).map { p =>
       p.copy(
         EnableBackendV2Config = true,
@@ -550,8 +492,7 @@ class CHIBackendV2Config(n: Int = 1) extends Config(
       )
     }
   })
-)
-class BackendV2Config(n: Int = 1) extends CHIBackendV2Config(n) with DeprecatedConfigWarning
+) with DeprecatedConfigWarning
 
 class CVMCompile extends Config((site, here, up) => {
   case CVMParamsKey => up(CVMParamsKey).copy(
@@ -575,75 +516,45 @@ class CVMTestCompile extends Config((site, here, up) => {
     HasBitmapCheckDefault = true))
 })
 
-class TLMinimalAliasDebugConfig(n: Int = 1) extends Config(
-  L3CacheConfig("512KB", inclusive = false)
+class MinimalAliasDebugConfig(n: Int = 1) extends Config(
+  OpenLLCConfig("512KB")
     ++ L2CacheConfig("256KB", inclusive = true)
     ++ WithNKBL1D(128)
-    ++ new TLMinimalConfig(n)
-)
-class MinimalAliasDebugConfig(n: Int = 1) extends TLMinimalAliasDebugConfig(n) with DeprecatedConfigWarning
+    ++ new MinimalConfig(n)
+) with DeprecatedConfigWarning
 
-class TLMediumConfig(n: Int = 1) extends Config(
-  L3CacheConfig("4MB", inclusive = false, banks = 4)
-    ++ L2CacheConfig("512KB", inclusive = true)
-    ++ WithNKBL1D(128)
-    ++ new BaseConfig(n)
-)
-class MediumConfig(n: Int = 1) extends TLMediumConfig(n) with DeprecatedConfigWarning
+class MediumConfig(n: Int = 1) extends DefaultConfig(n) with DeprecatedConfigWarning
 
-class CHIFuzzConfig(dummy: Int = 0) extends Config(
+class FuzzConfig(dummy: Int = 0) extends Config(
   new WithFuzzer
-    ++ new CHIConfig(1)
-)
-class FuzzConfig(dummy: Int = 0) extends CHIFuzzConfig(dummy) with DeprecatedConfigWarning
+    ++ new DefaultConfig(1)
+) with DeprecatedConfigWarning
 
-class TLConfig(n: Int = 1) extends Config(
-  L3CacheConfig("16MB", inclusive = false, banks = 4, ways = 16)
-    ++ L2CacheConfig("2MB", inclusive = true, banks = 4)
+class DefaultConfig(n: Int = 1) extends Config(
+  OpenLLCConfig("16MB", ways = 16, banks = 4)
+    ++ L2CacheConfig("2MB", inclusive = true, banks = 4, tp = false)
     ++ WithNKBL1D(64, ways = 4)
     ++ new BaseConfig(n)
 )
-class DefaultConfig(n: Int = 1) extends TLConfig(n) with DeprecatedConfigWarning
 
-class TLCVMConfig(n: Int = 1) extends Config(
+class CVMConfig(n: Int = 1) extends Config(
   new CVMCompile
-    ++ new TLConfig(n)
-)
-class CVMConfig(n: Int = 1) extends TLCVMConfig(n) with DeprecatedConfigWarning
+    ++ new DefaultConfig(n)
+) with DeprecatedConfigWarning
 
-class TLCVMTestConfig(n: Int = 1) extends Config(
+class CVMTestConfig(n: Int = 1) extends Config(
   new CVMTestCompile
-    ++ new TLConfig(n)
-)
-class CVMTestConfig(n: Int = 1) extends TLCVMTestConfig(n) with DeprecatedConfigWarning
-
-class WithCHI extends Config((_, _, _) => {
-  case EnableCHI => true
-})
-
-class CHIConfig(n: Int = 1) extends Config(
-  L2CacheConfig("2MB", inclusive = true, banks = 4, tp = false)
-    ++ new TLConfig(n)
-    ++ new WithCHI
-)
-class KunminghuV2Config(n: Int = 1) extends CHIConfig(n) with DeprecatedConfigWarning
-
-class CHIMinimalConfig(n: Int = 1) extends Config(
-  L2CacheConfig("128KB", inclusive = true, banks = 1, tp = false)
-    ++ WithNKBL1D(32, ways = 4)
-    ++ new TLMinimalConfig(n)
-    ++ new WithCHI
-)
-class KunminghuV2MinimalConfig(n: Int = 1) extends CHIMinimalConfig(n) with DeprecatedConfigWarning
+    ++ new DefaultConfig(n)
+) with DeprecatedConfigWarning
 
 class XSNoCTopConfig(n: Int = 1) extends Config(
-  (new CHIConfig(n)).alter((site, here, up) => {
+  (new DefaultConfig(n)).alter((site, here, up) => {
     case SoCParamsKey => up(SoCParamsKey).copy(UseXSNoCTop = true)
   })
 )
 
 class XSNoCTopMinimalConfig(n: Int = 1) extends Config(
-  (new CHIMinimalConfig(n)).alter((site, here, up) => {
+  (new MinimalConfig(n)).alter((site, here, up) => {
     case SoCParamsKey => up(SoCParamsKey).copy(UseXSNoCTop = true)
   })
 )
@@ -660,8 +571,8 @@ class XSNoCDiffTopMinimalConfig(n: Int = 1) extends Config(
   })
 )
 
-class TLFpgaDefaultConfig(n: Int = 1) extends Config(
-  (L3CacheConfig("3MB", inclusive = false, banks = 1, ways = 6)
+class FpgaDefaultConfig(n: Int = 1) extends Config(
+  (OpenLLCConfig("3MB", banks = 1, ways = 6)
     ++ L2CacheConfig("1MB", inclusive = true, banks = 4)
     ++ WithNKBL1D(64, ways = 4)
     ++ new BaseConfig(n)).alter((site, here, up) => {
@@ -669,17 +580,11 @@ class TLFpgaDefaultConfig(n: Int = 1) extends Config(
       AlwaysBasicDiff = false,
       AlwaysBasicDB = false
     )
-    case SoCParamsKey => up(SoCParamsKey).copy(
-      L3CacheParamsOpt = Some(up(SoCParamsKey).L3CacheParamsOpt.get.copy(
-        sramClkDivBy2 = false,
-      )),
-    )
   })
-)
-class FpgaDefaultConfig(n: Int = 1) extends TLFpgaDefaultConfig(n) with DeprecatedConfigWarning
+) with DeprecatedConfigWarning
 
-class TLFpgaDiffDefaultConfig(n: Int = 1) extends Config(
-  (L3CacheConfig("3MB", inclusive = false, banks = 1, ways = 6)
+class FpgaDiffDefaultConfig(n: Int = 1) extends Config(
+  (OpenLLCConfig("3MB", banks = 1, ways = 6)
     ++ L2CacheConfig("1MB", inclusive = true, banks = 4)
     ++ WithNKBL1D(64, ways = 4)
     ++ new BaseConfig(n)).alter((site, here, up) => {
@@ -688,30 +593,22 @@ class TLFpgaDiffDefaultConfig(n: Int = 1) extends Config(
       AlwaysBasicDB = false
     )
     case SoCParamsKey => up(SoCParamsKey).copy(
-      UseXSTileDiffTop = true,
-      L3CacheParamsOpt = Some(up(SoCParamsKey).L3CacheParamsOpt.get.copy(
-        sramClkDivBy2 = false,
-      )),
+      UseXSTileDiffTop = true
     )
   })
-)
-class FpgaDiffDefaultConfig(n: Int = 1) extends TLFpgaDiffDefaultConfig(n) with DeprecatedConfigWarning
+) with DeprecatedConfigWarning
 
-class TLFpgaDiffMinimalConfig(n: Int = 1) extends Config(
-  (new TLMinimalConfig(n)).alter((site, here, up) => {
+class FpgaDiffMinimalConfig(n: Int = 1) extends Config(
+  (new MinimalConfig(n)).alter((site, here, up) => {
     case DebugOptionsKey => up(DebugOptionsKey).copy(
       AlwaysBasicDiff = true,
       AlwaysBasicDB = false
     )
     case SoCParamsKey => up(SoCParamsKey).copy(
-      UseXSTileDiffTop = true,
-      L3CacheParamsOpt = Some(up(SoCParamsKey).L3CacheParamsOpt.get.copy(
-        sramClkDivBy2 = false,
-      )),
+      UseXSTileDiffTop = true
     )
   })
-)
-class FpgaDiffMinimalConfig(n: Int = 1) extends TLFpgaDiffMinimalConfig(n) with DeprecatedConfigWarning
+) with DeprecatedConfigWarning
 
 trait DeprecatedConfigWarning {
   val className = this.getClass().getSimpleName()

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -25,11 +25,9 @@ import xiangshan._
 import utils._
 import utility._
 import utility.sram.SramBroadcastBundle
-import huancun.{HCCacheParameters, HCCacheParamsKey, HuanCun, PrefetchRecv, TPmetaResp}
-import coupledL2.EnableCHI
-import coupledL2.tl2chi.CHILogger
-import openLLC.{OpenLLC, OpenLLCParamKey, OpenNCB}
-import openLLC.TargetBinder._
+import xscache.chi.CHILogger
+import xscache.openLLC.{OpenLLC, OpenLLCParamKey, OpenNCB}
+import xscache.openLLC.TargetBinder._
 import cc.xiangshan.openncb._
 import system._
 import device._
@@ -102,19 +100,6 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
       case PerfCounterOptionsKey => up(PerfCounterOptionsKey).copy(perfDBHartID = coreParams.HartId)
     })))
   )
-
-  val l3cacheOpt = soc.L3CacheParamsOpt.map(l3param =>
-    LazyModule(new HuanCun()(new Config((_, _, _) => {
-      case HCCacheParamsKey => l3param.copy(
-        hartIds = tiles.map(_.HartId),
-        FPGAPlatform = debugOpts.FPGAPlatform
-      )
-      case MaxHartIdBits => p(MaxHartIdBits)
-      case LogUtilsOptionsKey => p(LogUtilsOptionsKey)
-      case PerfCounterOptionsKey => p(PerfCounterOptionsKey)
-    })))
-  )
-
   val chi_llcBridge_opt = Option.when(enableCHI)(
     LazyModule(new OpenNCB()(p.alter((site, here, up) => {
       case NCBParametersKey => new NCBParameters(
@@ -147,15 +132,6 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     })))
   ))
 
-  // receive all prefetch req from cores
-  val memblock_pf_recv_nodes: Seq[Option[BundleBridgeSink[PrefetchRecv]]] = core_with_l2.map(_.core_l3_pf_port).map{
-    x => x.map(_ => BundleBridgeSink(Some(() => new PrefetchRecv)))
-  }
-
-  val l3_pf_sender_opt = soc.L3CacheParamsOpt.getOrElse(HCCacheParameters()).prefetch match {
-    case Some(pf) => Some(BundleBridgeSource(() => new PrefetchRecv))
-    case None => None
-  }
   val nmiIntNode = IntSourceNode(IntSourcePortSimple(1, NumCores, (new NonmaskableInterruptIO).elements.size))
   val nmi = InModuleBody(nmiIntNode.makeIOs())
 
@@ -169,10 +145,6 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
       misc.peripheral_ports.get(i) := core_with_l2(i).tl_uncache
     }
     core_with_l2(i).memory_port.foreach(port => (misc.core_to_l3_ports.get)(i) :=* port)
-    memblock_pf_recv_nodes(i).map(recv => {
-      println(s"Connecting Core_${i}'s L1 pf source to L3!")
-      recv := core_with_l2(i).core_l3_pf_port.get
-    })
     misc.SepTLXbarOpt.foreach { SepTLXbarOpt =>
       // SeperateBus can only be connected to DebugModule now in non-XSNoCTop environment
       println(s"SeparateDM: ${SeperateDM}")
@@ -184,44 +156,11 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
       SepTLXbarOpt := core_with_l2(i).sep_tl_opt.get
     }
   }
-  l3cacheOpt.map(_.ctlnode.map(_ := misc.peripheralXbar.get))
-  l3cacheOpt.map(_.intnode.map(int => {
-    misc.plic.intnode := IntBuffer() := int
-  }))
-
-  val core_rst_nodes = if(l3cacheOpt.nonEmpty && l3cacheOpt.get.rst_nodes.nonEmpty){
-    l3cacheOpt.get.rst_nodes.get
-  } else {
-    core_with_l2.map(_ => BundleBridgeSource(() => Reset()))
-  }
+  val core_rst_nodes = core_with_l2.map(_ => BundleBridgeSource(() => Reset()))
 
   core_rst_nodes.zip(core_with_l2.map(_.core_reset_sink)).foreach({
     case (source, sink) =>  sink := source
   })
-
-  l3cacheOpt match {
-    case Some(l3) =>
-      misc.l3_out :*= l3.node :*= misc.l3_banked_xbar.get
-      l3.pf_recv_node.map(recv => {
-        println("Connecting L1 prefetcher to L3!")
-        recv := l3_pf_sender_opt.get
-      })
-      l3.tpmeta_recv_node.foreach(recv => {
-        for ((core, i) <- core_with_l2.zipWithIndex) {
-          println(s"Connecting core_$i\'s L2 TPmeta request to L3!")
-          recv := core.core_l3_tpmeta_source_port.get
-        }
-      })
-      l3.tpmeta_send_node.foreach(send => {
-        val broadcast = LazyModule(new ValidIOBroadcast[TPmetaResp]())
-        broadcast.node := send
-        for ((core, i) <- core_with_l2.zipWithIndex) {
-          println(s"Connecting core_$i\'s L2 TPmeta response to L3!")
-          core.core_l3_tpmeta_sink_port.get := broadcast.node
-        }
-      })
-    case None =>
-  }
 
   chi_llcBridge_opt match {
     case Some(ncb) =>
@@ -231,10 +170,10 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 
   chi_mmioBridge_opt.foreach { e =>
     e match {
-      case Some(ncb) =>
-        misc.soc_xbar.get := ncb.axi4node
-      case None =>
-    }
+    case Some(ncb) =>
+      misc.soc_xbar.get := ncb.axi4node
+    case None =>
+  }
   }
 
   class XSTopImp(wrapper: XSTop) extends LazyRawModuleImp(wrapper)
@@ -395,37 +334,21 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
       }
     }
 
-    if(l3cacheOpt.isEmpty || l3cacheOpt.get.rst_nodes.isEmpty){
-      // tie off core soft reset
-      for(node <- core_rst_nodes){
-        node.out.head._1 := false.B.asAsyncReset
-      }
+    // tie off core soft reset
+    for(node <- core_rst_nodes){
+      node.out.head._1 := false.B.asAsyncReset
     }
 
-    l3cacheOpt match {
+    chi_openllc_opt match {
       case Some(l3) =>
-        l3.pf_recv_node match {
-          case Some(recv) =>
-            l3_pf_sender_opt.get.out.head._1.addr_valid := VecInit(memblock_pf_recv_nodes.map(_.get.in.head._1.addr_valid)).asUInt.orR
-            for (i <- 0 until NumCores) {
-              when(memblock_pf_recv_nodes(i).get.in.head._1.addr_valid) {
-                l3_pf_sender_opt.get.out.head._1.addr := memblock_pf_recv_nodes(i).get.in.head._1.addr
-                l3_pf_sender_opt.get.out.head._1.l2_pf_en := memblock_pf_recv_nodes(i).get.in.head._1.l2_pf_en
-              }
-            }
-          case None =>
+        l3.io.debugTopDown.robHeadPaddr := core_with_l2.map(_.module.io.debugTopDown.robHeadPaddr)
+        core_with_l2.zip(l3.io.debugTopDown.addrMatch).foreach { case (tile, l3Match) =>
+          tile.module.io.debugTopDown.l3MissMatch := l3Match
         }
-        l3.module.io.debugTopDown.robHeadPaddr := core_with_l2.map(_.module.io.debugTopDown.robHeadPaddr)
-        core_with_l2.zip(l3.module.io.debugTopDown.addrMatch).foreach { case (tile, l3Match) => tile.module.io.debugTopDown.l3MissMatch := l3Match }
-        core_with_l2.foreach(_.module.io.l3Miss := l3.module.io.l3Miss)
+        core_with_l2.foreach(_.module.io.l3Miss := l3.io.l3Miss)
       case None =>
-    }
-
-    (chi_openllc_opt, l3cacheOpt) match {
-      case (None, None) =>
         core_with_l2.foreach(_.module.io.debugTopDown.l3MissMatch := false.B)
         core_with_l2.foreach(_.module.io.l3Miss := false.B)
-      case _ =>
     }
 
     core_with_l2.zipWithIndex.foreach { case (tile, i) =>
@@ -454,12 +377,12 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 
     withClockAndReset(io.clock, reset_sync) {
       // Modules are reset one by one
-      // reset ----> SYNC --> {SoCMisc, L3 Cache, Cores}
-      val resetChain = Seq(Seq(misc.module) ++ l3cacheOpt.map(_.module))
+      // reset ----> SYNC --> {SoCMisc, Cores}
+      val resetChain = Seq(Seq(misc.module))
       ResetGen(resetChain, reset_sync, !debugOpts.ResetGen)
-      // Ensure that cores could be reset when DM disable `hartReset` or l3cacheOpt.isEmpty.
+      // Ensure that cores could be reset when DM disable `hartReset`.
       val dmResetReqVec = misc.module.debug_module_io.resetCtrl.hartResetReq.getOrElse(0.U.asTypeOf(Vec(core_with_l2.map(_.module).length, Bool())))
-      val syncResetCores = if(l3cacheOpt.nonEmpty) l3cacheOpt.map(_.module).get.reset.asBool else misc.module.reset.asBool
+      val syncResetCores = misc.module.reset.asBool
       (core_with_l2.map(_.module)).zip(dmResetReqVec).map { case(core, dmResetReq) =>
         ResetGen(Seq(Seq(core)), (syncResetCores || dmResetReq).asAsyncReset, !debugOpts.ResetGen)
       }

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -32,7 +32,7 @@ import freechips.rocketchip.devices.debug.DebugModuleKey
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
-import coupledL2.tl2chi.{CHIAsyncBridgeSink, PortIO}
+import xscache.chi.{CHIAsyncBridgeSink, PortIO}
 import freechips.rocketchip.tile.MaxHartIdBits
 import freechips.rocketchip.util.{AsyncQueueParams, AsyncQueueSource}
 import chisel3.experimental.annotate

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -38,7 +38,7 @@ case class YamlConfig(
   PMAConfigs: Option[List[PMAConfigEntry]],
   EnableCHIAsyncBridge: Option[Boolean],
   L2CacheConfig: Option[L2CacheConfig],
-  L3CacheConfig: Option[L3CacheConfig],
+  OpenLLCConfig: Option[OpenLLCConfig],
   HartIDBits: Option[Int],
   DebugAttachProtocals: Option[List[String]],
   DebugModuleParams: Option[DebugModuleParams],
@@ -97,7 +97,7 @@ object YamlParser {
       })
     }
     yamlConfig.L2CacheConfig.foreach(l2 => newConfig = newConfig.alter(l2))
-    yamlConfig.L3CacheConfig.foreach(l3 => newConfig = newConfig.alter(l3))
+    yamlConfig.OpenLLCConfig.foreach(llc => newConfig = newConfig.alter(llc))
     yamlConfig.DebugAttachProtocals.foreach { protocols =>
       newConfig = newConfig.alter((site, here, up) => {
         case ExportDebug => DebugAttachParams(protocols = protocols.map {
@@ -160,7 +160,7 @@ object YamlParser {
     }
     yamlConfig.CHIIssue.foreach { issue =>
       newConfig = newConfig.alter((site, here, up) => {
-        case coupledL2.tl2chi.CHIIssue => issue
+        case xscache.chi.CHIIssue => issue
       })
     }
     yamlConfig.WFIClockGate.foreach { enable =>
@@ -190,12 +190,12 @@ object YamlParser {
     }
     yamlConfig.EnableCHINS.foreach { enable =>
       newConfig = newConfig.alter((site, here, up) => {
-        case coupledL2.tl2chi.NonSecureKey => enable
+        case xscache.chi.NonSecureKey => enable
       })
     }
     yamlConfig.CHIAddrWidth.foreach { width =>
       newConfig = newConfig.alter((site, here, up) => {
-        case coupledL2.tl2chi.CHIAddrWidthKey => width
+        case xscache.chi.CHIAddrWidthKey => width
       })
     }
     yamlConfig.CVMParams.foreach { cvmParams =>

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -25,10 +25,10 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tile.{BusErrorUnit, BusErrorUnitParams, BusErrors, MaxHartIdBits}
 import freechips.rocketchip.tilelink._
-import coupledL2.{EnableCHI, L2ParamKey, PrefetchCtrlFromCore}
-import coupledL2.tl2tl.TL2TLCoupledL2
-import coupledL2.tl2chi.{CHIIssue, PortIO, TL2CHICoupledL2, CHIAddrWidthKey, NonSecureKey}
-import huancun.BankBitsKey
+import xscache.coupledL2.{L2ParamKey, PrefetchCtrlFromCore}
+import xscache.chi.{CHIIssue, CHIAddrWidthKey, NonSecureKey, PortIO}
+import xscache.coupledL2.CoupledL2
+import xscache.common.BankBitsKey
 import system.HasSoCParameter
 import top.BusPerfMonitor
 import utility._
@@ -78,7 +78,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
   val l1_xbar = TLXbar()
   val mmio_xbar = TLXbar()
   val mmio_port = TLIdentityNode() // to L3
-  val memory_port = if (enableCHI && enableL2) None else Some(TLIdentityNode())
+  val memory_port = if (enableL2) None else Some(TLIdentityNode())
   val beu = LazyModule(new BusErrorUnit(
     new XSL1BusErrors(),
     BusErrorUnitParams(soc.BEURange.base, soc.BEURange.mask.toInt + 1)
@@ -90,7 +90,6 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
   val sep_tl_port_opt = Option.when(SeperateBus != top.SeperatedBusType.NONE)(TLTempNode())
 
   val misc_l2_pmu = BusPerfMonitor(name = "Misc_L2", enable = !debugOpts.FPGAPlatform) // l1D & l1I & PTW
-  val l2_l3_pmu = BusPerfMonitor(name = "L2_L3", enable = !debugOpts.FPGAPlatform && !enableCHI, stat_latency = true)
   val xbar_l2_buffer = TLBuffer()
 
   val enbale_tllog = !debugOpts.FPGAPlatform && debugOpts.AlwaysBasicDB
@@ -116,7 +115,6 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
         hasMbist = hasMbist,
         PrivateClintRange = if(UsePrivateClint) Some(TIMERRange) else None
       )
-      case EnableCHI => p(EnableCHI)
       case CHIIssue => p(CHIIssue)
       case CHIAddrWidthKey => p(CHIAddrWidthKey)
       case NonSecureKey => p(NonSecureKey)
@@ -125,8 +123,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       case LogUtilsOptionsKey => p(LogUtilsOptionsKey)
       case PerfCounterOptionsKey => p(PerfCounterOptionsKey)
     })
-    if (enableCHI) Some(LazyModule(new TL2CHICoupledL2()(new Config(config))))
-    else Some(LazyModule(new TL2TLCoupledL2()(new Config(config))))
+    Some(LazyModule(new CoupledL2()(new Config(config))))
   } else None
   val l2_binder = coreParams.L2CacheParamsOpt.map(_ => BankBinder(coreParams.L2NBanks, 64))
 
@@ -135,13 +132,8 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
   l2cache match {
     case Some(l2) =>
       l2_binder.get :*= l2.node :*= xbar_l2_buffer :*= l1_xbar :=* misc_l2_pmu
-      l2 match {
-        case l2: TL2TLCoupledL2 =>
-          memory_port.get := l2_l3_pmu := TLClientsMerger() := TLXbar() :=* l2_binder.get
-        case l2: TL2CHICoupledL2 =>
-          l2.managerNode := TLXbar() :=* l2_binder.get
-          l2.mmioNode := mmio_port
-      }
+      l2.managerNode := TLXbar() :=* l2_binder.get
+      l2.mmioNode := mmio_port
     case None =>
       memory_port.get := l1_xbar
   }
@@ -354,12 +346,11 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       l2.io.l2_tlb_req.pmp_resp.mmio := io.l2_pmp_resp.mmio
       l2.io.l2_tlb_req.pmp_resp.atomic := io.l2_pmp_resp.atomic
       l2cache.get match {
-        case l2cache: TL2CHICoupledL2 =>
+        case l2cache: CoupledL2 =>
           val l2 = l2cache.module
-          l2.io_nodeID := io.nodeID.get
-          io.chi.get <> l2.io_chi
-          l2.io_cpu_wfi.foreach { _:= io.cpu_wfi.fromCore }
-        case l2cache: TL2TLCoupledL2 =>
+          l2.io.nodeID := io.nodeID.get
+          io.chi.get <> l2.io.chi
+          l2.io.cpu_wfi.foreach { _ := io.cpu_wfi.fromCore }
       }
 
       beu.module.io.errors.l2.ecc_error.valid := l2.io.error.valid

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -18,8 +18,8 @@ package xiangshan
 
 import chisel3._
 import chisel3.util._
-import coupledL2._
-import coupledL2.tl2chi._
+import xscache.coupledL2._
+import xscache.chi._
 import freechips.rocketchip.diplomacy.AddressSet
 import freechips.rocketchip.tile.MaxHartIdBits
 import org.chipsalliance.cde.config.{Field, Parameters}
@@ -278,8 +278,8 @@ case class XSCoreParameters
     name = "l2",
     ways = 8,
     sets = 1024, // default 512KB L2
-    prefetch = Seq(coupledL2.prefetch.PrefetchReceiverParams(), coupledL2.prefetch.BOPParameters(),
-      coupledL2.prefetch.TPParameters()),
+    prefetch = Seq(xscache.coupledL2.prefetch.PrefetchReceiverParams(), xscache.coupledL2.prefetch.BOPParameters(),
+      xscache.coupledL2.prefetch.TPParameters()),
   )),
   L2NBanks: Int = 1,
   usePTWRepeater: Boolean = false,
@@ -751,7 +751,7 @@ trait HasXSParameter {
   def EnableAtCommitMissTrigger = coreParams.EnableAtCommitMissTrigger
   def EnableStorePrefetchSMS = coreParams.EnableStorePrefetchSMS
   def EnableStorePrefetchSPB = coreParams.EnableStorePrefetchSPB
-  def HasCMO = coreParams.HasCMO && p(EnableCHI)
+  def HasCMO = coreParams.HasCMO
   require(LoadPipelineWidth == backendParams.LdExuCnt, "LoadPipelineWidth must be equal exuParameters.LduCnt!")
   require(StorePipelineWidth == backendParams.StaCnt, "StorePipelineWidth must be equal exuParameters.StuCnt!")
   def Enable3Load3Store = (LoadPipelineWidth == 3 && StorePipelineWidth == 3)

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -20,7 +20,7 @@ import org.chipsalliance.cde.config
 import org.chipsalliance.cde.config.Parameters
 import chisel3._
 import chisel3.util._
-import coupledL2.PrefetchCtrlFromCore
+import xscache.coupledL2.PrefetchCtrlFromCore
 import freechips.rocketchip.diplomacy.{BundleBridgeSource, LazyModule, LazyModuleImp}
 import freechips.rocketchip.tile.HasFPUParameters
 import system.HasSoCParameter

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -28,8 +28,7 @@ import system.HasSoCParameter
 import top.{ArgParser, BusPerfMonitor, Generator}
 import utility._
 import utility.sram.SramBroadcastBundle
-import coupledL2.EnableCHI
-import coupledL2.tl2chi.PortIO
+import xscache.chi.PortIO
 import xiangshan.backend.trace.TraceCoreInterface
 
 class XSTile()(implicit p: Parameters) extends LazyModule
@@ -43,7 +42,6 @@ class XSTile()(implicit p: Parameters) extends LazyModule
   val enableL2 = coreParams.L2CacheParamsOpt.isDefined
   // =========== Public Ports ============
   val memBlock = core.memBlock.inner
-  val core_l3_pf_port = memBlock.l3_pf_sender_opt
   val memory_port = if (enableCHI && enableL2) None else Some(l2top.inner.memory_port.get)
   val tl_uncache = l2top.inner.mmio_port
   val sep_tl_opt = l2top.inner.sep_tl_port_opt

--- a/src/main/scala/xiangshan/XSTileWrap.scala
+++ b/src/main/scala/xiangshan/XSTileWrap.scala
@@ -25,7 +25,7 @@ import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 import system.HasSoCParameter
-import coupledL2.tl2chi.{AsyncPortIO, CHIAsyncBridgeSource, PortIO}
+import xscache.chi.{AsyncPortIO, CHIAsyncBridgeSource, PortIO}
 import utility.sram.SramBroadcastBundle
 import utility.{DFTResetSignals, IntBuffer, ResetGen}
 import xiangshan.backend.trace.TraceCoreInterface

--- a/src/main/scala/xiangshan/backend/fu/vector/Mgu.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/Mgu.scala
@@ -24,7 +24,7 @@ import chisel3.util._
 import chisel3.simulator.scalatest.ChiselSim
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import top.{ArgParser, TLConfig}
+import top.{ArgParser, DefaultConfig}
 import xiangshan._
 import xiangshan.backend.fu.vector.Bundles.{VSew, Vl}
 import xiangshan.backend.fu.vector.Utils.VecDataToMaskDataVec
@@ -211,7 +211,7 @@ object VerilogMgu extends App {
 
 class MguTest extends AnyFlatSpec with Matchers with ChiselSim {
 
-  val defaultConfig = (new TLConfig).alterPartial({
+  val defaultConfig = (new DefaultConfig).alterPartial({
     case XSCoreParamsKey => XSCoreParameters()
   })
 

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -19,11 +19,11 @@ package xiangshan.cache
 import chisel3._
 import chisel3.experimental.ExtModule
 import chisel3.util._
-import coupledL2.{IsKeywordKey, IsKeywordField, MemBackTypeMMField, MemPageTypeNCField, PCField, VaddrField}
+import xscache.coupledL2.{IsKeywordKey, IsKeywordField, MemBackTypeMMField, MemPageTypeNCField, PCField, VaddrField}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util.BundleFieldBase
-import huancun.{AliasField, PrefetchField}
+import xscache.common.{AliasField, PrefetchField}
 import org.chipsalliance.cde.config.Parameters
 import utility._
 import utils._

--- a/src/main/scala/xiangshan/cache/dcache/Uncache.scala
+++ b/src/main/scala/xiangshan/cache/dcache/Uncache.scala
@@ -26,7 +26,7 @@ import freechips.rocketchip.tilelink.{TLArbiter, TLBundleA, TLBundleD, TLClientN
 import xiangshan._
 import xiangshan.mem._
 import xiangshan.mem.Bundles._
-import coupledL2.{MemBackTypeMM, MemBackTypeMMField, MemPageTypeNC, MemPageTypeNCField}
+import xscache.coupledL2.{MemBackTypeMM, MemBackTypeMMField, MemPageTypeNC, MemPageTypeNCField}
 import difftest._
 
 trait HasUncacheBufferParameters extends HasXSParameter with HasDCacheParameters {

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -26,10 +26,10 @@ package xiangshan.cache
 import chisel3._
 import chisel3.experimental.dataview._
 import chisel3.util._
-import coupledL2.{IsKeywordKey, MemBackTypeMM, MemPageTypeNC, PCKey, VaddrKey}
+import xscache.coupledL2.{IsKeywordKey, MemBackTypeMM, MemPageTypeNC, PCKey, VaddrKey}
 import difftest._
 import freechips.rocketchip.tilelink._
-import huancun.{AliasKey, DirtyKey, PrefetchKey}
+import xscache.common.{AliasKey, DirtyKey, PrefetchKey}
 import org.chipsalliance.cde.config.Parameters
 import utility._
 import xiangshan._

--- a/src/main/scala/xiangshan/cache/mmu/BitmapCheck.scala
+++ b/src/main/scala/xiangshan/cache/mmu/BitmapCheck.scala
@@ -23,7 +23,7 @@ import xiangshan.cache.{HasDCacheParameters, MemoryOpConstants}
 import utils._
 import utility._
 import utility.mbist.MbistPipeline
-import coupledL2.utils.SplittedSRAM
+import xscache.coupledL2.utils.SplittedSRAM
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.tilelink._
 import xiangshan.backend.fu.{PMPReqBundle, PMPRespBundle}

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -25,7 +25,7 @@ import xiangshan._
 import xiangshan.cache.{HasDCacheParameters, MemoryOpConstants}
 import utils._
 import utility._
-import coupledL2.utils.SplittedSRAM
+import xscache.coupledL2.utils.SplittedSRAM
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.tilelink._
 import utility.mbist.MbistPipeline

--- a/src/main/scala/xiangshan/frontend/icache/ICache.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICache.scala
@@ -23,15 +23,15 @@
 
 package xiangshan.frontend.icache
 
-import coupledL2.MemBackTypeMMField
 import freechips.rocketchip.diplomacy.IdRange
 import freechips.rocketchip.diplomacy.LazyModule
 import freechips.rocketchip.tilelink.TLClientNode
 import freechips.rocketchip.tilelink.TLMasterParameters
 import freechips.rocketchip.tilelink.TLMasterPortParameters
-import huancun.AliasField
 import org.chipsalliance.cde.config.Parameters
 import utility.ReqSourceField
+import xscache.common.AliasField
+import xscache.coupledL2.MemBackTypeMMField
 
 class ICache()(implicit p: Parameters) extends LazyModule with HasICacheParameters {
   override def shouldBeInlined: Boolean = false

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMshr.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMshr.scala
@@ -17,14 +17,14 @@ package xiangshan.frontend.icache
 
 import chisel3._
 import chisel3.util._
-import coupledL2.MemBackTypeMM
 import freechips.rocketchip.tilelink.TLEdgeOut
-import huancun.AliasKey
 import org.chipsalliance.cde.config.Parameters
 import utility.MemReqSource
 import utility.ReqSourceKey
 import utility.XSPerfHistogram
 import xiangshan.WfiReqBundle
+import xscache.common.AliasKey
+import xscache.coupledL2.MemBackTypeMM
 
 class ICacheMshr(edge: TLEdgeOut, isFetch: Boolean, ID: Int)(implicit p: Parameters) extends ICacheModule {
   class ICacheMshrIO(edge: TLEdgeOut)(implicit p: Parameters) extends ICacheBundle {

--- a/src/main/scala/xiangshan/frontend/instruncache/InstrUncache.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/InstrUncache.scala
@@ -15,14 +15,14 @@
 
 package xiangshan.frontend.instruncache
 
-import coupledL2.MemBackTypeMMField
-import coupledL2.MemPageTypeNCField
 import freechips.rocketchip.diplomacy.IdRange
 import freechips.rocketchip.diplomacy.LazyModule
 import freechips.rocketchip.tilelink.TLClientNode
 import freechips.rocketchip.tilelink.TLMasterParameters
 import freechips.rocketchip.tilelink.TLMasterPortParameters
 import org.chipsalliance.cde.config.Parameters
+import xscache.coupledL2.MemBackTypeMMField
+import xscache.coupledL2.MemPageTypeNCField
 
 class InstrUncache(implicit p: Parameters) extends LazyModule with HasInstrUncacheParameters {
   override def shouldBeInlined: Boolean = false

--- a/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheEntry.scala
+++ b/src/main/scala/xiangshan/frontend/instruncache/InstrUncacheEntry.scala
@@ -17,8 +17,6 @@ package xiangshan.frontend.instruncache
 
 import chisel3._
 import chisel3.util._
-import coupledL2.MemBackTypeMM
-import coupledL2.MemPageTypeNC
 import freechips.rocketchip.tilelink.TLBundleA
 import freechips.rocketchip.tilelink.TLBundleD
 import freechips.rocketchip.tilelink.TLEdgeOut
@@ -26,6 +24,8 @@ import org.chipsalliance.cde.config.Parameters
 import utils.EnumUInt
 import xiangshan.WfiReqBundle
 import xiangshan.frontend.ifu.PreDecodeHelper
+import xscache.coupledL2.MemBackTypeMM
+import xscache.coupledL2.MemPageTypeNC
 
 // One miss entry deals with one mmio request
 class InstrUncacheEntry(edge: TLEdgeOut)(implicit p: Parameters) extends InstrUncacheModule with PreDecodeHelper {

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -18,13 +18,13 @@ package xiangshan.mem
 
 import chisel3._
 import chisel3.util._
-import coupledL2.{PrefetchCtrlFromCore, PrefetchRecv}
+import xscache.coupledL2.{PrefetchCtrlFromCore, PrefetchRecv}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts.{IntSinkNode, IntSinkPortSimple}
 import freechips.rocketchip.tile.HasFPUParameters
 import freechips.rocketchip.tilelink._
 import org.chipsalliance.cde.config.Parameters
-import system.{HasSoCParameter, SoCParamsKey}
+import system.HasSoCParameter
 import utility._
 import utility.mbist.{MbistInterface, MbistPipeline}
 import utility.sram.{SramBroadcastBundle, SramHelper}
@@ -326,8 +326,6 @@ class MemBlockInlined()(implicit p: Parameters) extends LazyModule
   // NOTE: we currently only use one output port to L2 and L3 prefetch sender respectively
   val l2_pf_sender_opt = if (coreParams.prefetcher.nonEmpty)
     Some(BundleBridgeSource(() => new PrefetchRecv)) else None
-  val l3_pf_sender_opt = if (p(SoCParamsKey).L3CacheParamsOpt.nonEmpty && coreParams.prefetcher.nonEmpty)
-    Some(BundleBridgeSource(() => new huancun.PrefetchRecv)) else None
   val frontendBridge = LazyModule(new FrontendBridge)
   // interrupt sinks
   val clint_int_sink = IntSinkNode(IntSinkPortSimple(1, 2))
@@ -750,12 +748,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   outer.l2_pf_sender_opt.foreach(_.out.head._1.addr := prefetcher.io.l1_pf_to_l2.addr)
   outer.l2_pf_sender_opt.foreach(_.out.head._1.pf_source :=  prefetcher.io.l1_pf_to_l2.pf_source)
   outer.l2_pf_sender_opt.foreach(_.out.head._1.l2_pf_en := prefetcher.io.l1_pf_to_l2.l2_pf_en)
-  outer.l3_pf_sender_opt.foreach(_.out.head._1.addr_valid := prefetcher.io.l1_pf_to_l3.addr_valid)
-  outer.l3_pf_sender_opt.foreach(_.out.head._1.addr := prefetcher.io.l1_pf_to_l3.addr)
-  outer.l3_pf_sender_opt.foreach(_.out.head._1.l2_pf_en := prefetcher.io.l1_pf_to_l3.l2_pf_en)
   XSPerfAccumulate("prefetch_fire_l1", l1_pf_req.fire)
   XSPerfAccumulate("prefetch_fire_l2", outer.l2_pf_sender_opt.map(_.out.head._1.addr_valid).getOrElse(false.B))
-  XSPerfAccumulate("prefetch_fire_l3", outer.l3_pf_sender_opt.map(_.out.head._1.addr_valid).getOrElse(false.B))
 
   /** prefetcher site in L2 */
   dtlb_reqs(L2toL1DTLBPortIndex) <> io.l2_tlb_req

--- a/src/main/scala/xiangshan/mem/prefetch/BasePrefecher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/BasePrefecher.scala
@@ -18,7 +18,7 @@ package xiangshan.mem.prefetch
 
 import chisel3._
 import chisel3.util._
-import coupledL2.PrefetchCtrlFromCore
+import xscache.coupledL2.PrefetchCtrlFromCore
 import org.chipsalliance.cde.config.Parameters
 import utility.MemReqSource
 import xiangshan._

--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
@@ -98,8 +98,7 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
     val pmp_resp = Vec(prefetcherNum, Flipped(new PMPRespBundle()))
     // prefetch req sender
     val l1_pf_to_l1 = DecoupledIO(new L1PrefetchReq())
-    val l1_pf_to_l2 = Output(new coupledL2.PrefetchRecv())
-    val l1_pf_to_l3 = Output(new huancun.PrefetchRecv())
+    val l1_pf_to_l2 = Output(new xscache.coupledL2.PrefetchRecv())
   })
 
   def isLoadAccess(uop: DynInst): Bool = FuType.isLoad(uop.fuType) || FuType.isVLoad(uop.fuType)
@@ -321,9 +320,6 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
   io.l1_pf_to_l2.addr := l2_pf_req.bits.addr
   io.l1_pf_to_l2.pf_source := l2_pf_req.bits.source
   io.l1_pf_to_l2.l2_pf_en := RegNextN(io.pfCtrlFromCSR.l2_pf_enable, L2_PF_REG_CNT, Some(true.B))
-  io.l1_pf_to_l3.addr_valid := l3_pf_req.valid
-  io.l1_pf_to_l3.addr := l3_pf_req.bits.addr
-  io.l1_pf_to_l3.l2_pf_en := RegNextN(io.pfCtrlFromCSR.l2_pf_enable, L3_PF_REG_CNT, Some(true.B))
 
   val l2_trace = Wire(new LoadPfDbBundle)
   l2_trace.paddr := l2_pf_req.bits.addr
@@ -334,15 +330,6 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
     l2_trace_table.log(l2_trace, l2_pf_req.valid, "L2SMS", clock, reset)
   }.otherwise {
     l2_trace_table.log(l2_trace, l2_pf_req.valid, "L2Unknown", clock, reset)
-  }
-
-  val l3_trace = Wire(new LoadPfDbBundle)
-  l3_trace.paddr := l3_pf_req.bits.addr
-  val l3_trace_table = ChiselDB.createTable(s"L3PrefetchTrace$hartId", new LoadPfDbBundle, basicDB = false)
-  when(l3_pf_req.bits.source === MemReqSource.Prefetch2L3Stream.id.U || l3_pf_req.bits.source === MemReqSource.Prefetch2L3Stride.id.U) {
-    l3_trace_table.log(l3_trace, l3_pf_req.valid, "L3StreamStride", clock, reset)
-  }.otherwise {
-    l3_trace_table.log(l3_trace, l3_pf_req.valid, "L3Unknown", clock, reset)
   }
 
   val arb_seq = Seq(l1_pf_arb, l2_pf_arb, l3_pf_arb)

--- a/src/test/scala/cache/WpuTest.scala
+++ b/src/test/scala/cache/WpuTest.scala
@@ -3,14 +3,14 @@ package cache
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import org.scalatest.flatspec.AnyFlatSpec
-import top.TLConfig
+import top.DefaultConfig
 import xiangshan.cache.wpu.DCacheWpuWrapper
 import xiangshan.{XSCoreParamsKey, XSTileKey}
 
 class WpuBasicTest extends AnyFlatSpec with ChiselSim {
   behavior of "DCacheWPU"
   it should ("run") in {
-    val defaultConfig = (new TLConfig)
+    val defaultConfig = (new DefaultConfig)
     implicit val config = defaultConfig.alterPartial({
       case XSCoreParamsKey => defaultConfig(XSTileKey).head.copy()
     })

--- a/src/test/scala/xiangshan/XSTester.scala
+++ b/src/test/scala/xiangshan/XSTester.scala
@@ -8,12 +8,12 @@ import svsim.CommonCompilationSettings.VerilogPreprocessorDefine
 import svsim.verilator.Backend.CompilationSettings.{TraceKind, TraceStyle}
 import org.scalatest.flatspec._
 import org.scalatest.matchers.should._
-import top.TLConfig
+import top.DefaultConfig
 import xiangshan.backend.regfile.IntPregParams
 
 abstract class XSTester extends AnyFlatSpec with ChiselSim with Matchers {
   behavior of "XiangShan Module"
-  val defaultConfig = (new TLConfig)
+  val defaultConfig = (new DefaultConfig)
   implicit val config: org.chipsalliance.cde.config.Parameters = defaultConfig.alterPartial({
     // Get XSCoreParams and pass it to the "small module"
     case XSCoreParamsKey => defaultConfig(XSTileKey).head.copy(

--- a/src/test/scala/xiangshan/backend/fu/VsetModuleMain.scala
+++ b/src/test/scala/xiangshan/backend/fu/VsetModuleMain.scala
@@ -4,14 +4,14 @@ import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import top.TLConfig
+import top.DefaultConfig
 import xiangshan.backend.fu.vector.Bundles.{VLmul, VSew}
 import xiangshan.{VSETOpType, XSCoreParameters, XSCoreParamsKey, XSTileKey}
 import xiangshan.backend.fu.vector.Bundles.VType
 
 class VsetModuleMain extends AnyFlatSpec with Matchers with ChiselSim {
 
-  val defaultConfig = (new TLConfig).alterPartial({
+  val defaultConfig = (new DefaultConfig).alterPartial({
     case XSCoreParamsKey => XSCoreParameters()
   })
 

--- a/src/test/scala/xiangshan/backend/fu/vector/ByteMaskTailGenTest.scala
+++ b/src/test/scala/xiangshan/backend/fu/vector/ByteMaskTailGenTest.scala
@@ -4,7 +4,7 @@ import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import top.TLConfig
+import top.DefaultConfig
 import xiangshan.backend.fu.vector.Bundles.VSew
 import xiangshan.{XSCoreParameters, XSCoreParamsKey}
 
@@ -12,7 +12,7 @@ class ByteMaskTailGenTest extends AnyFlatSpec with Matchers with ChiselSim {
 
   println("Generating the ByteMaskTailGen hardware")
 
-  val defaultConfig = (new TLConfig).alterPartial({
+  val defaultConfig = (new DefaultConfig).alterPartial({
     case XSCoreParamsKey => XSCoreParameters()
   })
 

--- a/src/test/scala/xiangshan/frontend/FrontendTrigger.scala
+++ b/src/test/scala/xiangshan/frontend/FrontendTrigger.scala
@@ -4,14 +4,14 @@ import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
-import top.TLConfig
+import top.DefaultConfig
 import utility.{LogUtilsOptions, LogUtilsOptionsKey}
 import xiangshan.{DebugOptionsKey, XSCoreParameters, XSCoreParamsKey}
 import xiangshan.frontend.PrunedAddrInit
 
 
 class FrontendTriggerTest extends AnyFlatSpec with Matchers with ChiselSim {
-  implicit val defaultConfig: org.chipsalliance.cde.config.Parameters = (new TLConfig).alterPartial {
+  implicit val defaultConfig: org.chipsalliance.cde.config.Parameters = (new DefaultConfig).alterPartial {
     case XSCoreParamsKey => XSCoreParameters()
   }.alter((site, here, up) => {
     case LogUtilsOptionsKey => LogUtilsOptions(


### PR DESCRIPTION
This PR completes the XiangShan cleanup after removing the legacy TileLink-based cache path and consolidating the repo around a single CHI-based config. It removes the remaining TileLink/HuanCun-specific wiring, configs, and build flow dependencies, aligns the codebase with the refactored XSCache submodule, and makes `DefaultConfig` the primary user-facing configuration while keeping `BackendV2Config` available in perf-trigger workflows. In parallel, the CI/test flow is simplified by moving the basic EMU coverage into the dedicated emu-basics workflow and removing redundant coverage from emu.yml.

Concretely, this pr removes huancun submodule and its build dependencies, drops the old TL L3 parameter system from SoC/top-level configs, updates imports and package references to the new `xscache.{coupledL2, openLLC, chi, common}` hierarchy, and cleans up scripts, docs, and workflow defaults to reflect the CHI-only world.