### PR TITLE
feat(LoadQueueReplay): add support of fast wakeup for C_MA & C_FF

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -106,6 +106,7 @@ case class XSCoreParameters
   LoadQueueRAWSize: Int = 56, // NOTE: make sure that LoadQueueRAWSize is power of 2.
   RollbackGroupSize: Int = 8,
   LoadQueueReplaySize: Int = 120,
+  LoadDependenceScoreBoardWidth: Int = 4,
   LoadUncacheBufferSize: Int = 16,
   LoadQueueNWriteBanks: Int = 8, // NOTE: make sure that LoadQueueRARSize/LoadQueueRAWSize is divided by LoadQueueNWriteBanks
   StoreQueueSize: Int = 64,
@@ -706,6 +707,7 @@ trait HasXSParameter {
   val RAWlgSelectGroupSize = log2Ceil(RollbackGroupSize)
   val RAWTotalDelayCycles = scala.math.ceil(log2Ceil(LoadQueueRAWSize).toFloat / RAWlgSelectGroupSize).toInt + 1 - 2
   def LoadQueueReplaySize = coreParams.LoadQueueReplaySize
+  def LoadDependenceScoreBoardWidth = coreParams.LoadDependenceScoreBoardWidth
   def LoadUncacheBufferSize = coreParams.LoadUncacheBufferSize
   def LoadQueueNWriteBanks = coreParams.LoadQueueNWriteBanks
   def StoreQueueSize = coreParams.StoreQueueSize

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -198,6 +198,8 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   memBlock.io.ooo_to_mem.backendToTopBypass := backend.io.toTop
   memBlock.io.ooo_to_mem.intIssue <> backend.io.mem.intIssue
   memBlock.io.ooo_to_mem.vecIssue <> backend.io.mem.vecIssue
+  memBlock.io.ooo_to_mem.wakeupToLRQ <> backend.io.mem.wakeupToLRQ
+  memBlock.io.ooo_to_mem.wakeupToLRQCancel := backend.io.mem.wakeupToLRQCancel
 
   // By default, instructions do not have exceptions when they enter the function units.
   memBlock.io.ooo_to_mem.intIssue.flatten.foreach { case x => x.bits.flushPipe.foreach(_ := false.B) }

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -315,6 +315,8 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   fpRegion.io.wakeupFromI2F. foreach(x => x := intRegion.io.cross.I2FWakeupOut.get)
   intRegion.io.F2IWakeupIn.  foreach(x => x := fpRegion.io.cross.F2IWakeupOut.get)
   intRegion.io.wakeupFromLDU.foreach(x => x := io.mem.wakeup)
+  intRegion.io.wakeupToLRQ.foreach(x => io.mem.wakeupToLRQ.zip(x.flatten).foreach { case (sink, source) => sink := source })
+  intRegion.io.wakeupToLRQCancel.foreach(x => io.mem.wakeupToLRQCancel.zip(x.flatten).foreach { case (sink, source) => sink := source })
   intRegion.io.staFeedback.  foreach(x => x := io.mem.staIqFeedback)
   vecRegion.io.vstuFeedback. foreach(x => x := io.mem.vstuIqFeedback)
   intRegion.io.ldCancel := io.mem.ldCancel
@@ -692,6 +694,8 @@ class BackendMemIO(implicit p: Parameters, params: BackendParams) extends XSBund
 
   val intIssue = intSchdParams.genExuInputCopySrcBundleMemBlock
   val vecIssue = vecSchdParams.genExuInputCopySrcBundleMemBlock
+  val wakeupToLRQ = Vec(params.StaCnt + params.StdCnt, ValidIO(new IssueQueueLRQWakeUpBundle))
+  val wakeupToLRQCancel = Vec(params.StaCnt + params.StdCnt, new IssueQueueLRQWakeUpCancelBundle)
 
   // store event difftest information
   val storeDebugInfo = Vec(EnsbufferWidth, new Bundle {

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -810,6 +810,15 @@ object Bundles {
     }
   }
 
+  class IssueQueueLRQWakeUpBundle(implicit p: Parameters) extends XSBundle {
+    val sqIdx = new SqPtr
+  }
+
+  class IssueQueueLRQWakeUpCancelBundle(implicit p: Parameters) extends XSBundle {
+    val og0Cancel = Bool()
+    val og1Cancel = Bool()
+  }
+
   class VPUCtrlSignals(implicit p: Parameters) extends XSBundle {
     // vtype
     val vill      = Bool()
@@ -1378,7 +1387,7 @@ class ExuOutputVLoad(val params: ExeUnitParams)(implicit val p: Parameters) exte
     val perfDebugInfo  = Option.when(backendParams.debugEn)(new PerfDebugInfo())
     val debug_seqNum   = Option.when(backendParams.debugEn)(InstSeqNum())
   }
-  
+
   class MemDebugBundle(implicit p: Parameters) extends XSBundle {
     val isMMIO = Option.when(backendParams.basicDebugEn)(Bool())
     val isNCIO = Option.when(backendParams.basicDebugEn)(Bool())

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -183,6 +183,13 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
     imp.io.s2Resp.get.head.lqIdx.foreach(_ := feedBack.bits.lqIdx)
     imp.io.s2Resp.get.head.sqIdx.foreach(_ := feedBack.bits.sqIdx)
   }
+  val stDataIQs = issueQueues.filter(iq => iq.param.StdCnt > 0)
+  if (params.isIntSchd) {
+    val lrqWakeupFromIQ = (stAddrIQs ++ stDataIQs).flatMap(_.io.wakeupToLRQ.get)
+    val lrqWakeupCancelFromIQ = (stAddrIQs ++ stDataIQs).flatMap(_.io.wakeupToLRQCancel.get)
+    io.wakeupToLRQ.get.flatten.zip(lrqWakeupFromIQ).foreach { case (sink, source) => sink := source }
+    io.wakeupToLRQCancel.get.flatten.zip(lrqWakeupCancelFromIQ).foreach { case (sink, source) => sink := source }
+  }
   val vecStuIQs = issueQueues.filter(iq => iq.param.VstuCnt > 0)
   vecStuIQs.zipWithIndex.foreach { case(imp, i) =>
     imp.io.memIO.get.lqDeqPtr.get := io.lqDeqPtr.get
@@ -258,7 +265,6 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
     }
   }
   // std dispatch
-  val stDataIQs = issueQueues.filter(iq => iq.param.StdCnt > 0)
   val staEnqs = stAddrIQs.map(_.io.enq).flatten
   val stdEnqs = stDataIQs.map(_.io.enq).flatten.take(staEnqs.size)
   val noStdExuParams = params.issueBlockParams.map(x => Seq.fill(x.numEnq)(x.exuBlockParams)).flatten.filter { x => x.map(!_.hasStdFu).reduce(_ && _) }
@@ -860,6 +866,9 @@ class RegionIO(val params: SchdBlockParams)(implicit p: Parameters) extends XSBu
   val wakeupFromF2I = Option.when(params.isIntSchd)(Flipped(ValidIO(new IssueQueueIQWakeUpBundle(params.backendParam.getExuIdxF2I, params.backendParam))))
   val cross = new ExuCrossRegion(params)
   val toMemExu = Option.when(!params.isFpSchd)(params.genNewExuInputCopySrcBundleMemBlock)
+  //to Mem, wake up LoadQueueReplay
+  val wakeupToLRQ = Option.when(params.isIntSchd)(intSchdParam.genMemWakeupLRQBundle)
+  val wakeupToLRQCancel = Option.when(params.isIntSchd)(intSchdParam.genMemWakeupCancelBundle)
   // fromMem
   val wakeupFromLDU = Option.when(params.isIntSchd)(Vec(params.LdExuCnt, Flipped(Valid(new MemWakeUpBundle))))
   val staFeedback = Option.when(params.isIntSchd)(Flipped(Vec(params.StaCnt, new MemRSFeedbackIO)))
@@ -945,4 +954,3 @@ class RegionIO(val params: SchdBlockParams)(implicit p: Parameters) extends XSBu
   val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(Bool())))
   val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(iqDeqSum, ValidIO(new RobPtr())))
 }
