### PR TITLE
fix(MemBlock): fix logic for misaligned vector store split issues

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1607,9 +1607,6 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     vsSplit(i).io.vstdMisalign.get.storeMisalignBufferEmpty  := storeMisalignBuffer.io.toVecSplit.empty
     vsSplit(i).io.vstdMisalign.get.scalaIssueValid := storeUnits(i).io.stin.valid
     vsSplit(i).io.vstdMisalign.get.scalaIssueRobIdx := storeUnits(i).io.stin.bits.uop.robIdx
-    vsSplit(i).io.vstdMisalign.get.storePipeEmpty := !storeUnits.map(_.io.s1_s2_valid).reduce(_||_)
-    storeUnits(i).io.vecMisalignBlockScalaIssue := vsSplit.map(_.io.vstdMisalign.get.blockScalaIssue).reduce(_||_)
-
   }
   (0 until VlduCnt).foreach{i =>
     vlSplit(i).io.redirect <> redirect

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -76,7 +76,6 @@ class StoreUnit(implicit p: Parameters) extends XSModule
     val sqCommitRobIdx = Input(new RobPtr)
 
     val s1_s2_valid = Output(Bool())
-    val vecMisalignBlockScalaIssue = Input(Bool())
 
   })
 

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -477,7 +477,7 @@ class VSSplitBufferImp(implicit p: Parameters) extends VSplitBuffer(isVStore = t
   lazy val canToMisalignBuffer = io.vstdMisalign.get.storeMisalignBufferEmpty &&
     (!io.vstdMisalign.get.scalaIssueValid || issueUop.robIdx < io.vstdMisalign.get.scalaIssueRobIdx)
 
-  override lazy val misalignedCanGo = io.vstdMisalign.get.storePipeEmpty && canToMisalignBuffer
+  override lazy val misalignedCanGo = canToMisalignBuffer
 
   // split data
   val splitData = genVSData(
@@ -517,8 +517,6 @@ class VSSplitBufferImp(implicit p: Parameters) extends VSplitBuffer(isVStore = t
     vstd.bits.vecDebug.get.start  := Mux(splitIdx === 0.U, usVaddrOffset, 0.U)// for unaligned store event
     vstd.bits.vecDebug.get.offset := usVaddrOffset
   }
-
-  io.vstdMisalign.get.blockScalaIssue := RegNext(issueValid && canToMisalignBuffer && !addrAligned)
 }
 
 class VLSplitBufferImp(implicit p: Parameters) extends VSplitBuffer(isVStore = false){

--- a/src/main/scala/xiangshan/mem/vector/VecBundle.scala
+++ b/src/main/scala/xiangshan/mem/vector/VecBundle.scala
@@ -230,13 +230,10 @@ class FeedbackToLsqIO(implicit p: Parameters) extends VLSUBundle{
   def isLast = feedback(VecFeedbacks.LAST)
 }
 
-class storeMisaignIO(implicit p: Parameters) extends Bundle{
-  val storePipeEmpty            = Input(Bool())
+class storeMisalignIO(implicit p: Parameters) extends Bundle{
   val storeMisalignBufferEmpty  = Input(Bool())
   val scalaIssueValid           = Input(Bool())
   val scalaIssueRobIdx          = Input(new RobPtr)
-  val blockScalaIssue           = Output(Bool())
-
 }
 
 class VSplitIO(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBundle{
@@ -245,7 +242,7 @@ class VSplitIO(isVStore: Boolean=false)(implicit p: Parameters) extends VLSUBund
   val toMergeBuffer       = new ToMergeBufferIO(isVStore) //to merge buffer req mergebuffer entry
   val out                 = Decoupled(new VecPipeBundle(isVStore))// to scala pipeline
   val vstd                = OptionWrapper(isVStore, Valid(new MemExuOutput(isVector = true)))
-  val vstdMisalign        = OptionWrapper(isVStore, new storeMisaignIO)
+  val vstdMisalign        = OptionWrapper(isVStore, new storeMisalignIO)
   val threshold           = if(isVStore) Flipped(ValidIO(new SqPtr)) else Flipped(ValidIO(new LqPtr))
   val fromPipeline        = OptionWrapper(!isVStore, Vec(LoadPipelineWidth, Flipped(ValidIO(new VecPipelineFeedbackIO(isVStore)))))
 }
@@ -263,7 +260,7 @@ class VSplitBufferIO(isVStore: Boolean=false)(implicit p: Parameters) extends VL
   val in                  = Flipped(Decoupled(new VLSBundle()))
   val out                 = Decoupled(new VecPipeBundle(isVStore))//to scala pipeline
   val vstd                = OptionWrapper(isVStore, ValidIO(new MemExuOutput(isVector = true)))
-  val vstdMisalign        = OptionWrapper(isVStore, new storeMisaignIO)
+  val vstdMisalign        = OptionWrapper(isVStore, new storeMisalignIO)
   val fromPipeline        = OptionWrapper(!isVStore, Vec(LoadPipelineWidth, Flipped(ValidIO(new VecPipelineFeedbackIO(isVStore)))))
 }
 


### PR DESCRIPTION
**Bug Symptom:** 
Vector misaligned store instructions are stuck.


**Cause Analysis:** 
Under the previous mechanism, non-vector misaligned stores had to wait for two store units to become idle before they could execute. If the vector misaligned store was the oldest instruction at that time, the store unit might continuously replay younger misaligned stores, preventing the oldest vector store from executing.

**Fix:**
Now that we have the ability to reissue vector store UOPs on an element-by-element basis, we theoretically no longer need to wait for the store unit to be empty.