### PR TITLE
feat(topdown): add OoO-window bottleneck attribution

### DIFF
--- a/scripts/top-down/README.md
+++ b/scripts/top-down/README.md
@@ -52,7 +52,7 @@ optional arguments:
 # python top_down.py -b <...>/base_perf_report -r <...>/ref_perf_report -j <...>/checkpoint.json --base-issue 6 --ref-issue 8 --base-label Base --ref-label Feature1
 ```
 
-脚本运行结束后，会生成 `results` 目录：
+默认配置下，脚本运行结束后会生成 `results` 目录：
 
 ```shell
 # tree results
@@ -60,30 +60,36 @@ results
 ├── result_backend.png
 ├── result_custom.png
 ├── result_frontend.png
+├── result_intel_topdown.png
 ├── result_mem.png
+├── result_robhead.png
 ├── results_base.csv
 ├── results_ref.csv
 ├── results-weighted_base.csv
 ├── results-weighted_ref.csv
 └── result_total.png
 
-0 directories, 9 files
+0 directories, 11 files
 ```
 
 其中：
 
 - `result_total.png` 为 Top-down 总体粗粒度聚合堆叠条形图，用于展示各 benchmark 在整体视角下的瓶颈构成。
 - `result_frontend.png`、`result_backend.png`、`result_mem.png` 和 `result_custom.png` 分别对前端、后端、访存及自定义子维度进行进一步拆分，便于从特定维度开展更细粒度的瓶颈分析。
+- `result_intel_topdown.png` 为类似 Intel Top-down 口径的派生分析图，将执行槽位拆分为 `Base`、`FetchLatencyBound`、`FetchBandwidthBound`、`BadSpec`、`CoreBound`、`L1Bound`、`L2Bound`、`L3Bound`、`MemBound` 和 `StoreBound`。
+- `result_robhead.png` 为 ROB 头部等待原因分析图，将 `wait*Cycle` 计数器归一化拆分为 `mul`、`ldu`、`stu`、`fma`、`fdivsqrt` 和 `other`。
 - `results_base.csv` 与 `results_ref.csv` 保存原始统计结果，按采样点记录各 Top-down 计数器数值。
 - `results-weighted_base.csv` 与 `results-weighted_ref.csv` 则基于原始统计结果，结合各采样点对应权重完成加权汇总，可用于人工检查、后续分析或重新绘图。
 
-### config.py 使用方法
+### configs.py 使用方法
 
 `configs.py` 是 Top-down 分析工具的配置文件，主要可配置项包括：
 
 - **自定义子维度**：用户可在 `configs.py` 中修改 `xs_custom_rename_map`，以将部分阻塞归因重新聚类并生成对应图表。具体格式可参考其他子维度的重命名映射，例如 `xs_frontend_rename_map`。
 - **benchmark_list**：用户可通过配置 `benchmark_list` 选择部分 checkpoint 子项进行单独绘图分析；若未额外指定，则默认对全部 checkpoint 作图。`INT_ONLY` 和 `FP_ONLY` 可用于快速筛选仅整数或仅浮点 benchmark。
 - **xx_ANALYSE**：用户可通过配置此类选项，关闭部分子维度的绘图分析。
+- **INTEL_TOPDOWN_ANALYSE**：打开后额外生成 `result_intel_topdown.png`。该分析依赖 `targets` 中的 `if_fetch_bubble`、`if_fetch_bubble_eq_max`、`inst_spec`、`recovery_bubble`、`mem_stall_anyload`、`mem_stall_store`、`mem_stall_l1miss`、`mem_stall_l2miss`、`mem_stall_l3miss` 和 `total_cycles` 等计数器，并需要正确的 issue width。
+- **ROBHEAD_ANALYSE**：打开后额外生成 `result_robhead.png`。该分析依赖 `targets` 中的 `waitAluCycle`、`waitMulCycle`、`waitDivCycle`、`waitBrhCycle`、`waitJmpCycle`、`waitCsrCycle`、`waitFenCycle`、`waitBkuCycle`、`waitLduCycle`、`waitStuCycle`、`waitAtmCycle`、`waitfaluCycle`、`waitfmacCycle`、`waitfcvtCycle`、`waitfDivSqrtCycle` 和 `waitfcmpCycle` 等 ROB 头部等待周期计数器。
 
 ### draw.py 使用方法
 
@@ -103,6 +109,8 @@ options:
                         base label (default: BASE)
   --ref-label REF_LABEL
                         ref label (default: REF)
+  --issue-width ISSUE_WIDTH
+                        issue width for intel topdown analyse (default: 8)
 ```
 
 使用示例如下：
@@ -110,7 +118,10 @@ options:
 ```shell
 # python3 draw.py --base-label Base --ref-label Feature1
 # python3 draw.py -b <...>/xxxresults-weighted_base.csv -r <...>/xxxresults-weighted_ref.csv --base-label Base --ref-label Feature1
+# python3 draw.py -b results/results-weighted_base.csv --base-label Base --issue-width 8
 ```
+
+`draw.py` 会根据 `configs.py` 中开启的 `TOTAL_ANALYSE`、`BACKEND_ANALYSE`、`FRONTEND_ANALYSE`、`MEM_ANALYSE`、`CUSTOM_ANALYSE`、`INTEL_TOPDOWN_ANALYSE` 和 `ROBHEAD_ANALYSE` 依次生成对应图表。直接运行 `top_down.py` 时，绘图阶段的 issue width 会由 `--base-issue`、`--ref-issue` 推导；单独运行 `draw.py` 重新绘图时，需要通过 `--issue-width` 指定 Intel Top-down 分析使用的 issue width，默认值为 8。
 
 ---
 
@@ -168,7 +179,7 @@ Example commands:
 # python top_down.py -b <...>/base_perf_report -r <...>/ref_perf_report -j <...>/checkpoint.json --base-issue 6 --ref-issue 8 --base-label Base --ref-label Feature1
 ```
 
-After execution, a `results` directory will be generated:
+With the default configuration, a `results` directory will be generated after execution:
 
 ```shell
 # tree results
@@ -176,20 +187,24 @@ results
 ├── result_backend.png
 ├── result_custom.png
 ├── result_frontend.png
+├── result_intel_topdown.png
 ├── result_mem.png
+├── result_robhead.png
 ├── results_base.csv
 ├── results_ref.csv
 ├── results-weighted_base.csv
 ├── results-weighted_ref.csv
 └── result_total.png
 
-0 directories, 9 files
+0 directories, 11 files
 ```
 
 Among them:
 
 - `result_total.png` is the coarse-grained stacked bar chart for overall Top-down analysis, showing the bottleneck composition of each benchmark from a global perspective.
 - `result_frontend.png`, `result_backend.png`, `result_mem.png`, and `result_custom.png` further break down the frontend, backend, memory, and custom sub-dimensions, respectively, making it easier to perform fine-grained bottleneck analysis from specific viewpoints.
+- `result_intel_topdown.png` is a derived Intel-like Top-down view. It partitions execution slots into `Base`, `FetchLatencyBound`, `FetchBandwidthBound`, `BadSpec`, `CoreBound`, `L1Bound`, `L2Bound`, `L3Bound`, `MemBound`, and `StoreBound`.
+- `result_robhead.png` is a ROB-head wait reason view. It normalizes `wait*Cycle` counters into `mul`, `ldu`, `stu`, `fma`, `fdivsqrt`, and `other`.
 - `results_base.csv` and `results_ref.csv` store the raw statistical results, recording the values of each Top-down counter at each sampling point.
 - `results-weighted_base.csv` and `results-weighted_ref.csv` provide weighted summaries based on the raw results and the corresponding weights of sampling points, and can be used for manual inspection, further analysis, or redrawing figures.
 
@@ -200,6 +215,8 @@ Among them:
 - **Custom sub-dimensions**: Users can modify `xs_custom_rename_map` in `configs.py` to regroup selected stall attributions and generate customized plots. The format can refer to the rename maps of other sub-dimensions, such as `xs_frontend_rename_map`.
 - **benchmark_list**: Users can configure `benchmark_list` to select a subset of checkpoints for standalone plotting and analysis. If not specified, all checkpoints will be plotted by default. `INT_ONLY` and `FP_ONLY` can be used to quickly generate plots for integer-only or floating-point-only benchmarks.
 - **xx_ANALYSE**: Users can disable plotting for selected sub-dimensions through this type of option.
+- **INTEL_TOPDOWN_ANALYSE**: When enabled, the tool additionally generates `result_intel_topdown.png`. This analysis depends on counters in `targets`, including `if_fetch_bubble`, `if_fetch_bubble_eq_max`, `inst_spec`, `recovery_bubble`, `mem_stall_anyload`, `mem_stall_store`, `mem_stall_l1miss`, `mem_stall_l2miss`, `mem_stall_l3miss`, and `total_cycles`, and requires the correct issue width.
+- **ROBHEAD_ANALYSE**: When enabled, the tool additionally generates `result_robhead.png`. This analysis depends on ROB-head wait cycle counters in `targets`, including `waitAluCycle`, `waitMulCycle`, `waitDivCycle`, `waitBrhCycle`, `waitJmpCycle`, `waitCsrCycle`, `waitFenCycle`, `waitBkuCycle`, `waitLduCycle`, `waitStuCycle`, `waitAtmCycle`, `waitfaluCycle`, `waitfmacCycle`, `waitfcvtCycle`, `waitfDivSqrtCycle`, and `waitfcmpCycle`.
 
 ### How to use draw.py
 
@@ -219,6 +236,8 @@ options:
                         base label (default: BASE)
   --ref-label REF_LABEL
                         ref label (default: REF)
+  --issue-width ISSUE_WIDTH
+                        issue width for intel topdown analyse (default: 8)
 ```
 
 Example commands:
@@ -226,4 +245,7 @@ Example commands:
 ```shell
 # python3 draw.py --base-label Base --ref-label Feature1
 # python3 draw.py -b <...>/xxxresults-weighted_base.csv -r <...>/xxxresults-weighted_ref.csv --base-label Base --ref-label Feature1
+# python3 draw.py -b results/results-weighted_base.csv --base-label Base --issue-width 8
 ```
+
+`draw.py` generates the enabled figures according to `TOTAL_ANALYSE`, `BACKEND_ANALYSE`, `FRONTEND_ANALYSE`, `MEM_ANALYSE`, `CUSTOM_ANALYSE`, `INTEL_TOPDOWN_ANALYSE`, and `ROBHEAD_ANALYSE` in `configs.py`. When running `top_down.py` directly, the issue width used by the plotting stage is inferred from `--base-issue` and `--ref-issue`. When rerunning `draw.py` standalone, use `--issue-width` to specify the issue width for Intel Top-down analysis. The default value is 8.

--- a/scripts/top-down/configs.py
+++ b/scripts/top-down/configs.py
@@ -14,6 +14,8 @@ BACKEND_ANALYSE = True
 FRONTEND_ANALYSE = True
 MEM_ANALYSE = True
 CUSTOM_ANALYSE = True
+INTEL_TOPDOWN_ANALYSE = True
+ROBHEAD_ANALYSE = True
 
 # Not benchmark_list canbe add here to specify benchmark to draw, use like:
 # benchmark_list = {'libquantum','h264ref','namd', 'gamess'}
