### PR TITLE
ci(emu): migrate to new checkpoints

### DIFF
--- a/.github/workflows/emu-performance-summary.yml
+++ b/.github/workflows/emu-performance-summary.yml
@@ -98,6 +98,88 @@ jobs:
             python3 -c "print(f'{(float($1) - float($2)) / float($2) * 100:.2f}')" "$@"
           }
 
+          print_report_table() {
+            title="$1"
+            current_pattern="$2"
+            base_mode="$3"
+            collapsible="$4"
+
+            current_values=()
+            base_values=()
+            has_na=false
+
+            if [ "${collapsible}" = "true" ]; then
+              echo "<details>"
+              echo "<summary>${title}</summary>"
+            else
+              echo "### ${title}"
+            fi
+            echo
+
+            echo "| Testcase | Current | Base | Diff |"
+            echo "| -------- | ------- | ---- | ---- |"
+
+            for file in ${current_pattern}; do
+              if [ ! -f "${file}" ]; then
+                continue
+              fi
+
+              name=$(basename "${file}" | cut -d '-' -f 2-)
+              ipc=$(cat "${file}")
+
+              if [ "${base_mode}" = "default" ] && [[ "${name}" == legacy-* ]]; then
+                continue
+              fi
+
+              base_file=""
+              if [ -f "base/ipc-${name}" ]; then
+                base_file="base/ipc-${name}"
+              elif [ "${base_mode}" = "legacy" ]; then
+                actual_name="${name#legacy-}"
+                if [ -f "base/ipc-${actual_name}" ]; then
+                  base_file="base/ipc-${actual_name}"
+                fi
+              fi
+
+              if [ -n "${base_file}" ]; then
+                base_ipc=$(cat "${base_file}")
+                current_values+=("${ipc}")
+                base_values+=("${base_ipc}")
+                echo "| ${name} | ${ipc} | ${base_ipc} | $(diff "${ipc}" "${base_ipc}")% |"
+              else
+                echo "| ${name} | ${ipc} | N/A | N/A |"
+                has_na=true
+              fi
+            done
+
+            if [ ${#current_values[@]} -gt 0 ]; then
+              current_geomean=$(geomean "${current_values[@]}")
+              base_geomean=$(geomean "${base_values[@]}")
+              geomean_diff=$(diff "${current_geomean}" "${base_geomean}")
+            else
+              current_geomean="N/A"
+              base_geomean="N/A"
+              geomean_diff="N/A"
+            fi
+
+            echo "| **GEOMEAN** | **${current_geomean}** | **${base_geomean}** | **${geomean_diff}%** |"
+            echo
+            if [ "${has_na}" = true ]; then
+              echo "**NOTE**: Some testcases do not have base data, diff is shown as N/A and GEOMEAN is calculated only from matched pairs."
+              echo
+            fi
+
+            if [ "${base_mode}" = "legacy" ]; then
+              echo "**NOTE**: We're migrating to new checkpoints (see #6181), legacy testcases and reports are going to be removed. Please use the new IPC reports for future comparisons."
+              echo
+            fi
+
+            if [ "${collapsible}" = "true" ]; then
+              echo "</details>"
+              echo
+            fi
+          }
+
           {
             echo "## Emu - Performance Summary"
             echo
@@ -114,31 +196,10 @@ jobs:
             fi
             echo "| Current | ${HEAD_SHA} | ${{ steps.runs.outputs.head_run_id }} |"
             echo
-            echo "### IPC Report"
-            echo "| Testcase | Current | Base | Diff |"
-            echo "| -------- | ------- | ---- | ---- |"
-
-            has_na=false
-            for file in current/ipc-*; do
-              name=$(basename "${file}" | cut -d '-' -f 2-)
-              ipc=$(cat "${file}")
-              if [ -f "base/ipc-${name}" ]; then
-                base_ipc=$(cat "base/ipc-${name}")
-                echo "| ${name} | ${ipc} | ${base_ipc} | $(diff "${ipc}" "${base_ipc}")% |"
-              else
-                echo "| ${name} | ${ipc} | N/A | N/A |"
-                has_na=true
-              fi
-            done
-
-            current_geomean=$(geomean $(cat current/ipc-* | xargs))
-            base_geomean=$(geomean $(cat base/ipc-* | xargs) 2>/dev/null || echo "N/A")
-            geomean_diff=$(diff "${current_geomean}" "${base_geomean}" 2>/dev/null || echo "N/A")
-            echo "| **GEOMEAN** | **${current_geomean}** | **${base_geomean}** | **${geomean_diff}%** |"
-            echo
-            if [ "${has_na}" = true ]; then
-              echo "**NOTE**: Some testcases do not have base data, diff is shown as N/A and GEOMEAN diff may not be accurate."
+            if [ -n "$(ls current/ipc-legacy-* 2>/dev/null)" ]; then
+              print_report_table "IPC Report (Legacy)" "current/ipc-legacy-*" "legacy" "true"
             fi
+            print_report_table "IPC Report" "current/ipc-*" "default" "false"
           } > report.md
 
           cat report.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -13,7 +13,8 @@ env:
   NEMU_HOME: /nfs/home/share/ci-workloads/NEMU
   AM_HOME: /nfs/home/share/ci-workloads/nexus-am
   PERF_HOME: /nfs/home/ci-runner/emu-performance/${{ github.run_number }}
-  CKPT_HOME: /nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260122/checkpoint-0-0-0
+  CKPT_HOME_LEGACY: /nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260122/checkpoint-0-0-0
+  CKPT_HOME: /nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260604/checkpoint
 
 jobs:
   changes:
@@ -76,8 +77,8 @@ jobs:
             echo "cluster=open" >> ${GITHUB_OUTPUT}
           fi
 
-  run:
-    name: EMU - Performance - Run
+  run-legacy:
+    name: EMU - Performance - Run (Legacy)
     needs: build
     runs-on:
       - ${{ needs.build.outputs.cluster }} # use same cluster as builder to avoid cross-cluster network copy & pgo issue
@@ -146,7 +147,119 @@ jobs:
           - name: sphinx3
             ckpt: 141036
       fail-fast: false
-      max-parallel: 12 # TODO: increase this to 16 after dropping legacy workflow
+      max-parallel: 12
+    steps:
+      - name: Cleanup orphan EMU
+        run: |
+          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Get artifact
+        run: |
+          python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py --clean
+          mkdir -p build
+          echo "Getting EMU binary from ${PERF_HOME}/emu"
+          cp -L ${PERF_HOME}/emu ${GITHUB_WORKSPACE}/build/emu
+      - name: Run SPEC06 Test - ${{ matrix.name }}
+        id: run
+        shell: bash
+        run: |
+          export CKPT=$(find "${CKPT_HOME_LEGACY}/${{ matrix.name }}/${{ matrix.ckpt }}" -type f \( -name "*.gz" -o -name "*.zstd" \) | head -n 1)
+          echo "Running checkpoint: ${CKPT}"
+          # TODO: remove --disable-fork to enable lightSSS when gsim supports it
+          python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
+            --wave-dump ${PERF_HOME} \
+            --numa --threads 1 \
+            --max-instr 5000000 \
+            --disable-fork \
+            ${CKPT} \
+            2> stderr.log | tee stdout.log
+          grep -oP 'IPC = \K\d+\.\d+' stdout.log > "${PERF_HOME}/ipc-legacy-${{ matrix.name }}_${{ matrix.ckpt }}"
+          echo "IPC: $(cat "${PERF_HOME}/ipc-legacy-${{ matrix.name }}_${{ matrix.ckpt }}")"
+      - name: Archive log
+        if: ${{ always() && steps.run.outcome != 'skipped' }}
+        run: |
+          # if run step failed, do not sort
+          if [[ "${{ steps.run.outcome }}" == "failure" ]]; then
+            cat stderr.log
+          else
+            mv stderr.log stderr.log.raw
+            cat stderr.log.raw | sort | tee stderr.log
+          fi
+          tar -czvf "${PERF_HOME}/legacy-${{ matrix.name }}_${{ matrix.ckpt }}.tar.gz" stdout.log stderr.log
+
+  run:
+    name: EMU - Performance - Run
+    needs: build
+    runs-on:
+      - ${{ needs.build.outputs.cluster }} # use same cluster as builder to avoid cross-cluster network copy & pgo issue
+      - runner
+    timeout-minutes: 300
+    continue-on-error: false
+    strategy:
+      matrix:
+        include:
+          - name: perlbench_diffmail
+            ckpt: 9946
+          - name: bzip2_liberty
+            ckpt: 4496
+          - name: gcc_s04
+            ckpt: 1168
+          - name: mcf
+            ckpt: 11002
+          - name: gobmk_trevorc
+            ckpt: 8642
+          - name: hmmer_nph3
+            ckpt: 15841
+          - name: sjeng
+            ckpt: 25706
+          - name: libquantum
+            ckpt: 26410
+          - name: h264ref_foreman.baseline
+            ckpt: 18835
+          - name: omnetpp
+            ckpt: 6881
+          - name: astar_rivers
+            ckpt: 8019
+          - name: xalancbmk
+            ckpt: 9937
+          - name: bwaves
+            ckpt: 11749
+          - name: gamess_gradient
+            ckpt: 14462
+          - name: milc
+            ckpt: 24615
+          - name: zeusmp
+            ckpt: 30668
+          - name: gromacs
+            ckpt: 63029
+          - name: cactusADM
+            ckpt: 69738
+          - name: leslie3d
+            ckpt: 80046
+          - name: namd
+            ckpt: 31308
+          - name: dealII
+            ckpt: 63755
+          - name: soplex_ref
+            ckpt: 17104
+          - name: povray
+            ckpt: 33275
+          - name: calculix
+            ckpt: 92312
+          - name: GemsFDTD
+            ckpt: 46103
+          - name: tonto
+            ckpt: 68419
+          - name: lbm
+            ckpt: 24591
+          - name: wrf
+            ckpt: 50751
+          - name: sphinx3
+            ckpt: 82804
+      fail-fast: false
+      max-parallel: 12
     steps:
       - name: Cleanup orphan EMU
         run: |
@@ -193,6 +306,7 @@ jobs:
     needs:
       - build # needed to get the cluster info
       - run
+      - run-legacy
     runs-on:
       - ${{ needs.build.outputs.cluster }} # use same cluster as builder/runner to access NFS
       - runner

--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -76,76 +76,6 @@ jobs:
             echo "cluster=open" >> ${GITHUB_OUTPUT}
           fi
 
-  run-legacy: # TODO: drop this after most of the dev branches are migrated to the new workflow
-    name: EMU - Performance - Run (legacy)
-    needs: build
-    runs-on:
-      - ${{ needs.build.outputs.cluster }} # use same cluster as builder to avoid cross-cluster network copy & pgo issue
-      - runner
-    timeout-minutes: 300
-    continue-on-error: false
-    strategy:
-      matrix:
-        name:
-          # Vector-related workloads are temporarily disabled in CI due to the ongoing vector refactor.
-          # - hmmer-Vector
-          - mcf
-          - xalancbmk
-          - gcc
-          - namd
-          - milc
-          - lbm
-          - gromacs
-          - wrf
-          - astar
-        with-restore-bin: [true]
-        # exclude:
-        #   - name: hmmer-Vector
-        # include:
-        #   - name: hmmer-Vector
-        #     with-restore-bin: false
-      fail-fast: false
-      max-parallel: 4
-    steps:
-      - name: Cleanup orphan EMU
-        run: |
-          pkill -9 -e -f ${GITHUB_WORKSPACE}/build/emu || true
-      - uses: actions/checkout@v7
-        with:
-          submodules: true
-      - name: Get artifact
-        run: |
-          python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py --clean
-          mkdir -p build
-          echo "Getting EMU binary from ${PERF_HOME}/emu"
-          cp -L ${PERF_HOME}/emu ${GITHUB_WORKSPACE}/build/emu
-      - name: Run Legacy CI Test - ${{ matrix.name }}
-        id: run
-        shell: bash
-        run: |
-          # TODO: remove --disable-fork to enable lightSSS when gsim supports it
-          python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
-            --wave-dump ${PERF_HOME} \
-            --numa --threads 1 \
-            --max-instr 5000000 \
-            --disable-fork \
-            --ci ${{ matrix.name }} \
-            ${{ matrix.with-restore-bin && '--gcpt-restore-bin /nfs/home/share/ci-workloads/fix-gcpt/gcpt.bin' || '' }} \
-            2> stderr.log | tee stdout.log
-          grep -oP 'IPC = \K\d+\.\d+' stdout.log > "${PERF_HOME}/ipc-legacy-${{ matrix.name }}"
-          echo "IPC: $(cat "${PERF_HOME}/ipc-legacy-${{ matrix.name }}")"
-      - name: Archive log
-        if: ${{ always() && steps.run.outcome != 'skipped' }}
-        run: |
-          # if run step failed, do not sort
-          if [[ "${{ steps.run.outcome }}" == "failure" ]]; then
-            cat stderr.log
-          else
-            mv stderr.log stderr.log.raw
-            cat stderr.log.raw | sort | tee stderr.log
-          fi
-          tar -czvf "${PERF_HOME}/legacy_${{ matrix.name }}.tar.gz" stdout.log stderr.log
-
   run:
     name: EMU - Performance - Run
     needs: build
@@ -263,7 +193,6 @@ jobs:
     needs:
       - build # needed to get the cluster info
       - run
-      - run-legacy # TODO: drop this
     runs-on:
       - ${{ needs.build.outputs.cluster }} # use same cluster as builder/runner to access NFS
       - runner


### PR DESCRIPTION
follow #6181

- drop existing legacy gcc12 benchmarks, i.e. `xiangshan.py --ci mcf` etc.
- migrate to new gcc15-0604 checkpoints.
- mark old gcc15-0122 checkpoints as legacy and generate report separately.