### PR TITLE
fix(Top-down): fix some top-down perf counters of mem-block

### DIFF
--- a/scripts/top-down/configs.py
+++ b/scripts/top-down/configs.py
@@ -137,7 +137,6 @@ xs_backend_rename_map = {
 xs_mem_rename_map = {
     'MemNotReadyStall': 'MergeMemNotReadyStall',
 
-    'LoadTLBStall': 'MergeLoadTLBStall',
     'LoadL1Stall': 'MergeLoadL1Stall',
     'LoadL2Stall': 'MergeLoadL2Stall',
     'LoadL3Stall': 'MergeLoadL3Stall',
@@ -147,17 +146,17 @@ xs_mem_rename_map = {
     'SqStall': 'MergeSqStall',
     'LqStall': 'MergeLqStall',
 
-
     'AtomicStall': 'MergeAtomicStall',
 
-    'LoadMSHRReplayStall': 'MergeMSHRReplayStall',
-    'LoadVioReplayStall': 'MergeLoadVioReplay',
-    'LoadUncacheReplayStall': 'MergeUncacheReplayStall',
-    'LoadForwardFailReplayStall': 'MergeForwardFailReplayStall',
-    'LoadDCacheMissReplayStall': 'MergeDCacheMissReplayStall',
-    'LoadBankConflictReplayStall': 'MergeBankConflictReplayStall',
-    'LoadNukeQueryReplayStall': 'MergeNukeQueryReplayStall',
-    'LoadOtherReplayStall': 'MergeOtherReplayStall',
+    'LoadTLBStall': 'MergeLoadReplay',
+    'LoadMSHRReplayStall': 'MergeLoadReplay',
+    'LoadVioReplayStall': 'MergeLoadReplay',
+    'LoadUncacheReplayStall': 'MergeLoadReplay',
+    'LoadForwardFailReplayStall': 'MergeLoadReplay',
+    'LoadDCacheMissReplayStall': 'MergeLoadReplay',
+    'LoadBankConflictReplayStall': 'MergeLoadReplay',
+    'LoadNukeQueryReplayStall': 'MergeLoadReplay',
+    'LoadOtherReplayStall': 'MergeLoadReplay',
 
     'MemVioRedirectStall': 'MergeMemVioRedirect',
     'MemVioRedirectBubble': 'MergeMemVioRedirect',
@@ -227,7 +226,6 @@ xs_coarse_rename_map = {
     'StoreIQFullStall': 'MergeCore',
     'OtherIQFullStall': 'MergeCore',
 
-    'LoadTLBStall': 'MergeLoad',
     'LoadL1Stall': 'MergeLoad',
     'LoadL2Stall': 'MergeLoad',
     'LoadL3Stall': 'MergeLoad',
@@ -237,10 +235,11 @@ xs_coarse_rename_map = {
     'AtomicStall': 'MergeMisc',
 
     'FlushedInsts': 'MergeBadSpecInst',
-    'LoadVioReplayStall': 'MergeBadSpec',
 
+    'LoadTLBStall': 'MergeLoad',
     'LoadMSHRReplayStall': 'MergeLoad',
     'LoadUncacheReplayStall': 'MergeLoad',
+    'LoadVioReplayStall': 'MergeLoad',
     'LoadForwardFailReplayStall': 'MergeLoad',
     'LoadDCacheMissReplayStall': 'MergeLoad',
     'LoadBankConflictReplayStall': 'MergeLoad',

--- a/scripts/top-down/configs.py
+++ b/scripts/top-down/configs.py
@@ -152,6 +152,12 @@ xs_mem_rename_map = {
 
     'LoadMSHRReplayStall': 'MergeMSHRReplayStall',
     'LoadVioReplayStall': 'MergeLoadVioReplay',
+    'LoadUncacheReplayStall': 'MergeUncacheReplayStall',
+    'LoadForwardFailReplayStall': 'MergeForwardFailReplayStall',
+    'LoadDCacheMissReplayStall': 'MergeDCacheMissReplayStall',
+    'LoadBankConflictReplayStall': 'MergeBankConflictReplayStall',
+    'LoadNukeQueryReplayStall': 'MergeNukeQueryReplayStall',
+    'LoadOtherReplayStall': 'MergeOtherReplayStall',
 
     'MemVioRedirectStall': 'MergeMemVioRedirect',
     'MemVioRedirectBubble': 'MergeMemVioRedirect',
@@ -234,6 +240,12 @@ xs_coarse_rename_map = {
     'LoadVioReplayStall': 'MergeBadSpec',
 
     'LoadMSHRReplayStall': 'MergeLoad',
+    'LoadUncacheReplayStall': 'MergeLoad',
+    'LoadForwardFailReplayStall': 'MergeLoad',
+    'LoadDCacheMissReplayStall': 'MergeLoad',
+    'LoadBankConflictReplayStall': 'MergeLoad',
+    'LoadNukeQueryReplayStall': 'MergeLoad',
+    'LoadOtherReplayStall': 'MergeLoad',
 
     'ControlRedirectStall': 'MergeBadSpec',
     'MemVioRedirectStall': 'MergeBadSpec',
@@ -290,6 +302,12 @@ xs_fine_grain_rename_map = {
     'LoadVioReplayStall': None,
 
     'LoadMSHRReplayStall': None,
+    'LoadUncacheReplayStall': None,
+    'LoadForwardFailReplayStall': None,
+    'LoadDCacheMissReplayStall': None,
+    'LoadBankConflictReplayStall': None,
+    'LoadNukeQueryReplayStall': None,
+    'LoadOtherReplayStall': None,
 
     'ControlRecoveryStall': 'MergeBadSpecWalking',
     'MemVioRecoveryStall': 'MergeBadSpecWalking',
@@ -378,6 +396,12 @@ targets = {
 
     'LoadVioReplayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadVioReplayStall,\s+(\d+)',
     'LoadMSHRReplayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadMSHRReplayStall,\s+(\d+)',
+    'LoadUncacheReplayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadUncacheReplayStall,\s+(\d+)',
+    'LoadForwardFailReplayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadForwardFailReplayStall,\s+(\d+)',
+    'LoadDCacheMissReplayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadDCacheMissReplayStall,\s+(\d+)',
+    'LoadBankConflictReplayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadBankConflictReplayStall,\s+(\d+)',
+    'LoadNukeQueryReplayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadNukeQueryReplayStall,\s+(\d+)',
+    'LoadOtherReplayStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: LoadOtherReplayStall,\s+(\d+)',
 
 
     'ControlRedirectStall': fr'{XS_CORE_PREFIX}.backend.*?ctrlBlock\.dispatch: ControlRedirectStall,\s+(\d+)',

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -514,9 +514,12 @@ class BackendInlinedImp(override val wrapper: BackendInlined)(implicit p: Parame
     ctrlBlock.io.memHyPcRead(i).offset := issueHya(i).bits.ftqOffset.get
   })
 
-  ctrlBlock.io.robio.robHeadLsIssue := issue.flatten.map(deq =>
-    deq.fire && deq.bits.robIdx === ctrlBlock.io.robio.robDeqPtr
-  ).reduce(_ || _)
+  ctrlBlock.io.robio.debugMemIssueFire.foreach { fires =>
+    issue.flatten.zip(fires).foreach { case (deq, v) =>
+      v.valid := deq.fire
+      v.bits := deq.bits.robIdx
+    }
+  }
   ctrlBlock.io.robio.debugIQDeqRobIdxVec.foreach(_ := intRegion.io.debugIQDeqRobIdxVec.get ++
     fpRegion.io.debugIQDeqRobIdxVec.get ++ vecRegion.io.debugIQDeqRobIdxVec.get)
 

--- a/src/main/scala/xiangshan/backend/BackendParams.scala
+++ b/src/main/scala/xiangshan/backend/BackendParams.scala
@@ -117,6 +117,10 @@ case class BackendParams(
   def CsrCnt = allSchdParams.map(_.CsrCnt).sum
   def IqCnt = allSchdParams.map(_.issueBlockParams.length).sum
 
+  def memIssuePortNum: Int =
+    intSchdParams.map(_.issueBlockParams.filter(_.isMemBlockIQ).map(_.numDeq).sum).getOrElse(0) +
+    vecSchdParams.map(_.issueBlockParams.filter(_.isMemBlockIQ).map(_.numDeq).sum).getOrElse(0)
+
   def numPcMemReadPort = allExuParams.filter(_.needPc).size
   def numTargetReadPort = allRealExuParams.count(x => x.needTarget)
 

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -834,24 +834,27 @@ class CtrlBlockImp(
 
   io.debugTopDown.fromRob := rob.io.debugTopDown.toCore
   io.debugRolling := rob.io.debugRolling
+
   // mem topdown reason collect
-  val notIssue = !rob.io.debugTopDown.toDispatch.robHeadLsIssued
   val tlbReplay = io.debugTopDown.fromCore.fromMem.robHeadTlbReplay
   val tlbMiss = io.debugTopDown.fromCore.fromMem.robHeadTlbMiss
   val vioReplay = io.debugTopDown.fromCore.fromMem.robHeadLoadVio
   val mshrReplay = io.debugTopDown.fromCore.fromMem.robHeadLoadMSHR
-  val ldReplay = io.debugTopDown.fromCore.fromMem.robHeadLdReplay
   val uncacheReplay = io.debugTopDown.fromCore.fromMem.robHeadUncacheReplay
   val forwardFailReplay = io.debugTopDown.fromCore.fromMem.robHeadForwardFailReplay
   val dcacheMissReplay = io.debugTopDown.fromCore.fromMem.robHeadDCacheMissReplay
   val bankConflictReplay = io.debugTopDown.fromCore.fromMem.robHeadBankConflictReplay
   val nukeQueryReplay = io.debugTopDown.fromCore.fromMem.robHeadNukeQueryReplay
-  val classifiedReplay = tlbMiss || tlbReplay || mshrReplay || vioReplay ||
-    uncacheReplay || forwardFailReplay || dcacheMissReplay || bankConflictReplay || nukeQueryReplay
+  val classifiedReplay = tlbMiss || tlbReplay || mshrReplay || vioReplay || uncacheReplay ||
+                         forwardFailReplay || dcacheMissReplay || bankConflictReplay || nukeQueryReplay
+  val ldReplay = io.debugTopDown.fromCore.fromMem.robHeadLdReplay
   val otherReplay = ldReplay && !classifiedReplay
-  val l1Miss = io.debugTopDown.fromCore.fromMem.robHeadMissInDCache
-  val l2Miss = io.debugTopDown.fromCore.l2MissMatch
+  
   val l3Miss = io.debugTopDown.fromCore.l3MissMatch
+  val l2Miss = io.debugTopDown.fromCore.l2MissMatch
+  val l1Miss = io.debugTopDown.fromCore.fromMem.robHeadMissInDCache
+  val notIssue = !rob.io.debugTopDown.toDispatch.robHeadLsIssued
+
   val ldReason = Mux(l3Miss, LoadMemStall.id.U,
     Mux(l2Miss, LoadL3Stall.id.U,
       Mux(l1Miss, LoadL2Stall.id.U,
@@ -866,6 +869,7 @@ class CtrlBlockImp(
                         Mux(nukeQueryReplay, LoadNukeQueryReplayStall.id.U,
                           Mux(otherReplay, LoadOtherReplayStall.id.U,
                               LoadL1Stall.id.U)))))))))))))
+  
   dispatch.io.debugLoadReason.foreach(_ := ldReason)
   dispatch.io.debugRobTrueCommit.foreach(_ := rob.io.debugTopDown.toDispatch.robTrueCommit)
   rename.io.debugLoadReason.foreach(_ := ldReason)

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -806,7 +806,7 @@ class CtrlBlockImp(
   io.diff_vl_rat .foreach(_ := rename.io.diff_vl_rat.get)
 
   rob.io.debug_ls := io.robio.debug_ls
-  rob.io.debugHeadLsIssue := io.robio.robHeadLsIssue
+  rob.io.debugMemIssueFire.foreach(_ := io.robio.debugMemIssueFire.get)
   rob.io.lsTopdownInfo := io.robio.lsTopdownInfo
   rob.io.csr.criticalErrorState := io.robio.csr.criticalErrorState
   rob.io.debugEnqLsq := io.debugEnqLsq
@@ -835,7 +835,7 @@ class CtrlBlockImp(
   io.debugTopDown.fromRob := rob.io.debugTopDown.toCore
   io.debugRolling := rob.io.debugRolling
   // mem topdown reason collect
-  val notIssue = !rob.io.debugTopDown.toDispatch.robHeadLsIssue
+  val notIssue = !rob.io.debugTopDown.toDispatch.robHeadLsIssued
   val tlbReplay = io.debugTopDown.fromCore.fromMem.robHeadTlbReplay
   val tlbMiss = io.debugTopDown.fromCore.fromMem.robHeadTlbMiss
   val vioReplay = io.debugTopDown.fromCore.fromMem.robHeadLoadVio
@@ -964,7 +964,7 @@ class CtrlBlockIO()(implicit p: Parameters, params: BackendParams) extends XSBun
     val lsq = new RobLsqIO
     val lsTopdownInfo = Vec(params.LduCnt + params.HyuCnt, Input(new LsTopdownInfo))
     val debug_ls = Input(new DebugLSIO())
-    val robHeadLsIssue = Input(Bool())
+    val debugMemIssueFire = Option.when(backendParams.debugEn)(Vec(params.memIssuePortNum, Flipped(ValidIO(new RobPtr()))))
     val robDeqPtr = Output(new RobPtr)
     val commitVType = new Bundle {
       val vtype = Output(ValidIO(VType()))

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -840,6 +840,15 @@ class CtrlBlockImp(
   val tlbMiss = io.debugTopDown.fromCore.fromMem.robHeadTlbMiss
   val vioReplay = io.debugTopDown.fromCore.fromMem.robHeadLoadVio
   val mshrReplay = io.debugTopDown.fromCore.fromMem.robHeadLoadMSHR
+  val ldReplay = io.debugTopDown.fromCore.fromMem.robHeadLdReplay
+  val uncacheReplay = io.debugTopDown.fromCore.fromMem.robHeadUncacheReplay
+  val forwardFailReplay = io.debugTopDown.fromCore.fromMem.robHeadForwardFailReplay
+  val dcacheMissReplay = io.debugTopDown.fromCore.fromMem.robHeadDCacheMissReplay
+  val bankConflictReplay = io.debugTopDown.fromCore.fromMem.robHeadBankConflictReplay
+  val nukeQueryReplay = io.debugTopDown.fromCore.fromMem.robHeadNukeQueryReplay
+  val classifiedReplay = tlbMiss || tlbReplay || mshrReplay || vioReplay ||
+    uncacheReplay || forwardFailReplay || dcacheMissReplay || bankConflictReplay || nukeQueryReplay
+  val otherReplay = ldReplay && !classifiedReplay
   val l1Miss = io.debugTopDown.fromCore.fromMem.robHeadMissInDCache
   val l2Miss = io.debugTopDown.fromCore.l2MissMatch
   val l3Miss = io.debugTopDown.fromCore.l3MissMatch
@@ -847,11 +856,16 @@ class CtrlBlockImp(
     Mux(l2Miss, LoadL3Stall.id.U,
       Mux(l1Miss, LoadL2Stall.id.U,
         Mux(notIssue, MemNotReadyStall.id.U,
-          Mux(tlbMiss, LoadTLBStall.id.U,
-            Mux(tlbReplay, LoadTLBStall.id.U,
-              Mux(mshrReplay, LoadMSHRReplayStall.id.U,
-                Mux(vioReplay, LoadVioReplayStall.id.U,
-                  LoadL1Stall.id.U))))))))
+          Mux(uncacheReplay, LoadUncacheReplayStall.id.U,
+            Mux(vioReplay, LoadVioReplayStall.id.U,
+              Mux(tlbMiss || tlbReplay, LoadTLBStall.id.U,
+                Mux(forwardFailReplay, LoadForwardFailReplayStall.id.U,
+                  Mux(mshrReplay, LoadMSHRReplayStall.id.U,
+                    Mux(dcacheMissReplay, LoadDCacheMissReplayStall.id.U,
+                      Mux(bankConflictReplay, LoadBankConflictReplayStall.id.U,
+                        Mux(nukeQueryReplay, LoadNukeQueryReplayStall.id.U,
+                          Mux(otherReplay, LoadOtherReplayStall.id.U,
+                              LoadL1Stall.id.U)))))))))))))
   dispatch.io.debugLoadReason.foreach(_ := ldReason)
   dispatch.io.debugRobTrueCommit.foreach(_ := rob.io.debugTopDown.toDispatch.robTrueCommit)
   rename.io.debugLoadReason.foreach(_ := ldReason)

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -127,7 +127,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     val debugIQDeqRobIdxVec = Option.when(backendParams.debugEn)(Vec(IssueQueueDeqSum, Flipped(ValidIO(new RobPtr()))))
     val debugRobHeadStall = Option.when(backendParams.debugEn)(Output(Bool()))
     val debugEnqLsq = Input(new LsqEnqIO)
-    val debugHeadLsIssue = Input(Bool())
+    val debugMemIssueFire = Option.when(backendParams.debugEn)(Vec(params.memIssuePortNum, Flipped(ValidIO(new RobPtr()))))
     val lsTopdownInfo = Vec(LduCnt + HyuCnt, Input(new LsTopdownInfo))
     val debugTopDown = new Bundle {
       val toCore = new RobCoreTopDownIO
@@ -322,8 +322,6 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     snapshotPtrVec(i) := snapshotPtrVec(0) + i.U
   }
   val snapshots = SnapshotGenerator(snapshotPtrVec, snptEnq, io.snpt.snptDeq, io.redirect.valid, io.snpt.flushVec)
-  val debug_lsIssue = WireDefault(debug_lsIssued)
-  debug_lsIssue(deqPtr.value) := io.debugHeadLsIssue
 
   /**
    * states of Rob
@@ -562,10 +560,12 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     }
   }
 
-  // lsIssue
-  when(io.debugHeadLsIssue) {
-    debug_lsIssued(deqPtr.value) := true.B
-  }
+  // Set load/store entry to issued when mem issue fire
+  io.debugMemIssueFire.foreach(_.foreach { v =>
+    when(v.valid) {
+      debug_lsIssued(v.bits.value) := true.B
+    }
+  })
 
   /**
    * Writeback (from execution units)
@@ -1431,7 +1431,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   io.debugTopDown.toCore.robHeadPaddr.valid := debug_lsTopdownInfo(deqPtr.value).s2.paddr_valid
   io.debugTopDown.toCore.robHeadPaddr.bits := debug_lsTopdownInfo(deqPtr.value).s2.paddr_bits
   io.debugTopDown.toDispatch.robTrueCommit := ifCommitReg(trueCommitCnt)
-  io.debugTopDown.toDispatch.robHeadLsIssue := debug_lsIssue(deqPtr.value)
+  io.debugTopDown.toDispatch.robHeadLsIssued := debug_lsIssued(deqPtr.value)
   io.debugTopDown.robHeadLqIdx.valid := debug_lqIdxValid(deqPtr.value)
   io.debugTopDown.robHeadLqIdx.bits := robEntries(deqPtr.value).debug_lqIdx.getOrElse(0.U.asTypeOf( new LqPtr))
 

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -281,7 +281,7 @@ class RobCoreTopDownIO(implicit p: Parameters) extends XSBundle {
 
 class RobDispatchTopDownIO extends Bundle {
   val robTrueCommit = Output(UInt(64.W))
-  val robHeadLsIssue = Output(Bool())
+  val robHeadLsIssued = Output(Bool())
 }
 
 class RobDebugRollingIO extends Bundle {

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -742,7 +742,6 @@ class DCacheToLsuIO(implicit p: Parameters) extends DCacheBundle {
 class DCacheTopDownIO(implicit p: Parameters) extends DCacheBundle {
   val robHeadVaddr = Flipped(Valid(UInt(VAddrBits.W)))
   val robHeadMissInDCache = Output(Bool())
-  val robHeadOtherReplay = Input(Bool())
 }
 
 class DCacheIO(implicit p: Parameters) extends DCacheBundle {

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -1545,7 +1545,6 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   io.debugTopDown.toCore.robHeadDCacheMissReplay := lsq.io.debugTopDown.robHeadDCacheMissReplay
   io.debugTopDown.toCore.robHeadBankConflictReplay := lsq.io.debugTopDown.robHeadBankConflictReplay
   io.debugTopDown.toCore.robHeadNukeQueryReplay := lsq.io.debugTopDown.robHeadNukeQueryReplay
-  dcache.io.debugTopDown.robHeadOtherReplay := lsq.io.debugTopDown.robHeadOtherReplay
   dcache.io.debugRolling := io.debugRolling
 
   lsq.io.noUopsIssued := io.topDownInfo.toBackend.noUopsIssued

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -249,6 +249,12 @@ class MemCoreTopDownIO extends Bundle {
   val robHeadTlbMiss = Output(Bool())
   val robHeadLoadVio = Output(Bool())
   val robHeadLoadMSHR = Output(Bool())
+  val robHeadLdReplay = Output(Bool())
+  val robHeadUncacheReplay = Output(Bool())
+  val robHeadForwardFailReplay = Output(Bool())
+  val robHeadDCacheMissReplay = Output(Bool())
+  val robHeadBankConflictReplay = Output(Bool())
+  val robHeadNukeQueryReplay = Output(Bool())
 }
 
 class fetch_to_mem(implicit p: Parameters) extends XSBundle{
@@ -1533,6 +1539,12 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   io.debugTopDown.toCore.robHeadTlbMiss := lsq.io.debugTopDown.robHeadTlbMiss
   io.debugTopDown.toCore.robHeadLoadVio := lsq.io.debugTopDown.robHeadLoadVio
   io.debugTopDown.toCore.robHeadLoadMSHR := lsq.io.debugTopDown.robHeadLoadMSHR
+  io.debugTopDown.toCore.robHeadLdReplay := lsq.io.debugTopDown.robHeadLdReplay
+  io.debugTopDown.toCore.robHeadUncacheReplay := lsq.io.debugTopDown.robHeadUncacheReplay
+  io.debugTopDown.toCore.robHeadForwardFailReplay := lsq.io.debugTopDown.robHeadForwardFailReplay
+  io.debugTopDown.toCore.robHeadDCacheMissReplay := lsq.io.debugTopDown.robHeadDCacheMissReplay
+  io.debugTopDown.toCore.robHeadBankConflictReplay := lsq.io.debugTopDown.robHeadBankConflictReplay
+  io.debugTopDown.toCore.robHeadNukeQueryReplay := lsq.io.debugTopDown.robHeadNukeQueryReplay
   dcache.io.debugTopDown.robHeadOtherReplay := lsq.io.debugTopDown.robHeadOtherReplay
   dcache.io.debugRolling := io.debugRolling
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -148,6 +148,12 @@ class LoadQueueTopDownIO(implicit p: Parameters) extends XSBundle {
   val robHeadTlbMiss = Output(Bool())
   val robHeadLoadVio = Output(Bool())
   val robHeadLoadMSHR = Output(Bool())
+  val robHeadLdReplay = Output(Bool())
+  val robHeadUncacheReplay = Output(Bool())
+  val robHeadForwardFailReplay = Output(Bool())
+  val robHeadDCacheMissReplay = Output(Bool())
+  val robHeadBankConflictReplay = Output(Bool())
+  val robHeadNukeQueryReplay = Output(Bool())
   val robHeadMissInDTlb = Input(Bool())
   val robHeadOtherReplay = Output(Bool())
 }

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -155,7 +155,6 @@ class LoadQueueTopDownIO(implicit p: Parameters) extends XSBundle {
   val robHeadBankConflictReplay = Output(Bool())
   val robHeadNukeQueryReplay = Output(Bool())
   val robHeadMissInDTlb = Input(Bool())
-  val robHeadOtherReplay = Output(Bool())
 }
 
 class LoadQueue(implicit p: Parameters) extends XSModule

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -827,6 +827,9 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val rob_head_rar_nack        = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_RAR)
   val rob_head_raw_nack        = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_RAW)
   val rob_head_other_replay    = lq_match && (rob_head_rar_nack || rob_head_raw_nack || rob_head_forward_fail)
+  val rob_head_uncache         = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_UNCACHE)
+  val rob_head_smf             = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_SMF)
+  val rob_head_nuke_query      = rob_head_rar_nack || rob_head_raw_nack
 
   val rob_head_vio_replay = rob_head_nuke || rob_head_mem_amb
 
@@ -835,6 +838,12 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   io.debugTopDown.robHeadTlbMiss := rob_head_tlb_miss && rob_head_miss_in_dtlb
   io.debugTopDown.robHeadLoadVio := rob_head_vio_replay
   io.debugTopDown.robHeadLoadMSHR := rob_head_mshrfull_replay
+  io.debugTopDown.robHeadLdReplay := lq_match
+  io.debugTopDown.robHeadUncacheReplay := rob_head_uncache
+  io.debugTopDown.robHeadForwardFailReplay := rob_head_forward_fail
+  io.debugTopDown.robHeadDCacheMissReplay := rob_head_dcache_miss
+  io.debugTopDown.robHeadBankConflictReplay := rob_head_confilct_replay
+  io.debugTopDown.robHeadNukeQueryReplay := rob_head_nuke_query
   io.debugTopDown.robHeadOtherReplay := rob_head_other_replay
   val perfValidCount = RegNext(PopCount(allocated))
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -826,25 +826,21 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val rob_head_dcache_miss     = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_DM)
   val rob_head_rar_nack        = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_RAR)
   val rob_head_raw_nack        = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_RAW)
-  val rob_head_other_replay    = lq_match && (rob_head_rar_nack || rob_head_raw_nack || rob_head_forward_fail)
   val rob_head_uncache         = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_UNCACHE)
   val rob_head_smf             = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_SMF)
   val rob_head_nuke_query      = rob_head_rar_nack || rob_head_raw_nack
 
-  val rob_head_vio_replay = rob_head_nuke || rob_head_mem_amb
-
+  io.debugTopDown.robHeadLdReplay := lq_match
   val rob_head_miss_in_dtlb = io.debugTopDown.robHeadMissInDTlb
   io.debugTopDown.robHeadTlbReplay := rob_head_tlb_miss && !rob_head_miss_in_dtlb
   io.debugTopDown.robHeadTlbMiss := rob_head_tlb_miss && rob_head_miss_in_dtlb
-  io.debugTopDown.robHeadLoadVio := rob_head_vio_replay
+  io.debugTopDown.robHeadLoadVio := rob_head_nuke || rob_head_mem_amb
   io.debugTopDown.robHeadLoadMSHR := rob_head_mshrfull_replay
-  io.debugTopDown.robHeadLdReplay := lq_match
   io.debugTopDown.robHeadUncacheReplay := rob_head_uncache
   io.debugTopDown.robHeadForwardFailReplay := rob_head_forward_fail
   io.debugTopDown.robHeadDCacheMissReplay := rob_head_dcache_miss
   io.debugTopDown.robHeadBankConflictReplay := rob_head_confilct_replay
   io.debugTopDown.robHeadNukeQueryReplay := rob_head_nuke_query
-  io.debugTopDown.robHeadOtherReplay := rob_head_other_replay
   val perfValidCount = RegNext(PopCount(allocated))
 
   //  perf cnt

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -1233,6 +1233,12 @@ package object xiangshan {
     // xs replay (different to gem5)
     val LoadVioReplayStall = Value("LoadVioReplayStall")
     val LoadMSHRReplayStall = Value("LoadMSHRReplayStall")
+    val LoadUncacheReplayStall = Value("LoadUncacheReplayStall")
+    val LoadForwardFailReplayStall = Value("LoadForwardFailReplayStall")
+    val LoadDCacheMissReplayStall = Value("LoadDCacheMissReplayStall")
+    val LoadBankConflictReplayStall = Value("LoadBankConflictReplayStall")
+    val LoadNukeQueryReplayStall = Value("LoadNukeQueryReplayStall")
+    val LoadOtherReplayStall = Value("LoadOtherReplayStall")
 
     // bad speculation
     val ControlRedirectStall = Value("ControlRedirectStall")


### PR DESCRIPTION
Fix ldReason notIssue logic.

Split load replay counters by cause. Track each load replay reason separately in perf counters. In mem top-down charts, roll them up under LoadReplay for a cleaner view.