### PR TITLE
submodule(difftest): expose cpu/mem AXI4 for fpgadiff

### DIFF
--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -20,7 +20,7 @@ package top
 import chisel3._
 import chisel3.util._
 import chisel3.experimental.dataview._
-import difftest.{DifftestModule, HasDiffTestInterfaces}
+import difftest.{DifftestMemIO, DifftestModule, HasDiffTestInterfaces}
 import xiangshan._
 import utils._
 import utility._
@@ -489,6 +489,7 @@ class XSTileDiffTop(implicit p: Parameters) extends XSTop {
     override def cpuName: Option[String] = Some("XiangShan")
     override protected def implicitClock: Clock = io.clock
     override protected def implicitReset: Reset = io.reset
+    override def difftestMemIO: Option[DifftestMemIO] = Some(DifftestMemIO(memory))
   }
   override lazy val module = new XSTileDiffTopImp(this)
 }

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -23,6 +23,7 @@ import chisel3.util._
 import chisel3.experimental.dataview._
 import device.{AXI4MemorySlave, SimJTAG}
 import difftest._
+import difftest.fpga.DifftestMemCtrl
 import freechips.rocketchip.amba.axi4.AXI4Bundle
 import freechips.rocketchip.diplomacy.{DisableMonitors, LazyModule}
 import freechips.rocketchip.util.HeterogeneousBag
@@ -56,7 +57,8 @@ class XiangShanSim(implicit p: Parameters) extends Module with HasDiffTestInterf
     dynamicLatency = debugOpts.UseDRAMSim
   )
   val simAXIMem = Module(l_simAXIMem.module)
-  l_simAXIMem.io_axi4.elements.head._2 :<>= soc.memory.viewAs[AXI4Bundle].waiveAll
+  val memIO = DifftestMemCtrl.exposeIO(soc.memory.viewAs[AXI4Bundle], l_simAXIMem.io_axi4.elements.head._2)
+  override def difftestMemIO: Option[DifftestMemIO] = Some(memIO)
 
   soc.io.clock := clock
   soc.io.reset := (reset.asBool || soc.io.debug_reset).asAsyncReset


### PR DESCRIPTION
This change expose AXI4 of cpu/mem to difftest, so difftest can write/init DDR with unified AXI4 selected from cpu and init stream.

Note we use Difftest (instead of XS) AXI4Bundle type for XiangShanSim, which explictly set type of exposed CPU/MEM IO to avoid implicit direction from Diplomacy (such as AXI4MemorySlave).

And for FPGA, we will exposed cpu IO as XiangShan AXI4Type to keep ports same as XSTop.