### PR TITLE
perf(MemBlock): optimize L1DCache index

### DIFF
--- a/src/main/scala/xiangshan/cache/L1Cache.scala
+++ b/src/main/scala/xiangshan/cache/L1Cache.scala
@@ -86,7 +86,7 @@ trait HasL1CacheParameters extends HasXSParameter
   def get_phy_tag(paddr: PrunedAddr): UInt = (paddr >> pgUntagBits).asUInt
   def get_vir_tag(vaddr: UInt) = (vaddr >> untagBits).asUInt
   def get_tag(addr: UInt) = get_phy_tag(addr)
-  def get_dcache_idx(addr: UInt) = Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(untagBits-3, blockOffBits))
+  def get_dcache_idx(addr: UInt) = Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(untagBits - 1 - (untagBits-pgUntagBits), blockOffBits))
   def get_idx(addr: UInt) = addr(untagBits-1, blockOffBits)
   def get_idx(addr: PrunedAddr) = addr(untagBits-1, blockOffBits)
   def get_untag(addr: UInt) = addr(pgUntagBits-1, 0)

--- a/src/main/scala/xiangshan/cache/L1Cache.scala
+++ b/src/main/scala/xiangshan/cache/L1Cache.scala
@@ -80,8 +80,15 @@ trait HasL1CacheParameters extends HasXSParameter
   def refillWords = refillBytes / wordBytes
   def modeId = 1 //DCache index & alias mode: 1 for hash vaddr, 2 for direct extract vaddr[13:6]
   def hashBitPairs(addr: UInt, hi: Int = PAddrBits - 1, lo: Int = pgIdxBits, step: Int = 2): UInt = {
-    require(hi > lo && (hi - lo + 1) % step == 0, "Invalid bit range or step")
-    (lo to hi by step).map(i => addr(i + step - 1, i)).reduce(_ ^ _)
+    require(hi >= lo)
+    require(step > 0)
+    if ((hi - lo + 1) <= step){
+      addr(hi, lo)
+    } else{
+      val remain = (hi - lo + 1) % step
+      val xortmp = (lo to (hi - remain) by step).map(i => addr(i + step - 1, i)).reduce(_ ^ _)
+      if (remain == 0) xortmp else Cat(xortmp(step - 1, remain), xortmp(remain - 1, 0) ^ addr(hi, hi - remain + 1))
+    }
   }
   def get_phy_tag(paddr: UInt) = (paddr >> pgUntagBits).asUInt
   def get_phy_tag(paddr: PrunedAddr): UInt = (paddr >> pgUntagBits).asUInt
@@ -92,7 +99,7 @@ trait HasL1CacheParameters extends HasXSParameter
       case 1 => Cat(
                  hashBitPairs(addr, PAddrBits - 1, pgIdxBits),               // hash vaddr[47:12]
                  addr(untagBits - 1 - (untagBits-pgUntagBits), blockOffBits) // vaddr[11:6]
-                )
+                )(idxBits - 1, 0)
       case 2 => addr(untagBits - 1, blockOffBits) // vaddr[13:6]
       case _ => throw new IllegalArgumentException(s"Invalid L1DCache index modeId: $modeId")
     }

--- a/src/main/scala/xiangshan/cache/L1Cache.scala
+++ b/src/main/scala/xiangshan/cache/L1Cache.scala
@@ -79,7 +79,6 @@ trait HasL1CacheParameters extends HasXSParameter
   def blockWords = blockBytes / wordBytes
   def refillWords = refillBytes / wordBytes
   def hashBitPairs(addr: UInt, hi: Int = PAddrBits - 1, lo: Int = pgIdxBits, step: Int = 2): UInt = {
-    print(s"hashBitPairs: data=${addr.getWidth} bits, hi=$hi, lo=$lo, step=$step\n")
     require(hi > lo && (hi - lo + 1) % step == 0, "Invalid bit range or step")
     (lo to hi by step).map(i => addr(i + step - 1, i)).reduce(_ ^ _)
   }

--- a/src/main/scala/xiangshan/cache/L1Cache.scala
+++ b/src/main/scala/xiangshan/cache/L1Cache.scala
@@ -78,6 +78,7 @@ trait HasL1CacheParameters extends HasXSParameter
   // the number of words in a block
   def blockWords = blockBytes / wordBytes
   def refillWords = refillBytes / wordBytes
