### PR TITLE
fix(perf): add `cpu_cycle` & `ref_cpu_cycle` perf counter

### DIFF
--- a/src/main/scala/system/SoC.scala
+++ b/src/main/scala/system/SoC.scala
@@ -35,7 +35,7 @@ import freechips.rocketchip.diplomacy.{AddressSet, IdRange, InModuleBody, LazyMo
 import freechips.rocketchip.interrupts.{IntSourceNode, IntSourcePortSimple}
 import freechips.rocketchip.regmapper.{RegField, RegFieldDesc, RegFieldGroup}
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util.{AsyncQueueParams}
+import freechips.rocketchip.util.{AsyncQueueParams, AsyncQueueSource, AsyncBundle}
 import top.BusPerfMonitor
 import xiangshan.backend.fu.{MemoryRange, PMAConfigEntry, PMAConst}
 import xiangshan.{DebugOptionsKey, PMParameKey, XSTileKey}
@@ -633,7 +633,10 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
     val pll0_lock = IO(Input(Bool()))
     val pll0_ctrl = IO(Output(Vec(6, UInt(32.W))))
     val cacheable_check = IO(new TLPMAIO)
-    val clintTime = IO(Output(ValidIO(UInt(64.W))))
+    val clintTime = IO(EnableClintAsyncBridge match {
+      case Some(param) => new AsyncBundle(UInt(64.W), param)
+      case None => (ValidIO(UInt(64.W)))
+    })
     val scntIO = IO(new Bundle {
       val update_en = Input(Bool())
       val update_value = Input(UInt(timeWidth.W))
@@ -669,7 +672,17 @@ class MemMisc()(implicit p: Parameters) extends BaseSoC
     val pll_lock = RegNext(next = pll0_lock, init = false.B)
 
     // timer instance
-    clintTime :=   syscnt.module.io.time // syscnt ->timeasync
+    EnableClintAsyncBridge match {
+      case Some(param) =>
+        withClockAndReset(rtc_clock, rtc_reset) {
+          val time_source = Module(new AsyncQueueSource(UInt(64.W), param))
+          time_source.io.enq.valid := syscnt.module.io.time.valid
+          time_source.io.enq.bits := syscnt.module.io.time.bits
+          clintTime <> time_source.io.async
+        }
+      case None =>
+        clintTime <> syscnt.module.io.time
+    }
     timer.module.io.time <> syscnt.module.io.time
     timer.module.io.hartId := 0.U
 

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -42,6 +42,7 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.amba.axi4._
 import freechips.rocketchip.jtag.JTAGIO
+import freechips.rocketchip.util.{AsyncQueueParams, AsyncQueueSink}
 import chisel3.experimental.annotate
 import sifive.enterprise.firrtl.NestedPrefixModulesAnnotation
 
@@ -441,7 +442,17 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     misc.module.bus_clock := io.clock
     misc.module.bus_reset := io.reset
 
-
+    val clintTime = WireInit(0.U.asTypeOf(ValidIO(UInt(64.W))))
+    EnableClintAsyncBridge match {
+      case Some(param) =>
+        val time_sink = withClockAndReset(core_with_l2.head.module.clock, core_with_l2.head.module.reset)(Module(new AsyncQueueSink(UInt(64.W), param)))
+        time_sink.io.async <> misc.module.clintTime
+        time_sink.io.deq.ready := true.B
+        clintTime.valid := time_sink.io.deq.valid
+        clintTime.bits  := time_sink.io.deq.bits
+      case None =>
+       clintTime := misc.module.clintTime
+    }
 
     for ((core, i) <- core_with_l2.zipWithIndex) {
       core.module.io.hartId := i.U
@@ -455,7 +466,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
       imsic_bus_tops(i).module.teemsiio zip core.module.io.teemsiAck foreach { case (teemsiio, teemsiAck) =>
         teemsiio.vld_ack := teemsiAck
       }
-      core.module.io.clintTime := misc.module.clintTime
+      core.module.io.clintTime := clintTime
       io.riscv_halt(i) := core.module.io.cpu_halt
       io.riscv_critical_error(i) := core.module.io.cpu_crtical_error
       // trace Interface

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -932,7 +932,13 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
   val memSchedulerPerf = memScheduler.asInstanceOf[SchedulerMemImp].getPerfEvents
   val dataPathPerf = dataPath.getPerfEvents
 
-  val perfBackend  = Seq()
+  XSPerfAccumulate("cpu_cycle", true.B)
+  XSPerfAccumulate("ref_cpu_cycle", io.fromTop.clintTime.valid)
+
+  val perfBackend  = Seq(
+    ("cpu_cycle",     true.B),
+    ("ref_cpu_cycle", io.fromTop.clintTime.valid)
+  )
   // let index = 0 be no event
   val allPerfEvents = Seq(("noEvent", 0.U)) ++ ctrlBlockPerf  ++ dataPathPerf ++
     intSchedulerPerf ++ fpSchedulerPerf ++ vecSchedulerPerf ++ memSchedulerPerf ++ perfBackend


### PR DESCRIPTION
  * mcycle do not support counter overflow, so add new `cpu_cycle` for programmable counters.
 * map `ref_cpu_cycle` to `mtime`. (sbi spec: counts fixed-frequency clock cycles while the CPU clock is not halted. The fixed-frequency of countin might, for example, be the same frequency at which the time CSR counts.)

 **this pr should be rebased & merge.**