@@ -323,7 +325,11 @@ xs_fine_grain_rename_map = {
 XS_CORE_PREFIX = r'\[PERF\s*\]\[time=\s*\d+\].*?\.core'
 
 targets = {
+    'if_fetch_bubble': fr'{XS_CORE_PREFIX}.frontend.*?ibuffer: if_fetch_bubble,\s+(\d+)',
+    'if_fetch_bubble_eq_max': fr'{XS_CORE_PREFIX}.frontend.*?ibuffer: if_fetch_bubble_eq_max,\s+(\d+)',
+
     'NoStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: NoStall,\s+(\d+)',
+
     'OverrideBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: OverrideBubble,\s+(\d+)',
     'FtqUpdateBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FtqUpdateBubble,\s+(\d+)',
     'TAGEMissBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: TAGEMissBubble,\s+(\d+)',
@@ -414,6 +420,34 @@ targets = {
     'FlushedInsts': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FlushedInsts,\s+(\d+)',
     'SpecialInsts': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: SpecialInsts,\s+(\d+)',
     'BackendOtherCoreStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: BackendOtherCoreStall,\s+(\d+)',
+
+    'inst_spec': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.decode: inst_spec,\s+(\d+)',
+    'recovery_bubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.decode: recovery_bubble,\s+(\d+)',
+    'br_mis_pred': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: br_mis_pred,\s+(\d+)',
+    'total_flush': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: total_flush,\s+(\d+)',
+    'exec_stall_cycle': fr'{XS_CORE_PREFIX}.backend.*?topDownMod: exec_stall_cycle,\s+(\d+)',
+    'mem_stall_store': fr'{XS_CORE_PREFIX}.backend.*?topDownMod: mem_stall_store,\s+(\d+)',
+    'mem_stall_l1miss': fr'{XS_CORE_PREFIX}.backend.*?topDownMod: mem_stall_l1miss,\s+(\d+)',
+    'mem_stall_l2miss': fr'{XS_CORE_PREFIX}.backend.*?topDownMod: mem_stall_l2miss,\s+(\d+)',
+    'mem_stall_l3miss': fr'{XS_CORE_PREFIX}.backend.*?topDownMod: mem_stall_l3miss,\s+(\d+)',
+    'mem_stall_anyload': fr'{XS_CORE_PREFIX}.backend.*?topDownMod: mem_stall_anyload,\s+(\d+)',
+
+    'waitAluCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitAluCycle,\s+(\d+)',
+    'waitMulCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitMulCycle,\s+(\d+)',
+    'waitDivCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitDivCycle,\s+(\d+)',
+    'waitBrhCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitBrhCycle,\s+(\d+)',
+    'waitJmpCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitJmpCycle,\s+(\d+)',
+    'waitCsrCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitCsrCycle,\s+(\d+)',
+    'waitFenCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitFenCycle,\s+(\d+)',
+    'waitBkuCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitBkuCycle,\s+(\d+)',
+    'waitLduCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitLduCycle,\s+(\d+)',
+    'waitStuCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitStuCycle,\s+(\d+)',
+    'waitAtmCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitAtmCycle,\s+(\d+)',
+    'waitfaluCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitfaluCycle,\s+(\d+)',
+    'waitfmacCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitfmacCycle,\s+(\d+)',
+    'waitfcvtCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitfcvtCycle,\s+(\d+)',
+    'waitfDivSqrtCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitfDivSqrtCycle,\s+(\d+)',
+    'waitfcmpCycle': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: waitfcmpCycle,\s+(\d+)',
 
     "commitInstr": fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: commitInstr,\s+(\d+)',
     "total_cycles": fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock.rob: clock_cycle,\s+(\d+)'

--- a/scripts/top-down/configs.py
+++ b/scripts/top-down/configs.py
@@ -78,6 +78,7 @@ xs_frontend_rename_map = {
 
 xs_backend_rename_map = {
 
+    'IssueCancelStall': 'MergeCancelStall',
     'DivStall': 'MergeExecStall',
     'IntNotReadyStall': 'MergeExecStall',
     'FPNotReadyStall': 'MergeExecStall',
@@ -176,6 +177,7 @@ xs_coarse_rename_map = {
     'FetchFragBubble': 'MergeFrontend',
     'FrontendOtherCoreStall': "MergeCoreOther",
 
+    'IssueCancelStall': 'MergeCore',
     'DivStall': 'MergeCore',
     'IntNotReadyStall': 'MergeCore',
     'FPNotReadyStall': 'MergeCore',
@@ -325,6 +327,7 @@ targets = {
     'FetchFragBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FetchFragBubble,\s+(\d+)',
     'FrontendOtherCoreStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FrontendOtherCoreStall,\s+(\d+)',
 
+    'IssueCancelStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IssueCancelStall,\s+(\d+)',
     'DivStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: DivStall,\s+(\d+)',
     'IntNotReadyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IntNotReadyStall,\s+(\d+)',
     'FPNotReadyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FPNotReadyStall,\s+(\d+)',

--- a/scripts/top-down/configs.py
+++ b/scripts/top-down/configs.py
@@ -27,6 +27,7 @@ xs_custom_rename_map = {
     'LoadIQFullStall': 'MergeIQFullStallLoad',
     'StoreIQFullStall': 'MergeIQFullStallStore',
     'OtherIQFullStall': 'MergeIQFullStall',
+    'RobHeadNotIssued': 'MergeRobHeadNotIssued',
 
     'IQEnqPolicyStallIssued': 'MergeIQpolicyStall',
     'IQEnqPolicyStall': 'MergeIQpolicyStall',
@@ -78,7 +79,10 @@ xs_frontend_rename_map = {
 
 xs_backend_rename_map = {
 
-    'IssueCancelStall': 'MergeCancelStall',
+    'IssueCancelStallOg0': 'MergeCancelStall',
+    'IssueCancelStallOg1': 'MergeCancelStall',
+    'IssueCancelStallOther': 'MergeCancelStall',
+    'IssueDelayStall': 'MergeIssueDelayStall',
     'DivStall': 'MergeExecStall',
     'IntNotReadyStall': 'MergeExecStall',
     'FPNotReadyStall': 'MergeExecStall',
@@ -112,6 +116,7 @@ xs_backend_rename_map = {
     'LoadIQFullStall': 'MergeIQFullStall',
     'StoreIQFullStall': 'MergeIQFullStall',
     'OtherIQFullStall': 'MergeIQFullStall',
+    'RobHeadNotIssued': 'MergeIQpolicyStall',
 
     'ControlRecoveryStall': 'MergeRabWalkStall',
     'MemVioRecoveryStall': 'MergeRabWalkStall',
@@ -136,6 +141,8 @@ xs_backend_rename_map = {
 }
 
 xs_mem_rename_map = {
+    'IssueCancelStallLd': 'MergeCancelStall',
+    'IssueCancelStallSt': 'MergeCancelStall',
     'MemNotReadyStall': 'MergeMemNotReadyStall',
 
     'LoadTLBStall': 'MergeLoadTLBStall',
@@ -177,7 +184,12 @@ xs_coarse_rename_map = {
     'FetchFragBubble': 'MergeFrontend',
     'FrontendOtherCoreStall': "MergeCoreOther",
 
-    'IssueCancelStall': 'MergeCore',
+    'IssueCancelStallOg0': 'MergeCore',
+    'IssueCancelStallOg1': 'MergeCore',
+    'IssueCancelStallLd': 'MergeLoad',
+    'IssueCancelStallSt': 'MergeStore',
+    'IssueCancelStallOther': 'MergeCore',
+    'IssueDelayStall': 'MergeCore',
     'DivStall': 'MergeCore',
     'IntNotReadyStall': 'MergeCore',
     'FPNotReadyStall': 'MergeCore',
@@ -222,6 +234,7 @@ xs_coarse_rename_map = {
     'LoadIQFullStall': 'MergeCore',
     'StoreIQFullStall': 'MergeCore',
     'OtherIQFullStall': 'MergeCore',
+    'RobHeadNotIssued': 'MergeCore',
 
     'LoadTLBStall': 'MergeLoad',
     'LoadL1Stall': 'MergeLoad',
@@ -327,7 +340,12 @@ targets = {
     'FetchFragBubble': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FetchFragBubble,\s+(\d+)',
     'FrontendOtherCoreStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FrontendOtherCoreStall,\s+(\d+)',
 
-    'IssueCancelStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IssueCancelStall,\s+(\d+)',
+    'IssueCancelStallOg0': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IssueCancelStallOg0,\s+(\d+)',
+    'IssueCancelStallOg1': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IssueCancelStallOg1,\s+(\d+)',
+    'IssueCancelStallLd': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IssueCancelStallLd,\s+(\d+)',
+    'IssueCancelStallSt': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IssueCancelStallSt,\s+(\d+)',
+    'IssueCancelStallOther': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IssueCancelStallOther,\s+(\d+)',
+    'IssueDelayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IssueDelayStall,\s+(\d+)',
     'DivStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: DivStall,\s+(\d+)',
     'IntNotReadyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: IntNotReadyStall,\s+(\d+)',
     'FPNotReadyStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: FPNotReadyStall,\s+(\d+)',
@@ -370,6 +388,7 @@ targets = {
     'LoadIQFullStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadIQFullStall,\s+(\d+)',
     'StoreIQFullStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: StoreIQFullStall,\s+(\d+)',
     'OtherIQFullStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: OtherIQFullStall,\s+(\d+)',
+    'RobHeadNotIssued': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: RobHeadNotIssued,\s+(\d+)',
 
     'LoadTLBStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadTLBStall,\s+(\d+)',
     'LoadL1Stall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadL1Stall,\s+(\d+)',

--- a/scripts/top-down/draw.py
+++ b/scripts/top-down/draw.py
@@ -7,10 +7,85 @@ import argparse
 import os.path as osp
 
 
-def draw(out_csv_paths=None, labels=None):
+ROBHEAD_COLUMN_ORDER = ['mul', 'ldu', 'stu', 'fma', 'fdivsqrt', 'other']
+
+
+def run_intel_topdown_analyse(df, issue_width):
+    analysed_df = df.copy(deep=True)
+    original_columns = set(analysed_df.columns)
+    icount = 20 * 10 ** 6
+    analysed_df['Base'] = icount
+    analysed_df['FetchLatencyBound'] = analysed_df['if_fetch_bubble_eq_max'] * issue_width
+    analysed_df['FetchBandwidthBound'] = analysed_df['if_fetch_bubble'] - analysed_df['FetchLatencyBound']
+    print(f'FetchLatencyBound: {analysed_df["FetchLatencyBound"]}')
+    analysed_df['BadSpec'] = analysed_df['inst_spec'] - icount + analysed_df['recovery_bubble']
+    print(f'BadSpec Insts: {analysed_df["BadSpec"]}')
+    # analysed_df['CoreBound'] = (analysed_df['exec_stall_cycle'] - analysed_df['mem_stall_anyload'] - analysed_df['mem_stall_store']) * issue_width
+
+    analysed_df['L1Bound'] = (analysed_df['mem_stall_anyload'] - analysed_df['mem_stall_l1miss']) * issue_width
+    print(f'L1Bound: {analysed_df["L1Bound"]}')
+    analysed_df['L2Bound'] = (analysed_df['mem_stall_l1miss'] - analysed_df['mem_stall_l2miss']) * issue_width
+    print(f'L2Bound: {analysed_df["L2Bound"]}')
+    analysed_df['L3Bound'] = (analysed_df['mem_stall_l2miss'] - analysed_df['mem_stall_l3miss']) * issue_width
+    print(f'L3Bound: {analysed_df["L3Bound"]}')
+    analysed_df['MemBound'] = analysed_df['mem_stall_l3miss'] * issue_width
+    analysed_df['StoreBound'] = analysed_df['mem_stall_store'] * issue_width
+    analysed_df['CoreBound'] = analysed_df['total_cycles'] * issue_width - icount - analysed_df['FetchLatencyBound'] - analysed_df['FetchBandwidthBound'] - analysed_df['BadSpec'] - analysed_df['mem_stall_anyload']*issue_width - analysed_df['StoreBound']
+    print(f'CoreBound: {analysed_df["CoreBound"]}')
+    total_cycles = analysed_df['total_cycles'] * issue_width
+    print(f'Total Cycles: {total_cycles}')
+    partition_sum = analysed_df['Base'] + analysed_df['FetchLatencyBound'] + analysed_df['FetchBandwidthBound'] + analysed_df['BadSpec'] + analysed_df['CoreBound'] + analysed_df['L1Bound'] + analysed_df['L2Bound'] + analysed_df['L3Bound'] + analysed_df['MemBound'] + analysed_df['StoreBound']
+    print(f'Partition Sum: {partition_sum}')
+    generated_columns = [col for col in analysed_df.columns if col not in original_columns]
+    return analysed_df[['cpi'] + generated_columns]
+
+
+def run_robhead_analyse(df):
+    analysed_df = df.copy(deep=True)
+    kept_wait_cycle_map = {
+        'mul': 'waitMulCycle',
+        'ldu': 'waitLduCycle',
+        'stu': 'waitStuCycle',
+        'fma': 'waitfmacCycle',
+        'fdivsqrt': 'waitfDivSqrtCycle',
+    }
+    other_wait_cycle_columns = [
+        'waitAluCycle',
+        'waitDivCycle',
+        'waitBrhCycle',
+        'waitJmpCycle',
+        'waitCsrCycle',
+        'waitFenCycle',
+        'waitBkuCycle',
+        'waitAtmCycle',
+        'waitfaluCycle',
+        'waitfcvtCycle',
+        'waitfcmpCycle',
+    ]
+
+    all_wait_cycle_columns = list(kept_wait_cycle_map.values()) + other_wait_cycle_columns
+    for column in all_wait_cycle_columns:
+        if column not in analysed_df.columns:
+            analysed_df[column] = 0.0
+    total_wait_cycles = analysed_df[all_wait_cycle_columns].sum(axis=1)
+
+    for output_column, input_column in kept_wait_cycle_map.items():
+        analysed_df[output_column] = analysed_df[input_column]
+    analysed_df['other'] = analysed_df[other_wait_cycle_columns].sum(axis=1)
+
+    normalizer = total_wait_cycles.replace(0, np.nan)
+    analysed_df[ROBHEAD_COLUMN_ORDER] = analysed_df[ROBHEAD_COLUMN_ORDER].div(normalizer, axis=0).fillna(0.0)
+
+    partition_sum = analysed_df[ROBHEAD_COLUMN_ORDER].sum(axis=1)
+    print(f'ROB Head Wait Partition Sum: {partition_sum}')
+    return analysed_df[['cpi'] + ROBHEAD_COLUMN_ORDER]
+
+
+def draw(out_csv_paths=None, labels=None, issue_width=8):
 
     assert len(out_csv_paths) == len(labels)
     assert 1 <= len(out_csv_paths) <= 2
+    issue_width = float(issue_width)
 
     results = {labels[i]: (out_csv_paths[i], labels[i]) for i in range(len(out_csv_paths))}
 
@@ -53,6 +128,8 @@ def draw(out_csv_paths=None, labels=None):
     frontend_analyse = cf.FRONTEND_ANALYSE
     mem_analyse = cf.MEM_ANALYSE
     custom_analyse = cf.CUSTOM_ANALYSE
+    intel_topdown_analyse = getattr(cf, 'INTEL_TOPDOWN_ANALYSE', False)
+    robhead_analyse = getattr(cf, 'ROBHEAD_ANALYSE', False)
     fine_grain_rename = False
 
     analyse_jobs = []
@@ -70,6 +147,10 @@ def draw(out_csv_paths=None, labels=None):
             analyse_jobs.append(("mem", cf.xs_mem_rename_map))
         if custom_analyse:
             analyse_jobs.append(("custom", cf.xs_custom_rename_map))
+        if intel_topdown_analyse:
+            analyse_jobs.append(("intel_topdown", None))
+        if robhead_analyse:
+            analyse_jobs.append(("robhead", None))
     if not analyse_jobs:
         analyse_jobs.append(("default", cf.xs_coarse_rename_map))
 
@@ -115,8 +196,11 @@ def draw(out_csv_paths=None, labels=None):
                 cols_to_drop = existing_columns - cols_to_keep
                 df.drop(columns=cols_to_drop, inplace=True)
 
-            # Merge df columns according to the rename map if value starting with 'Merge'
-            if rename and current_rename_map is not None:
+            if tag == 'intel_topdown':
+                df = run_intel_topdown_analyse(df, issue_width)
+            elif tag == 'robhead':
+                df = run_robhead_analyse(df)
+            elif rename and current_rename_map is not None:
                 rename_with_map(df, current_rename_map)
                 icount = 20 * 10 ** 6
                 if 'BadSpecInst' in df.columns:
@@ -250,6 +334,8 @@ if __name__ == '__main__':
                         help=f'base label (default: BASE)')
     parser.add_argument('--ref-label', default='REF',
                         help=f'ref label (default: REF)')
+    parser.add_argument('--issue-width', type=float, default=8,
+                        help='issue width for intel topdown analyse (default: 8)')
     opt = parser.parse_args()
 
     base_csv = opt.base_weighted_csv
@@ -262,8 +348,8 @@ if __name__ == '__main__':
         f'Neither base nor ref csv exists: base={base_csv}, ref={ref_csv}'
 
     if base_exists and ref_exists:
-        draw([base_csv, ref_csv], [opt.base_label, opt.ref_label])
+        draw([base_csv, ref_csv], [opt.base_label, opt.ref_label], opt.issue_width)
     elif base_exists:
-        draw([base_csv], [opt.base_label])
+        draw([base_csv], [opt.base_label], opt.issue_width)
     else:
-        draw([ref_csv], [opt.ref_label])
+        draw([ref_csv], [opt.ref_label], opt.issue_width)

--- a/scripts/top-down/top_down.py
+++ b/scripts/top-down/top_down.py
@@ -198,6 +198,9 @@ if __name__ == '__main__':
 
     base_scale = 1.0
     ref_scale  = 1.0
+    base_issue = 8.0 if opt.base_issue is None else float(opt.base_issue)
+    ref_issue = 8.0 if opt.ref_issue is None else float(opt.ref_issue)
+    draw_issue_width = 8.0
 
     if opt.base_stat_dir and opt.ref_stat_dir:
         if opt.base_issue is None or opt.ref_issue is None:
@@ -217,8 +220,13 @@ if __name__ == '__main__':
 
         print(f"[INFO] issue widths: base={b}, ref={r}")
         print(f"[INFO] computed scales: BASE scale={base_scale:.6f}, REF scale={ref_scale:.6f}")
+        draw_issue_width = max(b, r)
     else:
         print("[INFO] only one stat dir provided -> scale=1.0")
+        if opt.base_stat_dir:
+            draw_issue_width = base_issue
+        elif opt.ref_stat_dir:
+            draw_issue_width = ref_issue
 
     if opt.base_stat_dir:
         print(f"[INFO] Run BASE with scale={base_scale:.6f}")
@@ -234,5 +242,4 @@ if __name__ == '__main__':
 
     if not out_csv_paths:
         raise SystemExit("Error: please provide at least one of --base-stat-dir or --ref-stat-dir")
-    draw(out_csv_paths, labels)
-
+    draw(out_csv_paths, labels, draw_issue_width)

--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -855,10 +855,10 @@ class L2ToL1Hint(implicit p: Parameters) extends XSBundle with HasDCacheParamete
 }
 
 class TopDownInfo(implicit p: Parameters) extends XSBundle {
-  val lqEmpty = Input(Bool())
-  val sqEmpty = Input(Bool())
+  val replayAllocate = Input(Bool())
+  val sqFull  = Input(Bool())
+  val sbFull  = Input(Bool())
   val l1Miss = Input(Bool())
-  val noUopsIssued = Output(Bool())
   val l2TopMiss = Input(new TopDownFromL2Top)
 }
 

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -259,9 +259,9 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   memBlock.io.wfi <> backend.io.mem.wfi
   memBlock.io.topDownInfo.fromL2Top.l2Miss := io.topDownInfo.l2Miss
   memBlock.io.topDownInfo.fromL2Top.l3Miss := io.topDownInfo.l3Miss
-  memBlock.io.topDownInfo.toBackend.noUopsIssued := backend.io.topDownInfo.noUopsIssued
-  backend.io.topDownInfo.lqEmpty := memBlock.io.topDownInfo.toBackend.lqEmpty
-  backend.io.topDownInfo.sqEmpty := memBlock.io.topDownInfo.toBackend.sqEmpty
+  backend.io.topDownInfo.replayAllocate := memBlock.io.topDownInfo.toBackend.replayAllocate
+  backend.io.topDownInfo.sqFull  := memBlock.io.topDownInfo.toBackend.sqFull
+  backend.io.topDownInfo.sbFull  := memBlock.io.topDownInfo.toBackend.sbFull
   backend.io.topDownInfo.l1Miss := memBlock.io.topDownInfo.toBackend.l1Miss
   backend.io.topDownInfo.l2TopMiss.l2Miss := memBlock.io.topDownInfo.toBackend.l2TopMiss.l2Miss
   backend.io.topDownInfo.l2TopMiss.l3Miss := memBlock.io.topDownInfo.toBackend.l2TopMiss.l3Miss

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -519,6 +519,10 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   ).reduce(_ || _)
   ctrlBlock.io.robio.debugIQDeqRobIdxVec.foreach(_ := intRegion.io.debugIQDeqRobIdxVec.get ++
     fpRegion.io.debugIQDeqRobIdxVec.get ++ vecRegion.io.debugIQDeqRobIdxVec.get)
+  ctrlBlock.io.robio.debugIQSrcReadyVec.foreach(_ := intRegion.io.debugIQSrcReadyVec.get ++
+    fpRegion.io.debugIQSrcReadyVec.get ++ vecRegion.io.debugIQSrcReadyVec.get)
+  ctrlBlock.io.robio.topdownIQInfoVec.foreach(_ := intRegion.io.topdownIQInfoVec.get ++
+    fpRegion.io.topdownIQInfoVec.get ++ vecRegion.io.topdownIQInfoVec.get)
 
   // mem io
   io.mem.robLsqIO <> ctrlBlock.io.robio.lsq

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -517,8 +517,6 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   ctrlBlock.io.robio.robHeadLsIssue := issue.flatten.map(deq =>
     deq.fire && deq.bits.robIdx === ctrlBlock.io.robio.robDeqPtr
   ).reduce(_ || _)
-  ctrlBlock.io.robio.debugIQDeqRobIdxVec.foreach(_ := intRegion.io.debugIQDeqRobIdxVec.get ++
-    fpRegion.io.debugIQDeqRobIdxVec.get ++ vecRegion.io.debugIQDeqRobIdxVec.get)
   ctrlBlock.io.robio.topdownIQInfoVec.foreach(_ := intRegion.io.topdownIQInfoVec.get ++
     fpRegion.io.topdownIQInfoVec.get ++ vecRegion.io.topdownIQInfoVec.get)
 

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -519,8 +519,6 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   ).reduce(_ || _)
   ctrlBlock.io.robio.debugIQDeqRobIdxVec.foreach(_ := intRegion.io.debugIQDeqRobIdxVec.get ++
     fpRegion.io.debugIQDeqRobIdxVec.get ++ vecRegion.io.debugIQDeqRobIdxVec.get)
-  ctrlBlock.io.robio.debugIQSrcReadyVec.foreach(_ := intRegion.io.debugIQSrcReadyVec.get ++
-    fpRegion.io.debugIQSrcReadyVec.get ++ vecRegion.io.debugIQSrcReadyVec.get)
   ctrlBlock.io.robio.topdownIQInfoVec.foreach(_ := intRegion.io.topdownIQInfoVec.get ++
     fpRegion.io.topdownIQInfoVec.get ++ vecRegion.io.topdownIQInfoVec.get)
 

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -551,12 +551,12 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   topDownMod.io.vecTopDown.uopsIssued    := vecRegion.io.uopTopDown.uopsIssued
   topDownMod.io.vecTopDown.uopsIssuedCnt := vecRegion.io.uopTopDown.uopsIssuedCnt
   topDownMod.io.vecTopDown.noStoreIssued := vecRegion.io.uopTopDown.noStoreIssued
-  topDownMod.io.topDownInfo.lqEmpty := DelayN(io.topDownInfo.lqEmpty, 2)
-  topDownMod.io.topDownInfo.sqEmpty := DelayN(io.topDownInfo.sqEmpty, 2)
+  topDownMod.io.topDownInfo.replayAllocate := DelayN(io.topDownInfo.replayAllocate, 2)
+  topDownMod.io.topDownInfo.sqFull  := DelayN(io.topDownInfo.sqFull, 2)
+  topDownMod.io.topDownInfo.sbFull  := DelayN(io.topDownInfo.sbFull, 2)
   topDownMod.io.topDownInfo.l1Miss  := RegNext(io.topDownInfo.l1Miss)
   topDownMod.io.topDownInfo.l2TopMiss.l2Miss := io.topDownInfo.l2TopMiss.l2Miss
   topDownMod.io.topDownInfo.l2TopMiss.l3Miss := io.topDownInfo.l2TopMiss.l3Miss
-  io.topDownInfo.noUopsIssued := RegNext(topDownMod.io.topDownInfo.noUopsIssued)
 
   private val cg = ClockGate.genTeSrc
   dontTouch(cg)

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -341,6 +341,9 @@ object Bundles {
     val ld   = 3.U(3.W)
     val st   = 4.U(3.W)
 
+    val all = Seq(og0, og1, ld, st)
+    val num = all.length
+
     def isnone(cancelSource: UInt): Bool = cancelSource === none
     def isog0(cancelSource: UInt): Bool = cancelSource === og0
     def isog1(cancelSource: UInt): Bool = cancelSource === og1

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -350,6 +350,7 @@ object Bundles {
   class TopdownIQInfo(implicit p: Parameters) extends XSBundle {
     val robIdx = new RobPtr
     val cancelSource = IQCancelSource()
+    val srcReady = Bool()
   }
 
   class DispatchOutBaseUop(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -349,8 +349,13 @@ object Bundles {
   }
   class TopdownIQInfo(implicit p: Parameters) extends XSBundle {
     val robIdx = new RobPtr
+    val fuType = FuType()
     val cancelSource = IQCancelSource()
     val srcReady = Bool()
+  }
+
+  class TopdownIQExtendedInfo(implicit p: Parameters) extends TopdownIQInfo {
+    val idealIssueTime = Bool()
   }
 
   class DispatchOutBaseUop(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -332,6 +332,26 @@ object Bundles {
     }
   }
 
+  object IQCancelSource {
+    def apply() = UInt(3.W)
+
+    val none = 0.U(3.W)
+    val og0  = 1.U(3.W)
+    val og1  = 2.U(3.W)
+    val ld   = 3.U(3.W)
+    val st   = 4.U(3.W)
+
+    def isnone(cancelSource: UInt): Bool = cancelSource === none
+    def isog0(cancelSource: UInt): Bool = cancelSource === og0
+    def isog1(cancelSource: UInt): Bool = cancelSource === og1
+    def isld(cancelSource: UInt): Bool = cancelSource === ld
+    def isst(cancelSource: UInt): Bool = cancelSource === st
+  }
+  class TopdownIQInfo(implicit p: Parameters) extends XSBundle {
+    val robIdx = new RobPtr
+    val cancelSource = IQCancelSource()
+  }
+
   class DispatchOutBaseUop(implicit p: Parameters) extends XSBundle {
     def numSrc = backendParams.numSrc
     // from frontend
@@ -525,6 +545,7 @@ object Bundles {
     // from dispatch
     val srcLoadDependency = Vec(numSrc, Vec(LoadPipelineWidth, UInt(LoadDependencyWidth.W)))
     val debug             = OptionWrapper(backendParams.debugEn, new IssueQueueInDebug)
+    val debugLastIssueCancelSource = OptionWrapper(backendParams.debugEn, IQCancelSource())
   }
   class ExuToRob(val params: ExeUnitParams)(implicit p: Parameters) extends XSBundle {
     val robIdx = new RobPtr

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -352,6 +352,7 @@ object Bundles {
     val fuType = FuType()
     val cancelSource = IQCancelSource()
     val srcReady = Bool()
+    val issued = Bool()
   }
 
   class TopdownIQExtendedInfo(implicit p: Parameters) extends TopdownIQInfo {

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -976,7 +976,7 @@ class CtrlBlockIO()(implicit p: Parameters, params: BackendParams) extends XSBun
       val pc     = Output(UInt(VAddrBits.W))
     })
     val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(IssueQueueDeqSum, Flipped(ValidIO(new RobPtr()))))
-    val topdownIQInfoVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new TopdownIQInfo())))))
+    val topdownIQInfoVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new TopdownIQExtendedInfo())))))
   }
 
   val toDecode = new Bundle {

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -776,6 +776,7 @@ class CtrlBlockImp(
   dispatch.io.debugIQValidNumVec.foreach(_ := io.toDispatch.debugIQValidNumVec.get)
   dispatch.io.debugIQEnqHasIssuedVec.foreach(_ := io.toDispatch.debugIQEnqHasIssuedVec.get)
   dispatch.io.debugRobHeadStall.foreach(_ := rob.io.debugRobHeadStall.get)
+  dispatch.io.debugRobHeadIssueCancelStall.foreach(_ := rob.io.debugRobHeadIssueCancelStall.get)
   val toIssueBlockUops = Seq(io.toIssueBlock.intUops, io.toIssueBlock.fpUops, io.toIssueBlock.vfUops).flatten
   println(s"[CtrlBlock] toIssueBlockUops.size = ${toIssueBlockUops.size}")
   println(s"[CtrlBlock] io.toIssueBlock.intUops.size = ${io.toIssueBlock.intUops.size}")
@@ -884,6 +885,7 @@ class CtrlBlockImp(
   rename.io.debugLoadReason.foreach(_ := ldReason)
   rename.io.debugRobHeadFuType.foreach(_ := rob.io.debugRobHeadFuType)
   rename.io.debugRobHeadStall.foreach(_ := rob.io.debugRobHeadStall.get)
+  rename.io.debugRobHeadIssueCancelStall.foreach(_ := rob.io.debugRobHeadIssueCancelStall.get)
 
   io.perfInfo.ctrlInfo.robFull := GatedValidRegNext(rob.io.robFull)
   io.perfInfo.ctrlInfo.intdqFull := false.B

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -837,7 +837,6 @@ class CtrlBlockImp(
   rob.io.csr.criticalErrorState := io.robio.csr.criticalErrorState
   rob.io.debugEnqLsq := io.debugEnqLsq
   rob.io.debugInstrAddrTransType := io.fromCSR.instrAddrTransType
-  rob.io.debugIQDeqRobIdxVec.foreach(_ := io.robio.debugIQDeqRobIdxVec.get)
   rob.io.topdownIQInfoVec.foreach(_ := io.robio.topdownIQInfoVec.get)
 
   io.robio.robDeqPtr := rob.io.robDeqPtr
@@ -975,7 +974,6 @@ class CtrlBlockIO()(implicit p: Parameters, params: BackendParams) extends XSBun
       val robidx = Input(new RobPtr)
       val pc     = Output(UInt(VAddrBits.W))
     })
-    val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(IssueQueueDeqSum, Flipped(ValidIO(new RobPtr()))))
     val topdownIQInfoVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new TopdownIQExtendedInfo())))))
   }
 

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -740,7 +740,6 @@ class CtrlBlockImp(
   dispatch.io.enqRob.resp := enqRob.resp
   rob.io.enq.needAlloc := enqRob.needAlloc
   rob.io.enq.req := enqRob.req
-  dispatch.io.robHeadFuType := rob.io.debugRobHeadFuType
   dispatch.io.stallReason <> rename.io.stallReason.out
   dispatch.io.wakeUpAll.wakeUpInt := io.toDispatch.wakeUpInt
   dispatch.io.wakeUpAll.wakeUpFp  := io.toDispatch.wakeUpFp
@@ -776,7 +775,6 @@ class CtrlBlockImp(
   dispatch.io.debugIQValidNumVec.foreach(_ := io.toDispatch.debugIQValidNumVec.get)
   dispatch.io.debugIQEnqHasIssuedVec.foreach(_ := io.toDispatch.debugIQEnqHasIssuedVec.get)
   dispatch.io.debugRobHeadStall.foreach(_ := rob.io.debugRobHeadStall.get)
-  dispatch.io.debugRobHeadIssueCancelStall.foreach(_ := rob.io.debugRobHeadIssueCancelStall.get)
   val toIssueBlockUops = Seq(io.toIssueBlock.intUops, io.toIssueBlock.fpUops, io.toIssueBlock.vfUops).flatten
   println(s"[CtrlBlock] toIssueBlockUops.size = ${toIssueBlockUops.size}")
   println(s"[CtrlBlock] io.toIssueBlock.intUops.size = ${io.toIssueBlock.intUops.size}")
@@ -840,6 +838,8 @@ class CtrlBlockImp(
   rob.io.debugEnqLsq := io.debugEnqLsq
   rob.io.debugInstrAddrTransType := io.fromCSR.instrAddrTransType
   rob.io.debugIQDeqRobIdxVec.foreach(_ := io.robio.debugIQDeqRobIdxVec.get)
+  rob.io.debugIQSrcReadyVec.foreach(_ := io.robio.debugIQSrcReadyVec.get)
+  rob.io.topdownIQInfoVec.foreach(_ := io.robio.topdownIQInfoVec.get)
 
   io.robio.robDeqPtr := rob.io.robDeqPtr
 
@@ -861,31 +861,10 @@ class CtrlBlockImp(
   io.toVecExcpMod.ratOldPest := rename.io.ratOldPdest
 
   io.debugTopDown.fromRob := rob.io.debugTopDown.toCore
+  rob.io.debugTopDown.fromCore := io.debugTopDown.fromCore
   io.debugRolling := rob.io.debugRolling
-  // mem topdown reason collect
-  val notIssue = !rob.io.debugTopDown.toDispatch.robHeadLsIssue
-  val tlbReplay = io.debugTopDown.fromCore.fromMem.robHeadTlbReplay
-  val tlbMiss = io.debugTopDown.fromCore.fromMem.robHeadTlbMiss
-  val vioReplay = io.debugTopDown.fromCore.fromMem.robHeadLoadVio
-  val mshrReplay = io.debugTopDown.fromCore.fromMem.robHeadLoadMSHR
-  val l1Miss = io.debugTopDown.fromCore.fromMem.robHeadMissInDCache
-  val l2Miss = io.debugTopDown.fromCore.l2MissMatch
-  val l3Miss = io.debugTopDown.fromCore.l3MissMatch
-  val ldReason = Mux(l3Miss, LoadMemStall.id.U,
-    Mux(l2Miss, LoadL3Stall.id.U,
-      Mux(l1Miss, LoadL2Stall.id.U,
-        Mux(notIssue, MemNotReadyStall.id.U,
-          Mux(tlbMiss, LoadTLBStall.id.U,
-            Mux(tlbReplay, LoadTLBStall.id.U,
-              Mux(mshrReplay, LoadMSHRReplayStall.id.U,
-                Mux(vioReplay, LoadVioReplayStall.id.U,
-                  LoadL1Stall.id.U))))))))
-  dispatch.io.debugLoadReason.foreach(_ := ldReason)
   dispatch.io.debugRobTrueCommit.foreach(_ := rob.io.debugTopDown.toDispatch.robTrueCommit)
-  rename.io.debugLoadReason.foreach(_ := ldReason)
-  rename.io.debugRobHeadFuType.foreach(_ := rob.io.debugRobHeadFuType)
   rename.io.debugRobHeadStall.foreach(_ := rob.io.debugRobHeadStall.get)
-  rename.io.debugRobHeadIssueCancelStall.foreach(_ := rob.io.debugRobHeadIssueCancelStall.get)
 
   io.perfInfo.ctrlInfo.robFull := GatedValidRegNext(rob.io.robFull)
   io.perfInfo.ctrlInfo.intdqFull := false.B
@@ -997,6 +976,8 @@ class CtrlBlockIO()(implicit p: Parameters, params: BackendParams) extends XSBun
       val pc     = Output(UInt(VAddrBits.W))
     })
     val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(IssueQueueDeqSum, Flipped(ValidIO(new RobPtr()))))
+    val debugIQSrcReadyVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new RobPtr())))))
+    val topdownIQInfoVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new TopdownIQInfo())))))
   }
 
   val toDecode = new Bundle {

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -838,7 +838,6 @@ class CtrlBlockImp(
   rob.io.debugEnqLsq := io.debugEnqLsq
   rob.io.debugInstrAddrTransType := io.fromCSR.instrAddrTransType
   rob.io.debugIQDeqRobIdxVec.foreach(_ := io.robio.debugIQDeqRobIdxVec.get)
-  rob.io.debugIQSrcReadyVec.foreach(_ := io.robio.debugIQSrcReadyVec.get)
   rob.io.topdownIQInfoVec.foreach(_ := io.robio.topdownIQInfoVec.get)
 
   io.robio.robDeqPtr := rob.io.robDeqPtr
@@ -958,6 +957,7 @@ class CtrlBlockIO()(implicit p: Parameters, params: BackendParams) extends XSBun
 
   val csrCtrl = Input(new CustomCSRCtrlIO)
   val IssueQueueDeqSum  = backendParams.allIssueParams.map(_.numDeq).sum
+  val iqEntryNum = backendParams.allIssueParams.map(_.numEntries).sum
   val robio = new Bundle {
     val csr = new RobCSRIO
     val exception = ValidIO(new ExceptionInfo)
@@ -976,7 +976,6 @@ class CtrlBlockIO()(implicit p: Parameters, params: BackendParams) extends XSBun
       val pc     = Output(UInt(VAddrBits.W))
     })
     val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(IssueQueueDeqSum, Flipped(ValidIO(new RobPtr()))))
