### PR TITLE
fix(TopDown): correct memory stall attribution

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -826,10 +826,10 @@ class L2ToL1Hint(implicit p: Parameters) extends XSBundle with HasDCacheParamete
 }
 
 class TopDownInfo(implicit p: Parameters) extends XSBundle {
-  val lqEmpty = Input(Bool())
-  val sqEmpty = Input(Bool())
+  val replayAllocate = Input(Bool())
+  val sqFull = Input(Bool())
+  val sbFull = Input(Bool())
   val l1Miss = Input(Bool())
-  val noUopsIssued = Output(Bool())
   val l2TopMiss = Input(new TopDownFromL2Top)
 }
 

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -372,6 +372,11 @@ case class XSCoreParameters
 
   def vlWidth = log2Up(VLEN) + 1
 
+  /*
+    Top-Down, ExecutionStall used
+  */
+  def fewUops = 4
+
   /**
    * the minimum element length of vector elements
    */

--- a/src/main/scala/xiangshan/XSCore.scala
+++ b/src/main/scala/xiangshan/XSCore.scala
@@ -288,9 +288,9 @@ class XSCoreImp(outer: XSCoreBase) extends LazyModuleImp(outer)
   memBlock.io.wfi <> backend.io.mem.wfi
   memBlock.io.topDownInfo.fromL2Top.l2Miss := io.topDownInfo.l2Miss
   memBlock.io.topDownInfo.fromL2Top.l3Miss := io.topDownInfo.l3Miss
-  memBlock.io.topDownInfo.toBackend.noUopsIssued := backend.io.topDownInfo.noUopsIssued
-  backend.io.topDownInfo.lqEmpty := memBlock.io.topDownInfo.toBackend.lqEmpty
-  backend.io.topDownInfo.sqEmpty := memBlock.io.topDownInfo.toBackend.sqEmpty
+  backend.io.topDownInfo.replayAllocate := memBlock.io.topDownInfo.toBackend.replayAllocate
+  backend.io.topDownInfo.sqFull := memBlock.io.topDownInfo.toBackend.sqFull
+  backend.io.topDownInfo.sbFull := memBlock.io.topDownInfo.toBackend.sbFull
   backend.io.topDownInfo.l1Miss := memBlock.io.topDownInfo.toBackend.l1Miss
   backend.io.topDownInfo.l2TopMiss.l2Miss := memBlock.io.topDownInfo.toBackend.l2TopMiss.l2Miss
   backend.io.topDownInfo.l2TopMiss.l3Miss := memBlock.io.topDownInfo.toBackend.l2TopMiss.l3Miss

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -495,8 +495,9 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   dataPath.io.fromBypassNetwork := bypassNetwork.io.toDataPath
   dataPath.io.fromVecExcpMod.r := vecExcpMod.o.toVPRF.r
   dataPath.io.fromVecExcpMod.w := vecExcpMod.o.toVPRF.w
-  dataPath.io.topDownInfo.lqEmpty := DelayN(io.topDownInfo.lqEmpty, 2)
-  dataPath.io.topDownInfo.sqEmpty := DelayN(io.topDownInfo.sqEmpty, 2)
+  dataPath.io.topDownInfo.replayAllocate := DelayN(io.topDownInfo.replayAllocate, 2)
+  dataPath.io.topDownInfo.sqFull := DelayN(io.topDownInfo.sqFull, 2)
+  dataPath.io.topDownInfo.sbFull := DelayN(io.topDownInfo.sbFull, 2)
   dataPath.io.topDownInfo.l1Miss := RegNext(io.topDownInfo.l1Miss)
   dataPath.io.topDownInfo.l2TopMiss.l2Miss := io.topDownInfo.l2TopMiss.l2Miss
   dataPath.io.topDownInfo.l2TopMiss.l3Miss := io.topDownInfo.l2TopMiss.l3Miss
@@ -873,8 +874,6 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   ctrlBlock.io.debugTopDown.fromCore := io.debugTopDown.fromCore
 
   io.debugRolling := ctrlBlock.io.debugRolling
