### PR TITLE
fix(LoadUnit, DCache): requests killed no longer read the bank

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -307,7 +307,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s1_will_send_miss_req = s1_valid && !s1_nack && !s1_hit
 
   // data read
-  io.banked_data_read.valid := s1_fire && !s1_nack && !s1_is_prefetch
+  io.banked_data_read.valid := s1_fire && !s1_nack && !s1_is_prefetch && !io.lsu.s1_kill_data_read
   io.banked_data_read.bits.addr := s1_vaddr
   io.banked_data_read.bits.addr_dup := s1_vaddr_dup
   io.banked_data_read.bits.kill := io.lsu.s1_kill_data_read

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -936,6 +936,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   val s1_hw_prf           = s1_in.isHWPrefetch
   val s1_sw_prf           = s1_prf && !s1_hw_prf
   val s1_tlb_memidx       = io.tlb.resp.bits.memidx
+  val s1_misalign_kill    = RegEnable(s0_rs_cross16Bytes && !s0_addr_aligned && !s0_hw_prf_select, false.B, s0_fire)
 
   s1_vaddr_hi         := s1_in.vaddr(VAddrBits - 1, 6)
   s1_vaddr_lo         := s1_in.vaddr(5, 0)
@@ -955,8 +956,8 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   io.dcache.s1_paddr_dup_lsu    <> s1_paddr_dup_lsu
   io.dcache.s1_paddr_dup_dcache <> s1_paddr_dup_dcache
-  io.dcache.s1_kill             := s1_kill || s1_dly_err || s1_tlb_miss || s1_exception
-  io.dcache.s1_kill_data_read   := s1_kill || s1_dly_err || s1_tlb_fast_miss
+  io.dcache.s1_kill             := s1_kill || s1_dly_err || s1_tlb_miss || s1_exception || s1_misalign_kill
+  io.dcache.s1_kill_data_read   := s1_misalign_kill
 
   // store to load forwarding
   io.sbuffer.valid := s1_valid && !(s1_exception || s1_tlb_miss || s1_kill || s1_dly_err || s1_prf)


### PR DESCRIPTION
**Bug Symptom:** Vector load hangs due to misalignment

**Cause Analysis:** 
For vec loads, when newer misaligned elements occupy the misalignbuffer, older elements can be dispatched from the replayqueue; however, these older elements may cause bank conflicts with load requests from the misalignbuffer. Since the elements in the misalignbuffer are newer, they will trigger bank conflicts. At the same time, because misaligned elements from the replay queue cannot enter the misalign buffer, they enter the replay queue to await reissuance. This leads to a deadlock.

**Fix:**
In fact, elements that need to enter the misalign buffer do not need to read the bank, as they will not be reading data on this occasion.