+  def modeId = 1 //DCache index & alias mode: 1 for hash vaddr, 2 for direct extract vaddr[13:6]
   def hashBitPairs(addr: UInt, hi: Int = PAddrBits - 1, lo: Int = pgIdxBits, step: Int = 2): UInt = {
     require(hi > lo && (hi - lo + 1) % step == 0, "Invalid bit range or step")
     (lo to hi by step).map(i => addr(i + step - 1, i)).reduce(_ ^ _)
@@ -86,7 +87,16 @@ trait HasL1CacheParameters extends HasXSParameter
   def get_phy_tag(paddr: PrunedAddr): UInt = (paddr >> pgUntagBits).asUInt
   def get_vir_tag(vaddr: UInt) = (vaddr >> untagBits).asUInt
   def get_tag(addr: UInt) = get_phy_tag(addr)
-  def get_dcache_idx(addr: UInt) = Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(untagBits - 1 - (untagBits-pgUntagBits), blockOffBits))
+  def get_dcache_idx(addr: UInt, modeId: Int = modeId) = {
+    modeId match {
+      case 1 => Cat(
+                 hashBitPairs(addr, PAddrBits - 1, pgIdxBits),               // hash vaddr[47:12]
+                 addr(untagBits - 1 - (untagBits-pgUntagBits), blockOffBits) // vaddr[11:6]
+                )
+      case 2 => addr(untagBits - 1, blockOffBits) // vaddr[13:6]
+      case _ => throw new IllegalArgumentException(s"Invalid L1DCache index modeId: $modeId")
+    }
+  }
   def get_idx(addr: UInt) = addr(untagBits-1, blockOffBits)
   def get_idx(addr: PrunedAddr) = addr(untagBits-1, blockOffBits)
   def get_untag(addr: UInt) = addr(pgUntagBits-1, 0)

--- a/src/main/scala/xiangshan/cache/L1Cache.scala
+++ b/src/main/scala/xiangshan/cache/L1Cache.scala
@@ -78,11 +78,16 @@ trait HasL1CacheParameters extends HasXSParameter
   // the number of words in a block
   def blockWords = blockBytes / wordBytes
   def refillWords = refillBytes / wordBytes
-
+  def hashBitPairs(addr: UInt, hi: Int = PAddrBits - 1, lo: Int = pgIdxBits, step: Int = 2): UInt = {
+    print(s"hashBitPairs: data=${addr.getWidth} bits, hi=$hi, lo=$lo, step=$step\n")
+    require(hi > lo && (hi - lo + 1) % step == 0, "Invalid bit range or step")
+    (lo to hi by step).map(i => addr(i + step - 1, i)).reduce(_ ^ _)
+  }
   def get_phy_tag(paddr: UInt) = (paddr >> pgUntagBits).asUInt
   def get_phy_tag(paddr: PrunedAddr): UInt = (paddr >> pgUntagBits).asUInt
   def get_vir_tag(vaddr: UInt) = (vaddr >> untagBits).asUInt
   def get_tag(addr: UInt) = get_phy_tag(addr)
+  def get_dcache_idx(addr: UInt) = Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(untagBits-3, blockOffBits))
   def get_idx(addr: UInt) = addr(untagBits-1, blockOffBits)
   def get_idx(addr: PrunedAddr) = addr(untagBits-1, blockOffBits)
   def get_untag(addr: UInt) = addr(pgUntagBits-1, 0)

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -242,14 +242,28 @@ trait HasDCacheParameters
     if(DCacheSetDivBits == 0) 0.U else addr(DCacheSetOffset + DCacheSetDivBits - 1, DCacheSetOffset)
   }
 
-  def addr_to_dcache_div_set(addr: UInt) = {
+  def addr_to_dcache_div_set(addr: UInt, modeId: Int = modeId) = {
     require(addr.getWidth >= DCacheAboveIndexOffset)
-    Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(DCacheAboveIndexOffset- 1 - (untagBits-pgUntagBits), DCacheSetOffset + DCacheSetDivBits))
+    modeId match {
+      case 1 => Cat(
+                 hashBitPairs(addr, PAddrBits - 1, pgIdxBits),
+                 addr(DCacheAboveIndexOffset- 1 - (untagBits-pgUntagBits), DCacheSetOffset + DCacheSetDivBits)
+                )
+      case 2 => addr(DCacheAboveIndexOffset - 1, DCacheSetOffset + DCacheSetDivBits)
+      case _ => throw new IllegalArgumentException(s"Invalid L1DCache index modeId: $modeId")
+    }
   }
 
-  def addr_to_dcache_set(addr: UInt) = {
+  def addr_to_dcache_set(addr: UInt, modeId: Int = modeId) = {
     require(addr.getWidth >= DCacheAboveIndexOffset)
-    Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(DCacheAboveIndexOffset- 1 - (untagBits-pgUntagBits), DCacheSetOffset))
+    modeId match {
+      case 1 => Cat(
+                 hashBitPairs(addr, PAddrBits - 1, pgIdxBits),
+                 addr(DCacheAboveIndexOffset- 1 - (untagBits-pgUntagBits), DCacheSetOffset)
+                )
+      case 2 => addr(DCacheAboveIndexOffset - 1, DCacheSetOffset)
+      case _ => throw new IllegalArgumentException(s"Invalid L1DCache index modeId: $modeId")
+    }
   }
 
   def get_data_of_bank(bank: Int, data: UInt) = {
@@ -262,19 +276,23 @@ trait HasDCacheParameters
     data(DCacheSRAMRowBytes * (bank + 1) - 1, DCacheSRAMRowBytes * bank)
   }
 
