### PR TITLE
fix(csr): fix first fetch fault after satp flush

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -96,6 +96,7 @@ class CtrlFlow(implicit p: Parameters) extends XSBundle {
   val pc = UInt(VAddrBits.W)
   val foldpc = UInt(MemPredPCWidth.W)
   val exceptionVec = ExceptSparseVec(ExceptionNO.fromFrontendSet)
+  val satpFlushFirstFetchFault = Bool()
   val backendException = Bool()
   val trigger = TriggerAction()
   val isRvc = Bool()
@@ -223,6 +224,8 @@ class Redirect(implicit p: Parameters) extends FrontendRedirect {
   val isMisPred: Bool = Bool()
 
   val fullTarget: UInt = UInt(XLEN.W) // only used for tval storage in backend
+
+  val satpFlush = Bool()
 
   val stFtqIdx = new FtqPtr // for load violation predict
   val stFtqOffset: UInt = UInt(FetchBlockInstOffsetWidth.W)
@@ -524,7 +527,7 @@ class TlbMbmcBundle(implicit p: Parameters) extends MbmcStruct {
   }
 }
 
-class MmptStruct(implicit p: Parameters) extends XSBundle { // add new mpt csr 
+class MmptStruct(implicit p: Parameters) extends XSBundle { // add new mpt csr
     val mode = UInt(4.W)
     val sdid = UInt(6.W)
     val optOutInNode = UInt(1.W) // skip intermediate node MPT check

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -107,6 +107,7 @@ object Bundles {
   class DecodeInUop(implicit p: Parameters) extends XSBundle {
     val foldpc = UInt(MemPredPCWidth.W) // for mdp
     val exceptionVec = ExceptSparseVec(ExceptionNO.fromFrontendSet)
+    val satpFlushFirstFetchFault = Bool()
     val isFetchMalAddr = Bool()
     val trigger = TriggerAction()
     val isRVC = Bool()
@@ -136,6 +137,7 @@ object Bundles {
   class DecodeOutUop(implicit p: Parameters) extends XSBundle {
     val foldpc = UInt(MemPredPCWidth.W) // for mdp
     val exceptionVec = ExceptSparseVec(ExceptionNO.decodeSet)
+    val satpFlushFirstFetchFault = Bool()
     val isFetchMalAddr = Bool()
     val trigger = TriggerAction()
     val isRVC = Bool()
@@ -231,6 +233,7 @@ object Bundles {
   class RenameOutUop(implicit p: Parameters) extends XSBundle {
     def numSrc = backendParams.numSrc
     val exceptionVec = ExceptSparseVec(ExceptionNO.decodeSet)
+    val satpFlushFirstFetchFault = Bool()
     val isFetchMalAddr = Bool()
     val trigger = TriggerAction()
     val isRVC = Bool()
@@ -1394,6 +1397,7 @@ class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) exte
     val vxsat        = Option.when(params.writeVxsat)(Bool())
     val exceptionVec = ExceptSparseVec(params.exceptionOut)
     val flushPipe    = Option.when(params.flushPipe)(Bool())
+    val satpFlush    = Option.when(params.satpFlush)(Bool())
     val trigger      = Option.when(params.trigger)(TriggerAction())
     val isRVC        = Option.when(params.needIsRVC)(Bool())
     val replay       = Option.when(params.replayInst)(Bool())
@@ -1668,6 +1672,7 @@ class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) exte
   class WriteBackRobBundle(val params: ExeUnitParams, backendParams: BackendParams)(implicit p: Parameters) extends Bundle with BundleSource {
     val robIdx        = new RobPtr()(p)
     val flushPipe     = Option.when(params.flushPipe)(Bool())
+    val satpFlush     = Option.when(params.satpFlush)(Bool())
     val replay        = Option.when(params.replayInst)(Bool())
     val redirect      = Option.when(params.hasRedirect)(ValidIO(new Redirect))
     val fflags        = Option.when(params.writeFflags)(UInt(5.W))
@@ -1703,6 +1708,7 @@ class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) exte
     val instr = UInt(32.W)
     val commitType = CommitType()
     val exceptionVec = ExceptSparseVec() // TODO: optimize valid indices
+    val satpFlushFirstFetchFault = Bool()
     val isPcBkpt = Bool()
     val isFetchMalAddr = Bool()
     val gpaddr = UInt(XLEN.W)

--- a/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnit.scala
@@ -422,6 +422,7 @@ class ExeUnitImp(implicit p: Parameters, val exuParams: ExeUnitParams) extends X
   io.out.bits.toRob.bits.vxsat.       foreach(x => x := Mux1H(fuOutValidOH, fuOutresVec.map(_.vxsat.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.vxsat.get)))))
   io.out.bits.toRob.bits.exceptionVec := ExceptSparseVec.mux1h(fuOutValidOH, fuOutBitsVec.map(_.ctrl.exceptionVec))
   io.out.bits.toRob.bits.flushPipe.   foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.flushPipe.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.flushPipe.get)))))
+  io.out.bits.toRob.bits.satpFlush.   foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.satpFlush.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.satpFlush.get)))))
   io.out.bits.toRob.bits.replay.      foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.replay.getOrElse(0.U.asTypeOf(io.out.bits.toRob.bits.replay.get)))))
   io.out.bits.toRob.bits.isRVC.       foreach(x => x := Mux1H(fuOutValidOH, fuOutBitsVec.map(_.ctrl.isRVC.getOrElse(false.B))))
 

