### PR TITLE
fix(Ifu): Pbmt.IO should wait for last commit

### DIFF
--- a/src/main/scala/xiangshan/frontend/ifu/IfuUncacheUnit.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/IfuUncacheUnit.scala
@@ -82,13 +82,12 @@ class IfuUncacheUnit(implicit p: Parameters) extends IfuModule with IfuHelper {
     uncacheFinish     := false.B
   }
 
-  // last instruction finish
-  private val reqIsMmio = io.req.valid && io.req.bits.isMmio
-
   switch(uncacheState) {
     is(UncacheFsmState.Idle) {
+      // pbmt.nc does not need to wait for last commit as it's idempotent area, while pbmt.io and (pbmt.pma && mmio) needs.
+      val shouldWait = io.req.bits.isMmio || Pbmt.isIO(io.req.bits.pbmt)
       when(io.req.valid) {
-        uncacheState := Mux(reqIsMmio, UncacheFsmState.WaitLastCommit, UncacheFsmState.SendReq)
+        uncacheState := Mux(shouldWait, UncacheFsmState.WaitLastCommit, UncacheFsmState.SendReq)
         uncachePAddr := io.req.bits.paddr
         isMmio       := io.req.bits.isMmio
         itlbPbmt     := io.req.bits.pbmt


### PR DESCRIPTION
Fixes #6134

Also remove redundant logic `io.req.valid &&`, this signal is used only when `io.req.valid`