### PR TITLE
perf(Sbuffer): set in.req.ready to true if req can be merged

### DIFF
--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -343,32 +343,26 @@ class Sbuffer(implicit p: Parameters)
   val evenInvalidMask = GetEvenBits(invalidMask.asUInt)
   val oddInvalidMask = GetOddBits(invalidMask.asUInt)
 
-  def getFirstOneOH(input: UInt): UInt = {
-    assert(input.getWidth > 1)
-    val output = WireInit(VecInit(input.asBools))
-    (1 until input.getWidth).map(i => {
-      output(i) := !input(i - 1, 0).orR && input(i)
-    })
-    output.asUInt
+  // set only the first one to one, example: 10011010 -> 00000010
+  def setFirstOneOH(in: UInt):(UInt, Bool) = { // return (result, isAllZero)
+    val size = in.getWidth
+    if (size == 1) { (in, !in(0)) } else {
+      val hi = setFirstOneOH(in(size - 1, size / 2))
+      val lo = setFirstOneOH(in(size / 2 - 1, 0))
+      val outHi = Mux(lo._2, hi._1, 0.U)
+      (Cat(outHi, lo._1), hi._2 && lo._2)
+    }
   }
 
-  val evenRawInsertVec = getFirstOneOH(evenInvalidMask)
-  val oddRawInsertVec = getFirstOneOH(oddInvalidMask)
-  val (evenRawInsertIdx, evenCanInsert) = PriorityEncoderWithFlag(evenInvalidMask)
-  val (oddRawInsertIdx, oddCanInsert) = PriorityEncoderWithFlag(oddInvalidMask)
-  val evenInsertIdx = Cat(evenRawInsertIdx, 0.U(1.W)) // slow to generate, for debug only
-  val oddInsertIdx = Cat(oddRawInsertIdx, 1.U(1.W)) // slow to generate, for debug only
+  val setFirstOneEven = setFirstOneOH(evenInvalidMask)
+  val setFirstOneOdd = setFirstOneOH(oddInvalidMask)
+  val (evenRawInsertVec, evenCanInsert) = (setFirstOneEven._1, !setFirstOneEven._2)
+  val (oddRawInsertVec, oddCanInsert) = (setFirstOneOdd._1, !setFirstOneOdd._2)
   val evenInsertVec = GetEvenBits.reverse(evenRawInsertVec)
   val oddInsertVec = GetOddBits.reverse(oddRawInsertVec)
 
   val firstInsertEven = PopCount(evenInvalidMask) >= PopCount(oddInvalidMask)
   val secondInsertEven = Mux(canMerge(0), firstInsertEven, !firstInsertEven)
-
-  val firstInsertIdx = Mux(firstInsertEven, evenInsertIdx, oddInsertIdx) // slow to generate, for debug only
-  val secondInsertIdx = Mux(sameTag,
-    firstInsertIdx,
-    Mux(secondInsertEven, evenInsertIdx, oddInsertIdx)
-  ) // slow to generate, for debug only
   val firstInsertVec = Mux(firstInsertEven, evenInsertVec, oddInsertVec)
   val secondInsertVec = Mux(sameTag,
     firstInsertVec,
@@ -385,6 +379,14 @@ class Sbuffer(implicit p: Parameters)
   val enqAllowed = sbuffer_state =/= x_drain_sbuffer
   io.in.req(0).ready := (firstCanInsert || canMerge(0)) && enqAllowed
   io.in.req(1).ready := (secondCanInsert || canMerge(1)) && enqAllowed && io.in.req(0).ready
+
+  // this group of signals are only for debug or assert
+  val evenRawInsertIdx = PriorityEncoderWithFlag(evenInvalidMask)._1
+  val oddRawInsertIdx = PriorityEncoderWithFlag(oddInvalidMask)._1
+  val evenInsertIdx = Cat(evenRawInsertIdx, 0.U(1.W)) 
+  val oddInsertIdx = Cat(oddRawInsertIdx, 1.U(1.W)) 
+  val firstInsertIdx = Mux(firstInsertEven, evenInsertIdx, oddInsertIdx) 
+  val secondInsertIdx = Mux(sameTag, firstInsertIdx, Mux(secondInsertEven, evenInsertIdx, oddInsertIdx)) 
 
   for (i <- 0 until EnsbufferWidth) {
     // train

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -374,20 +374,17 @@ class Sbuffer(implicit p: Parameters)
     firstInsertVec,
     Mux(secondInsertEven, evenInsertVec, oddInsertVec)
   )
-  val firstCanInsert = sbuffer_state =/= x_drain_sbuffer && Mux(firstInsertEven, evenCanInsert, oddCanInsert)
-  val secondCanInsert = sbuffer_state =/= x_drain_sbuffer && Mux(sameTag,
-    firstCanInsert,
-    Mux(secondInsertEven, evenCanInsert, oddCanInsert)
-  ) && (EnsbufferWidth >= 1).B
-  val enqAllowed = sbuffer_state =/= x_drain_sbuffer
+  val firstCanInsert = Mux(firstInsertEven, evenCanInsert, oddCanInsert)
+  val secondCanInsert = Mux(sameTag, firstCanInsert, Mux(secondInsertEven, evenCanInsert, oddCanInsert)) &&
+                       (EnsbufferWidth >= 2).B
   val forward_need_uarch_drain = WireInit(false.B)
   val merge_need_uarch_drain = WireInit(false.B)
   val do_uarch_drain = GatedValidRegNext(forward_need_uarch_drain) || GatedValidRegNext(GatedValidRegNext(merge_need_uarch_drain))
   XSPerfAccumulate("do_uarch_drain", do_uarch_drain)
 
-  // Allow merge when assigned insert bank is full; still block all enq during x_drain_sbuffer.
-  io.in.req(0).ready := firstCanInsert || (enqAllowed && canMerge(0))
-  io.in.req(1).ready := (secondCanInsert || (enqAllowed && canMerge(1))) && io.in.req(0).ready
+  val enqAllowed = sbuffer_state =/= x_drain_sbuffer
+  io.in.req(0).ready := (firstCanInsert || canMerge(0)) && enqAllowed
+  io.in.req(1).ready := (secondCanInsert || canMerge(1)) && enqAllowed && io.in.req(0).ready
 
   for (i <- 0 until EnsbufferWidth) {
     // train

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -361,10 +361,11 @@ class Sbuffer(implicit p: Parameters)
   val evenInsertVec = GetEvenBits.reverse(evenRawInsertVec)
   val oddInsertVec = GetOddBits.reverse(oddRawInsertVec)
 
-  val enbufferSelReg = RegInit(false.B)
-  when(io.in.req(0).valid) {
-    enbufferSelReg := ~enbufferSelReg
-  }
+  // val enbufferSelReg = RegInit(false.B)
+  // when(io.in.req(0).valid) {
+  //   enbufferSelReg := ~enbufferSelReg
+  // }
+  val enbufferSelReg = PopCount(evenInvalidMask) >= PopCount(oddInvalidMask)
 
   val firstInsertIdx = Mux(enbufferSelReg, evenInsertIdx, oddInsertIdx) // slow to generate, for debug only
   val secondInsertIdx = Mux(sameTag,

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -375,19 +375,21 @@ class Sbuffer(implicit p: Parameters)
   val secondInsertVec = Mux(sameTag,
     firstInsertVec,
     Mux(~enbufferSelReg, evenInsertVec, oddInsertVec)
-  ) // slow to generate, for debug only
+  )
   val firstCanInsert = sbuffer_state =/= x_drain_sbuffer && Mux(enbufferSelReg, evenCanInsert, oddCanInsert)
   val secondCanInsert = sbuffer_state =/= x_drain_sbuffer && Mux(sameTag,
     firstCanInsert,
     Mux(~enbufferSelReg, evenCanInsert, oddCanInsert)
   ) && (EnsbufferWidth >= 1).B
+  val enqAllowed = sbuffer_state =/= x_drain_sbuffer
   val forward_need_uarch_drain = WireInit(false.B)
   val merge_need_uarch_drain = WireInit(false.B)
   val do_uarch_drain = GatedValidRegNext(forward_need_uarch_drain) || GatedValidRegNext(GatedValidRegNext(merge_need_uarch_drain))
   XSPerfAccumulate("do_uarch_drain", do_uarch_drain)
 
-  io.in.req(0).ready := firstCanInsert
-  io.in.req(1).ready := secondCanInsert && io.in.req(0).ready
+  // Allow merge when assigned insert bank is full; still block all enq during x_drain_sbuffer.
+  io.in.req(0).ready := firstCanInsert || (enqAllowed && canMerge(0))
+  io.in.req(1).ready := (secondCanInsert || (enqAllowed && canMerge(1))) && io.in.req(0).ready
 
   for (i <- 0 until EnsbufferWidth) {
     // train

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -285,7 +285,9 @@ class Sbuffer(implicit p: Parameters)
   // insert and merge: cohCount=0
   // every cycle cohCount+=1
   // if cohCount(EvictCountBits-1)==1, evict
-  val cohTimeOutMask = VecInit(widthMap(i => cohCount(i) >= io.csrCtrl.sbuffer_timeout && stateVec(i).isActive()))
+  val cohTimeOutMask_wire = VecInit(widthMap(i => cohCount(i) >= io.csrCtrl.sbuffer_timeout && stateVec(i).isActive()))
+  val cohTimeOutMask = RegInit(VecInit(Seq.fill(StoreBufferSize)(false.B)))
+  cohTimeOutMask := cohTimeOutMask_wire
   val (cohTimeOutIdx, cohHasTimeOut) = PriorityEncoderWithFlag(cohTimeOutMask)
   val cohTimeOutOH = PriorityEncoderOH(cohTimeOutMask)
   val missqReplayTimeOutMask = VecInit(widthMap(i => missqReplayCount(i)(MissqReplayCountBits - 1) && stateVec(i).w_timeout))
@@ -335,10 +337,11 @@ class Sbuffer(implicit p: Parameters)
     assert(!(PopCount(mergeMask(i).asUInt) > 1.U && io.in.req(i).fire && io.in.req(i).bits.vecValid))
   }
 
-  // insert condition
-  // firstInsert: the first invalid entry
-  // if first entry canMerge or second entry has the same ptag with the first entry,
-  // secondInsert equal the first invalid entry, otherwise, the second invalid entry
+  // insert (enqueue) scenario:
+  // -- if even bank is more empty, the first req inserted into even bank, the second inserted into odd bank
+  // -- if the first or second req can be merged into an existing line, it is merged
+  // -- if the first and second req are in the same line, they can be inserted or merged into the same entry
+  // -- if the first can be merged and the second cannot be merged, the second req is inserted into the more empty bank
   val invalidMask = VecInit(stateVec.map(s => s.isInvalid()))
   val evenInvalidMask = GetEvenBits(invalidMask.asUInt)
   val oddInvalidMask = GetOddBits(invalidMask.asUInt)
@@ -364,17 +367,10 @@ class Sbuffer(implicit p: Parameters)
   val firstInsertEven = PopCount(evenInvalidMask) >= PopCount(oddInvalidMask)
   val secondInsertEven = Mux(canMerge(0), firstInsertEven, !firstInsertEven)
   val firstInsertVec = Mux(firstInsertEven, evenInsertVec, oddInsertVec)
-  val secondInsertVec = Mux(sameTag,
-    firstInsertVec,
-    Mux(secondInsertEven, evenInsertVec, oddInsertVec)
-  )
+  val secondInsertVec = Mux(sameTag, firstInsertVec, Mux(secondInsertEven, evenInsertVec, oddInsertVec))
   val firstCanInsert = Mux(firstInsertEven, evenCanInsert, oddCanInsert)
   val secondCanInsert = Mux(sameTag, firstCanInsert, Mux(secondInsertEven, evenCanInsert, oddCanInsert)) &&
                        (EnsbufferWidth >= 2).B
-  val forward_need_uarch_drain = WireInit(false.B)
-  val merge_need_uarch_drain = WireInit(false.B)
-  val do_uarch_drain = GatedValidRegNext(forward_need_uarch_drain) || GatedValidRegNext(GatedValidRegNext(merge_need_uarch_drain))
-  XSPerfAccumulate("do_uarch_drain", do_uarch_drain)
 
   val enqAllowed = sbuffer_state =/= x_drain_sbuffer
   io.in.req(0).ready := (firstCanInsert || canMerge(0)) && enqAllowed
@@ -383,10 +379,15 @@ class Sbuffer(implicit p: Parameters)
   // this group of signals are only for debug or assert
   val evenRawInsertIdx = PriorityEncoderWithFlag(evenInvalidMask)._1
   val oddRawInsertIdx = PriorityEncoderWithFlag(oddInvalidMask)._1
-  val evenInsertIdx = Cat(evenRawInsertIdx, 0.U(1.W)) 
-  val oddInsertIdx = Cat(oddRawInsertIdx, 1.U(1.W)) 
-  val firstInsertIdx = Mux(firstInsertEven, evenInsertIdx, oddInsertIdx) 
-  val secondInsertIdx = Mux(sameTag, firstInsertIdx, Mux(secondInsertEven, evenInsertIdx, oddInsertIdx)) 
+  val evenInsertIdx = Cat(evenRawInsertIdx, 0.U(1.W))
+  val oddInsertIdx = Cat(oddRawInsertIdx, 1.U(1.W))
+  val firstInsertIdx = Mux(firstInsertEven, evenInsertIdx, oddInsertIdx)
+  val secondInsertIdx = Mux(sameTag, firstInsertIdx, Mux(secondInsertEven, evenInsertIdx, oddInsertIdx))
+
+  val forward_need_uarch_drain = WireInit(false.B)
+  val merge_need_uarch_drain = WireInit(false.B)
+  val do_uarch_drain = GatedValidRegNext(forward_need_uarch_drain) || GatedValidRegNext(GatedValidRegNext(merge_need_uarch_drain))
+  XSPerfAccumulate("do_uarch_drain", do_uarch_drain)
 
   for (i <- 0 until EnsbufferWidth) {
     // train

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -362,7 +362,7 @@ class Sbuffer(implicit p: Parameters)
   val oddInsertVec = GetOddBits.reverse(oddRawInsertVec)
 
   val firstInsertEven = PopCount(evenInvalidMask) >= PopCount(oddInvalidMask)
-  val secondInsertEven = !firstInsertEven || canMerge(0)
+  val secondInsertEven = Mux(canMerge(0), firstInsertEven, !firstInsertEven)
 
   val firstInsertIdx = Mux(firstInsertEven, evenInsertIdx, oddInsertIdx) // slow to generate, for debug only
   val secondInsertIdx = Mux(sameTag,

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -361,26 +361,23 @@ class Sbuffer(implicit p: Parameters)
   val evenInsertVec = GetEvenBits.reverse(evenRawInsertVec)
   val oddInsertVec = GetOddBits.reverse(oddRawInsertVec)
 
-  // val enbufferSelReg = RegInit(false.B)
-  // when(io.in.req(0).valid) {
-  //   enbufferSelReg := ~enbufferSelReg
-  // }
-  val enbufferSelReg = PopCount(evenInvalidMask) >= PopCount(oddInvalidMask)
+  val firstInsertEven = PopCount(evenInvalidMask) >= PopCount(oddInvalidMask)
+  val secondInsertEven = !firstInsertEven || canMerge(0)
 
-  val firstInsertIdx = Mux(enbufferSelReg, evenInsertIdx, oddInsertIdx) // slow to generate, for debug only
+  val firstInsertIdx = Mux(firstInsertEven, evenInsertIdx, oddInsertIdx) // slow to generate, for debug only
   val secondInsertIdx = Mux(sameTag,
     firstInsertIdx,
-    Mux(~enbufferSelReg, evenInsertIdx, oddInsertIdx)
+    Mux(secondInsertEven, evenInsertIdx, oddInsertIdx)
   ) // slow to generate, for debug only
-  val firstInsertVec = Mux(enbufferSelReg, evenInsertVec, oddInsertVec)
+  val firstInsertVec = Mux(firstInsertEven, evenInsertVec, oddInsertVec)
   val secondInsertVec = Mux(sameTag,
     firstInsertVec,
-    Mux(~enbufferSelReg, evenInsertVec, oddInsertVec)
+    Mux(secondInsertEven, evenInsertVec, oddInsertVec)
   )
-  val firstCanInsert = sbuffer_state =/= x_drain_sbuffer && Mux(enbufferSelReg, evenCanInsert, oddCanInsert)
+  val firstCanInsert = sbuffer_state =/= x_drain_sbuffer && Mux(firstInsertEven, evenCanInsert, oddCanInsert)
   val secondCanInsert = sbuffer_state =/= x_drain_sbuffer && Mux(sameTag,
     firstCanInsert,
-    Mux(~enbufferSelReg, evenCanInsert, oddCanInsert)
+    Mux(secondInsertEven, evenCanInsert, oddCanInsert)
   ) && (EnsbufferWidth >= 1).B
   val enqAllowed = sbuffer_state =/= x_drain_sbuffer
   val forward_need_uarch_drain = WireInit(false.B)

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -341,7 +341,6 @@ class Sbuffer(implicit p: Parameters)
   // -- if even bank is more empty, the first req inserted into even bank, the second inserted into odd bank
   // -- if the first or second req can be merged into an existing line, it is merged
   // -- if the first and second req are in the same line, they can be inserted or merged into the same entry
-  // -- if the first can be merged and the second cannot be merged, the second req is inserted into the more empty bank
   val invalidMask = VecInit(stateVec.map(s => s.isInvalid()))
   val evenInvalidMask = GetEvenBits(invalidMask.asUInt)
   val oddInvalidMask = GetOddBits(invalidMask.asUInt)

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -365,7 +365,7 @@ class Sbuffer(implicit p: Parameters)
   val oddInsertVec = GetOddBits.reverse(oddRawInsertVec)
 
   val firstInsertEven = PopCount(evenInvalidMask) >= PopCount(oddInvalidMask)
-  val secondInsertEven = Mux(canMerge(0), firstInsertEven, !firstInsertEven)
+  val secondInsertEven = !firstInsertEven
   val firstInsertVec = Mux(firstInsertEven, evenInsertVec, oddInsertVec)
   val secondInsertVec = Mux(sameTag, firstInsertVec, Mux(secondInsertEven, evenInsertVec, oddInsertVec))
   val firstCanInsert = Mux(firstInsertEven, evenCanInsert, oddCanInsert)
@@ -374,7 +374,7 @@ class Sbuffer(implicit p: Parameters)
 
   val enqAllowed = sbuffer_state =/= x_drain_sbuffer
   io.in.req(0).ready := (firstCanInsert || canMerge(0)) && enqAllowed
-  io.in.req(1).ready := (secondCanInsert || canMerge(1)) && enqAllowed && io.in.req(0).ready
+  io.in.req(1).ready := (secondCanInsert || canMerge(1)) && io.in.req(0).ready
 
   // this group of signals are only for debug or assert
   val evenRawInsertIdx = PriorityEncoderWithFlag(evenInvalidMask)._1


### PR DESCRIPTION
Set io.in.req.ready to true if io.in.req can be merged into Sbuffer.

The first input req choose the more empty bank.

Register the cohTimeOutMask to get better timing.

Rewrite some code to be more concise.

SPEC06 1.0c score got  0.08%  improvement.
base (be3c06a):      19.809
this PR (4ddeb85):  19.825