--- a/src/main/scala/xiangshan/backend/exu/ExeUnitParams.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnitParams.scala
@@ -87,6 +87,7 @@ case class ExeUnitParams(
   val exceptionOut: Seq[Int] = fuConfigs.map(_.exceptionOut).reduce(_ ++ _).distinct.sorted
   val hasLoadError: Boolean = fuConfigs.map(_.hasLoadError).reduce(_ || _)
   val flushPipe: Boolean = fuConfigs.map(_.flushPipe).reduce(_ || _)
+  val satpFlush: Boolean = fuConfigs.map(_.isCsr).reduce(_ || _)
   val replayInst: Boolean = fuConfigs.map(_.replayInst).reduce(_ || _)
   val trigger: Boolean = fuConfigs.map(_.trigger).reduce(_ || _)
   val needExceptionGen: Boolean = exceptionOut.nonEmpty || flushPipe || replayInst || trigger
@@ -511,7 +512,7 @@ case class ExeUnitParams(
   def genMemWriteBackBundle(implicit p: Parameters): MemWriteBack = {
     new MemWriteBack(this)
   }
-  
+
   def genWriteBackRobBundle(implicit p: Parameters): WriteBackRobBundle = {
     new WriteBackRobBundle(this, backendParam)
   }

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -82,6 +82,7 @@ class FuncUnitCtrlOutput(cfg: FuConfig)(implicit p: Parameters) extends XSBundle
   val vlWen         = OptionWrapper(cfg.needVlWen, Bool())
   val exceptionVec  = ExceptSparseVec(cfg.exceptionOut)
   val flushPipe     = OptionWrapper(cfg.flushPipe,  Bool())
+  val satpFlush     = OptionWrapper(cfg.isCsr,      Bool())
   val replay        = OptionWrapper(cfg.replayInst, Bool())
   val isRVC         = OptionWrapper(cfg.hasIsRVC, Bool())
   val fpu           = OptionWrapper(cfg.writeFflags, new FPUCtrlSignals)

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/CSREvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/CSREvent.scala
@@ -128,6 +128,7 @@ class TrapEntryEventInput(implicit val p: Parameters) extends Bundle with HasXSP
   val isFetchBkpt = Input(Bool())
   val trapIsForVSnonLeafPTE = Input(Bool())
   val hasDTExcp = Input(Bool())
+  val satpFlushFirstFetchFault = Input(Bool())
 
   // always current privilege
   val iMode = Input(new PrivState())
@@ -146,6 +147,8 @@ class TrapEntryEventInput(implicit val p: Parameters) extends Bundle with HasXSP
   val satp = Input(new SatpBundle)
   val vsatp = Input(new SatpBundle)
   val hgatp = Input(new HgatpBundle)
+  val oldSatp = Input(new SatpBundle)
+  val oldVsatp = Input(new SatpBundle)
   val mbmc = Input(new MbmcBundle)
   val mmpt = Option.when(HasMptCheck) (Input(new MmptBundle)) //HasMptCheck
   // from mem

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryDEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryDEvent.scala
@@ -40,6 +40,8 @@ class TrapEntryDEventModule(implicit val p: Parameters) extends Module with CSRE
   private val satp    = current.satp
   private val vsatp   = current.vsatp
   private val hgatp   = current.hgatp
+  private val oldSatp = current.oldSatp
+  private val oldVsatp = current.oldVsatp
 
   private val hasTrap                      = in.hasTrap
   private val debugMode                    = in.debugMode
@@ -50,6 +52,7 @@ class TrapEntryDEventModule(implicit val p: Parameters) extends Module with CSRE
   private val hasSingleStep                = in.hasSingleStep
   private val criticalErrorStateEnterDebug = in.criticalErrorStateEnterDebug
   private val isFetchMalAddr               = in.isFetchMalAddr
+  private val satpFlushFirstFetchFault     = in.satpFlushFirstFetchFault
 
   private val hasExceptionInDmode = debugMode && hasTrap
   val cause = MuxCase(DcsrCause.None.asUInt, Seq(
@@ -62,8 +65,8 @@ class TrapEntryDEventModule(implicit val p: Parameters) extends Module with CSRE
 
   private val trapPC = genTrapVA(
     iMode,
-    satp,
-    vsatp,
+    oldSatp,
+    oldVsatp,
     hgatp,
     in.trapPc,
   )
@@ -88,7 +91,9 @@ class TrapEntryDEventModule(implicit val p: Parameters) extends Module with CSRE
   out.dcsr.bits.V             := current.privState.V.asUInt
   out.dcsr.bits.PRV           := current.privState.PRVM.asUInt
   out.dcsr.bits.CAUSE         := cause
-  out.dpc.bits.epc            := Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1))
+  out.dpc.bits.epc            := Mux(satpFlushFirstFetchFault,
+                                  trapPC(63, 1),
+                                  Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1)))
 
   out.targetPc.bits.pc        := RegEnable(debugPc, valid || hasExceptionInDmode)
   out.targetPc.bits.raiseIPF  := false.B

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryHSEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryHSEvent.scala
@@ -34,6 +34,8 @@ class TrapEntryHSEventModule(implicit val p: Parameters) extends Module with CSR
   private val satp = current.satp
   private val vsatp = current.vsatp
   private val hgatp = current.hgatp
+  private val oldSatp = current.oldSatp
+  private val oldVsatp = current.oldVsatp
 
   private val highPrioTrapNO = in.causeNO.ExceptionCode.asUInt
   private val isException = !in.causeNO.Interrupt.asBool
@@ -41,13 +43,21 @@ class TrapEntryHSEventModule(implicit val p: Parameters) extends Module with CSR
 
   private val trapPC = genTrapVA(
     iMode,
-    satp,
-    vsatp,
+    oldSatp,
+    oldVsatp,
     hgatp,
     in.trapPc,
   )
 
   private val trapPCGPA = in.trapPcGPA
+
+  private val trapPCGPAFromSatpFlush = genTrapVA(
+    iMode,
+    oldSatp,
+    oldVsatp,
+    hgatp,
+    in.trapPcGPA,
+  )
 
   private val trapMemVA = in.memExceptionVAddr
 
@@ -71,6 +81,7 @@ class TrapEntryHSEventModule(implicit val p: Parameters) extends Module with CSR
 
   private val isLSGuestExcp    = isException && ExceptionNO.getLSGuestPageFault.map(_.U === highPrioTrapNO).reduce(_ || _)
   private val isFetchGuestExcp = isException && ExceptionNO.EX_IGPF.U === highPrioTrapNO
+  private val satpFlushFirstFetchFault = in.satpFlushFirstFetchFault
   // Software breakpoint exceptions are permitted to write either 0 or the pc to xtval
   // We fill pc here
   private val tvalFillPc       = (isFetchExcp || isFetchGuestExcp) && !fetchCrossPage || isFetchBkpt
@@ -96,6 +107,13 @@ class TrapEntryHSEventModule(implicit val p: Parameters) extends Module with CSR
     (isLSGuestExcp                                         ) -> trapMemGPA,
   ))
 
+  private val tval2FromSatpFlush = Mux1H(Seq(
+    (isFetchGuestExcp && isFetchMalAddr                    ) -> in.fetchMalTval,
+    (isFetchGuestExcp && !isFetchMalAddr && !fetchCrossPage) -> trapPCGPAFromSatpFlush,
+    (isFetchGuestExcp && !isFetchMalAddr && fetchCrossPage ) -> (trapPCGPAFromSatpFlush + 2.U),
+    (isLSGuestExcp                                         ) -> trapMemGPA,
+  ))
+
   out := DontCare
 
   out.privState.valid := valid
@@ -118,11 +136,15 @@ class TrapEntryHSEventModule(implicit val p: Parameters) extends Module with CSR
     // SPVP is not PrivMode enum type, so asUInt and shrink the width
   out.hstatus.bits.SPVP         := Mux(!current.privState.isVirtual, in.hstatus.SPVP.asUInt, current.privState.PRVM.asUInt(0, 0))
   out.hstatus.bits.GVA          := tvalFillGVA
-  out.sepc.bits.epc             := Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1))
+  out.sepc.bits.epc             := Mux(satpFlushFirstFetchFault,
+                                    trapPC(63, 1),
+                                    Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1)))
   out.scause.bits.Interrupt     := isInterrupt
   out.scause.bits.ExceptionCode := highPrioTrapNO
