### PR TITLE
feat(aia): support chiselAIA(APLIC/IMSIC) for XSTop

### DIFF
--- a/src/main/scala/device/imsic_axi_top.scala
+++ b/src/main/scala/device/imsic_axi_top.scala
@@ -54,9 +54,15 @@ class imsic_bus_top(implicit p: Parameters) extends LazyModule with HasSoCParame
   val tl_s = tl.map(x => InModuleBody(x(1).makeIOs()))
 
   // AXI4 Bus
-  val axi_reg_imsic = Option.when(soc.IMSICBusType == device.IMSICBusType.AXI)(LazyModule(new aia.AXIRegIMSIC_WRAP(soc.IMSICParams, seperateBus = false)))
+  val axi_reg_imsic = Option.when(soc.IMSICBusType == device.IMSICBusType.AXI)(LazyModule(new aia.AXIRegIMSIC_WRAP(soc.IMSICParams, beatBytes = 8, seperateBus = false)))
 
-  val axi = axi_reg_imsic.map { axi_reg_imsic =>
+  val axi_mem_xbar = axi_reg_imsic.map { axi_reg_imsic =>
+    val imsic_mem_xbar = AXI4Xbar()
+    axi_reg_imsic.imsic_xbar1to2 := imsic_mem_xbar
+    imsic_mem_xbar
+  }
+
+  val axi = axi_mem_xbar.map { imsic_mem_xbar =>
     val axinode = AXI4MasterNode(Seq(AXI4MasterPortParameters(
       Seq(AXI4MasterParameters(
         name = "s_axi_",
@@ -64,11 +70,12 @@ class imsic_bus_top(implicit p: Parameters) extends LazyModule with HasSoCParame
         maxFlight = Some(0)
       ))
     )))
-    axi_reg_imsic.imsic_xbar1to2 := AXI4Buffer() := axinode
+    imsic_mem_xbar := AXI4Buffer() := axinode
     axinode
   }
 
   val axi4 = axi.map(x => InModuleBody(x.makeIOs()))
+  val aplic_axi4 = axi_mem_xbar
 
   class imsic_bus_top_imp(wrapper: imsic_bus_top) extends LazyModuleImp(wrapper) {
     val msiio = IO(Flipped(new aia.MSITransBundle(soc.IMSICParams)))

--- a/src/main/scala/device/imsic_axi_top.scala
+++ b/src/main/scala/device/imsic_axi_top.scala
@@ -54,7 +54,7 @@ class imsic_bus_top(implicit p: Parameters) extends LazyModule with HasSoCParame
   val tl_s = tl.map(x => InModuleBody(x(1).makeIOs()))
 
   // AXI4 Bus
-  val axi_reg_imsic = Option.when(soc.IMSICBusType == device.IMSICBusType.AXI)(LazyModule(new aia.AXIRegIMSIC_WRAP(soc.IMSICParams, beatBytes = 8, seperateBus = false)))
+  val axi_reg_imsic = Option.when(soc.IMSICBusType == device.IMSICBusType.AXI)(LazyModule(new aia.AXIRegIMSIC_WRAP(soc.IMSICParams, seperateBus = false)))
 
   val axi_mem_xbar = axi_reg_imsic.map { axi_reg_imsic =>
     val imsic_mem_xbar = AXI4Xbar()

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -546,7 +546,7 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
 
   val plic = LazyModule(new TLPLIC(PLICParams(soc.PLICRange.base), 8))
   val plicSource = LazyModule(new IntSourceNodeToModule(NrExtIntr))
-  val aplic = LazyModule(new aia.AXI4APLIC(soc.APLICParams, 8))
+  val aplic = LazyModule(new aia.AXI4APLIC(soc.APLICParams))
 
   plic.intnode := plicSource.sourceNode
   if (enableCHI) { plic.node := device_xbar.get }
@@ -554,10 +554,14 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
   if (enableCHI) {
     aplic.fromCPU :=
       TLToAXI4() :=
+      TLFragmenter(4, 8, holdFirstDeny = true) :=
+      TLWidthWidget(8) :=
       device_xbar.get
   } else {
     aplic.fromCPU :=
       TLToAXI4() :=
+      TLFragmenter(4, 8, holdFirstDeny = true) :=
+      TLWidthWidget(8) :=
       peripheralXbar.get
   }
 

--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -16,6 +16,7 @@
 
 package system
 
+import aia.APLICParams
 import org.chipsalliance.cde.config.{Field, Parameters}
 import chisel3._
 import chisel3.util._
@@ -81,6 +82,7 @@ case class SoCParameters
   EnableICacheCtrl: Boolean = true,
   ICacheCtrlRange: AddressSet = AddressSet(0x38022080L, 0x7f),
   PLICRange: AddressSet = AddressSet(0x3c000000L, PLICConsts.size(PLICConsts.maxMaxHarts) - 1),
+  APLICRange: AddressSet = AddressSet(0x31100000L, 0xffff),
   PLLRange: AddressSet = AddressSet(0x3a000000L, 0xfff),
   UARTLiteForDTS: Boolean = true, // should be false in SimMMIO
   extIntrs: Int = 64,
@@ -118,6 +120,16 @@ case class SoCParameters
     iselectWidth = 12,
     EnableImsicAsyncBridge = true,
     HasTEEIMSIC = false
+  ),
+  APLICParams: APLICParams = aia.APLICParams(
+    aplicIntSrcWidth = 6,
+    imsicIntSrcWidth = 9,
+    baseAddr = 0x31100000L,
+    mBaseAddr = 0x3A800000L,
+    sgBaseAddr = 0x3B000000L,
+    membersNum = 64,
+    groupsNum = 1,
+    geilen = 7
   ),
   EnableCHIAsyncBridge: Option[AsyncQueueParams] = Some(AsyncQueueParams(depth = 4, sync = 3, safe = true)),
   EnableClintAsyncBridge: Option[AsyncQueueParams] = Some(AsyncQueueParams(depth = 8, sync = 3, safe = true)),
@@ -215,20 +227,36 @@ trait HasPeripheralRanges {
   private def soc = p(SoCParamsKey)
   private def dm = p(DebugModuleKey)
   private def pmParams = p(PMParameKey)
+  private def numCores = p(XSTileKey).size
 
   private def mmpma = pmParams.mmpma
+  private def imsicMRange(hartIndex: Int) = AddressSet(
+    soc.IMSICParams.mAddr + (hartIndex.toLong << soc.IMSICParams.intFileMemWidth),
+    (1L << soc.IMSICParams.intFileMemWidth) - 1
+  )
+  private def imsicSGRange(hartIndex: Int) = {
+    val strideWidth = soc.IMSICParams.intFileMemWidth + log2Ceil(1 + soc.IMSICParams.geilen)
+    AddressSet(
+      soc.IMSICParams.sgAddr + (hartIndex.toLong << strideWidth),
+      (1L << strideWidth) - 1
+    )
+  }
+  private def imsicRanges = (0 until numCores).flatMap { i =>
+    Seq(s"IMSIC_${i}_M" -> imsicMRange(i), s"IMSIC_${i}_SG" -> imsicSGRange(i))
+  }.toMap
 
   def onChipPeripheralRanges: Map[String, AddressSet] = Map(
     "TIMER" -> soc.TIMERRange,
     "SYSCNT" -> soc.SYSCNTRange,
     "BEU"   -> soc.BEURange,
     "PLIC"  -> soc.PLICRange,
+    "APLIC" -> soc.APLICRange,
     "PLL"   -> soc.PLLRange,
     "UARTLITE" -> soc.UARTLiteRange,
     "UART16550" -> soc.UART16550Range,
     "DEBUG" -> dm.get.address,
     "MMPMA" -> AddressSet(mmpma.address, mmpma.mask)
-  ) ++ (
+  ) ++ imsicRanges ++ (
     if (soc.L3CacheParamsOpt.map(_.ctrl.isDefined).getOrElse(false))
       Map("L3CTL" -> AddressSet(soc.L3CacheParamsOpt.get.ctrl.get.address, 0xffff))
     else
@@ -518,10 +546,20 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
 
   val plic = LazyModule(new TLPLIC(PLICParams(soc.PLICRange.base), 8))
   val plicSource = LazyModule(new IntSourceNodeToModule(NrExtIntr))
+  val aplic = LazyModule(new aia.AXI4APLIC(soc.APLICParams, 8))
 
   plic.intnode := plicSource.sourceNode
   if (enableCHI) { plic.node := device_xbar.get }
   else { plic.node := peripheralXbar.get }
+  if (enableCHI) {
+    aplic.fromCPU :=
+      TLToAXI4() :=
+      device_xbar.get
+  } else {
+    aplic.fromCPU :=
+      TLToAXI4() :=
+      peripheralXbar.get
+  }
 
   val pll_node = TLRegisterNode(
     address = Seq(soc.PLLRange),
@@ -601,11 +639,15 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
 
     // sync external interrupts
     require(plicSource.module.in.length == ext_intrs.getWidth)
-    for ((plic_in, interrupt) <- plicSource.module.in.zip(ext_intrs.asBools)) {
+    require(aplic.module.intSrcs.length <= ext_intrs.getWidth)
+    val extIntrsSync = Wire(Vec(ext_intrs.getWidth, Bool()))
+    for ((sync_intr, interrupt) <- extIntrsSync.zip(ext_intrs.asBools)) {
       val ext_intr_sync = RegInit(0.U(3.W))
       ext_intr_sync := Cat(ext_intr_sync(1, 0), interrupt)
-      plic_in := ext_intr_sync(2)
+      sync_intr := ext_intr_sync(2)
     }
+    plicSource.module.in.zip(extIntrsSync).foreach { case (plic_in, interrupt) => plic_in := interrupt }
+    aplic.module.intSrcs.zip(extIntrsSync).foreach { case (aplic_in, interrupt) => aplic_in := interrupt }
 
     pma.module.io <> cacheable_check
 
@@ -659,4 +701,3 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
 
 class SoCMisc()(implicit p: Parameters) extends MemMisc
   with HaveSlaveAXI4Port
-

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -52,6 +52,7 @@ object ArgParser {
       |--disable-clockgate
       |--enable-dfx
       |--dump-csr
+      |--imsic-bus-type <NONE|TL|AXI>
       |""".stripMargin
 
   def getConfigByName(confString: String): Parameters = {

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -200,6 +200,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
           AXI4Buffer() :=
           AXI4UserYanker() :=
           TLToAXI4() :=
+          TLFragmenter(4, 8, holdFirstDeny = true) :=
           TLWidthWidget(8) :=
           misc.device_xbar.get
       } else {
@@ -207,6 +208,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
           AXI4Buffer() :=
           AXI4UserYanker() :=
           TLToAXI4() :=
+          TLFragmenter(4, 8, holdFirstDeny = true) :=
           TLWidthWidget(8) :=
           misc.peripheralXbar.get
       }

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -159,6 +159,59 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
   }
   val nmiIntNode = IntSourceNode(IntSourcePortSimple(1, NumCores, (new NonmaskableInterruptIO).elements.size))
   val nmi = InModuleBody(nmiIntNode.makeIOs())
+  private def imsicParamsForHart(hartIndex: Int): aia.IMSICParams = {
+    val params = soc.IMSICParams
+    params.copy(
+      mAddr = params.mAddr + (hartIndex.toLong << params.intFileMemWidth),
+      sgAddr = params.sgAddr + (hartIndex.toLong << (params.intFileMemWidth + log2Ceil(1 + params.geilen)))
+    )
+  }
+  val imsic_bus_tops = Seq.tabulate(NumCores) { i =>
+    LazyModule(new imsic_bus_top()(p.alter((_, _, up) => {
+      case SoCParamsKey => up(SoCParamsKey).copy(IMSICParams = imsicParamsForHart(i))
+    })))
+  }
+  imsic_bus_tops.zipWithIndex.foreach { case (imsic_bus_top, i) =>
+    imsic_bus_top.aplic_axi4.foreach { aplic_axi4 =>
+      val hartImsicParams = imsicParamsForHart(i)
+      aplic_axi4 := aia.AXI4Map { addrSet =>
+        val base = addrSet.base.toLong
+        val (groupID, memberID) = soc.APLICParams.hartIndex_to_gh(i)
+        val mOffset = (groupID.toLong << soc.APLICParams.groupStrideWidth) +
+          (memberID.toLong << soc.APLICParams.mStrideWidth)
+        val sgOffset = (groupID.toLong << soc.APLICParams.groupStrideWidth) +
+          (memberID.toLong << soc.APLICParams.sgStrideWidth)
+        if (base == hartImsicParams.mAddr) {
+          soc.APLICParams.mBaseAddr + mOffset
+        } else if (base == hartImsicParams.sgAddr) {
+          soc.APLICParams.sgBaseAddr + sgOffset
+        } else if (base == hartImsicParams.tee_mAddr) {
+          soc.APLICParams.mBaseAddr + mOffset
+        } else if (base == hartImsicParams.tee_sgAddr) {
+          soc.APLICParams.sgBaseAddr + sgOffset
+        } else {
+          base
+        }
+      } := misc.aplic.toIMSIC
+    }
+    imsic_bus_top.axi_mem_xbar.foreach { imsicXbar =>
+      if (enableCHI) {
+        imsicXbar :=
+          AXI4Buffer() :=
+          AXI4UserYanker() :=
+          TLToAXI4() :=
+          TLWidthWidget(8) :=
+          misc.device_xbar.get
+      } else {
+        imsicXbar :=
+          AXI4Buffer() :=
+          AXI4UserYanker() :=
+          TLToAXI4() :=
+          TLWidthWidget(8) :=
+          misc.peripheralXbar.get
+      }
+    }
+  }
 
   for (i <- 0 until NumCores) {
     core_with_l2(i).clint_int_node := misc.timer.intnode
@@ -329,7 +382,38 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 
     io.pll0_ctrl <> misc.module.pll0_ctrl
 
-    val msiInfo = WireInit(0.U.asTypeOf(ValidIO(UInt(soc.IMSICParams.MSI_INFO_WIDTH.W))))
+    val imsic_axi4 = Option.when(NumCores == 1)(imsic_bus_tops.head.axi4.map { x =>
+      IO(Flipped(new VerilogAXI4Record(x.elts.head.params.copy(addrBits = 32))))
+    }).flatten
+    val imsic_axi4s = Option.when(NumCores > 1)(imsic_bus_tops.head.axi4.map { x =>
+      IO(Vec(NumCores, Flipped(new VerilogAXI4Record(x.elts.head.params.copy(addrBits = 32)))))
+    }).flatten
+    imsic_bus_tops.zipWithIndex.foreach { case (imsic_bus_top, i) =>
+      imsic_bus_top.axi4.foreach { x =>
+        val imsic_axi4_port = if (NumCores == 1) imsic_axi4.get else imsic_axi4s.get(i)
+        imsic_axi4_port.viewAs[AXI4Bundle] <> x.elements.head._2
+      }
+      imsic_bus_top.tl_m.foreach { x =>
+        val imsic_m_tl = IO(chiselTypeOf(x.getWrappedValue))
+        imsic_m_tl.suggestName(if (NumCores == 1) "imsic_m_tl" else s"imsic_${i}_m_tl")
+        x <> imsic_m_tl
+      }
+      imsic_bus_top.tl_s.foreach { x =>
+        val imsic_s_tl = IO(chiselTypeOf(x.getWrappedValue))
+        imsic_s_tl.suggestName(if (NumCores == 1) "imsic_s_tl" else s"imsic_${i}_s_tl")
+        x <> imsic_s_tl
+      }
+      imsic_bus_top.module.msi.foreach { x =>
+        val imsic = IO(chiselTypeOf(x))
+        imsic.suggestName(if (NumCores == 1) "imsic" else s"imsic_${i}")
+        x <> imsic
+      }
+      imsic_bus_top.module.teemsi.foreach { x =>
+        val teemsi = IO(chiselTypeOf(x))
+        teemsi.suggestName(if (NumCores == 1) "teemsi" else s"teemsi_${i}")
+        x <> teemsi
+      }
+    }
     // syscnt io input descrip
     val ref_reset_sync = withClockAndReset(io.rtc_clock, io.reset) { ResetGen() }
     misc.module.scntIO.update_en := false.B
@@ -344,8 +428,16 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 
     for ((core, i) <- core_with_l2.zipWithIndex) {
       core.module.io.hartId := i.U
-      core.module.io.msiInfo := msiInfo
-      core.module.io.teemsiInfo.foreach(_ := msiInfo)
+      core.module.io.msiInfo.valid := imsic_bus_tops(i).module.msiio.vld_req
+      core.module.io.msiInfo.bits := imsic_bus_tops(i).module.msiio.data
+      imsic_bus_tops(i).module.msiio.vld_ack := core.module.io.msiAck
+      imsic_bus_tops(i).module.teemsiio zip core.module.io.teemsiInfo foreach { case (teemsiio, teemsiInfo) =>
+        teemsiInfo.valid := teemsiio.vld_req
+        teemsiInfo.bits := teemsiio.data
+      }
+      imsic_bus_tops(i).module.teemsiio zip core.module.io.teemsiAck foreach { case (teemsiio, teemsiAck) =>
+        teemsiio.vld_ack := teemsiAck
+      }
       core.module.io.clintTime := misc.module.clintTime
       io.riscv_halt(i) := core.module.io.cpu_halt
       io.riscv_critical_error(i) := core.module.io.cpu_crtical_error

--- a/src/main/scala/xiangshan/backend/fu/PMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/PMA.scala
@@ -132,6 +132,7 @@ trait PMAMethod extends PMAConst {
       MemMap("h00_3802_2100", "h00_38FF_FFFF",   "h0", "Reserved",    ""),
       MemMap("h00_3900_0000", "h00_3900_1FFF",   "h0", "L3CacheCtrl",  "RW"),
       MemMap("h00_3900_2000", "h00_39FF_FFFF",   "h0", "Reserved",    ""),
+      MemMap("h00_3110_0000", "h00_3110_FFFF",   "h0", "APLIC",       "RW"),
       MemMap("h00_3A00_0000", "h00_3FFF_FFFF",   "h0", "",            "RW),
          Sub("h00_3A00_0000", "h00_3A00_0FFF",   "h0", "PLL0",        "RW),
          Sub('h00_3A00_1000", "h00_3A7F_FFFF",   "h0", "Reserved",    "RW"),

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -43,6 +43,14 @@ class XiangShanSim(implicit p: Parameters) extends Module with HasDiffTestInterf
   if (!l_soc.module.dma.isEmpty) {
     l_soc.module.dma.get <> WireDefault(0.U.asTypeOf(l_soc.module.dma.get))
   }
+  l_soc.module.imsic_axi4.foreach { port =>
+    port <> WireDefault(0.U.asTypeOf(port))
+  }
+  l_soc.module.imsic_axi4s.foreach { ports =>
+    ports.foreach { port =>
+      port <> WireDefault(0.U.asTypeOf(port))
+    }
+  }
 
   val l_simMMIO = LazyModule(new SimMMIO(l_soc.misc.peripheralNode.in.head._2)(p.alter((site, here, up) => {
     case SoCParamsKey => up(SoCParamsKey).copy(UARTLiteForDTS = false)


### PR DESCRIPTION
Instantiate ChiselAIA APLIC in MemMisc and connect XSTop MSI delivery through per-hart AXI IMSIC wrappers. CPU MMIO can reach APLIC/IMSIC, and external interrupts are fed to APLIC while keeping the existing PLIC path.

This does not change NoCTop wiring: XSNoCTop does not instantiate MemMisc or SoCMisc, and still only exposes its existing interrupt IOs and HasIMSIC path.