-
-  io.topDownInfo.noUopsIssued := RegNext(dataPath.io.topDownInfo.noUopsIssued)
 
   private val cg = ClockGate.genTeSrc
   dontTouch(cg)

--- a/src/main/scala/xiangshan/backend/datapath/DataPath.scala
+++ b/src/main/scala/xiangshan/backend/datapath/DataPath.scala
@@ -284,10 +284,10 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
   private val vlDiffReadData: Option[UInt] =
     OptionWrapper(backendParams.basicDebugEn, Wire(UInt(VlData().dataWidth.W)))
 
-  vecDiffReadData.foreach(_ := 
+  vecDiffReadData.foreach(_ :=
     v0DiffReadData
     .get
-    .map(x => Seq(x(63, 0), x(127, 64))).flatten ++ 
+    .map(x => Seq(x(63, 0), x(127, 64))).flatten ++
     vfDiffReadData
     .get
     .map(x => Seq(x(63, 0), x(127, 64))).flatten
@@ -454,14 +454,14 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
     readPorts
   }
 
-  private val regCacheReadReq = fromIntIQ.flatten.filter(_.bits.exuParams.numIntSrc > 0).flatMap(IssueBundle2RCReadPort(_)) ++ 
+  private val regCacheReadReq = fromIntIQ.flatten.filter(_.bits.exuParams.numIntSrc > 0).flatMap(IssueBundle2RCReadPort(_)) ++
                                 fromMemIQ.flatten.filter(_.bits.exuParams.numIntSrc > 0).flatMap(IssueBundle2RCReadPort(_))
   private val regCacheReadData = regCache.io.readPorts.map(_.data)
 
   println(s"[DataPath] regCache readPorts size: ${regCache.io.readPorts.size}, regCacheReadReq size: ${regCacheReadReq.size}")
   require(regCache.io.readPorts.size == regCacheReadReq.size, "reg cache's readPorts size should be equal to regCacheReadReq")
 
-  regCache.io.readPorts.zip(regCacheReadReq).foreach{ case (r, req) => 
+  regCache.io.readPorts.zip(regCacheReadReq).foreach{ case (r, req) =>
     r.ren := req.ren
     r.addr := req.addr
   }
@@ -469,11 +469,11 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
   val s1_RCReadData: MixedVec[MixedVec[Vec[UInt]]] = Wire(MixedVec(toExu.map(x => MixedVec(x.map(_.bits.src.cloneType).toSeq))))
   s1_RCReadData.foreach(_.foreach(_.foreach(_ := 0.U)))
   s1_RCReadData.zip(toExu).filter(_._2.map(_.bits.params.isIntExeUnit).reduce(_ || _)).flatMap(_._1).flatten
-    .zip(regCacheReadData.take(params.getIntExuRCReadSize)).foreach{ case (s1_data, rdata) => 
+    .zip(regCacheReadData.take(params.getIntExuRCReadSize)).foreach{ case (s1_data, rdata) =>
       s1_data := rdata
     }
   s1_RCReadData.zip(toExu).filter(_._2.map(x => x.bits.params.isMemExeUnit && x.bits.params.readIntRf).reduce(_ || _)).flatMap(_._1).flatten
-    .zip(regCacheReadData.takeRight(params.getMemExuRCReadSize)).foreach{ case (s1_data, rdata) => 
+    .zip(regCacheReadData.takeRight(params.getMemExuRCReadSize)).foreach{ case (s1_data, rdata) =>
       s1_data := rdata
     }
 
@@ -655,7 +655,7 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
       }
   }
 
-  io.og0Cancel := og0FailedVec2.flatten.zip(params.allExuParams).map{ case (cancel, params) => 
+  io.og0Cancel := og0FailedVec2.flatten.zip(params.allExuParams).map{ case (cancel, params) =>
                     if (params.isIQWakeUpSource && params.latencyCertain && params.wakeUpFuLatancySet.contains(0)) cancel else false.B
                   }.toSeq
   io.og1Cancel := toFlattenExu.map(x => x.valid && !x.fire)
@@ -685,25 +685,25 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
           if (k == 3) {(
             Seq(None)
             :+
-            OptionWrapper(s1_v0PregRData(i)(j).isDefinedAt(k) && srcDataTypeSet.intersect(V0RegSrcDataSet).nonEmpty, 
+            OptionWrapper(s1_v0PregRData(i)(j).isDefinedAt(k) && srcDataTypeSet.intersect(V0RegSrcDataSet).nonEmpty,
               (SrcType.isV0(s1_srcType(i)(j)(k)) -> s1_v0PregRData(i)(j)(k)))
           )}
           else if (k == 4) {(
             Seq(None)
             :+
-            OptionWrapper(s1_vlPregRData(i)(j).isDefinedAt(k) && srcDataTypeSet.intersect(VlRegSrcDataSet).nonEmpty, 
+            OptionWrapper(s1_vlPregRData(i)(j).isDefinedAt(k) && srcDataTypeSet.intersect(VlRegSrcDataSet).nonEmpty,
               (SrcType.isVp(s1_srcType(i)(j)(k)) -> s1_vlPregRData(i)(j)(k)))
           )}
           else {(
             Seq(None)
             :+
-            OptionWrapper(s1_intPregRData(i)(j).isDefinedAt(k) && srcDataTypeSet.intersect(IntRegSrcDataSet).nonEmpty, 
+            OptionWrapper(s1_intPregRData(i)(j).isDefinedAt(k) && srcDataTypeSet.intersect(IntRegSrcDataSet).nonEmpty,
               (SrcType.isXp(s1_srcType(i)(j)(k)) -> s1_intPregRData(i)(j)(k)))
             :+
             OptionWrapper(s1_vfPregRData(i)(j).isDefinedAt(k) && srcDataTypeSet.intersect(VecRegSrcDataSet).nonEmpty,
               (SrcType.isVp(s1_srcType(i)(j)(k)) -> s1_vfPregRData(i)(j)(k)))
             :+
-            OptionWrapper(s1_fpPregRData(i)(j).isDefinedAt(k) && srcDataTypeSet.intersect(FpRegSrcDataSet).nonEmpty, 
+            OptionWrapper(s1_fpPregRData(i)(j).isDefinedAt(k) && srcDataTypeSet.intersect(FpRegSrcDataSet).nonEmpty,
               (SrcType.isFp(s1_srcType(i)(j)(k)) -> s1_fpPregRData(i)(j)(k)))
           )}
         ).filter(_.nonEmpty).map(_.get)
@@ -803,7 +803,7 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
   XSPerfHistogram(s"VfUopAfterArb_hist", PopCount(fromVfIQ.flatten.map(_.fire)), true.B, 0, 8, 2)
 
   // datasource perf counter (after arbiter)
-  fromIQ.foreach(iq => iq.foreach{exu => 
+  fromIQ.foreach(iq => iq.foreach{exu =>
     val exuParams = exu.bits.exuParams
     if (exuParams.isIntExeUnit) {
       for (i <- 0 until 2) {
@@ -824,37 +824,41 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
   })
 
   // Top-Down
-  def FewUops = 4
-
-  val lqEmpty = io.topDownInfo.lqEmpty
-  val sqEmpty = io.topDownInfo.sqEmpty
-  val l1Miss = io.topDownInfo.l1Miss
-  val l2Miss = io.topDownInfo.l2TopMiss.l2Miss
-  val l3Miss = io.topDownInfo.l2TopMiss.l3Miss
-
-  val uopsIssued = fromIQ.flatten.map(_.fire).reduce(_ || _)
-  val uopsIssuedCnt = PopCount(fromIQ.flatten.map(_.fire))
-  val fewUopsIssued = (0 until FewUops).map(_.U === uopsIssuedCnt).reduce(_ || _)
-
-  val stallLoad = !uopsIssued
+  val IQsFireDelay = fromFlattenIQ.map { case x =>
+    val delayed = Wire(Bool())
+    delayed := RegNext(x.fire)
+    delayed
+  }
+  val uopsIssued = IQsFireDelay.reduce(_ || _)
+  val uopsIssuedCnt = PopCount(IQsFireDelay)
 
   val noStoreIssued = !fromMemIQ.flatten.filter(memIq => memIq.bits.exuParams.fuConfigs.contains(FuConfig.StaCfg) ||
                                                          memIq.bits.exuParams.fuConfigs.contains(FuConfig.StdCfg)
   ).map(_.fire).reduce(_ || _)
-  val stallStore = uopsIssued && noStoreIssued
 
-  val stallLoadReg = DelayN(stallLoad, 2)
-  val stallStoreReg = DelayN(stallStore, 2)
+  val fewUopsIssued = (0 until p(XSCoreParamsKey).fewUops).map(_.U === uopsIssuedCnt).reduce(_ || _)
 
-  val memStallAnyLoad = stallLoadReg && !lqEmpty
-  val memStallStore = stallStoreReg && !sqEmpty
+  val stallLoad  = fewUopsIssued && !uopsIssued
+  val stallStore = fewUopsIssued && uopsIssued && RegNext(noStoreIssued)
+
+  val stallLoadDly = RegNext(stallLoad)
+  val stallStoreDly = RegNext(stallStore)
+
+  val replayAllocate = io.topDownInfo.replayAllocate
+  val sqFull = io.topDownInfo.sqFull
+  val sbFull = io.topDownInfo.sbFull
+  val l1Miss = io.topDownInfo.l1Miss
+  val l2Miss = io.topDownInfo.l2TopMiss.l2Miss
+  val l3Miss = io.topDownInfo.l2TopMiss.l3Miss
+
+  val memStallAnyLoad = stallLoadDly && replayAllocate
+  val memStallStore = stallStoreDly && (sqFull || sbFull)
   val memStallL1Miss = memStallAnyLoad && l1Miss
   val memStallL2Miss = memStallL1Miss && l2Miss
   val memStallL3Miss = memStallL2Miss && l3Miss
 
-  io.topDownInfo.noUopsIssued := stallLoad
-
   XSPerfAccumulate("exec_stall_cycle",   fewUopsIssued)
+  XSPerfAccumulate("mem_stall_anyload",  memStallAnyLoad)
   XSPerfAccumulate("mem_stall_store",    memStallStore)
   XSPerfAccumulate("mem_stall_l1miss",   memStallL1Miss)
   XSPerfAccumulate("mem_stall_l2miss",   memStallL2Miss)
@@ -862,6 +866,7 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
 
   val perfEvents = Seq(
     ("EXEC_STALL_CYCLE",  fewUopsIssued),
+    ("MEMSTALL_ANY_LOAD", memStallAnyLoad),
     ("MEMSTALL_STORE",    memStallStore),
     ("MEMSTALL_L1MISS",   memStallL1Miss),
     ("MEMSTALL_L2MISS",   memStallL2Miss),
@@ -934,17 +939,17 @@ class DataPathIO()(implicit p: Parameters, params: BackendParams) extends XSBund
 
   val fromPcTargetMem = Flipped(new PcToDataPathIO(params))
 
-  val fromBypassNetwork: Vec[RCWritePort] = Vec(params.getIntExuRCWriteSize + params.getMemExuRCWriteSize, 
+  val fromBypassNetwork: Vec[RCWritePort] = Vec(params.getIntExuRCWriteSize + params.getMemExuRCWriteSize,
     new RCWritePort(params.intSchdParams.get.rfDataWidth, RegCacheIdxWidth, params.intSchdParams.get.pregIdxWidth, params.debugEn)
   )
 
   val toBypassNetworkRCData: MixedVec[MixedVec[Vec[UInt]]] = MixedVec(
-    Seq(intSchdParams, fpSchdParams, vfSchdParams, memSchdParams).map(schd => schd.issueBlockParams.map(iq => 
+    Seq(intSchdParams, fpSchdParams, vfSchdParams, memSchdParams).map(schd => schd.issueBlockParams.map(iq =>
       MixedVec(iq.exuBlockParams.map(exu => Output(Vec(exu.numRegSrc, UInt(exu.srcDataBitsMax.W)))))
     )).flatten
   )
 
-  val toWakeupQueueRCIdx: Vec[UInt] = Vec(params.getIntExuRCWriteSize + params.getMemExuRCWriteSize, 
+  val toWakeupQueueRCIdx: Vec[UInt] = Vec(params.getIntExuRCWriteSize + params.getMemExuRCWriteSize,
     Output(UInt(RegCacheIdxWidth.W))
   )
 

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -2145,9 +2145,9 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   dcache.io.debugTopDown.robHeadOtherReplay := lsq.io.debugTopDown.robHeadOtherReplay
   dcache.io.debugRolling := io.debugRolling
 
-  lsq.io.noUopsIssued := io.topDownInfo.toBackend.noUopsIssued
-  io.topDownInfo.toBackend.lqEmpty := lsq.io.lqEmpty
-  io.topDownInfo.toBackend.sqEmpty := lsq.io.sqEmpty
+  io.topDownInfo.toBackend.replayAllocate := lsq.io.replayAllocate
+  io.topDownInfo.toBackend.sqFull := lsq.io.sqFull
+  io.topDownInfo.toBackend.sbFull := sbuffer.io.sbFull
   io.topDownInfo.toBackend.l1Miss := dcache.io.l1Miss
   io.topDownInfo.toBackend.l2TopMiss.l2Miss := RegNext(io.topDownInfo.fromL2Top.l2Miss)
   io.topDownInfo.toBackend.l2TopMiss.l3Miss := RegNext(io.topDownInfo.fromL2Top.l3Miss)

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -134,7 +134,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
     val wfi = Flipped(new WfiReqBundle)
     // top-down
     val debugTopDown = new LoadQueueTopDownIO
-    val noUopsIssued = Input(Bool())
+    val replayAllocate = Output(Bool())
 
     val diffStore = Flipped(new DiffStoreIO)
   })
@@ -321,7 +321,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   }
 
   loadQueue.io.debugTopDown <> io.debugTopDown
-  loadQueue.io.noUopsIssed := io.noUopsIssued
+  io.replayAllocate := loadQueue.io.replayAllocate
 
   assert(!(loadQueue.io.uncache.resp.valid && storeQueue.io.uncache.resp.valid))
   assert(!(loadQueue.io.uncache.idResp.valid && storeQueue.io.uncache.idResp.valid))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -205,7 +205,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     val lqDeqPtr = Output(new LqPtr)
 
     val debugTopDown = new LoadQueueTopDownIO
-    val noUopsIssed = Input(Bool())
+    val replayAllocate = Output(Bool())
 
     val lqDeqRobIdx = Output(new RobPtr)
     val lqDeqUopIdx = Output(UopIdx())
@@ -341,7 +341,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
 
   loadQueueReplay.io.debugTopDown <> io.debugTopDown
 
-  virtualLoadQueue.io.noUopsIssued := io.noUopsIssed
+  io.replayAllocate := loadQueueReplay.io.replayAllocate
 
   val full_mask = Cat(loadQueueRAR.io.lqFull, loadQueueRAW.io.lqFull, loadQueueReplay.io.lqFull)
   XSPerfAccumulate("full_mask_000", full_mask === 0.U)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -212,6 +212,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val tlbReplayDelayCycleCtrl = Vec(4, Input(UInt(ReSelectLen.W)))
 
     val debugTopDown = new LoadQueueTopDownIO
+    val replayAllocate = Output(Bool())
   })
 
   println("LoadQueueReplay size: " + LoadQueueReplaySize)
@@ -803,6 +804,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   io.debugTopDown.robHeadLoadVio := rob_head_vio_replay
   io.debugTopDown.robHeadLoadMSHR := rob_head_mshrfull_replay
   io.debugTopDown.robHeadOtherReplay := rob_head_other_replay
+  io.replayAllocate := allocated.asUInt.orR
   val perfValidCount = RegNext(PopCount(allocated))
 
   //  perf cnt
@@ -833,6 +835,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("replay_dcache_miss", replayDCacheMissCount)
   XSPerfAccumulate("replay_hint_wakeup", s0_hintSelValid)
   XSPerfAccumulate("replay_hint_priority_beat1", io.l2_hint.valid && io.l2_hint.bits.isKeyword)
+  XSPerfAccumulate("replay_allocate", io.replayAllocate)
 
   val perfEvents: Seq[(String, UInt)] = Seq(
     ("enq", enqNumber),

--- a/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
@@ -53,8 +53,6 @@ class VirtualLoadQueue(implicit p: Parameters) extends XSModule
     // to dispatch
     val lqDeq       = Output(UInt(log2Up(CommitWidth + 1).W))
     val lqCancelCnt = Output(UInt(log2Up(VirtualLoadQueueSize+1).W))
-    // for topdown
-    val noUopsIssued = Input(Bool())
 
     val lqDeqRobIdx = Output(new RobPtr)
     val lqDeqUopIdx = Output(UopIdx())
@@ -283,17 +281,7 @@ class VirtualLoadQueue(implicit p: Parameters) extends XSModule
   QueuePerf(VirtualLoadQueueSize, PopCount(vecValidVec), !allowEnqueue)
   io.lqFull := !allowEnqueue
 
-  def NLoadNotCompleted = 1
-  val validCountReg = RegNext(validCount)
-  val noUopsIssued = io.noUopsIssued
-  val stallLoad = io.noUopsIssued && (validCountReg >= NLoadNotCompleted.U)
-  val memStallAnyLoad = RegNext(stallLoad)
-
-  XSPerfAccumulate("mem_stall_anyload", memStallAnyLoad)
-
-  val perfEvents: Seq[(String, UInt)] = Seq(
-    ("MEMSTALL_ANY_LOAD", memStallAnyLoad),
-  )
+  val perfEvents: Seq[(String, UInt)] = Seq()
   generatePerfEvent()
 
   // debug info

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -198,6 +198,7 @@ class Sbuffer(implicit p: Parameters)
     val forward = Vec(LoadPipelineWidth, Flipped(new LoadForwardQueryIO))
     val sqempty = Input(Bool())
     val sbempty = Output(Bool())
+    val sbFull = Output(Bool())
     val flush = Flipped(new SbufferFlushBundle)
     val csrCtrl = Flipped(new CustomCSRCtrlIO)
     val store_prefetch = Vec(StorePipelineWidth, DecoupledIO(new StorePrefetchReq)) // to dcache
@@ -547,6 +548,7 @@ class Sbuffer(implicit p: Parameters)
   XSDebug(p"ActiveCount[$ActiveCount]\n")
 
   io.sbempty := GatedValidRegNext(empty)
+  io.sbFull := GatedValidRegNext(ValidCount === (StoreBufferSize).U)
   io.flush.empty := GatedValidRegNext(empty && io.sqempty)
   // lru.io.flush := sbuffer_state === x_drain_all && empty
   switch(sbuffer_state){


### PR DESCRIPTION
Replace the LQ/SQ non-empty with concrete memory-pressure signals so TopDown events reflect the actual source of execution stalls.

- Align issued-uop accounting with backend and memory status signals.
- Attribute load stalls to load replay allocation.
- Attribute store stalls to SQ or store-buffer saturation.
- Move MEMSTALL_ANY_LOAD accounting into DataPath.
- Propagate replayAllocate, sqFull, and sbFull through the core interfaces.
- Centralize the few-uops threshold in the core parameters.