### PR TITLE
timing(icache, ifu): retime IFU compact and ICache miss response paths

### DIFF
--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -188,11 +188,16 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_mshrDatas       = fromMiss.bits.data.asTypeOf(Vec(DataBanks, UInt(ICacheDataBits.W)))
   private val s1_mshrMaybeRvcMap = fromMiss.bits.maybeRvcMap.asTypeOf(Vec(DataBanks, UInt(MaxInstNumPerBank.W)))
 
+  private val s1_mshrValidReg       = RegNext(s1_mshrValid)
+  private val s1_bankMshrValidReg   = RegNext(s1_bankMshrValid)
+  private val s1_mshrDatasReg       = RegNext(s1_mshrDatas)
+  private val s1_mshrMaybeRvcMapReg = RegNext(s1_mshrMaybeRvcMap)
+
   private val s1_hits = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
     VecInit((0 until PortNumber).map { portIdx =>
       DataHoldBypass(
-        s1_mshrValid(reqIdx)(portIdx) || s1_sramHits(reqIdx)(portIdx),
-        s1_mshrValid(reqIdx)(portIdx) || s1_sramValid(reqIdx)(portIdx)
+        s1_mshrValidReg(reqIdx)(portIdx) || s1_sramHits(reqIdx)(portIdx),
+        s1_mshrValidReg(reqIdx)(portIdx) || s1_sramValid(reqIdx)(portIdx)
       )
     })
   })
@@ -203,11 +208,11 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     VecInit((0 until DataBanks).map { bankIdx =>
       DataHoldBypass(
         Mux(
-          s1_bankMshrValid(reqIdx)(bankIdx),
-          s1_mshrDatas(bankIdx),
+          s1_bankMshrValidReg(reqIdx)(bankIdx),
+          s1_mshrDatasReg(bankIdx),
           s1_sramDatas(reqIdx)(bankIdx)
         ),
-        s1_bankMshrValid(reqIdx)(bankIdx) || s1_bankSramValid(reqIdx)(bankIdx)
+        s1_bankMshrValidReg(reqIdx)(bankIdx) || s1_bankSramValid(reqIdx)(bankIdx)
       )
     }).asUInt
   })
@@ -219,15 +224,15 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     VecInit((0 until DataBanks).map { bankIdx =>
       DataHoldBypass(
         Mux(
-          s1_bankMshrValid(reqIdx)(bankIdx),
-          s1_mshrMaybeRvcMap(bankIdx),
+          s1_bankMshrValidReg(reqIdx)(bankIdx),
+          s1_mshrMaybeRvcMapReg(bankIdx),
           Mux(
             s1_lineSel(reqIdx)(bankIdx),
             sramMaybeRvcMap(1)(bankIdx),
             sramMaybeRvcMap(0)(bankIdx)
           )
         ),
-        s1_bankMshrValid(reqIdx)(bankIdx) || s1_bankSramValid(reqIdx)(bankIdx)
+        s1_bankMshrValidReg(reqIdx)(bankIdx) || s1_bankSramValid(reqIdx)(bankIdx)
       )
     }).asUInt
   })
@@ -235,8 +240,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_tlCorrupt = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
     VecInit((0 until PortNumber).map { portIdx =>
       DataHoldBypass(
-        s1_mshrValid(reqIdx)(portIdx) && fromMiss.bits.corrupt,
-        s1_mshrValid(reqIdx)(portIdx) || s1_sramValid(reqIdx)(portIdx)
+        s1_mshrValidReg(reqIdx)(portIdx) && RegNext(fromMiss.bits.corrupt),
+        s1_mshrValidReg(reqIdx)(portIdx) || s1_sramValid(reqIdx)(portIdx)
       )
     })
   })
@@ -244,8 +249,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_tlDenied = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
     VecInit((0 until PortNumber).map { portIdx =>
       DataHoldBypass(
-        s1_mshrValid(reqIdx)(portIdx) && fromMiss.bits.denied,
-        s1_mshrValid(reqIdx)(portIdx) || s1_sramValid(reqIdx)(portIdx)
+        s1_mshrValidReg(reqIdx)(portIdx) && RegNext(fromMiss.bits.denied),
+        s1_mshrValidReg(reqIdx)(portIdx) || s1_sramValid(reqIdx)(portIdx)
       )
     })
   })

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -239,18 +239,18 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
 
   private val s1_tlCorrupt = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
     VecInit((0 until PortNumber).map { portIdx =>
-      DataHoldBypass(
-        s1_mshrValidReg(reqIdx)(portIdx) && RegNext(fromMiss.bits.corrupt),
-        s1_mshrValidReg(reqIdx)(portIdx) || s1_sramValid(reqIdx)(portIdx)
+      RegEnable(
+        s1_mshrValid(reqIdx)(portIdx) && fromMiss.bits.corrupt,
+        s1_mshrValid(reqIdx)(portIdx) || s0_fire
       )
     })
   })
 
   private val s1_tlDenied = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
     VecInit((0 until PortNumber).map { portIdx =>
-      DataHoldBypass(
-        s1_mshrValidReg(reqIdx)(portIdx) && RegNext(fromMiss.bits.denied),
-        s1_mshrValidReg(reqIdx)(portIdx) || s1_sramValid(reqIdx)(portIdx)
+      RegEnable(
+        s1_mshrValid(reqIdx)(portIdx) && fromMiss.bits.denied,
+        s1_mshrValid(reqIdx)(portIdx) || s0_fire
       )
     })
   })

--- a/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
@@ -139,30 +139,31 @@ trait IfuHelper extends HasIfuParameters with PreDecodeHelper {
     out
   }
 