-    val debugIQSrcReadyVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new RobPtr())))))
     val topdownIQInfoVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new TopdownIQInfo())))))
   }
 

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -832,24 +832,7 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
         sink.valid := source.valid
         // connect base info
         connectSamePort(sink.bits, source.bits)
-        // generate extend info
-
-        //      val currentPipelineNum = Mux1H(source.bits.fuType, fuMapPipelineNum)
-        //      val currentRobIdx = source.bits.robIdx
-        //      val robIdxVec = topdownIQInfoVec.map(_.bits.robIdx)
-        //      val srcReadyVec = topdownIQInfoVec.map(_.bits.srcReady)
-        //      val validVec = topdownIQInfoVec.map(_.valid)
-        //      val olderRobIdxVec = robIdxVec.map(_ > currentRobIdx)
-        //      val olderIdealCanIssueVec = Wire(Vec(io.iqEntryNum, Bool()))
-        //      olderIdealCanIssueVec := VecInit(olderRobIdxVec.zip(srcReadyVec).zip(validVec).map{ case((older, srcReady), valid) =>
-        //        older && srcReady && valid
-        //      })
-        //      val olderIdealCanIssueNum = PopCount(olderIdealCanIssueVec)
-        ////      val olderIdealCanIssueNum = PopCount(olderIdealCanIssueVec.take(10))
         sink.bits.idealIssueTime := ideal.idealIssueTime
-      //      if(backendParams.debugEn){
-      //        dontTouch(olderIdealCanIssueVec)
-      //      }
     })
   }
 

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -798,6 +798,15 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
     sink.bits := source.bits.robIdx
   })
 
+  val srcReadyVec = issueQueues.flatMap(_.io.srcReadyVec)
+  val robIdxVec = issueQueues.flatMap(_.io.debugRobIdxVec.get)
+  val validVec = issueQueues.flatMap(_.io.validVec)
+  io.debugIQSrcReadyVec.foreach(_.zip(srcReadyVec.zip(robIdxVec)).foreach{ case(sink, (valid, robIdx)) =>
+    sink.valid := valid
+    sink.bits := robIdx
+  })
+  val topdownIQInfoVec = issueQueues.flatMap(_.io.topdownIQInfoVec.get)
+  io.topdownIQInfoVec.foreach( _ := topdownIQInfoVec)
 
 
   if (params.isIntSchd) {
@@ -964,4 +973,6 @@ class RegionIO(val params: SchdBlockParams)(implicit p: Parameters) extends XSBu
   val debugIQValidNumVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(UInt(maxIQSize.U.getWidth.W))))
   val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(Bool())))
   val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(iqDeqSum, ValidIO(new RobPtr())))
+  val debugIQSrcReadyVec = Option.when(backendParams.debugEn)(Output(Vec(iqEntryNum, ValidIO(new RobPtr()))))
+  val topdownIQInfoVec = Option.when(backendParams.debugEn)(Output(Vec(iqEntryNum, ValidIO(new TopdownIQInfo()))))
 }

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -801,10 +801,6 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
   val srcReadyVec = issueQueues.flatMap(_.io.srcReadyVec)
   val robIdxVec = issueQueues.flatMap(_.io.debugRobIdxVec.get)
   val validVec = issueQueues.flatMap(_.io.validVec)
-  io.debugIQSrcReadyVec.foreach(_.zip(srcReadyVec.zip(robIdxVec)).foreach{ case(sink, (valid, robIdx)) =>
-    sink.valid := valid
-    sink.bits := robIdx
-  })
   val topdownIQInfoVec = issueQueues.flatMap(_.io.topdownIQInfoVec.get)
   io.topdownIQInfoVec.foreach( _ := topdownIQInfoVec)
 
@@ -970,9 +966,9 @@ class RegionIO(val params: SchdBlockParams)(implicit p: Parameters) extends XSBu
   // TopDown
   val uopTopDown = new UopTopDown
   val iqDeqSum = params.issueBlockParams.map(_.numDeq).sum
+  val iqEntryNum = params.issueBlockParams.map(_.numEntries).sum
   val debugIQValidNumVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(UInt(maxIQSize.U.getWidth.W))))
   val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(Bool())))
   val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(iqDeqSum, ValidIO(new RobPtr())))
-  val debugIQSrcReadyVec = Option.when(backendParams.debugEn)(Output(Vec(iqEntryNum, ValidIO(new RobPtr()))))
   val topdownIQInfoVec = Option.when(backendParams.debugEn)(Output(Vec(iqEntryNum, ValidIO(new TopdownIQInfo()))))
 }

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -801,8 +801,47 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
   val srcReadyVec = issueQueues.flatMap(_.io.srcReadyVec)
   val robIdxVec = issueQueues.flatMap(_.io.debugRobIdxVec.get)
   val validVec = issueQueues.flatMap(_.io.validVec)
+  val allIssueParams = backendParams.allIssueParams.filter(_.StdCnt == 0)
+  val allExuParams = allIssueParams.map(_.exuBlockParams).flatten
+  val allFuConfigs = allExuParams.map(_.fuConfigs).flatten.toSet.toSeq
+  val sortedFuConfigs = allFuConfigs.sortBy(_.fuType.id)
+
+  val fuConfigsInIssueParams = allIssueParams.map(_.allExuParams.map(_.fuConfigs).flatten.toSet.toSeq)
+  val fuMapPipelineNum = sortedFuConfigs.map( fu => {
+    val fuInIQIdx = fuConfigsInIssueParams.zipWithIndex.filter { case (f, i) => f.contains(fu) }.map(_._2)
+    var pipeLineNum = fuInIQIdx.length
+    if (fu.fuType == FuType.stu) {
+      pipeLineNum = pipeLineNum * 2
+    }
+    println(s"fu : ${fu.name} pipelinenum: ${pipeLineNum}")
+    pipeLineNum.asUInt
+  })
+
   val topdownIQInfoVec = issueQueues.flatMap(_.io.topdownIQInfoVec.get)
-  io.topdownIQInfoVec.foreach( _ := topdownIQInfoVec)
+
+  io.topdownIQInfoVec.foreach( _.zip(topdownIQInfoVec).foreach{ case (sink, source) =>
+      sink.valid := source.valid
+      // connect base info
+      connectSamePort(sink.bits, source.bits)
+      // generate extend info
+      val currentPipelineNum = Mux1H(source.bits.fuType, fuMapPipelineNum)
+      val currentRobIdx = source.bits.robIdx
+      val robIdxVec = topdownIQInfoVec.map(_.bits.robIdx)
+      val srcReadyVec = topdownIQInfoVec.map(_.bits.srcReady)
+      val validVec = topdownIQInfoVec.map(_.valid)
+      val olderRobIdxVec = robIdxVec.map(_ > currentRobIdx)
+      val olderIdealCanIssueVec = Wire(Vec(io.iqEntryNum, Bool()))
+      olderIdealCanIssueVec := VecInit(olderRobIdxVec.zip(srcReadyVec).zip(validVec).map{ case((older, srcReady), valid) =>
+        older && srcReady && valid
+      })
+      val olderIdealCanIssueNum = PopCount(olderIdealCanIssueVec)
+//      val olderIdealCanIssueNum = PopCount(olderIdealCanIssueVec.take(10))
+      sink.bits.idealIssueTime := (olderIdealCanIssueNum < currentPipelineNum) && source.bits.srcReady
+      if(backendParams.debugEn){
+        dontTouch(olderIdealCanIssueVec)
+      }
+    }
+  )
 
 
   if (params.isIntSchd) {
@@ -970,5 +1009,5 @@ class RegionIO(val params: SchdBlockParams)(implicit p: Parameters) extends XSBu
   val debugIQValidNumVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(UInt(maxIQSize.U.getWidth.W))))
   val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(Bool())))
   val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(iqDeqSum, ValidIO(new RobPtr())))
-  val topdownIQInfoVec = Option.when(backendParams.debugEn)(Output(Vec(iqEntryNum, ValidIO(new TopdownIQInfo()))))
+  val topdownIQInfoVec = Option.when(backendParams.debugEn)(Output(Vec(iqEntryNum, ValidIO(new TopdownIQExtendedInfo()))))
 }

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -33,6 +33,7 @@ import xiangshan.backend.fu.wrapper.{CSRInput, CSRToDecode}
 import xiangshan.backend.rob.RobPtr
 import xiangshan.backend.issue.EntryBundles.RespType
 import xiangshan.backend.issue._
+import difftest.common.TopdownIQInfoCollect
 
 
 class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModule with HasCriticalErrors {
@@ -792,11 +793,6 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
     issueQueueEnqHasIssuedVec(sta) := Mux(staValidNum(i) > stdValidNum(i), staEnqHasIssuedVec(i), stdEnqHasIssuedVec(i))
   }
 
-  val issueQueueDeqVec = issueQueues.flatMap(_.io.deqDelay)
-  io.debugIQDeqRobIdxVec.foreach(_.zip(issueQueueDeqVec).foreach{ case(sink, source) =>
-    sink.valid := source.valid
-    sink.bits := source.bits.robIdx
-  })
 
   val srcReadyVec = issueQueues.flatMap(_.io.srcReadyVec)
   val robIdxVec = issueQueues.flatMap(_.io.debugRobIdxVec.get)
@@ -818,30 +814,45 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
   })
 
   val topdownIQInfoVec = issueQueues.flatMap(_.io.topdownIQInfoVec.get)
-
-  io.topdownIQInfoVec.foreach( _.zip(topdownIQInfoVec).foreach{ case (sink, source) =>
+  if(backendParams.debugEn) {
+    val topdownIQInfoCollect = Module(new TopdownIQInfoCollect(io.iqEntryNum))
+    topdownIQInfoCollect.io.in.zip(topdownIQInfoVec).foreach{ case (sink, source) =>
       sink.valid := source.valid
-      // connect base info
-      connectSamePort(sink.bits, source.bits)
-      // generate extend info
+      sink.robIdx := source.bits.robIdx.value
+      sink.robFlag := source.bits.robIdx.flag
+      sink.srcReady := source.bits.srcReady
       val currentPipelineNum = Mux1H(source.bits.fuType, fuMapPipelineNum)
-      val currentRobIdx = source.bits.robIdx
-      val robIdxVec = topdownIQInfoVec.map(_.bits.robIdx)
-      val srcReadyVec = topdownIQInfoVec.map(_.bits.srcReady)
-      val validVec = topdownIQInfoVec.map(_.valid)
-      val olderRobIdxVec = robIdxVec.map(_ > currentRobIdx)
-      val olderIdealCanIssueVec = Wire(Vec(io.iqEntryNum, Bool()))
-      olderIdealCanIssueVec := VecInit(olderRobIdxVec.zip(srcReadyVec).zip(validVec).map{ case((older, srcReady), valid) =>
-        older && srcReady && valid
-      })
-      val olderIdealCanIssueNum = PopCount(olderIdealCanIssueVec)
-//      val olderIdealCanIssueNum = PopCount(olderIdealCanIssueVec.take(10))
-      sink.bits.idealIssueTime := (olderIdealCanIssueNum < currentPipelineNum) && source.bits.srcReady
-      if(backendParams.debugEn){
-        dontTouch(olderIdealCanIssueVec)
-      }
+      sink.pipeNum := currentPipelineNum
+      sink.cancelSource := source.bits.cancelSource
+      sink.futype := OHToUInt(source.bits.fuType)
+      sink.issued := source.bits.issued
     }
-  )
+    io.topdownIQInfoVec.foreach( _.zip(topdownIQInfoVec).zip(topdownIQInfoCollect.io.out).foreach{
+      case ((sink, source), ideal) =>
+        sink.valid := source.valid
+        // connect base info
+        connectSamePort(sink.bits, source.bits)
+        // generate extend info
+
+        //      val currentPipelineNum = Mux1H(source.bits.fuType, fuMapPipelineNum)
+        //      val currentRobIdx = source.bits.robIdx
+        //      val robIdxVec = topdownIQInfoVec.map(_.bits.robIdx)
+        //      val srcReadyVec = topdownIQInfoVec.map(_.bits.srcReady)
+        //      val validVec = topdownIQInfoVec.map(_.valid)
+        //      val olderRobIdxVec = robIdxVec.map(_ > currentRobIdx)
+        //      val olderIdealCanIssueVec = Wire(Vec(io.iqEntryNum, Bool()))
+        //      olderIdealCanIssueVec := VecInit(olderRobIdxVec.zip(srcReadyVec).zip(validVec).map{ case((older, srcReady), valid) =>
+        //        older && srcReady && valid
+        //      })
+        //      val olderIdealCanIssueNum = PopCount(olderIdealCanIssueVec)
+        ////      val olderIdealCanIssueNum = PopCount(olderIdealCanIssueVec.take(10))
+        sink.bits.idealIssueTime := ideal.idealIssueTime
+      //      if(backendParams.debugEn){
+      //        dontTouch(olderIdealCanIssueVec)
+      //      }
+    })
+  }
+
 
 
   if (params.isIntSchd) {
@@ -1008,6 +1019,5 @@ class RegionIO(val params: SchdBlockParams)(implicit p: Parameters) extends XSBu
   val iqEntryNum = params.issueBlockParams.map(_.numEntries).sum
   val debugIQValidNumVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(UInt(maxIQSize.U.getWidth.W))))
   val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(IQNum, Output(Bool())))
-  val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(iqDeqSum, ValidIO(new RobPtr())))
   val topdownIQInfoVec = Option.when(backendParams.debugEn)(Output(Vec(iqEntryNum, ValidIO(new TopdownIQExtendedInfo()))))
 }

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -33,7 +33,7 @@ import xiangshan.backend.fu.wrapper.{CSRInput, CSRToDecode}
 import xiangshan.backend.rob.RobPtr
 import xiangshan.backend.issue.EntryBundles.RespType
 import xiangshan.backend.issue._
-import difftest.common.TopdownIQInfoCollect
+import difftest.plugin.topdown.TopdownIQInfoCollect
 
 
 class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModule with HasCriticalErrors {

--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -795,7 +795,6 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
 
 
   val srcReadyVec = issueQueues.flatMap(_.io.srcReadyVec)
-  val robIdxVec = issueQueues.flatMap(_.io.debugRobIdxVec.get)
   val validVec = issueQueues.flatMap(_.io.validVec)
   val allIssueParams = backendParams.allIssueParams.filter(_.StdCnt == 0)
   val allExuParams = allIssueParams.map(_.exuBlockParams).flatten
@@ -813,8 +812,8 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
     pipeLineNum.asUInt
   })
 
