### PR TITLE
fix(LoadPipe): suppress S3 hit metadata updates on s2 kill

### DIFF
--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -538,6 +538,11 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s3_hit_prefetch = RegEnable(s2_hit_prefetch, s2_fire)
   val s3_error = s3_tag_error || s3_flag_error || s3_data_error
 
+  // Register the S2 kill (includes load breakpoint trigger exception) so that
+  // hit-side replacement/access-flag metadata updates in S3 can be suppressed
+  // for loads that are architecturally killed by an exception.
+  val s3_kill = RegEnable(io.lsu.s2_kill, s2_fire)
+
   // error_delayed signal will be used to update uop.exception 1 cycle after load writeback
   resp.bits.error_delayed := s3_error && (s3_hit || s3_tag_error) && s3_valid
   resp.bits.tl_error_delayed.tl_denied := s3_tl_error.tl_denied & s3_valid
@@ -556,12 +561,12 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // report tag error / l2 corrupted to CACHE_ERROR csr
   io.error.valid := s3_error && s3_valid
 
-  io.replace_access.valid := s3_valid && s3_hit
+  io.replace_access.valid := s3_valid && s3_hit && !s3_kill
   io.replace_access.bits.set := RegNext(RegNext(get_idx(s1_req.vaddr)))
   io.replace_access.bits.way := RegNext(RegNext(OHToUInt(s1_tag_match_way_dup_dc)))
 
   // update access bit
-  io.access_flag_write.valid := s3_valid && s3_hit && !s3_is_prefetch
+  io.access_flag_write.valid := s3_valid && s3_hit && !s3_is_prefetch && !s3_kill
   io.access_flag_write.bits.idx := get_idx(s3_vaddr)
   io.access_flag_write.bits.way_en := s3_tag_match_way
   io.access_flag_write.bits.flag := true.B
@@ -569,7 +574,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // clear prefetch source when prefetch hit
   // so that next load to the same line won't be considered as prefetch hit
   // A prefetch block will only be counted once
-  val s3_clear_pf_flag_en = s3_valid && s3_hit && !s3_is_prefetch && isFromL1Prefetch(s3_hit_prefetch)
+  val s3_clear_pf_flag_en = s3_valid && s3_hit && !s3_is_prefetch && !s3_kill && isFromL1Prefetch(s3_hit_prefetch)
   io.prefetch_flag_write.valid := s3_clear_pf_flag_en && !io.counter_filter_query.resp
   io.prefetch_flag_write.bits.idx := get_idx(s3_vaddr)
   io.prefetch_flag_write.bits.way_en := s3_tag_match_way


### PR DESCRIPTION
This PR aims to solve this issue:
https://github.com/OpenXiangShan/XiangShan/issues/6153

Summary:
- Gate DCache hit-side replace_access, access_flag, and prefetch metadata updates on s3_kill.
- Prevents exception-killed loads (e.g. load breakpoint trigger) from updating replacement state when S1 DCache lookup is not suppressed.

Problem to solve:
A load that matches a breakpoint trigger is killed in S2, but S1 does not assert dcacheKill, so the DCache lookup still proceeds. On a cache hit, S3 could still update PLRU/access metadata even though the load is architecturally squashed.
This can leak a secret through microarchitectural cache state:
- A secret-dependent, trigger-matched load updates replacement metadata before trap handling.
- After exception recovery, ordinary probe loads observe different hit/miss patterns for same-set lines.
- An attacker can recover which protected address was selected without reading the data directly.