-  def compact(in: Vec[Instruction]): (Vec[Instruction], UInt) = {
+  def compact(in: Vec[Instruction], fire: Bool): (Vec[Instruction], UInt) = {
     val n = in.length
     require(n > 0)
 
     val out = WireDefault(0.U.asTypeOf(in))
 
+    val inReg = RegEnable(in, fire)
     // rank(i) = number of valid elements in [0, i)
-    val rank = Wire(Vec(n, UInt(log2Ceil(n + 1).W)))
-    rank(0) := 0.U
-    for (i <- 1 until n) {
-      rank(i) := rank(i - 1) + in(i - 1).valid
-    }
+    val validVec = VecInit(in.map(_.valid))
 
-    val count = PopCount(in.map(_.valid))
+    val rank = VecInit((0 until n).map { i =>
+      if (i == 0) 0.U
+      else PopCount(validVec.take(i))
+    })
+    val hitMaskVec = VecInit((0 until n).map { i =>
+      VecInit((0 until n).map(j => validVec(j) && rank(j) === i.U)).asUInt
+    })
+    val hitMaskVecReg = RegEnable(hitMaskVec, fire)
+    val count         = PopCount(validVec)
+    val countReg      = RegEnable(count, fire)
 
     for (j <- 0 until n) {
-      val hitMask = (0 until n).map(i => in(i).valid && (rank(i) === j.U))
-      when(hitMask.reduce(_ || _)) {
-        out(j) := Mux1H(hitMask, in)
-      }
-      out(j).valid := j.U < count
+      out(j) := Mux1H(hitMaskVecReg(j), inReg)
     }
-
-    (out, count)
+    (out, countReg)
   }
 
   def align[T <: Data](in: Vec[T], shamt: UInt): Vec[T] = {

--- a/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
@@ -139,31 +139,35 @@ trait IfuHelper extends HasIfuParameters with PreDecodeHelper {
     out
   }
 
-  def compact(in: Vec[Instruction], fire: Bool): (Vec[Instruction], UInt) = {
+  def compact(in: Vec[Instruction], fire: Bool): Vec[Instruction] = {
     val n = in.length
     require(n > 0)
 
-    val out = WireDefault(0.U.asTypeOf(in))
-
-    val inReg = RegEnable(in, fire)
-    // rank(i) = number of valid elements in [0, i)
+    // 1. Valid flag vector
     val validVec = VecInit(in.map(_.valid))
 
+    // rank(i) = number of valid elements in [0, i)
     val rank = VecInit((0 until n).map { i =>
       if (i == 0) 0.U
       else PopCount(validVec.take(i))
     })
-    val hitMaskVec = VecInit((0 until n).map { i =>
-      VecInit((0 until n).map(j => validVec(j) && rank(j) === i.U)).asUInt
-    })
-    val hitMaskVecReg = RegEnable(hitMaskVec, fire)
-    val count         = PopCount(validVec)
-    val countReg      = RegEnable(count, fire)
 
-    for (j <- 0 until n) {
-      out(j) := Mux1H(hitMaskVecReg(j), inReg)
+    val inReg = RegEnable(in, fire)
+
+    // 3. Output vector, default all zeros
+    val out = WireDefault(0.U.asTypeOf(in))
+
+    for (idx <- 0 until n) {
+      val instrRange = idx until Math.min(2 * idx + 2, FetchBlockInstNum)
+      val validOH = instrRange.map {
+        i => validVec(i) && rank(i) === idx.U
+      }
+      val validOHReg   = RegEnable(VecInit(validOH), fire)
+      val candidateReg = instrRange.map(inReg(_))
+      out(idx)       := Mux1H(validOHReg, candidateReg)
+      out(idx).valid := validOHReg.reduce(_ || _)
     }
-    (out, countReg)
+    out
   }
 
   def align[T <: Data](in: Vec[T], shamt: UInt): Vec[T] = {

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -140,7 +140,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   private val s0_totalEndPos = Mux(
     s0_fetchBlock(1).valid,
-    s0_fetchBlock(1).takenCfiOffset.bits + s0_fetchBlock(0).size,
+    (s0_fetchBlock(1).takenCfiOffset.bits + s0_fetchBlock(0).size)(FetchBlockInstOffsetWidth - 1, 0),
     s0_fetchBlock(0).takenCfiOffset.bits
   )
 
@@ -155,8 +155,6 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s0_rawInstrVec       = instrBoundary.io.resp.rawInstrVec
   private val s0_instrEndMask      = instrBoundary.io.resp.instrEndMask
   private val s0_rawInstrValid     = VecInit(s0_rawInstrVec.map(_.valid)).asUInt
-  private val s0_firstBlockInstrCount =
-    PopCount(s0_rawInstrValid & VecInit(s0_rawInstrVec.map(instr => !instr.blockSel)).asUInt)
 
   // When invalidTaken is true, we can not flush s2_prevLastIsHalfRvi because the fetch block after it is fall-through.
   when(backendRedirect) {
@@ -172,6 +170,10 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // When an exception occurs, forward the exception information immediately instead of
   // waiting for instruction concatenation to complete.
   private val s0_hasException = s0_icacheMeta(0).exception.hasException
+  private val s0_instrCount = Mux(s0_hasException, 1.U((log2Ceil(FetchBlockInstNum) + 1).W), PopCount(s0_instrEndMask))
+  private val s0_firstRange = VecInit(s0_rawInstrVec.map(instr => !instr.blockSel)).asUInt
+  private val s0_firstRawInstrValid = s0_rawInstrValid & s0_firstRange
+  private val s0_totalRawInstrValid = s0_rawInstrValid
   /* --------------------------------------------------------------------------------------------------------------
      stage 1
      - cat half rvi instruction
@@ -183,27 +185,35 @@ class Ifu(implicit p: Parameters) extends IfuModule
   s1_fire  := s1_valid && s2_ready
   s1_ready := s1_fire || !s1_valid
 
-  private val s1_hasException = RegEnable(s0_hasException, s0_fire)
-  private val s1_fetchBlock   = RegEnable(s0_fetchBlock, s0_fire)  // Consider the impact of invalidTaken.
-  private val s1_totalEndPos  = RegEnable(s0_totalEndPos, s0_fire) // Consider the impact of invalidTaken.
-  private val s1_instrEndMask = RegEnable(s0_instrEndMask, s0_fire)
-  private val (s1_compactedInstrVec, s1_instrCount) = compact(s0_rawInstrVec, s0_fire)
-  private val s1_firstBlockInstrCount               = RegEnable(s0_firstBlockInstrCount, s0_fire)
-  private val s1_realInstrCount = Mux(s1_hasException, 1.U((log2Ceil(FetchBlockInstNum) + 1).W), s1_instrCount)
-  private val s1_realInstrValid =
-    Mux(s1_hasException, 1.U(FetchBlockInstNum.W), UIntToMask(s1_instrCount, FetchBlockInstNum))
+  private val s1_hasException      = RegEnable(s0_hasException, s0_fire)
+  private val s1_fetchBlock        = RegEnable(s0_fetchBlock, s0_fire)
+  private val s1_totalEndPos       = RegEnable(s0_totalEndPos, s0_fire)
+  private val s1_instrEndMask      = RegEnable(s0_instrEndMask, s0_fire)
+  private val s1_compactedInstrVec = compact(s0_rawInstrVec, s0_fire)
+  // The pre-calculated enqueue amount required when estimating whether the IBuffer can be enqueued.
+  private val s1_specInstrCount       = RegEnable(s0_instrCount, s0_fire)
+  private val s1_firstRange           = RegEnable(s0_firstRange, s0_fire)
+  private val s1_totalRawInstrValid   = RegEnable(s0_totalRawInstrValid, s0_fire)
+  private val s1_firstRawInstrValid   = s1_totalRawInstrValid & s1_firstRange
+  private val s1_firstRawInstrEndMask = s1_instrEndMask.asUInt & s1_firstRange
   private val s1_invalidTaken = VecInit(
     s1_fetchBlock(0).takenCfiOffset.valid && !s1_instrEndMask(s1_fetchBlock(0).takenCfiOffset.bits),
     s1_fetchBlock(1).valid && s1_fetchBlock(1).takenCfiOffset.valid &&
       !s1_instrEndMask(s1_totalEndPos)
-  ) // Consider the impact of invalidTaken.
+  )
   private val s1_predTakenIdx = VecInit(
-    Mux(s1_invalidTaken(0), s1_firstBlockInstrCount, s1_firstBlockInstrCount - 1.U),
-    Mux(s1_invalidTaken(1), s1_realInstrCount, s1_realInstrCount - 1.U)
+    PopCount(s1_firstRawInstrValid) - 1.U,
+    PopCount(s1_totalRawInstrValid) - 1.U
   )
 
   dontTouch(s1_fetchBlock)
-
+  private val s1_instrCount = Mux(
+    s1_invalidTaken(0),
+    PopCount(s1_firstRawInstrEndMask),
+    s1_specInstrCount
+  )
+  private val s1_instrValid =
+    Mux(s1_instrCount === FetchBlockInstNum.U, ~0.U(FetchBlockInstNum.W), UIntToMask(s1_instrCount, FetchBlockInstNum))
   private val s1_prevIBufEnqPtr     = RegInit(0.U.asTypeOf(new IBufPtr))
   private val s1_prevEndIsHalfRvi   = RegEnable(s0_prevEndIsHalfRvi, s0_fire)
   private val s1_prevEndHalfRviData = RegInit(0.U(16.W))
@@ -212,9 +222,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_firstEndIsHalfRvi = RegEnable(s0_firstEndIsHalfRvi, s0_fire)
   private val s1_totalEndIsHalfRvi = RegEnable(s0_totalEndIsHalfRvi, s0_fire)
 
-  private val s1_instrData  = RegEnable(s0_icacheData.data, s0_fire)
+  private val s1_instrData    = RegEnable(s0_icacheData.data, s0_fire)
   private val s1_icacheMetaIn = RegEnable(s0_icacheMeta, s0_fire)
-  private val s1_instrVec   = s1_compactedInstrVec
+  private val s1_instrVec     = s1_compactedInstrVec
 
   // ICache mainPipe send parity check result 1 cycle after io.fromICache.req.fire, here merge into icacheMeta.
   // for better timing.
@@ -246,48 +256,45 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_mergedInvalidTakenMask = s1_invalidTakenMask(0) | s1_invalidTakenMask(1)
   dontTouch(s1_mergedInvalidTakenMask)
 
-  private val s1_fixedInstrVec = WireDefault(s1_instrVec)
-  s1_fixedInstrVec(0).data := Mux(
-    s1_prevEndIsHalfRvi,
-    Cat(s1_instrVec(0).data(15, 0), s1_prevEndHalfRviData),
-    s1_instrVec(0).data
-  )
-  s1_fixedInstrVec(0).isPrevEndHalfRvi := s1_prevEndIsHalfRvi
-  s1_fixedInstrVec(0).endOffset        := Mux(s1_prevEndIsHalfRvi, 0.U, s1_instrVec(0).endOffset)
-  s1_fixedInstrVec.zipWithIndex.foreach { case (instr, i) =>
-    instr.isPredTaken  := s1_mergedPredTakenMask(i)
-    instr.invalidTaken := s1_mergedInvalidTakenMask(i)
-  }
-
-  private val s1_alignShiftNum = s1_prevIBufEnqPtr.value(1, 0)
-  dontTouch(s1_alignShiftNum)
-  private val s1_alignedInstrVec = align(s1_fixedInstrVec, s1_alignShiftNum)
-
-  private val s1_baseAlignedInstrPcVec = VecInit(s1_alignedInstrVec.map(instr => getInstrPc(instr, s1_fetchBlock)))
+  private val s1_alignShiftNum         = s1_prevIBufEnqPtr.value(1, 0)
+  private val s1_baseAlignedInstrVec   = align(s1_instrVec, s1_alignShiftNum)
+  private val s1_baseAlignedInstrPcVec = VecInit(s1_baseAlignedInstrVec.map(instr => getInstrPc(instr, s1_fetchBlock)))
+  private val s1_alignedInstrValid     = (s1_instrValid << s1_alignShiftNum).pad(IBufferEnqueueWidth)
+  private val s1_alignedPredTakenMask  = (s1_mergedPredTakenMask << s1_alignShiftNum).pad(IBufferEnqueueWidth)
+  private val s1_alignedInvalidTakenMask = (s1_mergedInvalidTakenMask << s1_alignShiftNum).pad(IBufferEnqueueWidth)
 
   private val s1_firstEndPos       = s1_fetchBlock(0).takenCfiOffset.bits
   private val s1_firstEndHalfRviPc = s1_fetchBlock(0).startVAddr + (s1_firstEndPos << 1)
   private val s1_totalEndHalfRviPc = Mux(
     s1_fetchBlock(1).valid,
-    s1_fetchBlock(1).startVAddr + ((s1_totalEndPos - s1_fetchBlock(0).size) << 1),
+    s1_fetchBlock(1).startVAddr + ((s1_fetchBlock(1).takenCfiOffset.bits) << 1),
     s1_firstEndHalfRviPc
   )
 
+  private val s1_firstEndHalfRviData = s1_instrData(s1_firstEndPos)
+  private val s1_totalEndHalfRviData = s1_instrData(s1_totalEndPos)
+
+  // Patch instruction data
   private val s1_alignedInstrPcVec = WireDefault(s1_baseAlignedInstrPcVec)
-  for (i <- 0 until IBufferEnqueueWidth) {
-    when(s1_alignedInstrVec(i).isPrevEndHalfRvi) {
-      s1_alignedInstrPcVec(i) := s1_prevEndHalfRviPc
-    }.elsewhen(s1_alignedInstrVec(i).invalidTaken) {
-      s1_alignedInstrPcVec(i) := Mux(
-        s1_alignedInstrVec(i).blockSel,
-        s1_totalEndHalfRviPc,
-        s1_firstEndHalfRviPc
+  private val s1_alignedInstrVec   = WireDefault(s1_baseAlignedInstrVec)
+  for (i <- 0 until IfuAlignWidth) {
+    when(s1_alignShiftNum === i.U) {
+      s1_alignedInstrPcVec(i) := Mux(s1_prevEndIsHalfRvi, s1_prevEndHalfRviPc, s1_baseAlignedInstrPcVec(i))
+      s1_alignedInstrVec(i).data := Mux(
+        s1_prevEndIsHalfRvi,
+        Cat(s1_baseAlignedInstrVec(i).data(15, 0), s1_prevEndHalfRviData),
+        s1_baseAlignedInstrVec(i).data
       )
+      s1_alignedInstrVec(i).isPrevEndHalfRvi := s1_prevEndIsHalfRvi
+      s1_alignedInstrVec(i).endOffset        := Mux(s1_prevEndIsHalfRvi, 0.U, s1_baseAlignedInstrVec(i).endOffset)
     }
   }
 
-  private val s1_firstEndHalfRviData = s1_instrData(s1_firstEndPos)
-  private val s1_totalEndHalfRviData = s1_instrData(s1_totalEndPos)
+  for (i <- 0 until IBufferEnqueueWidth) {
+    s1_alignedInstrVec(i).valid        := s1_alignedInstrValid(i)
+    s1_alignedInstrVec(i).isPredTaken  := s1_alignedPredTakenMask(i)
+    s1_alignedInstrVec(i).invalidTaken := s1_alignedInvalidTakenMask(i)
+  }
 
   private val s1_alignedFoldPc =
     VecInit(s1_alignedInstrPcVec.map(i => XORFold(i(VAddrBits - 1, 1), MemPredPCWidth)))
@@ -314,10 +321,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
   }.elsewhen(uncacheRedirect.valid) {
     s1_prevIBufEnqPtr := uncacheRedirect.prevIBufEnqPtr + uncacheRedirect.instrCount
   }.elsewhen(s1_fire && !s1_icacheMeta(0).isUncache) {
-    s1_prevIBufEnqPtr := s1_prevIBufEnqPtr + s1_realInstrCount
+    s1_prevIBufEnqPtr := s1_prevIBufEnqPtr + s1_specInstrCount
   }
 
-  private val s1_alignedInstrValid = s1_realInstrValid << s1_alignShiftNum
   // reqIsUncache is used to limit the number of fetch requests and enable special pre-decode configurations.
   private val s1_reqIsUncache = s1_valid && s1_icacheMeta(0).isUncache
   // useUncacheFetch controls whether the instruction fetch operation follows the uncache control logic.
@@ -351,7 +357,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s2_totalEndHalfRviPc   = RegEnable(s1_totalEndHalfRviPc, s1_fire)
   private val s2_totalEndHalfRviData = RegEnable(s1_totalEndHalfRviData, s1_fire)
 
-  private val s2_instrCount        = RegEnable(s1_realInstrCount, s1_fire)
+  private val s2_instrCount        = RegEnable(s1_instrCount, s1_fire)
   private val s2_alignedInstrValid = RegEnable(s1_alignedInstrValid, s1_fire)
   private val s2_icacheMeta        = RegEnable(s1_icacheMeta, s1_fire)
   private val s2_alignedInstrVec   = RegEnable(s1_alignedInstrVec, s1_fire)
@@ -383,15 +389,15 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s2_endOffsetVec = VecInit(s2_expandedInstrVec.map(_.endOffset))
   dontTouch(s2_blockSel)
 
-  private val s2_pdInfoVec     = Wire(Vec(IBufferEnqueueWidth, new PreDecodeInfo))
-  private val s2_jumpOffsetVec = Wire(Vec(IBufferEnqueueWidth, PrunedAddr(VAddrBits)))
+  private val s2_alignedPdInfoVec     = Wire(Vec(IBufferEnqueueWidth, new PreDecodeInfo))
+  private val s2_alignedJumpOffsetVec = Wire(Vec(IBufferEnqueueWidth, PrunedAddr(VAddrBits)))
   s2_alignedInstrVec.zipWithIndex.foreach { case (instr, i) =>
     val jalOffset = getJalOffset(instr.data, instr.isRvc)
     val brOffset  = getBrOffset(instr.data, instr.isRvc)
-    s2_pdInfoVec(i).valid       := instr.valid
-    s2_pdInfoVec(i).isRVC       := instr.isRvc
-    s2_pdInfoVec(i).brAttribute := BranchAttribute.decode(instr.data, instr.valid && s2_valid)
-    s2_jumpOffsetVec(i)         := Mux(s2_pdInfoVec(i).isBr, brOffset, jalOffset)
+    s2_alignedPdInfoVec(i).valid       := instr.valid
+    s2_alignedPdInfoVec(i).isRVC       := instr.isRvc
+    s2_alignedPdInfoVec(i).brAttribute := BranchAttribute.decode(instr.data, instr.valid && s2_valid)
+    s2_alignedJumpOffsetVec(i)         := Mux(s2_alignedPdInfoVec(i).isBr, brOffset, jalOffset)
   }
 
   private val s2_reqIsUncache    = RegEnable(s1_reqIsUncache, false.B, s1_fire)
@@ -458,17 +464,17 @@ class Ifu(implicit p: Parameters) extends IfuModule
   s2_ready := (io.toIBuffer.ready && (s2_uncacheCanGo || !s2_reqIsUncache)) || !s2_valid
 
   /* ** prediction result check ** */
-  checkerIn.valid                 := s2_valid
-  checkerIn.bits.jumpOffsetVec    := s2_jumpOffsetVec
-  checkerIn.bits.pdInfoVec        := s2_pdInfoVec
-  checkerIn.bits.instrPcVec       := s2_alignedInstrPcVec
-  checkerIn.bits.expandedInstrVec := s2_expandedInstrVec
+  checkerIn.valid              := s2_valid
+  checkerIn.bits.jumpOffsetVec := s2_alignedJumpOffsetVec
+  checkerIn.bits.pdInfoVec     := s2_alignedPdInfoVec
+  checkerIn.bits.instrPcVec    := s2_alignedInstrPcVec
+  checkerIn.bits.instrVec      := s2_alignedInstrVec
 
   private val s2_fixedInstrValid = checkerOutStage1.fixedInstrValid.asUInt
   dontTouch(s2_fixedInstrValid)
 
   /* ** frontend Trigger  ** */
-  frontendTrigger.io.pds             := s2_pdInfoVec
+  frontendTrigger.io.pds             := s2_alignedPdInfoVec
   frontendTrigger.io.pc              := s2_alignedInstrPcVec
   frontendTrigger.io.data            := 0.U.asTypeOf(Vec(IBufferEnqueueWidth + 1, UInt(16.W)))
   frontendTrigger.io.frontendTrigger := io.frontendTrigger
@@ -487,13 +493,13 @@ class Ifu(implicit p: Parameters) extends IfuModule
   }
 
   /* in s2, prevInstrCount equals to next cycle's IBuffer.numFromFetch without predChecker. "prev" means s1;
-   * when s1 fire (s1_valid && s2_ready), use s1_instrCount;
+   * when s1 fire (s1_valid && s2_ready), use s1_specInstrCount;
    * else when s2 stall (s2_valid && !s2_ready). use s2_instrCount because prevInstrCount equals to current instrCount;
    * otherwise, we don't care about prevInstrCount because next cycle's toIBuffer.valid won't set.
    */
   io.toIBuffer.bits.prevInstrCount := Mux(
     s1_fire,
-    Mux(s1_reqIsUncache, 1.U, s1_instrCount),
+    Mux(s1_reqIsUncache, 1.U, s1_specInstrCount),
     Mux(s2_reqIsUncache, 1.U, s2_instrCount)
   )
 

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -194,12 +194,14 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_specInstrCount       = RegEnable(s0_instrCount, s0_fire)
   private val s1_firstRange           = RegEnable(s0_firstRange, s0_fire)
   private val s1_totalRawInstrValid   = RegEnable(s0_totalRawInstrValid, s0_fire)
+  private val s1_firstEndIsHalfRvi    = RegEnable(s0_firstEndIsHalfRvi, s0_fire)
+  private val s1_totalEndIsHalfRvi    = RegEnable(s0_totalEndIsHalfRvi, s0_fire)
   private val s1_firstRawInstrValid   = s1_totalRawInstrValid & s1_firstRange
   private val s1_firstRawInstrEndMask = s1_instrEndMask.asUInt & s1_firstRange
   private val s1_invalidTaken = VecInit(
-    s1_fetchBlock(0).takenCfiOffset.valid && !s1_instrEndMask(s1_fetchBlock(0).takenCfiOffset.bits),
+    s1_fetchBlock(0).takenCfiOffset.valid && s1_firstEndIsHalfRvi,
     s1_fetchBlock(1).valid && s1_fetchBlock(1).takenCfiOffset.valid &&
-      !s1_instrEndMask(s1_totalEndPos)
+      s1_totalEndIsHalfRvi
   )
   private val s1_predTakenIdx = VecInit(
     PopCount(s1_firstRawInstrValid) - 1.U,
@@ -218,9 +220,6 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_prevEndIsHalfRvi   = RegEnable(s0_prevEndIsHalfRvi, s0_fire)
   private val s1_prevEndHalfRviData = RegInit(0.U(16.W))
   private val s1_prevEndHalfRviPc   = RegInit(0.U.asTypeOf(PrunedAddr(VAddrBits)))
-
-  private val s1_firstEndIsHalfRvi = RegEnable(s0_firstEndIsHalfRvi, s0_fire)
-  private val s1_totalEndIsHalfRvi = RegEnable(s0_totalEndIsHalfRvi, s0_fire)
 
   private val s1_instrData    = RegEnable(s0_icacheData.data, s0_fire)
   private val s1_icacheMetaIn = RegEnable(s0_icacheMeta, s0_fire)

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -154,47 +154,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s0_totalEndIsHalfRvi = instrBoundary.io.resp.totalEndIsHalfRvi
   private val s0_rawInstrVec       = instrBoundary.io.resp.rawInstrVec
   private val s0_instrEndMask      = instrBoundary.io.resp.instrEndMask
-
-  // The BPU predicted taken, but the end of the fetch block falls in the middle of an instruction.
-  private val s0_invalidTaken = VecInit(
-    s0_fetchBlock(0).takenCfiOffset.valid && !s0_instrEndMask(s0_fetchBlock(0).takenCfiOffset.bits),
-    s0_fetchBlock(1).valid && s0_fetchBlock(1).takenCfiOffset.valid &&
-      !s0_instrEndMask(s0_fetchBlock(1).takenCfiOffset.bits + s0_fetchBlock(0).size)
-  )
-  dontTouch(s0_invalidTaken)
-
-  private val s0_fixedFetchBlock = WireDefault(s0_fetchBlock)
-  when(s0_invalidTaken(0)) {
-    s0_fixedFetchBlock(1).valid := false.B
-  }
-
-  dontTouch(s0_fixedFetchBlock)
-
-  private val s0_fixedTotalEndPos       = Mux(s0_invalidTaken(0), s0_fetchBlock(0).takenCfiOffset.bits, s0_totalEndPos)
-  private val s0_fixedTotalEndIsHalfRvi = Mux(s0_invalidTaken(0), s0_firstEndIsHalfRvi, s0_totalEndIsHalfRvi)
-  private val s0_fixedInvalidTaken      = VecInit(s0_invalidTaken(0), s0_invalidTaken(1) && !s0_invalidTaken(0))
-
-  private val s0_fixedRawInstrVec = WireDefault(s0_rawInstrVec)
-  s0_fixedRawInstrVec.foreach { instr =>
-    when(s0_invalidTaken(0) && instr.blockSel) {
-      instr.valid := false.B
-    }
-  }
-
-  private val s0_rawInstrValid = VecInit(s0_fixedRawInstrVec.map(_.valid)).asUInt
+  private val s0_rawInstrValid     = VecInit(s0_rawInstrVec.map(_.valid)).asUInt
   private val s0_firstBlockInstrCount =
-    PopCount(s0_rawInstrValid & VecInit(s0_fixedRawInstrVec.map(instr => !instr.blockSel)).asUInt)
-
-  private val (s0_compactedInstrVec, s0_instrCount) = compact(s0_fixedRawInstrVec)
-
-  private val s0_fixedCompactedInstrVec = WireDefault(s0_compactedInstrVec)
-  s0_fixedCompactedInstrVec.zipWithIndex.foreach { case (instr, i) =>
-    when(s0_fixedFetchBlock(1).valid && i.U >= s0_firstBlockInstrCount) {
-      instr.blockSel := true.B
-    }
-  }
-
-  private val s0_instrValid = VecInit(s0_fixedCompactedInstrVec.map(_.valid)).asUInt
+    PopCount(s0_rawInstrValid & VecInit(s0_rawInstrVec.map(instr => !instr.blockSel)).asUInt)
 
   // When invalidTaken is true, we can not flush s2_prevLastIsHalfRvi because the fetch block after it is fall-through.
   when(backendRedirect) {
@@ -204,35 +166,12 @@ class Ifu(implicit p: Parameters) extends IfuModule
   }.elsewhen(uncacheRedirect.valid) {
     s0_prevEndIsHalfRvi := uncacheRedirect.isHalfInstr
   }.elsewhen(s0_fire && !s0_icacheMeta(0).isUncache) {
-    s0_prevEndIsHalfRvi := s0_fixedTotalEndIsHalfRvi
-  }
-
-  private val s0_predTakenIdx = VecInit(
-    Mux(s0_invalidTaken(0), s0_firstBlockInstrCount, s0_firstBlockInstrCount - 1.U),
-    Mux(s0_invalidTaken(1), s0_instrCount, s0_instrCount - 1.U)
-  )
-  dontTouch(s0_predTakenIdx)
-
-  when(s0_fire && s0_invalidTaken(0)) {
-    assert(
-      PopCount(s0_rawInstrValid & VecInit(s0_rawInstrVec.map(instr => !instr.blockSel)).asUInt) < FetchBlockInstNum.U
-    )
-  }
-  when(s0_fire && s0_invalidTaken(1)) {
-    assert(PopCount(s0_rawInstrValid) < FetchBlockInstNum.U)
+    s0_prevEndIsHalfRvi := s0_totalEndIsHalfRvi
   }
 
   // When an exception occurs, forward the exception information immediately instead of
   // waiting for instruction concatenation to complete.
-  private val s0_hasException   = s0_icacheMeta(0).exception.hasException
-  private val s0_realInstrValid = Mux(s0_hasException, 1.U(FetchBlockInstNum.W), s0_instrValid)
-  private val s0_realInstrCount = Mux(s0_hasException, 1.U((log2Ceil(FetchBlockInstNum) + 1).W), s0_instrCount)
-
-  private val s0_realInstrVec = WireDefault(s0_fixedCompactedInstrVec)
-  s0_realInstrVec.zipWithIndex.foreach { case (instr, i) =>
-    instr.valid := s0_realInstrValid(i)
-  }
-
+  private val s0_hasException = s0_icacheMeta(0).exception.hasException
   /* --------------------------------------------------------------------------------------------------------------
      stage 1
      - cat half rvi instruction
@@ -244,10 +183,24 @@ class Ifu(implicit p: Parameters) extends IfuModule
   s1_fire  := s1_valid && s2_ready
   s1_ready := s1_fire || !s1_valid
 
-  private val s1_fetchBlock   = RegEnable(s0_fixedFetchBlock, s0_fire)
-  private val s1_predTakenIdx = RegEnable(s0_predTakenIdx, s0_fire)
-  private val s1_invalidTaken = RegEnable(s0_fixedInvalidTaken, s0_fire)
-  private val s1_instrCount   = RegEnable(s0_realInstrCount, s0_fire)
+  private val s1_hasException = RegEnable(s0_hasException, s0_fire)
+  private val s1_fetchBlock   = RegEnable(s0_fetchBlock, s0_fire)  // Consider the impact of invalidTaken.
+  private val s1_totalEndPos  = RegEnable(s0_totalEndPos, s0_fire) // Consider the impact of invalidTaken.
+  private val s1_instrEndMask = RegEnable(s0_instrEndMask, s0_fire)
+  private val (s1_compactedInstrVec, s1_instrCount) = compact(s0_rawInstrVec, s0_fire)
+  private val s1_firstBlockInstrCount               = RegEnable(s0_firstBlockInstrCount, s0_fire)
+  private val s1_realInstrCount = Mux(s1_hasException, 1.U((log2Ceil(FetchBlockInstNum) + 1).W), s1_instrCount)
+  private val s1_realInstrValid =
+    Mux(s1_hasException, 1.U(FetchBlockInstNum.W), UIntToMask(s1_instrCount, FetchBlockInstNum))
+  private val s1_invalidTaken = VecInit(
+    s1_fetchBlock(0).takenCfiOffset.valid && !s1_instrEndMask(s1_fetchBlock(0).takenCfiOffset.bits),
+    s1_fetchBlock(1).valid && s1_fetchBlock(1).takenCfiOffset.valid &&
+      !s1_instrEndMask(s1_totalEndPos)
+  ) // Consider the impact of invalidTaken.
+  private val s1_predTakenIdx = VecInit(
+    Mux(s1_invalidTaken(0), s1_firstBlockInstrCount, s1_firstBlockInstrCount - 1.U),
+    Mux(s1_invalidTaken(1), s1_realInstrCount, s1_realInstrCount - 1.U)
+  )
 
   dontTouch(s1_fetchBlock)
 
@@ -257,12 +210,11 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_prevEndHalfRviPc   = RegInit(0.U.asTypeOf(PrunedAddr(VAddrBits)))
 
   private val s1_firstEndIsHalfRvi = RegEnable(s0_firstEndIsHalfRvi, s0_fire)
-  private val s1_totalEndIsHalfRvi = RegEnable(s0_fixedTotalEndIsHalfRvi, s0_fire)
+  private val s1_totalEndIsHalfRvi = RegEnable(s0_totalEndIsHalfRvi, s0_fire)
 
-  private val s1_instrData    = RegEnable(s0_icacheData.data, s0_fire)
-  private val s1_totalEndPos  = RegEnable(s0_fixedTotalEndPos, s0_fire)
+  private val s1_instrData  = RegEnable(s0_icacheData.data, s0_fire)
   private val s1_icacheMetaIn = RegEnable(s0_icacheMeta, s0_fire)
-  private val s1_instrVec     = RegEnable(s0_realInstrVec, s0_fire)
+  private val s1_instrVec   = s1_compactedInstrVec
 
   // ICache mainPipe send parity check result 1 cycle after io.fromICache.req.fire, here merge into icacheMeta.
   // for better timing.
@@ -313,10 +265,6 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   private val s1_baseAlignedInstrPcVec = VecInit(s1_alignedInstrVec.map(instr => getInstrPc(instr, s1_fetchBlock)))
 
-  private val s1_alignedInstrPcLowerBitsVec = VecInit(s1_alignedInstrVec.map { instr =>
-    getInstrPcLowerBits(instr, s1_fetchBlock)
-  })
-
   private val s1_firstEndPos       = s1_fetchBlock(0).takenCfiOffset.bits
   private val s1_firstEndHalfRviPc = s1_fetchBlock(0).startVAddr + (s1_firstEndPos << 1)
   private val s1_totalEndHalfRviPc = Mux(
@@ -366,9 +314,10 @@ class Ifu(implicit p: Parameters) extends IfuModule
   }.elsewhen(uncacheRedirect.valid) {
     s1_prevIBufEnqPtr := uncacheRedirect.prevIBufEnqPtr + uncacheRedirect.instrCount
   }.elsewhen(s1_fire && !s1_icacheMeta(0).isUncache) {
-    s1_prevIBufEnqPtr := s1_prevIBufEnqPtr + s1_instrCount
+    s1_prevIBufEnqPtr := s1_prevIBufEnqPtr + s1_realInstrCount
   }
 
+  private val s1_alignedInstrValid = s1_realInstrValid << s1_alignShiftNum
   // reqIsUncache is used to limit the number of fetch requests and enable special pre-decode configurations.
   private val s1_reqIsUncache = s1_valid && s1_icacheMeta(0).isUncache
   // useUncacheFetch controls whether the instruction fetch operation follows the uncache control logic.
@@ -402,7 +351,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s2_totalEndHalfRviPc   = RegEnable(s1_totalEndHalfRviPc, s1_fire)
   private val s2_totalEndHalfRviData = RegEnable(s1_totalEndHalfRviData, s1_fire)
 
-  private val s2_instrCount        = RegEnable(s1_instrCount, s1_fire)
+  private val s2_instrCount        = RegEnable(s1_realInstrCount, s1_fire)
+  private val s2_alignedInstrValid = RegEnable(s1_alignedInstrValid, s1_fire)
   private val s2_icacheMeta        = RegEnable(s1_icacheMeta, s1_fire)
   private val s2_alignedInstrVec   = RegEnable(s1_alignedInstrVec, s1_fire)
   private val s2_alignedInstrPcVec = RegEnable(s1_alignedInstrPcVec, s1_fire)
@@ -429,11 +379,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
     instr.data := expandedData
   }
 
-  private val s2_blockSel      = VecInit(s2_expandedInstrVec.map(_.blockSel))
-  private val s2_endOffsetVec  = VecInit(s2_expandedInstrVec.map(_.endOffset))
-  private val s2_rawInstrValid = VecInit(s2_expandedInstrVec.map(_.valid)).asUInt
+  private val s2_blockSel     = VecInit(s2_expandedInstrVec.map(_.blockSel))
+  private val s2_endOffsetVec = VecInit(s2_expandedInstrVec.map(_.endOffset))
   dontTouch(s2_blockSel)
-  dontTouch(s2_rawInstrValid)
 
   private val s2_pdInfoVec     = Wire(Vec(IBufferEnqueueWidth, new PreDecodeInfo))
   private val s2_jumpOffsetVec = Wire(Vec(IBufferEnqueueWidth, PrunedAddr(VAddrBits)))
@@ -446,9 +394,6 @@ class Ifu(implicit p: Parameters) extends IfuModule
     s2_jumpOffsetVec(i)         := Mux(s2_pdInfoVec(i).isBr, brOffset, jalOffset)
   }
 
-  private val s2_uncacheLowerPc = RegEnable(s1_alignedInstrPcLowerBitsVec(s1_alignShiftNum), s1_fire)
-  private val s2_uncachePc =
-    catPC(s2_uncacheLowerPc, s2_fetchBlock(0).pcUpperBits, s2_fetchBlock(0).pcUpperBitsPlus1)
   private val s2_reqIsUncache    = RegEnable(s1_reqIsUncache, false.B, s1_fire)
   private val s2_useUncacheFetch = RegEnable(s1_useUncacheFetch, s1_fire)
   private val s2_uncacheCanGo =
@@ -532,7 +477,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   /* ** send to IBuffer ** */
   io.toIBuffer.valid               := s2_toIBufferValid
   io.toIBuffer.bits.instrs         := s2_expandedInstrDataVec
-  io.toIBuffer.bits.valid          := s2_rawInstrValid
+  io.toIBuffer.bits.valid          := s2_alignedInstrValid
   io.toIBuffer.bits.enqEnable      := s2_fixedInstrValid
   io.toIBuffer.bits.isRvc          := s2_expandedInstrVec.map(_.isRvc)
   io.toIBuffer.bits.pc             := s2_alignedInstrPcVec // for debug

--- a/src/main/scala/xiangshan/frontend/ifu/InstrBoundary.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/InstrBoundary.scala
@@ -42,7 +42,7 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
 
   private val data     = io.req.icacheData.data
   private val range    = io.req.icacheData.range
-  private val mayBeRvc = io.req.icacheData.maybeRvcMap
+  private val maybeRvc = io.req.icacheData.maybeRvcMap
   private val blockSel = io.req.icacheData.blockSel
 
   // We compute the boundaries of instructions in the first half of the fetch block directly, and compute the boundaries
@@ -61,7 +61,7 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
     require(HasCExtension, "C Extension can not be disabled in XiangShan")
     for (i <- start until end) {
       boundary(i) := {
-        if (i == start) !firstInstrIsHalfRvi else !boundary(i - 1) || mayBeRvc(i - 1)
+        if (i == start) !firstInstrIsHalfRvi else !boundary(i - 1) || maybeRvc(i - 1)
       }
     }
   }
@@ -72,7 +72,7 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
 
   for (i <- FetchBlockInstNum / 2 until FetchBlockInstNum) {
     boundary(i) := Mux(
-      boundary(FetchBlockInstNum / 2 - 1) && !mayBeRvc(FetchBlockInstNum / 2 - 1),
+      boundary(FetchBlockInstNum / 2 - 1) && !maybeRvc(FetchBlockInstNum / 2 - 1),
       latterHalfBoundary1(i),
       latterHalfBoundary2(i)
     )
@@ -90,23 +90,10 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
         (i.U === io.req.fetchBlock(0).takenCfiOffset.bits) &&
         !blockSel(i) && blockSel(i + 1)
       }
-
-    val canUseNextHalf =
-      if (i == FetchBlockInstNum - 1) {
-        false.B
-      } else {
-        val sameBlock = blockSel(i) === blockSel(i + 1)
-
-        range(i + 1) && (sameBlock || crossBlockFallThrough)
-      }
-
     instr.valid := {
       if (i == 0)
-        io.req.firstInstrIsHalfRvi || (isStart && (mayBeRvc(i) || canUseNextHalf))
-      else if (i == FetchBlockInstNum - 1)
-        isStart && mayBeRvc(i)
-      else
-        isStart && (mayBeRvc(i) || canUseNextHalf)
+        io.req.firstInstrIsHalfRvi || isStart
+      else isStart
     } && range(i)
 
     instr.data := {
@@ -116,15 +103,15 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
         Cat(data(i + 1), data(i))
     }
 
-    instr.isRvc := isStart && mayBeRvc(i)
-
-    val fixedBlockSel = blockSel(i) || (crossBlockFallThrough && !mayBeRvc(i))
+    instr.isRvc := isStart && maybeRvc(i)
+    // Not involved in the instruction delimiting logic; timing impact should be controllable.
+    val fixedBlockSel = blockSel(i) || (crossBlockFallThrough && !maybeRvc(i))
     instr.blockSel := fixedBlockSel
 
     instr.isPredTaken       := false.B
     instr.invalidTaken      := false.B
     instr.isPrevEndHalfRvi  := false.B
-    instr.isCrossBlockInstr := crossBlockFallThrough && !mayBeRvc(i)
+    instr.isCrossBlockInstr := crossBlockFallThrough && !maybeRvc(i)
 
     val startOffset = Mux(
       fixedBlockSel,
@@ -132,20 +119,20 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
       i.U(FetchBlockInstOffsetWidth.W)
     )
     instr.startOffset := startOffset
-    instr.endOffset   := Mux(mayBeRvc(i), startOffset, startOffset + 1.U)
+    instr.endOffset   := Mux(maybeRvc(i), startOffset, startOffset + 1.U)
 
     instr
   }
 
-  io.resp.instrEndMask := boundary.zip(mayBeRvc.asBools).zip(range.asBools).map { case ((boundary, isRvc), range) =>
+  io.resp.instrEndMask := boundary.zip(maybeRvc.asBools).zip(range.asBools).map { case ((boundary, isRvc), range) =>
     (!boundary || (boundary && isRvc)) && range
   }
 
   private val firstEndPos = io.req.fetchBlock(0).takenCfiOffset.bits
-  io.resp.firstEndIsHalfRvi := range(firstEndPos) && boundary(firstEndPos) && !mayBeRvc(firstEndPos)
+  io.resp.firstEndIsHalfRvi := range(firstEndPos) && boundary(firstEndPos) && !maybeRvc(firstEndPos)
 
   private val totalEndPos = io.req.totalEndPos
-  io.resp.totalEndIsHalfRvi := range(totalEndPos) && boundary(totalEndPos) && !mayBeRvc(totalEndPos)
+  io.resp.totalEndIsHalfRvi := range(totalEndPos) && boundary(totalEndPos) && !maybeRvc(totalEndPos)
 
   // For differential test only. Will be optimized out in release
   private val boundDiff = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(false.B)))

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -32,10 +32,10 @@ import xiangshan.frontend.bpu.BranchAttribute
 class PredChecker(implicit p: Parameters) extends IfuModule {
   class PredCheckerIO extends IfuBundle {
     class PredCheckerReq(implicit p: Parameters) extends IfuBundle {
-      val expandedInstrVec: Vec[Instruction]   = Vec(IBufferEnqueueWidth, new Instruction)
-      val jumpOffsetVec:    Vec[PrunedAddr]    = Vec(IBufferEnqueueWidth, PrunedAddr(VAddrBits))
-      val pdInfoVec:        Vec[PreDecodeInfo] = Vec(IBufferEnqueueWidth, new PreDecodeInfo)
-      val instrPcVec:       Vec[PrunedAddr]    = Vec(IBufferEnqueueWidth, PrunedAddr(VAddrBits))
+      val instrVec:      Vec[Instruction]   = Vec(IBufferEnqueueWidth, new Instruction)
+      val jumpOffsetVec: Vec[PrunedAddr]    = Vec(IBufferEnqueueWidth, PrunedAddr(VAddrBits))
+      val pdInfoVec:     Vec[PreDecodeInfo] = Vec(IBufferEnqueueWidth, new PreDecodeInfo)
+      val instrPcVec:    Vec[PrunedAddr]    = Vec(IBufferEnqueueWidth, PrunedAddr(VAddrBits))
     }
 
     class PredCheckerResp(implicit p: Parameters) extends IfuBundle {
@@ -58,12 +58,12 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
 
   val io: PredCheckerIO = IO(new PredCheckerIO)
 
-  private val expandedInstrVec = io.req.bits.expandedInstrVec
-  private val endOffsetVec     = VecInit(expandedInstrVec.map(_.endOffset))
-  private val blockSel         = VecInit(expandedInstrVec.map(_.blockSel))
-  private val instrValid       = VecInit(expandedInstrVec.map(_.valid))
-  private val isPredTaken      = VecInit(expandedInstrVec.map(_.isPredTaken))
-  private val invalidTaken     = VecInit(expandedInstrVec.map(_.invalidTaken))
+  private val instrVec     = io.req.bits.instrVec
+  private val endOffsetVec = VecInit(instrVec.map(_.endOffset))
+  private val blockSel     = VecInit(instrVec.map(_.blockSel))
+  private val instrValid   = VecInit(instrVec.map(_.valid))
+  private val isPredTaken  = VecInit(instrVec.map(_.isPredTaken))
+  private val invalidTaken = VecInit(instrVec.map(_.invalidTaken))
 
   private val pdInfoVec     = io.req.bits.pdInfoVec
   private val instrPcVec    = io.req.bits.instrPcVec
@@ -108,7 +108,7 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   }).asUInt
 
   private val fixedInstrValid = VecInit((0 until IBufferEnqueueWidth).map(i =>
-    expandedInstrVec(i).valid && fixedRange(i)
+    instrVec(i).valid && fixedRange(i)
   ))
   io.resp.stage1Out.fixedInstrValid := fixedInstrValid
 
@@ -138,10 +138,10 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
       mispredIdx.valid &&
       (pdInfoVec(mispredIdx.bits).isJal || pdInfoVec(mispredIdx.bits).isBr)
 
-  private val finalIsRVC        = expandedInstrVec(mispredIdx.bits).isRvc
+  private val finalIsRVC        = instrVec(mispredIdx.bits).isRvc
   private val finalInvalidTaken = invalidTaken(mispredIdx.bits)
   private val finalNotCfiTaken  = notCfiTaken(mispredIdx.bits)
-  private val finalSelectBlock  = expandedInstrVec(mispredIdx.bits).blockSel
+  private val finalSelectBlock  = instrVec(mispredIdx.bits).blockSel
   private val finalPc           = instrPcVec(mispredIdx.bits)
   private val finalAttribute    = pdInfoVec(mispredIdx.bits).brAttribute
   private val fixedTaken        = fixedTakenVec(mispredIdx.bits)


### PR DESCRIPTION
1. Change the PopCount logic in the compact stage from serial to parallel.
2. Remove the instruction range reduction logic from the timing-critical instrBoundary.
3. Shift the invalidTaken-related paths that can be deferred to later stages.
4. Add a pipeline register to the return path signals of the ICache MissUnit