-  def get_alias(vaddr: UInt): UInt ={
+  def get_alias(vaddr: UInt, modeId: Int = modeId): UInt ={
     // require(blockOffBits + idxBits > pgIdxBits)
     if(blockOffBits + idxBits > pgIdxBits){
-      hashBitPairs(vaddr, PAddrBits - 1, pgIdxBits)
+      modeId match {
+        case 1 => hashBitPairs(vaddr, PAddrBits - 1, pgIdxBits)
+        case 2 => vaddr(blockOffBits + idxBits - 1, pgIdxBits)
+        case _ => throw new IllegalArgumentException(s"Invalid L1DCache alias modeId: $modeId")
+      }
     }else{
       0.U
     }
   }
 
-  def is_alias_match(vaddr0: UInt, vaddr1: UInt): Bool = {
+  def is_alias_match(vaddr0: UInt, vaddr1: UInt, modeId: Int = modeId): Bool = {
     require(vaddr0.getWidth == VAddrBits && vaddr1.getWidth == VAddrBits)
     if(blockOffBits + idxBits > pgIdxBits) {
-      hashBitPairs(vaddr0, PAddrBits - 1, pgIdxBits) === hashBitPairs(vaddr1, PAddrBits - 1, pgIdxBits)
+      get_alias(vaddr0, modeId) === get_alias(vaddr1, modeId)
     }else {
       // no alias problem
       true.B
@@ -1513,7 +1531,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     // have alias problem, extra alias bits needed for index
     val alias_addr_frag = bus.b.bits.data(2, 1)
     missQueue.io.probe.req.bits.vaddr := Cat(
-      bus.b.bits.address(PAddrBits - 1, DCacheAboveIndexOffset), // dontcare
+      0.U(PAddrBits - 1, DCacheAboveIndexOffset), // dontcare
       alias_addr_frag(DCacheAboveIndexOffset - DCacheTagOffset - 1, 0), // index
       bus.b.bits.address(DCacheTagOffset - 1, 0)                 // index & others
     )

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -245,13 +245,11 @@ trait HasDCacheParameters
   def addr_to_dcache_div_set(addr: UInt) = {
     require(addr.getWidth >= DCacheAboveIndexOffset)
     Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(DCacheAboveIndexOffset-3, DCacheSetOffset + DCacheSetDivBits))
-    // Cat(addr(DCacheAboveIndexOffset + 3, DCacheAboveIndexOffset + 2), addr(DCacheAboveIndexOffset - 1 - 2, DCacheSetOffset + DCacheSetDivBits))
   }
 
   def addr_to_dcache_set(addr: UInt) = {
     require(addr.getWidth >= DCacheAboveIndexOffset)
     Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(DCacheAboveIndexOffset-3, DCacheSetOffset))
-    // Cat(addr(DCacheAboveIndexOffset + 3, DCacheAboveIndexOffset +2), addr(DCacheAboveIndexOffset-1 -2, DCacheSetOffset))
   }
 
   def get_data_of_bank(bank: Int, data: UInt) = {
@@ -277,7 +275,6 @@ trait HasDCacheParameters
     require(vaddr0.getWidth == VAddrBits && vaddr1.getWidth == VAddrBits)
     if(blockOffBits + idxBits > pgIdxBits) {
       hashBitPairs(vaddr0, PAddrBits - 1, pgIdxBits) === hashBitPairs(vaddr1, PAddrBits - 1, pgIdxBits)
-      //vaddr0(PAddrBits - 1, pgIdxBits) === vaddr1(PAddrBits - 1, pgIdxBits)
     }else {
       // no alias problem
       true.B
@@ -1686,11 +1683,11 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   // ld_access.zip(ldu).foreach {
   //   case (a, u) =>
   //     a.valid := RegNext(u.io.lsu.req.fire) && !u.io.lsu.s1_kill
-  //     a.bits.idx := RegEnable(get_dcache_idx(u.io.lsu.req.bits.vaddr), u.io.lsu.req.fire)
+  //     a.bits.idx := RegEnable(get_idx(u.io.lsu.req.bits.vaddr), u.io.lsu.req.fire)
   //     a.bits.tag := get_tag(u.io.lsu.s1_paddr_dup_dcache)
   // }
   // st_access.valid := RegNext(mainPipe.io.store_req.fire)
-  // st_access.bits.idx := RegEnable(get_dcache_idx(mainPipe.io.store_req.bits.vaddr), mainPipe.io.store_req.fire)
+  // st_access.bits.idx := RegEnable(get_idx(mainPipe.io.store_req.bits.vaddr), mainPipe.io.store_req.fire)
   // st_access.bits.tag := RegEnable(get_tag(mainPipe.io.store_req.bits.addr), mainPipe.io.store_req.fire)
   // val access_info = ld_access.toSeq ++ Seq(st_access)
   // val early_replace = RegNext(missQueue.io.debug_early_replace) // TODO: clock gate

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -244,12 +244,12 @@ trait HasDCacheParameters
 
   def addr_to_dcache_div_set(addr: UInt) = {
     require(addr.getWidth >= DCacheAboveIndexOffset)
-    Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(DCacheAboveIndexOffset-3, DCacheSetOffset + DCacheSetDivBits))
+    Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(DCacheAboveIndexOffset- 1 - (untagBits-pgUntagBits), DCacheSetOffset + DCacheSetDivBits))
   }
 
   def addr_to_dcache_set(addr: UInt) = {
     require(addr.getWidth >= DCacheAboveIndexOffset)
-    Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(DCacheAboveIndexOffset-3, DCacheSetOffset))
+    Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(DCacheAboveIndexOffset- 1 - (untagBits-pgUntagBits), DCacheSetOffset))
   }
 
   def get_data_of_bank(bank: Int, data: UInt) = {

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -244,12 +244,14 @@ trait HasDCacheParameters
 
   def addr_to_dcache_div_set(addr: UInt) = {
     require(addr.getWidth >= DCacheAboveIndexOffset)
-    addr(DCacheAboveIndexOffset - 1, DCacheSetOffset + DCacheSetDivBits)
+    Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(DCacheAboveIndexOffset-3, DCacheSetOffset + DCacheSetDivBits))
+    // Cat(addr(DCacheAboveIndexOffset + 3, DCacheAboveIndexOffset + 2), addr(DCacheAboveIndexOffset - 1 - 2, DCacheSetOffset + DCacheSetDivBits))
   }
 
   def addr_to_dcache_set(addr: UInt) = {
     require(addr.getWidth >= DCacheAboveIndexOffset)
-    addr(DCacheAboveIndexOffset-1, DCacheSetOffset)
+    Cat(hashBitPairs(addr, PAddrBits - 1, pgIdxBits), addr(DCacheAboveIndexOffset-3, DCacheSetOffset))
+    // Cat(addr(DCacheAboveIndexOffset + 3, DCacheAboveIndexOffset +2), addr(DCacheAboveIndexOffset-1 -2, DCacheSetOffset))
   }
 
   def get_data_of_bank(bank: Int, data: UInt) = {
@@ -265,7 +267,7 @@ trait HasDCacheParameters
   def get_alias(vaddr: UInt): UInt ={
     // require(blockOffBits + idxBits > pgIdxBits)
     if(blockOffBits + idxBits > pgIdxBits){
-      vaddr(blockOffBits + idxBits - 1, pgIdxBits)
+      hashBitPairs(vaddr, PAddrBits - 1, pgIdxBits)
     }else{
       0.U
     }
@@ -274,7 +276,8 @@ trait HasDCacheParameters
   def is_alias_match(vaddr0: UInt, vaddr1: UInt): Bool = {
     require(vaddr0.getWidth == VAddrBits && vaddr1.getWidth == VAddrBits)
     if(blockOffBits + idxBits > pgIdxBits) {
-      vaddr0(blockOffBits + idxBits - 1, pgIdxBits) === vaddr1(blockOffBits + idxBits - 1, pgIdxBits)
+      hashBitPairs(vaddr0, PAddrBits - 1, pgIdxBits) === hashBitPairs(vaddr1, PAddrBits - 1, pgIdxBits)
+      //vaddr0(PAddrBits - 1, pgIdxBits) === vaddr1(PAddrBits - 1, pgIdxBits)
     }else {
       // no alias problem
       true.B
@@ -406,7 +409,7 @@ class DCacheLineReq(implicit p: Parameters) extends DCacheBundle
     XSDebug(cond, "DCacheLineReq: cmd: %x addr: %x data: %x mask: %x id: %d\n",
       cmd, addr, data, mask, id)
   }
-  def idx: UInt = get_idx(vaddr)
+  def idx: UInt = get_dcache_idx(vaddr)
 }
 
 class DCacheWordReqWithVaddr(implicit p: Parameters) extends DCacheWordReq {
@@ -1683,11 +1686,11 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   // ld_access.zip(ldu).foreach {
   //   case (a, u) =>
   //     a.valid := RegNext(u.io.lsu.req.fire) && !u.io.lsu.s1_kill
-  //     a.bits.idx := RegEnable(get_idx(u.io.lsu.req.bits.vaddr), u.io.lsu.req.fire)
+  //     a.bits.idx := RegEnable(get_dcache_idx(u.io.lsu.req.bits.vaddr), u.io.lsu.req.fire)
   //     a.bits.tag := get_tag(u.io.lsu.s1_paddr_dup_dcache)
   // }
   // st_access.valid := RegNext(mainPipe.io.store_req.fire)
-  // st_access.bits.idx := RegEnable(get_idx(mainPipe.io.store_req.bits.vaddr), mainPipe.io.store_req.fire)
+  // st_access.bits.idx := RegEnable(get_dcache_idx(mainPipe.io.store_req.bits.vaddr), mainPipe.io.store_req.fire)
   // st_access.bits.tag := RegEnable(get_tag(mainPipe.io.store_req.bits.addr), mainPipe.io.store_req.fire)
   // val access_info = ld_access.toSeq ++ Seq(st_access)
   // val early_replace = RegNext(missQueue.io.debug_early_replace) // TODO: clock gate

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -248,7 +248,7 @@ trait HasDCacheParameters
       case 1 => Cat(
                  hashBitPairs(addr, PAddrBits - 1, pgIdxBits),
                  addr(DCacheAboveIndexOffset- 1 - (untagBits-pgUntagBits), DCacheSetOffset + DCacheSetDivBits)
-                )
+                )(idxBits - DCacheSetDivBits - 1, 0)
       case 2 => addr(DCacheAboveIndexOffset - 1, DCacheSetOffset + DCacheSetDivBits)
       case _ => throw new IllegalArgumentException(s"Invalid L1DCache index modeId: $modeId")
     }
@@ -260,7 +260,7 @@ trait HasDCacheParameters
       case 1 => Cat(
                  hashBitPairs(addr, PAddrBits - 1, pgIdxBits),
                  addr(DCacheAboveIndexOffset- 1 - (untagBits-pgUntagBits), DCacheSetOffset)
-                )
+                )(DCacheAboveIndexOffset - DCacheSetOffset - 1, 0)
       case 2 => addr(DCacheAboveIndexOffset - 1, DCacheSetOffset)
       case _ => throw new IllegalArgumentException(s"Invalid L1DCache index modeId: $modeId")
     }
