### PR TITLE
submodule(difftest): expose CPU/MEM AXI for fpgadiff

### DIFF
--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -20,7 +20,7 @@ package top
 import chisel3._
 import chisel3.util._
 import chisel3.experimental.dataview._
-import difftest.{DifftestModule, HasDiffTestInterfaces}
+import difftest.{DifftestMemIO, DifftestModule, HasDiffTestInterfaces}
 import xiangshan._
 import utils._
 import utility._
@@ -401,6 +401,7 @@ class XSTileDiffTop(implicit p: Parameters) extends XSTop {
     override def cpuName: Option[String] = Some("XiangShan")
     override protected def implicitClock: Clock = io.clock
     override protected def implicitReset: Reset = io.reset
+    override def difftestMemIO: Option[DifftestMemIO] = Some(DifftestMemIO(memory))
   }
   override lazy val module = new XSTileDiffTopImp(this)
 }

--- a/src/test/scala/top/SimTop.scala
+++ b/src/test/scala/top/SimTop.scala
@@ -23,6 +23,7 @@ import chisel3.util._
 import chisel3.experimental.dataview._
 import device.{AXI4MemorySlave, SimJTAG}
 import difftest._
+import difftest.fpga.DifftestMemCtrl
 import freechips.rocketchip.amba.axi4._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util.HeterogeneousBag
@@ -43,7 +44,7 @@ class MemXbar(implicit p: Parameters) extends LazyModule
       aligned = true
     ))
   )))
-  
+
   val devNode = AXI4MasterNode(Seq(AXI4MasterPortParameters(
     Seq(AXI4MasterParameters(
       name = "device_node",
@@ -83,7 +84,7 @@ class MemXbar(implicit p: Parameters) extends LazyModule
   val io_memNode = InModuleBody {memNode.makeIOs()}
 
   lazy val module = new Imp
-  class Imp extends LazyModuleImp(this) 
+  class Imp extends LazyModuleImp(this)
 }
 
 class XiangShanSim(implicit p: Parameters) extends Module with HasDiffTestInterfaces {
@@ -114,11 +115,16 @@ class XiangShanSim(implicit p: Parameters) extends Module with HasDiffTestInterf
     useBlackBox = true,
     dynamicLatency = debugOpts.UseDRAMSim
   )
-  val simAXIMem = Module(l_simAXIMem.module) 
+  val simAXIMem = Module(l_simAXIMem.module)
 
   l_memXbar.io_cpuNode.elements.head._2 :<>= soc.memory.viewAs[AXI4Bundle].waiveAll
   l_memXbar.io_devNode.elements.head._2 <> l_simMMIO.io_mem.elements.head._2
   l_simAXIMem.io_axi4.elements.head._2 <> l_memXbar.io_memNode.elements.head._2
+
+  val memIO = Option.when(DifftestModule.isFPGA) {
+    DifftestMemCtrl.exposeIO(soc.memory.viewAs[AXI4Bundle], l_simAXIMem.io_axi4.elements.head._2)
+  }
+  override def difftestMemIO: Option[DifftestMemIO] = memIO
 
   soc.io.clock := clock
   soc.io.reset := (reset.asBool || soc.io.debug_reset).asAsyncReset


### PR DESCRIPTION
Corresponding kunminghu-v2 changes:
https://github.com/OpenXiangShan/XiangShan/pull/6026 
https://github.com/OpenXiangShan/XiangShan/pull/6049 
https://github.com/OpenXiangShan/XiangShan/pull/6055