-  out.stval.bits.ALL            := Mux(isFetchMalAddrExcp, in.fetchMalTval, tval)
-  out.htval.bits.ALL            := tval2 >> 2
+  out.stval.bits.ALL            := Mux(satpFlushFirstFetchFault,
+                                    tval,
+                                    Mux(isFetchMalAddrExcp, in.fetchMalTval, tval))
+  out.htval.bits.ALL            := Mux(satpFlushFirstFetchFault, tval2FromSatpFlush >> 2, tval2 >> 2)
   out.htinst.bits.ALL           := Mux(isFetchGuestExcp && in.trapIsForVSnonLeafPTE || isLSGuestExcp && in.memExceptionIsForVSnonLeafPTE, 0x3000.U, 0.U)
 
   dontTouch(isLSGuestExcp)

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala
@@ -32,6 +32,8 @@ class TrapEntryMEventModule(implicit val p: Parameters) extends Module with CSRE
   private val vsatp = current.vsatp
   private val hgatp = current.hgatp
   private val isDTExcp = current.hasDTExcp
+  private val oldSatp = current.oldSatp
+  private val oldVsatp = current.oldVsatp
 
   private val highPrioTrapNO = in.causeNO.ExceptionCode.asUInt
   private val isException = !in.causeNO.Interrupt.asBool
@@ -39,13 +41,21 @@ class TrapEntryMEventModule(implicit val p: Parameters) extends Module with CSRE
 
   private val trapPC = genTrapVA(
     iMode,
-    satp,
-    vsatp,
+    oldSatp,
+    oldVsatp,
     hgatp,
     in.trapPc,
   )
 
   private val trapPCGPA = in.trapPcGPA
+
+  private val trapPCGPAFromSatpFlush = genTrapVA(
+    iMode,
+    oldSatp,
+    oldVsatp,
+    hgatp,
+    in.trapPcGPA,
+  )
 
   private val trapMemVA = in.memExceptionVAddr
 
@@ -69,6 +79,7 @@ class TrapEntryMEventModule(implicit val p: Parameters) extends Module with CSRE
 
   private val isLSGuestExcp    = isException && ExceptionNO.getLSGuestPageFault.map(_.U === highPrioTrapNO).reduce(_ || _)
   private val isFetchGuestExcp = isException && ExceptionNO.EX_IGPF.U === highPrioTrapNO
+  private val satpFlushFirstFetchFault = in.satpFlushFirstFetchFault
   // Software breakpoint exceptions are permitted to write either 0 or the pc to xtval
   // We fill pc here
   private val tvalFillPc       = (isFetchExcp || isFetchGuestExcp) && !fetchCrossPage || isFetchBkpt
@@ -94,6 +105,13 @@ class TrapEntryMEventModule(implicit val p: Parameters) extends Module with CSRE
     (isLSGuestExcp                                         ) -> trapMemGPA,
   ))
 
+  private val tval2FromSatpFlush = Mux1H(Seq(
+    (isFetchGuestExcp && isFetchMalAddr                    ) -> in.fetchMalTval,
+    (isFetchGuestExcp && !isFetchMalAddr && !fetchCrossPage) -> trapPCGPAFromSatpFlush,
+    (isFetchGuestExcp && !isFetchMalAddr && fetchCrossPage ) -> (trapPCGPAFromSatpFlush + 2.U),
+    (isLSGuestExcp                                         ) -> trapMemGPA,
+  ))
+
   private val precause = Cat(isInterrupt, highPrioTrapNO)
 
   out := DontCare
@@ -113,11 +131,17 @@ class TrapEntryMEventModule(implicit val p: Parameters) extends Module with CSRE
   out.mstatus.bits.MPIE         := current.mstatus.MIE
   out.mstatus.bits.MIE          := 0.U
   out.mstatus.bits.MDT          := 1.U
-  out.mepc.bits.epc             := Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1))
+  out.mepc.bits.epc             := Mux(satpFlushFirstFetchFault,
+                                    trapPC(63, 1),
+                                    Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1)))
   out.mcause.bits.Interrupt     := isInterrupt && !isDTExcp
   out.mcause.bits.ExceptionCode := Mux(isDTExcp, ExceptionNO.EX_DT.U, highPrioTrapNO)
-  out.mtval.bits.ALL            := Mux(isFetchMalAddrExcp, in.fetchMalTval, tval)
-  out.mtval2.bits.ALL           := Mux(isDTExcp, precause, tval2 >> 2)
+  out.mtval.bits.ALL            := Mux(satpFlushFirstFetchFault,
+                                    tval,
+                                    Mux(isFetchMalAddrExcp, in.fetchMalTval, tval))
+  out.mtval2.bits.ALL           := Mux(isDTExcp,
+                                    precause,
+                                    Mux(satpFlushFirstFetchFault, tval2FromSatpFlush >> 2, tval2 >> 2))
   out.mtinst.bits.ALL           := Mux(isFetchGuestExcp && in.trapIsForVSnonLeafPTE || isLSGuestExcp && in.memExceptionIsForVSnonLeafPTE, 0x3000.U, 0.U)
 
   dontTouch(isLSGuestExcp)

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMNEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMNEvent.scala
@@ -24,16 +24,19 @@ class TrapEntryMNEventModule(implicit val p: Parameters) extends Module with CSR
   private val satp  = current.satp
   private val vsatp = current.vsatp
   private val hgatp = current.hgatp
+  private val oldSatp = current.oldSatp
+  private val oldVsatp = current.oldVsatp
 
   private val highPrioTrapNO = in.causeNO.ExceptionCode.asUInt
   private val isInterrupt = in.causeNO.Interrupt.asBool
 
   private val isFetchMalAddr = in.isFetchMalAddr
+  private val satpFlushFirstFetchFault = in.satpFlushFirstFetchFault
 
   private val trapPC = genTrapVA(
     iMode,
-    satp,
-    vsatp,
+    oldSatp,
+    oldVsatp,
     hgatp,
     in.trapPc,
   )
@@ -48,7 +51,9 @@ class TrapEntryMNEventModule(implicit val p: Parameters) extends Module with CSR
   out.mnstatus.bits.MNPP         := current.privState.PRVM
   out.mnstatus.bits.MNPV         := current.privState.V
   out.mnstatus.bits.NMIE         := 0.U
-  out.mnepc.bits.epc             := Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1))
+  out.mnepc.bits.epc             := Mux(satpFlushFirstFetchFault,
+                                      trapPC(63, 1),
+                                      Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1)))
   out.mncause.bits.Interrupt     := isInterrupt
   out.mncause.bits.ExceptionCode := highPrioTrapNO
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryVSEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryVSEvent.scala
@@ -34,6 +34,8 @@ class TrapEntryVSEventModule(implicit val p: Parameters) extends Module with CSR
   private val satp = current.satp
   private val vsatp = current.vsatp
   private val hgatp = current.hgatp
+  private val oldSatp = current.oldSatp
+  private val oldVsatp = current.oldVsatp
 
   private val trapCode = in.causeNO.ExceptionCode.asUInt
   private val isException = !in.causeNO.Interrupt.asBool
@@ -56,8 +58,8 @@ class TrapEntryVSEventModule(implicit val p: Parameters) extends Module with CSR
 
   private val trapPC = genTrapVA(
     iMode,
-    satp,
-    vsatp,
+    oldSatp,
+    oldVsatp,
     hgatp,
     in.trapPc,
   )
