### PR TITLE
fix(VSplit): fix split order of ordered index load

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1618,6 +1618,24 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vlSplit(i).io.toMergeBuffer <> vlMergeBuffer.io.fromSplit(i)
     vlSplit(i).io.threshold.valid := vlMergeBuffer.io.toSplit.threshold
     vlSplit(i).io.threshold.bits  := lsq.io.lqDeqPtr
+    vlSplit(i).io.fromPipeline.foreach { case port =>
+      port.zipWithIndex.map{case (sink, j) =>
+        if(j == MisalignWBPort) {
+          when(loadUnits(j).io.vecldout.valid) {
+            sink.valid := loadUnits(j).io.vecldout.valid
+            sink.bits  := loadUnits(j).io.vecldout.bits
+          } .otherwise {
+            sink.valid   := loadMisalignBuffer.io.vecWriteBack.valid
+            sink.bits    := loadMisalignBuffer.io.vecWriteBack.bits
+          }
+        }else {
+          sink.valid := loadUnits(j).io.vecldout.valid
+          sink.bits  := loadUnits(j).io.vecldout.bits
+        }
+
+      }
+    }
+
     NewPipelineConnect(
       vlSplit(i).io.out, loadUnits(i).io.vecldin, loadUnits(i).io.vecldin.fire,
       Mux(vlSplit(i).io.out.fire, vlSplit(i).io.out.bits.uop.robIdx.needFlush(io.redirect), loadUnits(i).io.vecldin.bits.uop.robIdx.needFlush(io.redirect)),

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -40,7 +40,9 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
   //TODO vdIdxReg should no longer be useful, don't delete it for now
   val vdIdxReg = RegInit(0.U(3.W))
 
-  val mergeBufferNack = io.threshold.valid && ({
+  //                                           Ensure the sequence of vec index order uop.
+  val mergeBufferNack = (io.threshold.valid || isOrderIndexed(io.in.bits.uop.fuOpType(6,5)) && !isVStore.B) &&
+   ({
     (isVStore, io.threshold.bits) match {
       case (true,  p: SqPtr) => p =/= io.in.bits.uop.sqIdx
       case (false, p: LqPtr) => p =/= io.in.bits.uop.lqIdx
@@ -418,7 +420,8 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
   /** Issue to scala pipeline**/
 
   lazy val misalignedCanGo = true.B
-  val allowIssue = (addrAligned || misalignedCanGo) && io.out.ready
+  lazy val splitCanGo      = true.B
+  val allowIssue = (addrAligned || misalignedCanGo) && io.out.ready && splitCanGo
   val issueCount = Mux(usNoSplit, 2.U, (PopCount(inActiveIssue) + PopCount(activeIssue))) // for dont need split unit-stride, issue two flow
   val dataIssued = RegInit(false.B)
 
@@ -461,7 +464,7 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
   }
 
   // out connect
-  io.out.valid := issueValid && vecActive && (addrAligned || misalignedCanGo) // TODO: inactive unit-stride uop do not send to pipeline
+  io.out.valid := issueValid && vecActive && (addrAligned || misalignedCanGo) && splitCanGo
 
   XSPerfAccumulate("out_valid",             io.out.valid)
   XSPerfAccumulate("out_fire",              io.out.fire)
@@ -522,6 +525,52 @@ class VLSplitBufferImp(implicit p: Parameters) extends VSplitBuffer(isVStore = f
   io.out.bits.uop.lqIdx := issueUop.lqIdx + splitIdx
   io.out.bits.uop.exceptionVec(loadAddrMisaligned) := !addrAligned && !issuePreIsSplit && io.out.bits.mask.orR
   io.out.bits.uop.fuType := FuType.vldu.U
+
+  // stop and wait to avoid RAR violation of order index
+  object StopAndWaitState extends ChiselEnum {
+    val idle   = Value
+    val send   = Value
+    val stop   = Value
+  }
+
+  lazy val stopWaitState     = RegInit(StopAndWaitState.idle)
+  lazy val stopWaitStateNext = WireInit(stopWaitState)
+  stopWaitState              := stopWaitStateNext
+
+  val pipelineWbValid = io.fromPipeline.get.map{case port =>
+    port.valid && port.bits.mBIndex === issueMbIndex
+  }.reduce(_ || _)
+
+  // stop and wait state
+  switch(stopWaitState) {
+    is(StopAndWaitState.idle) {
+      when(isOrderIndexed(issueInstType) && io.out.fire && !splitFinish && !needCancel) { // have one active element issue, only order index need it
+        stopWaitStateNext := StopAndWaitState.stop
+      }
+    }
+    is(StopAndWaitState.send) {
+      when(splitFinish || needCancel) {
+        stopWaitStateNext := StopAndWaitState.idle
+      }.elsewhen(io.out.fire) {
+        stopWaitStateNext := StopAndWaitState.stop
+      }
+    }
+    is(StopAndWaitState.stop) {
+      when(splitFinish || needCancel) {
+        stopWaitStateNext := StopAndWaitState.idle
+      }.elsewhen(pipelineWbValid) {
+        stopWaitStateNext := StopAndWaitState.send
+      }
+    }
+  }
+
+  // if it's a normal vector instruction, it will always be idle.
+  // if it's a order index instruction, it will wait element writeback after first active element issue.
+  override lazy val splitCanGo = stopWaitState =/= StopAndWaitState.stop
+
+  XSError((stopWaitState === StopAndWaitState.stop || stopWaitState === StopAndWaitState.send) &&
+    !isOrderIndexed(issueInstType), "normal vector load instruction do not need to wait!\n")
+  XSError(!allocated && stopWaitState =/= StopAndWaitState.idle, "invalid entry do not need to wait!\n")
 }
 
 class VSSplitPipelineImp(implicit p: Parameters) extends VSplitPipeline(isVStore = true){
@@ -556,6 +605,7 @@ class VLSplitImp(implicit p: Parameters) extends VLSUModule{
 
   // Split Buffer
   splitBuffer.io.redirect <> io.redirect
+  splitBuffer.io.fromPipeline.get := io.fromPipeline.get
   io.out <> splitBuffer.io.out
 }
 

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -247,6 +247,7 @@ class VSplitIO(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBund
   val vstd                = OptionWrapper(isVStore, Valid(new MemExuOutput(isVector = true)))
   val vstdMisalign        = OptionWrapper(isVStore, new storeMisaignIO)
   val threshold           = if(isVStore) Flipped(ValidIO(new SqPtr)) else Flipped(ValidIO(new LqPtr))
+  val fromPipeline        = OptionWrapper(!isVStore, Vec(LoadPipelineWidth, Flipped(ValidIO(new VecPipelineFeedbackIO(isVStore)))))
 }
 
 class VSplitPipelineIO(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle{
@@ -263,6 +264,7 @@ class VSplitBufferIO(isVStore: Boolean=false)(implicit p: Parameters) extends VL
   val out                 = Decoupled(new VecPipeBundle(isVStore))//to scala pipeline
   val vstd                = OptionWrapper(isVStore, ValidIO(new MemExuOutput(isVector = true)))
   val vstdMisalign        = OptionWrapper(isVStore, new storeMisaignIO)
+  val fromPipeline        = OptionWrapper(!isVStore, Vec(LoadPipelineWidth, Flipped(ValidIO(new VecPipelineFeedbackIO(isVStore)))))
 }
 
 class VMergeBufferIO(isVStore : Boolean=false)(implicit p: Parameters) extends VLSUBundle{

--- a/src/main/scala/xiangshan/mem/vector/VecCommon.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecCommon.scala
@@ -92,6 +92,7 @@ trait HasVLSUParameters extends HasXSParameter with VLSUConstants {
   def isNotIndexed(instType: UInt) = instType(0) === "b0".U
   def isSegment(instType: UInt) = instType(2) === "b1".U
   def is128Bit(alignedType: UInt) = alignedType(2) === "b1".U
+  def isOrderIndexed(instType: UInt) = instType === "b11".U
 
   def mergeDataWithMask(oldData: UInt, newData: UInt, mask: UInt): Vec[UInt] = {
     require(oldData.getWidth == newData.getWidth)


### PR DESCRIPTION
Modify:

	* The order index load split and get data one by one. implementing wait-and-go using a state machine.

	* The uop of order index load need wait it become head of load queue. ensure that uops are executed sequence.

Potential Risks:

	* The timing of issue will deteriorate.

	* The timing of send request to LDU will deteriorate.

	* The performance of order index load will deteriorate.