@@ -280,7 +280,7 @@ trait HasDCacheParameters
     // require(blockOffBits + idxBits > pgIdxBits)
     if(blockOffBits + idxBits > pgIdxBits){
       modeId match {
-        case 1 => hashBitPairs(vaddr, PAddrBits - 1, pgIdxBits)
+        case 1 => hashBitPairs(vaddr, PAddrBits - 1, pgIdxBits)(blockOffBits + idxBits - pgIdxBits - 1, 0)
         case 2 => vaddr(blockOffBits + idxBits - 1, pgIdxBits)
         case _ => throw new IllegalArgumentException(s"Invalid L1DCache alias modeId: $modeId")
       }

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -150,11 +150,11 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val tag_read = io.tag_read.bits
 
   // Tag read for new requests
-  meta_read.idx := get_idx(io.lsu.req.bits.vaddr)
+  meta_read.idx := get_dcache_idx(io.lsu.req.bits.vaddr)
   meta_read.way_en := ~0.U(nWays.W)
   // meta_read.tag := DontCare
 
-  tag_read.idx := get_idx(io.lsu.req.bits.vaddr)
+  tag_read.idx := get_dcache_idx(io.lsu.req.bits.vaddr)
   tag_read.way_en := ~0.U(nWays.W)
 
   // --------------------------------------------------------------------------------
@@ -275,7 +275,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
   // io.replace_way.set.valid := RegNext(s0_fire)
   io.replace_way.set.valid := false.B
-  io.replace_way.set.bits := get_idx(s1_vaddr)
+  io.replace_way.set.bits := get_dcache_idx(s1_vaddr)
   io.replace_way.dmWay := get_direct_map_way(s1_vaddr)
   val s1_invalid_vec = wayMap(w => !meta_resp(w).coh.isValid())
   val s1_have_invalid_way = s1_invalid_vec.asUInt.orR
@@ -563,12 +563,12 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.error.valid := s3_error && s3_valid
 
   io.replace_access.valid := s3_valid && s3_hit
-  io.replace_access.bits.set := RegNext(RegNext(get_idx(s1_req.vaddr)))
+  io.replace_access.bits.set := RegNext(RegNext(get_dcache_idx(s1_req.vaddr)))
   io.replace_access.bits.way := RegNext(RegNext(OHToUInt(s1_tag_match_way_dup_dc)))
 
   // update access bit
   io.access_flag_write.valid := s3_valid && s3_hit && !s3_is_prefetch
-  io.access_flag_write.bits.idx := get_idx(s3_vaddr)
+  io.access_flag_write.bits.idx := get_dcache_idx(s3_vaddr)
   io.access_flag_write.bits.way_en := s3_tag_match_way
   io.access_flag_write.bits.flag := true.B
 
@@ -577,7 +577,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // A prefetch block will only be counted once
   val s3_clear_pf_flag_en = s3_valid && s3_hit && !s3_is_prefetch && isFromL1Prefetch(s3_hit_prefetch)
   io.prefetch_flag_write.valid := s3_clear_pf_flag_en && !io.counter_filter_query.resp
-  io.prefetch_flag_write.bits.idx := get_idx(s3_vaddr)
+  io.prefetch_flag_write.bits.idx := get_dcache_idx(s3_vaddr)
   io.prefetch_flag_write.bits.way_en := s3_tag_match_way
   io.prefetch_flag_write.bits.source := L1_HW_PREFETCH_CLEAR
 
@@ -588,11 +588,11 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.latency_flag_write.bits.latency := 0.U
 
   io.counter_filter_query.req.valid := s3_clear_pf_flag_en
-  io.counter_filter_query.req.bits.idx := get_idx(s3_vaddr)
+  io.counter_filter_query.req.bits.idx := get_dcache_idx(s3_vaddr)
   io.counter_filter_query.req.bits.way := OHToUInt(s3_tag_match_way)
 
   io.counter_filter_enq.valid := io.prefetch_flag_write.valid
-  io.counter_filter_enq.bits.idx := get_idx(s3_vaddr)
+  io.counter_filter_enq.bits.idx := get_dcache_idx(s3_vaddr)
   io.counter_filter_enq.bits.way := OHToUInt(s3_tag_match_way)
 
   hit_pf_in_cache := s3_clear_pf_flag_en && !io.counter_filter_query.resp

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -294,7 +294,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     name = Some("main_pipe_req")
   )
 