@@ -80,6 +82,7 @@ class TrapEntryVSEventModule(implicit val p: Parameters) extends Module with CSR
   private val isFetchMalAddr = in.isFetchMalAddr
   private val isFetchMalAddrExcp = isException && isFetchMalAddr
   private val isIllegalInst  = isException && (EX_II.U === highPrioTrapNO || EX_VI.U === highPrioTrapNO)
+  private val satpFlushFirstFetchFault = in.satpFlushFirstFetchFault
 
   // Software breakpoint exceptions are permitted to write either 0 or the pc to xtval
   // We fill pc here
@@ -114,10 +117,14 @@ class TrapEntryVSEventModule(implicit val p: Parameters) extends Module with CSR
   out.vsstatus.bits.SIE          := 0.U
   out.vsstatus.bits.SDT          := in.henvcfg.DTE.asBool // when DTE open set SDT to 1, else SDT is readonly 0
   // SPVP is not PrivMode enum type, so asUInt and shrink the width
-  out.vsepc.bits.epc             := Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1))
+  out.vsepc.bits.epc             := Mux(satpFlushFirstFetchFault,
+                                      trapPC(63, 1),
+                                      Mux(isFetchMalAddr, in.fetchMalTval(63, 1), trapPC(63, 1)))
   out.vscause.bits.Interrupt     := isInterrupt
   out.vscause.bits.ExceptionCode := Mux(virtualInterruptIsHvictlInject && isInterrupt, hvictlIID, highPrioTrapNO)
-  out.vstval.bits.ALL            := Mux(isFetchMalAddrExcp, in.fetchMalTval, tval)
+  out.vstval.bits.ALL            := Mux(satpFlushFirstFetchFault,
+                                      tval,
+                                      Mux(isFetchMalAddrExcp, in.fetchMalTval, tval))
   dontTouch(tvalFillGVA)
 }
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -150,6 +150,7 @@ class NewCSR(implicit val p: Parameters) extends Module
         val isHls = Bool()
         val isFetchMalAddr = Bool()
         val isForVSnonLeafPTE = Bool()
+        val satpFlushFirstFetchFault = Bool()
       })
       val commit = Input(new RobCommitCSR)
       val robDeqPtr = Input(new RobPtr)
@@ -183,6 +184,8 @@ class NewCSR(implicit val p: Parameters) extends Module
         val vlenb = UInt(XLEN.W)
         val off = Bool()
       }
+      val satp  = Valid(UInt(SatpMode.getWidth.W))
+      val vsatp = Valid(UInt(SatpMode.getWidth.W))
       // debug
       val debugMode = Bool()
       val singleStepFlag = Bool()
@@ -232,6 +235,10 @@ class NewCSR(implicit val p: Parameters) extends Module
 
     val fetchMalTval = Input(UInt(XLEN.W))
 
+    val oldSatpMode  = Input(UInt(SatpMode.getWidth.W))
+    val oldVsatpMode = Input(UInt(SatpMode.getWidth.W))
+    val oldPrivState = Input(new PrivState)
+
     val distributedWenLegal = Output(Bool())
 
     val trapTargetPc = ValidIO(new TargetPCBundle)
@@ -271,6 +278,11 @@ class NewCSR(implicit val p: Parameters) extends Module
   val trapIsFetchMalAddr = io.fromRob.trap.bits.isFetchMalAddr
   val trapIsFetchBkpt = io.fromRob.trap.bits.isFetchBkpt
   val trapIsForVSnonLeafPTE = io.fromRob.trap.bits.isForVSnonLeafPTE
+  val trapIsSatpFlushFirstFetchFault = io.fromRob.trap.bits.satpFlushFirstFetchFault
+
+  val oldSatpMode  = io.oldSatpMode
+  val oldVsatpMode = io.oldVsatpMode
+  val oldPrivState = io.oldPrivState
 
   // debug_intrrupt
   val debugIntrEnable = RegInit(true.B) // debug interrupt will be handle only when debugIntrEnable
@@ -840,9 +852,10 @@ class NewCSR(implicit val p: Parameters) extends Module
         in.isFetchBkpt := trapIsFetchBkpt
         in.trapIsForVSnonLeafPTE := trapIsForVSnonLeafPTE
         in.hasDTExcp := hasDTExcp
+        in.satpFlushFirstFetchFault := trapIsSatpFlushFirstFetchFault
 
-        in.iMode.PRVM := PRVM
-        in.iMode.V := V
+        in.iMode.PRVM := Mux(trapIsSatpFlushFirstFetchFault, oldPrivState.PRVM, PRVM)
+        in.iMode.V := Mux(trapIsSatpFlushFirstFetchFault, oldPrivState.V, V)
         // when NMIE is zero, force to behave as MPRV is zero
         in.dMode.PRVM := Mux(mstatus.regOut.MPRV.asBool && mnstatus.regOut.NMIE.asBool, mstatus.regOut.MPP, PRVM)
         in.dMode.V := V.asUInt.asBool || mstatus.regOut.MPRV && mnstatus.regOut.NMIE.asBool && (mstatus.regOut.MPP =/= PrivMode.M) && mstatus.regOut.MPV
@@ -859,6 +872,12 @@ class NewCSR(implicit val p: Parameters) extends Module
         in.satp  := satp.regOut
         in.vsatp := vsatp.regOut
         in.hgatp := hgatp.regOut