-

--- a/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
@@ -59,6 +59,8 @@ case class IssueBlockParams(
 
   def isStdIQ: Boolean = StdCnt > 0
 
+  def isStoreIQ: Boolean = isStAddrIQ || isStdIQ
+
   def isHyAddrIQ: Boolean = HyuCnt > 0
 
   def isVecLduIQ: Boolean = (VlduCnt + VseglduCnt) > 0
@@ -406,6 +408,14 @@ case class IssueBlockParams(
     MixedVec(this.exuBlockParams.map(x => DecoupledIO(x.genNewExuInputCopySrcBundle)))
   }
 
+  def genMemWakeupLRQBundle(implicit p: Parameters): MixedVec[ValidIO[IssueQueueLRQWakeUpBundle]] = {
+    MixedVec(this.exuBlockParams.filter(_.hasStoreFu).map(x => ValidIO(new IssueQueueLRQWakeUpBundle)))
+  }
+
+  def genMemWakeupCancelBundle(implicit p: Parameters): MixedVec[IssueQueueLRQWakeUpCancelBundle] = {
+    MixedVec(this.exuBlockParams.filter(_.hasStoreFu).map(x => new IssueQueueLRQWakeUpCancelBundle))
+  }
+
   def genExuOutputDecoupledBundle(implicit p: Parameters): MixedVec[DecoupledIO[ExuOutput]] = {
     MixedVec(this.exuParams.map(x => DecoupledIO(x.genExuOutputBundle)))
   }
@@ -485,6 +495,14 @@ case class IssueBlockParams(
 
   def genIQWakeUpSinkValidBundle(implicit p: Parameters): MixedVec[ValidIO[IssueQueueIQWakeUpBundle]] = {
     MixedVec(this.wakeUpInExuSources.map(x => ValidIO(new IssueQueueIQWakeUpBundle(backendParam.getExuIdx(x.name), backendParam))))
+  }
+
+  def genIOWakeUpLRQValidBundle(implicit p: Parameters): MixedVec[ValidIO[IssueQueueLRQWakeUpBundle]] = {
+    MixedVec(exuBlockParams.filter(_.hasStoreFu).map(x => ValidIO(new IssueQueueLRQWakeUpBundle)))
+  }
+
+  def genIOWakeUpCancelBundle(implicit p: Parameters): MixedVec[IssueQueueLRQWakeUpCancelBundle] = {
+    MixedVec(exuBlockParams.filter(_.hasStoreFu).map(x => Output(new IssueQueueLRQWakeUpCancelBundle)))
   }
 
   def genOGRespBundle(implicit p: Parameters) = {

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -34,6 +34,9 @@ class IssueQueueIO()(implicit p: Parameters, params: IssueBlockParams) extends X
   val wakeupFromF2I: Option[ValidIO[IssueQueueIQWakeUpBundle]] = Option.when(params.needWakeupFromF2I)(Flipped(ValidIO(new IssueQueueIQWakeUpBundle(params.backendParam.getExuIdxF2I, params.backendParam))))
   val wakeupFromWBDelayed: MixedVec[ValidIO[IssueQueueWBWakeUpBundle]] = Flipped(params.genWBWakeUpSinkValidBundle)
   val wakeupFromIQDelayed: MixedVec[ValidIO[IssueQueueIQWakeUpBundle]] = Flipped(params.genIQWakeUpSinkValidBundle)
+  //to Mem, wake up LoadQueueReplay
+  val wakeupToLRQ = Option.when(params.isStAddrIQ || params.isStdIQ)(params.genIOWakeUpLRQValidBundle)
+  val wakeupToLRQCancel = Option.when(params.isStAddrIQ || params.isStdIQ)(params.genIOWakeUpCancelBundle)
   val vlFromIntIsZero = Input(Bool())
   val vlFromIntIsVlmax = Input(Bool())
   val vlFromVfIsZero = Input(Bool())
@@ -948,6 +951,41 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
     dontTouch(io.deqDelay)
     dontTouch(deqBeforeDly)
   }
+  // sta wake up LRQ in og1, std wake up LRQ in og0.
+  io.wakeupToLRQ.foreach { case wakeupOption =>
+    wakeupOption.zipWithIndex.foreach { case (wakeup, i) =>
+      if (param.isStAddrIQ) { // sta iq
+        val wakeupValid = io.deqDelay(i).fire
+        wakeup.valid := RegNext(wakeupValid) // next cycle is og1
+        wakeup.bits.sqIdx := RegNext(entries.io.deqOg1Payload(i).sqIdx.get)
+      }
+      else { // std iq
+        val wakeupValid = deqBeforeDly(i).fire
+        wakeup.valid := RegNext(wakeupValid) // next cycle is og0
+        wakeup.bits.sqIdx := entries.io.deqOg1Payload(i).sqIdx.get
+      }
+
+    }
+  }
+  io.wakeupToLRQCancel.foreach { case wakeupCancelOption =>
+    wakeupCancelOption.zip(param.exuBlockParams.filter(_.hasStoreFu)).zipWithIndex.foreach { case ((wakeupCancel, exuParam), i) =>
+      if (param.isStAddrIQ) { // sta iq: wakeup reaches LRQ in og1; cancel can happen in og1/s0/s1.
+        val og0Fire = io.deqDelay(i).fire
+        val og1Fire = RegNext(og0Fire)
+        val og1LoadDependency = RegEnable(io.deqDelay(i).bits.loadDependency.get, og0Fire)
+        val og1LoadCancel = LoadShouldCancel(Some(og1LoadDependency), io.ldCancel)
+        wakeupCancel.og0Cancel := false.B
+        wakeupCancel.og1Cancel := RegNext(og1Fire && (io.og1Cancel(exuParam.exuIdx) || og1LoadCancel))
+      }
+      else { // std iq: wakeup reaches LRQ in og0; cancel can happen in og0/og1/s0/s1.
+        val og0Fire = RegNext(deqBeforeDly(i).fire)
+        val og1Fire = RegNext(og0Fire)
+        wakeupCancel.og0Cancel := RegNext(og0Fire && io.og0Cancel(exuParam.exuIdx))
+        wakeupCancel.og1Cancel := RegNext(og1Fire && io.og1Cancel(exuParam.exuIdx))
+      }
+    }
+  }
+
   io.wakeupToIQ.zipWithIndex.foreach { case (wakeup, i) =>
     if (wakeUpQueues(i).nonEmpty) {
       wakeup.valid := wakeUpQueues(i).get.io.deq.valid

--- a/src/main/scala/xiangshan/backend/issue/SchdBlockParams.scala
+++ b/src/main/scala/xiangshan/backend/issue/SchdBlockParams.scala
@@ -103,7 +103,7 @@ case class SchdBlockParams(
   def needSrcVxrm: Boolean = issueBlockParams.map(_.needSrcVxrm).reduce(_ || _)
 
   def writeVConfig: Boolean = issueBlockParams.map(_.writeVConfig).reduce(_ || _)
-  
+
   def writeVType: Boolean = issueBlockParams.map(_.writeVType).reduce(_ || _)
 
   def numRedirect: Int = issueBlockParams.map(_.numRedirect).sum
@@ -152,6 +152,14 @@ case class SchdBlockParams(
     MixedVec(this.issueBlockParams.filter(_.isMemBlockIQ).map(_.genNewExuInputDecoupledCopySrcBundle))
   }
 
+  def genMemWakeupLRQBundle(implicit p: Parameters): MixedVec[MixedVec[ValidIO[IssueQueueLRQWakeUpBundle]]] = {
+    MixedVec(this.issueBlockParams.filter(_.isStoreIQ).map(_.genMemWakeupLRQBundle))
+  }
+
+  def genMemWakeupCancelBundle(implicit p: Parameters): MixedVec[MixedVec[IssueQueueLRQWakeUpCancelBundle]] = {
+    MixedVec(this.issueBlockParams.filter(_.isStoreIQ).map(_.genMemWakeupCancelBundle))
+  }
+
   def genExuOutputDecoupledBundle(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[ExuOutput]]] = {
     MixedVec(this.issueBlockParams.map(_.genExuOutputDecoupledBundle))
   }
@@ -187,7 +195,7 @@ case class SchdBlockParams(
   def genExuOutputDecoupledBundleNoMemBlock(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[ExuOutput]]] = {
     MixedVec(this.issueBlockParams.filterNot(_.isMemBlockIQ).map(_.genExuOutputDecoupledBundle))
   }
-  
+
   def genNewExuOutputDecoupledBundleNoMemBlock(implicit p: Parameters): MixedVec[MixedVec[DecoupledIO[NewExuOutput]]] = {
     MixedVec(this.issueBlockParams.filterNot(_.isMemBlockIQ).map(_.genNewExuOutputDecoupledBundle))
   }

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -194,6 +194,8 @@ class ooo_to_mem(implicit p: Parameters) extends MemBlockBundle {
 
   val intIssue: MixedVec[MixedVec[DecoupledIO[ExuInput]]] = Flipped(intSchdParams.genExuInputCopySrcBundleMemBlock)
   val vecIssue: MixedVec[MixedVec[DecoupledIO[ExuInput]]] = Flipped(vecSchdParams.genExuInputCopySrcBundleMemBlock)
+  val wakeupToLRQ = Flipped(Vec(StaCnt + StdCnt, ValidIO(new IssueQueueLRQWakeUpBundle)))
+  val wakeupToLRQCancel = Input(Vec(StaCnt + StdCnt, new IssueQueueLRQWakeUpCancelBundle))
 }
 
 class mem_to_ooo(implicit p: Parameters) extends MemBlockBundle {
@@ -439,6 +441,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
 
   val intIssue: Seq[DecoupledIO[ExuInput]] = io.ooo_to_mem.intIssue.flatten
   val vecIssue: Seq[DecoupledIO[ExuInput]] = io.ooo_to_mem.vecIssue.flatten
+  val wakeupToLRQCancel = Wire(Vec(StaCnt + StdCnt, new LRQWakeUpCancelBundle))
   val issueLda = intIssue.filter(_.bits.params.hasLoadFu)
   val issueSta = intIssue.filter(_.bits.params.hasStoreAddrFu)
   val issueStd = intIssue.filter(_.bits.params.hasStdFu)
@@ -492,6 +495,21 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   val newLoadUnits = Seq.tabulate(LduCnt)(i => Module(new NewLoadUnit(ldaParams(i))))
   val storeUnits = Seq.tabulate(StaCnt)(i => Module(new NewStoreUnit(staParams(i))))
   val stdExeUnits = Seq.tabulate(StdCnt)(i => Module(new StdExeUnit(stdParams(i))))
+
+  wakeupToLRQCancel.take(StaCnt).zip(storeUnits).zip(io.ooo_to_mem.wakeupToLRQCancel.take(StaCnt)).foreach {
+    case ((sink, stu), source) =>
+      sink.og0Cancel := source.og0Cancel
+      sink.og1Cancel := source.og1Cancel
+      sink.s0Cancel := RegNext(!stu.io.stin.ready)
+      sink.s1Cancel := stu.io.feedBackSlow.valid && !stu.io.feedBackSlow.bits.hit
+  }
+  wakeupToLRQCancel.drop(StaCnt).take(StdCnt).zip(stdExeUnits).zip(io.ooo_to_mem.wakeupToLRQCancel.drop(StaCnt).take(StdCnt)).foreach {
+    case ((sink, std), source) =>
+      sink.og0Cancel := source.og0Cancel
+      sink.og1Cancel := source.og1Cancel
+      sink.s0Cancel := RegNext(!std.io.in.ready)
+      sink.s1Cancel := false.B // TODO: will be used in the future.
+  }
   val atomicsUnit = Module(new AtomicsUnit(mouParam))
 
   // The number of vector load/store units is decoupled with the number of load/store units
@@ -1028,6 +1046,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
 
   //  lsq.io.rob            <> io.lsqio.rob
   lsq.io.enq            <> io.ooo_to_mem.enqLsq
+  lsq.io.wakeupToLRQ <> io.ooo_to_mem.wakeupToLRQ
+  lsq.io.wakeupToLRQCancel := wakeupToLRQCancel
   lsq.io.brqRedirect    <> redirect
 
   //  violation rollback

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQBundle.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQBundle.scala
@@ -28,6 +28,13 @@ import xiangshan.cache.{CMOReq, CMOResp, DCacheWordReqWithVaddrAndPfFlag, Uncach
 import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.mem.Bundles.{SQForward, StoreMaskBundle}
 
+  class LRQWakeUpCancelBundle(implicit p: Parameters) extends XSBundle {
+    val og0Cancel = Bool()
+    val og1Cancel = Bool()
+    val s0Cancel  = Bool()
+    val s1Cancel  = Bool()
+  }
+
 class StoreQueueEnqIO(implicit p: Parameters) extends MemBlockBundle {
   // Bundle define
 
@@ -112,7 +119,7 @@ class StoreAddrIO(implicit p: Parameters) extends MemBlockBundle {
   * means this write request need to write whole cacheline.
   * */
   val wlineflag          = Bool() // store write the whole cache line.
-  
+
   // misalign
   val isUnalign   = Bool()
   val cross16Byte = Bool()

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -22,7 +22,7 @@ import chisel3.util._
 import utils._
 import utility._
 import xiangshan._
-import xiangshan.backend.Bundles.{DynInst, ExuOutput, MemExuOutput, MemToRob, UopIdx, connectSamePort}
+import xiangshan.backend.Bundles.{DynInst, ExuOutput, IssueQueueLRQWakeUpBundle, MemExuOutput, MemToRob, UopIdx, connectSamePort}
 import xiangshan.backend._
 import xiangshan.backend.rob.{RobLsqIO, RobPtr}
 import xiangshan.backend.fu.FuType
@@ -117,6 +117,8 @@ class LsqWrapper(implicit p: Parameters) extends XSModule
     val issuePtrExt = Output(new SqPtr)
     val l2_hint = Input(Valid(new L2ToL1Hint()))
     val tlb_hint = Flipped(new TlbHintIO)
+    val wakeupToLRQ = Vec(StaCnt + StdCnt, Flipped(ValidIO(new IssueQueueLRQWakeUpBundle)))
+    val wakeupToLRQCancel = Input(Vec(StaCnt + StdCnt, new LRQWakeUpCancelBundle))
     val cmoOpReq  = DecoupledIO(new CMOReq)
     val cmoOpResp = Flipped(DecoupledIO(new CMOResp))
     val flushSbuffer = new SbufferFlushBundle
@@ -233,6 +235,8 @@ class LsqWrapper(implicit p: Parameters) extends XSModule
   loadQueue.io.lqDeq               <> io.lqDeq
   loadQueue.io.l2_hint             <> io.l2_hint
   loadQueue.io.tlb_hint            <> io.tlb_hint
+  loadQueue.io.wakeupToLRQ         <> io.wakeupToLRQ
+  loadQueue.io.wakeupToLRQCancel   := io.wakeupToLRQCancel
   loadQueue.io.lqEmpty             <> io.lqEmpty
   io.mdpTrain                      := loadQueue.io.mdpTrain
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -26,7 +26,7 @@ import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.backend._
 import xiangshan.backend.fu.fpu._
 import xiangshan.backend.rob.RobLsqIO
-import xiangshan.backend.Bundles.{DynInst, ExuOutput, MemExuOutput}
+import xiangshan.backend.Bundles.{DynInst, ExuOutput, IssueQueueLRQWakeUpBundle, MemExuOutput}
 import xiangshan.backend.rob.RobPtr
 import xiangshan.mem.mdp._
 import xiangshan.mem.Bundles._
@@ -199,6 +199,8 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     val tlbReplayDelayCycleCtrl = Vec(4, Input(UInt(ReSelectLen.W)))
     val l2_hint = Input(Valid(new L2ToL1Hint()))
     val tlb_hint = Flipped(new TlbHintIO)
+    val wakeupToLRQ = Vec(StaCnt + StdCnt, Flipped(ValidIO(new IssueQueueLRQWakeUpBundle)))
+    val wakeupToLRQCancel = Input(Vec(StaCnt + StdCnt, new LRQWakeUpCancelBundle))
     val lqEmpty = Output(Bool())
 
     // mdp train io
@@ -278,8 +280,6 @@ class LoadQueue(implicit p: Parameters) extends XSModule
    */
   loadQueueReplay.io.redirect         <> io.redirect
   loadQueueReplay.io.enq              <> io.ldu.ldin // from load_s3
-  loadQueueReplay.io.storeAddrIn      <> io.sta.storeAddrIn // from store_s1
-  loadQueueReplay.io.storeDataIn      <> io.std.storeDataIn // from store_s0
   loadQueueReplay.io.replay           <> io.replay
   loadQueueReplay.io.loadWakeup       <> io.loadWakeup
   loadQueueReplay.io.stAddrReadySqPtr <> io.sq.stAddrReadySqPtr
@@ -295,6 +295,10 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   loadQueueReplay.io.l2_hint          <> io.l2_hint
   loadQueueReplay.io.tlb_hint         <> io.tlb_hint
   loadQueueReplay.io.tlbReplayDelayCycleCtrl <> io.tlbReplayDelayCycleCtrl
+  loadQueueReplay.io.storeAddrWakeup.zip(io.wakeupToLRQ.take(StaCnt)).foreach { case (sink, source) => sink := source }
+  loadQueueReplay.io.storeDataWakeup.zip(io.wakeupToLRQ.drop(StaCnt).take(StdCnt)).foreach { case (sink, source) => sink := source }
+  loadQueueReplay.io.storeAddrWakeupCancel.zip(io.wakeupToLRQCancel.take(StaCnt)).foreach { case (sink, source) => sink := source }
+  loadQueueReplay.io.storeDataWakeupCancel.zip(io.wakeupToLRQCancel.drop(StaCnt).take(StdCnt)).foreach { case (sink, source) => sink := source }
 
   loadQueueReplay.io.mmioWakeup := uncacheBuffer.io.mmioWakeup
   loadQueueReplay.io.ncWakeup := uncacheBuffer.io.ncWakeup

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -21,12 +21,13 @@ import chisel3.util._
 import utility._
 import xiangshan._
 import xiangshan.ExceptionNO._
-import xiangshan.backend.Bundles.{DynInst, ExuOutput, MemExuOutput}
+import xiangshan.backend.Bundles.{DynInst, ExuOutput, MemExuOutput, IssueQueueLRQWakeUpBundle}
 import xiangshan.mem.Bundles._
 import xiangshan.cache._
 import xiangshan.cache.wpu.ReplayCarry
 import xiangshan.cache.mmu._
 import math._
+import yunsuan.VectorElementFormat
 
 object LoadReplayCauses {
   // these causes have priority, lower coding has higher priority.
@@ -164,6 +165,27 @@ object AgeDetector {
   }
 }
 
+object StoreWakeupShouldCancel {
+  def apply(scoreboard: Seq[UInt], storeCancel: Seq[LRQWakeUpCancelBundle], isStd: Boolean): Bool = {
+    require(scoreboard.head.getWidth >= (if (isStd) 4 else 3))
+    require(scoreboard.length == storeCancel.length)
+    if (isStd) {
+      val og0Cancel = scoreboard.zip(storeCancel.map(_.og0Cancel)).map { case (sc, cancel) => sc(0) && cancel }.reduce(_ || _)
+      val og1Cancel = scoreboard.zip(storeCancel.map(_.og1Cancel)).map { case (sc, cancel) => sc(1) && cancel }.reduce(_ || _)
+      val s0Cancel = scoreboard.zip(storeCancel.map(_.s0Cancel)).map { case (sc, cancel) => sc(2) && cancel }.reduce(_ || _)
+      val s1Cancel = scoreboard.zip(storeCancel.map(_.s1Cancel)).map { case (sc, cancel) => sc(3) && cancel }.reduce(_ || _)
+
+      og0Cancel || og1Cancel || s0Cancel || s1Cancel
+    } else {
+      val og1Cancel = scoreboard.zip(storeCancel.map(_.og1Cancel)).map { case (sc, cancel) => sc(0) && cancel }.reduce(_ || _)
+      val s0Cancel = scoreboard.zip(storeCancel.map(_.s0Cancel)).map { case (sc, cancel) => sc(1) && cancel }.reduce(_ || _)
+      val s1Cancel = scoreboard.zip(storeCancel.map(_.s1Cancel)).map { case (sc, cancel) => sc(2) && cancel }.reduce(_ || _)
+
+      og1Cancel || s0Cancel || s1Cancel
+    }
+  }
+}
+
 
 class LoadQueueReplay(implicit p: Parameters) extends XSModule
   with HasDCacheParameters
@@ -181,11 +203,13 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     // from load unit s3
     val enq = Vec(LoadPipelineWidth, Flipped(Decoupled(new LqWriteBundle)))
 
-    // from sta s1
-    val storeAddrIn = Vec(StorePipelineWidth, Flipped(Valid(new StoreAddrIO)))
+    // from sta og1
+    val storeAddrWakeup = Vec(StorePipelineWidth, Flipped(ValidIO(new IssueQueueLRQWakeUpBundle)))
+    val storeAddrWakeupCancel = Vec(StorePipelineWidth, Input(new LRQWakeUpCancelBundle))
 
-    // from std s1
-    val storeDataIn = Vec(StorePipelineWidth, Flipped(Valid(new StoreQueueDataWrite)))
+    // from std og1
+    val storeDataWakeup = Vec(StorePipelineWidth, Flipped(ValidIO(new IssueQueueLRQWakeUpBundle)))
+    val storeDataWakeupCancel = Vec(StorePipelineWidth, Input(new LRQWakeUpCancelBundle))
 
     // queue-based replay
     val replay = Vec(LoadPipelineWidth, Decoupled(new LoadReplayIO))
@@ -271,6 +295,8 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val dataInLastBeatReg = RegInit(VecInit(List.fill(LoadQueueReplaySize)(false.B)))
   //  LoadQueueReplay deallocate
   val freeMaskVec = Wire(Vec(LoadQueueReplaySize, Bool()))
+  // LoadQueueReplaySize * StorePipelineWidth
+  val storeIssueScoreBoard = RegInit(VecInit(List.fill(LoadQueueReplaySize)(VecInit(List.fill(StorePipelineWidth)(0.U(LoadDependenceScoreBoardWidth.W))))))
 
   /**
    * Enqueue
@@ -301,6 +327,8 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val dataNotBlockVec = Wire(Vec(LoadQueueReplaySize, Bool()))
   val storeAddrValidVec = addrNotBlockVec.asUInt | storeAddrInSameCycleVec.asUInt
   val storeDataValidVec = dataNotBlockVec.asUInt | storeDataInSameCycleVec.asUInt
+  val storeAddrWakeupVec = WireInit(VecInit(Seq.fill(LoadQueueReplaySize)(VecInit(Seq.fill(StorePipelineWidth)(false.B)))))
+  val storeDataWakeupVec = WireInit(VecInit(Seq.fill(LoadQueueReplaySize)(VecInit(Seq.fill(StorePipelineWidth)(false.B)))))
 
   // store data valid check
   val stAddrReadyVec = io.stAddrReadyVec
@@ -312,17 +340,18 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     dataNotBlockVec(i) := isAfter(io.stDataReadySqPtr, blockSqIdx(i)) || stDataReadyVec(blockSqIdx(i).value) || io.sqEmpty // for better timing
     addrNotBlockVec(i) := isAfter(io.stAddrReadySqPtr, blockSqIdx(i)) || !strict(i) && stAddrReadyVec(blockSqIdx(i).value) || io.sqEmpty // for better timing
     // store address execute
-    storeAddrInSameCycleVec(i) := VecInit((0 until StorePipelineWidth).map(w => {
-      io.storeAddrIn(w).valid &&
-      !io.storeAddrIn(w).bits.tlbMiss &&
-      blockSqIdx(i) === io.storeAddrIn(w).bits.uop.sqIdx
-    })).asUInt.orR // for better timing
+    (0 until StorePipelineWidth).map(w => {
+      storeAddrWakeupVec(i)(w) := io.storeAddrWakeup(w).valid &&
+        blockSqIdx(i) === io.storeAddrWakeup(w).bits.sqIdx
+    })
+    storeAddrInSameCycleVec(i) := storeAddrWakeupVec(i).asUInt.orR // for better timing
 
     // store data execute
-    storeDataInSameCycleVec(i) := VecInit((0 until StorePipelineWidth).map(w => {
-      io.storeDataIn(w).valid &&
-      blockSqIdx(i) === io.storeDataIn(w).bits.sqIdx
-    })).asUInt.orR // for better timing
+    (0 until StorePipelineWidth).map(w => {
+      storeDataWakeupVec(i)(w) := io.storeDataWakeup(w).valid &&
+        blockSqIdx(i) === io.storeDataWakeup(w).bits.sqIdx
+    })
+    storeDataInSameCycleVec(i) := storeDataWakeupVec(i).asUInt.orR // for better timing
 
   }
 
@@ -346,6 +375,17 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val lqIdxMatchNc = VecInit((0 until LoadQueueReplaySize).map { i =>
     io.ncWakeup.valid && io.ncWakeup.bits === uop(i).lqIdx
   })
+
+  val storeAddrWakeupCancelVec = VecInit((0 until LoadQueueReplaySize).map(i =>
+    allocated(i) && cause(i)(LoadReplayCauses.C_MA) &&
+      StoreWakeupShouldCancel(storeIssueScoreBoard(i), io.storeAddrWakeupCancel, isStd = false)
+  ))
+  val storeDataWakeupCancelVec = VecInit((0 until LoadQueueReplaySize).map(i =>
+    allocated(i) && cause(i)(LoadReplayCauses.C_FF) &&
+      StoreWakeupShouldCancel(storeIssueScoreBoard(i), io.storeDataWakeupCancel, isStd = true)
+  ))
+  val storeAddrWakeupCount = PopCount((0 until LoadQueueReplaySize).map(i => storeAddrWakeupVec(i).asUInt.orR && allocated(i)))
+  val storeDataWakeupCount = PopCount((0 until LoadQueueReplaySize).map(i => storeDataWakeupVec(i).asUInt.orR && allocated(i)))
   // update blocking condition
   (0 until LoadQueueReplaySize).map(i => {
     // case C_MA
@@ -388,6 +428,34 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       blocking(i) := Mux(!isAfter(uop(i).sqIdx, io.sqDeqPtr), false.B, blocking(i))
     }
   })
+
+  (0 until LoadQueueReplaySize).foreach { case i =>
+    when(cause(i)(LoadReplayCauses.C_MA) || cause(i)(LoadReplayCauses.C_FF)) {
+      when(storeAddrWakeupVec(i).reduce(_ || _) || storeDataWakeupVec(i).reduce(_ || _)) {
+        when(cause(i)(LoadReplayCauses.C_MA)) {
+          storeIssueScoreBoard(i).zip(storeAddrWakeupVec(i)).foreach{ case (sink, source) =>
+            sink := Cat(0.U((LoadDependenceScoreBoardWidth - 1).W), source && allocated(i))
+          }
+        }
+        when(cause(i)(LoadReplayCauses.C_FF)) {
+          storeIssueScoreBoard(i).zip(storeDataWakeupVec(i)).foreach{ case (sink, source) =>
+            sink := Cat(0.U((LoadDependenceScoreBoardWidth - 1).W), source && allocated(i))
+          }
+        }
+      }.otherwise {
+        storeIssueScoreBoard(i).foreach { case x =>
+          x := x << 1.U
+        }
+      }
+    }.otherwise {
+      storeIssueScoreBoard(i).foreach { case x =>
+        x := 0.U
+      }
+    }
+
+      XSError(allocated(i) && cause(i)(LoadReplayCauses.C_MA) && PopCount(storeAddrWakeupVec(i)) > 1.U, s"storeAddrWakeup source exceed 1! ${i}\n")
+      XSError(allocated(i) && cause(i)(LoadReplayCauses.C_FF) && PopCount(storeDataWakeupVec(i)) > 1.U, s"storeDataWakeup source exceed 1! ${i}\n")
+  }
 
   //  Replay is splitted into 3 stages
   require((LoadQueueReplaySize % LoadPipelineWidth) == 0)
@@ -533,32 +601,37 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   def coldDownNow(i: Int) = coldCounter(i) >= ColdDownThreshold
 
   val replay_req = io.replay
+  val s1_cancelReplay = Wire(Vec(LoadPipelineWidth, Bool()))
+  val s2_cancelReplay = Wire(Vec(LoadPipelineWidth, Bool()))
 
   for (i <- 0 until LoadPipelineWidth) {
     val s0_can_go = s1_can_go(i) ||
+                    s1_cancelReplay(i) ||
                     uop(s1_oldestSel(i).bits).robIdx.needFlush(io.redirect) ||
                     uop(s1_oldestSel(i).bits).robIdx.needFlush(RegNext(io.redirect))
     val s0_oldestSelIndexOH = s0_oldestSel(i).bits // one-hot
-    s1_oldestSel(i).valid := RegEnable(s0_oldestSel(i).valid, false.B, s0_can_go)
+    val s0_oldestSelV = s0_oldestSel(i).valid
+    s1_oldestSel(i).valid := RegEnable(s0_oldestSelV, false.B, s0_can_go)
     s1_oldestSel(i).bits := RegEnable(OHToUInt(s0_oldestSel(i).bits), s0_can_go)
 
     for (j <- 0 until LoadQueueReplaySize) {
-      when (s0_can_go && s0_oldestSel(i).valid && s0_oldestSelIndexOH(j)) {
+      when (s0_can_go && s0_oldestSelV && s0_oldestSelIndexOH(j)) {
         scheduled(j) := true.B
       }
     }
   }
-  val s2_cancelReplay = Wire(Vec(LoadPipelineWidth, Bool()))
   for (i <- 0 until LoadPipelineWidth) {
-    val s1_cancel = uop(s1_oldestSel(i).bits).robIdx.needFlush(io.redirect) ||
-                    uop(s1_oldestSel(i).bits).robIdx.needFlush(RegNext(io.redirect))
-    val s1_oldestSelV = s1_oldestSel(i).valid && !s1_cancel
+    val s1_replayIdx = s1_oldestSel(i).bits
+    val s1_redirectCancel = uop(s1_replayIdx).robIdx.needFlush(io.redirect) ||
+      uop(s1_replayIdx).robIdx.needFlush(RegNext(io.redirect))
+    s1_cancelReplay(i) := s1_redirectCancel
+    val s1_oldestSelV = s1_oldestSel(i).valid && !s1_cancelReplay(i)
     s1_can_go(i)          := replayCanFire(i) && (!s2_oldestSel(i).valid || replay_req(i).fire) || s2_cancelReplay(i)
     s2_oldestSel(i).valid := RegEnable(Mux(s1_can_go(i), s1_oldestSelV, false.B), false.B, (s1_can_go(i) || replay_req(i).fire))
     s2_oldestSel(i).bits  := RegEnable(s1_oldestSel(i).bits, s1_can_go(i))
 
-    vaddrModule.io.ren(i) := s1_oldestSel(i).valid && s1_can_go(i)
-    vaddrModule.io.raddr(i) := s1_oldestSel(i).bits
+    vaddrModule.io.ren(i) := s1_oldestSelV && s1_can_go(i)
+    vaddrModule.io.raddr(i) := s1_replayIdx
   }
 
   for (i <- 0 until LoadPipelineWidth) {
@@ -574,7 +647,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     s2_can_go(i) := DontCare
     val replay_req_vaddr = vaddrModule.io.rdata(i)
     val replay_req_size = LSUOpType.size(s2_replayUop.fuOpType)
-    replay_req(i).valid := s2_oldestSel(i).valid
+    replay_req(i).valid := s2_oldestSel(i).valid && !s2_cancelReplay(i)
     replay_req(i).bits.entrance := Mux(
       s2_replayCauses(LoadReplayCauses.C_DM) || s2_replayCauses(LoadReplayCauses.C_UNCACHE),
       LoadEntrance.replayHiPrio.U,
@@ -852,6 +925,21 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val replayForwardFailCount  = PopCount(io.enq.map(enq => enq.fire && !enq.bits.isLoadReplay && enq.bits.rep_info.cause(LoadReplayCauses.C_FF)))
   val replayDCacheMissCount   = PopCount(io.enq.map(enq => enq.fire && !enq.bits.isLoadReplay && enq.bits.rep_info.cause(LoadReplayCauses.C_DM)))
   val replayMultiMatchCount   = PopCount(io.enq.map(enq => enq.fire && !enq.bits.isLoadReplay && enq.bits.rep_info.cause(LoadReplayCauses.C_SMF)))
+  val replayStoreAddrWakeupCancelCount = PopCount(storeAddrWakeupCancelVec)
+  val replayStoreDataWakeupCancelCount = PopCount(storeDataWakeupCancelVec)
+  def storeIssueScoreBoardDelay3(idx: UInt): Bool = {
+    VecInit(storeIssueScoreBoard.map(scoreBoard =>
+      VecInit(scoreBoard.map(_(2))).asUInt.orR
+    ))(idx)
+  }
+  val replayStoreAddrWakeupDelay3FireCount = PopCount(io.replay.map(r =>
+    r.fire && r.bits.cause.get(LoadReplayCauses.C_MA) &&
+      storeIssueScoreBoardDelay3(r.bits.replayQueueIdx.get)
+  ))
+  val replayStoreDataWakeupDelay3FireCount = PopCount(io.replay.map(r =>
+    r.fire && r.bits.cause.get(LoadReplayCauses.C_FF) &&
+      storeIssueScoreBoardDelay3(r.bits.replayQueueIdx.get)
+  ))
   XSPerfAccumulate("enq", enqNumber)
   XSPerfAccumulate("deq", deqNumber)
   XSPerfAccumulate("deq_block", deqBlockCount)
@@ -868,6 +956,12 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("replay_hint_wakeup", s0_hintSelValid)
   XSPerfAccumulate("replay_hint_priority_beat1", io.l2_hint.valid && io.l2_hint.bits.isKeyword)
   XSPerfAccumulate("replay_storeQueue_multi_match", replayMultiMatchCount)
+  XSPerfAccumulate("replay_store_addr_wakeup", storeAddrWakeupCount)
+  XSPerfAccumulate("replay_store_data_wakeup", storeDataWakeupCount)
+  XSPerfAccumulate("replay_store_addr_wakeup_cancel", replayStoreAddrWakeupCancelCount)
+  XSPerfAccumulate("replay_store_data_wakeup_cancel", replayStoreDataWakeupCancelCount)
+  XSPerfAccumulate("replay_store_addr_wakeup_delay3_fire", replayStoreAddrWakeupDelay3FireCount)
+  XSPerfAccumulate("replay_store_data_wakeup_delay3_fire", replayStoreDataWakeupDelay3FireCount)
 
   // replay counter
   val perfReplayCounter = RegInit(VecInit(Seq.fill(LoadQueueReplaySize)(0.U(8.W))))

--- a/src/main/scala/xiangshan/mem/pipeline/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/Bundles.scala
@@ -103,6 +103,7 @@ class LoadPipeBundle(
   def isNCReplay(): Bool = uncacheReplay.getOrElse(false.B) && ncReplay.getOrElse(false.B)
   def isMMIOReplay(): Bool = uncacheReplay.getOrElse(false.B) && !ncReplay.getOrElse(false.B)
   def isUncacheReplay(): Bool = uncacheReplay.getOrElse(false.B)
+  def isReplayHiPrioEntrance(): Bool = LoadEntrance.isReplayHiPrio(entrance)
 
   // vector
   val elemIdx = Option.when(param.hasVector)(UInt(elemIdxBits.W))
@@ -241,7 +242,7 @@ class StorePipeBundle(
   // StoreSet
   val ssid = Option.when(param.hasStoreSet)(UInt(SSIDWidth.W))
   val storeSetHit = Option.when(param.hasStoreSet)(Bool())
-  
+
   // Unalign handling
   val align = Option.when(param.hasUnalignHandling)(Bool())
   val unalignHead = Option.when(param.hasUnalignHandling)(Bool())
@@ -268,7 +269,7 @@ class StorePipeBundle(
   val mbIndex = Option.when(param.hasVector)(UInt(vlmBindexBits.W))
   val vecTriggerMask = Option.when(param.hasVector)(UInt((VLEN/8).W))
   val vecVaddrOffset = Option.when(param.hasVector)(UInt(VAddrBits.W))
-  
+
   def DontCareUnalign(): Unit = {
     align.get := DontCare
     unalignHead.get := DontCare

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -129,7 +129,7 @@ class LoadUnitS0(param: ExeUnitParams)(
   replay.noQuery.get := io.replay.bits.uncacheReplay.get
   replay.DontCarePAddr()
   replay.DontCareUnalign() // assign later in sink
-  val replayIsHiPrio = io.replay.bits.forwardDChannel.get || io.replay.bits.isUncacheReplay()
+  val replayIsHiPrio = io.replay.bits.isReplayHiPrioEntrance()
   replayHiPrio.valid := io.replay.valid && replayIsHiPrio
   replayHiPrio.bits := replay
   replayHiPrio.bits.entrance := LoadEntrance.replayHiPrio.U
@@ -146,7 +146,7 @@ class LoadUnitS0(param: ExeUnitParams)(
   // 3. low-priority replay from LRQ
   val replayStall = io.ldin.valid && isAfter(io.replay.bits.uop.lqIdx, io.ldin.bits.lqIdx.get) ||
     io.vecldin.valid && isAfter(io.replay.bits.uop.lqIdx, io.vecldin.bits.uop.lqIdx)
-  val replayIsLoPrio = !io.replay.bits.forwardDChannel.get && !io.replay.bits.isUncacheReplay() && !replayStall
+  val replayIsLoPrio = !io.replay.bits.isReplayHiPrioEntrance() && !replayStall
   replayLoPrio.valid := io.replay.valid && replayIsLoPrio
   replayLoPrio.bits := replay
   replayLoPrio.bits.entrance := LoadEntrance.replayLoPrio.U

--- a/src/main/scala/xiangshan/mem/pipeline/package.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/package.scala
@@ -80,6 +80,7 @@ object LoadEntrance extends ChiselOHEnum {
   def isHWPrefetch(source: UInt): Bool = IsOneOf(source, prefetchHiConf, prefetchLoConf)
   def isVectorIssue(source: UInt): Bool = IsOneOf(source, vectorIssue)
   def isScalarIssue(source: UInt): Bool = IsOneOf(source, scalarIssue)
+  def isReplayHiPrio(source: UInt): Bool = IsOneOf(source, replayHiPrio)
 
   def findNameById(id: Int): String = {
     values.find(_.id == id).map(_.getName).getOrElse("UNKNOWN")
@@ -88,7 +89,7 @@ object LoadEntrance extends ChiselOHEnum {
 
 class LoadAccessType extends Bundle {
   val instrType = InstrType()
-  val pftType = PrefetchType() // only 
+  val pftType = PrefetchType() // only
   val pftCoh = PrefetchCoh()
 
   import InstrType._
@@ -164,7 +165,7 @@ object StoreStage extends Enumeration {
 trait OnStoreStage {
   import StoreStage._
   implicit val s: StoreStage
-  
+
   def is(sn: StoreStage): Boolean = s.id == sn.id
   def after(s1: StoreStage, s2: StoreStage): Boolean = s1.id >= s2.id
   def isS0: Boolean = is(StoreS0())


### PR DESCRIPTION
This PR add the support of fast wakeup for load of mdp hit && forward fail. 

The timing of Sta wakeup:  

<img width="5444" height="3616" alt="image" src="https://github.com/user-attachments/assets/2fa857c3-04b4-47f5-a7fa-e6db9a3aaa85" />


The timing of Std wakeup:  

<img width="4884" height="3776" alt="image" src="https://github.com/user-attachments/assets/79c2af96-c276-4874-af32-e91aa8b26ab0" />


The timing of Cancel

<img width="5484" height="1404" alt="image" src="https://github.com/user-attachments/assets/14285051-34c3-497c-b25b-a71e041a0d79" />

Note: The Std pipeline only has 1 stage. Here, a virtual pipeline stage is drawn for easier comparison.

Performance (have Cancel): 

<img width="567" height="1041" alt="image" src="https://github.com/user-attachments/assets/56c72bf6-c433-4075-8e87-583032eea954" />


Performance (don't have cancel)

<img width="639" height="1041" alt="image" src="https://github.com/user-attachments/assets/3287f0ea-afd4-4ab2-994c-4f83ccb212c2" />

**Cancel has little impact on performance, so we don't need to add extra overhead just for cancel.**

**std's wake up can 1 cycle early.**

<img width="4884" height="3772" alt="image" src="https://github.com/user-attachments/assets/c70f0d3e-250b-4819-86a7-61c2e1c8066d" />

Performance (**Current version**)

<img width="636" height="1050" alt="image" src="https://github.com/user-attachments/assets/2c7e586c-645b-4041-87c9-8013ff38e0fe" />