-  val store_idx = get_idx(io.store_req.bits.vaddr)
+  val store_idx = get_dcache_idx(io.store_req.bits.vaddr)
   // manually assign store_req.ready for better timing
   // now store_req set conflict check is done in parallel with req arbiter
   store_req.ready := io.meta_read.ready && io.tag_read.ready && s1_ready && !store_set_conflict &&
@@ -303,7 +303,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   prefetch_req.ready := io.meta_read.ready && io.tag_read.ready && s1_ready && !set_conflict &&
     !io.probe_req.valid && !io.refill_req.valid
   val s0_req = req.bits
-  val s0_idx = get_idx(s0_req.vaddr)
+  val s0_idx = get_dcache_idx(s0_req.vaddr)
   val s0_need_tag = io.tag_read.valid
   val s0_can_go = io.meta_read.ready && io.tag_read.ready && s1_ready && !set_conflict
   val s0_fire = req.valid && s0_can_go
@@ -368,7 +368,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s1_need_tag = RegEnable(s0_need_tag, s0_fire)
   val s1_can_go = s2_ready && (io.data_readline.ready || !s1_need_data)
   val s1_fire = s1_valid && s1_can_go
-  val s1_idx = get_idx(s1_req.vaddr)
+  val s1_idx = get_dcache_idx(s1_req.vaddr)
   val s1_dmWay = RegEnable(get_direct_map_way(s0_req.vaddr), s0_fire)
   val s1_isPrefetch = !s1_req.replace && !s1_req.probe && !s1_req.miss && s1_req.isPrefetch
 
