### PR TITLE
feat(extLLC): support external LLC integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ FPGA_MEM_ARGS = --firtool-opt "--repl-seq-mem --repl-seq-mem-file=$(TOP).$(RTL_S
 SIM_MEM_ARGS = --firtool-opt "--repl-seq-mem --repl-seq-mem-file=$(SIM_TOP).$(RTL_SUFFIX).conf"
 MFC_ARGS = --target $(CHISEL_TARGET) \
            --firtool-opt "-O=release --disable-annotation-unknown --lowering-options=explicitBitcast,disallowLocalVariables,disallowPortDeclSharing,locationInfoStyle=none"
+RTL_INCLUDE ?=
 
 ifeq ($(CHISEL_TARGET),systemverilog)
 MFC_ARGS += --split-verilog --dump-fir
@@ -338,14 +339,14 @@ reformat:
 
 # verilator simulation
 emu-mk: sim-verilog
-	$(MAKE) -C ./difftest emu-mk NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+	$(MAKE) -C ./difftest emu-mk NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX) RTL_INCLUDE="$(RTL_INCLUDE)"
 
 emu: $(call docker-deps,emu-mk)
 	$(MAKE) -C ./difftest emu NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
 
 # vcs simulation
 simv: sim-verilog
-	$(MAKE) -C ./difftest simv NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
+	$(MAKE) -C ./difftest simv NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX) RTL_INCLUDE="$(RTL_INCLUDE)"
 
 simv-run:
 	$(MAKE) -C ./difftest simv-run NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -50,6 +50,7 @@ object ArgParser {
       |--disable-perf
       |--disable-alwaysdb
       |--disable-clockgate
+      |--external-llc
       |--enable-dfx
       |--dump-csr
       |""".stripMargin
@@ -159,6 +160,10 @@ object ArgParser {
         case "--disable-clockgate" :: tail =>
           nextOption(config.alter((site, here, up) => {
             case XSTileKey => up(XSTileKey).map(_.copy(EnableClockGate = false))
+          }), tail)
+        case "--external-llc" :: tail =>
+          nextOption(config.alter((site, here, up) => {
+            case UseExternalLLCKey => true
           }), tail)
         case "--xstop-prefix" :: value :: tail =>
           nextOption(config.alter((site, here, up) => {

--- a/src/main/scala/top/ExternalLLC.scala
+++ b/src/main/scala/top/ExternalLLC.scala
@@ -1,0 +1,107 @@
+package top
+
+import chisel3._
+import chisel3.experimental.dataview._
+import coupledL2.tl2chi.PortIO
+import freechips.rocketchip.amba.axi4._
+import freechips.rocketchip.diplomacy.{AddressSet, IdRange, LazyModule, LazyModuleImp, ValName}
+import org.chipsalliance.cde.config.{Field, Parameters}
+import system.HasSoCParameter
+import utils.VerilogAXI4Record
+
+case object UseExternalLLCKey extends Field[Boolean](false)
+
+object ExternalLLCAddressMap {
+  val Control = AddressSet(0x20000000L, 0x0fffffffL)
+  val BootSram = AddressSet(0x37f00000L, 0xfffffL)
+  val BootSramBytes = 0x100000L
+}
+
+object ExternalLLCAxiParams {
+  val VisibleIdBits = 6
+  val DdrcIdBits = 14
+}
+
+// Match OpenNCB's forced-INCR memory AXI behavior expected by XiangShan AXI4 slaves.
+class AXI4ForceIncr()(implicit p: Parameters, valName: ValName) extends LazyModule {
+  val node = AXI4AdapterNode()
+
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out).foreach { case ((in, _), (out, _)) =>
+      def alignToTransfer(addr: UInt, bytes1: UInt): UInt = {
+        val mask = Wire(UInt(addr.getWidth.W))
+        mask := bytes1
+        addr & ~mask
+      }
+
+      out.aw.valid := in.aw.valid
+      in.aw.ready := out.aw.ready
+      out.aw.bits := in.aw.bits
+      out.aw.bits.addr := alignToTransfer(in.aw.bits.addr, in.aw.bits.bytes1())
+      out.aw.bits.burst := AXI4Parameters.BURST_INCR
+
+      out.w :<>= in.w
+      in.b :<>= out.b
+
+      out.ar.valid := in.ar.valid
+      in.ar.ready := out.ar.ready
+      out.ar.bits := in.ar.bits
+      out.ar.bits.addr := alignToTransfer(in.ar.bits.addr, in.ar.bits.bytes1())
+      out.ar.bits.burst := AXI4Parameters.BURST_INCR
+
+      in.r :<>= out.r
+    }
+  }
+}
+
+object AXI4ForceIncr {
+  def apply()(implicit p: Parameters, valName: ValName): AXI4Node = LazyModule(new AXI4ForceIncr()).node
+}
+
+class ExternalLLC()(implicit override val p: Parameters) extends LazyModule with HasSoCParameter {
+  val ddrcAXI4Node = AXI4MasterNode(Seq(AXI4MasterPortParameters(
+    Seq(AXI4MasterParameters(
+      name = "external-llc",
+      id = IdRange(0, 1 << ExternalLLCAxiParams.DdrcIdBits),
+      aligned = true,
+      maxFlight = Some(1)
+    ))
+  )))
+  val axi4node = AXI4IdentityNode()
+
+  axi4node :=
+    AXI4UserYanker(Some(1)) :=
+    AXI4IdIndexer(idBits = ExternalLLCAxiParams.VisibleIdBits) :=
+    AXI4ForceIncr() :=
+    ddrcAXI4Node
+
+  lazy val module = new ExternalLLCImp(this)
+}
+
+class ExternalLLCImp(wrapper: ExternalLLC)(implicit override val p: Parameters) extends LazyModuleImp(wrapper)
+  with HasSoCParameter {
+  val io = IO(new Bundle {
+    val clock = Input(Clock())
+    val reset = Input(Bool())
+    val rn = Vec(NumCores, Flipped(new PortIO))
+  })
+
+  val (axi, edge) = wrapper.ddrcAXI4Node.out.head
+  val wrapperBlackBox = Module(new ExternalLLCWrapper(edge.bundle))
+
+  wrapperBlackBox.io.clock := io.clock
+  wrapperBlackBox.io.reset := io.reset
+  wrapperBlackBox.io.rn <> io.rn
+  axi <> wrapperBlackBox.io.ddrc.viewAs[AXI4Bundle]
+}
+
+class ExternalLLCWrapper(ddrcParams: AXI4BundleParameters)(implicit val p: Parameters) extends BlackBox
+  with HasSoCParameter {
+  val io = IO(new Bundle {
+    val clock = Input(Clock())
+    val reset = Input(Bool())
+
+    val rn = Vec(NumCores, Flipped(new PortIO))
+    val ddrc = new VerilogAXI4Record(ddrcParams)
+  })
+}

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -86,6 +86,9 @@ trait HasDTSImp[+L <: BaseXSSoc] { this: LazyRawModuleImp =>
 
 class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 {
+  private val useExternalLLC = p(UseExternalLLCKey)
+  require(!useExternalLLC || enableCHI, "External LLC requires CHI")
+
   val nocMisc = if (enableCHI) Some(LazyModule(new MemMisc())) else None
   val socMisc = if (!enableCHI) Some(LazyModule(new SoCMisc())) else None
   val misc: MemMisc = if (enableCHI) nocMisc.get else socMisc.get
@@ -116,7 +119,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     })))
   )
 
-  val chi_llcBridge_opt = Option.when(enableCHI)(
+  val chi_llcBridge_opt = Option.when(enableCHI && !useExternalLLC)(
     LazyModule(new OpenNCB()(p.alter((site, here, up) => {
       case NCBParametersKey => new NCBParameters(
         outstandingDepth    = 64,
@@ -129,6 +132,10 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
       )
     })))
   )
+  val chi_extllc_opt = Option.when(useExternalLLC) {
+    require(NumCores <= 2, s"External LLC wrapper currently supports up to two RNs, got $NumCores")
+    LazyModule(new ExternalLLC())
+  }
 
   val chi_mmioBridge_opt = Seq.fill(NumCores)(Option.when(enableCHI)(
     LazyModule(new OpenNCB()(p.alter((site, here, up) => {
@@ -230,6 +237,10 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     case None =>
   }
 
+  chi_extllc_opt.foreach { externalLLC =>
+    misc.soc_xbar.get := externalLLC.axi4node
+  }
+
   chi_mmioBridge_opt.foreach { e =>
     e match {
       case Some(ncb) =>
@@ -257,7 +268,6 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
       case None =>
     }
 
-    memory.viewAs[AXI4Bundle] <> misc.memory.elements.head._2
     peripheral.viewAs[AXI4Bundle] <> misc.peripheral.elements.head._2
 
     val io = IO(new Bundle {
@@ -302,7 +312,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 
     val reset_sync = withClockAndReset(io.clock, io.reset) { ResetGen() }
     val jtag_reset_sync = withClockAndReset(io.systemjtag.jtag.TCK, io.systemjtag.reset) { ResetGen() }
-    val chi_openllc_opt = Option.when(enableCHI)(
+    val chi_openllc_opt = Option.when(enableCHI && !useExternalLLC) {
       withClockAndReset(io.clock, io.reset) {
         Module(new OpenLLC()(p.alter((site, here, up) => {
           case OpenLLCParamKey => soc.OpenLLCParamsOpt.get.copy(
@@ -311,7 +321,12 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
           )
         })))
       }
-    )
+    }
+    chi_extllc_opt.foreach { externalLLC =>
+      externalLLC.module.io.clock := io.clock
+      externalLLC.module.io.reset := io.reset.asBool
+    }
+    memory.viewAs[AXI4Bundle] <> misc.memory.elements.head._2
 
     // override LazyRawModuleImp's clock and reset
     childClock := io.clock
@@ -375,34 +390,47 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     }
 
     withClockAndReset(io.clock, io.reset) {
-      Option.when(enableCHI)(true.B).foreach { _ =>
+      if (enableCHI) {
+        val llcRouteId = NumCores * 2
         for ((core, i) <- core_with_l2.zipWithIndex) {
+          val coreCHI = core.module.io.chi.get
           val mmioLogger = CHILogger(s"L2[${i}]_MMIO", true)
           val llcLogger = CHILogger(s"L2[${i}]_LLC", true)
-          dontTouch(core.module.io.chi.get)
+          val mmioRouteId = NumCores + i
+          val lowAddressRange = AddressSet(0x0L, 0x00007fffffffL)
+          val externalLLCControlRange = ExternalLLCAddressMap.Control
+          val mmioRanges = if (useExternalLLC) lowAddressRange.subtract(externalLLCControlRange) else Seq(lowAddressRange)
+          val chiRouteMap = Map[AddressSet, Int]() ++
+            mmioRanges.map(_ -> mmioRouteId) ++
+            AddressSet(0x0L, 0xffffffffffffL).subtract(lowAddressRange).map(_ -> llcRouteId) ++
+            Option.when(useExternalLLC)(externalLLCControlRange -> llcRouteId)
+          dontTouch(coreCHI)
           bind(
-            route(
-              core.module.io.chi.get, Map((AddressSet(0x0L, 0x00007fffffffL), NumCores + i)) ++ AddressSet(0x0L,
-              0xffffffffffffL).subtract(AddressSet(0x0L, 0x00007fffffffL)).map(addr => (addr, NumCores * 2)).toMap
-            ),
-            Map((NumCores + i) -> mmioLogger.io.up, (NumCores * 2) -> llcLogger.io.up)
+            route(coreCHI, chiRouteMap),
+            Map(mmioRouteId -> mmioLogger.io.up, llcRouteId -> llcLogger.io.up)
           )
           chi_mmioBridge_opt(i).get.module.io.chi.connect(mmioLogger.io.down)
-          chi_openllc_opt.get.io.rn(i) <> llcLogger.io.down
-          require(core.module.io.chi.get.getWidth == llcLogger.io.up.getWidth)
-          require(llcLogger.io.down.getWidth == chi_openllc_opt.get.io.rn(i).getWidth)
+          val llcRN = chi_extllc_opt match {
+            case Some(externalLLC) =>
+              externalLLC.module.io.rn(i)
+            case None =>
+              chi_openllc_opt.get.io.rn(i)
+          }
+          llcRN <> llcLogger.io.down
+          require(llcLogger.io.down.getWidth == llcRN.getWidth)
+          require(coreCHI.getWidth == llcLogger.io.up.getWidth)
         }
-        val memLogger = CHILogger(s"LLC_MEM", true)
-        chi_openllc_opt.get.io.sn.connect(memLogger.io.up)
-        chi_llcBridge_opt.get.module.io.chi.connect(memLogger.io.down)
-        chi_openllc_opt.get.io.nodeID := (NumCores * 2).U
-        chi_openllc_opt.foreach { l3 =>
-          l3.io.debugTopDown.robHeadPaddr := core_with_l2.map(_.module.io.debugTopDown.robHeadPaddr)
+        chi_openllc_opt.foreach { openLLC =>
+          val memLogger = CHILogger(s"LLC_MEM", true)
+          openLLC.io.sn.connect(memLogger.io.up)
+          chi_llcBridge_opt.get.module.io.chi.connect(memLogger.io.down)
+          openLLC.io.nodeID := llcRouteId.U
+          openLLC.io.debugTopDown.robHeadPaddr := core_with_l2.map(_.module.io.debugTopDown.robHeadPaddr)
+          core_with_l2.zip(openLLC.io.debugTopDown.addrMatch).foreach { case (tile, l3Match) =>
+            tile.module.io.debugTopDown.l3MissMatch := l3Match
+          }
+          core_with_l2.foreach(_.module.io.l3Miss := openLLC.io.l3Miss)
         }
-        core_with_l2.zip(chi_openllc_opt.get.io.debugTopDown.addrMatch).foreach { case (tile, l3Match) =>
-          tile.module.io.debugTopDown.l3MissMatch := l3Match
-        }
-        core_with_l2.map(_.module.io.l3Miss := (if (chi_openllc_opt.nonEmpty) chi_openllc_opt.get.io.l3Miss else false.B))
       }
     }
 

--- a/src/test/scala/top/SimMMIO.scala
+++ b/src/test/scala/top/SimMMIO.scala
@@ -35,10 +35,13 @@ class SimMMIO(edge: AXI4EdgeParameters)(implicit p: Parameters) extends LazyModu
 
   // val uartRange = AddressSet(0x40600000, 0x3f) // ?
   val flashRange = AddressSet(0x10000000L, 0xfffffff)
+  private val useExternalLLC = p(UseExternalLLCKey)
+  private val externalLLCBootSramRange = ExternalLLCAddressMap.BootSram
+  private val externalLLCBootRanges = Option.when(useExternalLLC)(externalLLCBootSramRange).toSeq
   val sdRange = AddressSet(0x40002000L, 0xfff)
   val intrGenRange = AddressSet(0x40070000L, 0x0000ffffL)
 
-  val illegalRange = (onChipPeripheralRanges.values ++ Seq(
+  val illegalRange = (onChipPeripheralRanges.values ++ externalLLCBootRanges ++ Seq(
     soc.UARTLiteRange,
     soc.UART16550Range,
     flashRange,
@@ -47,6 +50,9 @@ class SimMMIO(edge: AXI4EdgeParameters)(implicit p: Parameters) extends LazyModu
   )).foldLeft(Seq(AddressSet(0x0, 0x7fffffffL)))((acc, x) => acc.flatMap(_.subtract(x)))
 
   val flash = LazyModule(new AXI4Flash(Seq(AddressSet(0x10000000L, 0xfffffff))))
+  val bootSram = Option.when(useExternalLLC) {
+    LazyModule(new AXI4RAM(Seq(externalLLCBootSramRange), memByte = ExternalLLCAddressMap.BootSramBytes))
+  }
   val uartLite = LazyModule(new AXI4UART(Seq(soc.UARTLiteRange)))
   private val uart16550Params = UART16550Params(address = soc.UART16550Range.base)
   val uart16550 = LazyModule(new AXI4UART16550(uart16550Params))
@@ -68,6 +74,7 @@ class SimMMIO(edge: AXI4EdgeParameters)(implicit p: Parameters) extends LazyModu
   uart16550.controlXing() := axiBus
   // vga.node :*= axiBus
   flash.node := axiBus
+  bootSram.foreach(_.node := axiBus)
   sd.node := axiBus
   intrGen.node := axiBus
   error.node := axiBus


### PR DESCRIPTION
Add an --external-llc option that replaces the OpenLLC CHI path with an ExternalLLC blackbox wrapper. The wrapper keeps the CHI RN interface in XiangShan, routes external-LLC control accesses to the LLC path, and connects the wrapper DDR AXI master through the existing memory diplomacy path.

Pass `RTL_INCLUDE` through sim build targets so wrapper and external RTL files can live outside XiangShan, and add the soft-sim boot SRAM range used by external LLC boot code.