### PR TITLE
fix(StoreQueue): fix cbo handle earlier than instruction commit

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
@@ -893,7 +893,7 @@ abstract class NewStoreQueueBase(implicit p: Parameters) extends LSQModule {
     cboState := cboStateNext
 
     private val cboCanHandle = headCtrlEntry.allValid && !headCtrlEntry.hasException && headCtrlEntry.allocated &&
-      headCtrlEntry.isCbo
+      headCtrlEntry.isCbo && headCtrlEntry.committed
 
     switch(cboState) {
       is(CboState.idle) {


### PR DESCRIPTION
This PR fixed bug of `cboState` start before the `cbo` instruction reach the head of rob, which was reported by #6062  . 