+        in.oldSatp  := Mux(trapIsSatpFlushFirstFetchFault,
+                        Cat(oldSatpMode, 0.U((XLEN - SatpMode.getWidth).W)).asTypeOf(in.oldSatp),
+                        satp.regOut)
+        in.oldVsatp := Mux(trapIsSatpFlushFirstFetchFault,
+                        Cat(oldVsatpMode, 0.U((XLEN - SatpMode.getWidth).W)).asTypeOf(in.oldVsatp),
+                        vsatp.regOut)
         if (HasBitmapCheck) {
           in.mbmc := mbmc.get.regOut
         } else {
@@ -1164,6 +1183,10 @@ class NewCSR(implicit val p: Parameters) extends Module
                         (vstopi.regOut.IID.asUInt =/= 0.U)
   io.status.debugMode := debugMode
   io.status.singleStepFlag := !debugMode && dcsr.regOut.STEP
+  io.status.satp.valid  := satp.w.wen
+  io.status.satp.bits   := satp.regOut.MODE.asUInt
+  io.status.vsatp.valid := vsatp.w.wen
+  io.status.vsatp.bits  := vsatp.regOut.MODE.asUInt
 
   private val nonDebugTrapEventValid = Cat(Seq(trapEntryMEvent, trapEntryMNEvent, trapEntryHSEvent, trapEntryVSEvent).map(_.valid)).asUInt.orR
   private val delayedPcFromXtvec = RegEnable(trapHandleMod.io.out.pcFromXtvec, nonDebugTrapEventValid)

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/SatpFlushMod.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/SatpFlushMod.scala
@@ -1,0 +1,49 @@
+package xiangshan.backend.fu.NewCSR
+
+import chisel3._
+import chisel3.util._
+import xiangshan.backend.fu.NewCSR.CSRDefines._
+import xiangshan.backend.fu.NewCSR.CSRBundles.PrivState
+
+
+class SatpFlushMod extends Module {
+  val in  = IO(Input(new SatpFlushMod.In))
+  val out = IO(Output(new SatpFlushMod.Out))
+
+  private val oldPrivState = Reg(new PrivState)
+  private val oldSatpMode  = Reg(UInt(SatpMode.getWidth.W))
+  private val oldVsatpMode = Reg(UInt(SatpMode.getWidth.W))
+
+  private val privState = in.privState
+
+  private val satpWen   = in.satp.valid
+  private val vsatpWen  = in.vsatp.valid
+  private val satpMode  = in.satp.bits
+  private val vsatpMode = in.vsatp.bits
+
+  private val wen = satpWen || vsatpWen
+
+  when(wen) {
+    oldSatpMode  := satpMode
+    oldVsatpMode := vsatpMode
+    oldPrivState := privState
+  }
+
+  out.oldSatpMode  := oldSatpMode
+  out.oldVsatpMode := oldVsatpMode
+  out.oldPrivState := oldPrivState
+}
+
+object SatpFlushMod {
+  class In extends Bundle {
+    val satp      = Valid(UInt(SatpMode.getWidth.W))
+    val vsatp     = Valid(UInt(SatpMode.getWidth.W))
+    val privState = new PrivState
+  }
+
+  class Out extends Bundle {
+    val oldSatpMode  = UInt(SatpMode.getWidth.W)
+    val oldVsatpMode = UInt(SatpMode.getWidth.W)
+    val oldPrivState = new PrivState
+  }
+}

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -36,6 +36,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   val vlFromPreg = csrIn.vpu.vl
 
   val flushPipe = Wire(Bool())
+  val satpFlush = Wire(Bool())
   val flush = io.flush.valid
 
   /** Alias of input signals */
@@ -65,6 +66,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   val csrMod = Module(new NewCSR)
   val trapInstMod = Module(new TrapInstMod)
   val trapTvalMod = Module(new TrapTvalMod)
+  val satpFlushMod = Module(new SatpFlushMod)
 
   private val privState = csrMod.io.status.privState
   // The real reg value in CSR, with no read mask
@@ -121,6 +123,9 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   csrMod.io.fromMem.excpVA  := csrIn.memExceptionVAddr
   csrMod.io.fromMem.excpGPA := csrIn.memExceptionGPAddr
   csrMod.io.fromMem.excpIsForVSnonLeafPTE := csrIn.memExceptionIsForVSnonLeafPTE
+  csrMod.io.oldSatpMode  := satpFlushMod.out.oldSatpMode
+  csrMod.io.oldVsatpMode := satpFlushMod.out.oldVsatpMode
+  csrMod.io.oldPrivState := satpFlushMod.out.oldPrivState
 
   csrMod.io.fromRob.trap.valid := csrIn.exception.valid
   csrMod.io.fromRob.trap.bits.pc := csrIn.exception.bits.pc
@@ -137,6 +142,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   csrMod.io.fromRob.trap.bits.isHls := csrIn.exception.bits.isHls
   csrMod.io.fromRob.trap.bits.isFetchMalAddr := csrIn.exception.bits.isFetchMalAddr
   csrMod.io.fromRob.trap.bits.isForVSnonLeafPTE := csrIn.exception.bits.isForVSnonLeafPTE
+  csrMod.io.fromRob.trap.bits.satpFlushFirstFetchFault := csrIn.exception.bits.satpFlushFirstFetchFault
 
   csrMod.io.fromRob.commit.fflags := setFflags
   csrMod.io.fromRob.commit.fsDirty := setFsDirty
@@ -202,6 +208,12 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   trapTvalMod.io.fromCtrlBlock.flush := io.flush
   trapTvalMod.io.fromCtrlBlock.robDeqPtr := io.csrio.get.robDeqPtr
 
+  satpFlushMod.in.satp.valid  := csrMod.io.status.satp.valid
+  satpFlushMod.in.satp.bits   := csrMod.io.status.satp.bits
+  satpFlushMod.in.vsatp.valid := csrMod.io.status.vsatp.valid
+  satpFlushMod.in.vsatp.bits  := csrMod.io.status.vsatp.bits
+  satpFlushMod.in.privState   := csrMod.io.status.privState
+
   val imsic = Module(new aia.IMSIC_WRAP(soc.IMSICParams))
   imsic.fromCSR.addr.valid := csrMod.toAIA.addr.valid
   imsic.fromCSR.addr.bits.addr := csrMod.toAIA.addr.bits.addr
@@ -253,6 +265,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   val isXRet = valid && func === CSROpType.jmp && !isEcall && !isEbreak
 
   flushPipe := csrMod.io.out.bits.flushPipe
+  satpFlush := csrMod.io.status.satp.valid || csrMod.io.status.vsatp.valid
 
   // tlb
   val tlb = Wire(new TlbCsrBundle)
@@ -312,6 +325,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
     exceptionVec.map(x => DelayNWithValid(x, csrModOutValid, 3)._2)
   )
   io.out.bits.ctrl.flushPipe.get := Mux(isXRetReg, flushPipe, DelayNWithValid(flushPipe, csrModOutValid, 3)._2)
+  io.out.bits.ctrl.satpFlush.get := Mux(isXRetReg, satpFlush, DelayNWithValid(satpFlush, csrModOutValid, 3)._2)
   io.out.bits.res.data := DelayNWithValid(csrMod.io.out.bits.rData, csrModOutValid, 3)._2
 
   /** initialize NewCSR's io_out_ready from wrapper's io */