@@ -496,7 +496,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s2_need_eviction = RegEnable(s1_need_eviction, s1_fire)
   val s2_need_data = RegEnable(s1_need_data, s1_fire)
   val s2_need_tag = RegEnable(s1_need_tag, s1_fire)
-  val s2_idx = get_idx(s2_req.vaddr)
+  val s2_idx = get_dcache_idx(s2_req.vaddr)
 
   val s2_way_en = RegEnable(s1_way_en, s1_fire)
   val s2_tag = Mux(s2_need_replacement, s2_repl_tag, RegEnable(s1_tag, s1_fire))
@@ -896,11 +896,11 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   //assert(RegNext(!s3_valid || !(s3_req.source === STORE_SOURCE.U && !s3_req.probe) || s3_hit)) // miss store should never come to s3 ,fixed(reserve)
 
   io.meta_read.valid := req.valid
-  io.meta_read.bits.idx := get_idx(s0_req.vaddr)
+  io.meta_read.bits.idx := get_dcache_idx(s0_req.vaddr)
   io.meta_read.bits.way_en := Mux(s0_req.replace, s0_req.replace_way_en, ~0.U(nWays.W))
 
   io.tag_read.valid := req.valid && !s0_req.replace
-  io.tag_read.bits.idx := get_idx(s0_req.vaddr)
+  io.tag_read.bits.idx := get_dcache_idx(s0_req.vaddr)
   io.tag_read.bits.way_en := ~0.U(nWays.W)
 
   io.data_read_intend := s1_valid && s1_need_data