-  val topdownIQInfoVec = issueQueues.flatMap(_.io.topdownIQInfoVec.get)
   if(backendParams.debugEn) {
+    val topdownIQInfoVec = issueQueues.flatMap(_.io.topdownIQInfoVec.get)
     val topdownIQInfoCollect = Module(new TopdownIQInfoCollect(io.iqEntryNum))
     topdownIQInfoCollect.io.in.zip(topdownIQInfoVec).foreach{ case (sink, source) =>
       sink.valid := source.valid

--- a/src/main/scala/xiangshan/backend/TopDownGen.scala
+++ b/src/main/scala/xiangshan/backend/TopDownGen.scala
@@ -16,27 +16,27 @@ class TopDownGen(implicit p: Parameters) extends XSModule
 
   val fewUopsIssued = (0 until p(XSCoreParamsKey).fewUops).map(_.U === uopsIssuedCnt).reduce(_ || _)
 
-  val stallLoad = !uopsIssued
-  val stallStore = uopsIssued && RegNext(noStoreIssued)
+  val stallLoad  = fewUopsIssued && !uopsIssued
+  val stallStore = fewUopsIssued && uopsIssued && RegNext(noStoreIssued)
 
   val stallLoadDly = RegNext(stallLoad)
   val stallStoreDly = RegNext(stallStore)
 
-  val lqEmpty = io.topDownInfo.lqEmpty
-  val sqEmpty = io.topDownInfo.sqEmpty
+  val replayAllocate = io.topDownInfo.replayAllocate
+  val sqFull  = io.topDownInfo.sqFull
+  val sbFull  = io.topDownInfo.sbFull
   val l1Miss = io.topDownInfo.l1Miss
   val l2Miss = io.topDownInfo.l2TopMiss.l2Miss
   val l3Miss = io.topDownInfo.l2TopMiss.l3Miss
 
-  val memStallAnyLoad = stallLoadDly && !lqEmpty
-  val memStallStore = stallStoreDly && !sqEmpty
+  val memStallAnyLoad = stallLoadDly && replayAllocate
+  val memStallStore = stallStoreDly && (sqFull || sbFull)
   val memStallL1Miss = memStallAnyLoad && l1Miss
   val memStallL2Miss = memStallL1Miss && l2Miss
   val memStallL3Miss = memStallL2Miss && l3Miss
 
-  io.topDownInfo.noUopsIssued := stallLoad
-  
   XSPerfAccumulate("exec_stall_cycle",   fewUopsIssued)
+  XSPerfAccumulate("mem_stall_anyload",  memStallAnyLoad)
   XSPerfAccumulate("mem_stall_store",    memStallStore)
   XSPerfAccumulate("mem_stall_l1miss",   memStallL1Miss)
   XSPerfAccumulate("mem_stall_l2miss",   memStallL2Miss)
@@ -44,6 +44,7 @@ class TopDownGen(implicit p: Parameters) extends XSModule
 
   val perfEvents = Seq(
     ("EXEC_STALL_CYCLE",  fewUopsIssued),
+    ("MEMSTALL_ANY_LOAD", memStallAnyLoad),
     ("MEMSTALL_STORE",    memStallStore),
     ("MEMSTALL_L1MISS",   memStallL1Miss),
     ("MEMSTALL_L2MISS",   memStallL2Miss),

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -149,15 +149,12 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     val lfst = new DispatchLFSTIO
 
     // perf only
-    val robHeadFuType = Input(FuType())
     val stallReason = Flipped(new StallReasonIO(RenameWidth))
     val debugBlockBackward = Option.when(backendParams.debugEn)(Input(Bool()))
     val debugWaitForward   = Option.when(backendParams.debugEn)(Input(Bool()))
     val debugIQValidNumVec = Option.when(backendParams.debugEn)(Vec(issueQueueNum, Input(UInt(maxIQSize.U.getWidth.W))))
     val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(issueQueueNum, Input(Bool())))
-    val debugRobHeadStall = Option.when(backendParams.debugEn)(Input(Bool()))
-    val debugRobHeadIssueCancelStall = Option.when(backendParams.debugEn)(Input(Bool()))
-    val debugLoadReason = Option.when(backendParams.debugEn)(Input(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))
+    val debugRobHeadStall = Option.when(backendParams.debugEn)(Flipped(ValidIO(Input(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))))
     val debugRobTrueCommit = Option.when(backendParams.debugEn)(Input(UInt(64.W)))
   })
   // Deq for std's IQ is not assigned in Dispatch2Iq, so add one more src for it.
@@ -900,7 +897,6 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   XSPerfAccumulate("stall_cycle_lsqFull", dispatchBlock && !lsqCanAccept)
 
 
-  val ldReason = io.debugLoadReason.getOrElse(0.U)
 
   val fusedVec = (0 until RenameWidth).map{ case i =>
     if (i == 0 || !backendParams.debugEn) false.B
@@ -1023,27 +1019,16 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val dispatchStall = !(inReadyVec.reduce(_ || _))
   val dispatchStallReason = Wire(chiselTypeOf(io.stallReason.reason(0)))
 
-  val robHeadStall = io.debugRobHeadStall.getOrElse(false.B)
-  val robHeadIssuedCancel = io.debugRobHeadIssueCancelStall.getOrElse(false.B)
+  val robHeadStall = io.debugRobHeadStall.map(_.valid).getOrElse(false.B)
+  val robHeadStallReason = io.debugRobHeadStall.map(_.bits).getOrElse(0.U)
 
-  val robHeadFutype = io.robHeadFuType
 
   val robStall = !isWaitForwardOrBlockBackward && !hasSpecialInst&& !io.enqRob.canAccept
   val lsqStall = !lsqCanAccept
   val roblsqStall = robStall ||  lsqStall
   val lqStall  = io.fromLsqEnqCtrl.lqStall.getOrElse(false.B)
   val sqStall  = io.fromLsqEnqCtrl.sqStall.getOrElse(false.B)
-  val robHeadStallReason = MuxCase(OtherNotReadyStall.id.U, Seq(
-    FuType.isAMO(robHeadFutype)          -> AtomicStall.id.U          ,
-    FuType.isStoreVstore(robHeadFutype)  -> StoreStall.id.U           ,
-    FuType.isLoadVload(robHeadFutype)    -> ldReason                  ,
-    FuType.isDivSqrt(robHeadFutype)      -> DivStall.id.U             ,
-    FuType.isInt(robHeadFutype)          -> IntNotReadyStall.id.U     ,
-    FuType.isFArith(robHeadFutype)       -> FPNotReadyStall.id.U      ,
-  ))
-
   val roblsqStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
-    robHeadIssuedCancel                  -> IssueCancelStall.id.U     ,
     robHeadStall                         -> robHeadStallReason        ,
     robStall                             -> RobStall.id.U             ,
     lqStall                              -> LqStall.id.U              ,
@@ -1070,7 +1055,6 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     FuType.isStoreVstore(issueQueueStallFutype) -> BalanceDispatchPolicyStallStore.id.U ,
   ))
   val issueQueueStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
-    robHeadIssuedCancel                         -> IssueCancelStall.id.U       ,
     robHeadStall                                -> robHeadStallReason          ,
     fromRenameMapIQEnqHasIssuedNotFull(0)       -> IQEnqPolicyStallIssued.id.U ,
     fromRenameMapIQNotFull(0)                   -> IQEnqPolicyStall.id.U       ,
@@ -1088,7 +1072,6 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val dispatchlsqStall = dispatchlsqBubbleVec.reduce(_ && _)
   val dispatchlsqStallFutype = PriorityMux(dispatchlsqBubbleVec , fuTypes)
   val dispatchlsqStallReason = MuxCase(NoStall.id.U, Seq(
-    robHeadIssuedCancel                          -> IssueCancelStall.id.U ,
     robHeadStall                                 -> robHeadStallReason    ,
     FuType.isLoadVload(dispatchlsqStallFutype)   -> LqStall.id.U          ,
     FuType.isStoreVstore(dispatchlsqStallFutype) -> SqStall.id.U          ,
@@ -1138,7 +1121,6 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val issueQueueBubble = issueQueueStallVec.reduce(_ || _)
 
   val issueQueueBubbleReason = MuxCase(OtherBalanceDispatchPolicyStall.id.U, Seq(
-    robHeadIssuedCancel                         -> IssueCancelStall.id.U       ,
     robHeadStall                                -> robHeadStallReason          ,
     issueQueueEnqPolicyStallIssued              -> IQEnqPolicyStallIssued.id.U ,
     issueQueueEnqPolicyStall                    -> IQEnqPolicyStall.id.U       ,
@@ -1157,7 +1139,6 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val dispatchlsqBubble = dispatchlsqBubbleVec.reduce(_ || _)
   val dispatchlsqBubbleFutype = PriorityMux(dispatchlsqBubbleVec , fuTypes)
   val dispatchlsqBubbleReason = MuxCase(NoStall.id.U, Seq(
-    robHeadIssuedCancel                           -> IssueCancelStall.id.U ,
     robHeadStall                                  -> robHeadStallReason    ,
     FuType.isLoadVload(dispatchlsqBubbleFutype)   -> LqStall.id.U  ,
     FuType.isStoreVstore(dispatchlsqBubbleFutype) -> SqStall.id.U ,

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -154,7 +154,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     val debugWaitForward   = Option.when(backendParams.debugEn)(Input(Bool()))
     val debugIQValidNumVec = Option.when(backendParams.debugEn)(Vec(issueQueueNum, Input(UInt(maxIQSize.U.getWidth.W))))
     val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(issueQueueNum, Input(Bool())))
-    val debugRobHeadStall = Option.when(backendParams.debugEn)(Flipped(ValidIO(Input(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))))
+    val debugRobHeadStall = Option.when(backendParams.debugEn)(Flipped(Valid(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W))))
     val debugRobTrueCommit = Option.when(backendParams.debugEn)(Input(UInt(64.W)))
   })
   // Deq for std's IQ is not assigned in Dispatch2Iq, so add one more src for it.

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -156,6 +156,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     val debugIQValidNumVec = Option.when(backendParams.debugEn)(Vec(issueQueueNum, Input(UInt(maxIQSize.U.getWidth.W))))
     val debugIQEnqHasIssuedVec = Option.when(backendParams.debugEn)(Vec(issueQueueNum, Input(Bool())))
     val debugRobHeadStall = Option.when(backendParams.debugEn)(Input(Bool()))
+    val debugRobHeadIssueCancelStall = Option.when(backendParams.debugEn)(Input(Bool()))
     val debugLoadReason = Option.when(backendParams.debugEn)(Input(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))
     val debugRobTrueCommit = Option.when(backendParams.debugEn)(Input(UInt(64.W)))
   })
@@ -1023,6 +1024,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val dispatchStallReason = Wire(chiselTypeOf(io.stallReason.reason(0)))
 
   val robHeadStall = io.debugRobHeadStall.getOrElse(false.B)
+  val robHeadIssuedCancel = io.debugRobHeadIssueCancelStall.getOrElse(false.B)
 
   val robHeadFutype = io.robHeadFuType
 
@@ -1041,6 +1043,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   ))
 
   val roblsqStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+    robHeadIssuedCancel                  -> IssueCancelStall.id.U     ,
     robHeadStall                         -> robHeadStallReason        ,
     robStall                             -> RobStall.id.U             ,
     lqStall                              -> LqStall.id.U              ,
@@ -1067,6 +1070,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     FuType.isStoreVstore(issueQueueStallFutype) -> BalanceDispatchPolicyStallStore.id.U ,
   ))
   val issueQueueStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
+    robHeadIssuedCancel                         -> IssueCancelStall.id.U       ,
     robHeadStall                                -> robHeadStallReason          ,
     fromRenameMapIQEnqHasIssuedNotFull(0)       -> IQEnqPolicyStallIssued.id.U ,
     fromRenameMapIQNotFull(0)                   -> IQEnqPolicyStall.id.U       ,
@@ -1084,9 +1088,10 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val dispatchlsqStall = dispatchlsqBubbleVec.reduce(_ && _)
   val dispatchlsqStallFutype = PriorityMux(dispatchlsqBubbleVec , fuTypes)
   val dispatchlsqStallReason = MuxCase(NoStall.id.U, Seq(
-    robHeadStall                                 -> robHeadStallReason ,
-    FuType.isLoadVload(dispatchlsqStallFutype)   -> LqStall.id.U       ,
-    FuType.isStoreVstore(dispatchlsqStallFutype) -> SqStall.id.U       ,
+    robHeadIssuedCancel                          -> IssueCancelStall.id.U ,
+    robHeadStall                                 -> robHeadStallReason    ,
+    FuType.isLoadVload(dispatchlsqStallFutype)   -> LqStall.id.U          ,
+    FuType.isStoreVstore(dispatchlsqStallFutype) -> SqStall.id.U          ,
   ))
 
   // block backward will not stall whole pipe in current cycle
