### PR TITLE
fix(mret): fix vsstatus Valid Path in MretEvent

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/MretEvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/MretEvent.scala
@@ -60,6 +60,7 @@ class MretEventModule(implicit p: Parameters) extends Module with CSREventBase {
 
   out.privState.valid := valid
   out.mstatus  .valid := valid
+  out.vsstatus .valid := valid
   out.targetPc .valid := valid
 
   out.privState.bits          := outPrivState


### PR DESCRIPTION
When executing the `mret` instruction, the control logic of `vsstatus` was not connected, resulting in the inability to clear `vsstatus.SDT` when `mret` enters `VU` mode.