@@ -1127,7 +1127,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
 
   // TODO: consider block policy of a finer granularity
   io.status.s0_set.valid := req.valid
-  io.status.s0_set.bits := get_idx(s0_req.vaddr)
+  io.status.s0_set.bits := get_dcache_idx(s0_req.vaddr)
   io.status.s1.valid := s1_valid
   io.status.s1.bits.set := s1_idx
   io.status.s1.bits.way_en := s1_way_en
@@ -1140,13 +1140,13 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
 
   for ((s, i) <- io.status_dup.zipWithIndex) {
     s.s1.valid := s1_valid
-    s.s1.bits.set := RegEnable(get_idx(s0_req.vaddr), s0_fire)
+    s.s1.bits.set := RegEnable(get_dcache_idx(s0_req.vaddr), s0_fire)
     s.s1.bits.way_en := s1_way_en
     s.s2.valid := s2_valid && !RegEnable(s1_req.replace, s1_fire)
-    s.s2.bits.set := RegEnable(get_idx(s1_req.vaddr), s1_fire)
+    s.s2.bits.set := RegEnable(get_dcache_idx(s1_req.vaddr), s1_fire)
     s.s2.bits.way_en := s2_way_en
     s.s3.valid := s3_valid && !RegEnable(s2_req.replace, s2_fire_to_s3)
-    s.s3.bits.set := RegEnable(get_idx(s2_req.vaddr), s2_fire_to_s3)
+    s.s3.bits.set := RegEnable(get_dcache_idx(s2_req.vaddr), s2_fire_to_s3)
     s.s3.bits.way_en := RegEnable(s2_way_en, s2_fire_to_s3)
   }
   dontTouch(io.status_dup)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -301,7 +301,7 @@ class MissReqPipeRegBundle(edge: TLEdgeOut)(implicit p: Parameters) extends DCac
     )._2
     acquire := Mux(req.full_overwrite, acquirePerm, acquireBlock)
     // resolve cache alias by L2
-    acquire.user.lift(AliasKey).foreach(_ :=  hashBitPairs(req.vaddr))
+    acquire.user.lift(AliasKey).foreach(_ :=  get_alias(req.vaddr))
     // pass vaddr to l2
     acquire.user.lift(VaddrKey).foreach(_ := req.vaddr(VAddrBits - 1, blockOffBits))
     // pass pc to l2
@@ -953,7 +953,7 @@ for(i <- 0 until reqNum) {
   )._2
   io.mem_acquire.bits := Mux(full_overwrite, acquirePerm, acquireBlock)
   // resolve cache alias by L2
-  io.mem_acquire.bits.user.lift(AliasKey).foreach( _ := hashBitPairs(req.vaddr))
+  io.mem_acquire.bits.user.lift(AliasKey).foreach( _ := get_alias(req.vaddr))
   // pass vaddr to l2
   io.mem_acquire.bits.user.lift(VaddrKey).foreach( _ := req.vaddr(VAddrBits-1, blockOffBits))
   // pass pc to l2

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -301,7 +301,7 @@ class MissReqPipeRegBundle(edge: TLEdgeOut)(implicit p: Parameters) extends DCac
     )._2
     acquire := Mux(req.full_overwrite, acquirePerm, acquireBlock)
     // resolve cache alias by L2
-    acquire.user.lift(AliasKey).foreach(_ := req.vaddr(13, 12))
+    acquire.user.lift(AliasKey).foreach(_ :=  hashBitPairs(req.vaddr))
     // pass vaddr to l2
     acquire.user.lift(VaddrKey).foreach(_ := req.vaddr(VAddrBits - 1, blockOffBits))
     // pass pc to l2
@@ -953,7 +953,7 @@ for(i <- 0 until reqNum) {
   )._2
   io.mem_acquire.bits := Mux(full_overwrite, acquirePerm, acquireBlock)
   // resolve cache alias by L2