@@ -1133,11 +1138,12 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val issueQueueBubble = issueQueueStallVec.reduce(_ || _)
 
   val issueQueueBubbleReason = MuxCase(OtherBalanceDispatchPolicyStall.id.U, Seq(
+    robHeadIssuedCancel                         -> IssueCancelStall.id.U       ,
     robHeadStall                                -> robHeadStallReason          ,
     issueQueueEnqPolicyStallIssued              -> IQEnqPolicyStallIssued.id.U ,
     issueQueueEnqPolicyStall                    -> IQEnqPolicyStall.id.U       ,
-    balanceDispatchStall                        -> balanceDispatchStallReason  ,
     dispatchBandWidthPolicyBubble               -> dispatchBandWidthPolicyBubbleReason ,
+    balanceDispatchStall                        -> balanceDispatchStallReason  ,
     FuType.isAlu(issueQueueStallFutype)         -> IntIQFullStallAlu.id.U      ,
     FuType.isBJU(issueQueueStallFutype)         -> IntIQFullStallBrh.id.U      ,
     FuType.isInt(issueQueueStallFutype)         -> IntIQFullStallOther.id.U    ,
@@ -1151,6 +1157,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   val dispatchlsqBubble = dispatchlsqBubbleVec.reduce(_ || _)
   val dispatchlsqBubbleFutype = PriorityMux(dispatchlsqBubbleVec , fuTypes)
   val dispatchlsqBubbleReason = MuxCase(NoStall.id.U, Seq(
+    robHeadIssuedCancel                           -> IssueCancelStall.id.U ,
     robHeadStall                                  -> robHeadStallReason    ,
     FuType.isLoadVload(dispatchlsqBubbleFutype)   -> LqStall.id.U  ,
     FuType.isStoreVstore(dispatchlsqBubbleFutype) -> SqStall.id.U ,

--- a/src/main/scala/xiangshan/backend/issue/Entries.scala
+++ b/src/main/scala/xiangshan/backend/issue/Entries.scala
@@ -107,7 +107,8 @@ class Entries(implicit p: Parameters, params: IssueBlockParams) extends XSModule
   val perfOg0CancelVec       = OptionWrapper(params.hasIQWakeUp, Wire(Vec(params.numEntries, Vec(params.numRegSrc, Bool()))))
   val perfWakeupByWBVec      = Wire(Vec(params.numEntries, Vec(params.numRegSrc, Bool())))
   val perfWakeupByIQVec      = OptionWrapper(params.hasIQWakeUp, Wire(Vec(params.numEntries, Vec(params.numRegSrc, Vec(params.numWakeupFromIQ, Bool())))))
-  val debugCancelSourceVec = OptionWrapper(backendParams.debugEn, Wire(Vec(params.numEntries, IQCancelSource())))
+  val debugCancelSourceVec   = OptionWrapper(backendParams.debugEn, Wire(Vec(params.numEntries, IQCancelSource())))
+  val debugSrcReadyVec       = OptionWrapper(backendParams.debugEn, Wire(Vec(params.numEntries, Bool())))
   //cancel bypass
   val cancelBypassVec        = Wire(Vec(params.numEntries, Bool()))
 
@@ -422,6 +423,8 @@ class Entries(implicit p: Parameters, params: IssueBlockParams) extends XSModule
   io.issuedRegNext                  := issuedVecRegNext.asUInt
   io.debugRobIdxVec.foreach(_       := robIdxVec)
   io.debugCancelSourceVec.foreach(_ := debugCancelSourceVec.get)
+  io.debugSrcReadyVec.foreach(_     := debugSrcReadyVec.get)
+
 
 
   def EntriesConnect(in: CommonInBundle, out: CommonOutBundle, entryIdx: Int) = {
@@ -466,6 +469,9 @@ class Entries(implicit p: Parameters, params: IssueBlockParams) extends XSModule
     }
     debugCancelSourceVec.foreach { case cancelSourceVec =>
       cancelSourceVec(entryIdx)       := out.debugCancelSource.get
+    }
+    debugSrcReadyVec.foreach { case srcReadyVec =>
+      srcReadyVec(entryIdx)     := out.debugSrcReady.get
     }
     validVecRegNext(entryIdx)   := out.validRegNext
     issuedVecRegNext(entryIdx)  := out.issuedRegNext
@@ -608,6 +614,7 @@ class EntriesIO(implicit p: Parameters, params: IssueBlockParams) extends XSBund
   // todpown
   val debugRobIdxVec = Option.when(backendParams.debugEn)(Output(Vec(params.numEntries, new RobPtr)))
   val debugCancelSourceVec = Option.when(backendParams.debugEn)(Output(Vec(params.numEntries, IQCancelSource())))
+  val debugSrcReadyVec = Option.when(backendParams.debugEn)(Output(Vec(params.numEntries, Bool())))
 
   def wakeup = wakeUpFromWB ++ wakeUpFromIQ
 }

--- a/src/main/scala/xiangshan/backend/issue/Entries.scala
+++ b/src/main/scala/xiangshan/backend/issue/Entries.scala
@@ -107,6 +107,7 @@ class Entries(implicit p: Parameters, params: IssueBlockParams) extends XSModule
   val perfOg0CancelVec       = OptionWrapper(params.hasIQWakeUp, Wire(Vec(params.numEntries, Vec(params.numRegSrc, Bool()))))
   val perfWakeupByWBVec      = Wire(Vec(params.numEntries, Vec(params.numRegSrc, Bool())))
   val perfWakeupByIQVec      = OptionWrapper(params.hasIQWakeUp, Wire(Vec(params.numEntries, Vec(params.numRegSrc, Vec(params.numWakeupFromIQ, Bool())))))
+  val debugCancelSourceVec = OptionWrapper(backendParams.debugEn, Wire(Vec(params.numEntries, IQCancelSource())))
   //cancel bypass
   val cancelBypassVec        = Wire(Vec(params.numEntries, Bool()))
 
@@ -419,6 +420,8 @@ class Entries(implicit p: Parameters, params: IssueBlockParams) extends XSModule
   io.robIdx.foreach(_               := robIdxVec)
   io.validRegNext                   := validVecRegNext.asUInt
   io.issuedRegNext                  := issuedVecRegNext.asUInt
+  io.debugRobIdxVec.foreach(_       := robIdxVec)
+  io.debugCancelSourceVec.foreach(_ := debugCancelSourceVec.get)
 
 
   def EntriesConnect(in: CommonInBundle, out: CommonOutBundle, entryIdx: Int) = {
@@ -460,6 +463,9 @@ class Entries(implicit p: Parameters, params: IssueBlockParams) extends XSModule
       perfLdCancelVec.get(entryIdx)   := out.perfLdCancel.get
       perfOg0CancelVec.get(entryIdx)  := out.perfOg0Cancel.get
       perfWakeupByIQVec.get(entryIdx) := out.perfWakeupByIQ.get
+    }
+    debugCancelSourceVec.foreach { case cancelSourceVec =>
+      cancelSourceVec(entryIdx)       := out.debugCancelSource.get
     }
     validVecRegNext(entryIdx)   := out.validRegNext
     issuedVecRegNext(entryIdx)  := out.issuedRegNext
@@ -598,6 +604,10 @@ class EntriesIO(implicit p: Parameters, params: IssueBlockParams) extends XSBund
   val simpEntryEnqSelVec = OptionWrapper(params.hasCompAndSimp, Vec(params.numEnq, Output(UInt(params.numSimp.W))))
   val compEntryEnqSelVec = OptionWrapper(params.hasCompAndSimp, Vec(params.numEnq, Output(UInt(params.numComp.W))))
   val othersEntryEnqSelVec = OptionWrapper(params.isAllComp || params.isAllSimp, Vec(params.numEnq, Output(UInt((params.numEntries - params.numEnq).W))))
+
+  // todpown
+  val debugRobIdxVec = Option.when(backendParams.debugEn)(Output(Vec(params.numEntries, new RobPtr)))
+  val debugCancelSourceVec = Option.when(backendParams.debugEn)(Output(Vec(params.numEntries, IQCancelSource())))
 
   def wakeup = wakeUpFromWB ++ wakeUpFromIQ
 }

--- a/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
+++ b/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
@@ -184,7 +184,8 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     val perfOg0Cancel         = Option.when(params.hasIQWakeUp)(Output(Vec(params.numRegSrc, Bool())))
     val perfWakeupByWB        = Output(Vec(params.numRegSrc, Bool()))
     val perfWakeupByIQ        = Option.when(params.hasIQWakeUp)(Output(Vec(params.numRegSrc, Vec(params.numWakeupFromIQ, Bool()))))
-    val debugCancelSource   = Option.when(backendParams.debugEn)(Output(IQCancelSource()))
+    val debugCancelSource     = Option.when(backendParams.debugEn)(Output(IQCancelSource()))
+    val debugSrcReady         = Option.when(backendParams.debugEn)(Output(Bool()))
   }
 
   class CommonWireBundle(implicit p: Parameters, params: IssueBlockParams) extends XSBundle {
@@ -463,6 +464,7 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     commonOut.issued                                  := entryReg.status.issued
     commonOut.canIssue                                := (if (isComp) (common.canIssue || hasIQWakeupGet.canIssueBypass) && !common.flushed
                                                           else common.canIssue && !common.flushed)
+    commonOut.debugSrcReady.foreach(_                 := entryReg.status.srcReady)
     commonOut.srcReady                                := common.canIssue
     commonOut.fuType                                  := IQFuType.readFuType(status.fuType, params.getFuCfgs.map(_.fuType)).asUInt
     commonOut.robIdx                                  := status.robIdx

--- a/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
+++ b/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
@@ -184,6 +184,7 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     val perfOg0Cancel         = Option.when(params.hasIQWakeUp)(Output(Vec(params.numRegSrc, Bool())))
     val perfWakeupByWB        = Output(Vec(params.numRegSrc, Bool()))
     val perfWakeupByIQ        = Option.when(params.hasIQWakeUp)(Output(Vec(params.numRegSrc, Vec(params.numWakeupFromIQ, Bool()))))
+    val debugCancelSource   = Option.when(backendParams.debugEn)(Output(IQCancelSource()))
   }
 
   class CommonWireBundle(implicit p: Parameters, params: IssueBlockParams) extends XSBundle {
@@ -336,6 +337,12 @@ object EntryBundles extends HasCircularQueuePtrHelper {
                                                             status.issueTimer === params.issueTimerMaxValue.U && entryReg.payload.og1Payload.sqIdx.get === commonIn.issueResp.sqIdx.get
                                                           else true.B)
     val respIssueFail                                  = commonIn.issueResp.failed && sqIdxHit
+    val ldIssueCancel                                  = status.issued && srcCancelByLoad
+    val og0IssueCancel                                 = status.issued && respIssueFail && status.issueTimer === 0.U
+    val og1IssueCancel                                 = status.issued && respIssueFail && status.issueTimer === 1.U
+    val stIssueCancel                                  = if (params.needFeedBackSqIdx)
+      status.issued && respIssueFail && status.issueTimer === params.issueTimerMaxValue.U
+    else false.B
     entryUpdate.status.robIdx                         := status.robIdx
     entryUpdate.status.fuType                         := IQFuType.readFuType(status.fuType, params.getFuCfgs.map(_.fuType))
     entryUpdate.status.srcStatus.zip(status.srcStatus).zipWithIndex.foreach { case ((srcStatusNext, srcStatus), srcIdx) =>
@@ -441,6 +448,12 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     entryUpdate.status.issueTimer                     := Mux(validReg && status.issued, updateIssueTimer, 0.U)
     entryUpdate.status.deqPortIdx                     := Mux(commonIn.deqSel, commonIn.deqPortIdxWrite, Mux(status.issued, status.deqPortIdx, 0.U))
     entryUpdate.payload                               := entryReg.payload
+    entryUpdate.payload.debugLastIssueCancelSource.foreach ( _ := MuxCase(IQCancelSource.none, Seq(
+      ldIssueCancel -> IQCancelSource.ld,
+      og0IssueCancel -> IQCancelSource.og0,
+      og1IssueCancel -> IQCancelSource.og1,
+      stIssueCancel -> IQCancelSource.st,
+    )))
   }
 
   def CommonOutConnect(commonOut: CommonOutBundle, common: CommonWireBundle, hasIQWakeup: Option[CommonIQWakeupBundle], validReg: Bool, entryUpdate: EntryBundle, entryReg: EntryBundle, status: Status, commonIn: CommonInBundle, isEnq: Boolean, isComp: Boolean)(implicit p: Parameters, params: IssueBlockParams) = {
@@ -542,6 +555,9 @@ object EntryBundles extends HasCircularQueuePtrHelper {
       commonOut.perfLdCancel.get                      := common.srcCancelVec.map(_ && validReg)
       commonOut.perfOg0Cancel.get                     := hasIQWakeupGet.srcWakeupByIQButCancel.map(_.asUInt.orR && validReg)
       commonOut.perfWakeupByIQ.get                    := hasIQWakeupGet.srcWakeupByIQ.map(x => VecInit(x.map(_ && validReg)))
+    }
+    commonOut.debugCancelSource.zip(entryReg.payload.debugLastIssueCancelSource).foreach { case (sourceOut, cancelSource) =>
+      sourceOut                                      := cancelSource
     }
     // vecMem
     if (params.isVecMemIQ) {

--- a/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
+++ b/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
@@ -449,7 +449,7 @@ object EntryBundles extends HasCircularQueuePtrHelper {
     entryUpdate.status.issueTimer                     := Mux(validReg && status.issued, updateIssueTimer, 0.U)
     entryUpdate.status.deqPortIdx                     := Mux(commonIn.deqSel, commonIn.deqPortIdxWrite, Mux(status.issued, status.deqPortIdx, 0.U))
     entryUpdate.payload                               := entryReg.payload
-    entryUpdate.payload.debugLastIssueCancelSource.foreach ( _ := MuxCase(IQCancelSource.none, Seq(
+    entryUpdate.payload.debugLastIssueCancelSource.foreach ( _ := MuxCase(entryReg.payload.debugLastIssueCancelSource.get, Seq(
       ldIssueCancel -> IQCancelSource.ld,
       og0IssueCancel -> IQCancelSource.og0,
       og1IssueCancel -> IQCancelSource.og1,

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -222,9 +222,6 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
   val srcReadyVec = VecInit(entries.io.srcReady.asBools)
   val validVecRegNext = VecInit(entries.io.validRegNext.asBools)
   val issuedVecRegNext = VecInit(entries.io.issuedRegNext.asBools)
-  val cancelSourceVec = entries.io.debugCancelSourceVec.get
-  val debugSrcReadyVec = entries.io.debugSrcReadyVec.get
-  val robIdxVec = entries.io.debugRobIdxVec.get
   val fuTypeVec = Wire(Vec(params.numEntries, FuType()))
   io.validVec := validVec
   io.issuedVec := issuedVec
@@ -232,6 +229,9 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
   io.srcReadyVec := srcReadyVec
   io.debugRobIdxVec.foreach(_ := entries.io.debugRobIdxVec.get)
   io.topdownIQInfoVec.foreach{ case infoVec =>
+    val cancelSourceVec = entries.io.debugCancelSourceVec.get
+    val debugSrcReadyVec = entries.io.debugSrcReadyVec.get
+    val robIdxVec = entries.io.debugRobIdxVec.get
     infoVec.zip(cancelSourceVec).zip(validVec).zip(robIdxVec)
       .zip(debugSrcReadyVec).zip(fuTypeVec).zip(issuedVec).foreach{
       case ((((((sink, cancel),valid),robIdx), srcReady), fuType), issued) =>{

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -225,17 +225,20 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
   val cancelSourceVec = entries.io.debugCancelSourceVec.get
   val debugSrcReadyVec = entries.io.debugSrcReadyVec.get
   val robIdxVec = entries.io.debugRobIdxVec.get
+  val fuTypeVec = Wire(Vec(params.numEntries, FuType()))
   io.validVec := validVec
   io.issuedVec := issuedVec
   io.canIssueVec := canIssueVec
   io.srcReadyVec := srcReadyVec
   io.debugRobIdxVec.foreach(_ := entries.io.debugRobIdxVec.get)
   io.topdownIQInfoVec.foreach{ case infoVec =>
-    infoVec.zip(cancelSourceVec).zip(validVec).zip(robIdxVec).zip(debugSrcReadyVec).foreach{ case ((((sink, cancel),valid),robIdx), srcReady) =>
+    infoVec.zip(cancelSourceVec).zip(validVec).zip(robIdxVec).zip(debugSrcReadyVec).zip(fuTypeVec).foreach{
+      case (((((sink, cancel),valid),robIdx), srcReady), fuType) =>
       sink.valid := valid
       sink.bits.robIdx := robIdx
       sink.bits.cancelSource := cancel
       sink.bits.srcReady := srcReady
+      sink.bits.fuType := fuType
     }
   }
   dontTouch(canIssueVec)
@@ -248,7 +251,7 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
   // (deqIdx)(srcIdx)
   val finalExuSources: Option[Vec[Vec[ExuSource]]] = exuSources.map(x => VecInit(finalDeqSelOHVec.map(oh => Mux1H(oh, x))))
 
-  val fuTypeVec = Wire(Vec(params.numEntries, FuType()))
+
   io.fuTypeVec := fuTypeVec
   val deqEntryVec = Wire(Vec(params.numDeq, ValidIO(new EntryBundle(isDeq = true))))
   val canIssueMergeAllBusy = Wire(Vec(params.numDeq, UInt(params.numEntries.W)))

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -58,6 +58,8 @@ class IssueQueueIO()(implicit p: Parameters, params: IssueBlockParams) extends X
   val fuTypeVec = Output(Vec(params.numEntries, FuType()))
   val canIssueVec = Output(Vec(params.numEntries, Bool()))
   val srcReadyVec = Output(Vec(params.numEntries, Bool()))
+  val topdownIQInfoVec = Option.when(backendParams.debugEn)(Output(Vec(params.numEntries, ValidIO(new TopdownIQInfo()))))
+  val debugRobIdxVec =  Option.when(backendParams.debugEn)(Output(Vec(params.numEntries, new RobPtr())))
 
   val deqDelay: MixedVec[DecoupledIO[Og0InUop]] = params.genIssueDecoupledBundle// = deq.cloneType
   val deqOg1Payload: MixedVec[IssueQueueDeqOg1Payload] = params.genIssueDeqOg1PayloadBundle
@@ -219,10 +221,20 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
   val srcReadyVec = VecInit(entries.io.srcReady.asBools)
   val validVecRegNext = VecInit(entries.io.validRegNext.asBools)
   val issuedVecRegNext = VecInit(entries.io.issuedRegNext.asBools)
+  val cancelSourceVec = entries.io.debugCancelSourceVec.get
+  val robIdxVec = entries.io.debugRobIdxVec.get
   io.validVec := validVec
   io.issuedVec := issuedVec
   io.canIssueVec := canIssueVec
   io.srcReadyVec := srcReadyVec
+  io.debugRobIdxVec.foreach(_ := entries.io.debugRobIdxVec.get)
+  io.topdownIQInfoVec.foreach{ case infoVec =>
+    infoVec.zip(cancelSourceVec).zip(validVec).zip(robIdxVec).foreach{ case (((sink, cancel),valid),robIdx) =>
+      sink.valid := valid
+      sink.bits.robIdx := robIdx
+      sink.bits.cancelSource := cancel
+    }
+  }
   dontTouch(canIssueVec)
   val deqFirstIssueVec = entries.io.isFirstIssue
 
@@ -336,6 +348,7 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
       // dirty code, for uopidx and lastUop's assign
       enq.bits.payload.og1Payload.vpu.foreach(_.vuopIdx         := s0_enqBits(enqIdx).uopIdx.get)
       enq.bits.payload.og1Payload.vpu.foreach(_.lastUop         := s0_enqBits(enqIdx).lastUop.get)
+      enq.bits.payload.debugLastIssueCancelSource.foreach(_     := IQCancelSource.none)
     }
     entriesIO.og0Resp                                           := io.og0Resp
     entriesIO.og1Resp                                           := io.og1Resp

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -12,6 +12,7 @@ import xiangshan.backend.fu.{FuConfig, FuType}
 import xiangshan.backend.fu.FuConfig._
 import xiangshan.mem.{LqPtr, SqPtr}
 import utility.PerfCCT
+import xiangshan.backend.rob.RobPtr
 
 class IssueQueueIO()(implicit p: Parameters, params: IssueBlockParams) extends XSBundle {
   // Inputs
@@ -222,6 +223,7 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
   val validVecRegNext = VecInit(entries.io.validRegNext.asBools)
   val issuedVecRegNext = VecInit(entries.io.issuedRegNext.asBools)
   val cancelSourceVec = entries.io.debugCancelSourceVec.get
+  val debugSrcReadyVec = entries.io.debugSrcReadyVec.get
   val robIdxVec = entries.io.debugRobIdxVec.get
   io.validVec := validVec
   io.issuedVec := issuedVec
@@ -229,10 +231,11 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
   io.srcReadyVec := srcReadyVec
   io.debugRobIdxVec.foreach(_ := entries.io.debugRobIdxVec.get)
   io.topdownIQInfoVec.foreach{ case infoVec =>
-    infoVec.zip(cancelSourceVec).zip(validVec).zip(robIdxVec).foreach{ case (((sink, cancel),valid),robIdx) =>
+    infoVec.zip(cancelSourceVec).zip(validVec).zip(robIdxVec).zip(debugSrcReadyVec).foreach{ case ((((sink, cancel),valid),robIdx), srcReady) =>
       sink.valid := valid
       sink.bits.robIdx := robIdx
       sink.bits.cancelSource := cancel
+      sink.bits.srcReady := srcReady
     }
   }
   dontTouch(canIssueVec)

--- a/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueQueue.scala
@@ -232,13 +232,16 @@ class IssueQueueImp(implicit p: Parameters, params: IssueBlockParams) extends XS
   io.srcReadyVec := srcReadyVec
   io.debugRobIdxVec.foreach(_ := entries.io.debugRobIdxVec.get)
   io.topdownIQInfoVec.foreach{ case infoVec =>
-    infoVec.zip(cancelSourceVec).zip(validVec).zip(robIdxVec).zip(debugSrcReadyVec).zip(fuTypeVec).foreach{
-      case (((((sink, cancel),valid),robIdx), srcReady), fuType) =>
-      sink.valid := valid
-      sink.bits.robIdx := robIdx
-      sink.bits.cancelSource := cancel
-      sink.bits.srcReady := srcReady
-      sink.bits.fuType := fuType
+    infoVec.zip(cancelSourceVec).zip(validVec).zip(robIdxVec)
+      .zip(debugSrcReadyVec).zip(fuTypeVec).zip(issuedVec).foreach{
+      case ((((((sink, cancel),valid),robIdx), srcReady), fuType), issued) =>{
+        sink.valid := valid
+        sink.bits.robIdx := robIdx
+        sink.bits.cancelSource := cancel
+        sink.bits.srcReady := srcReady
+        sink.bits.fuType := fuType
+        sink.bits.issued := issued
+      }
     }
   }
   dontTouch(canIssueVec)

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -97,6 +97,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     val debugOutValidVec = OptionWrapper(backendParams.debugEn, Vec(RenameWidth, Input(Bool())))
     val debugRobHeadFuType = Option.when(backendParams.debugEn)(Input(FuType()))
     val debugRobHeadStall = Option.when(backendParams.debugEn)(Input(Bool()))
+    val debugRobHeadIssueCancelStall = Option.when(backendParams.debugEn)(Input(Bool()))
     val debugLoadReason = Option.when(backendParams.debugEn)(Input(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))
     val stallReason = new Bundle {
       val in = Flipped(new StallReasonIO(RenameWidth))
@@ -951,6 +952,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
 
   // TODO make all stall reason option to remove getorElse
   val robHeadStall = io.debugRobHeadStall.getOrElse(false.B)
+  val robIssueCancel = io.debugRobHeadIssueCancelStall.getOrElse(false.B)
   val robHeadFutype = io.debugRobHeadFuType.getOrElse(0.U)
   val ldReason = io.debugLoadReason.getOrElse(0.U)
 
@@ -964,13 +966,14 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   ))
   val freelistStall = intFlStall || fpFlStall || vecFlStall || v0FlStall || vlFlStall
   val freelistStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
-    robHeadStall  -> robHeadStallReason,
-    multiFlStall  -> MultiFlStall.id.U,
-    intFlStall    -> IntFlStall.id.U,
-    fpFlStall     -> FpFlStall.id.U,
-    vecFlStall    -> VecFlStall.id.U,
-    v0FlStall     -> V0FlStall.id.U,
-    vlFlStall     -> VlFlStall.id.U,
+    robIssueCancel -> IssueCancelStall.id.U,
+    robHeadStall   -> robHeadStallReason,
+    multiFlStall   -> MultiFlStall.id.U,
+    intFlStall     -> IntFlStall.id.U,
+    fpFlStall      -> FpFlStall.id.U,
+    vecFlStall     -> VecFlStall.id.U,
+    v0FlStall      -> V0FlStall.id.U,
+    vlFlStall      -> VlFlStall.id.U,
   ))
   renameStallReason := MuxCase(BackendOtherCoreStall.id.U, Seq(
     redirectStall -> redirectStallReason,

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -95,10 +95,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     // perf only
     val debugDispatchAllFire = OptionWrapper(backendParams.debugEn, Input(Bool()))
     val debugOutValidVec = OptionWrapper(backendParams.debugEn, Vec(RenameWidth, Input(Bool())))
-    val debugRobHeadFuType = Option.when(backendParams.debugEn)(Input(FuType()))
-    val debugRobHeadStall = Option.when(backendParams.debugEn)(Input(Bool()))
-    val debugRobHeadIssueCancelStall = Option.when(backendParams.debugEn)(Input(Bool()))
-    val debugLoadReason = Option.when(backendParams.debugEn)(Input(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))
+    val debugRobHeadStall = Option.when(backendParams.debugEn)(Flipped(ValidIO(Input(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))))
     val stallReason = new Bundle {
       val in = Flipped(new StallReasonIO(RenameWidth))
       val out = new StallReasonIO(RenameWidth)
@@ -951,22 +948,11 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   )) > 1.U
 
   // TODO make all stall reason option to remove getorElse
-  val robHeadStall = io.debugRobHeadStall.getOrElse(false.B)
-  val robIssueCancel = io.debugRobHeadIssueCancelStall.getOrElse(false.B)
-  val robHeadFutype = io.debugRobHeadFuType.getOrElse(0.U)
-  val ldReason = io.debugLoadReason.getOrElse(0.U)
+  val robHeadStall = io.debugRobHeadStall.map(_.valid).getOrElse(false.B)
+  val robHeadStallReason = io.debugRobHeadStall.map(_.bits).getOrElse(0.U)
 
-  val robHeadStallReason = MuxCase(OtherNotReadyStall.id.U, Seq(
-    FuType.isAMO(robHeadFutype)          -> AtomicStall.id.U          ,
-    FuType.isStoreVstore(robHeadFutype)  -> StoreStall.id.U           ,
-    FuType.isLoadVload(robHeadFutype)    -> ldReason                  ,
-    FuType.isDivSqrt(robHeadFutype)      -> DivStall.id.U             ,
-    FuType.isInt(robHeadFutype)          -> IntNotReadyStall.id.U     ,
-    FuType.isFArith(robHeadFutype)       -> FPNotReadyStall.id.U      ,
-  ))
   val freelistStall = intFlStall || fpFlStall || vecFlStall || v0FlStall || vlFlStall
   val freelistStallReason = MuxCase(BackendOtherCoreStall.id.U, Seq(
-    robIssueCancel -> IssueCancelStall.id.U,
     robHeadStall   -> robHeadStallReason,
     multiFlStall   -> MultiFlStall.id.U,
     intFlStall     -> IntFlStall.id.U,

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -126,7 +126,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     val debugBlockBackward = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugWaitForward   = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(IssueQueueDeqSum, Flipped(ValidIO(new RobPtr()))))
-    val topdownIQInfoVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new TopdownIQInfo())))))
+    val topdownIQInfoVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new TopdownIQExtendedInfo())))))
     val debugRobHeadStall = Option.when(backendParams.debugEn)(ValidIO(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))
     val debugEnqLsq = Input(new LsqEnqIO)
     val debugHeadLsIssue = Input(Bool())
@@ -1551,6 +1551,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val bypassLatency = 3.U
   val writeBackLatency = 1.U
 
+
   val candidateIQDeqVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.IssueQueueDeqSum, Bool()))))
   candidateIQDeqVec.foreach( _ := VecInit.tabulate(RobSize, io.IssueQueueDeqSum){ (index, i) =>
     val deq = io.debugIQDeqRobIdxVec.get(i)
@@ -1572,20 +1573,23 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       val hasWriteBack = robEntries(i).uopNum === 0.U
       val isRobHead = i.U === deqPtr.value
       val issued = candidateIQDeqVec.get(i).reduce(_ || _)
+
       val topdownIQInfoCandidate = candidateTopdownIQInfoVec.get(i)
-      val topdownIQInfo = PriorityMuxDefault(topdownIQInfoCandidate.zip(io.topdownIQInfoVec.get.map(_.bits)), 0.U.asTypeOf(new TopdownIQInfo()))
+      val topdownIQInfo = PriorityMuxDefault(topdownIQInfoCandidate.zip(io.topdownIQInfoVec.get.map(_.bits)),
+        0.U.asTypeOf(new TopdownIQExtendedInfo()))
       val topdownIQCancelSource = topdownIQInfo.cancelSource
-      val topdownIQSrcReady = topdownIQInfo.srcReady
+      val topdownIQIdealIssue = topdownIQInfo.idealIssueTime
+
       val topdownCanceledUpdate = issued && robEntries(i).topdownIssued.get || robEntries(i).topdownCanceled.get
       val topdownIssuedUpdate = issued || robEntries(i).topdownIssued.get
       val topdownRobHeadUpdate = isRobHead || robEntries(i).topdownRobHead.get
-      val topdownSrcReadyUpdate = topdownIQSrcReady || robEntries(i).topdownSrcReady.get
+      val topdownIdealIssueUpdate = topdownIQIdealIssue || robEntries(i).topdownIdealIssue.get
       val topdownCancelSrcUpdate = Mux(topdownCanceledUpdate, topdownIQCancelSource, robEntries(i).topdownCanceled.get)
 
       robEntries(i).topdownCanceled.foreach(_ := topdownCanceledUpdate)
       robEntries(i).topdownIssued.foreach(_ := topdownIssuedUpdate)
       robEntries(i).topdownRobHead.foreach(_ := topdownRobHeadUpdate)
-      robEntries(i).topdownSrcReady.foreach(_ := topdownSrcReadyUpdate)
+      robEntries(i).topdownIdealIssue.foreach(_ := topdownIdealIssueUpdate)
 
       robEntries(i).topdownIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
         robEntries(i).topdownIssueTime.get +& topdownIssuedUpdate))
@@ -1595,10 +1599,10 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       ))
       robEntries(i).topdownRobHeadTime.foreach(_ := Mux(hasWriteBack , 0.U,
         robEntries(i).topdownRobHeadTime.get +& topdownRobHeadUpdate))
