### PR TITLE
feat(MMU): add ptehelper support

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -76,7 +76,7 @@ case class XSCoreParameters
   AsidLength: Int = 16,
   SdidLength: Int = 6,
   VmidLength: Int = 14,
-  EnbaleTlbDebug: Boolean = false,
+  EnableTlbDebug: Boolean = false,
   EnableClockGate: Boolean = true,
   EnableJal: Boolean = false,
   EnableSv48: Boolean = true,
@@ -639,7 +639,7 @@ trait HasXSParameter {
   def HasFPU = coreParams.HasFPU
   def HasVPU = coreParams.HasVPU
   def HasCustomCSRCacheOp = coreParams.HasCustomCSRCacheOp
-  def EnbaleTlbDebug = coreParams.EnbaleTlbDebug
+  def EnableTlbDebug = coreParams.EnableTlbDebug
   def EnableCommitGHistDiff = coreParams.EnableCommitGHistDiff
   def EnableClockGate = coreParams.EnableClockGate
 

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -72,7 +72,7 @@ case class XSCoreParameters
   AsidLength: Int = 16,
   SdidLength: Int = 6,
   VmidLength: Int = 14,
-  EnbaleTlbDebug: Boolean = false,
+  EnableTlbDebug: Boolean = false,
   EnableClockGate: Boolean = true,
   EnableJal: Boolean = false,
   EnableSv48: Boolean = true,
@@ -720,7 +720,7 @@ trait HasXSParameter {
   def HasFPU = coreParams.HasFPU
   def HasVPU = coreParams.HasVPU
   def HasCustomCSRCacheOp = coreParams.HasCustomCSRCacheOp
-  def EnbaleTlbDebug = coreParams.EnbaleTlbDebug
+  def EnableTlbDebug = coreParams.EnableTlbDebug
   def EnableCommitGHistDiff = coreParams.EnableCommitGHistDiff
   def EnableClockGate = coreParams.EnableClockGate
 

--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -454,7 +454,7 @@ class CSR(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg)
   val sieMask = "h222".U & mideleg
   val sipMask = "h222".U & mideleg
   val sipWMask = "h2".U(XLEN.W) // ssip is writeable in smode
-  val satp = if(EnbaleTlbDebug) RegInit(UInt(XLEN.W), "h8000000000087fbe".U) else RegInit(0.U(XLEN.W))
+  val satp = if(EnableTlbDebug) RegInit(UInt(XLEN.W), "h8000000000087fbe".U) else RegInit(0.U(XLEN.W))
   // val satp = RegInit(UInt(XLEN.W), "h8000000000087fbe".U) // only use for tlb naive debug
   // val satpMask = "h80000fffffffffff".U(XLEN.W) // disable asid, mode can only be 8 / 0
   // TODO: use config to control the length of asid

--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -20,7 +20,6 @@ package xiangshan.cache.mmu
 
 import org.chipsalliance.cde.config.Parameters
 import chisel3._
-import chisel3.experimental.ExtModule
 import chisel3.util._
 import xiangshan._
 import xiangshan.cache.{HasDCacheParameters, MemoryOpConstants}
@@ -1118,16 +1117,6 @@ class BlockHelper(latency: Int)(implicit p: Parameters) extends XSModule {
   }
 }
 
-class PTEHelper() extends ExtModule {
-  val clock  = IO(Input(Clock()))
-  val enable = IO(Input(Bool()))
-  val satp   = IO(Input(UInt(64.W)))
-  val vpn    = IO(Input(UInt(64.W)))
-  val pte    = IO(Output(UInt(64.W)))
-  val level  = IO(Output(UInt(8.W)))
-  val pf     = IO(Output(UInt(8.W)))
-}
-
 class PTWDelayN[T <: Data](gen: T, n: Int, flush: Bool) extends Module {
   val io = IO(new Bundle() {
     val in = Input(gen)
@@ -1138,7 +1127,12 @@ class PTWDelayN[T <: Data](gen: T, n: Int, flush: Bool) extends Module {
   val t = RegInit(VecInit(Seq.fill(n)(0.U.asTypeOf(gen))))
   out(0) := io.in
   if (n == 1) {
-    io.out := out(0)
+    when (io.ptwflush) {
+      out(0) := 0.U.asTypeOf(gen)
+      io.out := 0.U.asTypeOf(gen)
+    }.otherwise {
+      io.out := out(0)
+    }
   } else {
     when (io.ptwflush) {
       for (i <- 0 until n) {
@@ -1165,48 +1159,73 @@ object PTWDelayN {
   }
 }
 
+// FakePTW: Software PTW implementation using DPI-C PteHelper
+// Used when coreParams.softPTW is enabled for debug/simulation
+// Supports H-extension two-stage address translation
 class FakePTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
   val io = IO(new L2TLBIO)
+
   val flush = VecInit(Seq.fill(PtwWidth)(false.B))
-  flush(0) := DelayN(io.sfence.valid || io.csr.tlb.satp.changed || io.csr.tlb.vsatp.changed || io.csr.tlb.hgatp.changed || io.csr.tlb.priv.virt_changed, itlbParams.fenceDelay)
-  flush(1) := DelayN(io.sfence.valid || io.csr.tlb.satp.changed || io.csr.tlb.vsatp.changed || io.csr.tlb.hgatp.changed || io.csr.tlb.priv.virt_changed, ldtlbParams.fenceDelay)
+  val flushCond = io.sfence.valid ||
+    io.csr.tlb.satp.changed ||
+    io.csr.tlb.vsatp.changed ||
+    io.csr.tlb.hgatp.changed ||
+    io.csr.tlb.priv.virt_changed
+  flush(0) := DelayN(flushCond, itlbParams.fenceDelay)
+  flush(1) := DelayN(flushCond, ldtlbParams.fenceDelay)
+
   for (i <- 0 until PtwWidth) {
-    val helper = Module(new PTEHelper())
+    val helper = Module(new PteHelper())
     helper.clock := clock
-    helper.satp := io.csr.tlb.satp.ppn
+    helper.connectCsr(io.csr.tlb)
 
     if (coreParams.softPTWDelay == 1) {
-      helper.enable := io.tlb(i).req(0).fire
-      helper.vpn := io.tlb(i).req(0).bits.vpn
+      helper.connectReq(
+        reqVpn = io.tlb(i).req(0).bits.vpn,
+        reqS2xlate = io.tlb(i).req(0).bits.s2xlate,
+        reqEnable = io.tlb(i).req(0).fire && !reset.asBool
+      )
     } else {
-      helper.enable := PTWDelayN(io.tlb(i).req(0).fire, coreParams.softPTWDelay - 1, flush(i))
-      helper.vpn := PTWDelayN(io.tlb(i).req(0).bits.vpn, coreParams.softPTWDelay - 1, flush(i))
+      helper.connectReq(
+        reqVpn = PTWDelayN(io.tlb(i).req(0).bits.vpn, coreParams.softPTWDelay - 1, flush(i)),
+        reqS2xlate = PTWDelayN(io.tlb(i).req(0).bits.s2xlate, coreParams.softPTWDelay - 1, flush(i)),
+        reqEnable = PTWDelayN(io.tlb(i).req(0).fire, coreParams.softPTWDelay - 1, flush(i)) && !reset.asBool
+      )
     }
 
-    val pte = helper.pte.asTypeOf(new PteBundle)
-    val level = helper.level
-    val pf = helper.pf
+    val helperResult = PteHelperResult.fromHelper(helper, helper.enable)
+    val vpnDelayed = PTWDelayN(io.tlb(i).req(0).bits.vpn, coreParams.softPTWDelay, flush(i))
+    val s2xlateReg = if (coreParams.softPTWDelay == 1) {
+      RegEnable(io.tlb(i).req(0).bits.s2xlate, io.tlb(i).req(0).fire)
+    } else {
+      PTWDelayN(io.tlb(i).req(0).bits.s2xlate, coreParams.softPTWDelay, flush(i))
+    }
+
+    // Request/response handshake logic
     val empty = RegInit(true.B)
-    when (io.tlb(i).req(0).fire) {
+    when (flush(i)) {
+      empty := true.B
+    }.elsewhen (io.tlb(i).req(0).fire) {
       empty := false.B
-    } .elsewhen (io.tlb(i).resp.fire || flush(i)) {
+    }.elsewhen (io.tlb(i).resp.fire) {
       empty := true.B
     }
-
-    io.tlb(i).req(0).ready := empty || io.tlb(i).resp.fire
+    io.tlb(i).req(0).ready := !flush(i) && (empty || io.tlb(i).resp.fire)
     io.tlb(i).resp.valid := PTWDelayN(io.tlb(i).req(0).fire, coreParams.softPTWDelay, flush(i))
     assert(!io.tlb(i).resp.valid || io.tlb(i).resp.ready)
-    io.tlb(i).resp.bits.s1.entry.tag := PTWDelayN(io.tlb(i).req(0).bits.vpn, coreParams.softPTWDelay, flush(i))
-    io.tlb(i).resp.bits.s1.entry.pbmt := pte.pbmt
-    io.tlb(i).resp.bits.s1.entry.ppn := pte.ppn
-    io.tlb(i).resp.bits.s1.entry.perm.map(_ := pte.getPerm())
-    io.tlb(i).resp.bits.s1.entry.level.map(_ := level)
-    io.tlb(i).resp.bits.s1.pf := pf
-    io.tlb(i).resp.bits.s1.af := DontCare // TODO: implement it
-    io.tlb(i).resp.bits.s1.entry.v := !pf
-    io.tlb(i).resp.bits.s1.entry.prefetch := DontCare
-    io.tlb(i).resp.bits.s1.entry.asid := io.csr.tlb.satp.asid
+
+    helperResult.fillS1Resp(
+      resp = io.tlb(i).resp.bits.s1,
+      vpn = vpnDelayed,
+      s2xlate = s2xlateReg,
+      asid = io.csr.tlb.satp.asid,
+      vsasid = io.csr.tlb.vsatp.asid,
+      vmid = io.csr.tlb.hgatp.vmid
+    )
+    helperResult.fillS2Resp(io.tlb(i).resp.bits.s2, vpnDelayed, s2xlateReg, io.csr.tlb.hgatp.vmid)
+    io.tlb(i).resp.bits.s2xlate := s2xlateReg
   }
+  io.wfi.wfiSafe := true.B
 }
 
 class L2TLBWrapper()(implicit p: Parameters) extends LazyModule with HasXSParameter {
@@ -1221,13 +1240,12 @@ class L2TLBWrapper()(implicit p: Parameters) extends LazyModule with HasXSParame
   class L2TLBWrapperImp(wrapper: LazyModule) extends LazyModuleImp(wrapper) with HasPerfEvents {
     val io = IO(new L2TLBIO)
     val perfEvents = if (useSoftPTW) {
-      val fake_ptw = Module(new FakePTW())
-      io <> fake_ptw.io
+      val fakePtw = Module(new FakePTW())
+      io <> fakePtw.io
       Seq()
-    }
-    else {
-        io <> ptw.module.io
-        ptw.module.getPerfEvents
+    } else {
+      io <> ptw.module.io
+      ptw.module.getPerfEvents
     }
     generatePerfEvent()
   }

--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -20,7 +20,6 @@ package xiangshan.cache.mmu
 
 import org.chipsalliance.cde.config.Parameters
 import chisel3._
-import chisel3.experimental.ExtModule
 import chisel3.util._
 import xiangshan._
 import xiangshan.cache.{HasDCacheParameters, MemoryOpConstants}
@@ -1138,16 +1137,6 @@ class BlockHelper(latency: Int)(implicit p: Parameters) extends XSModule {
   }
 }
 
-class PTEHelper() extends ExtModule {
-  val clock  = IO(Input(Clock()))
-  val enable = IO(Input(Bool()))
-  val satp   = IO(Input(UInt(64.W)))
-  val vpn    = IO(Input(UInt(64.W)))
-  val pte    = IO(Output(UInt(64.W)))
-  val level  = IO(Output(UInt(8.W)))
-  val pf     = IO(Output(UInt(8.W)))
-}
-
 class PTWDelayN[T <: Data](gen: T, n: Int, flush: Bool) extends Module {
   val io = IO(new Bundle() {
     val in = Input(gen)
@@ -1158,7 +1147,12 @@ class PTWDelayN[T <: Data](gen: T, n: Int, flush: Bool) extends Module {
   val t = RegInit(VecInit(Seq.fill(n)(0.U.asTypeOf(gen))))
   out(0) := io.in
   if (n == 1) {
-    io.out := out(0)
+    when (io.ptwflush) {
+      out(0) := 0.U.asTypeOf(gen)
+      io.out := 0.U.asTypeOf(gen)
+    }.otherwise {
+      io.out := out(0)
+    }
   } else {
     when (io.ptwflush) {
       for (i <- 0 until n) {
@@ -1185,48 +1179,73 @@ object PTWDelayN {
   }
 }
 
+// FakePTW: Software PTW implementation using DPI-C PteHelper
+// Used when coreParams.softPTW is enabled for debug/simulation
+// Supports H-extension two-stage address translation
 class FakePTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
   val io = IO(new L2TLBIO)
+
   val flush = VecInit(Seq.fill(PtwWidth)(false.B))
-  flush(0) := DelayN(io.sfence.valid || io.csr.tlb.satp.changed || io.csr.tlb.vsatp.changed || io.csr.tlb.hgatp.changed || io.csr.tlb.priv.virt_changed, itlbParams.fenceDelay)
-  flush(1) := DelayN(io.sfence.valid || io.csr.tlb.satp.changed || io.csr.tlb.vsatp.changed || io.csr.tlb.hgatp.changed || io.csr.tlb.priv.virt_changed, ldtlbParams.fenceDelay)
+  val flushCond = io.sfence.valid ||
+    io.csr.tlb.satp.changed ||
+    io.csr.tlb.vsatp.changed ||
+    io.csr.tlb.hgatp.changed ||
+    io.csr.tlb.priv.virt_changed
+  flush(0) := DelayN(flushCond, itlbParams.fenceDelay)
+  flush(1) := DelayN(flushCond, ldtlbParams.fenceDelay)
+
   for (i <- 0 until PtwWidth) {
-    val helper = Module(new PTEHelper())
+    val helper = Module(new PteHelper())
     helper.clock := clock
-    helper.satp := io.csr.tlb.satp.ppn
+    helper.connectCsr(io.csr.tlb)
 
     if (coreParams.softPTWDelay == 1) {
-      helper.enable := io.tlb(i).req(0).fire
-      helper.vpn := io.tlb(i).req(0).bits.vpn
+      helper.connectReq(
+        reqVpn = io.tlb(i).req(0).bits.vpn,
+        reqS2xlate = io.tlb(i).req(0).bits.s2xlate,
+        reqEnable = io.tlb(i).req(0).fire && !reset.asBool
+      )
     } else {
-      helper.enable := PTWDelayN(io.tlb(i).req(0).fire, coreParams.softPTWDelay - 1, flush(i))
-      helper.vpn := PTWDelayN(io.tlb(i).req(0).bits.vpn, coreParams.softPTWDelay - 1, flush(i))
+      helper.connectReq(
+        reqVpn = PTWDelayN(io.tlb(i).req(0).bits.vpn, coreParams.softPTWDelay - 1, flush(i)),
+        reqS2xlate = PTWDelayN(io.tlb(i).req(0).bits.s2xlate, coreParams.softPTWDelay - 1, flush(i)),
+        reqEnable = PTWDelayN(io.tlb(i).req(0).fire, coreParams.softPTWDelay - 1, flush(i)) && !reset.asBool
+      )
     }
 
-    val pte = helper.pte.asTypeOf(new PteBundle)
-    val level = helper.level
-    val pf = helper.pf
+    val helperResult = PteHelperResult.fromHelper(helper, helper.enable)
+    val vpnDelayed = PTWDelayN(io.tlb(i).req(0).bits.vpn, coreParams.softPTWDelay, flush(i))
+    val s2xlateReg = if (coreParams.softPTWDelay == 1) {
+      RegEnable(io.tlb(i).req(0).bits.s2xlate, io.tlb(i).req(0).fire)
+    } else {
+      PTWDelayN(io.tlb(i).req(0).bits.s2xlate, coreParams.softPTWDelay, flush(i))
+    }
+
+    // Request/response handshake logic
     val empty = RegInit(true.B)
-    when (io.tlb(i).req(0).fire) {
+    when (flush(i)) {
+      empty := true.B
+    }.elsewhen (io.tlb(i).req(0).fire) {
       empty := false.B
-    } .elsewhen (io.tlb(i).resp.fire || flush(i)) {
+    }.elsewhen (io.tlb(i).resp.fire) {
       empty := true.B
     }
-
-    io.tlb(i).req(0).ready := empty || io.tlb(i).resp.fire
+    io.tlb(i).req(0).ready := !flush(i) && (empty || io.tlb(i).resp.fire)
     io.tlb(i).resp.valid := PTWDelayN(io.tlb(i).req(0).fire, coreParams.softPTWDelay, flush(i))
     assert(!io.tlb(i).resp.valid || io.tlb(i).resp.ready)
-    io.tlb(i).resp.bits.s1.entry.tag := PTWDelayN(io.tlb(i).req(0).bits.vpn, coreParams.softPTWDelay, flush(i))
-    io.tlb(i).resp.bits.s1.entry.pbmt := pte.pbmt
-    io.tlb(i).resp.bits.s1.entry.ppn := pte.ppn
-    io.tlb(i).resp.bits.s1.entry.perm.map(_ := pte.getPerm())
-    io.tlb(i).resp.bits.s1.entry.level.map(_ := level)
-    io.tlb(i).resp.bits.s1.pf := pf
-    io.tlb(i).resp.bits.s1.af := DontCare // TODO: implement it
-    io.tlb(i).resp.bits.s1.entry.v := !pf
-    io.tlb(i).resp.bits.s1.entry.prefetch := DontCare
-    io.tlb(i).resp.bits.s1.entry.asid := io.csr.tlb.satp.asid
+
+    helperResult.fillS1Resp(
+      resp = io.tlb(i).resp.bits.s1,
+      vpn = vpnDelayed,
+      s2xlate = s2xlateReg,
+      asid = io.csr.tlb.satp.asid,
+      vsasid = io.csr.tlb.vsatp.asid,
+      vmid = io.csr.tlb.hgatp.vmid
+    )
+    helperResult.fillS2Resp(io.tlb(i).resp.bits.s2, vpnDelayed, s2xlateReg, io.csr.tlb.hgatp.vmid)
+    io.tlb(i).resp.bits.s2xlate := s2xlateReg
   }
+  io.wfi.wfiSafe := true.B
 }
 
 class L2TLBWrapper()(implicit p: Parameters) extends LazyModule with HasXSParameter {
@@ -1241,13 +1260,12 @@ class L2TLBWrapper()(implicit p: Parameters) extends LazyModule with HasXSParame
   class L2TLBWrapperImp(wrapper: LazyModule) extends LazyModuleImp(wrapper) with HasPerfEvents {
     val io = IO(new L2TLBIO)
     val perfEvents = if (useSoftPTW) {
-      val fake_ptw = Module(new FakePTW())
-      io <> fake_ptw.io
+      val fakePtw = Module(new FakePTW())
+      io <> fakePtw.io
       Seq()
-    }
-    else {
-        io <> ptw.module.io
-        ptw.module.getPerfEvents
+    } else {
+      io <> ptw.module.io
+      ptw.module.getPerfEvents
     }
     generatePerfEvent()
   }

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -111,6 +111,21 @@ class TlbPermBundle(implicit p: Parameters) extends TlbBundle {
     this
   }
 
+  def apply(pte: PteBundle, pf: Bool, af: Bool, entryValid: Bool) = {
+    this.pf := pf
+    this.af := af
+    this.v := entryValid
+    this.d := pte.perm.d
+    this.a := pte.perm.a
+    this.g := pte.perm.g
+    this.u := pte.perm.u
+    this.x := pte.perm.x
+    this.w := pte.perm.w
+    this.r := pte.perm.r
+
+    this
+  }
+
   override def toPrintable: Printable = {
     p"pf:${pf} af:${af} d:${d} a:${a} g:${g} u:${u} x:${x} w:${w} r:${r} "
   }
@@ -144,6 +159,21 @@ class TlbSectorPermBundle(implicit p: Parameters) extends TlbBundle {
 
     this
   }
+  def apply(pte: PteBundle, pf: Bool, af: Bool, entryValid: Bool) = {
+    this.pf := pf
+    this.af := af
+    this.v := entryValid
+    this.d := pte.perm.d
+    this.a := pte.perm.a
+    this.g := pte.perm.g
+    this.u := pte.perm.u
+    this.x := pte.perm.x
+    this.w := pte.perm.w
+    this.r := pte.perm.r
+
+    this
+  }
+
   override def toPrintable: Printable = {
     p"pf:${pf} af:${af} d:${d} a:${a} g:${g} u:${u} x:${x} w:${w} r:${r} "
   }

--- a/src/main/scala/xiangshan/cache/mmu/PteHelper.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PteHelper.scala
@@ -1,0 +1,173 @@
+/***************************************************************************************
+* Copyright (c) 2021-2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2021 Peng Cheng Laboratory
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+package xiangshan.cache.mmu
+
+import chisel3._
+import chisel3.experimental.ExtModule
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+import xiangshan._
+
+class PteHelper() extends ExtModule {
+  val clock = IO(Input(Clock()))
+  val enable = IO(Input(Bool()))
+  val satp = IO(Input(UInt(64.W)))
+  val vsatp = IO(Input(UInt(64.W)))
+  val hgatp = IO(Input(UInt(64.W)))
+  val mPBMTE = IO(Input(Bool()))
+  val hPBMTE = IO(Input(Bool()))
+  val vpn = IO(Input(UInt(64.W)))
+  val s2xlate = IO(Input(UInt(8.W)))
+  val pte = IO(Output(UInt(64.W)))
+  val level = IO(Output(UInt(8.W)))
+  val pfType = IO(Output(UInt(8.W)))
+  val s1_pte = IO(Output(UInt(64.W)))
+  val s2_pte = IO(Output(UInt(64.W)))
+  val s1_level = IO(Output(UInt(8.W)))
+
+  def connectCsr(csr: TlbCsrBundle): Unit = {
+    satp := Cat(csr.satp.mode, csr.satp.asid, csr.satp.ppn)
+    vsatp := Cat(csr.vsatp.mode, csr.vsatp.asid, csr.vsatp.ppn)
+    hgatp := Cat(csr.hgatp.mode, csr.hgatp.vmid, csr.hgatp.ppn)
+    mPBMTE := csr.mPBMTE
+    hPBMTE := csr.hPBMTE
+  }
+
+  def connectReq(reqVpn: UInt, reqS2xlate: UInt, reqEnable: Bool): Unit = {
+    enable := reqEnable
+    vpn := reqVpn
+    s2xlate := reqS2xlate
+  }
+}
+
+trait HasPteHelperResultConst extends HasTlbConst {
+  def genFullPPN(ptePPN: UInt, level: UInt, vpn: UInt, napot: Bool): UInt = {
+    val napotPPN = Cat(ptePPN(ptePPNLen - 1, pteNapotBits), vpn(pteNapotBits - 1, 0))
+    MuxLookup(level, 0.U(ptePPNLen.W))(Seq(
+      3.U -> Cat(ptePPN(ptePPNLen - 1, vpnnLen * 3), vpn(vpnnLen * 3 - 1, 0)),
+      2.U -> Cat(ptePPN(ptePPNLen - 1, vpnnLen * 2), vpn(vpnnLen * 2 - 1, 0)),
+      1.U -> Cat(ptePPN(ptePPNLen - 1, vpnnLen), vpn(vpnnLen - 1, 0)),
+      0.U -> Mux(napot, napotPPN, ptePPN)
+    ))
+  }
+}
+
+class PteHelperStageResult(implicit p: Parameters) extends TlbBundle with HasPteHelperResultConst {
+  val pte = new PteBundle
+  val level = UInt(8.W)
+
+  def fullPPN(vpn: UInt): UInt = {
+    genFullPPN(pte.getPPN(), level, vpn, pte.isNapot(level))
+  }
+}
+
+class PteHelperResult(implicit p: Parameters) extends TlbBundle with HasPteHelperResultConst {
+  val pte = new PteBundle
+  val level = UInt(8.W)
+  val pfType = UInt(8.W)
+  val s1 = new PteHelperStageResult
+  val s2 = new PteHelperStageResult
+
+  def hasPf: Bool = pfType === 1.U
+
+  def hasGpf: Bool = pfType === 2.U
+
+  def hasNoPf: Bool = pfType === 0.U
+
+  def finalPPN(vpn: UInt, s2xlate: UInt): UInt = {
+    val singleStagePPN = genFullPPN(pte.getPPN(), level, vpn, pte.isNapot(level))
+    val gpaPPN = s1.fullPPN(vpn)
+    val hpaPPN = s2.fullPPN(gpaPPN)
+    Mux(s2xlate === allStage, hpaPPN, singleStagePPN)
+  }
+
+  def s1TranslatedPPN(vpn: UInt): UInt = {
+    s1.fullPPN(vpn)
+  }
+
+  def s1RespPte(s2xlate: UInt): PteBundle = {
+    Mux(s2xlate === allStage, s1.pte, pte)
+  }
+
+  def s2RespPte(s2xlate: UInt): PteBundle = {
+    Mux(s2xlate === allStage, s2.pte, pte)
+  }
+
+  def fillS1Resp(resp: PtwSectorResp, vpn: UInt, s2xlate: UInt, asid: UInt, vsasid: UInt, vmid: UInt): Unit = {
+    val isAllStage = s2xlate === allStage
+    val respPte = s1RespPte(s2xlate)
+    val respLevel = Mux(isAllStage, s1.level, level)
+    val respFullPPN = respPte.getPPN()
+    val respNapot = respPte.n.asBool && respPte.ppn(3, 0) === 8.U && respLevel === 0.U
+
+    resp.entry.tag := vpn(vpn.getWidth - 1, sectortlbwidth)
+    resp.entry.pbmt := respPte.pbmt
+    resp.entry.ppn := respFullPPN(ptePPNLen - 1, sectortlbwidth)
+    resp.entry.perm.map(_ := respPte.getPerm())
+    resp.entry.level.map(_ := respLevel)
+    resp.entry.v := Mux(isAllStage, s1.pte.perm.v, hasNoPf)
+    resp.entry.prefetch := false.B
+    resp.entry.asid := Mux(s2xlate =/= noS2xlate, vsasid, asid)
+    resp.entry.vmid.map(_ := vmid)
+    resp.entry.n.map(_ := Mux(respNapot, 1.U, 0.U))
+    resp.pf := hasPf
+    resp.af := false.B
+    resp.addr_low := vpn(sectortlbwidth - 1, 0)
+    for (j <- 0 until tlbcontiguous) {
+      resp.ppn_low(j) := respFullPPN(sectortlbwidth - 1, 0)
+      resp.valididx(j) := (j.U === vpn(sectortlbwidth - 1, 0)) || (respLevel =/= 0.U)
+      resp.pteidx(j) := j.U === vpn(sectortlbwidth - 1, 0)
+    }
+  }
+
+  def fillS2Resp(resp: HptwResp, vpn: UInt, s2xlate: UInt, vmid: UInt): Unit = {
+    val isAllStage = s2xlate === allStage
+    val respPte = s2RespPte(s2xlate)
+    val respLevel = Mux(isAllStage, s2.level, level)
+    val s2Tag = Mux(isAllStage, s1TranslatedPPN(vpn)(gvpnLen - 1, 0), vpn(gvpnLen - 1, 0))
+    val respNapot = respPte.n.asBool && respPte.ppn(3, 0) === 8.U && respLevel === 0.U
+    val hasS2Resp = (s2xlate === onlyStage2) || (isAllStage && respPte.asUInt =/= 0.U)
+
+    resp.entry.tag := s2Tag
+    resp.entry.pbmt := respPte.pbmt
+    resp.entry.ppn := respPte.ppn
+    resp.entry.perm.map(_ := respPte.getPerm())
+    resp.entry.level.map(_ := respLevel)
+    resp.entry.v := hasS2Resp && !hasGpf
+    resp.entry.asid := DontCare
+    resp.entry.vmid.map(_ := vmid)
+    resp.entry.n.map(_ := Mux(respNapot, 1.U, 0.U))
+    resp.entry.prefetch := false.B
+    resp.gpf := hasGpf
+    resp.gaf := false.B
+  }
+}
+
+object PteHelperResult {
+  def fromHelper(helper: PteHelper, enable: Bool)(implicit p: Parameters): PteHelperResult = {
+    val result = Wire(new PteHelperResult)
+    result.pte := RegEnable(helper.pte, enable).asTypeOf(new PteBundle)
+    result.level := RegEnable(helper.level, enable)
+    result.pfType := RegEnable(helper.pfType, enable)
+    result.s1.pte := RegEnable(helper.s1_pte, enable).asTypeOf(new PteBundle)
+    result.s1.level := RegEnable(helper.s1_level, enable)
+    result.s2.pte := RegEnable(helper.s2_pte, enable).asTypeOf(new PteBundle)
+    result.s2.level := result.level
+    result
+  }
+}

--- a/src/main/scala/xiangshan/cache/mmu/PteHelper.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PteHelper.scala
@@ -1,0 +1,207 @@
+/***************************************************************************************
+* Copyright (c) 2021-2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2021 Peng Cheng Laboratory
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+package xiangshan.cache.mmu
+
+import chisel3._
+import chisel3.experimental.ExtModule
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+import xiangshan._
+
+class PteHelper() extends ExtModule {
+  val clock = IO(Input(Clock()))
+  val enable = IO(Input(Bool()))
+  val satp = IO(Input(UInt(64.W)))
+  val vsatp = IO(Input(UInt(64.W)))
+  val hgatp = IO(Input(UInt(64.W)))
+  val mPBMTE = IO(Input(Bool()))
+  val hPBMTE = IO(Input(Bool()))
+  val vpn = IO(Input(UInt(64.W)))
+  val s2xlate = IO(Input(UInt(8.W)))
+  val pte = IO(Output(UInt(64.W)))
+  val level = IO(Output(UInt(8.W)))
+  val pfType = IO(Output(UInt(8.W)))
+  val s1_pte = IO(Output(UInt(64.W)))
+  val s2_pte = IO(Output(UInt(64.W)))
+  val s1_level = IO(Output(UInt(8.W)))
+
+  private val cppExtModule =
+    """
+      |void PteHelper (
+      |  uint8_t   enable,
+      |  uint64_t  satp,
+      |  uint64_t  vsatp,
+      |  uint64_t  hgatp,
+      |  uint8_t   mPBMTE,
+      |  uint8_t   hPBMTE,
+      |  uint64_t  vpn,
+      |  uint8_t   s2xlate,
+      |  uint64_t& pte,
+      |  uint8_t&  level,
+      |  uint8_t&  pfType,
+      |  uint64_t& s1_pte,
+      |  uint64_t& s2_pte,
+      |  uint8_t&  s1_level
+      |) {
+      |  pte = 0;
+      |  level = 0;
+      |  pfType = 0;
+      |  s1_pte = 0;
+      |  s2_pte = 0;
+      |  s1_level = 0;
+      |  if (enable) {
+      |    pfType = pte_helper(
+      |      satp, vsatp, hgatp, mPBMTE, hPBMTE, vpn, s2xlate,
+      |      &pte, &level, &s1_pte, &s2_pte, &s1_level
+      |    );
+      |  }
+      |}
+      |""".stripMargin
+  difftest.DifftestModule.createCppExtModule("PteHelper", cppExtModule, Some("\"golden.h\""))
+
+  def connectCsr(csr: TlbCsrBundle): Unit = {
+    satp := Cat(csr.satp.mode, csr.satp.asid, csr.satp.ppn)
+    vsatp := Cat(csr.vsatp.mode, csr.vsatp.asid, csr.vsatp.ppn)
+    hgatp := Cat(csr.hgatp.mode, csr.hgatp.vmid, csr.hgatp.ppn)
+    mPBMTE := csr.mPBMTE
+    hPBMTE := csr.hPBMTE
+  }
+
+  def connectReq(reqVpn: UInt, reqS2xlate: UInt, reqEnable: Bool): Unit = {
+    enable := reqEnable
+    vpn := reqVpn
+    s2xlate := reqS2xlate
+  }
+}
+
+trait HasPteHelperResultConst extends HasTlbConst {
+  def genFullPPN(ptePPN: UInt, level: UInt, vpn: UInt, napot: Bool): UInt = {
+    val napotPPN = Cat(ptePPN(ptePPNLen - 1, pteNapotBits), vpn(pteNapotBits - 1, 0))
+    MuxLookup(level, 0.U(ptePPNLen.W))(Seq(
+      3.U -> Cat(ptePPN(ptePPNLen - 1, vpnnLen * 3), vpn(vpnnLen * 3 - 1, 0)),
+      2.U -> Cat(ptePPN(ptePPNLen - 1, vpnnLen * 2), vpn(vpnnLen * 2 - 1, 0)),
+      1.U -> Cat(ptePPN(ptePPNLen - 1, vpnnLen), vpn(vpnnLen - 1, 0)),
+      0.U -> Mux(napot, napotPPN, ptePPN)
+    ))
+  }
+}
+
+class PteHelperStageResult(implicit p: Parameters) extends TlbBundle with HasPteHelperResultConst {
+  val pte = new PteBundle
+  val level = UInt(8.W)
+
+  def fullPPN(vpn: UInt): UInt = {
+    genFullPPN(pte.getPPN(), level, vpn, pte.isNapot(level))
+  }
+}
+
+class PteHelperResult(implicit p: Parameters) extends TlbBundle with HasPteHelperResultConst {
+  val pte = new PteBundle
+  val level = UInt(8.W)
+  val pfType = UInt(8.W)
+  val s1 = new PteHelperStageResult
+  val s2 = new PteHelperStageResult
+
+  def hasPf: Bool = pfType === 1.U
+
+  def hasGpf: Bool = pfType === 2.U
+
+  def hasNoPf: Bool = pfType === 0.U
+
+  def finalPPN(vpn: UInt, s2xlate: UInt): UInt = {
+    val singleStagePPN = genFullPPN(pte.getPPN(), level, vpn, pte.isNapot(level))
+    val gpaPPN = s1.fullPPN(vpn)
+    val hpaPPN = s2.fullPPN(gpaPPN)
+    Mux(s2xlate === allStage, hpaPPN, singleStagePPN)
+  }
+
+  def s1TranslatedPPN(vpn: UInt): UInt = {
+    s1.fullPPN(vpn)
+  }
+
+  def s1RespPte(s2xlate: UInt): PteBundle = {
+    Mux(s2xlate === allStage, s1.pte, pte)
+  }
+
+  def s2RespPte(s2xlate: UInt): PteBundle = {
+    Mux(s2xlate === allStage, s2.pte, pte)
+  }
+
+  def fillS1Resp(resp: PtwSectorResp, vpn: UInt, s2xlate: UInt, asid: UInt, vsasid: UInt, vmid: UInt): Unit = {
+    val isAllStage = s2xlate === allStage
+    val respPte = s1RespPte(s2xlate)
+    val respLevel = Mux(isAllStage, s1.level, level)
+    val respFullPPN = respPte.getPPN()
+    val respNapot = respPte.n.asBool && respPte.ppn(3, 0) === 8.U && respLevel === 0.U
+
+    resp.entry.tag := vpn(vpn.getWidth - 1, sectortlbwidth)
+    resp.entry.pbmt := respPte.pbmt
+    resp.entry.ppn := respFullPPN(ptePPNLen - 1, sectortlbwidth)
+    resp.entry.perm.map(_ := respPte.getPerm())
+    resp.entry.level.map(_ := respLevel)
+    resp.entry.v := Mux(isAllStage, s1.pte.perm.v, hasNoPf)
+    resp.entry.prefetch := false.B
+    resp.entry.asid := Mux(s2xlate =/= noS2xlate, vsasid, asid)
+    resp.entry.vmid.map(_ := vmid)
+    resp.entry.n.map(_ := Mux(respNapot, 1.U, 0.U))
+    resp.pf := hasPf
+    resp.af := false.B
+    resp.addr_low := vpn(sectortlbwidth - 1, 0)
+    for (j <- 0 until tlbcontiguous) {
+      resp.ppn_low(j) := respFullPPN(sectortlbwidth - 1, 0)
+      resp.valididx(j) := (j.U === vpn(sectortlbwidth - 1, 0)) || (respLevel =/= 0.U)
+      resp.pteidx(j) := j.U === vpn(sectortlbwidth - 1, 0)
+    }
+  }
+
+  def fillS2Resp(resp: HptwResp, vpn: UInt, s2xlate: UInt, vmid: UInt): Unit = {
+    val isAllStage = s2xlate === allStage
+    val respPte = s2RespPte(s2xlate)
+    val respLevel = Mux(isAllStage, s2.level, level)
+    val s2Tag = Mux(isAllStage, s1TranslatedPPN(vpn)(gvpnLen - 1, 0), vpn(gvpnLen - 1, 0))
+    val respNapot = respPte.n.asBool && respPte.ppn(3, 0) === 8.U && respLevel === 0.U
+    val hasS2Resp = (s2xlate === onlyStage2) || (isAllStage && respPte.asUInt =/= 0.U)
+
+    resp.entry.tag := s2Tag
+    resp.entry.pbmt := respPte.pbmt
+    resp.entry.ppn := respPte.ppn
+    resp.entry.perm.map(_ := respPte.getPerm())
+    resp.entry.level.map(_ := respLevel)
+    resp.entry.v := hasS2Resp && !hasGpf
+    resp.entry.asid := DontCare
+    resp.entry.vmid.map(_ := vmid)
+    resp.entry.n.map(_ := Mux(respNapot, 1.U, 0.U))
+    resp.entry.prefetch := false.B
+    resp.gpf := hasGpf
+    resp.gaf := false.B
+  }
+}
+
+object PteHelperResult {
+  def fromHelper(helper: PteHelper, enable: Bool)(implicit p: Parameters): PteHelperResult = {
+    val result = Wire(new PteHelperResult)
+    result.pte := RegEnable(helper.pte, enable).asTypeOf(new PteBundle)
+    result.level := RegEnable(helper.level, enable)
+    result.pfType := RegEnable(helper.pfType, enable)
+    result.s1.pte := RegEnable(helper.s1_pte, enable).asTypeOf(new PteBundle)
+    result.s1.level := RegEnable(helper.s1_level, enable)
+    result.s2.pte := RegEnable(helper.s2_pte, enable).asTypeOf(new PteBundle)
+    result.s2.level := result.level
+    result
+  }
+}

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -126,7 +126,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   val Sv48x4Enable = csr.hgatp.mode === 9.U
 
   val vmEnable = (0 until Width).map(i => !(isHyperInst(i) || virt_out(i)) && (
-    if (EnbaleTlbDebug) (Sv39Enable || Sv48Enable)
+    if (EnableTlbDebug) (Sv39Enable || Sv48Enable)
     else (Sv39Enable || Sv48Enable) && (mode(i) < ModeM))
   )
   val s2xlateEnable = (0 until Width).map(i =>
@@ -160,7 +160,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     resp(i).bits.fullva := RegEnable(EffectiveVa(i), req(i).valid)
   }
   val prevmEnable = (0 until Width).map(i => !(virt_in || req_in(i).bits.hyperinst) && (
-    if (EnbaleTlbDebug) (Sv39Enable || Sv48Enable)
+    if (EnableTlbDebug) (Sv39Enable || Sv48Enable)
     else (Sv39Enable || Sv48Enable) && (premode(i) < ModeM))
   )
   val pres2xlateEnable = (0 until Width).map(i =>

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -342,9 +342,9 @@ class TLBFakeFA(
   val sv39x4Enable = io.csr.hgatp.mode === Sv39x4
   val sv48x4Enable = io.csr.hgatp.mode === Sv48x4
 
-  val vmEnable = if (EnbaleTlbDebug) (sv39Enable || sv48Enable)
+  val vmEnable = if (EnableTlbDebug) (sv39Enable || sv48Enable)
     else ((sv39Enable || sv48Enable) && (mode < ModeM))
-  val s2xlateEnable = if (EnbaleTlbDebug) {
+  val s2xlateEnable = if (EnableTlbDebug) {
     sv39vsEnable || sv48vsEnable || sv39x4Enable || sv48x4Enable
   } else {
     (sv39vsEnable || sv48vsEnable || sv39x4Enable || sv48x4Enable) && (mode < ModeM)

--- a/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLBStorage.scala
@@ -321,54 +321,70 @@ class TLBFA(
   println(s"${parentName} tlb_fa: nSets${nSets} nWays:${nWays}")
 }
 
+// TLBFakeFA: Software TLB implementation using DPI-C PteHelper for debug/simulation
+// This module bypasses hardware page table walk and uses C++ reference model instead
 class TLBFakeFA(
-             ports: Int,
-             nDups: Int,
-             nSets: Int,
-             nWays: Int,
-             useDmode: Boolean = false
-           )(implicit p: Parameters) extends TlbModule with HasCSRConst{
+  ports: Int,
+  nDups: Int,
+  nSets: Int,
+  nWays: Int,
+  useDmode: Boolean = false
+)(implicit p: Parameters) extends TlbModule with HasCSRConst {
 
   val io = IO(new TlbStorageIO(nSets, nWays, ports, nDups))
   io.r.req.map(_.ready := true.B)
+
   val mode = if (useDmode) io.csr.priv.dmode else io.csr.priv.imode
-  val vmEnable = if (EnbaleTlbDebug) (io.csr.satp.mode === 8.U)
-    else (io.csr.satp.mode === 8.U && (mode < ModeM))
+  val sv39Enable = io.csr.satp.mode === Sv39
+  val sv48Enable = io.csr.satp.mode === Sv48
+  val sv39vsEnable = io.csr.vsatp.mode === Sv39
+  val sv48vsEnable = io.csr.vsatp.mode === Sv48
+  val sv39x4Enable = io.csr.hgatp.mode === Sv39x4
+  val sv48x4Enable = io.csr.hgatp.mode === Sv48x4
+
+  val vmEnable = if (EnbaleTlbDebug) (sv39Enable || sv48Enable)
+    else ((sv39Enable || sv48Enable) && (mode < ModeM))
+  val s2xlateEnable = if (EnbaleTlbDebug) {
+    sv39vsEnable || sv48vsEnable || sv39x4Enable || sv48x4Enable
+  } else {
+    (sv39vsEnable || sv48vsEnable || sv39x4Enable || sv48x4Enable) && (mode < ModeM)
+  }
 
   for (i <- 0 until ports) {
     val req = io.r.req(i)
     val resp = io.r.resp(i)
 
-    val helper = Module(new PTEHelper())
+    val helper = Module(new PteHelper())
     helper.clock := clock
-    helper.satp := io.csr.satp.ppn
-    helper.enable := req.fire && vmEnable
-    helper.vpn := req.bits.vpn
+    helper.connectCsr(io.csr)
 
-    val pte = helper.pte.asTypeOf(new PteBundle)
-    val ppn = pte.ppn
-    val vpn_reg = RegEnable(req.bits.vpn, req.valid)
-    val pf = helper.pf
-    val level = helper.level
+    val helperEnable = req.fire &&
+      Mux(req.bits.s2xlate === noS2xlate, vmEnable, s2xlateEnable) &&
+      !reset.asBool
+    helper.connectReq(req.bits.vpn, req.bits.s2xlate, helperEnable)
+
+    val helperResult = PteHelperResult.fromHelper(helper, helperEnable)
+    val pte = helperResult.pte
+    val s1Pte = helperResult.s1.pte
+    val s2Pte = helperResult.s2.pte
+
+    val vpnReg = RegEnable(req.bits.vpn, req.valid)
+    val s2xlateReg = RegEnable(req.bits.s2xlate, req.valid)
+    val isAllStage = s2xlateReg === allStage
+    val finalPPN = helperResult.finalPPN(vpnReg, s2xlateReg)
+    val s1RespPte = helperResult.s1RespPte(s2xlateReg)
+    val s2RespPte = helperResult.s2RespPte(s2xlateReg)
 
     resp.valid := RegNext(req.valid)
-    resp.bits.hit := true.B
+    resp.bits.hit := RegNext(helperEnable, false.B)
+
     for (d <- 0 until nDups) {
-      resp.bits.perm(d).pf := pf
-      resp.bits.perm(d).af := false.B
-      resp.bits.perm(d).d := pte.perm.d
-      resp.bits.perm(d).a := pte.perm.a
-      resp.bits.perm(d).g := pte.perm.g
-      resp.bits.perm(d).u := pte.perm.u
-      resp.bits.perm(d).x := pte.perm.x
-      resp.bits.perm(d).w := pte.perm.w
-      resp.bits.perm(d).r := pte.perm.r
-      resp.bits.pbmt(d) := pte.pbmt
-      resp.bits.ppn(d) := MuxLookup(level, 0.U)(Seq(
-        0.U -> Cat(ppn(ppn.getWidth-1, vpnnLen*2), vpn_reg(vpnnLen*2-1, 0)),
-        1.U -> Cat(ppn(ppn.getWidth-1, vpnnLen), vpn_reg(vpnnLen-1, 0)),
-        2.U -> ppn)
-      )
+      resp.bits.perm(d)(s1RespPte, helperResult.hasPf, false.B, Mux(isAllStage, s1Pte.perm.v, helperResult.hasNoPf))
+      resp.bits.pbmt(d) := s1RespPte.pbmt
+      resp.bits.ppn(d) := finalPPN
+      resp.bits.g_perm(d)(s2RespPte, helperResult.hasGpf, false.B, Mux(isAllStage, s2Pte.perm.v, helperResult.hasNoPf))
+      resp.bits.g_pbmt(d) := s2RespPte.pbmt
+      resp.bits.s2xlate(d) := s2xlateReg
     }
   }
 

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -545,7 +545,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   val sfence = RegNext(RegNext(io.ooo_to_mem.sfence))
   val tlbcsr = RegNext(RegNext(io.ooo_to_mem.tlbCsr))
   private val ptw = outer.ptw.module
-  private val ptw_to_l2_buffer = outer.ptw_to_l2_buffer.module
+  private val ptw_to_l2_buffer = if (!coreParams.softPTW) outer.ptw_to_l2_buffer.module else null
   private val l1d_to_l2_buffer = outer.l1d_to_l2_buffer.module
   ptw.io.hartId := io.hartId
   ptw.io.sfence <> sfence
@@ -1469,8 +1469,10 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   if (p(DebugOptionsKey).ResetGen) {
     val leftResetTree = ResetGenNode(
       Seq(
-        ModuleNode(ptw),
-        ModuleNode(ptw_to_l2_buffer),
+        ModuleNode(ptw)
+      )
+      ++ (if (!coreParams.softPTW) Seq(ModuleNode(ptw_to_l2_buffer)) else Seq())
+      ++ Seq(
         ModuleNode(lsq),
         ModuleNode(dtlb_st_tlb_st),
         ModuleNode(dtlb_prefetch_tlb_prefetch),

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -603,7 +603,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   val sfence = RegNext(RegNext(io.ooo_to_mem.sfence))
   val tlbcsr = RegNext(io.ooo_to_mem.tlbCsr)
   private val ptw = outer.ptw.module
-  private val ptw_to_l2_buffer = outer.ptw_to_l2_buffer.module
+  private val ptw_to_l2_buffer = if (!coreParams.softPTW) outer.ptw_to_l2_buffer.module else null
   private val l1d_to_l2_buffer = outer.l1d_to_l2_buffer.map(_.module)
   ptw.io.hartId := io.hartId
   ptw.io.sfence <> sfence
@@ -1298,8 +1298,10 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   if (p(DebugOptionsKey).ResetGen) {
     val leftResetTree = ResetGenNode(
       Seq(
-        ModuleNode(ptw),
-        ModuleNode(ptw_to_l2_buffer),
+        ModuleNode(ptw)
+      )
+      ++ (if (!coreParams.softPTW) Seq(ModuleNode(ptw_to_l2_buffer)) else Seq())
+      ++ Seq(
         ModuleNode(lsq),
         ModuleNode(dtlb_st_tlb_st),
         ModuleNode(dtlb_prefetch_tlb_prefetch),


### PR DESCRIPTION
Add ptehelper as a DPI-C backed ideal translation path for MMU
simulation studies. The feature can bypass selected hardware
translation structures and use a software page-table walk model to
evaluate the MMU translation performance upper bound.

softTLB replaces the L1 TLB storage with TLBFakeFA. The fake storage
returns a registered helper result on the cycle after a valid request
when translation is enabled, and it does not take the normal TLB miss
and refill path.

softPTW replaces the normal L2TLB implementation at the L2TLBWrapper
boundary with FakePTW. From the L1 TLB side this bypasses the L2TLB,
page-table cache, and PTW miss path, while still returning the normal
L2TLBIO response format.

Add PTEHelper, PteHelperResult, and shared response builders so the
softTLB and softPTW paths use the same PPN, permission, PBMT, NAPOT,
and stage-fault construction. The helper covers Sv39, Sv48, Sv39x4,
Sv48x4, PBMTE-gated PBMT checks, and two-stage translation results.

The softPTW path also avoids instantiating the normal PTW-to-L2 buffer
module in the reset tree when the normal L2TLB path is disabled.

The feature is controlled by the existing softTLB and softPTW fields in
core parameters. Both flags stay disabled by default.

Without enabling softtlb/softptw, it will not affect any of the original hardware logic.

Validated with rvh-test using softTLB and softPTW modes. Both modes
pass all rvh-test cases, including PBMT tests.