@@ -429,7 +443,7 @@ class CSRInput(implicit p: Parameters) extends XSBundle with HasSoCParameter {
 
 class CSRToDecode(implicit p: Parameters) extends XSBundle {
   val illegalInst = new Bundle {
-    
+
     val mfence = Option.when(HasMptCheck) (Bool())
     /**
      * illegal sfence.vma, sinval.vma

--- a/src/main/scala/xiangshan/backend/rob/ExceptionGen.scala
+++ b/src/main/scala/xiangshan/backend/rob/ExceptionGen.scala
@@ -141,6 +141,7 @@ class ExceptionGen(params: BackendParams)(implicit p: Parameters) extends XSModu
         current.exceptionVec := ExceptSparseVec.mux2(isVecUpdate, s1_out_bits.exceptionVec, current.exceptionVec)
         current.hasException := Mux(isVecUpdate, s1_out_bits.hasException, current.hasException)
         current.flushPipe := (s1_out_bits.flushPipe || current.flushPipe) && !s1_out_bits.exceptionVec.orR
+        current.satpFlush := s1_out_bits.satpFlush || current.satpFlush
         current.replayInst := s1_out_bits.replayInst || current.replayInst
         current.singleStep := s1_out_bits.singleStep || current.singleStep
         current.trigger   := Mux(isVecUpdate, s1_out_bits.trigger,    current.trigger)

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -663,6 +663,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   io.flushOut.bits.ftqOffset := Mux(needModifyFtqIdxOffset, firstVInstrFtqOffset, deqPtrEntry.ftqOffset)
   io.flushOut.bits.level := Mux(deqHasReplayInst || intrEnable || deqHasException || needModifyFtqIdxOffset, RedirectLevel.flush, RedirectLevel.flushAfter) // TODO use this to implement "exception next"
   io.flushOut.bits.interrupt := !isFlushPipe
+  io.flushOut.bits.satpFlush := isFlushPipe && exceptionDataRead.bits.satpFlush
   XSPerfAccumulate("flush_num", io.flushOut.valid)
   XSPerfAccumulate("interrupt_num", io.flushOut.valid && intrEnable)
   XSPerfAccumulate("exception_num", io.flushOut.valid && deqHasException)
@@ -677,6 +678,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   io.exception.bits.instr := RegEnable(debug_deqUop.debug_instr.getOrElse(0.U), exceptionHappen)
   io.exception.bits.commitType := RegEnable(deqPtrEntry.commitType, exceptionHappen)
   io.exception.bits.exceptionVec extendFrom RegEnable(exceptionDataRead.bits.exceptionVec, exceptionHappen)
+  io.exception.bits.satpFlushFirstFetchFault := RegEnable(exceptionDataRead.bits.satpFlushFirstFetchFault && deqHasException, exceptionHappen)
   // fetch trigger fire or execute ebreak
   io.exception.bits.isPcBkpt := RegEnable(
     exceptionDataRead.bits.exceptionVec(ExceptionNO.EX_BP) && (
@@ -1188,10 +1190,12 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     exceptionGen.io.enq(i).bits.ftqPtr := io.enq.req(i).bits.ftqPtr
     exceptionGen.io.enq(i).bits.ftqOffset := io.enq.req(i).bits.ftqOffset
     exceptionGen.io.enq(i).bits.exceptionVec := io.enq.req(i).bits.exceptionVec
+    exceptionGen.io.enq(i).bits.satpFlushFirstFetchFault := io.enq.req(i).bits.satpFlushFirstFetchFault
     exceptionGen.io.enq(i).bits.hasException := io.enq.req(i).bits.hasException
     exceptionGen.io.enq(i).bits.isEnqExcp := io.enq.req(i).bits.hasException
     exceptionGen.io.enq(i).bits.isFetchMalAddr := io.enq.req(i).bits.isFetchMalAddr
     exceptionGen.io.enq(i).bits.flushPipe := io.enq.req(i).bits.flushPipe
+    exceptionGen.io.enq(i).bits.satpFlush := false.B
     exceptionGen.io.enq(i).bits.isVset := io.enq.req(i).bits.isVset
     exceptionGen.io.enq(i).bits.replayInst := false.B
     XSError(canEnqueue(i) && io.enq.req(i).bits.replayInst, "enq should not set replayInst")
@@ -1224,10 +1228,12 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     exc_wb.bits.ftqPtr          := 0.U.asTypeOf(exc_wb.bits.ftqPtr)
     exc_wb.bits.ftqOffset       := 0.U.asTypeOf(exc_wb.bits.ftqOffset)
     exc_wb.bits.exceptionVec    := wb.bits.exceptionVec
+    exc_wb.bits.satpFlushFirstFetchFault := false.B
     exc_wb.bits.hasException    := wb.bits.exceptionVec.orR // Todo: use io.writebackNeedFlush(i) instead
     exc_wb.bits.isEnqExcp       := false.B
     exc_wb.bits.isFetchMalAddr  := false.B
     exc_wb.bits.flushPipe       := wb.bits.flushPipe.getOrElse(false.B)
+    exc_wb.bits.satpFlush       := wb.bits.satpFlush.getOrElse(false.B)
     exc_wb.bits.isVset          := false.B
     exc_wb.bits.replayInst      := wb.bits.replay.getOrElse(false.B)
     exc_wb.bits.singleStep      := false.B

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -316,8 +316,10 @@ class RobExceptionInfo(exceptList: Seq[Int]=ExceptionNO.all)(implicit p: Paramet
   // 0: is execute exception, 1: is fetch exception
   val isEnqExcp = Bool()
   val exceptionVec = ExceptSparseVec(exceptList)
+  val satpFlushFirstFetchFault = Bool()
   val isFetchMalAddr = Bool()
   val flushPipe = Bool()
+  val satpFlush = Bool()
   val isVset = Bool()
   val replayInst = Bool() // redirect to that inst itself
   val singleStep = Bool() // TODO add frontend hit beneath

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -99,6 +99,7 @@ class FtqFetchRequest(implicit p: Parameters) extends FrontendBundle with HasICa
   val ftqIdx:              FtqPtr          = new FtqPtr
   val vSetIdx:             Vec[UInt]       = Vec(PortNumber, UInt(idxBits.W))
   val hasBackendException: Bool            = Bool()
+  val hasSatpFlush:        Bool            = Bool()
 }
 
 class FtqToICacheIO(implicit p: Parameters) extends FrontendBundle {
@@ -312,6 +313,7 @@ class FetchToIBuffer(implicit p: Parameters) extends FrontendBundle {
 
   val exceptionType:      ExceptionType = new ExceptionType
   val isBackendException: Bool          = Bool()
+  val hasSatpFlush:       Bool          = Bool()
   val exceptionCrossPage: Bool          = Bool()
   val exceptionMask:      Vec[Bool]     = Vec(IBufferEnqueueWidth, Bool())
 

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -137,20 +137,24 @@ class Ftq(implicit p: Parameters) extends FtqModule
   private val redirect = Mux(backendRedirect.valid, backendRedirect, ifuRedirect)
 
   // Instruction page fault, guest page fault, and access fault are checked by backend and sent with redirect requests.
-  private val backendException    = RegInit(ExceptionType.None)
-  private val backendExceptionPtr = RegInit(FtqPtr(false.B, 0.U))
+  private val backendException = RegInit(ExceptionType.None)
+  private val hasSatpFlush     = RegInit(false.B)
+  private val backendFlagPtr   = RegInit(FtqPtr(false.B, 0.U))
+  private def hasBackendFlag   = backendException.hasException || hasSatpFlush
   when(backendRedirect.valid) {
     val exception = ExceptionType.fromBackend(backendRedirect.bits)
     backendException := exception
-    when(exception.hasException) {
-      backendExceptionPtr := backendRedirect.bits.newFtqIdx
+    hasSatpFlush     := backendRedirect.bits.satpFlush
+    when(backendRedirect.bits.hasBackendFault || backendRedirect.bits.satpFlush) {
+      backendFlagPtr := backendRedirect.bits.newFtqIdx
     }
-  }.elsewhen(distanceBetween(fetchPtr(0), backendExceptionPtr) >= 3.U) {
+  }.elsewhen(distanceBetween(fetchPtr(0), backendFlagPtr) >= 3.U) {
     // We cannot clear backendException flag too early (e.g. once fetch fire),
     // bpu may do an override and the flag can be lost in such case.
     // Here we use a magic number 3 (the length of ifu pipeline):
     //   if fetchPtr is ahead 3 fetch blocks, the marked block should be in ibuffer and cannot be flushed by bpu.
     backendException := ExceptionType.None
+    hasSatpFlush     := false.B
   }
 
   // --------------------------------------------------------------------------------
@@ -268,8 +272,8 @@ class Ftq(implicit p: Parameters) extends FtqModule
     distanceBetween(bpuPtr(0), pfPtr(0)) > 3.U &&
       // they also need to be on the same page, to prevent extra itlb port
       prefetchReq(0).vPageNumber === prefetchReq(1).vPageNumber &&
-      // and they cannot have known exception, otherwise we'll prefetch on the wrong path
-      !(backendException.hasException && (backendExceptionPtr === pfPtr(0) || backendExceptionPtr === pfPtr(1)))
+      // and they cannot have known exception or pending satp flush, or we may mark them on the wrong fetch block
+      !(hasBackendFlag && (backendFlagPtr === pfPtr(0) || backendFlagPtr === pfPtr(1)))
 
   // (io.toICache.toPrefetch.fire && twoPrefetchValid) is passed to apply(..., canAssert) to prevent assert(x-state)
   private val twoPrefetchCase = TwoPrefetchCase(prefetchReq, io.toICache.toPrefetch.fire && canTwoPrefetch)
@@ -277,13 +281,17 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // FIXME: backend redirect delay should be more than ITLB csr delay
   io.toICache.toPrefetch.valid := bpuPtr(0) > pfPtr(0) && !redirect.valid
   io.toICache.toPrefetch.bits.req.zipWithIndex.foreach { case (req, i) =>
-    req.startVAddr       := prefetchReq(i).startVAddr
-    req.nextLineVAddr    := prefetchReq(i).nextLineVAddr
-    req.vSetIdx          := prefetchReq(i).vSetIdx
-    req.isCrossLine      := prefetchReq(i).isCrossLine
-    req.ftqIdx           := pfPtr(i)
-    req.backendException := Mux(backendExceptionPtr === pfPtr(i), backendException, ExceptionType.None)
-    req.isSoftPrefetch   := false.B
+    req.startVAddr    := prefetchReq(i).startVAddr
+    req.nextLineVAddr := prefetchReq(i).nextLineVAddr
+    req.vSetIdx       := prefetchReq(i).vSetIdx
+    req.isCrossLine   := prefetchReq(i).isCrossLine
+    req.ftqIdx        := pfPtr(i)
+    if (i == 0) {
+      req.backendException := Mux(backendFlagPtr === pfPtr(0), backendException, ExceptionType.None)
+    } else { // we can do 2-prefetch only when !hasBackendFlag, so setting backendException on i != 0 is useless
+      req.backendException := ExceptionType.None
+    }
+    req.isSoftPrefetch := false.B
   }
   io.toICache.toPrefetch.bits.twoPrefetchCase := Mux(canTwoPrefetch, twoPrefetchCase, TwoPrefetchCase.Conflict)
 
@@ -299,22 +307,28 @@ class Ftq(implicit p: Parameters) extends FtqModule
   private val rawTwoFetchValid = distanceBetween(bpuPtr(0), fetchPtr(0)) > 3.U &&
     (fetchReq(0).size +& fetchReq(1).size) <= FetchBlockInstNum.U && // the unit of fetchReq size is half-word
     fetchReq(0).vPageNumber === fetchReq(1).vPageNumber &&
-    !(backendException.hasException && (
-      backendExceptionPtr === fetchPtr(0) || backendExceptionPtr === fetchPtr(1)
-    ))
+    !(hasBackendFlag && (backendFlagPtr === fetchPtr(0) || backendFlagPtr === fetchPtr(1)))
 
   io.toICache.toMainPipe.valid := bpuPtr(0) > fetchPtr(0) && !redirect.valid &&
     distanceBetween(fetchPtr(0), commitPtr(0)) < (FtqSize - 1).U
   io.toICache.toMainPipe.bits.req.zipWithIndex.foreach { case (req, i) =>
-    req.valid               := (if (i == 0) true.B else rawTwoFetchValid)
-    req.startVAddr          := fetchReq(i).startVAddr
-    req.nextLineVAddr       := fetchReq(i).nextLineVAddr
-    req.taken               := fetchReq(i).taken
-    req.endPosition         := fetchReq(i).endPosition
-    req.bankSel             := fetchReq(i).bankSel
-    req.ftqIdx              := fetchPtr(i)
-    req.vSetIdx             := fetchReq(i).vSetIdx
-    req.hasBackendException := backendException.hasException && backendExceptionPtr === fetchPtr(i)
+    req.valid         := (if (i == 0) true.B else rawTwoFetchValid)
+    req.startVAddr    := fetchReq(i).startVAddr
+    req.nextLineVAddr := fetchReq(i).nextLineVAddr
+    req.taken         := fetchReq(i).taken
+    req.endPosition   := fetchReq(i).endPosition
+    req.bankSel       := fetchReq(i).bankSel
+    req.ftqIdx        := fetchPtr(i)
+    req.vSetIdx       := fetchReq(i).vSetIdx
+    if (i == 0) {
+      req.hasBackendException := backendFlagPtr === fetchPtr(i) && backendException.hasException
+      req.hasSatpFlush        := backendFlagPtr === fetchPtr(i) && hasSatpFlush
+    } else {
+      // similar to 2-prefetch, setting these flags on i != 0 is useless, ICache/Ifu cannot handle them
+      req.hasBackendException := false.B
+      req.hasSatpFlush        := false.B
+    }
+
   }
 
   // --------------------------------------------------------------------------------
@@ -688,8 +702,8 @@ class Ftq(implicit p: Parameters) extends FtqModule
     io.toICache.toPrefetch.fire && !io.toICache.toPrefetch.bits.twoPrefetchCase.valid,
     Seq(
       ("fb_not_enough", distanceBetween(bpuPtr(0), pfPtr(0)) <= 3.U),
-      ("fb1_exception", backendException.hasException && backendExceptionPtr === pfPtr(0)),
-      ("fb2_exception", backendException.hasException && backendExceptionPtr === pfPtr(1)),
+      ("fb1_exception", backendException.hasException && backendFlagPtr === pfPtr(0)),
+      ("fb2_exception", backendException.hasException && backendFlagPtr === pfPtr(1)),
       ("page_conflict", prefetchReq(0).vPageNumber =/= prefetchReq(1).vPageNumber),
       ("sram_conflict", twoPrefetchCase.isConflict)
     ),
@@ -712,8 +726,8 @@ class Ftq(implicit p: Parameters) extends FtqModule
     io.toICache.toMainPipe.fire && !io.fromICache.fromMainPipe.realTwoFetchValid,
     Seq(
       ("fb_not_enough", distanceBetween(bpuPtr(0), fetchPtr(0)) <= 3.U),
-      ("fb1_exception", backendException.hasException && backendExceptionPtr === fetchPtr(0)),
-      ("fb2_exception", backendException.hasException && backendExceptionPtr === fetchPtr(1)),
+      ("fb1_exception", backendException.hasException && backendFlagPtr === fetchPtr(0)),
+      ("fb2_exception", backendException.hasException && backendFlagPtr === fetchPtr(1)),
       ("total_size", (fetchReq(0).size +& fetchReq(1).size) > FetchBlockInstNum.U),
       ("page_conflict", fetchReq(0).vPageNumber =/= fetchReq(1).vPageNumber)
     ) ++ TwoFetchFailReason.getValidSeq(io.fromICache.fromMainPipe.perf_twoFetchFailReason),

--- a/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
@@ -89,6 +89,7 @@ class IBufEntry(implicit p: Parameters) extends IBufferBundle {
     result.exceptionType      := exception.exceptionType
     result.exceptionCrossPage := exception.exceptionCrossPage
     result.isBackendException := exception.isBackendException
+    result.hasSatpFlush       := exception.hasSatpFlush
     result.triggered          := triggered
     result.isLastInFtqEntry   := isLastInFtqEntry
     result.debug_seqNum       := debug_seqNum
@@ -101,11 +102,13 @@ class IBufExceptionEntry(implicit p: Parameters) extends IBufferBundle {
   val exceptionType:      ExceptionType = new ExceptionType
   val exceptionCrossPage: Bool          = Bool()
   val isBackendException: Bool          = Bool()
+  val hasSatpFlush:       Bool          = Bool()
 
   def fromFetch(fetch: FetchToIBuffer): IBufExceptionEntry = {
     exceptionType      := fetch.exceptionType
     exceptionCrossPage := fetch.exceptionCrossPage
     isBackendException := fetch.isBackendException
+    hasSatpFlush       := fetch.hasSatpFlush
     this
   }
 }
@@ -124,6 +127,7 @@ class IBufOutEntry(implicit p: Parameters) extends IBufferBundle {
   val exceptionType:      ExceptionType = new ExceptionType
   val exceptionCrossPage: Bool          = Bool()
   val isBackendException: Bool          = Bool()
+  val hasSatpFlush:       Bool          = Bool()
   val triggered:          UInt          = TriggerAction()
   val isLastInFtqEntry:   Bool          = Bool()
   val instrEndOffset:     UInt          = UInt(FetchBlockInstOffsetWidth.W)
@@ -141,6 +145,7 @@ class IBufOutEntry(implicit p: Parameters) extends IBufferBundle {
     cf.exceptionVec(ExceptionNO.illegalInstr)        := exceptionType.isIll
     cf.exceptionVec(ExceptionNO.hardwareError)       := exceptionType.isHwe
     cf.backendException                              := isBackendException
+    cf.satpFlushFirstFetchFault                      := hasSatpFlush && exceptionType.hasException
     cf.trigger                                       := triggered
     cf.isRvc                                         := isRvc
     cf.fixedTaken                                    := fixedTaken

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -208,6 +208,7 @@ class ICacheRespBundle(implicit p: Parameters) extends ICacheBundle {
 class ICacheMeta(implicit p: Parameters) extends ICacheBundle {
   val exception:          ExceptionType = new ExceptionType
   val pmpMmio:            Bool          = Bool()
+  val hasSatpFlush:       Bool          = Bool()
   val isBackendException: Bool          = Bool()
   val isForVSnonLeafPTE:  Bool          = Bool()
   val itlbPbmt:           UInt          = UInt(Pbmt.width.W)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -406,6 +406,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     req.icacheMeta.exception          := s1_exceptionOut
     req.icacheMeta.pmpMmio            := s1_pmpMmio
     req.icacheMeta.isBackendException := s1_req(i).hasBackendException
+    req.icacheMeta.hasSatpFlush       := s1_req(i).hasSatpFlush
     req.icacheMeta.isForVSnonLeafPTE  := s1_exceptionInfo(i).isForVSnonLeafPTE
     req.icacheMeta.itlbPbmt           := s1_wayLookupEntry(i).itlbPbmt
     req.icacheMeta.pAddr              := getPAddrFromPTag(s1_vAddr(2 * i), s1_pTag)

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -523,10 +523,11 @@ class Ifu(implicit p: Parameters) extends IfuModule
   io.toIBuffer.bits.foldpc := s2_alignedFoldPc
   // mark the exception only on first instruction
   io.toIBuffer.bits.exceptionType := s2_icacheMeta(0).exception || s2_rvcException
-  // backendException only needs to be set for the first instruction.
+  // backend flags only needs to be set for the first instruction.
   // Other instructions in the same block may have pf or af set,
   // which is a side effect of the first instruction and actually not necessary.
   io.toIBuffer.bits.isBackendException := s2_icacheMeta(0).isBackendException
+  io.toIBuffer.bits.hasSatpFlush       := s2_icacheMeta(0).hasSatpFlush
   // if we have last half RV-I instruction, and has exception, we need to tell backend to caculate the correct pc
   io.toIBuffer.bits.exceptionCrossPage := s2_icacheMeta(0).exception.hasException && s2_prevEndIsHalfRvi
   // if icache respond with exception, it's marked on entire cacheline,

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
@@ -382,6 +382,7 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
     redirect.bits.robIdx      := rollbackLqWb(i).bits.robIdx
     redirect.bits.ftqIdx      := rollbackLqWb(i).bits.ftqPtr
     redirect.bits.ftqOffset   := rollbackLqWb(i).bits.ftqOffset
+    redirect.bits.satpFlush   := false.B
     redirect.bits.stIsRVC     := stIsRVC(i)
     redirect.bits.stFtqIdx    := stFtqIdx(i)
     redirect.bits.stFtqOffset := stFtqOffset(i)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -482,7 +482,7 @@ class LoadQueueUncache(implicit p: Parameters) extends XSModule
 
   /******************************************************************
    * Forward Logic
-   * 
+   *
    * s1 response paddr, s2 response forwardData
    ******************************************************************/
 
@@ -600,6 +600,7 @@ class LoadQueueUncache(implicit p: Parameters) extends XSModule
     redirect.bits             := DontCare
     redirect.bits.isRVC       := reqSelUops(i).isRVC
     redirect.bits.robIdx      := reqSelUops(i).robIdx
+    redirect.bits.satpFlush   := false.B
     redirect.bits.ftqIdx      := reqSelUops(i).ftqPtr
     redirect.bits.ftqOffset   := reqSelUops(i).ftqOffset
     redirect.bits.level       := RedirectLevel.flush

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -1707,6 +1707,7 @@ class LoadUnitS3(param: ExeUnitParams)(
   io.rollback.bits := DontCare
   io.rollback.bits.isRVC := uop.isRVC
   io.rollback.bits.robIdx := robIdx
+  io.rollback.bits.satpFlush := false.B
   io.rollback.bits.ftqIdx := uop.ftqPtr
   io.rollback.bits.ftqOffset := uop.ftqOffset
   io.rollback.bits.level := rollbackLevel


### PR DESCRIPTION
cherry-pick and merge kmh-v2 #5860 #6058

In `TrapEntry`, `genTrapVA` expands and interprets addresses according to the translation mode - `Base, Sv39, Sv48, or Sv39x4/Sv48x4`. For example, if a `CSR` is in `Sv39` mode before a write operation and chanages to `Bare` mode after the write, the high bits of `PC` may differ. In this case, it is necessary to revert to the mode that was in effect before the `CSR` was written:
* `mepc/sepc/vsepc`
* `mtval/stval/vstval`
* `mtval2/htval`