-      // only
-      robEntries(i).topdownLastShouldIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
-        Mux(topdownIQSrcReady && !robEntries(i).topdownSrcReady.get , 1.U,
-          robEntries(i).topdownLastShouldIssueTime.get +& robEntries(i).topdownSrcReady.get)
+      // only caculate rising edge of ideal issue
+      robEntries(i).topdownIdealIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
+        Mux(topdownIQIdealIssue && !robEntries(i).topdownIdealIssue.get , 1.U,
+          robEntries(i).topdownIdealIssueTime.get +& robEntries(i).topdownIdealIssue.get)
       ))
       robEntries(i).topdownCancelSource.foreach(_ := topdownCancelSrcUpdate)
     }
@@ -1609,19 +1613,19 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     val deqEntryNormalLatency = Mux1H(deqEntry.debug_fuType.get, sortedFulatency) +& bypassLatency +& writeBackLatency
     val issueTime = deqEntry.topdownIssueTime.get
     val lastIssueTime = deqEntry.topdownLastIssueTime.get
-    val lastShouldIssueTime = deqEntry.topdownLastShouldIssueTime.get
+    val lastIdealIssueTime = deqEntry.topdownIdealIssueTime.get
     val robHeadTime = deqEntry.topdownRobHeadTime.get
     val issued = candidateIQDeqVec.get(deqPtr.value).reduce(_ || _)
     when(deqEntry.valid){
       assert(issueTime >= lastIssueTime)
-      assert(lastIssueTime <= lastShouldIssueTime)
+      assert(lastIssueTime <= lastIdealIssueTime)
     }
     val waitTime = issueTime - robHeadTime
     val robHeadFutype = deqEntry.debug_fuType.get
     val robHeadExecStall = deqEntry.valid && (lastIssueTime > deqEntryNormalLatency) && (lastIssueTime > waitTime)
     val robHeadNotIssued = deqEntry.valid && (!deqEntry.topdownIssued.get && !issued)
     val robHeadIssueCancel = deqEntry.valid && deqEntry.topdownCanceled.get && (issueTime > deqEntryNormalLatency)
-    val robHeadIssueDelay = deqEntry.valid && (lastShouldIssueTime > deqEntryNormalLatency)
+    val robHeadIssueDelay = deqEntry.valid && (lastIdealIssueTime > deqEntryNormalLatency)
     val robHeadExecStallReason =  MuxCase(OtherNotReadyStall.id.U, Seq(
       FuType.isAMO(robHeadFutype)          -> AtomicStall.id.U          ,
       FuType.isStoreVstore(robHeadFutype)  -> StoreStall.id.U           ,

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -126,6 +126,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     val debugWaitForward   = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(IssueQueueDeqSum, Flipped(ValidIO(new RobPtr()))))
     val debugRobHeadStall = Option.when(backendParams.debugEn)(Output(Bool()))
+    val debugRobHeadIssueCancelStall = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugEnqLsq = Input(new LsqEnqIO)
     val debugHeadLsIssue = Input(Bool())
     val lsTopdownInfo = Vec(LduCnt + HyuCnt, Input(new LsTopdownInfo))
@@ -1539,7 +1540,10 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   })
   for (i <- 0 until RobSize) {
     when(robEntries(i).valid){
-      robEntries(i).topdownIssued.foreach(_ := candidateVec.get(i).reduce(_ || _) || robEntries(i).topdownIssued.get)
+      val issued = candidateVec.get(i).reduce(_ || _)
+      robEntries(i).topdownCanceled.foreach(_ := (issued && robEntries(i).topdownIssued.get)
+        || robEntries(i).topdownCanceled.get)
+      robEntries(i).topdownIssued.foreach(_ := issued || robEntries(i).topdownIssued.get)
     }
   }
   if (backendParams.debugEn) {
@@ -1549,15 +1553,23 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   for (i <- 0 until RobSize) {
     when(robEntries(i).valid){
       val hasWriteBack = robEntries(i).uopNum === 0.U
+      val issued = candidateVec.get(i).reduce(_ || _)
       robEntries(i).topdownIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
         robEntries(i).topdownIssueTime.get +& robEntries(i).topdownIssued.get) )
+      robEntries(i).topdownLastIssueTime.foreach(_ := Mux(hasWriteBack || issued , 0.U,
+        robEntries(i).topdownLastIssueTime.get +& robEntries(i).topdownIssued.get))
     }
   }
 
   io.debugRobHeadStall.foreach{ case stall =>
     val deqEntry = robEntries(deqPtr.value)
     val deqEntryNormalLatency = Mux1H(deqEntry.debug_fuType.get, sortedFulatency) +& bypassLatency +& writeBackLatency
-    stall := deqEntry.valid && (robEntries(deqPtr.value).topdownIssueTime.get > deqEntryNormalLatency)
+    stall := deqEntry.valid && (deqEntry.topdownLastIssueTime.get > deqEntryNormalLatency)
+  }
+  io.debugRobHeadIssueCancelStall.foreach{ case cancel =>
+    val deqEntry = robEntries(deqPtr.value)
+    val deqEntryNormalLatency = Mux1H(deqEntry.debug_fuType.get, sortedFulatency) +& bypassLatency +& writeBackLatency
+    cancel := deqEntry.valid && deqEntry.topdownCanceled.get && (deqEntry.topdownIssueTime.get > deqEntryNormalLatency)
   }
 
   //difftest signals

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -34,8 +34,7 @@ import utility._
 import utils._
 import xiangshan._
 import xiangshan.PerfDebugInfo
-import xiangshan.backend.GPAMemEntry
-import xiangshan.backend.{BackendParams, RatToVecExcpMod, RegWriteFromRab, VecExcpInfo}
+import xiangshan.backend.{BackendParams, Bundles, GPAMemEntry, RatToVecExcpMod, RegWriteFromRab, VecExcpInfo}
 import xiangshan.backend.Bundles._
 import xiangshan.backend.decode.isa.bitfield.XSInstBitFields
 import xiangshan.backend.fu.{FuConfig, FuType}
@@ -49,6 +48,8 @@ import xiangshan.backend.rob.RobBundles._
 import xiangshan.backend.trace._
 import chisel3.experimental.BundleLiterals._
 import chisel3.util.experimental.decode.TruthTable
+import xiangshan.TopDownCounters._
+import xiangshan.backend.dispatch._
 
 class Rob(params: BackendParams)(implicit p: Parameters) extends LazyModule with HasXSParameter {
   override def shouldBeInlined: Boolean = false
@@ -121,12 +122,12 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     })
     val IssueQueueDeqSum  = backendParams.allIssueParams.map(_.numDeq).sum
     val debug_ls = Flipped(new DebugLSIO)
-    val debugRobHeadFuType = Output(FuType())
     val debugBlockBackward = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugWaitForward   = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(IssueQueueDeqSum, Flipped(ValidIO(new RobPtr()))))
-    val debugRobHeadStall = Option.when(backendParams.debugEn)(Output(Bool()))
-    val debugRobHeadIssueCancelStall = Option.when(backendParams.debugEn)(Output(Bool()))
+    val debugIQSrcReadyVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new RobPtr())))))
+    val topdownIQInfoVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new TopdownIQInfo())))))
+    val debugRobHeadStall = Option.when(backendParams.debugEn)(ValidIO(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))
     val debugEnqLsq = Input(new LsqEnqIO)
     val debugHeadLsIssue = Input(Bool())
     val lsTopdownInfo = Vec(LduCnt + HyuCnt, Input(new LsTopdownInfo))
@@ -134,6 +135,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       val toCore = new RobCoreTopDownIO
       val toDispatch = new RobDispatchTopDownIO
       val robHeadLqIdx = Valid(new LqPtr)
+      val fromCore = new CoreDispatchTopDownIO
     }
     val debugRolling = new RobDebugRollingIO
     val debugInstrAddrTransType = Input(new AddrTransType)
@@ -368,9 +370,6 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val fflagsDataRead = Wire(Vec(CommitWidth, UInt(5.W)))
   val vxsatDataRead = Wire(Vec(CommitWidth, Bool()))
   io.robDeqPtr := deqPtr
