### PR TITLE
fix(csr, xstatus): mark HLV/HLVX/HSV memory traps as virtual

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryHSEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryHSEvent.scala
@@ -88,10 +88,9 @@ class TrapEntryHSEventModule(implicit val p: Parameters) extends Module with CSR
   private val tvalFillPcPlus2  = (isFetchExcp || isFetchGuestExcp) && fetchCrossPage
   private val tvalFillMemVaddr = isMemExcp || isMemBkpt
   private val tvalFillGVA      =
-    isHlsExcp && isMemExcp ||
     isLSGuestExcp|| isFetchGuestExcp ||
     (isFetchExcp || isFetchBkpt) && fetchIsVirt ||
-    (isMemExcp || isMemBkpt) && memIsVirt
+    (isMemExcp || isMemBkpt) && (memIsVirt || isHlsExcp)
   private val tvalFillInst     = isIllegalInst
 
   private val tval = Mux1H(Seq(

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/TrapEntryMEvent.scala
@@ -86,10 +86,9 @@ class TrapEntryMEventModule(implicit val p: Parameters) extends Module with CSRE
   private val tvalFillPcPlus2  = (isFetchExcp || isFetchGuestExcp) && fetchCrossPage
   private val tvalFillMemVaddr = isMemExcp || isMemBkpt
   private val tvalFillGVA      =
-    isHlsExcp && isMemExcp ||
     isLSGuestExcp|| isFetchGuestExcp ||
     (isFetchExcp || isFetchBkpt) && fetchIsVirt ||
-    (isMemExcp || isMemBkpt) && memIsVirt
+    (isMemExcp || isMemBkpt) && (memIsVirt || isHlsExcp)
   private val tvalFillInst     = isIllegalInst
 
   private val tval = Mux1H(Seq(


### PR DESCRIPTION
 * Treat HLV/HLVX/HSV memory exceptions as virtual memory traps when deciding whether to update htval/mtval.