-  io.mem_acquire.bits.user.lift(AliasKey).foreach( _ := req.vaddr(13, 12))
+  io.mem_acquire.bits.user.lift(AliasKey).foreach( _ := hashBitPairs(req.vaddr))
   // pass vaddr to l2
   io.mem_acquire.bits.user.lift(VaddrKey).foreach( _ := req.vaddr(VAddrBits-1, blockOffBits))
   // pass pc to l2

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
@@ -150,8 +150,9 @@ class ProbeQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule w
   if(DCacheAboveIndexOffset > DCacheTagOffset) {
     // have alias problem, extra alias bits needed for index
     req.vaddr := Cat(
-      io.mem_probe.bits.address(PAddrBits - 1, DCacheAboveIndexOffset), // dontcare
-      alias_addr_frag(DCacheAboveIndexOffset - DCacheTagOffset - 1, 0), // index
+      0.U(36.W),
+      // io.mem_probe.bits.address(PAddrBits - 1, DCacheAboveIndexOffset), // dontcare
+      alias_addr_frag(1 , 0), // index
       io.mem_probe.bits.address(DCacheTagOffset - 1, 0)                 // index & others
     )
   } else { // no alias problem

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
@@ -150,8 +150,7 @@ class ProbeQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule w
   if(DCacheAboveIndexOffset > DCacheTagOffset) {
     // have alias problem, extra alias bits needed for index
     req.vaddr := Cat(
-      0.U(36.W),
-      // io.mem_probe.bits.address(PAddrBits - 1, DCacheAboveIndexOffset), // dontcare
+      0.U(36.W), // dontcare
       alias_addr_frag(1 , 0), // index
       io.mem_probe.bits.address(DCacheTagOffset - 1, 0)                 // index & others
     )

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/Probe.scala
@@ -150,8 +150,8 @@ class ProbeQueue(edge: TLEdgeOut)(implicit p: Parameters) extends DCacheModule w
   if(DCacheAboveIndexOffset > DCacheTagOffset) {
     // have alias problem, extra alias bits needed for index
     req.vaddr := Cat(
-      0.U(36.W), // dontcare
-      alias_addr_frag(1 , 0), // index
+      0.U((PAddrBits - DCacheAboveIndexOffset).W), // dontcare
+      alias_addr_frag(DCacheAboveIndexOffset - DCacheTagOffset - 1 , 0), // index
       io.mem_probe.bits.address(DCacheTagOffset - 1, 0)                 // index & others
     )
   } else { // no alias problem

--- a/src/main/scala/xiangshan/cache/dcache/storepipe/StorePipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/storepipe/StorePipe.scala
@@ -95,11 +95,11 @@ class StorePipe(id: Int)(implicit p: Parameters) extends DCacheModule{
   val s0_fire = io.lsu.req.fire
 
   io.meta_read.valid        := s0_valid
-  io.meta_read.bits.idx     := get_idx(io.lsu.req.bits.vaddr)
+  io.meta_read.bits.idx     := get_dcache_idx(io.lsu.req.bits.vaddr)
   io.meta_read.bits.way_en  := ~0.U(nWays.W)
 
   io.tag_read.valid         := s0_valid
-  io.tag_read.bits.idx      := get_idx(io.lsu.req.bits.vaddr)
+  io.tag_read.bits.idx      := get_dcache_idx(io.lsu.req.bits.vaddr)
   io.tag_read.bits.way_en   := ~0.U(nWays.W)
 
   io.lsu.req.ready := io.meta_read.ready && io.tag_read.ready
@@ -139,7 +139,7 @@ class StorePipe(id: Int)(implicit p: Parameters) extends DCacheModule{
     * Don't choose a replace_way anymore
     */
   io.replace_way.set.valid := false.B
-  io.replace_way.set.bits  := get_idx(s1_req.vaddr)
+  io.replace_way.set.bits  := get_dcache_idx(s1_req.vaddr)
   io.replace_way.dmWay     := get_direct_map_way(s1_req.vaddr)
 
   val s1_need_replacement = !s1_tag_match.orR


### PR DESCRIPTION
perf(DCache): optimize L1DCache set indexing with configurable `modeId`

**Problem:**
 - Original vaddr[13:6] indexing caused frequent evictions in bwaves 
   due to sequential access patterns

**Solution:**
1. New optimized mode (modeId=1， default):
   - set[7:6] = hash(vaddr[47:12])
   - set[5:0] = vaddr[11:6]
   - alias = hash(vaddr[47:12])
   
   Benchmark results:
   - 10.64% performance gain in bwaves

2. Configurable modes:
   - modeId=1 ( default ): optimized mode
   - modeId=2: Original vaddr[13:6] indexing (vaddr[13:12] as alias)

The configurable design allows:
1. Immediate performance benefit through modeId=2
2. Flexibility for future indexing schemes
3. Safe fallback to original behavior

<img width="264" height="468" alt="image" src="https://github.com/user-attachments/assets/8cfeb91f-4c01-47c4-80dd-99f92abe2d9e" />
