### PR TITLE
ci(emu): dump wave to PERF_HOME in basics/performace

### DIFF
--- a/.github/workflows/emu-basics.yml
+++ b/.github/workflows/emu-basics.yml
@@ -12,7 +12,6 @@ env:
   NEMU_HOME: /nfs/home/share/ci-workloads/NEMU
   AM_HOME: /nfs/home/share/ci-workloads/nexus-am
   PERF_HOME: /nfs/home/ci-runner/emu-basics/${{ github.run_number }}
-  WAVE_HOME: /nfs/home/ci-runner/emu-basics/${{ github.run_number }}/wave
 
 jobs:
   changes:
@@ -49,7 +48,7 @@ jobs:
           submodules: true
       - name: Init
         run: |
-          mkdir -p ${PERF_HOME} ${WAVE_HOME}
+          mkdir -p ${PERF_HOME}
           make init-force
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py --clean
       - name: Build EMU
@@ -127,7 +126,7 @@ jobs:
         shell: bash
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
-            --wave-dump ${WAVE_HOME} \
+            --wave-dump ${PERF_HOME} \
             --numa --threads 8 \
             ${{ matrix.workload || format('--ci {0}', matrix.name) }} \
             ${{ matrix.extra }} \

--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -13,7 +13,6 @@ env:
   NEMU_HOME: /nfs/home/share/ci-workloads/NEMU
   AM_HOME: /nfs/home/share/ci-workloads/nexus-am
   PERF_HOME: /nfs/home/ci-runner/emu-performance/${{ github.run_number }}
-  WAVE_HOME: /nfs/home/ci-runner/emu-performance/${{ github.run_number }}/wave
   CKPT_HOME: /nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260122/checkpoint-0-0-0
 
 jobs:
@@ -53,7 +52,7 @@ jobs:
           submodules: true
       - name: Init
         run: |
-          mkdir -p ${PERF_HOME} ${WAVE_HOME}
+          mkdir -p ${PERF_HOME}
           make init-force
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py --clean
       - name: Build EMU
@@ -126,7 +125,7 @@ jobs:
         run: |
           # TODO: remove --disable-fork to enable lightSSS when gsim supports it
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
-            --wave-dump ${WAVE_HOME} \
+            --wave-dump ${PERF_HOME} \
             --numa --threads 1 \
             --max-instr 5000000 \
             --disable-fork \
@@ -239,7 +238,7 @@ jobs:
           echo "Running checkpoint: ${CKPT}"
           # TODO: remove --disable-fork to enable lightSSS when gsim supports it
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
-            --wave-dump ${WAVE_HOME} \
+            --wave-dump ${PERF_HOME} \
             --numa --threads 1 \
             --max-instr 5000000 \
             --disable-fork \


### PR DESCRIPTION
in these 2 workflows, we copied built emu to PERF_HOME to enable runner parallelism

and in xiangshan.py, it will copy emu & waveform to WAVE_HOME when failed

this result in redundant storage in /nfs/home/ci-runner/emu-{basics/performace}

since waveforms are named {time}_{begin-cycle}.fst, we don't need to worry about conflicts, so let's store it directly in PERF_HOME