### PR TITLE
refactor(bpu/replacer): unify ReplacerState porting

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtbReplacer.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtbReplacer.scala
@@ -28,35 +28,35 @@ import xiangshan.frontend.bpu.replacer.ReplacerState
 class AheadBtbReplacer(implicit p: Parameters) extends AheadBtbModule {
   val io: ReplacerIO = IO(new ReplacerIO)
 
-  // use PlruStateGen caclulate next state and replace way
-  private val states           = Module(new ReplacerState(NumSets, NumWays - 1, HasExtraReadPort = true))
+  // use PlruStateGen calculate next state and replace way
+  private val states           = Module(new ReplacerState(NumSets, NumWays - 1, NumExtraReadPort = 1))
   private val predReplacerGen  = Module(new PlruStateGen(NumWays, AccessSize = NumWays))
   private val writeReplacerGen = Module(new PlruStateGen(NumWays))
   private val writeTouch       = Wire(Valid(UInt(WayIdxWidth.W)))
   private val touchWays        = Seq.fill(NumWays)(Wire(Valid(UInt(WayIdxWidth.W))))
 
-  writeTouch.valid            := io.writeValid
-  writeTouch.bits             := io.writeWayIdx
-  states.io.trainReadSetIdx   := io.writeSetIdx
-  states.io.trainWriteValid   := io.writeValid
-  states.io.trainWriteSetIdx  := io.writeSetIdx
-  states.io.trainWriteState   := writeReplacerGen.io.nextState
-  writeReplacerGen.io.state   := states.io.trainReadState
-  writeReplacerGen.io.touches := Seq(writeTouch)
+  writeTouch.valid                 := io.writeValid
+  writeTouch.bits                  := io.writeWayIdx
+  states.io.trainRead.setIdx       := io.writeSetIdx
+  states.io.trainWrite.valid       := io.writeValid
+  states.io.trainWrite.bits.setIdx := io.writeSetIdx
+  states.io.trainWrite.bits.state  := writeReplacerGen.io.nextState
+  writeReplacerGen.io.state        := states.io.trainRead.state
+  writeReplacerGen.io.touches      := Seq(writeTouch)
 
   touchWays.zip(io.readWayMask).zipWithIndex.foreach { case ((t, r), i) =>
     t.valid := r
     t.bits  := i.U
   }
-  states.io.predictReadSetIdx  := io.readSetIdx
-  states.io.predictWriteValid  := io.readValid && io.readWayMask.reduce(_ || _)
-  states.io.predictWriteSetIdx := io.readSetIdx
-  states.io.predictWriteState  := predReplacerGen.io.nextState
-  predReplacerGen.io.state     := states.io.predictReadState
-  predReplacerGen.io.touches   := touchWays
+  states.io.predictRead.setIdx       := io.readSetIdx
+  states.io.predictWrite.valid       := io.readValid && io.readWayMask.reduce(_ || _)
+  states.io.predictWrite.bits.setIdx := io.readSetIdx
+  states.io.predictWrite.bits.state  := predReplacerGen.io.nextState
+  predReplacerGen.io.state           := states.io.predictRead.state
+  predReplacerGen.io.touches         := touchWays
 
-  states.io.readSetIdx.foreach(_ := io.replaceSetIdx)
-  private val replacerState = states.io.readState.getOrElse(0.U)
+  states.io.extraRead.head.setIdx := io.replaceSetIdx
+  private val replacerState = states.io.extraRead.head.state
 
   private val genReplaceWay = writeReplacerGen.getVictim(replacerState)
 

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbReplacer.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbReplacer.scala
@@ -52,8 +52,8 @@ class MainBtbReplacer(implicit p: Parameters) extends MainBtbModule {
 
   /* *** predict *** */
   // read current state
-  stateBank.io.predictReadSetIdx := io.predict.touch.bits.setIdx
-  private val predictState = stateBank.io.predictReadState
+  stateBank.io.predictRead.setIdx := io.predict.touch.bits.setIdx
+  private val predictState = stateBank.io.predictRead.state
 
   // compose touch way vec
   private val predictTouchWay = VecInit((0 until NumWay).map { i =>
@@ -69,20 +69,20 @@ class MainBtbReplacer(implicit p: Parameters) extends MainBtbModule {
   private val predictNextState = predictStateGen.io.nextState
 
   // write back next state
-  stateBank.io.predictWriteValid  := io.predict.touch.valid
-  stateBank.io.predictWriteSetIdx := io.predict.touch.bits.setIdx
-  stateBank.io.predictWriteState  := predictNextState
+  stateBank.io.predictWrite.valid       := io.predict.touch.valid
+  stateBank.io.predictWrite.bits.setIdx := io.predict.touch.bits.setIdx
+  stateBank.io.predictWrite.bits.state  := predictNextState
 
   /* *** train t0 *** */
   // read current state
-  stateBank.io.trainReadSetIdx := io.train.t0_setIdx
+  stateBank.io.trainRead.setIdx := io.train.t0_setIdx
 
   // if t1 is about to write the same set as t0 read, we need to use the updated state (trainStateGen.io.nextState)
   private val trainNextState = trainStateGen.io.nextState
   private val trainSameSet   = io.train.t1_touch.valid && (io.train.t1_touch.bits.setIdx === io.train.t0_setIdx)
   private val predictSameSet = io.predict.touch.valid && (io.predict.touch.bits.setIdx === io.train.t0_setIdx)
   private val trainState = MuxCase(
-    stateBank.io.trainReadState,
+    stateBank.io.trainRead.state,
     Seq(
       trainSameSet   -> trainNextState, // trainNextState has higher priority, see ReplacerState.scala
       predictSameSet -> predictNextState
@@ -111,9 +111,9 @@ class MainBtbReplacer(implicit p: Parameters) extends MainBtbModule {
   trainStateGen.io.touches := VecInit(Seq(trainTouchWay))
 
   // write back next state
-  stateBank.io.trainWriteValid  := io.train.t1_touch.valid
-  stateBank.io.trainWriteSetIdx := io.train.t1_touch.bits.setIdx
-  stateBank.io.trainWriteState  := trainNextState
+  stateBank.io.trainWrite.valid       := io.train.t1_touch.valid
+  stateBank.io.trainWrite.bits.setIdx := io.train.t1_touch.bits.setIdx
+  stateBank.io.trainWrite.bits.state  := trainNextState
 
   // we use t0_setIdx to pre-read stateBank for better timing, it's a tightly-coupled design,
   // so we require t1 to touch the same set

--- a/src/main/scala/xiangshan/frontend/bpu/replacer/ReplacerState.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/replacer/ReplacerState.scala
@@ -19,53 +19,55 @@ import chisel3._
 import chisel3.util._
 
 // Independent replacer state management enables finer-grained clock gating
-class ReplacerState(NumSets: Int, StateBits: Int, HasExtraReadPort: Boolean = false) extends Module {
+class ReplacerState(
+    NumSets:           Int,
+    StateBits:         Int,
+    NumExtraReadPort:  Int = 0,
+    NumExtraWritePort: Int = 0
+) extends Module {
   class ReplacerStateIO extends Bundle {
-    // Read and write for the state of the prediction table
-    val predictReadSetIdx: UInt = Input(UInt(log2Ceil(NumSets).W))
-    val predictReadState:  UInt = Output(UInt(StateBits.W))
-
-    val predictWriteValid:  Bool = Input(Bool())
-    val predictWriteSetIdx: UInt = Input(UInt(log2Ceil(NumSets).W))
-    val predictWriteState:  UInt = Input(UInt(StateBits.W))
-
-    // Read and write for the state of the training table
-    val trainReadSetIdx: UInt = Input(UInt(log2Ceil(NumSets).W))
-    val trainReadState:  UInt = Output(UInt(StateBits.W))
-
-    val trainWriteValid:  Bool = Input(Bool())
-    val trainWriteSetIdx: UInt = Input(UInt(log2Ceil(NumSets).W))
-    val trainWriteState:  UInt = Input(UInt(StateBits.W))
-
-    // Optional additional state read port provision
-    val readSetIdx: Option[UInt] = Option.when(HasExtraReadPort) {
-      Input(UInt(log2Ceil(NumSets).W))
+    class Read extends Bundle {
+      val setIdx: UInt = Input(UInt(SetIdxBits.W))
+      val state:  UInt = Output(UInt(StateBits.W))
     }
-    val readState: Option[UInt] = Option.when(HasExtraReadPort) {
-      Output(UInt(StateBits.W))
+
+    class Write extends Bundle { // direction included in Valid() call
+      val setIdx: UInt = UInt(SetIdxBits.W)
+      val state:  UInt = UInt(StateBits.W)
     }
+
+    // magic number 2: we need at least 2 ports for predict/train read/write
+    val read:  Vec[Read]         = Vec(2 + NumExtraReadPort, new Read)
+    val write: Vec[Valid[Write]] = Vec(2 + NumExtraWritePort, Flipped(Valid(new Write)))
+
+    def predictRead: Read      = read.head
+    def trainRead:   Read      = read.last
+    def extraRead:   Seq[Read] = read.init.tail
+
+    def predictWrite: Valid[Write]      = write.head
+    def trainWrite:   Valid[Write]      = write.last
+    def extraWrite:   Seq[Valid[Write]] = write.init.tail
   }
+
+  def SetIdxBits: Int = log2Ceil(NumSets)
+
+  require(NumExtraReadPort >= 0 && NumExtraWritePort >= 0, "NumExtraPort cannot be negative")
 
   val io: ReplacerStateIO = IO(new ReplacerStateIO)
 
   private val states = RegInit(VecInit(Seq.fill(NumSets)(0.U.asTypeOf(UInt(StateBits.W)))))
-  private val readWriteConflict =
-    io.predictWriteValid && io.trainWriteValid && (io.predictWriteSetIdx === io.trainWriteSetIdx)
 
-  when(readWriteConflict) {
-    states(io.trainWriteSetIdx) := io.trainWriteState
-  }.otherwise {
-    when(io.predictWriteValid) {
-      states(io.predictWriteSetIdx) := io.predictWriteState
-    }
-    when(io.trainWriteValid) {
-      states(io.trainWriteSetIdx) := io.trainWriteState
+  /* *** write *** */
+  // NOTE: when write-write conflict (write same setIdx), port with higher physical idx will take effect,
+  //       therefore, with the default parameter (2 ports), trainWrite has higher priority than predictWrite
+  // NOTE: we don't have to explicitly check if there's a conflict, chisel will handle this,
+  //       i.e. for { when(valid(i)) { state := ... } } will become a `if (valid_0) ... else if (valid_1) ...` chain
+  io.write.foreach { port =>
+    when(port.valid) {
+      states(port.bits.setIdx) := port.bits.state
     }
   }
-  io.predictReadState := states(io.predictReadSetIdx)
-  io.trainReadState   := states(io.trainReadSetIdx)
 
-  if (HasExtraReadPort) {
-    io.readState.get := states(io.readSetIdx.getOrElse(0.U))
-  }
+  /* *** read *** */
+  io.read.foreach(port => port.state := states(port.setIdx))
 }


### PR DESCRIPTION
for better scalability and easier maintainance (we can use `io.read/write.foreach(...)` to handle r/w oprations)

Also remove redundant `when (readWriteConflict) {...} .otherwise {...}` logic, chisel will handle this:
- current:
  ```verilog
  if (reset) begin
    states_0 <= 6'h0;
  end
  else if (io_predictWriteValid & io_trainWriteValid
           & io_predictWriteSetIdx == io_trainWriteSetIdx) begin
    if (io_trainWriteSetIdx == 8'h0)
      states_0 <= io_trainWriteState;
  end
  else begin
    if (io_trainWriteValid & io_trainReadSetIdx == 8'h0)
      states_0 <= io_trainWriteState;
    else if (io_predictWriteValid & io_predictWriteSetIdx == 8'h0)
      states_0 <= io_predictWriteState;
  end
  ```
- after:
  ```verilog
  if (reset) begin
    states_0 <= 6'h0;
  end
  else begin
    if (io_write_1_valid & io_write_1_bits_setIdx == 8'h0) // port 1 is train
      states_0 <= io_write_1_bits_state;
    else if (io_write_0_valid & io_write_0_bits_setIdx == 8'h0) // port 0 is predict
      states_0 <= io_write_0_bits_state;
  end
  ```
see comments before `io.write.foreach()`