### PR TITLE
fix(backend): give VFEX0 a private FP writeback port

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -429,7 +429,9 @@ case class XSCoreParameters
         ExeUnitParams(
           "VFEX0",
           Seq(VialuCfg, VfaluCfg, VfmaCfg, VimacCfg, VppuCfg, VipuCfg, VfcvtCfg, VSetRvfWvfCfg, VmoveCfg),
-          Seq(VfWB(port = 0, 0), V0WB(port = 0, 0), IntWB(port = 4, 1), FpWB(port = 6, 0)),
+          // VFEX0 has fixed latency and cannot stall on writeback, so give it a
+          // private FP port 8 instead of sharing port 6 with the load unit LDU2.
+          Seq(VfWB(port = 0, 0), V0WB(port = 0, 0), IntWB(port = 4, 1), FpWB(port = 8, 0)),
           Seq(Seq(VfRD(0, 0)), Seq(VfRD(1, 0)), Seq(VfRD(2, 0)), Seq(V0RD(0, 0))),
           vlWB = VlWB(port = vfSchdVlWbPort, 0),
           vlRD = VlRD(0, 0),


### PR DESCRIPTION
fix(backend): give VFEX0 a private FP writeback port

Hello, here is a pull request for a bug I found.

Two execution units in XiangShan write their floating-point results onto the same shared output port (FP writeback port 6). One of them, the vector-float unit VFEX0, has a fixed pipeline timing and physically cannot wait its turn. When a load happens to deliver its own result on the same cycle, the load wins the shared port and VFEX0's result is thrown away. In simulation, this trips an assertion and stops the run. In real silicon, where that assertion is gone, the floating-point register write simply vanishes and the program computes the wrong answer. An earlier upstream change, [PR #3363](https://github.com/OpenXiangShan/XiangShan/pull/3363), added a one-cycle latency to vector-float writebacks to the FP register file, but it does not prevent this collision: the unit VFEX0 contends with is an uncertain-latency load in a different scheduler, whose writeback cycle cannot be reserved against by any latency adjustment. The fix is to remove the sharing. Give VFEX0 its own private writeback port (port 8) so it never has to compete for the shared one. Every other fixed-timing FP producer in the design already owns a private port.

**Severity:** Assertion crash and silent data loss. A fixed-latency FP result is dropped. Under `--diff` this shows up as a regfile mismatch followed by `ABORT`. In synthesized hardware with the assertion compiled out it becomes a silently lost FP register write.

Assisted-by: Claude:claude-opus-4-8 [Claude Code]