-
-  // topdown
-  io.debugRobHeadFuType := robEntries(deqPtr.value).debug_fuType.getOrElse(0.U.asTypeOf(FuType()))
 
 
   /**
@@ -1525,6 +1524,25 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   }
 
   // topdown
+  val notIssue = !debug_lsIssue(deqPtr.value)
+  val tlbReplay = io.debugTopDown.fromCore.fromMem.robHeadTlbReplay
+  val tlbMiss = io.debugTopDown.fromCore.fromMem.robHeadTlbMiss
+  val vioReplay = io.debugTopDown.fromCore.fromMem.robHeadLoadVio
+  val mshrReplay = io.debugTopDown.fromCore.fromMem.robHeadLoadMSHR
+  val l1Miss = io.debugTopDown.fromCore.fromMem.robHeadMissInDCache
+  val l2Miss = io.debugTopDown.fromCore.l2MissMatch
+  val l3Miss = io.debugTopDown.fromCore.l3MissMatch
+  val ldReason = Mux(l3Miss, LoadMemStall.id.U,
+    Mux(l2Miss, LoadL3Stall.id.U,
+      Mux(l1Miss, LoadL2Stall.id.U,
+        Mux(notIssue, MemNotReadyStall.id.U,
+          Mux(tlbMiss, LoadTLBStall.id.U,
+            Mux(tlbReplay, LoadTLBStall.id.U,
+              Mux(mshrReplay, LoadMSHRReplayStall.id.U,
+                Mux(vioReplay, LoadVioReplayStall.id.U,
+                  LoadL1Stall.id.U))))))))
+
+
   val allIssueParams = backendParams.allIssueParams.filter(_.StdCnt == 0)
   val allExuParams = allIssueParams.map(_.exuBlockParams).flatten
   val allFuConfigs = allExuParams.map(_.fuConfigs).flatten.toSet.toSeq
@@ -1538,38 +1556,96 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     val deq = io.debugIQDeqRobIdxVec.get(i)
     deq.valid && (deq.bits.value === index.U)
   })
-  for (i <- 0 until RobSize) {
-    when(robEntries(i).valid){
-      val issued = candidateVec.get(i).reduce(_ || _)
-      robEntries(i).topdownCanceled.foreach(_ := (issued && robEntries(i).topdownIssued.get)
-        || robEntries(i).topdownCanceled.get)
-      robEntries(i).topdownIssued.foreach(_ := issued || robEntries(i).topdownIssued.get)
-    }
-  }
+  val candidateSrcReadyVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.iqEntryNum, Bool()))))
+  candidateSrcReadyVec.foreach( _ := VecInit.tabulate(RobSize, io.iqEntryNum){ (index, i) =>
+    val srcReady = io.debugIQSrcReadyVec.get(i)
+    srcReady.valid && (srcReady.bits.value === index.U)
+  })
+  val candidateTopdownIQInfoVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.iqEntryNum, Bool()))))
+  candidateTopdownIQInfoVec.foreach( _ := VecInit.tabulate(RobSize, io.iqEntryNum){ (index, i) =>
+    val topdownIQInfo = io.topdownIQInfoVec.get(i)
+    topdownIQInfo.valid && (topdownIQInfo.bits.robIdx.value === index.U)
+  })
+
   if (backendParams.debugEn) {
-    dontTouch(candidateVec.get)
+    dontTouch(candidateIQDeqVec.get)
+    dontTouch(candidateSrcReadyVec.get)
+    dontTouch(candidateTopdownIQInfoVec.get)
   }
 
   for (i <- 0 until RobSize) {
     when(robEntries(i).valid){
       val hasWriteBack = robEntries(i).uopNum === 0.U
-      val issued = candidateVec.get(i).reduce(_ || _)
+      val isRobHead = i.U === deqPtr.value
+      val issued = candidateIQDeqVec.get(i).reduce(_ || _)
+      val srcReady = candidateSrcReadyVec.get(i).reduce(_ || _)
+      val topdownIQInfoCandidate = candidateTopdownIQInfoVec.get(i)
+      val topdownIQInfo = PriorityMuxDefault(topdownIQInfoCandidate.zip(io.topdownIQInfoVec.get.map(_.bits)), 0.U.asTypeOf(new TopdownIQInfo()))
+      val topdownIQCancelSource = topdownIQInfo.cancelSource
+      val topdownCanceledUpdate = issued && robEntries(i).topdownIssued.get || robEntries(i).topdownCanceled.get
+      val topdownIssuedUpdate = issued || robEntries(i).topdownIssued.get
+      val topdownRobHeadUpdate = isRobHead || robEntries(i).topdownRobHead.get
+      val topdownSrcReadyUpdate = srcReady || robEntries(i).topdownSrcReady.get
+      val topdownCancelSrcUpdate = Mux(topdownCanceledUpdate, topdownIQCancelSource, robEntries(i).topdownCanceled.get)
+
+      robEntries(i).topdownCanceled.foreach(_ := topdownCanceledUpdate)
+      robEntries(i).topdownIssued.foreach(_ := topdownIssuedUpdate)
+      robEntries(i).topdownRobHead.foreach(_ := topdownRobHeadUpdate)
+
       robEntries(i).topdownIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
-        robEntries(i).topdownIssueTime.get +& robEntries(i).topdownIssued.get) )
-      robEntries(i).topdownLastIssueTime.foreach(_ := Mux(hasWriteBack || issued , 0.U,
-        robEntries(i).topdownLastIssueTime.get +& robEntries(i).topdownIssued.get))
+        robEntries(i).topdownIssueTime.get +& topdownIssuedUpdate))
+      robEntries(i).topdownLastIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
+        Mux(issued, 1.U,
+          robEntries(i).topdownLastIssueTime.get +& robEntries(i).topdownIssued.get)
+      ))
+      robEntries(i).topdownRobHeadTime.foreach(_ := Mux(hasWriteBack , 0.U,
+        robEntries(i).topdownRobHeadTime.get +& topdownRobHeadUpdate))
+      robEntries(i).topdownLastShouldIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
+        Mux(srcReady, 1.U,
+          robEntries(i).topdownLastShouldIssueTime.get +& robEntries(i).topdownSrcReady.get)
+      ))
+      robEntries(i).topdownCancelSource.foreach(_ := topdownCancelSrcUpdate)
     }
   }
 
   io.debugRobHeadStall.foreach{ case stall =>
     val deqEntry = robEntries(deqPtr.value)
     val deqEntryNormalLatency = Mux1H(deqEntry.debug_fuType.get, sortedFulatency) +& bypassLatency +& writeBackLatency
-    stall := deqEntry.valid && (deqEntry.topdownLastIssueTime.get > deqEntryNormalLatency)
-  }
-  io.debugRobHeadIssueCancelStall.foreach{ case cancel =>
-    val deqEntry = robEntries(deqPtr.value)
-    val deqEntryNormalLatency = Mux1H(deqEntry.debug_fuType.get, sortedFulatency) +& bypassLatency +& writeBackLatency
-    cancel := deqEntry.valid && deqEntry.topdownCanceled.get && (deqEntry.topdownIssueTime.get > deqEntryNormalLatency)
+    val issueTime = deqEntry.topdownIssueTime.get
+    val lastIssueTime = deqEntry.topdownLastIssueTime.get
+    val issued = candidateVec.get(deqPtr.value).reduce(_ || _)
+    when(deqEntry.valid){
+      assert(issueTime >= lastIssueTime)
+    }
+    val robHeadTime = deqEntry.topdownRobHeadTime.get
+    val waitTime = issueTime - robHeadTime
+    val robHeadFutype = deqEntry.debug_fuType.get
+    val robHeadExecStall = deqEntry.valid && (lastIssueTime > deqEntryNormalLatency) && (lastIssueTime > waitTime)
+    val robHeadNotIssued = deqEntry.valid && (!deqEntry.topdownIssued.get && !issued)
+    val robHeadIssueCancel = deqEntry.valid && deqEntry.topdownCanceled.get && (issueTime > deqEntryNormalLatency)
+    val robHeadExecStallReason =  MuxCase(OtherNotReadyStall.id.U, Seq(
+      FuType.isAMO(robHeadFutype)          -> AtomicStall.id.U          ,
+      FuType.isStoreVstore(robHeadFutype)  -> StoreStall.id.U           ,
+      FuType.isLoadVload(robHeadFutype)    -> ldReason                  ,
+      FuType.isDivSqrt(robHeadFutype)      -> DivStall.id.U             ,
+      FuType.isInt(robHeadFutype)          -> IntNotReadyStall.id.U     ,
+      FuType.isFArith(robHeadFutype)       -> FPNotReadyStall.id.U      ,
+    ))
+
+    val robHeadCancelSource = deqEntry.topdownCancelSource.get
+    val cancelStallReason = MuxCase(IssueCancelStallOther.id.U, Seq(
+      IQCancelSource.isog0(robHeadCancelSource) -> IssueCancelStallOg0.id.U  ,
+      IQCancelSource.isog1(robHeadCancelSource) -> IssueCancelStallOg1.id.U  ,
+      IQCancelSource.isld(robHeadCancelSource)  -> IssueCancelStallLd.id.U   ,
+      IQCancelSource.isst(robHeadCancelSource)  -> IssueCancelStallSt.id.U   ,
+    ))
+    stall.valid := robHeadExecStall || robHeadNotIssued || robHeadIssueCancel
+    stall.bits := MuxCase(BackendOtherCoreStall.id.U, Seq(
+      robHeadNotIssued                    -> RobHeadNotIssued.id.U     ,
+      robHeadExecStall                    -> robHeadExecStallReason    ,
+      robHeadIssueDelay                   -> IssueDelayStall.id.U      ,
+      robHeadIssueCancel                  -> cancelStallReason         ,
+    ))
   }
 
   //difftest signals

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1552,15 +1552,6 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val writeBackLatency = 1.U
 
 
-//  val candidateTopdownIQInfoVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.iqEntryNum, Bool()))))
-//  candidateTopdownIQInfoVec.foreach( _ := VecInit.tabulate(RobSize, io.iqEntryNum){ (index, i) =>
-//    val topdownIQInfo = io.topdownIQInfoVec.get(i)
-//    topdownIQInfo.valid && (topdownIQInfo.bits.robIdx.value === index.U)
-//  })
-//
-//  if (backendParams.debugEn) {
-//    dontTouch(candidateTopdownIQInfoVec.get)
-//  }
   if (backendParams.debugEn) {
     val topdownRobInfoCollect = Module(new TopdownRobInfoCollect(io.iqEntryNum, RobSize))
     topdownRobInfoCollect.io.in.zip(io.topdownIQInfoVec.get).foreach{ case (sink, source) =>
@@ -1593,6 +1584,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
         val topdownIdealIssueUpdate = topdownIQIdealIssue || robEntries(i).topdownIdealIssue.get
         val topdownCancelSrcUpdate = Mux(topdownCanceled, topdownIQCancelSource,
           robEntries(i).topdownCancelSource.get)
+        val topdownCancelTimeUpdate = topdownCanceled
         robEntries(i).topdownCanceled.foreach(_ := topdownCanceledUpdate)
         robEntries(i).topdownIssued.foreach(_ := topdownIssuedUpdate)
         robEntries(i).topdownRobHead.foreach(_ := topdownRobHeadUpdate)
@@ -1612,6 +1604,12 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
             robEntries(i).topdownIdealIssueTime.get +& robEntries(i).topdownIdealIssue.get)
         ))
         robEntries(i).topdownCancelSource.foreach(_ := topdownCancelSrcUpdate)
+        robEntries(i).topdownCancelTimeVec.foreach(_.zipWithIndex.foreach{ case (cancelTime, index) =>
+          val cancelMatch = topdownCancelSrcUpdate === index.asUInt
+          cancelTime := Mux(hasWriteBack, 0.U,
+            Mux(topdownCanceled && cancelMatch, robEntries(i).topdownCancelTimeVec.get(index) + robEntries(i).topdownLastIssueTime.get,
+              robEntries(i).topdownCancelTimeVec.get(index) +& (cancelMatch & topdownCancelTimeUpdate)))
+        })
       }
     }
     io.debugRobHeadStall.foreach{ case stall =>
@@ -1635,7 +1633,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       val robHeadExecStall = deqEntry.valid && (lastIssueTime > deqEntryNormalLatency) && (lastIssueTime > waitTime)
       val robHeadNotIssued = deqEntry.valid && (!deqEntry.topdownIssued.get && !issued)
       val robHeadIssueCancel = deqEntry.valid && deqEntry.topdownCanceled.get && (issueTime > deqEntryNormalLatency)
-      // issueDelay priority than cancel only calculate idealWaitTime stall
+      // issueDelay priority than cancel; only calculate idealWaitTime stall
       val robHeadIssueDelay = deqEntry.valid && (idealIssueTime > deqEntryNormalLatency) &&
         (robHeadTime < idealWaitTime)
       val robHeadExecStallReason =  MuxCase(OtherNotReadyStall.id.U, Seq(
@@ -1648,12 +1646,34 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       ))
 
       val robHeadCancelSource = deqEntry.topdownCancelSource.get
+
+      val cancelTimeVec = deqEntry.topdownCancelTimeVec.get
+      val cancelTimeFixVec = deqEntry.topdownCancelTimeFixVec.get
+      val fixedCancelTimeVec = cancelTimeVec.zip(cancelTimeFixVec).map{ case (time, fix) =>
+        Mux(time < fix, 0.U, time - fix)
+      }
+      val maxCancelTime = fixedCancelTimeVec.reduce{ (a,b) => Mux(a > b, a, b)}
+      val maxCancelTimeVec = VecInit(fixedCancelTimeVec.map(_ === maxCancelTime)).asUInt
+      val lastMaxCancelTimeOH = Reverse(PriorityEncoderOH(Reverse(maxCancelTimeVec)))
+      val lastMaxIdx = OHToUInt(lastMaxCancelTimeOH)
+      val cancelTimeFixUpdateVec = VecInit(cancelTimeFixVec.zip(lastMaxCancelTimeOH.asBools).map{
+        case (time, hit) => time +& hit
+      })
+
+      if (backendParams.debugEn){
+        dontTouch(VecInit(lastMaxCancelTimeOH.asBools))
+      }
+
+
       val cancelStallReason = MuxCase(IssueCancelStallOther.id.U, Seq(
-        IQCancelSource.isog0(robHeadCancelSource) -> IssueCancelStallOg0.id.U  ,
-        IQCancelSource.isog1(robHeadCancelSource) -> IssueCancelStallOg1.id.U  ,
-        IQCancelSource.isld(robHeadCancelSource)  -> IssueCancelStallLd.id.U   ,
-        IQCancelSource.isst(robHeadCancelSource)  -> IssueCancelStallSt.id.U   ,
+        IQCancelSource.isog0(lastMaxIdx) -> IssueCancelStallOg0.id.U  ,
+        IQCancelSource.isog1(lastMaxIdx) -> IssueCancelStallOg1.id.U  ,
+        IQCancelSource.isld(lastMaxIdx)  -> IssueCancelStallLd.id.U   ,
+        IQCancelSource.isst(lastMaxIdx)  -> IssueCancelStallSt.id.U   ,
       ))
+      deqEntry.topdownCancelTimeFixVec.foreach(_ := cancelTimeFixUpdateVec)
+
+
       stall.valid := robHeadExecStall || robHeadNotIssued || robHeadIssueCancel || robHeadIssueDelay
       stall.bits := MuxCase(BackendOtherCoreStall.id.U, Seq(
         robHeadNotIssued                    -> RobHeadNotIssued.id.U     ,

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -121,11 +121,11 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       val excpInfo = ValidIO(new VecExcpInfo)
     })
     val IssueQueueDeqSum  = backendParams.allIssueParams.map(_.numDeq).sum
+    val iqEntryNum = backendParams.allIssueParams.map(_.numEntries).sum
     val debug_ls = Flipped(new DebugLSIO)
     val debugBlockBackward = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugWaitForward   = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(IssueQueueDeqSum, Flipped(ValidIO(new RobPtr()))))
-    val debugIQSrcReadyVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new RobPtr())))))
     val topdownIQInfoVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new TopdownIQInfo())))))
     val debugRobHeadStall = Option.when(backendParams.debugEn)(ValidIO(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))
     val debugEnqLsq = Input(new LsqEnqIO)
@@ -1551,15 +1551,10 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val bypassLatency = 3.U
   val writeBackLatency = 1.U
 
-  val candidateVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.IssueQueueDeqSum, Bool()))))
-  candidateVec.foreach( _ := VecInit.tabulate(RobSize, io.IssueQueueDeqSum){ (index, i) =>
+  val candidateIQDeqVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.IssueQueueDeqSum, Bool()))))
+  candidateIQDeqVec.foreach( _ := VecInit.tabulate(RobSize, io.IssueQueueDeqSum){ (index, i) =>
     val deq = io.debugIQDeqRobIdxVec.get(i)
     deq.valid && (deq.bits.value === index.U)
-  })
-  val candidateSrcReadyVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.iqEntryNum, Bool()))))
-  candidateSrcReadyVec.foreach( _ := VecInit.tabulate(RobSize, io.iqEntryNum){ (index, i) =>
-    val srcReady = io.debugIQSrcReadyVec.get(i)
-    srcReady.valid && (srcReady.bits.value === index.U)
   })
   val candidateTopdownIQInfoVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.iqEntryNum, Bool()))))
   candidateTopdownIQInfoVec.foreach( _ := VecInit.tabulate(RobSize, io.iqEntryNum){ (index, i) =>
@@ -1569,7 +1564,6 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
 
   if (backendParams.debugEn) {
     dontTouch(candidateIQDeqVec.get)
-    dontTouch(candidateSrcReadyVec.get)
     dontTouch(candidateTopdownIQInfoVec.get)
   }
 
@@ -1578,19 +1572,20 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       val hasWriteBack = robEntries(i).uopNum === 0.U
       val isRobHead = i.U === deqPtr.value
       val issued = candidateIQDeqVec.get(i).reduce(_ || _)
-      val srcReady = candidateSrcReadyVec.get(i).reduce(_ || _)
       val topdownIQInfoCandidate = candidateTopdownIQInfoVec.get(i)
       val topdownIQInfo = PriorityMuxDefault(topdownIQInfoCandidate.zip(io.topdownIQInfoVec.get.map(_.bits)), 0.U.asTypeOf(new TopdownIQInfo()))
       val topdownIQCancelSource = topdownIQInfo.cancelSource
+      val topdownIQSrcReady = topdownIQInfo.srcReady
       val topdownCanceledUpdate = issued && robEntries(i).topdownIssued.get || robEntries(i).topdownCanceled.get
       val topdownIssuedUpdate = issued || robEntries(i).topdownIssued.get
       val topdownRobHeadUpdate = isRobHead || robEntries(i).topdownRobHead.get
-      val topdownSrcReadyUpdate = srcReady || robEntries(i).topdownSrcReady.get
+      val topdownSrcReadyUpdate = topdownIQSrcReady || robEntries(i).topdownSrcReady.get
       val topdownCancelSrcUpdate = Mux(topdownCanceledUpdate, topdownIQCancelSource, robEntries(i).topdownCanceled.get)
 
       robEntries(i).topdownCanceled.foreach(_ := topdownCanceledUpdate)
       robEntries(i).topdownIssued.foreach(_ := topdownIssuedUpdate)
       robEntries(i).topdownRobHead.foreach(_ := topdownRobHeadUpdate)
+      robEntries(i).topdownSrcReady.foreach(_ := topdownSrcReadyUpdate)
 
       robEntries(i).topdownIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
         robEntries(i).topdownIssueTime.get +& topdownIssuedUpdate))
@@ -1600,8 +1595,9 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       ))
       robEntries(i).topdownRobHeadTime.foreach(_ := Mux(hasWriteBack , 0.U,
         robEntries(i).topdownRobHeadTime.get +& topdownRobHeadUpdate))
+      // only
       robEntries(i).topdownLastShouldIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
-        Mux(srcReady, 1.U,
+        Mux(topdownIQSrcReady && !robEntries(i).topdownSrcReady.get , 1.U,
           robEntries(i).topdownLastShouldIssueTime.get +& robEntries(i).topdownSrcReady.get)
       ))
       robEntries(i).topdownCancelSource.foreach(_ := topdownCancelSrcUpdate)
@@ -1613,16 +1609,19 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     val deqEntryNormalLatency = Mux1H(deqEntry.debug_fuType.get, sortedFulatency) +& bypassLatency +& writeBackLatency
     val issueTime = deqEntry.topdownIssueTime.get
     val lastIssueTime = deqEntry.topdownLastIssueTime.get
-    val issued = candidateVec.get(deqPtr.value).reduce(_ || _)
+    val lastShouldIssueTime = deqEntry.topdownLastShouldIssueTime.get
+    val robHeadTime = deqEntry.topdownRobHeadTime.get
+    val issued = candidateIQDeqVec.get(deqPtr.value).reduce(_ || _)
     when(deqEntry.valid){
       assert(issueTime >= lastIssueTime)
+      assert(lastIssueTime <= lastShouldIssueTime)
     }
-    val robHeadTime = deqEntry.topdownRobHeadTime.get
     val waitTime = issueTime - robHeadTime
     val robHeadFutype = deqEntry.debug_fuType.get
     val robHeadExecStall = deqEntry.valid && (lastIssueTime > deqEntryNormalLatency) && (lastIssueTime > waitTime)
     val robHeadNotIssued = deqEntry.valid && (!deqEntry.topdownIssued.get && !issued)
     val robHeadIssueCancel = deqEntry.valid && deqEntry.topdownCanceled.get && (issueTime > deqEntryNormalLatency)
+    val robHeadIssueDelay = deqEntry.valid && (lastShouldIssueTime > deqEntryNormalLatency)
     val robHeadExecStallReason =  MuxCase(OtherNotReadyStall.id.U, Seq(
       FuType.isAMO(robHeadFutype)          -> AtomicStall.id.U          ,
       FuType.isStoreVstore(robHeadFutype)  -> StoreStall.id.U           ,

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1369,6 +1369,12 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   XSPerfAccumulate("waitStuCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.stu.U)
   XSPerfAccumulate("waitAtmCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.mou.U)
 
+  XSPerfAccumulate("waitfaluCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.falu.U)
+  XSPerfAccumulate("waitfmacCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.fmac.U)
+  XSPerfAccumulate("waitfcvtCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.fcvt.U)
+  XSPerfAccumulate("waitfDivSqrtCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.fDivSqrt.U)
+  XSPerfAccumulate("waitfcmpCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.fcmp.U)
+
   XSPerfAccumulate("waitVfaluCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.vfalu.U)
   XSPerfAccumulate("waitVfmaCycle" , deqNotWritebacked && deqHeadInfoFuType === FuType.vfma.U)
   XSPerfAccumulate("waitVfdivCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.vfdiv.U)

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -29,6 +29,7 @@ import chisel3._
 import chisel3.util._
 import chisel3.experimental.BundleLiterals._
 import difftest._
+import difftest.common._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utility._
 import utils._
@@ -125,7 +126,6 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     val debug_ls = Flipped(new DebugLSIO)
     val debugBlockBackward = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugWaitForward   = Option.when(backendParams.debugEn)(Output(Bool()))
-    val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(IssueQueueDeqSum, Flipped(ValidIO(new RobPtr()))))
     val topdownIQInfoVec = Option.when(backendParams.debugEn)(Input(Vec(iqEntryNum, Flipped(ValidIO(new TopdownIQExtendedInfo())))))
     val debugRobHeadStall = Option.when(backendParams.debugEn)(ValidIO(UInt(log2Ceil(TopDownCounters.NumStallReasons.id).W)))
     val debugEnqLsq = Input(new LsqEnqIO)
@@ -1552,103 +1552,116 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   val writeBackLatency = 1.U
 
 
-  val candidateIQDeqVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.IssueQueueDeqSum, Bool()))))
-  candidateIQDeqVec.foreach( _ := VecInit.tabulate(RobSize, io.IssueQueueDeqSum){ (index, i) =>
-    val deq = io.debugIQDeqRobIdxVec.get(i)
-    deq.valid && (deq.bits.value === index.U)
-  })
-  val candidateTopdownIQInfoVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.iqEntryNum, Bool()))))
-  candidateTopdownIQInfoVec.foreach( _ := VecInit.tabulate(RobSize, io.iqEntryNum){ (index, i) =>
-    val topdownIQInfo = io.topdownIQInfoVec.get(i)
-    topdownIQInfo.valid && (topdownIQInfo.bits.robIdx.value === index.U)
-  })
-
+//  val candidateTopdownIQInfoVec = Option.when(backendParams.debugEn)(Wire(Vec(RobSize, Vec(io.iqEntryNum, Bool()))))
+//  candidateTopdownIQInfoVec.foreach( _ := VecInit.tabulate(RobSize, io.iqEntryNum){ (index, i) =>
+//    val topdownIQInfo = io.topdownIQInfoVec.get(i)
+//    topdownIQInfo.valid && (topdownIQInfo.bits.robIdx.value === index.U)
+//  })
+//
+//  if (backendParams.debugEn) {
+//    dontTouch(candidateTopdownIQInfoVec.get)
+//  }
   if (backendParams.debugEn) {
-    dontTouch(candidateIQDeqVec.get)
-    dontTouch(candidateTopdownIQInfoVec.get)
-  }
-
-  for (i <- 0 until RobSize) {
-    when(robEntries(i).valid){
-      val hasWriteBack = robEntries(i).uopNum === 0.U
-      val isRobHead = i.U === deqPtr.value
-      val issued = candidateIQDeqVec.get(i).reduce(_ || _)
-
-      val topdownIQInfoCandidate = candidateTopdownIQInfoVec.get(i)
-      val topdownIQInfo = PriorityMuxDefault(topdownIQInfoCandidate.zip(io.topdownIQInfoVec.get.map(_.bits)),
-        0.U.asTypeOf(new TopdownIQExtendedInfo()))
-      val topdownIQCancelSource = topdownIQInfo.cancelSource
-      val topdownIQIdealIssue = topdownIQInfo.idealIssueTime
-
-      val topdownCanceledUpdate = issued && robEntries(i).topdownIssued.get || robEntries(i).topdownCanceled.get
-      val topdownIssuedUpdate = issued || robEntries(i).topdownIssued.get
-      val topdownRobHeadUpdate = isRobHead || robEntries(i).topdownRobHead.get
-      val topdownIdealIssueUpdate = topdownIQIdealIssue || robEntries(i).topdownIdealIssue.get
-      val topdownCancelSrcUpdate = Mux(topdownCanceledUpdate, topdownIQCancelSource, robEntries(i).topdownCanceled.get)
-
-      robEntries(i).topdownCanceled.foreach(_ := topdownCanceledUpdate)
-      robEntries(i).topdownIssued.foreach(_ := topdownIssuedUpdate)
-      robEntries(i).topdownRobHead.foreach(_ := topdownRobHeadUpdate)
-      robEntries(i).topdownIdealIssue.foreach(_ := topdownIdealIssueUpdate)
-
-      robEntries(i).topdownIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
-        robEntries(i).topdownIssueTime.get +& topdownIssuedUpdate))
-      robEntries(i).topdownLastIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
-        Mux(issued, 1.U,
-          robEntries(i).topdownLastIssueTime.get +& robEntries(i).topdownIssued.get)
-      ))
-      robEntries(i).topdownRobHeadTime.foreach(_ := Mux(hasWriteBack , 0.U,
-        robEntries(i).topdownRobHeadTime.get +& topdownRobHeadUpdate))
-      // only caculate rising edge of ideal issue
-      robEntries(i).topdownIdealIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
-        Mux(topdownIQIdealIssue && !robEntries(i).topdownIdealIssue.get , 1.U,
-          robEntries(i).topdownIdealIssueTime.get +& robEntries(i).topdownIdealIssue.get)
-      ))
-      robEntries(i).topdownCancelSource.foreach(_ := topdownCancelSrcUpdate)
+    val topdownRobInfoCollect = Module(new TopdownRobInfoCollect(io.iqEntryNum, RobSize))
+    topdownRobInfoCollect.io.in.zip(io.topdownIQInfoVec.get).foreach{ case (sink, source) =>
+      sink.valid := source.valid
+      sink.robIdx := source.bits.robIdx.value
+      sink.robFlag := source.bits.robIdx.flag
+      sink.issued := source.bits.issued
+      sink.cancelSource := source.bits.cancelSource
+      sink.idealIssueTime := source.bits.idealIssueTime
     }
-  }
+    val topdownRobCandidate = topdownRobInfoCollect.io.out
+    for (i <- 0 until RobSize) {
+      when(robEntries(i).valid){
+        val hasWriteBack = robEntries(i).uopNum === 0.U
+        val isRobHead = i.U === deqPtr.value
 
-  io.debugRobHeadStall.foreach{ case stall =>
-    val deqEntry = robEntries(deqPtr.value)
-    val deqEntryNormalLatency = Mux1H(deqEntry.debug_fuType.get, sortedFulatency) +& bypassLatency +& writeBackLatency
-    val issueTime = deqEntry.topdownIssueTime.get
-    val lastIssueTime = deqEntry.topdownLastIssueTime.get
-    val lastIdealIssueTime = deqEntry.topdownIdealIssueTime.get
-    val robHeadTime = deqEntry.topdownRobHeadTime.get
-    val issued = candidateIQDeqVec.get(deqPtr.value).reduce(_ || _)
-    when(deqEntry.valid){
-      assert(issueTime >= lastIssueTime)
-      assert(lastIssueTime <= lastIdealIssueTime)
+        val topdownIQInfoCandidate = Mux(topdownRobCandidate(i).valid, topdownRobCandidate(i),
+          0.U.asTypeOf(new TopdownRobInfo))
+        val topdownIQInfoValid = topdownIQInfoCandidate.valid
+        val topdownIQIssued = topdownIQInfoCandidate.issued
+        val topdownIQIdealIssue = topdownIQInfoCandidate.idealIssueTime
+
+        val topdownIQCancelSource = topdownIQInfoCandidate.cancelSource
+
+        val topdownIssuedUpdate = topdownIQIssued || robEntries(i).topdownIssued.get
+        val topdownCanceled= !topdownIQIssued && robEntries(i).topdownIssued.get && topdownIQInfoValid &&
+          topdownIQCancelSource =/= IQCancelSource.none
+        val topdownCanceledUpdate = topdownCanceled || robEntries(i).topdownCanceled.get
+        val topdownRobHeadUpdate = isRobHead || robEntries(i).topdownRobHead.get
+        val topdownIdealIssueUpdate = topdownIQIdealIssue || robEntries(i).topdownIdealIssue.get
+        val topdownCancelSrcUpdate = Mux(topdownCanceled, topdownIQCancelSource,
+          robEntries(i).topdownCancelSource.get)
+        robEntries(i).topdownCanceled.foreach(_ := topdownCanceledUpdate)
+        robEntries(i).topdownIssued.foreach(_ := topdownIssuedUpdate)
+        robEntries(i).topdownRobHead.foreach(_ := topdownRobHeadUpdate)
+        robEntries(i).topdownIdealIssue.foreach(_ := topdownIdealIssueUpdate)
+
+        robEntries(i).topdownIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
+          robEntries(i).topdownIssueTime.get +& topdownIssuedUpdate))
+        robEntries(i).topdownLastIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
+          Mux(topdownCanceled, 0.U,
+            robEntries(i).topdownLastIssueTime.get +& topdownIssuedUpdate)
+        ))
+        robEntries(i).topdownRobHeadTime.foreach(_ := Mux(hasWriteBack , 0.U,
+          robEntries(i).topdownRobHeadTime.get +& topdownRobHeadUpdate))
+        // only caculate rising edge of ideal issue
+        robEntries(i).topdownIdealIssueTime.foreach(_ := Mux(hasWriteBack , 0.U,
+          Mux(topdownIQIdealIssue && !robEntries(i).topdownIdealIssue.get , 1.U,
+            robEntries(i).topdownIdealIssueTime.get +& robEntries(i).topdownIdealIssue.get)
+        ))
+        robEntries(i).topdownCancelSource.foreach(_ := topdownCancelSrcUpdate)
+      }
     }
-    val waitTime = issueTime - robHeadTime
-    val robHeadFutype = deqEntry.debug_fuType.get
-    val robHeadExecStall = deqEntry.valid && (lastIssueTime > deqEntryNormalLatency) && (lastIssueTime > waitTime)
-    val robHeadNotIssued = deqEntry.valid && (!deqEntry.topdownIssued.get && !issued)
-    val robHeadIssueCancel = deqEntry.valid && deqEntry.topdownCanceled.get && (issueTime > deqEntryNormalLatency)
-    val robHeadIssueDelay = deqEntry.valid && (lastIdealIssueTime > deqEntryNormalLatency)
-    val robHeadExecStallReason =  MuxCase(OtherNotReadyStall.id.U, Seq(
-      FuType.isAMO(robHeadFutype)          -> AtomicStall.id.U          ,
-      FuType.isStoreVstore(robHeadFutype)  -> StoreStall.id.U           ,
-      FuType.isLoadVload(robHeadFutype)    -> ldReason                  ,
-      FuType.isDivSqrt(robHeadFutype)      -> DivStall.id.U             ,
-      FuType.isInt(robHeadFutype)          -> IntNotReadyStall.id.U     ,
-      FuType.isFArith(robHeadFutype)       -> FPNotReadyStall.id.U      ,
-    ))
+    io.debugRobHeadStall.foreach{ case stall =>
+      val deqEntry = robEntries(deqPtr.value)
+      val deqEntryNormalLatency = Mux1H(deqEntry.debug_fuType.get, sortedFulatency) +& bypassLatency +& writeBackLatency
+      val issueTime = deqEntry.topdownIssueTime.get
+      val lastIssueTime = deqEntry.topdownLastIssueTime.get
+      val idealIssueTime = deqEntry.topdownIdealIssueTime.get
+      val robHeadTime = deqEntry.topdownRobHeadTime.get
 
-    val robHeadCancelSource = deqEntry.topdownCancelSource.get
-    val cancelStallReason = MuxCase(IssueCancelStallOther.id.U, Seq(
-      IQCancelSource.isog0(robHeadCancelSource) -> IssueCancelStallOg0.id.U  ,
-      IQCancelSource.isog1(robHeadCancelSource) -> IssueCancelStallOg1.id.U  ,
-      IQCancelSource.isld(robHeadCancelSource)  -> IssueCancelStallLd.id.U   ,
-      IQCancelSource.isst(robHeadCancelSource)  -> IssueCancelStallSt.id.U   ,
-    ))
-    stall.valid := robHeadExecStall || robHeadNotIssued || robHeadIssueCancel
-    stall.bits := MuxCase(BackendOtherCoreStall.id.U, Seq(
-      robHeadNotIssued                    -> RobHeadNotIssued.id.U     ,
-      robHeadExecStall                    -> robHeadExecStallReason    ,
-      robHeadIssueDelay                   -> IssueDelayStall.id.U      ,
-      robHeadIssueCancel                  -> cancelStallReason         ,
-    ))
+      val topdownIQInfoCandidate = topdownRobCandidate(deqPtr.value)
+      val issued = topdownIQInfoCandidate.issued && topdownIQInfoCandidate.valid
+
+      when(deqEntry.valid){
+        assert(issueTime >= lastIssueTime)
+        assert(issueTime <= idealIssueTime)
+      }
+      val waitTime = idealIssueTime - robHeadTime
+      val idealWaitTime = idealIssueTime - issueTime
+      val robHeadFutype = deqEntry.debug_fuType.get
+      val robHeadExecStall = deqEntry.valid && (lastIssueTime > deqEntryNormalLatency) && (lastIssueTime > waitTime)
+      val robHeadNotIssued = deqEntry.valid && (!deqEntry.topdownIssued.get && !issued)
+      val robHeadIssueCancel = deqEntry.valid && deqEntry.topdownCanceled.get && (issueTime > deqEntryNormalLatency)
+      // issueDelay priority than cancel only calculate idealWaitTime stall
+      val robHeadIssueDelay = deqEntry.valid && (idealIssueTime > deqEntryNormalLatency) &&
+        (robHeadTime < idealWaitTime)
+      val robHeadExecStallReason =  MuxCase(OtherNotReadyStall.id.U, Seq(
+        FuType.isAMO(robHeadFutype)          -> AtomicStall.id.U          ,
+        FuType.isStoreVstore(robHeadFutype)  -> StoreStall.id.U           ,
+        FuType.isLoadVload(robHeadFutype)    -> ldReason                  ,
+        FuType.isDivSqrt(robHeadFutype)      -> DivStall.id.U             ,
+        FuType.isInt(robHeadFutype)          -> IntNotReadyStall.id.U     ,
+        FuType.isFArith(robHeadFutype)       -> FPNotReadyStall.id.U      ,
+      ))
+
+      val robHeadCancelSource = deqEntry.topdownCancelSource.get
+      val cancelStallReason = MuxCase(IssueCancelStallOther.id.U, Seq(
+        IQCancelSource.isog0(robHeadCancelSource) -> IssueCancelStallOg0.id.U  ,
+        IQCancelSource.isog1(robHeadCancelSource) -> IssueCancelStallOg1.id.U  ,
+        IQCancelSource.isld(robHeadCancelSource)  -> IssueCancelStallLd.id.U   ,
+        IQCancelSource.isst(robHeadCancelSource)  -> IssueCancelStallSt.id.U   ,
+      ))
+      stall.valid := robHeadExecStall || robHeadNotIssued || robHeadIssueCancel || robHeadIssueDelay
+      stall.bits := MuxCase(BackendOtherCoreStall.id.U, Seq(
+        robHeadNotIssued                    -> RobHeadNotIssued.id.U     ,
+        robHeadExecStall                    -> robHeadExecStallReason    ,
+        robHeadIssueDelay                   -> IssueDelayStall.id.U      ,
+        robHeadIssueCancel                  -> cancelStallReason         ,
+      ))
+    }
   }
 
   //difftest signals

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -30,6 +30,7 @@ import chisel3.util._
 import chisel3.experimental.BundleLiterals._
 import difftest._
 import difftest.common._
+import difftest.plugin.topdown._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utility._
 import utils._

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -94,6 +94,7 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val topdownIssued    = OptionWrapper(backendParams.debugEn, Bool())
     val topdownCanceled  = OptionWrapper(backendParams.debugEn, Bool())
     val topdownRobHead   = OptionWrapper(backendParams.debugEn, Bool())
+    val topdownSrcReady  = OptionWrapper(backendParams.debugEn, Bool())
     val topdownIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
     val topdownLastIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
     val topdownRobHeadTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
@@ -176,9 +177,11 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robEntry.topdownIssued.foreach(_ := false.B)
     robEntry.topdownCanceled.foreach(_ := false.B)
     robEntry.topdownRobHead.foreach(_ := false.B)
+    robEntry.topdownSrcReady.foreach(_ := false.B)
     robEntry.topdownIssueTime.foreach(_ := 0.U)
     robEntry.topdownLastIssueTime.foreach(_ := 0.U)
     robEntry.topdownRobHeadTime.foreach(_ := 0.U)
+    robEntry.topdownLastShouldIssueTime.foreach(_ := 0.U)
     robEntry.topdownCancelSource.foreach(_ := IQCancelSource.none)
   }
 

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -94,11 +94,11 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val topdownIssued    = OptionWrapper(backendParams.debugEn, Bool())
     val topdownCanceled  = OptionWrapper(backendParams.debugEn, Bool())
     val topdownRobHead   = OptionWrapper(backendParams.debugEn, Bool())
-    val topdownSrcReady  = OptionWrapper(backendParams.debugEn, Bool())
+    val topdownIdealIssue  = OptionWrapper(backendParams.debugEn, Bool())
     val topdownIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
     val topdownLastIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
     val topdownRobHeadTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
-    val topdownLastShouldIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
+    val topdownIdealIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
     val topdownCancelSource = OptionWrapper(backendParams.debugEn, IQCancelSource())
 
     def isWritebacked: Bool = !uopNum.orR
@@ -177,11 +177,11 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robEntry.topdownIssued.foreach(_ := false.B)
     robEntry.topdownCanceled.foreach(_ := false.B)
     robEntry.topdownRobHead.foreach(_ := false.B)
-    robEntry.topdownSrcReady.foreach(_ := false.B)
+    robEntry.topdownIdealIssue.foreach(_ := false.B)
     robEntry.topdownIssueTime.foreach(_ := 0.U)
     robEntry.topdownLastIssueTime.foreach(_ := 0.U)
     robEntry.topdownRobHeadTime.foreach(_ := 0.U)
-    robEntry.topdownLastShouldIssueTime.foreach(_ := 0.U)
+    robEntry.topdownIdealIssueTime.foreach(_ := 0.U)
     robEntry.topdownCancelSource.foreach(_ := IQCancelSource.none)
   }
 

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -100,7 +100,8 @@ object RobBundles extends HasCircularQueuePtrHelper {
     val topdownRobHeadTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
     val topdownIdealIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
     val topdownCancelSource = OptionWrapper(backendParams.debugEn, IQCancelSource())
-
+    val topdownCancelTimeVec = OptionWrapper(backendParams.debugEn, Vec(IQCancelSource.num, UInt(XLEN.W)))
+    val topdownCancelTimeFixVec = OptionWrapper(backendParams.debugEn, Vec(IQCancelSource.num, UInt(XLEN.W)))
     def isWritebacked: Bool = !uopNum.orR
     def isUopWritebacked: Bool = !uopNum.orR
 
@@ -183,6 +184,8 @@ object RobBundles extends HasCircularQueuePtrHelper {
     robEntry.topdownRobHeadTime.foreach(_ := 0.U)
     robEntry.topdownIdealIssueTime.foreach(_ := 0.U)
     robEntry.topdownCancelSource.foreach(_ := IQCancelSource.none)
+    robEntry.topdownCancelTimeVec.foreach(_.foreach(_ := 0.U))
+    robEntry.topdownCancelTimeFixVec.foreach(_.foreach(_ := 0.U))
   }
 
   def connectCommitEntry(robCommitEntry: RobCommitEntryBundle, robEntry: RobEntryBundle): Unit = {

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -26,7 +26,7 @@ import utility._
 import utils._
 import xiangshan._
 import xiangshan.backend.BackendParams
-import xiangshan.backend.Bundles.{DynInst, ExceptionInfo, ExuOutput, UopIdx, EnqRobUop}
+import xiangshan.backend.Bundles._
 import xiangshan.backend.fu.{FuConfig, FuType}
 import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.mem.{LqPtr, LsqEnqIO, SqPtr}
@@ -93,8 +93,12 @@ object RobBundles extends HasCircularQueuePtrHelper {
     // topdown
     val topdownIssued    = OptionWrapper(backendParams.debugEn, Bool())
     val topdownCanceled  = OptionWrapper(backendParams.debugEn, Bool())
+    val topdownRobHead   = OptionWrapper(backendParams.debugEn, Bool())
     val topdownIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
     val topdownLastIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
+    val topdownRobHeadTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
+    val topdownLastShouldIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
+    val topdownCancelSource = OptionWrapper(backendParams.debugEn, IQCancelSource())
 
     def isWritebacked: Bool = !uopNum.orR
     def isUopWritebacked: Bool = !uopNum.orR
@@ -171,8 +175,11 @@ object RobBundles extends HasCircularQueuePtrHelper {
     }
     robEntry.topdownIssued.foreach(_ := false.B)
     robEntry.topdownCanceled.foreach(_ := false.B)
+    robEntry.topdownRobHead.foreach(_ := false.B)
     robEntry.topdownIssueTime.foreach(_ := 0.U)
     robEntry.topdownLastIssueTime.foreach(_ := 0.U)
+    robEntry.topdownRobHeadTime.foreach(_ := 0.U)
+    robEntry.topdownCancelSource.foreach(_ := IQCancelSource.none)
   }
 
   def connectCommitEntry(robCommitEntry: RobCommitEntryBundle, robEntry: RobEntryBundle): Unit = {

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -92,7 +92,9 @@ object RobBundles extends HasCircularQueuePtrHelper {
     // debug_end
     // topdown
     val topdownIssued    = OptionWrapper(backendParams.debugEn, Bool())
+    val topdownCanceled  = OptionWrapper(backendParams.debugEn, Bool())
     val topdownIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
+    val topdownLastIssueTime = OptionWrapper(backendParams.debugEn, UInt(XLEN.W))
 
     def isWritebacked: Bool = !uopNum.orR
     def isUopWritebacked: Bool = !uopNum.orR
@@ -168,7 +170,9 @@ object RobBundles extends HasCircularQueuePtrHelper {
       robEntry.debug_sim_trig.foreach(_ := debug.debug_sim_trig)
     }
     robEntry.topdownIssued.foreach(_ := false.B)
+    robEntry.topdownCanceled.foreach(_ := false.B)
     robEntry.topdownIssueTime.foreach(_ := 0.U)
+    robEntry.topdownLastIssueTime.foreach(_ := 0.U)
   }
 
   def connectCommitEntry(robCommitEntry: RobCommitEntryBundle, robEntry: RobEntryBundle): Unit = {

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1585,9 +1585,9 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   dcache.io.debugTopDown.robHeadOtherReplay := lsq.io.debugTopDown.robHeadOtherReplay
   dcache.io.debugRolling := io.debugRolling
 
-  lsq.io.noUopsIssued := io.topDownInfo.toBackend.noUopsIssued
-  io.topDownInfo.toBackend.lqEmpty := lsq.io.lqEmpty
-  io.topDownInfo.toBackend.sqEmpty := lsq.io.sqEmpty
+  io.topDownInfo.toBackend.replayAllocate := lsq.io.replayAllocate
+  io.topDownInfo.toBackend.sqFull  := lsq.io.sqFull
+  io.topDownInfo.toBackend.sbFull  := sbuffer.io.sbFull
   io.topDownInfo.toBackend.l1Miss := dcache.io.l1Miss
   io.topDownInfo.toBackend.l2TopMiss.l2Miss := RegNext(io.topDownInfo.fromL2Top.l2Miss)
   io.topDownInfo.toBackend.l2TopMiss.l3Miss := RegNext(io.topDownInfo.fromL2Top.l3Miss)

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -150,7 +150,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule
     val ldExceptionInfo = ValidIO(new MemExceptionInfo)
     // top-down
     val debugTopDown = new LoadQueueTopDownIO
-    val noUopsIssued = Input(Bool())
+    val replayAllocate = Output(Bool())
 
     val diffStore = OptionWrapper(debugEn, Flipped(new DiffStoreIO))
   })
@@ -331,7 +331,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule
   }
 
   loadQueue.io.debugTopDown <> io.debugTopDown
-  loadQueue.io.noUopsIssed := io.noUopsIssued
+  loadQueue.io.replayAllocate <> io.replayAllocate
 
   assert(!(loadQueue.io.uncache.resp.valid && storeQueue.io.toUncacheBuffer.resp.valid))
   assert(!(loadQueue.io.uncache.idResp.valid && storeQueue.io.toUncacheBuffer.idResp.valid))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -233,7 +233,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     val rarValidCount = Output(UInt())
 
     val debugTopDown = new LoadQueueTopDownIO
-    val noUopsIssed = Input(Bool())
+    val replayAllocate = Output(Bool())
   })
 
   val loadQueueRAR = Module(new LoadQueueRAR)  //  read-after-read violation
@@ -329,8 +329,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   loadQueueReplay.io.vecFeedback := io.vecFeedback
 
   loadQueueReplay.io.debugTopDown <> io.debugTopDown
-
-  virtualLoadQueue.io.noUopsIssued := io.noUopsIssed
+  loadQueueReplay.io.replayAllocate <> io.replayAllocate
 
   val full_mask = Cat(loadQueueRAR.io.lqFull, loadQueueRAW.io.lqFull, loadQueueReplay.io.lqFull)
   XSPerfAccumulate("full_mask_000", full_mask === 0.U)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -237,6 +237,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val tlbReplayDelayCycleCtrl = Vec(4, Input(UInt(ReSelectLen.W)))
 
     val debugTopDown = new LoadQueueTopDownIO
+    val replayAllocate = Output(Bool())
   })
 
   println("LoadQueueReplay size: " + LoadQueueReplaySize)
@@ -954,6 +955,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   io.debugTopDown.robHeadLoadVio := rob_head_vio_replay
   io.debugTopDown.robHeadLoadMSHR := rob_head_mshrfull_replay
   io.debugTopDown.robHeadOtherReplay := rob_head_other_replay
+  io.replayAllocate := allocated.asUInt.orR
   val perfValidCount = RegNext(PopCount(allocated))
 
   //  perf cnt
@@ -1007,6 +1009,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("replay_store_data_wakeup_cancel", replayStoreDataWakeupCancelCount)
   XSPerfAccumulate("replay_store_addr_wakeup_delay3_fire", replayStoreAddrWakeupDelay3FireCount)
   XSPerfAccumulate("replay_store_data_wakeup_delay3_fire", replayStoreDataWakeupDelay3FireCount)
+  XSPerfAccumulate("replay_allocate", io.replayAllocate)
 
   // replay counter
   val perfReplayCounter = RegInit(VecInit(Seq.fill(LoadQueueReplaySize)(0.U(8.W))))

--- a/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
@@ -55,8 +55,6 @@ class VirtualLoadQueue(implicit p: Parameters) extends XSModule
     // tolsqEnqCtrl
     val lqRedirect  = ValidIO(new LqPtr)
     val lqRecoverStall = Output(Bool())
-    // for topdown
-    val noUopsIssued = Input(Bool())
   })
 
   println("VirtualLoadQueue: size: " + VirtualLoadQueueSize)
@@ -287,17 +285,7 @@ class VirtualLoadQueue(implicit p: Parameters) extends XSModule
   QueuePerf(VirtualLoadQueueSize, PopCount(vecValidVec), !allowEnqueue)
   io.lqFull := !allowEnqueue
 
-  def NLoadNotCompleted = 1
-  val validCountReg = RegNext(validCount)
-  val noUopsIssued = io.noUopsIssued
-  val stallLoad = io.noUopsIssued && (validCountReg >= NLoadNotCompleted.U)
-  val memStallAnyLoad = RegNext(stallLoad)
-
-  XSPerfAccumulate("mem_stall_anyload", memStallAnyLoad)
-
-  val perfEvents: Seq[(String, UInt)] = Seq(
-    ("MEMSTALL_ANY_LOAD", memStallAnyLoad),
-  )
+  val perfEvents: Seq[(String, UInt)] = Seq()
   generatePerfEvent()
 
   // debug info

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -200,6 +200,7 @@ class Sbuffer(implicit p: Parameters)
     val sqempty = Input(Bool())
     val physicalStoreQueueFull = Input(Bool())
     val sbempty = Output(Bool())
+    val sbFull  = Output(Bool())
     val mshr_store_empty = Input(Bool()) // sbuffer-flush must flush all store entries in mshr as well
     val flush = Flipped(new SbufferFlushBundle)
     val csrCtrl = Flipped(new CustomCSRCtrlIO)
@@ -552,6 +553,7 @@ class Sbuffer(implicit p: Parameters)
   XSDebug(p"ActiveCount[$ActiveCount]\n")
 
   io.sbempty := GatedValidRegNext(cmo_empty)
+  io.sbFull  := GatedValidRegNext(ValidCount === (StoreBufferSize).U)
   io.flush.empty := GatedValidRegNext(all_empty)
   // lru.io.flush := sbuffer_state === x_drain_all && empty
   switch(sbuffer_state){

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -1211,7 +1211,12 @@ package object xiangshan {
 
     // backend
     // long inst stall at rob head
-    val IssueCancelStall = Value("IssueCancelStall")
+    val IssueCancelStallOg0 = Value("IssueCancelStallOg0")
+    val IssueCancelStallOg1 = Value("IssueCancelStallOg1")
+    val IssueCancelStallLd = Value("IssueCancelStallLd")
+    val IssueCancelStallSt = Value("issueCancelStallSt")
+    val IssueCancelStallOther = Value("IssueCancelStallOther")
+    val IssueDelayStall = Value("IssueDelayStall")
     val DivStall = Value("DivStall") // int div, float div/sqrt
     val IntNotReadyStall = Value("IntNotReadyStall") // int-inst at rob head exec long
     val FPNotReadyStall = Value("FPNotReadyStall") // fp-inst at rob head exec long
@@ -1254,6 +1259,7 @@ package object xiangshan {
     val LoadIQFullStall = Value("LoadIQFullStall")
     val StoreIQFullStall = Value("StoreIQFullStall")
     val OtherIQFullStall = Value("OtherIQFullStall")
+    val RobHeadNotIssued = Value("RobHeadNotIssued")
 
     // memblock
     val LoadTLBStall = Value("LoadTLBStall")

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -1214,7 +1214,7 @@ package object xiangshan {
     val IssueCancelStallOg0 = Value("IssueCancelStallOg0")
     val IssueCancelStallOg1 = Value("IssueCancelStallOg1")
     val IssueCancelStallLd = Value("IssueCancelStallLd")
-    val IssueCancelStallSt = Value("issueCancelStallSt")
+    val IssueCancelStallSt = Value("IssueCancelStallSt")
     val IssueCancelStallOther = Value("IssueCancelStallOther")
     val IssueDelayStall = Value("IssueDelayStall")
     val DivStall = Value("DivStall") // int div, float div/sqrt

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -1211,6 +1211,7 @@ package object xiangshan {
 
     // backend
     // long inst stall at rob head
+    val IssueCancelStall = Value("IssueCancelStall")
     val DivStall = Value("DivStall") // int div, float div/sqrt
     val IntNotReadyStall = Value("IntNotReadyStall") // int-inst at rob head exec long
     val FPNotReadyStall = Value("FPNotReadyStall") // fp-inst at rob head exec long


### PR DESCRIPTION
This PR extends elaborated  TopDown analysis with a ROB-head-centered bottleneck attribution
flow. It uses the oldest in-flight instruction as the key observation point,
tracks its issue/readiness/cancel/resource state, and attributes exposed
performance loss to the dominant bottleneck during that instruction's lifetime.

The oldest unfinished instruction in the ROB is often the point where internal
pipeline bottlenecks become visible: it can block commit and delay ROB, physical
register, issue queue, and other resource release. Observing the ROB head gives a
direct signal for identifying where performance loss is exposed.

Since multiple stall events may overlap in the same cycle, this PR avoids simply
summing every event duration. Instead, it divides the ROB-head instruction
lifetime into time slices and attributes each slice to the dominant bottleneck,
so the final accounting better matches the actual exposed performance-loss
cycles.

- Classify ROB-head stalls into execution not-ready, issue delay, issue cancel,
  not-issued, memory, and other resource-related categories.
- Track source-ready and ideal issue timing to identify issue-delay contribution.
- Track cancel source and multi-cancel contribution by source, avoiding repeated
  over-counting when events overlap.
- Support TopDown collection across uniform and distributed issue queues.
- Move part of ROB/IQ TopDown collection to DPI-C to reduce compile overhead.
- Add ROB-head FP wait counters and Intel Topdown/ROB-head analysis scripts.
- Fix memory stall attribution using replay allocation, SQ full, and SBuffer full
  signals.
- Update top-down README and bump the difftest submodule.