### PR TITLE
fix(StoreQueue): StoreMisalignBuffer crosspage matching should use SQ rdataptr

### DIFF
--- a/src/main/scala/xiangshan/mem/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/Bundles.scala
@@ -283,7 +283,7 @@ object Bundles {
       // High page Paddr
       val paddr = UInt(PAddrBits.W)
 
-      val withSameUop = Bool()
+      val withSamePtr = Bool()
     })
     // from storeQueue to storeMisalignBuffer, provide detail info of this store
     val toStoreMisalignBuffer = Input(new XSBundle {

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -220,11 +220,15 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
     ExceptionNO.selectByFu(io.splitStoreResp.bits.uop.exceptionVec, StaCfg).asUInt.orR || TriggerAction.isDmode(io.splitStoreResp.bits.uop.trigger)
   val isUncache = (io.splitStoreResp.bits.mmio || io.splitStoreResp.bits.nc) && !io.splitStoreResp.bits.need_rep
 
-  io.sqControl.toStoreQueue.crossPageWithHit := io.sqControl.toStoreMisalignBuffer.sqPtr === req.uop.sqIdx && isCrossPage
-  io.sqControl.toStoreQueue.crossPageCanDeq := !isCrossPage || bufferState === s_block
+  val sameSqPtr = io.sqControl.toStoreMisalignBuffer.sqPtr === req.uop.sqIdx
+  val sameUop = io.sqControl.toStoreMisalignBuffer.uop.robIdx === req.uop.robIdx &&
+    io.sqControl.toStoreMisalignBuffer.uop.uopIdx === req.uop.uopIdx
+
+  io.sqControl.toStoreQueue.crossPageWithHit := sameSqPtr && isCrossPage
+  io.sqControl.toStoreQueue.crossPageCanDeq := !isCrossPage || bufferState === s_block || (req.isvec && bufferState === s_wb)
   io.sqControl.toStoreQueue.paddr := Cat(splitStoreResp(1).paddr(splitStoreResp(1).paddr.getWidth - 1, 3), 0.U(3.W))
 
-  io.sqControl.toStoreQueue.withSameUop := io.sqControl.toStoreMisalignBuffer.uop.robIdx === req.uop.robIdx && io.sqControl.toStoreMisalignBuffer.uop.uopIdx === req.uop.uopIdx && req.isvec && robMatch && isCrossPage
+  io.sqControl.toStoreQueue.withSamePtr := sameSqPtr && sameUop && req.isvec && robMatch && isCrossPage
 
   //state transition
   switch(bufferState) {

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -1468,7 +1468,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
   // For vector, when there is a store across pages with the same uop in storeMisalignBuffer, storequeue needs to mark this item as committed.
   // TODO FIXME Can vecMbCommit be removed?
-  when(io.maControl.toStoreQueue.withSameUop && allvalid(rdataPtrExt(0).value)) {
+  when(io.maControl.toStoreQueue.withSamePtr && allvalid(rdataPtrExt(0).value)) {
     vecMbCommit(rdataPtrExt(0).value) := true.B
   }
 

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -182,7 +182,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   )) + s0_addr_low
   val s0_rs_cross16Bytes = s0_addr_Up_low(4) =/= s0_addr_low(4)
   val s0_misalignWith16Byte = !s0_rs_cross16Bytes && !s0_addr_aligned && !s0_use_flow_prf
-  val s0_misalignNeedReplay = s0_rs_cross16Bytes && !(s0_uop.sqIdx === io.sqCommitPtr || s0_uop.robIdx === io.sqCommitRobIdx && s0_uop.uopIdx === io.sqCommitUopIdx)
+  val s0_misalignNeedReplay = s0_rs_cross16Bytes && !(s0_uop.sqIdx === io.sqCommitPtr)
   s0_is128bit := Mux(s0_use_flow_ma, io.misalign_stin.bits.is128bit, is128Bit(s0_vecstin.alignedType) || s0_misalignWith16Byte)
 
   s0_fullva := Mux(


### PR DESCRIPTION
Previously, we compared using robidx and uopidx. However, in vector scenarios, a single uop can contain multiple elements, which may incorrectly mark multiple consecutive StoreQueue entries as ready to commit. This is unreasonable.