### PR TITLE
feat(MMU): do not cache pageFault pte entries in TLB

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -580,6 +580,9 @@ class TlbCsrBundle(implicit p: Parameters) extends XSBundle {
   }
   val mPBMTE = Bool()
   val hPBMTE = Bool()
+  val pfRefresh = new Bundle {
+    val enable = Bool()
+  }
   val pmm = new Bundle {
     val mseccfg = UInt(2.W)
     val menvcfg = UInt(2.W)

--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -339,7 +339,7 @@ class L2TopInlined()(implicit p: Parameters) extends LazyModule
       io.l2_tlb_req.req.bits.cmd := l2.io.l2_tlb_req.req.bits.cmd
       io.l2_tlb_req.req.bits.size := l2.io.l2_tlb_req.req.bits.size
       io.l2_tlb_req.req.bits.kill := l2.io.l2_tlb_req.req.bits.kill
-      io.l2_tlb_req.req.bits.isPrefetch := l2.io.l2_tlb_req.req.bits.isPrefetch
+      io.l2_tlb_req.req.bits.fromHwPrefetch := l2.io.l2_tlb_req.req.bits.isPrefetch
       io.l2_tlb_req.req.bits.no_translate := l2.io.l2_tlb_req.req.bits.no_translate
       io.l2_tlb_req.req_kill := l2.io.l2_tlb_req.req_kill
       io.perfEvents := l2.io_perf

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRCustom.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRCustom.scala
@@ -104,6 +104,7 @@ class SlvpredctlBundle extends CSRBundle {
 }
 
 class SmblockctlBundle extends CSRBundle {
+  val PF_REFRESH_ENABLE                = RW(  32).withReset(true.B).withDescription("Enable clearing page-fault entries on L1 TLB hits.")
   val SBUFFER_TIMEOUT                  = SbufferTimeout(31, 10).withReset(SbufferTimeout.initValue).withDescription("Store-buffer flush timeout.")
   val HD_MISALIGN_LD_ENABLE            = RW(   9).withReset(true.B).withDescription("Enable hardware handling of misaligned loads.")
   val HD_MISALIGN_ST_ENABLE            = RW(   8).withReset(true.B).withDescription("Enable hardware handling of misaligned stores.")

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -220,6 +220,7 @@ class NewCSR(implicit val p: Parameters) extends Module
       val dvirt = Bool()
       val mPBMTE = Bool()
       val hPBMTE = Bool()
+      val pfRefreshEnable = Bool()
       val pmm = new Bundle {
         val mseccfg = UInt(2.W)
         val menvcfg = UInt(2.W)
@@ -1467,6 +1468,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   io.tlb.debug := debugMode
   io.tlb.mPBMTE := RegNext(menvcfg.regOut.PBMTE.asBool)
   io.tlb.hPBMTE := RegNext(henvcfg.regOut.PBMTE.asBool)
+  io.tlb.pfRefreshEnable := RegNext(smblockctl.regOut.PF_REFRESH_ENABLE.asBool)
   io.tlb.pmm.mseccfg := RegNext(mseccfg.regOut.PMM.asUInt)
   io.tlb.pmm.menvcfg := RegNext(menvcfg.regOut.PMM.asUInt)
   io.tlb.pmm.henvcfg := RegNext(henvcfg.regOut.PMM.asUInt)

--- a/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/CSR.scala
@@ -303,6 +303,9 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   tlb.mPBMTE := csrMod.io.tlb.mPBMTE
   tlb.hPBMTE := csrMod.io.tlb.hPBMTE
 
+  // custom TLB behavior controls
+  tlb.pfRefresh.enable := csrMod.io.tlb.pfRefreshEnable
+
   // pointer masking extension
   tlb.pmm := csrMod.io.tlb.pmm
 

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -202,6 +202,7 @@ class TlbSectorEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parame
   val g_perm = new TlbPermBundle
   val vmid = UInt(vmidLen.W)
   val s2xlate = UInt(2.W)
+  val entryFromHwPrefetch = Bool()
 
 
   /** level usage:
@@ -286,7 +287,7 @@ class TlbSectorEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parame
     vpn_hit && index_hit.reduce(_ || _) && PopCount(wb_valididx) === 1.U && s2xlate_hit && pteidx_hit
   }
 
-  def apply(item: PtwRespS2): TlbSectorEntry = {
+  def apply(item: PtwRespS2withMemIdx): TlbSectorEntry = {
     this.asid := item.s1.entry.asid
     val merge_level = MuxLookup(item.s2xlate, 2.U)(Seq(
       onlyStage1 -> item.s1.entry.level.getOrElse(0.U),
@@ -376,6 +377,7 @@ class TlbSectorEntry(pageNormal: Boolean, pageSuper: Boolean)(implicit p: Parame
     this.g_pbmt := item.s2.entry.pbmt
     this.g_perm.applyS2(item.s2)
     this.s2xlate := item.s2xlate
+    this.entryFromHwPrefetch := item.fromHwPrefetch
     this
   }
 
@@ -451,6 +453,7 @@ class TlbStorageIO(nSets: Int, nWays: Int, ports: Int, nDups: Int = 1)(implicit 
     val req = Vec(ports, Flipped(DecoupledIO(new Bundle {
       val vpn = Output(UInt(vpnLen.W))
       val s2xlate = Output(UInt(2.W))
+      val fromHwPrefetch = Output(Bool())
     })))
     val resp = Vec(ports, ValidIO(new Bundle{
       val hit = Output(Bool())
@@ -464,14 +467,16 @@ class TlbStorageIO(nSets: Int, nWays: Int, ports: Int, nDups: Int = 1)(implicit 
   }
   val w = Flipped(ValidIO(new Bundle {
     val wayIdx = Output(UInt(log2Up(nWays).W))
-    val data = Output(new PtwRespS2)
+    val data = Output(new PtwRespS2withMemIdx)
   }))
+  val pfClear = Input(Bool())
   val access = Vec(ports, new ReplaceAccessBundle(nSets, nWays))
 
-  def r_req_apply(valid: Bool, vpn: UInt, i: Int, s2xlate:UInt): Unit = {
+  def r_req_apply(valid: Bool, vpn: UInt, i: Int, s2xlate: UInt, fromHwPrefetch: Bool): Unit = {
     this.r.req(i).valid := valid
     this.r.req(i).bits.vpn := vpn
     this.r.req(i).bits.s2xlate := s2xlate
+    this.r.req(i).bits.fromHwPrefetch := fromHwPrefetch
 
   }
 
@@ -479,7 +484,7 @@ class TlbStorageIO(nSets: Int, nWays: Int, ports: Int, nDups: Int = 1)(implicit 
     (this.r.resp(i).bits.hit, this.r.resp(i).bits.ppn, this.r.resp(i).bits.perm, this.r.resp(i).bits.g_perm, this.r.resp(i).bits.pbmt, this.r.resp(i).bits.g_pbmt)
   }
 
-  def w_apply(valid: Bool, wayIdx: UInt, data: PtwRespS2): Unit = {
+  def w_apply(valid: Bool, wayIdx: UInt, data: PtwRespS2withMemIdx): Unit = {
     this.w.valid := valid
     this.w.bits.wayIdx := wayIdx
     this.w.bits.data := data
@@ -492,6 +497,7 @@ class TlbStorageWrapperIO(ports: Int, q: TLBParameters, nDups: Int = 1)(implicit
     val req = Vec(ports, Flipped(DecoupledIO(new Bundle {
       val vpn = Output(UInt(vpnLen.W))
       val s2xlate = Output(UInt(2.W))
+      val fromHwPrefetch = Output(Bool())
     })))
     val resp = Vec(ports, ValidIO(new Bundle{
       val hit = Output(Bool())
@@ -504,21 +510,23 @@ class TlbStorageWrapperIO(ports: Int, q: TLBParameters, nDups: Int = 1)(implicit
     }))
   }
   val w = Flipped(ValidIO(new Bundle {
-    val data = Output(new PtwRespS2)
+    val data = Output(new PtwRespS2withMemIdx)
   }))
+  val pfClear = Input(Bool())
   val replace = if (q.outReplace) Flipped(new TlbReplaceIO(ports, q)) else null
 
-  def r_req_apply(valid: Bool, vpn: UInt, i: Int, s2xlate: UInt): Unit = {
+  def r_req_apply(valid: Bool, vpn: UInt, i: Int, s2xlate: UInt, fromHwPrefetch: Bool): Unit = {
     this.r.req(i).valid := valid
     this.r.req(i).bits.vpn := vpn
     this.r.req(i).bits.s2xlate := s2xlate
+    this.r.req(i).bits.fromHwPrefetch := fromHwPrefetch
   }
 
   def r_resp_apply(i: Int) = {
     (this.r.resp(i).bits.hit, this.r.resp(i).bits.ppn, this.r.resp(i).bits.perm, this.r.resp(i).bits.g_perm, this.r.resp(i).bits.s2xlate, this.r.resp(i).bits.pbmt, this.r.resp(i).bits.g_pbmt)
   }
 
-  def w_apply(valid: Bool, data: PtwRespS2): Unit = {
+  def w_apply(valid: Bool, data: PtwRespS2withMemIdx): Unit = {
     this.w.valid := valid
     this.w.bits.data := data
   }
@@ -570,7 +578,7 @@ class TlbReq(implicit p: Parameters) extends TlbBundle {
   val size = Output(UInt(log2Ceil(log2Ceil(VLEN/8)+1).W))
   val kill = Output(Bool()) // Use for blocked tlb that need sync with other module like icache
   val memidx = Output(new MemBlockidxBundle)
-  val isPrefetch = Output(Bool())
+  val fromHwPrefetch = Output(Bool())
   // do not translate, but still do pmp/pma check
   val no_translate = Output(Bool())
   val pmp_addr = Output(UInt(PAddrBits.W)) // load s1 send prefetch paddr
@@ -853,10 +861,6 @@ class PteBundle(implicit p: Parameters) extends PtwBundle{
     canRefill
   }
 
-  def onlyPf(levelUInt: UInt, s2xlate: UInt, pbmte: Bool) = {
-    s2xlate === noS2xlate && isPf(levelUInt, pbmte) && !isAf()
-  }
-
   override def toPrintable: Printable = {
     p"ppn:0x${Hexadecimal(ppn)} perm:b${Binary(perm.asUInt)}"
   }
@@ -996,19 +1000,14 @@ class PtwEntries(num: Int, tagLen: Int, level: Int, hasPerm: Boolean, ReservedBi
   val ppns = Vec(num, UInt(gvpnLen.W))
   // valid or not, vs = 0 will not hit
   val vs   = Vec(num, Bool())
-  // only pf or not, onlypf = 1 means only trigger pf when nox2late
+  // Kept as a width-compatible SRAM payload field. The page-fault-only refill
+  // behavior was removed, so this field is always written as false and unused
   val onlypf = Vec(num, Bool())
   val perms = if (hasPerm) Some(Vec(num, new PtePermBundle)) else None
   val prefetch = Bool()
   val reservedBits = if(ReservedBits > 0) Some(UInt(ReservedBits.W)) else None
   // println(s"PtwEntries: tag:1*${tagLen} ppns:${num}*${ppnLen} vs:${num}*1")
-  // NOTE: vs is used for different usage:
-  // for l0, which store the leaf(leaves), vs is page fault or not.
-  // for l1, which shoule not store leaf, vs is valid or not, that will anticipate in hit check
-  // Because, l1 should not store leaf(no perm), it doesn't store perm.
-  // If l1 hit a leaf, the perm is still unavailble. Should still page walk. Complex but nothing helpful.
-  // TODO: divide vs into validVec and pfVec
-  // for l1: may valid but pf, so no need for page walk, return random pte with pf.
+  // NOTE: vs is the per-sector refill-valid bit for both l0 and l1
 
   def tagClip(vpn: UInt) = {
     require(vpn.getWidth == vpnLen)
@@ -1045,11 +1044,10 @@ class PtwEntries(num: Int, tagLen: Int, level: Int, hasPerm: Boolean, ReservedBi
       val denyNapotInSector = if (hasPerm && level == 0) pte.isNapot(levelUInt) else false.B
       val isRefillEntry = pte.canRefill(levelUInt, s2xlate, pbmte, mode) &&
         (if (hasPerm) pte.isLeaf() else !pte.isLeaf())
-      val onlyPf = (if (hasPerm) pte.onlyPf(levelUInt, s2xlate, pbmte) else false.B)
       ps.pbmts(i) := pte.pbmt
       ps.ppns(i) := pte.getPPN()
-      ps.vs(i)   := (isRefillEntry || onlyPf) && !denyNapotInSector
-      ps.onlypf(i) := onlyPf && !denyNapotInSector
+      ps.vs(i) := isRefillEntry && !denyNapotInSector
+      ps.onlypf(i) := false.B
       ps.perms.map(_(i) := pte.perm)
       when (s2xlate === onlyStage2) {
         // g bit in G-stage PTEs should be ignored by hardware
@@ -1083,7 +1081,7 @@ class PTWEntriesWithEcc(eccCode: Code, num: Int, tagLen: Int, level: Int, hasPer
     val data_align_num = data_length / ecc_block
     val data_not_align = (data_length % ecc_block) != 0 // ugly code
     val data_unalign_length = data_length - data_align_num * ecc_block
-    val eccBits_unalign = eccCode.width(data_unalign_length) - data_unalign_length
+    val eccBits_unalign = if (data_not_align) eccCode.width(data_unalign_length) - data_unalign_length else 0
 
     val eccBits = eccBits_per * data_align_num + eccBits_unalign
     (eccBits, eccBits_per, data_align_num, data_unalign_length)
@@ -1138,6 +1136,8 @@ class PtwReq(implicit p: Parameters) extends PtwBundle {
 class PtwReqwithMemIdx(implicit p: Parameters) extends PtwReq {
   val memidx = new MemBlockidxBundle
   val getGpa = Bool() // this req is to get gpa when having guest page fault
+  // True only when this PTW request is sourced solely from hardware prefetch
+  val fromHwPrefetch = Bool()
 }
 
 class PtwResp(implicit p: Parameters) extends PtwBundle {
@@ -1417,6 +1417,8 @@ class PtwRespS2(implicit p: Parameters) extends PtwBundle {
 class PtwRespS2withMemIdx(implicit p: Parameters) extends PtwRespS2 {
   val memidx = new MemBlockidxBundle()
   val getGpa = Bool() // this req is to get gpa when having guest page fault
+  // True only when this response/refill should keep hardware-prefetch-origin semantics
+  val fromHwPrefetch = Bool()
 }
 
 class L2TLBIO(implicit p: Parameters) extends PtwBundle {

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -567,8 +567,8 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
       // cause llptw will trigger bitmapcheck
       // add a coniditonal logic
       // (s2x_info =/= allStage || ishptw)
-      hit := Mux(bitmapEnable && (s2x_info =/= allStage || ishptw) && !hitWayData.onlypf(pte_index), ParallelOR(hitVec) && l0bitmapreg(hitWay)(pte_index) === 1.U, ParallelOR(hitVec))
-      when (bitmapEnable && (s2x_info =/= allStage || ishptw) && !hitWayData.onlypf(pte_index) && ParallelOR(hitVec) && l0bitmapreg(hitWay)(pte_index) === 0.U) {
+      hit := Mux(bitmapEnable && (s2x_info =/= allStage || ishptw), ParallelOR(hitVec) && l0bitmapreg(hitWay)(pte_index) === 1.U, ParallelOR(hitVec))
+      when (bitmapEnable && (s2x_info =/= allStage || ishptw) && ParallelOR(hitVec) && l0bitmapreg(hitWay)(pte_index) === 0.U) {
         jmp_bitmap_check := true.B
       }
     } else {
@@ -600,13 +600,13 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   val l0HitPPN = l0HitData.ppns
   val l0HitPbmt = l0HitData.pbmts
   val l0HitPerm = l0HitData.perms.getOrElse(0.U.asTypeOf(Vec(PtwL0SectorSize, new PtePermBundle)))
-  val l0HitValid = VecInit(l0HitData.onlypf.map(!_))
+  val l0SectorValid = l0HitData.vs
   val l0Ptes = WireInit(VecInit(Seq.fill(tlbcontiguous)(0.U(XLEN.W)))) // L0 lavel Page Table Entry Vector
   val l0cfs = WireInit(VecInit(Seq.fill(tlbcontiguous)(false.B))) // L0 lavel Bitmap Check Failed Vector
   if (HasBitmapCheck) {
     for (i <- 0 until tlbcontiguous) {
       // in l0 "n" is always false
-      l0Ptes(i) := Cat(0.U(pteNLen.W), l0HitData.pbmts(i).asUInt, 0.U(pteResLen.W), 0.U((ppnHignLen+ppnLen-gvpnLen).W), l0HitPPN(i), 0.U(pteRswLen.W),l0HitPerm(i).asUInt,l0HitValid(i).asUInt)
+      l0Ptes(i) := Cat(0.U(pteNLen.W), l0HitData.pbmts(i).asUInt, 0.U(pteResLen.W), 0.U((ppnHignLen+ppnLen-gvpnLen).W), l0HitPPN(i), 0.U(pteRswLen.W),l0HitPerm(i).asUInt,l0SectorValid(i).asUInt)
       l0cfs(i) := !l0BitmapCheckResult(i)
     }
 
@@ -689,7 +689,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   check_res.l3.map(_.apply(l3Hit.get, l3Pre.get, l3HitPPN.get, l3HitPbmt.get))
   check_res.l2.apply(l2Hit, l2Pre, l2HitPPN, l2HitPbmt)
   check_res.l1.apply(l1Hit, l1Pre, l1HitPPN, l1HitPbmt, ecc = l1eccError)
-  check_res.l0.apply(l0Hit, l0Pre, l0HitPPN, l0HitPbmt, l0HitPerm, l0eccError, valid = l0HitValid, jmp_bitmap_check = l0JmpBitmapCheck, hitway = l0HitWay, ptes = l0Ptes, cfs = l0cfs)
+  check_res.l0.apply(l0Hit, l0Pre, l0HitPPN, l0HitPbmt, l0HitPerm, l0eccError, valid = l0SectorValid, jmp_bitmap_check = l0JmpBitmapCheck, hitway = l0HitWay, ptes = l0Ptes, cfs = l0cfs)
   check_res.sp.apply(spHit, spPre, spHitData.ppn, spHitData.pbmt, spHitData.n.getOrElse(0.U), spHitPerm, false.B, spHitLevel, spValid, spJmpBitmapCheck, spPte)
 
   val resp_res = Reg(new PageCacheRespBundle)
@@ -952,7 +952,11 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   XSDebug(l2Refill, p"[l2 refill] l2v:${Binary(l2v)}->${Binary(l2v | l2RfOH)} l2g:${Binary(l2g)}->${Binary((l2g & ~l2RfOH) | Mux(memPte(2).perm.g, l2RfOH, 0.U))}\n")
 
   // L1 refill
-  val l1Refill = !flush_dup(1) && refill.levelOH.l1
+  val l1Refill =
+    !flush_dup(1) &&
+    refill.levelOH.l1 &&
+    !memPte(1).isLeaf() &&
+    memPte(1).canRefill(refill.level_dup(1), refill.req_info_dup(1).s2xlate, pbmte, io.csr_dup(1).hgatp.mode)
   val l1RefillIdx = genPtwL1SetIdx(refill.req_info_dup(1).vpn).suggestName(s"l1_refillIdx")
   val l1VictimWay = replaceWrapper(getl1vSet(refill.req_info_dup(1).vpn), ptwl1replace.way(l1RefillIdx)).suggestName(s"l1_victimWay")
   val l1VictimWayOH = UIntToOH(l1VictimWay).suggestName(s"l1_victimWayOH")
@@ -995,7 +999,12 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   XSDebug(l1Refill, p"[l1 refill] l1g:${Binary(l1g)} -> ${Binary(l1g & ~l1RfvOH | Mux(Cat(memPtes.map(_.perm.g)).andR, l1RfvOH, 0.U))}\n")
 
   // L0 refill
-  val l0Refill = !flush_dup(0) && refill.levelOH.l0 && !memPte(0).isNapot(refill.level_dup(0))
+  val l0Refill =
+    !flush_dup(0) &&
+    refill.levelOH.l0 &&
+    memPte(0).isLeaf() &&
+    memPte(0).canRefill(refill.level_dup(0), refill.req_info_dup(0).s2xlate, pbmte, io.csr_dup(0).hgatp.mode) &&
+    !memPte(0).isNapot(refill.level_dup(0))
   val l0RefillIdx = genPtwL0SetIdx(refill.req_info_dup(0).vpn).suggestName(s"l0_refillIdx")
   val l0VictimWay = replaceWrapper(getl0vSet(refill.req_info_dup(0).vpn), ptwl0replace.way(l0RefillIdx)).suggestName(s"l0_victimWay")
   val l0VictimWayOH = UIntToOH(l0VictimWay).asUInt.suggestName(s"l0_victimWayOH")
@@ -1048,8 +1057,8 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   val spRefill =
     !flush_dup(0) &&
     (refill.levelOH.sp || (refill.levelOH.l0 && memPte(0).isNapot(refill.level_dup(0)))) &&
-    ((memPte(0).isLeaf() && memPte(0).canRefill(refill.level_dup(0), refill.req_info_dup(0).s2xlate, pbmte, io.csr_dup(0).hgatp.mode)) ||
-    memPte(0).onlyPf(refill.level_dup(0), refill.req_info_dup(0).s2xlate, pbmte))
+    memPte(0).isLeaf() &&
+    memPte(0).canRefill(refill.level_dup(0), refill.req_info_dup(0).s2xlate, pbmte, io.csr_dup(0).hgatp.mode)
   val spRefillIdx = spreplace.way.suggestName(s"sp_refillIdx") // LFSR64()(log2Up(l2tlbParams.spSize)-1,0) // TODO: may be LRU
   val spRfOH = UIntToOH(spRefillIdx).asUInt.suggestName(s"sp_rfOH")
   when (spRefill) {
@@ -1060,7 +1069,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
       memSelData(0),
       refill.level_dup(0),
       refill_prefetch_dup(0),
-      !memPte(0).onlyPf(refill.level_dup(0), refill.req_info_dup(0).s2xlate, pbmte),
+      true.B,
       s2xlate = refill.req_info_dup(0).s2xlate
     )
     spreplace.access(spRefillIdx)

--- a/src/main/scala/xiangshan/cache/mmu/Repeater.scala
+++ b/src/main/scala/xiangshan/cache/mmu/Repeater.scala
@@ -158,6 +158,7 @@ class PTWFilterEntryIO(Width: Int, hasHint: Boolean = false)(implicit p: Paramet
   val refill = Output(Bool())
   val getGpa = Output(Bool())
   val memidx = Output(new MemBlockidxBundle)
+  val fromHwPrefetch = Output(Bool())
 }
 
 class PTWFilterEntry(Width: Int, Size: Int, hasHint: Boolean = false)(implicit p: Parameters) extends XSModule with HasPtwConst {
@@ -182,6 +183,7 @@ class PTWFilterEntry(Width: Int, Size: Int, hasHint: Boolean = false)(implicit p
   val s2xlate = Reg(Vec(Size, UInt(2.W)))
   val getGpa = Reg(Vec(Size, Bool()))
   val memidx = Reg(Vec(Size, new MemBlockidxBundle))
+  val fromHwPrefetch = Reg(Vec(Size, Bool()))
 
   val enqvalid = WireInit(VecInit(Seq.fill(Width)(false.B)))
   val canenq = WireInit(VecInit(Seq.fill(Width)(false.B)))
@@ -205,6 +207,7 @@ class PTWFilterEntry(Width: Int, Size: Int, hasHint: Boolean = false)(implicit p
   io.tlb.resp.bits.getGpa := 0.U.asTypeOf(Vec(Width, Bool()))
   io.memidx := 0.U.asTypeOf(new MemBlockidxBundle)
   io.getGpa := 0.U
+  io.fromHwPrefetch := false.B
 
   // ugly code, should be optimized later
   require(Width <= 4, s"DTLB Filter Width ($Width) must equal or less than 4")
@@ -263,6 +266,7 @@ class PTWFilterEntry(Width: Int, Size: Int, hasHint: Boolean = false)(implicit p
       s2xlate(enqidx(i)) := io.tlb.req(i).bits.s2xlate
       getGpa(enqidx(i)) := io.tlb.req(i).bits.getGpa
       memidx(enqidx(i)) := io.tlb.req(i).bits.memidx
+      fromHwPrefetch(enqidx(i)) := io.tlb.req(i).bits.fromHwPrefetch
     }
   }
 
@@ -282,6 +286,7 @@ class PTWFilterEntry(Width: Int, Size: Int, hasHint: Boolean = false)(implicit p
     v.zip(ptwResp_EntryMatchVec).map{ case (vi, mi) => when (mi) { vi := false.B }}
     io.memidx := memidx(ptwResp_EntryMatchFirst)
     io.getGpa := getGpa(ptwResp_EntryMatchFirst)
+    io.fromHwPrefetch := fromHwPrefetch(ptwResp_EntryMatchFirst)
   }
 
   when (io.flush) {
@@ -387,6 +392,7 @@ class PTWNewFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameter
   io.tlb.resp.bits.data.s1 := ptwResp.s1
   io.tlb.resp.bits.data.s2 := ptwResp.s2
   io.tlb.resp.bits.data.memidx := 0.U.asTypeOf(new MemBlockidxBundle)
+  io.tlb.resp.bits.data.fromHwPrefetch := false.B
   // vector used to represent different requestors of DTLB
   // (e.g. the store DTLB has StuCnt requestors)
   // However, it is only necessary to distinguish between different DTLB now
@@ -412,14 +418,17 @@ class PTWNewFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameter
   when (load_filter(0).refill) {
     io.tlb.resp.bits.vector(0) := true.B
     io.tlb.resp.bits.data.memidx := load_filter(0).memidx
+    io.tlb.resp.bits.data.fromHwPrefetch := load_filter(0).fromHwPrefetch
   }
   when (store_filter(0).refill) {
     io.tlb.resp.bits.vector(LdExuCnt + 1) := true.B
     io.tlb.resp.bits.data.memidx := store_filter(0).memidx
+    io.tlb.resp.bits.data.fromHwPrefetch := store_filter(0).fromHwPrefetch
   }
   when (prefetch_filter(0).refill) {
     io.tlb.resp.bits.vector(LdExuCnt + 1 + StaCnt) := true.B
     io.tlb.resp.bits.data.memidx := 0.U.asTypeOf(new MemBlockidxBundle)
+    io.tlb.resp.bits.data.fromHwPrefetch := prefetch_filter(0).fromHwPrefetch
   }
 
   val ptw_arb = Module(new RRArbiterInit(new PtwReq, 3))
@@ -449,6 +458,7 @@ class PTWFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameters) 
   val s2xlate = Reg(Vec(Size, UInt(2.W)))
   val getGpa = Reg(Vec(Size, Bool()))
   val memidx = Reg(Vec(Size, new MemBlockidxBundle))
+  val fromHwPrefetch = Reg(Vec(Size, Bool()))
   val enqPtr = RegInit(0.U(log2Up(Size).W)) // Enq
   val issPtr = RegInit(0.U(log2Up(Size).W)) // Iss to Ptw
   val deqPtr = RegInit(0.U(log2Up(Size).W)) // Deq
@@ -504,6 +514,7 @@ class PTWFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameters) 
   val filter_ports = (0 until Width).map(i => ParallelMux(newMatchVec(i).zip(ports_init).drop(i)))
   val resp_vector = RegEnable(ParallelMux(ptwResp_OldMatchVec zip ports), io.ptw.resp.fire)
   val resp_getGpa = RegEnable(ParallelMux(ptwResp_OldMatchVec zip getGpa), io.ptw.resp.fire)
+  val resp_fromHwPrefetch = RegEnable(ParallelMux(ptwResp_OldMatchVec zip fromHwPrefetch), io.ptw.resp.fire)
 
   def canMerge(index: Int) : Bool = {
     ptwResp_newMatchVec(index) || oldMatchVec(index) ||
@@ -546,6 +557,7 @@ class PTWFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameters) 
   io.tlb.resp.bits.data.s1 := ptwResp.s1
   io.tlb.resp.bits.data.s2 := ptwResp.s2
   io.tlb.resp.bits.data.memidx := RegNext(PriorityMux(ptwResp_OldMatchVec, memidx))
+  io.tlb.resp.bits.data.fromHwPrefetch := resp_fromHwPrefetch
   io.tlb.resp.bits.vector := resp_vector
   io.tlb.resp.bits.data.getGpa := RegNext(PriorityMux(ptwResp_OldMatchVec, getGpa))
   io.tlb.resp.bits.getGpa := DontCare
@@ -566,6 +578,7 @@ class PTWFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameters) 
         s2xlate(enqPtrVec(i)) := req.bits.s2xlate
         getGpa(enqPtrVec(i)) := req.bits.getGpa
         memidx(enqPtrVec(i)) := req.bits.memidx
+        fromHwPrefetch(enqPtrVec(i)) := req.bits.fromHwPrefetch
         ports(enqPtrVec(i)) := req_ports(i).asBools
       }
   }

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -236,8 +236,11 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   val entries = Module(new TlbStorageWrapper(Width, q, nRespDups))
   entries.io.base_connect(sfence, csr, csr.satp)
   if (q.outReplace) { io.replace <> entries.io.replace }
+  val pfClear = if (q.fetchi) Cat(flush_pipe).orR else Mux(need_gpa, need_gpa_robidx.needFlush(redirect), redirect.valid && !need_gpa_wire)
+  entries.io.pfClear := pfClear
   for (i <- 0 until Width) {
-    entries.io.r_req_apply(io.requestor(i).req.valid, get_pn(req_in(i).bits.vaddr), i, req_in_s2xlate(i))
+    val reqVpn = get_pn(req_in(i).bits.vaddr)
+    entries.io.r_req_apply(io.requestor(i).req.valid, reqVpn, i, req_in_s2xlate(i), req_in(i).bits.fromHwPrefetch)
     entries.io.w_apply(refill, ptw.resp.bits)
     // TODO: RegNext enable:req.valid
     resp(i).bits.debug.isFirstIssue := RegEnable(req(i).bits.debug.isFirstIssue, req(i).valid)
@@ -285,7 +288,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     val isOnlys2xlate = req_out_s2xlate(i) === onlyStage2
     val need_gpa_vpn_hit = need_gpa_vpn === get_pn(req_out(i).vaddr)
     val isitlb = TlbCmd.isExec(req_out(i).cmd)
-    val isPrefetch = req_out(i).isPrefetch
+    val fromHwPrefetch = req_out(i).fromHwPrefetch
     val currentRedirect = req_out(i).debug.robIdx.needFlush(redirect)
     val lastCycleRedirect = req_out(i).debug.robIdx.needFlush(RegNext(redirect))
 
@@ -294,7 +297,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       need_gpa := false.B
       resp_gpa_refill := false.B
       need_gpa_vpn := 0.U
-    }.elsewhen (req_out_v(i) && !p_hit && !(resp_gpa_refill && need_gpa_vpn_hit) && !isOnlys2xlate && hasGpf(i) && need_gpa === false.B && !io.requestor(i).req_kill && !isPrefetch && !currentRedirect && !lastCycleRedirect) {
+    }.elsewhen (req_out_v(i) && !p_hit && !(resp_gpa_refill && need_gpa_vpn_hit) && !isOnlys2xlate && hasGpf(i) && need_gpa === false.B && !io.requestor(i).req_kill && !fromHwPrefetch && !currentRedirect && !lastCycleRedirect) {
       when(canGetGpa(i)) {
         maybe_need_gpa_not_allow_refill := true.B
         need_gpa_wire := true.B
@@ -322,7 +325,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     }
 
     val hit = e_hit || p_hit
-    val miss = (!hit && enable) || hasGpf(i) && !p_hit && !(resp_gpa_refill && need_gpa_vpn_hit) && !isOnlys2xlate && !isPrefetch && !lastCycleRedirect
+    val miss = (!hit && enable) || hasGpf(i) && !p_hit && !(resp_gpa_refill && need_gpa_vpn_hit) && !isOnlys2xlate && !fromHwPrefetch && !lastCycleRedirect
     hit.suggestName(s"hit_read_${i}")
     miss.suggestName(s"miss_read_${i}")
 
@@ -552,6 +555,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     io.ptw.req(idx).bits.s2xlate := req_s2xlate
     io.ptw.req(idx).bits.getGpa := ptw_getGpa
     io.ptw.req(idx).bits.memidx := req_out(idx).memidx
+    io.ptw.req(idx).bits.fromHwPrefetch := req_out(idx).fromHwPrefetch
   }
 
   def handle_block(idx: Int): Unit = {
@@ -628,6 +632,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     ptw_req.bits.s2xlate := miss_req_s2xlate
     ptw_req.bits.getGpa := req_need_gpa && hitVec(idx)
     ptw_req.bits.memidx := miss_req_memidx
+    ptw_req.bits.fromHwPrefetch := req_out(idx).fromHwPrefetch
 
     io.tlbreplay(idx) := false.B
 

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -101,6 +101,13 @@ class TLBFA(
   val entries = Reg(Vec(nWays, new TlbSectorEntry(normalPage, superPage)))
   val g = entries.map(_.perm.g)
 
+  val pfClearEnable = io.csr.pfRefresh.enable
+  val pfHitClearMasks = WireInit(VecInit(Seq.fill(ports)(0.U(nWays.W))))
+  def hasPf(e: TlbSectorEntry): Bool = {
+    (e.s2xlate =/= onlyStage2 && e.perm.pf) ||
+      (e.s2xlate =/= onlyStage1 && e.s2xlate =/= noS2xlate && e.g_perm.pf)
+  }
+
   for (i <- 0 until ports) {
     val req = io.r.req(i)
     val resp = io.r.resp(i)
@@ -112,13 +119,23 @@ class TLBFA(
     val OnlyS2 = req.bits.s2xlate === onlyStage2
     val OnlyS1 = req.bits.s2xlate === onlyStage1
     val refill_mask = Mux(io.w.valid, UIntToOH(io.w.bits.wayIdx), 0.U(nWays.W))
-    val hitVec = VecInit((entries.zipWithIndex).zip(v zip refill_mask.asBools).map{
+    val rawHitVec = VecInit((entries.zipWithIndex).zip(v zip refill_mask.asBools).map{
       case (e, m) => {
         val s2xlate_hit = e._1.s2xlate === req.bits.s2xlate
         val hit = e._1.hit(vpn, Mux(hasS2xlate, io.csr.vsatp.asid, io.csr.satp.asid), vmid = io.csr.hgatp.vmid, hasS2xlate = hasS2xlate, onlyS2 = OnlyS2, onlyS1 = OnlyS1)
         s2xlate_hit && hit && m._1 && !m._2
       }
     })
+    // Normal requests should not consume PF entries installed by hardware prefetch
+    val clearHwPrefetchPfHit = req.fire && !req.bits.fromHwPrefetch
+    val hwPrefetchPfHitVec = VecInit(rawHitVec.zip(entries).map { case (hit, e) =>
+      hit && hasPf(e) && e.entryFromHwPrefetch
+    })
+    // Hide those entries from normal requests so the request misses and walks again
+    val hitVec = VecInit(rawHitVec.zip(hwPrefetchPfHitVec).map { case (hit, hwPrefetchPfHit) =>
+      hit && !(clearHwPrefetchPfHit && hwPrefetchPfHit)
+    })
+    pfHitClearMasks(i) := Mux(clearHwPrefetchPfHit, hwPrefetchPfHitVec.asUInt, 0.U(nWays.W))
 
     hitVec.suggestName("hitVec")
 
@@ -171,7 +188,13 @@ class TLBFA(
     entries(io.w.bits.wayIdx).apply(io.w.bits.data)
   }
   // write assert, should not duplicate with the existing entries
-  val w_hit_vec = VecInit(entries.zip(v).map{case (e, vi) => e.wbhit(io.w.bits.data, Mux(io.w.bits.data.s2xlate =/= noS2xlate, io.csr.vsatp.asid, io.csr.satp.asid), io.csr.hgatp.vmid, s2xlate = io.w.bits.data.s2xlate) && vi })
+  val pfHitClearMask = pfHitClearMasks.reduce(_ | _)
+  val redirectPfClearVec = VecInit(entries.map(hasPf))
+  val redirectPfClearMask = Mux(pfClearEnable && io.pfClear, redirectPfClearVec.asUInt, 0.U(nWays.W))
+  val clearMask = pfHitClearMask | redirectPfClearMask
+  val w_hit_vec = VecInit(entries.zip(v).zipWithIndex.map{case ((e, vi), i) =>
+    e.wbhit(io.w.bits.data, Mux(io.w.bits.data.s2xlate =/= noS2xlate, io.csr.vsatp.asid, io.csr.satp.asid), io.csr.hgatp.vmid, s2xlate = io.w.bits.data.s2xlate) && vi && !clearMask(i)
+  })
   XSError(io.w.valid && Cat(w_hit_vec).orR, s"${parentName} refill, duplicate with existing entries")
 
   val refill_vpn_reg = RegEnable(io.w.bits.data.s1.entry.tag, io.w.valid)
@@ -245,11 +268,11 @@ class TLBFA(
      *  sfence addr ---> |        |
      *  try to flush     |        |
      *                   +--------+
-     * 
-     * In this case, the VS-stage is a large page, while the G-stage is a small page. L1TLB stores them as a small page. 
-     * When hfence.vvma comes with an address in that VS large page but outside the small page, it should flush the VS page. 
+     *
+     * In this case, the VS-stage is a large page, while the G-stage is a small page. L1TLB stores them as a small page
+     * When hfence.vvma comes with an address in that VS large page but outside the small page, it should flush the VS page
      * However, since L1TLB always treats this entry as a small page, it cannot match this address, thus cannot flush this entry.
-     * 
+     *
     ***/
     // when (hfencev.bits.rs1) {
     //   // all addr
@@ -272,6 +295,12 @@ class TLBFA(
       v.zipWithIndex.map { case (a, i) => a := a && !(entries(i).s2xlate =/= noS2xlate) }
     }.otherwise {
       v.zipWithIndex.map { case (a, i) => a := a && !(entries(i).s2xlate =/= noS2xlate && entries(i).vmid === sfence.bits.id) }
+    }
+  }
+
+  for (i <- 0 until nWays) {
+    when (clearMask(i) && !(io.w.valid && io.w.bits.wayIdx === i.U)) {
+      v(i) := false.B
     }
   }
 
@@ -397,9 +426,11 @@ class TlbStorageWrapper(ports: Int, q: TLBParameters, nDups: Int = 1)(implicit p
       valid = io.r.req(i).valid,
       vpn = io.r.req(i).bits.vpn,
       i = i,
-      s2xlate = io.r.req(i).bits.s2xlate
+      s2xlate = io.r.req(i).bits.s2xlate,
+      fromHwPrefetch = io.r.req(i).bits.fromHwPrefetch
     )
   }
+  page.pfClear := io.pfClear
 
   for (i <- 0 until ports) {
     val q = page.r.req(i)

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -107,6 +107,7 @@ class TLBFA(
     (e.s2xlate =/= onlyStage2 && e.perm.pf) ||
       (e.s2xlate =/= onlyStage1 && e.s2xlate =/= noS2xlate && e.g_perm.pf)
   }
+  val redirectPfClearVec = VecInit(entries.map(e => pfClearEnable && io.pfClear && hasPf(e)))
 
   for (i <- 0 until ports) {
     val req = io.r.req(i)
@@ -132,8 +133,9 @@ class TLBFA(
       hit && hasPf(e) && e.entryFromHwPrefetch
     })
     // Hide those entries from normal requests so the request misses and walks again
-    val hitVec = VecInit(rawHitVec.zip(hwPrefetchPfHitVec).map { case (hit, hwPrefetchPfHit) =>
-      hit && !(clearHwPrefetchPfHit && hwPrefetchPfHit)
+    val hitVec = VecInit((rawHitVec zip hwPrefetchPfHitVec zip redirectPfClearVec).map {
+      case ((hit, hwPrefetchPfHit), redirectPfClear) =>
+        hit && !(clearHwPrefetchPfHit && hwPrefetchPfHit) && !redirectPfClear
     })
     pfHitClearMasks(i) := Mux(clearHwPrefetchPfHit, hwPrefetchPfHitVec.asUInt, 0.U(nWays.W))
 
@@ -189,8 +191,7 @@ class TLBFA(
   }
   // write assert, should not duplicate with the existing entries
   val pfHitClearMask = pfHitClearMasks.reduce(_ | _)
-  val redirectPfClearVec = VecInit(entries.map(hasPf))
-  val redirectPfClearMask = Mux(pfClearEnable && io.pfClear, redirectPfClearVec.asUInt, 0.U(nWays.W))
+  val redirectPfClearMask = redirectPfClearVec.asUInt
   val clearMask = pfHitClearMask | redirectPfClearMask
   val w_hit_vec = VecInit(entries.zip(v).zipWithIndex.map{case ((e, vi), i) =>
     e.wbhit(io.w.bits.data, Mux(io.w.bits.data.s2xlate =/= noS2xlate, io.csr.vsatp.asid, io.csr.satp.asid), io.csr.hgatp.vmid, s2xlate = io.w.bits.data.s2xlate) && vi && !clearMask(i)

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -874,7 +874,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
   io.iTLBInter.req.bits.vaddr              := f3_resend_vaddr
   io.iTLBInter.req.bits.debug.pc           := f3_resend_vaddr
   io.iTLBInter.req.bits.cmd                := TlbCmd.exec
-  io.iTLBInter.req.bits.isPrefetch         := false.B
+  io.iTLBInter.req.bits.fromHwPrefetch     := false.B
   io.iTLBInter.req.bits.kill               := false.B // IFU use itlb for mmio, doesn't need sync, set it to false
   io.iTLBInter.req.bits.no_translate       := false.B
   io.iTLBInter.req.bits.fullva             := 0.U

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -171,13 +171,14 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule with HasICac
   private val itlb_finish = tlb_valid_latch(0) && (!s1_doubleline || tlb_valid_latch(1))
 
   (0 until PortNumber).foreach { i =>
-    toITLB(i).valid             := s1_need_itlb(i) || (s0_valid && (if (i == 0) true.B else s0_doubleline))
-    toITLB(i).bits              := DontCare
-    toITLB(i).bits.size         := 3.U
-    toITLB(i).bits.vaddr        := Mux(s1_need_itlb(i), s1_req_vaddr(i), s0_req_vaddr(i))
-    toITLB(i).bits.debug.pc     := Mux(s1_need_itlb(i), s1_req_vaddr(i), s0_req_vaddr(i))
-    toITLB(i).bits.cmd          := TlbCmd.exec
-    toITLB(i).bits.no_translate := false.B
+    toITLB(i).valid               := s1_need_itlb(i) || (s0_valid && (if (i == 0) true.B else s0_doubleline))
+    toITLB(i).bits                := DontCare
+    toITLB(i).bits.size           := 3.U
+    toITLB(i).bits.vaddr          := Mux(s1_need_itlb(i), s1_req_vaddr(i), s0_req_vaddr(i))
+    toITLB(i).bits.debug.pc       := Mux(s1_need_itlb(i), s1_req_vaddr(i), s0_req_vaddr(i))
+    toITLB(i).bits.cmd            := TlbCmd.exec
+    toITLB(i).bits.fromHwPrefetch := false.B
+    toITLB(i).bits.no_translate   := false.B
   }
   fromITLB.foreach(_.ready := true.B)
   io.itlb.foreach(_.req_kill := false.B)

--- a/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/AtomicsUnit.scala
@@ -459,6 +459,7 @@ class AtomicsUnit(implicit p: Parameters) extends XSModule
   io.dtlb.req.bits.checkfullva := true.B
   io.dtlb.resp.ready      := true.B
   io.dtlb.req.bits.cmd    := Mux(isLr, TlbCmd.atom_read, TlbCmd.atom_write)
+  io.dtlb.req.bits.fromHwPrefetch := false.B
   io.dtlb.req.bits.debug.pc := uop.pc
   io.dtlb.req.bits.debug.robIdx := uop.robIdx
   io.dtlb.req.bits.debug.isFirstIssue := false.B

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -386,7 +386,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
                                          Mux(s0_sel_src.prf_wr, TlbCmd.write, TlbCmd.read),
                                          TlbCmd.read
                                        )
-  io.tlb.req.bits.isPrefetch         := s0_sel_src.prf
+  io.tlb.req.bits.fromHwPrefetch     := s0_hw_prf_select
   io.tlb.req.bits.vaddr              := s0_tlb_vaddr
   io.tlb.req.bits.fullva             := s0_tlb_fullva
   io.tlb.req.bits.checkfullva        := s0_src_select_vec(vec_iss_idx) || s0_src_select_vec(int_iss_idx)

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -215,7 +215,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.fullva             := s0_fullva
   io.tlb.req.bits.checkfullva        := s0_use_flow_rs || s0_use_flow_vec
   io.tlb.req.bits.cmd                := Mux(s0_isCbo_noZero, TlbCmd.read, TlbCmd.write)
-  io.tlb.req.bits.isPrefetch         := s0_use_flow_prf
+  io.tlb.req.bits.fromHwPrefetch     := s0_use_flow_prf
   io.tlb.req.bits.size               := s0_size
   io.tlb.req.bits.kill               := false.B
   io.tlb.req.bits.memidx.is_ld       := false.B

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -608,7 +608,7 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
       tlb_req_arb.io.in(i).bits.vaddr := l2_array(i - MLP_L1_SIZE).get_tlb_va()
     }
     tlb_req_arb.io.in(i).bits.cmd := TlbCmd.read
-    tlb_req_arb.io.in(i).bits.isPrefetch := true.B
+    tlb_req_arb.io.in(i).bits.fromHwPrefetch := true.B
     tlb_req_arb.io.in(i).bits.size := 3.U
     tlb_req_arb.io.in(i).bits.kill := false.B
     tlb_req_arb.io.in(i).bits.no_translate := false.B

--- a/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/SMSPrefetcher.scala
@@ -973,7 +973,7 @@ class PrefetchFilter()(implicit p: Parameters) extends XSModule with HasSMSModul
     tlb_req_arb.io.in(i).valid := v && not_tlbing_vec(i) && !ent.paddr_valid && !is_evicted
     tlb_req_arb.io.in(i).bits.vaddr := Cat(ent.region_addr, 0.U(log2Up(REGION_SIZE).W))
     tlb_req_arb.io.in(i).bits.cmd := TlbCmd.read
-    tlb_req_arb.io.in(i).bits.isPrefetch := true.B
+    tlb_req_arb.io.in(i).bits.fromHwPrefetch := true.B
     tlb_req_arb.io.in(i).bits.size := 3.U
     tlb_req_arb.io.in(i).bits.kill := false.B
     tlb_req_arb.io.in(i).bits.no_translate := false.B

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -456,6 +456,7 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
   io.dtlb.req.bits.fullva             := tlbReqVaddr
   io.dtlb.req.bits.checkfullva        := true.B
   io.dtlb.req.bits.size               := instMicroOp.alignedType(2,0)
+  io.dtlb.req.bits.fromHwPrefetch     := false.B
   io.dtlb.req.bits.memidx.is_ld       := isVSegLoad
   io.dtlb.req.bits.memidx.is_st       := isVSegStore
   io.dtlb.req.bits.debug.robIdx       := instMicroOp.uop.robIdx
@@ -960,4 +961,3 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
   io.exceptionInfo.bits.vl            := instMicroOp.exceptionVl.bits
   io.exceptionInfo.valid              := (state === s_finish) && instMicroOp.uop.exceptionVec.asUInt.orR && !isEmpty(enqPtr, deqPtr)
 }
-


### PR DESCRIPTION
Remove onlyPf from PTWCache while keeping the SRAM payload width stable with an always-false onlyPf placeholder.

Add CSR-controlled PF refresh support for L1TLB entries and carry hardware-prefetch origin through the TLB/PTW refill path.

Normal requests no longer consume PF entries installed by hardware prefetch; those entries are hidden on lookup and invalidated before the demand walk refills them.

Keep normal PF/GPF entries after lookup hits and clear them at redirect or flush-pipe boundaries, while preserving getGpa handling for all-stage GPF entries.

Update ready-to-run to the matching NEMU commit.