### PR TITLE
timing(icache, ifu): optimize IFU/ICache instruction alignment path

### DIFF
--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -110,11 +110,11 @@ class FtqToICacheIO(implicit p: Parameters) extends FrontendBundle {
 }
 
 class ICacheToIfuIO(implicit p: Parameters) extends FrontendBundle with HasICacheParameters {
-  val req:        DecoupledIO[Vec[MainPipeToIfuReq]] = DecoupledIO(Vec(FetchPorts, new MainPipeToIfuReq))
-  val corrupt:    Vec[Vec[Bool]]                     = Vec(FetchPorts, Vec(PortNumber, Bool()))
-  val topdown:    ICacheTopdownInfo                  = Output(new ICacheTopdownInfo)
-  val perf:       ICachePerfInfo                     = Output(new ICachePerfInfo)
-  val fetchReady: Bool                               = Output(Bool())
+  val req:        DecoupledIO[MainPipeToIfuReq] = DecoupledIO(new MainPipeToIfuReq)
+  val corrupt:    Vec[Vec[Bool]]                = Vec(FetchPorts, Vec(PortNumber, Bool()))
+  val topdown:    ICacheTopdownInfo             = Output(new ICacheTopdownInfo)
+  val perf:       ICachePerfInfo                = Output(new ICachePerfInfo)
+  val fetchReady: Bool                          = Output(Bool())
 }
 
 class IfuToInstrUncacheIO(implicit p: Parameters) extends FrontendBundle {

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -370,7 +370,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBase(
     "fetchedCacheLines",
     Mux(
       icache.io.toIfu.req.valid && icache.io.toIfu.req.ready,
-      Mux(icache.io.toIfu.req.bits(0).perf_isCrossLine, 2.U, 1.U),
+      Mux(icache.io.toIfu.req.bits.info(0).perf_isCrossLine, 2.U, 1.U),
       0.U
     )
   )

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -78,6 +78,13 @@ class MetaInfo(implicit p: Parameters) extends ICacheBundle {
   val metaCodes:   UInt = UInt(MetaEccBits.W)
 }
 
+class MaybeRvcShiftInfo(implicit p: Parameters) extends ICacheBundle {
+  val shiftNum:         Vec[UInt] = Vec(MaxFetchLineNum, UInt(log2Ceil(MaxInstNumPerBlock).W))
+  val shiftFlag:        Bool      = Bool()
+  val shiftMaybeRvcMap: Vec[UInt] = Vec(MaxFetchLineNum, UInt(MaxInstNumPerBlock.W))
+  val rangeVec:         Vec[UInt] = Vec(MaxFetchLineNum, UInt(MaxInstNumPerBlock.W))
+}
+
 /* ***** Array write ***** */
 // ICacheMissUnit <-> ICacheMetaArray
 class MetaWriteBundle(implicit p: Parameters) extends ICacheBundle {

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -221,27 +221,41 @@ class ICacheMeta(implicit p: Parameters) extends ICacheBundle {
   def isUncache: Bool = pmpMmio || Pbmt.isUncache(itlbPbmt)
 }
 
-class MainPipeToIfuReq(implicit p: Parameters) extends ICacheBundle {
+class FetchBlocktoIfuReq(implicit p: Parameters) extends ICacheBundle {
   val valid:          Bool        = Bool()
   val startVAddr:     GuardedPc   = GuardedPc()
   val ftqIdx:         FtqPtr      = new FtqPtr
   val takenCfiOffset: Valid[UInt] = Valid(UInt(CfiPositionWidth.W))
-  val range:          UInt        = UInt(FetchBlockInstNum.W)
+  // val range:          UInt        = UInt(FetchBlockInstNum.W)
   val size:           UInt        = UInt(log2Ceil(FetchBlockInstNum + 1).W)
 
   val data:        UInt = UInt(blockBits.W)
-  val maybeRvcMap: UInt = UInt(MaxInstNumPerBlock.W)
+  // val maybeRvcMap: UInt = UInt(MaxInstNumPerBlock.W)
 
   val icacheMeta: ICacheMeta = new ICacheMeta
 
   val perf_isCrossLine: Bool = Bool()
 }
 
+class MainPipeToIfuReq(implicit p: Parameters) extends ICacheBundle {
+  val range:       UInt = UInt(FetchBlockInstNum.W)
+  val maybeRvcMap: UInt = UInt(MaxInstNumPerBlock.W)
+  val info: Vec[FetchBlocktoIfuReq] = Vec(FetchPorts, new FetchBlocktoIfuReq)
+}
+
 class MainPipeToIfuIO(implicit p: Parameters) extends ICacheBundle {
-  val req: DecoupledIO[Vec[MainPipeToIfuReq]] = DecoupledIO(Vec(FetchPorts, new MainPipeToIfuReq))
+  val req: DecoupledIO[MainPipeToIfuReq] = DecoupledIO(new MainPipeToIfuReq)
   // for timing fix, sent 1 cycle after req is fired
   val corrupt: Vec[Vec[Bool]] = Vec(FetchPorts, Vec(PortNumber, Bool()))
 }
+
+// class MainPipeToIfuIO(implicit p: Parameters) extends ICacheBundle {
+//   class Req(implicit p: Parameters) extends ICacheBundle {
+//     val info: Vec[MainPipeToIfuReq] = Vec(FetchPorts, new MainPipeToIfuReq)
+//     val maybeRvcMap: UInt = UInt(MaxInstNumPerBlock.W)
+//   }
+//   val req: DecoupledIO[Req] = DecoupledIO(new Req)
+// }
 
 class WayLookupToMainPipeBundle(implicit p: Parameters) extends ICacheBundle {
   val wayLookupInfo: Vec[Valid[WayLookupBundle]] = Vec(FetchPorts, Valid(new WayLookupBundle))

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -78,14 +78,34 @@ class MetaInfo(implicit p: Parameters) extends ICacheBundle {
   val metaCodes:   UInt = UInt(MetaEccBits.W)
 }
 
-class MaybeRvcShiftInfo(implicit p: Parameters) extends ICacheBundle {
-  val shiftNum:          Vec[UInt]      = Vec(MaxFetchLineNum, UInt(log2Ceil(MaxInstNumPerBlock).W))
-  val shiftFlag:         Bool           = Bool()
-  val firstBlockRange:   UInt           = UInt(MaxInstNumPerBlock.W)
-  val totalBlockRange:   UInt           = UInt(MaxInstNumPerBlock.W)
-  val sramShiftMaybeRvc: Vec[Vec[UInt]] = Vec(MaxFetchReqNum, Vec(PortNumber, UInt(MaxInstNumPerBlock.W)))
-  val maybeRvcMaskVec:   Vec[Vec[UInt]] = Vec(MaxFetchReqNum, Vec(PortNumber, UInt(MaxInstNumPerBlock.W)))
-  val takenCfiOffset:    Vec[UInt]      = Vec(MaxFetchReqNum, UInt(CfiPositionWidth.W))
+// Info describing how to align the raw per-line maybeRvcMap into the fetch coordinate.
+// Naming convention:
+//   maybeRvcMap        : raw per-cache-line map, bit i = 2-byte slot i of the line.
+//   alignedMaybeRvcMap : map aligned to the fetch coordinate, bit 0 = the first fetched
+//                        instruction slot of req0 (what the IFU consumes).
+// "Shift" is reserved for the alignment operation/parameters (shiftNum,
+// shouldShiftRight, shiftMaybeRvc); "Aligned" marks the resulting maps.
+class MaybeRvcAlignInfo(implicit p: Parameters) extends ICacheBundle {
+  // shift parameters of the alignment operation
+  val shiftNum:         Vec[UInt] = Vec(MaxFetchLineNum, UInt(log2Ceil(MaxInstNumPerBlock).W))
+  val shouldShiftRight: Bool      = Bool()
+  // instruction ranges in the fetch coordinate
+  val firstBlockRange: UInt = UInt(MaxInstNumPerBlock.W)
+  val totalBlockRange: UInt = UInt(MaxInstNumPerBlock.W)
+  // raw SRAM per-line maps, pre-aligned into the fetch coordinate (done in s0)
+  val sramAlignedMaybeRvcMap: Vec[Vec[UInt]] = Vec(MaxFetchReqNum, Vec(PortNumber, UInt(MaxInstNumPerBlock.W)))
+  // masks in the fetch coordinate, used to gate the aligned maps per cache line
+  val alignedMaybeRvcMaskVec: Vec[Vec[UInt]] = Vec(MaxFetchReqNum, Vec(PortNumber, UInt(MaxInstNumPerBlock.W)))
+  val takenCfiOffset:         Vec[UInt]      = Vec(MaxFetchReqNum, UInt(CfiPositionWidth.W))
+
+  // shift-left flag of each maybeRvcMap, used by shiftConfig
+  // each maybeRvcMap should: (extraShiftNum, shiftLeft)
+  def shiftConfig: Seq[(Int, Bool)] = Seq(
+    (0, false.B),
+    (1, true.B),
+    (0, !this.shouldShiftRight),
+    (2, true.B)
+  )
 }
 
 /* ***** Array write ***** */
@@ -231,27 +251,26 @@ class ICacheMeta(implicit p: Parameters) extends ICacheBundle {
   def isUncache: Bool = pmpMmio || Pbmt.isUncache(itlbPbmt)
 }
 
-class FetchBlocktoIfuReq(implicit p: Parameters) extends ICacheBundle {
-  val valid:          Bool        = Bool()
-  val startVAddr:     GuardedPc   = GuardedPc()
-  val ftqIdx:         FtqPtr      = new FtqPtr
-  val takenCfiOffset: Valid[UInt] = Valid(UInt(CfiPositionWidth.W))
-  // val range:          UInt        = UInt(FetchBlockInstNum.W)
-  val size: UInt = UInt(log2Ceil(FetchBlockInstNum + 1).W)
+class FetchBlockInfo(implicit p: Parameters) extends ICacheBundle {
+  val valid:            Bool        = Bool()
+  val startVAddr:       GuardedPc   = GuardedPc()
+  val ftqIdx:           FtqPtr      = new FtqPtr
+  val takenCfiOffset:   Valid[UInt] = Valid(UInt(CfiPositionWidth.W))
+  val size:             UInt        = UInt(log2Ceil(FetchBlockInstNum + 1).W)
+  val data:             UInt        = UInt(blockBits.W)
+  val icacheMeta:       ICacheMeta  = new ICacheMeta
+  val perf_isCrossLine: Bool        = Bool()
 
-  val data: UInt = UInt(blockBits.W)
-  // val maybeRvcMap: UInt = UInt(MaxInstNumPerBlock.W)
-
-  val icacheMeta: ICacheMeta = new ICacheMeta
-
-  val perf_isCrossLine: Bool = Bool()
+  def endIndex: UInt =
+    startVAddr(log2Ceil(MaxInstNumPerBlock), instOffsetBits) + takenCfiOffset.bits
 }
 
 class MainPipeToIfuReq(implicit p: Parameters) extends ICacheBundle {
-  val firstRange:  UInt                    = UInt(FetchBlockInstNum.W)
-  val totalRange:  UInt                    = UInt(FetchBlockInstNum.W)
-  val maybeRvcMap: UInt                    = UInt(MaxInstNumPerBlock.W)
-  val info:        Vec[FetchBlocktoIfuReq] = Vec(FetchPorts, new FetchBlocktoIfuReq)
+  val firstRange: UInt = UInt(FetchBlockInstNum.W)
+  val totalRange: UInt = UInt(FetchBlockInstNum.W)
+  // aligned to the fetch coordinate (bit 0 = the first fetched instruction slot)
+  val maybeRvcMap: UInt                = UInt(MaxInstNumPerBlock.W)
+  val info:        Vec[FetchBlockInfo] = Vec(FetchPorts, new FetchBlockInfo)
 }
 
 class MainPipeToIfuIO(implicit p: Parameters) extends ICacheBundle {
@@ -259,14 +278,6 @@ class MainPipeToIfuIO(implicit p: Parameters) extends ICacheBundle {
   // for timing fix, sent 1 cycle after req is fired
   val corrupt: Vec[Vec[Bool]] = Vec(FetchPorts, Vec(PortNumber, Bool()))
 }
-
-// class MainPipeToIfuIO(implicit p: Parameters) extends ICacheBundle {
-//   class Req(implicit p: Parameters) extends ICacheBundle {
-//     val info: Vec[MainPipeToIfuReq] = Vec(FetchPorts, new MainPipeToIfuReq)
-//     val maybeRvcMap: UInt = UInt(MaxInstNumPerBlock.W)
-//   }
-//   val req: DecoupledIO[Req] = DecoupledIO(new Req)
-// }
 
 class WayLookupToMainPipeBundle(implicit p: Parameters) extends ICacheBundle {
   val wayLookupInfo: Vec[Valid[WayLookupBundle]] = Vec(FetchPorts, Valid(new WayLookupBundle))

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -79,10 +79,13 @@ class MetaInfo(implicit p: Parameters) extends ICacheBundle {
 }
 
 class MaybeRvcShiftInfo(implicit p: Parameters) extends ICacheBundle {
-  val shiftNum:         Vec[UInt] = Vec(MaxFetchLineNum, UInt(log2Ceil(MaxInstNumPerBlock).W))
-  val shiftFlag:        Bool      = Bool()
-  val shiftMaybeRvcMap: Vec[UInt] = Vec(MaxFetchLineNum, UInt(MaxInstNumPerBlock.W))
-  val rangeVec:         Vec[UInt] = Vec(MaxFetchLineNum, UInt(MaxInstNumPerBlock.W))
+  val shiftNum:          Vec[UInt]      = Vec(MaxFetchLineNum, UInt(log2Ceil(MaxInstNumPerBlock).W))
+  val shiftFlag:         Bool           = Bool()
+  val firstBlockRange:   UInt           = UInt(MaxInstNumPerBlock.W)
+  val totalBlockRange:   UInt           = UInt(MaxInstNumPerBlock.W)
+  val sramShiftMaybeRvc: Vec[Vec[UInt]] = Vec(MaxFetchReqNum, Vec(PortNumber, UInt(MaxInstNumPerBlock.W)))
+  val maybeRvcMaskVec:   Vec[Vec[UInt]] = Vec(MaxFetchReqNum, Vec(PortNumber, UInt(MaxInstNumPerBlock.W)))
+  val takenCfiOffset:    Vec[UInt]      = Vec(MaxFetchReqNum, UInt(CfiPositionWidth.W))
 }
 
 /* ***** Array write ***** */
@@ -234,9 +237,9 @@ class FetchBlocktoIfuReq(implicit p: Parameters) extends ICacheBundle {
   val ftqIdx:         FtqPtr      = new FtqPtr
   val takenCfiOffset: Valid[UInt] = Valid(UInt(CfiPositionWidth.W))
   // val range:          UInt        = UInt(FetchBlockInstNum.W)
-  val size:           UInt        = UInt(log2Ceil(FetchBlockInstNum + 1).W)
+  val size: UInt = UInt(log2Ceil(FetchBlockInstNum + 1).W)
 
-  val data:        UInt = UInt(blockBits.W)
+  val data: UInt = UInt(blockBits.W)
   // val maybeRvcMap: UInt = UInt(MaxInstNumPerBlock.W)
 
   val icacheMeta: ICacheMeta = new ICacheMeta
@@ -245,9 +248,10 @@ class FetchBlocktoIfuReq(implicit p: Parameters) extends ICacheBundle {
 }
 
 class MainPipeToIfuReq(implicit p: Parameters) extends ICacheBundle {
-  val range:       UInt = UInt(FetchBlockInstNum.W)
-  val maybeRvcMap: UInt = UInt(MaxInstNumPerBlock.W)
-  val info: Vec[FetchBlocktoIfuReq] = Vec(FetchPorts, new FetchBlocktoIfuReq)
+  val firstRange:  UInt                    = UInt(FetchBlockInstNum.W)
+  val totalRange:  UInt                    = UInt(FetchBlockInstNum.W)
+  val maybeRvcMap: UInt                    = UInt(MaxInstNumPerBlock.W)
+  val info:        Vec[FetchBlocktoIfuReq] = Vec(FetchPorts, new FetchBlocktoIfuReq)
 }
 
 class MainPipeToIfuIO(implicit p: Parameters) extends ICacheBundle {

--- a/src/main/scala/xiangshan/frontend/icache/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Helpers.scala
@@ -17,6 +17,8 @@ package xiangshan.frontend.icache
 
 import chisel3._
 import chisel3.util._
+import utility.UIntToMask
+import xiangshan.frontend.FtqFetchRequest
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
 import xiangshan.frontend.bpu.HasBpuParameters
@@ -112,6 +114,111 @@ trait ICacheMetaHelper extends HasICacheParameters {
 }
 
 trait ICacheDataHelper extends HasICacheParameters with ICacheCacheLineHelper {
+  def shiftSramMaybeRvc(
+      maybeRvcMap: UInt,
+      shiftNum: UInt,
+      leftShift: Bool,
+      secondShift: Boolean
+  ): UInt = {
+    val realShiftNum =
+      if (secondShift) Cat(shiftNum(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W)) else shiftNum(1, 0)
+    val shifted = Mux(leftShift, maybeRvcMap << realShiftNum, maybeRvcMap >> realShiftNum)
+    if (secondShift) shifted else shifted(MaxInstNumPerBlock - 1, 0)
+  }
+
+  def shiftSramMaybeRvcVec(
+      maybeRvcMap: Vec[UInt],
+      shiftNum: Vec[UInt],
+      shiftFlag: Bool,
+      secondShift: Boolean
+  ): Vec[Vec[UInt]] = VecInit(
+    VecInit(
+      shiftSramMaybeRvc(maybeRvcMap(0), shiftNum(0), leftShift = false.B, secondShift = secondShift),
+      shiftSramMaybeRvc(maybeRvcMap(1), shiftNum(1), leftShift = true.B, secondShift = secondShift)
+    ),
+    VecInit(
+      shiftSramMaybeRvc(maybeRvcMap(2), shiftNum(2), leftShift = !shiftFlag, secondShift = secondShift),
+      shiftSramMaybeRvc(maybeRvcMap(3), shiftNum(3), leftShift = true.B, secondShift = secondShift)
+    )
+  )
+
+  def genMaybeRvcShiftInfo(
+      req: Vec[FtqFetchRequest],
+      wayLookupEntry: Vec[WayLookupEntry],
+      firstFetchSize: UInt
+  ): MaybeRvcShiftInfo = {
+    val info = Wire(new MaybeRvcShiftInfo)
+
+    val req0Start = req(0).startVAddr(log2Ceil(MaxInstNumPerBlock), 1)
+    val req1Start = req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1)
+    val s0_takenCfiOffset = VecInit(req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
+    val secondFetchSize = s0_takenCfiOffset(1) +& 1.U
+    val totalFetchSize  = secondFetchSize +& firstFetchSize
+    val firstBlockRange = genInstRange(firstFetchSize)
+    val totalBlockRange = Mux(req(1).valid, genInstRange(totalFetchSize), firstBlockRange)
+
+    info.shiftNum(0)  := req0Start
+    info.shiftNum(1)  := ~info.shiftNum(0)
+    info.shiftFlag    := req1Start > firstFetchSize
+    info.shiftNum(2)  := Mux(info.shiftFlag, req1Start - firstFetchSize, firstFetchSize - req1Start)
+    info.shiftNum(3)  := ~req1Start + s0_takenCfiOffset(0)
+
+    info.shiftMaybeRvcMap(0) :=
+      shiftSramMaybeRvc(
+        wayLookupEntry(0).maybeRvcMap(0),
+        info.shiftNum(0),
+        leftShift = false.B,
+        secondShift = false
+      )
+    info.shiftMaybeRvcMap(1) :=
+      shiftSramMaybeRvc(
+        Cat(wayLookupEntry(0).maybeRvcMap(1), 0.U(1.W)),
+        info.shiftNum(1),
+        leftShift = true.B,
+        secondShift = false
+      )
+    info.shiftMaybeRvcMap(2) :=
+      shiftSramMaybeRvc(
+        wayLookupEntry(1).maybeRvcMap(0),
+        info.shiftNum(2),
+        leftShift = !info.shiftFlag,
+        secondShift = false
+      )
+    info.shiftMaybeRvcMap(3) :=
+      shiftSramMaybeRvc(
+        Cat(wayLookupEntry(1).maybeRvcMap(1), 0.U(2.W)),
+        info.shiftNum(3),
+        leftShift = true.B,
+        secondShift = false
+      )
+
+    info.rangeVec(0) := genInstRange(
+      Mux(
+        req(0).isCrossLine,
+        MaxInstNumPerBlock.U - info.shiftNum(0),
+        firstFetchSize
+      )
+    )
+    info.rangeVec(1) := firstBlockRange & ~info.rangeVec(0)
+    info.rangeVec(2) := Mux(
+      req(1).valid,
+      genInstRange(
+        firstFetchSize +& Mux(
+          req(1).isCrossLine,
+          MaxInstNumPerBlock.U - req1Start,
+          secondFetchSize
+        )
+      ) & ~firstBlockRange,
+      0.U
+    )
+    info.rangeVec(3) := Mux(req(1).valid, totalBlockRange & ~(firstBlockRange | info.rangeVec(2)), 0.U)
+
+    info
+  }
+
+  def genInstRange(size: UInt): UInt =
+    Mux(size >= MaxInstNumPerBlock.U, (~0.U(MaxInstNumPerBlock.W)), UIntToMask(size, MaxInstNumPerBlock))
+
   def getBankIdx(blkOffset: UInt): UInt =
     (blkOffset >> rowOffBits).asUInt
 

--- a/src/main/scala/xiangshan/frontend/icache/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Helpers.scala
@@ -283,24 +283,34 @@ trait ICacheMaybeRvcHelper extends HasICacheParameters with ICacheCacheLineHelpe
       leftShift:   Bool
   ): UInt = Mux(leftShift, maybeRvcMap << shiftNum, maybeRvcMap >> shiftNum)(MaxInstNumPerBlock - 1, 0)
 
-  def genInstRange(size: UInt): UInt =
-    Mux(size >= MaxInstNumPerBlock.U, ~0.U(MaxInstNumPerBlock.W), UIntToMask(size, MaxInstNumPerBlock))
-
-  def genMaybeRvcShiftInfo(
+  def genInstRange(size: UInt): UInt = {
+    // For max width = 2^N, shift amount bit-width (N+1) causes extra Mux stage.
+    // Since any value >= 2^N saturates to all-1, we check the MSB (size[N]) first.
+    // If set -> output all ones; else use lower N bits for UIntToMask.
+    // This reduces shifter width from (N+1) to N, improving timing.
+    require(isPow2(MaxInstNumPerBlock), s"MaxInstNumPerBlock ($MaxInstNumPerBlock) must be a power of two")
+    val sizeExt = size.pad(log2Ceil(MaxInstNumPerBlock) + 1) // Adapt to varying FetchSize values
+    val range = Mux(
+      sizeExt(log2Ceil(MaxInstNumPerBlock)),
+      Fill(MaxInstNumPerBlock, true.B),
+      UIntToMask(sizeExt(log2Ceil(MaxInstNumPerBlock) - 1, 0), MaxInstNumPerBlock)
+    )
+    range
+  }
+  def genMaybeRvcAlignInfo(
       req:            Vec[FtqFetchRequest],
       wayLookupEntry: Vec[WayLookupEntry]
-  ): MaybeRvcShiftInfo = {
-    val info = Wire(new MaybeRvcShiftInfo)
+  ): MaybeRvcAlignInfo = {
+    val info = Wire(new MaybeRvcAlignInfo)
 
-    val reqStart         = VecInit(req.map(_.startVAddr(log2Ceil(MaxInstNumPerBlock), 1)))
-    val takenCfiOffset   = VecInit(req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
-    val blockIsCrossLine = VecInit(req.map(req => isCrossLine(req.startVAddr, req.endPosition)))
-    val fetchSize        = VecInit(takenCfiOffset.map(_ +& 1.U))
-    val firstFetchSize   = fetchSize(0)
-    val secondFetchSize  = fetchSize(1)
-    val totalFetchSize   = firstFetchSize +& secondFetchSize
-    val firstBlockRange  = genInstRange(firstFetchSize)
-    val totalBlockRange  = Mux(req(1).valid, genInstRange(totalFetchSize), firstBlockRange)
+    val reqStart        = VecInit(req.map(_.startVAddr(log2Ceil(MaxInstNumPerBlock), 1)))
+    val takenCfiOffset  = VecInit(req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
+    val fetchSize       = VecInit(takenCfiOffset.map(_ +& 1.U))
+    val totalFetchSize  = fetchSize(0) +& fetchSize(1)
+    val firstBlockRange = genInstRange(fetchSize(0))
+    // Keep req(1).valid out of this s0 timing path. totalBlockRange is selected
+    // with the registered twoFetchValid in MainPipe before being sent to IFU.
+    val totalBlockRange = genInstRange(totalFetchSize)
 
     info.firstBlockRange := firstBlockRange
     info.totalBlockRange := totalBlockRange
@@ -314,62 +324,52 @@ trait ICacheMaybeRvcHelper extends HasICacheParameters with ICacheCacheLineHelpe
     info.shiftNum(1) := ~reqStart(0)
 
     // Line 2 belongs to req1's first cache line. It may be before or after the end of req0,
-    // so shiftFlag selects whether it should move right or left.
-    info.shiftFlag   := reqStart(1) > firstFetchSize
-    info.shiftNum(2) := Mux(info.shiftFlag, reqStart(1) - firstFetchSize, firstFetchSize - reqStart(1))
+    // so shouldShiftRight selects whether it should move right or left.
+    info.shouldShiftRight := reqStart(1) > fetchSize(0)
+    info.shiftNum(2)      := Mux(info.shouldShiftRight, reqStart(1) - fetchSize(0), fetchSize(0) - reqStart(1))
 
     // Line 3 is the cross-line tail of req1. The extra +2 shift is encoded by Cat(map, 0.U(2.W)) below.
     info.shiftNum(3) := ~reqStart(1) + takenCfiOffset(0)
 
-    // Apply the low bits in s0 so the registered map only needs coarse shifts in s1.
-    info.sramShiftMaybeRvc(0)(0) := shiftMaybeRvc(
-      wayLookupEntry(0).maybeRvcMap(0),
-      info.shiftNum(0),
-      leftShift = false.B
-    )
-    info.sramShiftMaybeRvc(0)(1) :=
-      shiftMaybeRvc(
-        Cat(wayLookupEntry(0).maybeRvcMap(1), 0.U(1.W)),
-        info.shiftNum(1),
-        leftShift = true.B
+    // Pre-align each raw SRAM per-line map into the fetch coordinate here in s0
+    // (the SRAM path is fully aligned in s0 and registered; the MSHR path reuses
+    // the same shiftNum/shouldShiftRight to align the missUnit map in s1).
+    // shiftConfig describes each maybeRvcMap: (extraShiftNum, shiftLeft).
+    info.shiftConfig.zipWithIndex.foreach { case (c, i) =>
+      val reqIdx  = i / PortNumber
+      val portIdx = i % PortNumber
+      info.sramAlignedMaybeRvcMap(reqIdx)(portIdx) := shiftMaybeRvc(
+        Cat(wayLookupEntry(reqIdx).maybeRvcMap(portIdx), 0.U(c._1.W)),
+        info.shiftNum(i),
+        leftShift = c._2
       )
-    info.sramShiftMaybeRvc(1)(0) :=
-      shiftMaybeRvc(
-        wayLookupEntry(1).maybeRvcMap(0),
-        info.shiftNum(2),
-        leftShift = !info.shiftFlag
-      )
-    info.sramShiftMaybeRvc(1)(1) :=
-      shiftMaybeRvc(
-        Cat(wayLookupEntry(1).maybeRvcMap(1), 0.U(2.W)),
-        info.shiftNum(3),
-        leftShift = true.B
-      )
+    }
 
-    info.maybeRvcMaskVec(0)(0) := genInstRange(
-      Mux(
-        blockIsCrossLine(0),
-        MaxInstNumPerBlock.U - info.shiftNum(0),
-        firstFetchSize
-      )
-    )
-    info.maybeRvcMaskVec(0)(1) := firstBlockRange & ~info.maybeRvcMaskVec(0)(0)
-    info.maybeRvcMaskVec(1)(0) := Mux(
-      req(1).valid,
-      genInstRange(
-        firstFetchSize +& Mux(
-          blockIsCrossLine(1),
-          MaxInstNumPerBlock.U - reqStart(1),
-          secondFetchSize
-        )
-      ) & ~firstBlockRange,
-      0.U
-    )
-    info.maybeRvcMaskVec(1)(1) := Mux(
-      req(1).valid,
-      totalBlockRange & ~(firstBlockRange | info.maybeRvcMaskVec(1)(0)),
-      0.U
-    )
+    // The following masks are all in the "combined coordinate" space:
+    // bit 0 corresponds to the first valid instruction slot of req0,
+    // consistent with the coordinate after aligning by sramAlignedMaybeRvcMap / mshrAlignedMaybeRvcMap.
+    //
+    // (0)(0): instructions of req0 in line0.
+    //   genInstRange(N - shiftNum(0)): all slots from req0 start to the end of line0.
+    //   & firstBlockRange clamps to req0's actual fetch range, i.e., min(N - reqStart(0), fetchSize(0)).
+    info.alignedMaybeRvcMaskVec(0)(0) := genInstRange(MaxInstNumPerBlock.U - info.shiftNum(0)) & firstBlockRange
+    // (0)(1): req0's tail across line1 = the part of firstBlockRange not covered by line0.
+    info.alignedMaybeRvcMaskVec(0)(1) := firstBlockRange & ~info.alignedMaybeRvcMaskVec(0)(0)
+
+    // req1 starts fetching at combined coordinate fetchSize(0). Its line0 can occupy at most N - reqStart(1) slots,
+    // so the upper bound for line0 mask is fetchSize(0) + (N - reqStart(1)).
+    // By the invariant fetchSize(0) + fetchSize(1) <= N (see constraints in Ftq), we have:
+    //   1) This upper bound <= 2*N, truncating to log2Ceil(N)+1 bits covers all valid values.
+    //   2) The only value that gets truncated is 2*N, which occurs iff fetchSize(0)=N and reqStart(1)=0,
+    //      in which case fetchSize(1)=0 and both masks are already zero. Thus truncation is safe,
+    //      and also reduces shifter width to improve timing.
+    val req1Line0End = (MaxInstNumPerBlock.U - reqStart(1) + fetchSize(0))(log2Ceil(MaxInstNumPerBlock), 0)
+    // (1)(0): instructions of req1 in line0 = [fetchSize(0), min(req1Line0End, fetchSize(0)+fetchSize(1))-1].
+    //   genInstRange(req1Line0End) provides the upper bound; & totalBlockRange clamps to the total fetch range.
+    //   & ~firstBlockRange removes req0's part.
+    info.alignedMaybeRvcMaskVec(1)(0) := genInstRange(req1Line0End) & totalBlockRange & ~firstBlockRange
+    // (1)(1): req1's tail in line1 = the part of totalBlockRange not covered by firstBlockRange and (1)(0).
+    info.alignedMaybeRvcMaskVec(1)(1) := totalBlockRange & ~(firstBlockRange | info.alignedMaybeRvcMaskVec(1)(0))
     info
   }
 }

--- a/src/main/scala/xiangshan/frontend/icache/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Helpers.scala
@@ -21,6 +21,7 @@ import utility.UIntToMask
 import xiangshan.frontend.FtqFetchRequest
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
+import xiangshan.frontend.bpu.HalfAlignHelper
 import xiangshan.frontend.bpu.HasBpuParameters
 
 trait ICacheEccHelper extends HasICacheParameters {
@@ -114,101 +115,6 @@ trait ICacheMetaHelper extends HasICacheParameters {
 }
 
 trait ICacheDataHelper extends HasICacheParameters with ICacheCacheLineHelper {
-  def shiftMaybeRvc(
-      maybeRvcMap: UInt,
-      shiftNum:    UInt,
-      leftShift:   Bool
-  ): UInt = Mux(leftShift, maybeRvcMap << shiftNum, maybeRvcMap >> shiftNum)(MaxInstNumPerBlock - 1, 0)
-
-  def genMaybeRvcShiftInfo(
-      req:            Vec[FtqFetchRequest],
-      wayLookupEntry: Vec[WayLookupEntry]
-  ): MaybeRvcShiftInfo = {
-    val info = Wire(new MaybeRvcShiftInfo)
-
-    val reqStart        = VecInit(req.map(_.startVAddr(log2Ceil(MaxInstNumPerBlock), 1)))
-    val takenCfiOffset = VecInit(req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
-    val fetchSize       = VecInit(takenCfiOffset.map(_ +& 1.U))
-    val firstFetchSize  = fetchSize(0)
-    val secondFetchSize = fetchSize(1)
-    val totalFetchSize  = firstFetchSize +& secondFetchSize
-    val firstBlockRange = genInstRange(firstFetchSize)
-    val totalBlockRange = Mux(req(1).valid, genInstRange(totalFetchSize), firstBlockRange)
-
-    info.firstBlockRange := firstBlockRange
-    info.totalBlockRange := totalBlockRange
-    info.takenCfiOffset  := takenCfiOffset
-
-    // Line 0 starts at req0.start, so shift right to align its first valid bit to bit 0.
-    info.shiftNum(0) := reqStart(0)
-
-    // Line 1 is the cross-line tail of req0. Its valid bits start at bit 0 and are placed
-    // after the line-0 fragment. The extra +1 shift is encoded by Cat(map, 0) below.
-    info.shiftNum(1) := ~reqStart(0)
-
-    // Line 2 belongs to req1's first cache line. It may be before or after the end of req0,
-    // so shiftFlag selects whether it should move right or left.
-    info.shiftFlag   := reqStart(1) > firstFetchSize
-    info.shiftNum(2) := Mux(info.shiftFlag, reqStart(1) - firstFetchSize, firstFetchSize - reqStart(1))
-
-    // Line 3 is the cross-line tail of req1. The extra +2 shift is encoded by Cat(map, 0.U(2.W)) below.
-    info.shiftNum(3) := ~reqStart(1) + req(0).takenCfiOffset.bits
-
-    // Apply the low bits in s0 so the registered map only needs coarse shifts in s1.
-    info.sramShiftMaybeRvc(0)(0) := shiftMaybeRvc(
-      wayLookupEntry(0).maybeRvcMap(0),
-      info.shiftNum(0),
-      leftShift = false.B
-    )
-    info.sramShiftMaybeRvc(0)(1) :=
-      shiftMaybeRvc(
-        Cat(wayLookupEntry(0).maybeRvcMap(1), 0.U(1.W)),
-        info.shiftNum(1),
-        leftShift = true.B
-      )
-    info.sramShiftMaybeRvc(1)(0) :=
-      shiftMaybeRvc(
-        wayLookupEntry(1).maybeRvcMap(0),
-        info.shiftNum(2),
-        leftShift = !info.shiftFlag
-      )
-    info.sramShiftMaybeRvc(1)(1) :=
-      shiftMaybeRvc(
-        Cat(wayLookupEntry(1).maybeRvcMap(1), 0.U(2.W)),
-        info.shiftNum(3),
-        leftShift = true.B
-      )
-
-    info.maybeRvcMaskVec(0)(0) := genInstRange(
-      Mux(
-        wayLookupEntry(0).isCrossLine,
-        MaxInstNumPerBlock.U - info.shiftNum(0),
-        firstFetchSize
-      )
-    )
-    info.maybeRvcMaskVec(0)(1) := firstBlockRange & ~info.maybeRvcMaskVec(0)(0)
-    info.maybeRvcMaskVec(1)(0) := Mux(
-      req(1).valid,
-      genInstRange(
-        firstFetchSize +& Mux(
-          wayLookupEntry(1).isCrossLine,
-          MaxInstNumPerBlock.U - reqStart(1),
-          secondFetchSize
-        )
-      ) & ~firstBlockRange,
-      0.U
-    )
-    info.maybeRvcMaskVec(1)(1) := Mux(
-      req(1).valid,
-      totalBlockRange & ~(firstBlockRange | info.maybeRvcMaskVec(1)(0)),
-      0.U
-    )
-    info
-  }
-
-  def genInstRange(size: UInt): UInt =
-    Mux(size >= MaxInstNumPerBlock.U, ~0.U(MaxInstNumPerBlock.W), UIntToMask(size, MaxInstNumPerBlock))
-
   def getBankIdx(blkOffset: UInt): UInt =
     (blkOffset >> rowOffBits).asUInt
 
@@ -368,4 +274,102 @@ trait ICacheCacheLineHelper extends HasICacheParameters with HasBpuParameters {
       // Generic fallback for other align sizes.
       getFetchBlockEndLineOffset(startPc, endPosition)._1
     }
+}
+
+trait ICacheMaybeRvcHelper extends HasICacheParameters with ICacheCacheLineHelper with HalfAlignHelper {
+  def shiftMaybeRvc(
+      maybeRvcMap: UInt,
+      shiftNum:    UInt,
+      leftShift:   Bool
+  ): UInt = Mux(leftShift, maybeRvcMap << shiftNum, maybeRvcMap >> shiftNum)(MaxInstNumPerBlock - 1, 0)
+
+  def genInstRange(size: UInt): UInt =
+    Mux(size >= MaxInstNumPerBlock.U, ~0.U(MaxInstNumPerBlock.W), UIntToMask(size, MaxInstNumPerBlock))
+
+  def genMaybeRvcShiftInfo(
+      req:            Vec[FtqFetchRequest],
+      wayLookupEntry: Vec[WayLookupEntry]
+  ): MaybeRvcShiftInfo = {
+    val info = Wire(new MaybeRvcShiftInfo)
+
+    val reqStart         = VecInit(req.map(_.startVAddr(log2Ceil(MaxInstNumPerBlock), 1)))
+    val takenCfiOffset   = VecInit(req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
+    val blockIsCrossLine = VecInit(req.map(req => isCrossLine(req.startVAddr, req.endPosition)))
+    val fetchSize        = VecInit(takenCfiOffset.map(_ +& 1.U))
+    val firstFetchSize   = fetchSize(0)
+    val secondFetchSize  = fetchSize(1)
+    val totalFetchSize   = firstFetchSize +& secondFetchSize
+    val firstBlockRange  = genInstRange(firstFetchSize)
+    val totalBlockRange  = Mux(req(1).valid, genInstRange(totalFetchSize), firstBlockRange)
+
+    info.firstBlockRange := firstBlockRange
+    info.totalBlockRange := totalBlockRange
+    info.takenCfiOffset  := takenCfiOffset
+
+    // Line 0 starts at req0.start, so shift right to align its first valid bit to bit 0.
+    info.shiftNum(0) := reqStart(0)
+
+    // Line 1 is the cross-line tail of req0. Its valid bits start at bit 0 and are placed
+    // after the line-0 fragment. The extra +1 shift is encoded by Cat(map, 0) below.
+    info.shiftNum(1) := ~reqStart(0)
+
+    // Line 2 belongs to req1's first cache line. It may be before or after the end of req0,
+    // so shiftFlag selects whether it should move right or left.
+    info.shiftFlag   := reqStart(1) > firstFetchSize
+    info.shiftNum(2) := Mux(info.shiftFlag, reqStart(1) - firstFetchSize, firstFetchSize - reqStart(1))
+
+    // Line 3 is the cross-line tail of req1. The extra +2 shift is encoded by Cat(map, 0.U(2.W)) below.
+    info.shiftNum(3) := ~reqStart(1) + takenCfiOffset(0)
+
+    // Apply the low bits in s0 so the registered map only needs coarse shifts in s1.
+    info.sramShiftMaybeRvc(0)(0) := shiftMaybeRvc(
+      wayLookupEntry(0).maybeRvcMap(0),
+      info.shiftNum(0),
+      leftShift = false.B
+    )
+    info.sramShiftMaybeRvc(0)(1) :=
+      shiftMaybeRvc(
+        Cat(wayLookupEntry(0).maybeRvcMap(1), 0.U(1.W)),
+        info.shiftNum(1),
+        leftShift = true.B
+      )
+    info.sramShiftMaybeRvc(1)(0) :=
+      shiftMaybeRvc(
+        wayLookupEntry(1).maybeRvcMap(0),
+        info.shiftNum(2),
+        leftShift = !info.shiftFlag
+      )
+    info.sramShiftMaybeRvc(1)(1) :=
+      shiftMaybeRvc(
+        Cat(wayLookupEntry(1).maybeRvcMap(1), 0.U(2.W)),
+        info.shiftNum(3),
+        leftShift = true.B
+      )
+
+    info.maybeRvcMaskVec(0)(0) := genInstRange(
+      Mux(
+        blockIsCrossLine(0),
+        MaxInstNumPerBlock.U - info.shiftNum(0),
+        firstFetchSize
+      )
+    )
+    info.maybeRvcMaskVec(0)(1) := firstBlockRange & ~info.maybeRvcMaskVec(0)(0)
+    info.maybeRvcMaskVec(1)(0) := Mux(
+      req(1).valid,
+      genInstRange(
+        firstFetchSize +& Mux(
+          blockIsCrossLine(1),
+          MaxInstNumPerBlock.U - reqStart(1),
+          secondFetchSize
+        )
+      ) & ~firstBlockRange,
+      0.U
+    )
+    info.maybeRvcMaskVec(1)(1) := Mux(
+      req(1).valid,
+      totalBlockRange & ~(firstBlockRange | info.maybeRvcMaskVec(1)(0)),
+      0.U
+    )
+    info
+  }
 }

--- a/src/main/scala/xiangshan/frontend/icache/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Helpers.scala
@@ -114,110 +114,100 @@ trait ICacheMetaHelper extends HasICacheParameters {
 }
 
 trait ICacheDataHelper extends HasICacheParameters with ICacheCacheLineHelper {
-  def shiftSramMaybeRvc(
+  def shiftMaybeRvc(
       maybeRvcMap: UInt,
-      shiftNum: UInt,
-      leftShift: Bool,
-      secondShift: Boolean
-  ): UInt = {
-    val realShiftNum =
-      if (secondShift) Cat(shiftNum(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W)) else shiftNum(1, 0)
-    val shifted = Mux(leftShift, maybeRvcMap << realShiftNum, maybeRvcMap >> realShiftNum)
-    if (secondShift) shifted else shifted(MaxInstNumPerBlock - 1, 0)
-  }
-
-  def shiftSramMaybeRvcVec(
-      maybeRvcMap: Vec[UInt],
-      shiftNum: Vec[UInt],
-      shiftFlag: Bool,
-      secondShift: Boolean
-  ): Vec[Vec[UInt]] = VecInit(
-    VecInit(
-      shiftSramMaybeRvc(maybeRvcMap(0), shiftNum(0), leftShift = false.B, secondShift = secondShift),
-      shiftSramMaybeRvc(maybeRvcMap(1), shiftNum(1), leftShift = true.B, secondShift = secondShift)
-    ),
-    VecInit(
-      shiftSramMaybeRvc(maybeRvcMap(2), shiftNum(2), leftShift = !shiftFlag, secondShift = secondShift),
-      shiftSramMaybeRvc(maybeRvcMap(3), shiftNum(3), leftShift = true.B, secondShift = secondShift)
-    )
-  )
+      shiftNum:    UInt,
+      leftShift:   Bool
+  ): UInt = Mux(leftShift, maybeRvcMap << shiftNum, maybeRvcMap >> shiftNum)(MaxInstNumPerBlock - 1, 0)
 
   def genMaybeRvcShiftInfo(
-      req: Vec[FtqFetchRequest],
-      wayLookupEntry: Vec[WayLookupEntry],
-      firstFetchSize: UInt
+      req:            Vec[FtqFetchRequest],
+      wayLookupEntry: Vec[WayLookupEntry]
   ): MaybeRvcShiftInfo = {
     val info = Wire(new MaybeRvcShiftInfo)
 
-    val req0Start = req(0).startVAddr(log2Ceil(MaxInstNumPerBlock), 1)
-    val req1Start = req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1)
-    val s0_takenCfiOffset = VecInit(req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
-    val secondFetchSize = s0_takenCfiOffset(1) +& 1.U
-    val totalFetchSize  = secondFetchSize +& firstFetchSize
+    val reqStart        = VecInit(req.map(_.startVAddr(log2Ceil(MaxInstNumPerBlock), 1)))
+    val takenCfiOffset = VecInit(req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
+    val fetchSize       = VecInit(takenCfiOffset.map(_ +& 1.U))
+    val firstFetchSize  = fetchSize(0)
+    val secondFetchSize = fetchSize(1)
+    val totalFetchSize  = firstFetchSize +& secondFetchSize
     val firstBlockRange = genInstRange(firstFetchSize)
     val totalBlockRange = Mux(req(1).valid, genInstRange(totalFetchSize), firstBlockRange)
 
-    info.shiftNum(0)  := req0Start
-    info.shiftNum(1)  := ~info.shiftNum(0)
-    info.shiftFlag    := req1Start > firstFetchSize
-    info.shiftNum(2)  := Mux(info.shiftFlag, req1Start - firstFetchSize, firstFetchSize - req1Start)
-    info.shiftNum(3)  := ~req1Start + s0_takenCfiOffset(0)
+    info.firstBlockRange := firstBlockRange
+    info.totalBlockRange := totalBlockRange
+    info.takenCfiOffset  := takenCfiOffset
 
-    info.shiftMaybeRvcMap(0) :=
-      shiftSramMaybeRvc(
-        wayLookupEntry(0).maybeRvcMap(0),
-        info.shiftNum(0),
-        leftShift = false.B,
-        secondShift = false
-      )
-    info.shiftMaybeRvcMap(1) :=
-      shiftSramMaybeRvc(
+    // Line 0 starts at req0.start, so shift right to align its first valid bit to bit 0.
+    info.shiftNum(0) := reqStart(0)
+
+    // Line 1 is the cross-line tail of req0. Its valid bits start at bit 0 and are placed
+    // after the line-0 fragment. The extra +1 shift is encoded by Cat(map, 0) below.
+    info.shiftNum(1) := ~reqStart(0)
+
+    // Line 2 belongs to req1's first cache line. It may be before or after the end of req0,
+    // so shiftFlag selects whether it should move right or left.
+    info.shiftFlag   := reqStart(1) > firstFetchSize
+    info.shiftNum(2) := Mux(info.shiftFlag, reqStart(1) - firstFetchSize, firstFetchSize - reqStart(1))
+
+    // Line 3 is the cross-line tail of req1. The extra +2 shift is encoded by Cat(map, 0.U(2.W)) below.
+    info.shiftNum(3) := ~reqStart(1) + req(0).takenCfiOffset.bits
+
+    // Apply the low bits in s0 so the registered map only needs coarse shifts in s1.
+    info.sramShiftMaybeRvc(0)(0) := shiftMaybeRvc(
+      wayLookupEntry(0).maybeRvcMap(0),
+      info.shiftNum(0),
+      leftShift = false.B
+    )
+    info.sramShiftMaybeRvc(0)(1) :=
+      shiftMaybeRvc(
         Cat(wayLookupEntry(0).maybeRvcMap(1), 0.U(1.W)),
         info.shiftNum(1),
-        leftShift = true.B,
-        secondShift = false
+        leftShift = true.B
       )
-    info.shiftMaybeRvcMap(2) :=
-      shiftSramMaybeRvc(
+    info.sramShiftMaybeRvc(1)(0) :=
+      shiftMaybeRvc(
         wayLookupEntry(1).maybeRvcMap(0),
         info.shiftNum(2),
-        leftShift = !info.shiftFlag,
-        secondShift = false
+        leftShift = !info.shiftFlag
       )
-    info.shiftMaybeRvcMap(3) :=
-      shiftSramMaybeRvc(
+    info.sramShiftMaybeRvc(1)(1) :=
+      shiftMaybeRvc(
         Cat(wayLookupEntry(1).maybeRvcMap(1), 0.U(2.W)),
         info.shiftNum(3),
-        leftShift = true.B,
-        secondShift = false
+        leftShift = true.B
       )
 
-    info.rangeVec(0) := genInstRange(
+    info.maybeRvcMaskVec(0)(0) := genInstRange(
       Mux(
-        req(0).isCrossLine,
+        wayLookupEntry(0).isCrossLine,
         MaxInstNumPerBlock.U - info.shiftNum(0),
         firstFetchSize
       )
     )
-    info.rangeVec(1) := firstBlockRange & ~info.rangeVec(0)
-    info.rangeVec(2) := Mux(
+    info.maybeRvcMaskVec(0)(1) := firstBlockRange & ~info.maybeRvcMaskVec(0)(0)
+    info.maybeRvcMaskVec(1)(0) := Mux(
       req(1).valid,
       genInstRange(
         firstFetchSize +& Mux(
-          req(1).isCrossLine,
-          MaxInstNumPerBlock.U - req1Start,
+          wayLookupEntry(1).isCrossLine,
+          MaxInstNumPerBlock.U - reqStart(1),
           secondFetchSize
         )
       ) & ~firstBlockRange,
       0.U
     )
-    info.rangeVec(3) := Mux(req(1).valid, totalBlockRange & ~(firstBlockRange | info.rangeVec(2)), 0.U)
-
+    info.maybeRvcMaskVec(1)(1) := Mux(
+      req(1).valid,
+      totalBlockRange & ~(firstBlockRange | info.maybeRvcMaskVec(1)(0)),
+      0.U
+    )
     info
   }
 
   def genInstRange(size: UInt): UInt =
-    Mux(size >= MaxInstNumPerBlock.U, (~0.U(MaxInstNumPerBlock.W)), UIntToMask(size, MaxInstNumPerBlock))
+    Mux(size >= MaxInstNumPerBlock.U, ~0.U(MaxInstNumPerBlock.W), UIntToMask(size, MaxInstNumPerBlock))
 
   def getBankIdx(blkOffset: UInt): UInt =
     (blkOffset >> rowOffBits).asUInt

--- a/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
@@ -220,8 +220,8 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
 
   // perf
   io.toIfu.perf.hits         := mainPipe.io.perf.rawHits
-  io.toIfu.perf.isDoubleLine := mainPipe.io.toIfu.req.bits(0).perf_isCrossLine
-  io.toIfu.perf.exception    := mainPipe.io.toIfu.req.bits(0).icacheMeta.exception
+  io.toIfu.perf.isDoubleLine := mainPipe.io.toIfu.req.bits.info(0).perf_isCrossLine
+  io.toIfu.perf.exception    := mainPipe.io.toIfu.req.bits.info(0).icacheMeta.exception
 
   // topdown perf
   // when mainPipe is handling a miss, it will create a bubble in Ifu pipe
@@ -252,7 +252,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
       "icache_miss_cnt",                // count misses when:
       mainPipe.io.toIfu.req.valid && (  // response is sent to Ifu, and
         !mainPipe.io.perf.rawHits(0) || // port 0 miss, or
-          mainPipe.io.toIfu.req.bits(0).perf_isCrossLine && !mainPipe.io.perf.rawHits(
+          mainPipe.io.toIfu.req.bits.info(0).perf_isCrossLine && !mainPipe.io.perf.rawHits(
             1
           ) // port 1 is needed and miss
       )

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -119,7 +119,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s0_totalBlockRange = Wire(UInt(MaxInstNumPerBlock.W))
   private val s0_shiftFlag      = Wire(Bool())
   private val s0_takenCfiOffset = VecInit(s0_req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
-  private val s0_firstFetchSize = s0_takenCfiOffset(0) + 1.U(log2Ceil(MaxInstNumPerBlock).W)
+  private val s0_firstFetchSize = s0_takenCfiOffset(0) +& 1.U(log2Ceil(MaxInstNumPerBlock).W)
+  private val s0_totalFetchSize = s0_takenCfiOffset(1) +& 1.U +& s0_firstFetchSize
   // 我将移位分为两次进行
   // shiftMaybeRvcMap(0)  := maybeRvcMap(0) >> s0_shiftNum(0)
   s0_shiftNum(0)  := s0_req(0).startVAddr(log2Ceil(MaxInstNumPerBlock), 1)
@@ -134,10 +135,10 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   )
   // shiftMaybeRvcMap(3)  := Cat(maybeRvcMap(3), 0.U(2.W)) << s0_shiftNum(3)
   s0_shiftNum(3) := ~s0_req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1) + s0_takenCfiOffset(0)
-  s0_firstBlockRange := UIntToMask(s0_firstFetchSize, MaxInstNumPerBlock)
+  s0_firstBlockRange := Mux(s0_firstFetchSize === MaxInstNumPerBlock.U, (~0.U(MaxInstNumPerBlock.W)), UIntToMask(s0_firstFetchSize, MaxInstNumPerBlock))
   s0_totalBlockRange := Mux(
     s0_req(1).valid,
-    UIntToMask(s0_takenCfiOffset(1) + 1.U + s0_firstFetchSize, MaxInstNumPerBlock),
+    Mux(s0_totalFetchSize === MaxInstNumPerBlock.U, (~0.U(MaxInstNumPerBlock.W)), UIntToMask(s0_totalFetchSize, MaxInstNumPerBlock)),
     s0_firstBlockRange
   )
   s0_shiftMaybeRvcMap(0) := s0_wayLookupEntry(0).maybeRvcMap(0) >> s0_shiftNum(0)(1, 0)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -39,6 +39,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     with ICacheAddrHelper
     with ICacheDataHelper
     with ICacheMissUpdateHelper
+    with ICacheMaybeRvcHelper
     with HalfAlignHelper {
 
   class ICacheMainPipeIO(implicit p: Parameters) extends ICacheBundle {
@@ -210,8 +211,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_maybeRvcMaskVec   = s1_maybeRvcShiftInfo.maybeRvcMaskVec
   private val s1_sramShiftMaybeRvc = s1_maybeRvcShiftInfo.sramShiftMaybeRvc
 
-  private val s1_wayMask     = VecInit(s1_wayLookupEntry.map(_.waymask))
-  private val s1_isCrossLine = VecInit(s1_req.map(req => isCrossLine(req.startVAddr, req.endPosition)))
+  private val s1_wayMask        = VecInit(s1_wayLookupEntry.map(_.waymask))
+  private val s1_isCrossLine    = VecInit(s1_req.map(req => isCrossLine(req.startVAddr, req.endPosition)))
   private val s1_takenCfiOffset = s1_maybeRvcShiftInfo.takenCfiOffset
 
   private val s1_pTag   = s1_wayLookupEntry(0).pTag
@@ -259,26 +260,24 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_mshrDatas       = fromMiss.bits.data.asTypeOf(Vec(DataBanks, UInt(ICacheDataBits.W)))
   private val s1_mshrMaybeRvcMap = fromMiss.bits.maybeRvcMap
 
-  // MSHR returns one raw cache-line maybeRvcMap, so align it in one step according to
-  // the hit request and line. This mirrors the four SRAM alignment cases without the
-  // s0/s1 fine/coarse split.
-  private val s1_shiftMshrMaybeRvc = Wire(UInt(MaxInstNumPerBlock.W))
-  s1_shiftMshrMaybeRvc := Mux(
-    s1_mshrValid(0).reduce(_ || _),
+  // MSHR returns one raw cache-line maybeRvcMap. Two fetch requests may access
+  // the same cache line with different offsets, so generate a per-fetch-request
+  // aligned map in one step. This mirrors the four SRAM alignment cases without
+  // the s0/s1 fine/coarse split.
+  private val s1_shiftMshrMaybeRvc = Wire(Vec(MaxFetchReqNum, UInt(MaxInstNumPerBlock.W)))
+  s1_shiftMshrMaybeRvc(0) := Mux(
+    s1_mshrValid(0)(0),
+    s1_mshrMaybeRvcMap >> s1_shiftNum(0),
+    Cat(s1_mshrMaybeRvcMap, 0.U(1.W)) << s1_shiftNum(1)
+  )
+  s1_shiftMshrMaybeRvc(1) := Mux(
+    s1_mshrValid(1)(0),
     Mux(
-      s1_mshrValid(0)(0),
-      s1_mshrMaybeRvcMap >> s1_shiftNum(0),
-      Cat(s1_mshrMaybeRvcMap, 0.U(1.W)) << s1_shiftNum(1)
+      s1_shiftFlag,
+      s1_mshrMaybeRvcMap >> s1_shiftNum(2),
+      s1_mshrMaybeRvcMap << s1_shiftNum(2)
     ),
-    Mux(
-      s1_mshrValid(1)(0),
-      Mux(
-        s1_shiftFlag,
-        s1_mshrMaybeRvcMap >> s1_shiftNum(2),
-        s1_mshrMaybeRvcMap << s1_shiftNum(2)
-      ),
-      Cat(s1_mshrMaybeRvcMap, 0.U(2.W)) << s1_shiftNum(3)
-    )
+    Cat(s1_mshrMaybeRvcMap, 0.U(2.W)) << s1_shiftNum(3)
   )
 
   private val s1_mshrValidReg       = RegNext(s1_mshrValid)
@@ -313,7 +312,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
       DataHoldBypass(
         Mux(
           s1_mshrValidReg(i)(j),
-          s1_mshrMaybeRvcMapReg,
+          s1_mshrMaybeRvcMapReg(i),
           s1_sramShiftMaybeRvc(i)(j)
         ),
         RegNext(s0_fire) || s1_mshrValidReg(i)(j)
@@ -420,14 +419,14 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   io.toIfu.req.bits.firstRange := s1_firstBlockRange
   io.toIfu.req.bits.totalRange := s1_totalBlockRange
   io.toIfu.req.bits.info.zipWithIndex.foreach { case (req, i) =>
-    req.valid            := s1_req(i).valid
-    req.startVAddr       := s1_req(i).startVAddr
-    req.ftqIdx           := s1_req(i).ftqIdx
+    req.valid                := s1_req(i).valid
+    req.startVAddr           := s1_req(i).startVAddr
+    req.ftqIdx               := s1_req(i).ftqIdx
     req.takenCfiOffset.valid := s1_req(i).taken
     req.takenCfiOffset.bits  := s1_takenCfiOffset(i)
-    req.size             := s1_takenCfiOffset(i) +& 1.U
-    req.data             := s1_data(i)
-    req.perf_isCrossLine := s1_isCrossLine(i)
+    req.size                 := s1_takenCfiOffset(i) +& 1.U
+    req.data                 := s1_data(i)
+    req.perf_isCrossLine     := s1_isCrossLine(i)
 
     req.icacheMeta.exception          := s1_exceptionOut
     req.icacheMeta.pmpMmio            := s1_pmpMmio

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -23,7 +23,6 @@ import org.chipsalliance.cde.config.Parameters
 import utility.ChiselDB
 import utility.DataHoldBypass
 import utility.ValidHold
-import utility.UIntToMask
 import utility.XSPerfAccumulate
 import utility.XSPerfHistogram
 import xiangshan.L1CacheErrorInfo
@@ -113,42 +112,20 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s0_wayLookupEntry = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.entry))
   private val s0_exceptionInfo  = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.exceptionEntry))
   private val s0_wayMask        = VecInit(s0_wayLookupEntry.map(_.waymask))
-  private val s0_shiftNum       = Wire(Vec(MaxFetchLineNum, UInt(log2Ceil(MaxInstNumPerBlock).W)))
-  private val s0_shiftMaybeRvcMap = Wire(Vec(MaxFetchLineNum, UInt(MaxInstNumPerBlock.W)))
   private val s0_firstBlockRange = Wire(UInt(MaxInstNumPerBlock.W))
   private val s0_totalBlockRange = Wire(UInt(MaxInstNumPerBlock.W))
-  private val s0_shiftFlag      = Wire(Bool())
   private val s0_takenCfiOffset = VecInit(s0_req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
   private val s0_firstFetchSize = s0_takenCfiOffset(0) +& 1.U(log2Ceil(MaxInstNumPerBlock).W)
-  private val s0_totalFetchSize = s0_takenCfiOffset(1) +& 1.U +& s0_firstFetchSize
-  // 我将移位分为两次进行
-  // shiftMaybeRvcMap(0)  := maybeRvcMap(0) >> s0_shiftNum(0)
-  s0_shiftNum(0)  := s0_req(0).startVAddr(log2Ceil(MaxInstNumPerBlock), 1)
-  // shiftMaybeRvcMap(1)  := Cat(maybeRvcMap(1), 0.U(1.W)) << s0_shiftNum(1)
-  s0_shiftNum(1)  := ~s0_shiftNum(0)
-  // shiftMaybeRvcMap(2)  := Mux(s0_shiftFlag, maybeRvcMap(2) >> s0_shiftNum(2), maybeRvcMap(2) << s0_shiftNum(2))
-  s0_shiftFlag    := s0_req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1) > s0_firstFetchSize
-  s0_shiftNum(2)  := Mux(
-    s0_shiftFlag,
-    s0_req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1) - s0_firstFetchSize,
-    s0_firstFetchSize - s0_req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1)
-  )
-  // shiftMaybeRvcMap(3)  := Cat(maybeRvcMap(3), 0.U(2.W)) << s0_shiftNum(3)
-  s0_shiftNum(3) := ~s0_req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1) + s0_takenCfiOffset(0)
-  s0_firstBlockRange := Mux(s0_firstFetchSize === MaxInstNumPerBlock.U, (~0.U(MaxInstNumPerBlock.W)), UIntToMask(s0_firstFetchSize, MaxInstNumPerBlock))
+  private val s0_secondFetchSize = s0_takenCfiOffset(1) +& 1.U
+  private val s0_totalFetchSize  = s0_secondFetchSize +& s0_firstFetchSize
+  private val s0_maybeRvcShiftInfo = genMaybeRvcShiftInfo(s0_req, s0_wayLookupEntry, s0_firstFetchSize)
+
+  s0_firstBlockRange := genInstRange(s0_firstFetchSize)
   s0_totalBlockRange := Mux(
     s0_req(1).valid,
-    Mux(s0_totalFetchSize === MaxInstNumPerBlock.U, (~0.U(MaxInstNumPerBlock.W)), UIntToMask(s0_totalFetchSize, MaxInstNumPerBlock)),
+    genInstRange(s0_totalFetchSize),
     s0_firstBlockRange
   )
-  s0_shiftMaybeRvcMap(0) := s0_wayLookupEntry(0).maybeRvcMap(0) >> s0_shiftNum(0)(1, 0)
-  s0_shiftMaybeRvcMap(1) := Cat(s0_wayLookupEntry(0).maybeRvcMap(1), 0.U(1.W)) << s0_shiftNum(1)(1, 0)
-  s0_shiftMaybeRvcMap(2) := Mux(
-    s0_shiftFlag,
-    s0_wayLookupEntry(1).maybeRvcMap(0) >> s0_shiftNum(2)(1, 0),
-    s0_wayLookupEntry(1).maybeRvcMap(0) << s0_shiftNum(2)(1, 0)
-  )
-  s0_shiftMaybeRvcMap(3) := Cat(s0_wayLookupEntry(1).maybeRvcMap(1), 0.U(2.W)) << s0_shiftNum(3)(1, 0)
 
   private val s0_dataSramReadConflict = {
     val reqValid = io.fromFtq.bits.req.map(_.valid).reduce(_ && _)
@@ -237,20 +214,15 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_wayLookupEntry = RegEnable(s0_wayLookupEntry, s0_fire)
   private val s1_exceptionInfo  = RegEnable(s0_exceptionInfo, s0_fire)
   private val s1_twoFetchValid  = RegEnable(s0_req(1).valid, s0_fire)
-  private val s1_shiftNum       = RegEnable(s0_shiftNum, s0_fire)
-  private val s1_shiftFlag      = RegEnable(s0_shiftFlag, s0_fire)
-  private val s1_shiftMaybeRvc  = RegEnable(s0_shiftMaybeRvcMap, s0_fire)
+  private val s1_maybeRvcShiftInfo = RegEnable(s0_maybeRvcShiftInfo, s0_fire)
   private val s1_firstBlockRange   = RegEnable(s0_firstBlockRange, s0_fire)
   private val s1_totalBlockRange   = RegEnable(s0_totalBlockRange, s0_fire)
-  private val s1_sramShiftMaybeRvc = Wire(Vec(MaxFetchReqNum, Vec(PortNumber, UInt(MaxInstNumPerBlock.W))))
-  s1_sramShiftMaybeRvc(0)(0) := s1_shiftMaybeRvc(0) >> Cat(s1_shiftNum(0)(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W))
-  s1_sramShiftMaybeRvc(0)(1) := s1_shiftMaybeRvc(1) << Cat(s1_shiftNum(1)(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W))
-  s1_sramShiftMaybeRvc(1)(0) := Mux(
-    s1_shiftFlag,
-    s1_shiftMaybeRvc(2) >> Cat(s1_shiftNum(2)(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W)),
-    s1_shiftMaybeRvc(2) << Cat(s1_shiftNum(2)(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W))
-  )
-  s1_sramShiftMaybeRvc(1)(1) := s1_shiftMaybeRvc(3) << Cat(s1_shiftNum(3)(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W))
+  private val s1_shiftNum          = s1_maybeRvcShiftInfo.shiftNum
+  private val s1_shiftFlag         = s1_maybeRvcShiftInfo.shiftFlag
+  private val s1_shiftMaybeRvcMap  = s1_maybeRvcShiftInfo.shiftMaybeRvcMap
+  private val s1_rangeVec          = s1_maybeRvcShiftInfo.rangeVec
+  private val s1_sramShiftMaybeRvc =
+    shiftSramMaybeRvcVec(s1_shiftMaybeRvcMap, s1_shiftNum, s1_shiftFlag, secondShift = true)
 
 
   private val s1_wayMask     = VecInit(s1_wayLookupEntry.map(_.waymask))
@@ -304,10 +276,18 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_shiftMshrMaybeRvc = Wire(UInt(MaxInstNumPerBlock.W))
   s1_shiftMshrMaybeRvc := Mux(
     s1_mshrValid(0).reduce(_ || _),
-    Mux(s1_mshrValid(0)(0), s1_mshrMaybeRvcMap >> s1_shiftNum(0), Cat(s1_mshrMaybeRvcMap, 0.U(1.W)) << s1_shiftNum(1)),
+    Mux(
+      s1_mshrValid(0)(0),
+      s1_mshrMaybeRvcMap >> s1_shiftNum(0),
+      Cat(s1_mshrMaybeRvcMap, 0.U(1.W)) << s1_shiftNum(1)
+    ),
     Mux(
       s1_mshrValid(1)(0),
-      Mux(s1_shiftFlag, s1_mshrMaybeRvcMap >> s1_shiftNum(2), s1_mshrMaybeRvcMap << s1_shiftNum(2)),
+      Mux(
+        s1_shiftFlag,
+        s1_mshrMaybeRvcMap >> s1_shiftNum(2),
+        s1_mshrMaybeRvcMap << s1_shiftNum(2)
+      ),
       Cat(s1_mshrMaybeRvcMap, 0.U(2.W)) << s1_shiftNum(3)
     )
   )
@@ -446,8 +426,11 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_exceptionOut = s1_exception || s1_tlException
 
   io.toIfu.req.valid := s1_valid && s1_fetchFinish && !s1_flush
-  io.toIfu.req.bits.maybeRvcMap := ((s1_maybeRvcMapVec(0)(0) | s1_maybeRvcMapVec(0)(1)) & s1_firstBlockRange) |
-    ((s1_maybeRvcMapVec(1)(0) | s1_maybeRvcMapVec(1)(1)) & (s1_totalBlockRange & ~s1_firstBlockRange))
+  io.toIfu.req.bits.maybeRvcMap :=
+    (s1_maybeRvcMapVec(0)(0) & s1_rangeVec(0)) |
+      (s1_maybeRvcMapVec(0)(1) & s1_rangeVec(1)) |
+      (s1_maybeRvcMapVec(1)(0) & s1_rangeVec(2)) |
+      (s1_maybeRvcMapVec(1)(1) & s1_rangeVec(3))
   io.toIfu.req.bits.range  := s1_totalBlockRange
   io.toIfu.req.bits.info.zipWithIndex.foreach { case (req, i) =>
     req.valid            := s1_req(i).valid

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -109,23 +109,10 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
 
   private val s0_ftqIdx = s0_req(0).ftqIdx
 
-  private val s0_wayLookupEntry = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.entry))
-  private val s0_exceptionInfo  = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.exceptionEntry))
-  private val s0_wayMask        = VecInit(s0_wayLookupEntry.map(_.waymask))
-  private val s0_firstBlockRange = Wire(UInt(MaxInstNumPerBlock.W))
-  private val s0_totalBlockRange = Wire(UInt(MaxInstNumPerBlock.W))
-  private val s0_takenCfiOffset = VecInit(s0_req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
-  private val s0_firstFetchSize = s0_takenCfiOffset(0) +& 1.U(log2Ceil(MaxInstNumPerBlock).W)
-  private val s0_secondFetchSize = s0_takenCfiOffset(1) +& 1.U
-  private val s0_totalFetchSize  = s0_secondFetchSize +& s0_firstFetchSize
-  private val s0_maybeRvcShiftInfo = genMaybeRvcShiftInfo(s0_req, s0_wayLookupEntry, s0_firstFetchSize)
-
-  s0_firstBlockRange := genInstRange(s0_firstFetchSize)
-  s0_totalBlockRange := Mux(
-    s0_req(1).valid,
-    genInstRange(s0_totalFetchSize),
-    s0_firstBlockRange
-  )
+  private val s0_wayLookupEntry    = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.entry))
+  private val s0_exceptionInfo     = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.exceptionEntry))
+  private val s0_wayMask           = VecInit(s0_wayLookupEntry.map(_.waymask))
+  private val s0_maybeRvcShiftInfo = genMaybeRvcShiftInfo(s0_req, s0_wayLookupEntry)
 
   private val s0_dataSramReadConflict = {
     val reqValid = io.fromFtq.bits.req.map(_.valid).reduce(_ && _)
@@ -209,25 +196,23 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
    * - send request to Mshr if ICache miss
    * - response to Ifu
    */
-  private val s1_valid          = ValidHold(s0_fire, s1_fire, s1_flush)
-  private val s1_req            = RegEnable(s0_req, s0_fire)
-  private val s1_wayLookupEntry = RegEnable(s0_wayLookupEntry, s0_fire)
-  private val s1_exceptionInfo  = RegEnable(s0_exceptionInfo, s0_fire)
-  private val s1_twoFetchValid  = RegEnable(s0_req(1).valid, s0_fire)
+  private val s1_valid             = ValidHold(s0_fire, s1_fire, s1_flush)
+  private val s1_req               = RegEnable(s0_req, s0_fire)
+  private val s1_wayLookupEntry    = RegEnable(s0_wayLookupEntry, s0_fire)
+  private val s1_exceptionInfo     = RegEnable(s0_exceptionInfo, s0_fire)
+  private val s1_twoFetchValid     = RegEnable(s0_req(1).valid, s0_fire)
   private val s1_maybeRvcShiftInfo = RegEnable(s0_maybeRvcShiftInfo, s0_fire)
-  private val s1_firstBlockRange   = RegEnable(s0_firstBlockRange, s0_fire)
-  private val s1_totalBlockRange   = RegEnable(s0_totalBlockRange, s0_fire)
+  private val s1_firstBlockRange   = s1_maybeRvcShiftInfo.firstBlockRange
+  private val s1_totalBlockRange   = s1_maybeRvcShiftInfo.totalBlockRange
   private val s1_shiftNum          = s1_maybeRvcShiftInfo.shiftNum
   private val s1_shiftFlag         = s1_maybeRvcShiftInfo.shiftFlag
-  private val s1_shiftMaybeRvcMap  = s1_maybeRvcShiftInfo.shiftMaybeRvcMap
-  private val s1_rangeVec          = s1_maybeRvcShiftInfo.rangeVec
-  private val s1_sramShiftMaybeRvc =
-    shiftSramMaybeRvcVec(s1_shiftMaybeRvcMap, s1_shiftNum, s1_shiftFlag, secondShift = true)
-
+  // rangeVec is used to mask the range for every cache line
+  private val s1_maybeRvcMaskVec   = s1_maybeRvcShiftInfo.maybeRvcMaskVec
+  private val s1_sramShiftMaybeRvc = s1_maybeRvcShiftInfo.sramShiftMaybeRvc
 
   private val s1_wayMask     = VecInit(s1_wayLookupEntry.map(_.waymask))
   private val s1_isCrossLine = VecInit(s1_req.map(req => isCrossLine(req.startVAddr, req.endPosition)))
-  private val s1_takenCfiOffset = RegEnable(s0_takenCfiOffset, s0_fire)
+  private val s1_takenCfiOffset = s1_maybeRvcShiftInfo.takenCfiOffset
 
   private val s1_pTag   = s1_wayLookupEntry(0).pTag
   private val s1_ftqIdx = s1_req(0).ftqIdx
@@ -273,6 +258,10 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   })
   private val s1_mshrDatas       = fromMiss.bits.data.asTypeOf(Vec(DataBanks, UInt(ICacheDataBits.W)))
   private val s1_mshrMaybeRvcMap = fromMiss.bits.maybeRvcMap
+
+  // MSHR returns one raw cache-line maybeRvcMap, so align it in one step according to
+  // the hit request and line. This mirrors the four SRAM alignment cases without the
+  // s0/s1 fine/coarse split.
   private val s1_shiftMshrMaybeRvc = Wire(UInt(MaxInstNumPerBlock.W))
   s1_shiftMshrMaybeRvc := Mux(
     s1_mshrValid(0).reduce(_ || _),
@@ -427,17 +416,15 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
 
   io.toIfu.req.valid := s1_valid && s1_fetchFinish && !s1_flush
   io.toIfu.req.bits.maybeRvcMap :=
-    (s1_maybeRvcMapVec(0)(0) & s1_rangeVec(0)) |
-      (s1_maybeRvcMapVec(0)(1) & s1_rangeVec(1)) |
-      (s1_maybeRvcMapVec(1)(0) & s1_rangeVec(2)) |
-      (s1_maybeRvcMapVec(1)(1) & s1_rangeVec(3))
-  io.toIfu.req.bits.range  := s1_totalBlockRange
+    s1_maybeRvcMapVec.flatten.zip(s1_maybeRvcMaskVec.flatten).map { case (a, b) => a & b }.reduce(_ | _)
+  io.toIfu.req.bits.firstRange := s1_firstBlockRange
+  io.toIfu.req.bits.totalRange := s1_totalBlockRange
   io.toIfu.req.bits.info.zipWithIndex.foreach { case (req, i) =>
     req.valid            := s1_req(i).valid
     req.startVAddr       := s1_req(i).startVAddr
     req.ftqIdx           := s1_req(i).ftqIdx
-    req.takenCfiOffset   := s1_takenCfiOffset(i)
-    // req.range            := s1_totalBlockRange
+    req.takenCfiOffset.valid := s1_req(i).taken
+    req.takenCfiOffset.bits  := s1_takenCfiOffset(i)
     req.size             := s1_takenCfiOffset(i) +& 1.U
     req.data             := s1_data(i)
     req.perf_isCrossLine := s1_isCrossLine(i)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -110,10 +110,26 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
 
   private val s0_ftqIdx = s0_req(0).ftqIdx
 
-  private val s0_wayLookupEntry    = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.entry))
-  private val s0_exceptionInfo     = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.exceptionEntry))
-  private val s0_wayMask           = VecInit(s0_wayLookupEntry.map(_.waymask))
-  private val s0_maybeRvcShiftInfo = genMaybeRvcShiftInfo(s0_req, s0_wayLookupEntry)
+  private val s0_wayLookupEntry = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.entry))
+  private val s0_exceptionInfo  = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.exceptionEntry))
+  private val s0_wayMask        = VecInit(s0_wayLookupEntry.map(_.waymask))
+
+  /* ------------------------------------------------------------------
+   * maybeRvc alignment
+   * ------------------------------------------------------------------
+   * Naming convention:
+   *   maybeRvcMap        : raw per-cache-line map, bit i = 2-byte slot i of the line
+   *                        (as stored in metadata / returned by the missUnit).
+   *   alignedMaybeRvcMap : map aligned to the fetch coordinate, bit 0 = the first
+   *                        fetched instruction slot of req0 (what the IFU consumes).
+   * "Shift" is reserved for the alignment operation/parameters (shiftNum,
+   * shouldShiftRight, shiftMaybeRvc); "Aligned" marks the resulting maps.
+   * Division of work:
+   *   - SRAM maps are fully aligned in s0 (genMaybeRvcAlignInfo) and registered.
+   *   - MSHR maps are aligned in s1 from the registered shift parameters, then
+   *     merged with the SRAM maps and masked before being sent to the IFU.
+   * ------------------------------------------------------------------ */
+  private val s0_maybeRvcAlignInfo = genMaybeRvcAlignInfo(s0_req, s0_wayLookupEntry)
 
   private val s0_dataSramReadConflict = {
     val reqValid = io.fromFtq.bits.req.map(_.valid).reduce(_ && _)
@@ -197,23 +213,34 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
    * - send request to Mshr if ICache miss
    * - response to Ifu
    */
-  private val s1_valid             = ValidHold(s0_fire, s1_fire, s1_flush)
-  private val s1_req               = RegEnable(s0_req, s0_fire)
-  private val s1_wayLookupEntry    = RegEnable(s0_wayLookupEntry, s0_fire)
-  private val s1_exceptionInfo     = RegEnable(s0_exceptionInfo, s0_fire)
-  private val s1_twoFetchValid     = RegEnable(s0_req(1).valid, s0_fire)
-  private val s1_maybeRvcShiftInfo = RegEnable(s0_maybeRvcShiftInfo, s0_fire)
-  private val s1_firstBlockRange   = s1_maybeRvcShiftInfo.firstBlockRange
-  private val s1_totalBlockRange   = s1_maybeRvcShiftInfo.totalBlockRange
-  private val s1_shiftNum          = s1_maybeRvcShiftInfo.shiftNum
-  private val s1_shiftFlag         = s1_maybeRvcShiftInfo.shiftFlag
-  // rangeVec is used to mask the range for every cache line
-  private val s1_maybeRvcMaskVec   = s1_maybeRvcShiftInfo.maybeRvcMaskVec
-  private val s1_sramShiftMaybeRvc = s1_maybeRvcShiftInfo.sramShiftMaybeRvc
+  private val s1_valid          = ValidHold(s0_fire, s1_fire, s1_flush)
+  private val s1_req            = RegEnable(s0_req, s0_fire)
+  private val s1_wayLookupEntry = RegEnable(s0_wayLookupEntry, s0_fire)
+  private val s1_exceptionInfo  = RegEnable(s0_exceptionInfo, s0_fire)
+  private val s1_twoFetchValid  = RegEnable(s0_req(1).valid, s0_fire)
+
+  // s1: registered alignment info (the SRAM aligned maps were pre-computed in s0).
+  private val s1_maybeRvcAlignInfo      = RegEnable(s0_maybeRvcAlignInfo, s0_fire)
+  private val s1_firstBlockRange        = s1_maybeRvcAlignInfo.firstBlockRange
+  private val s1_totalBlockRange        = s1_maybeRvcAlignInfo.totalBlockRange
+  private val s1_shiftNum               = s1_maybeRvcAlignInfo.shiftNum
+  private val s1_shouldShiftRight       = s1_maybeRvcAlignInfo.shouldShiftRight
+  private val s1_sramAlignedMaybeRvcMap = s1_maybeRvcAlignInfo.sramAlignedMaybeRvcMap
+
+  // The aligned masks gate the aligned maps for every cache line.
+  // req1's masks are only meaningful when the second fetch is valid; otherwise the
+  // raw req1 fields are garbage and must not leak into the merged aligned map.
+  private val s1_alignedMaybeRvcMaskVec = Wire(Vec(MaxFetchReqNum, Vec(PortNumber, UInt(MaxInstNumPerBlock.W))))
+  s1_alignedMaybeRvcMaskVec(0) := s1_maybeRvcAlignInfo.alignedMaybeRvcMaskVec(0)
+  s1_alignedMaybeRvcMaskVec(1) := Mux(
+    s1_twoFetchValid, // Defer twoFetchValid to the last stage for better timing.
+    s1_maybeRvcAlignInfo.alignedMaybeRvcMaskVec(1),
+    VecInit(Seq.fill(PortNumber)(0.U(MaxInstNumPerBlock.W)))
+  )
 
   private val s1_wayMask        = VecInit(s1_wayLookupEntry.map(_.waymask))
   private val s1_isCrossLine    = VecInit(s1_req.map(req => isCrossLine(req.startVAddr, req.endPosition)))
-  private val s1_takenCfiOffset = s1_maybeRvcShiftInfo.takenCfiOffset
+  private val s1_takenCfiOffset = s1_maybeRvcAlignInfo.takenCfiOffset
 
   private val s1_pTag   = s1_wayLookupEntry(0).pTag
   private val s1_ftqIdx = s1_req(0).ftqIdx
@@ -257,33 +284,34 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_bankMshrValid = VecInit((0 until MaxFetchReqNum).map { i =>
     getBankValid(s1_mshrValid(i), s1_offset(i))
   })
-  private val s1_mshrDatas       = fromMiss.bits.data.asTypeOf(Vec(DataBanks, UInt(ICacheDataBits.W)))
-  private val s1_mshrMaybeRvcMap = fromMiss.bits.maybeRvcMap
+  private val s1_mshrDatas = fromMiss.bits.data.asTypeOf(Vec(DataBanks, UInt(ICacheDataBits.W)))
 
-  // MSHR returns one raw cache-line maybeRvcMap. Two fetch requests may access
+  // s1: MSHR path - align the raw map returned by the missUnit.
+  // The missUnit returns one raw cache-line maybeRvcMap. Two fetch requests may access
   // the same cache line with different offsets, so generate a per-fetch-request
-  // aligned map in one step. This mirrors the four SRAM alignment cases without
-  // the s0/s1 fine/coarse split.
-  private val s1_shiftMshrMaybeRvc = Wire(Vec(MaxFetchReqNum, UInt(MaxInstNumPerBlock.W)))
-  s1_shiftMshrMaybeRvc(0) := Mux(
+  // aligned map in one step. This mirrors the four SRAM alignment cases (done in s0
+  // for the SRAM path); here it is done in s1 from the registered shift parameters.
+  private val s1_mshrRawMaybeRvcMap     = fromMiss.bits.maybeRvcMap
+  private val s1_mshrAlignedMaybeRvcMap = Wire(Vec(MaxFetchReqNum, UInt(MaxInstNumPerBlock.W)))
+  s1_mshrAlignedMaybeRvcMap(0) := Mux(
     s1_mshrValid(0)(0),
-    (s1_mshrMaybeRvcMap >> s1_shiftNum(0)).asUInt,
-    (Cat(s1_mshrMaybeRvcMap, 0.U(1.W)) << s1_shiftNum(1)).asUInt
+    (s1_mshrRawMaybeRvcMap >> s1_shiftNum(0)).asUInt,
+    (Cat(s1_mshrRawMaybeRvcMap, 0.U(1.W)) << s1_shiftNum(1)).asUInt
   )
-  s1_shiftMshrMaybeRvc(1) := Mux(
+  s1_mshrAlignedMaybeRvcMap(1) := Mux(
     s1_mshrValid(1)(0),
     Mux(
-      s1_shiftFlag,
-      (s1_mshrMaybeRvcMap >> s1_shiftNum(2)).asUInt,
-      (s1_mshrMaybeRvcMap << s1_shiftNum(2)).asUInt
+      s1_shouldShiftRight,
+      (s1_mshrRawMaybeRvcMap >> s1_shiftNum(2)).asUInt,
+      (s1_mshrRawMaybeRvcMap << s1_shiftNum(2)).asUInt
     ),
-    (Cat(s1_mshrMaybeRvcMap, 0.U(2.W)) << s1_shiftNum(3)).asUInt
+    (Cat(s1_mshrRawMaybeRvcMap, 0.U(2.W)) << s1_shiftNum(3)).asUInt
   )
 
-  private val s1_mshrValidReg       = RegNext(s1_mshrValid)
-  private val s1_bankMshrValidReg   = RegNext(s1_bankMshrValid)
-  private val s1_mshrDatasReg       = RegNext(s1_mshrDatas)
-  private val s1_mshrMaybeRvcMapReg = RegNext(s1_shiftMshrMaybeRvc)
+  private val s1_mshrValidReg              = RegNext(s1_mshrValid)
+  private val s1_bankMshrValidReg          = RegNext(s1_bankMshrValid)
+  private val s1_mshrDatasReg              = RegNext(s1_mshrDatas)
+  private val s1_mshrAlignedMaybeRvcMapReg = RegNext(s1_mshrAlignedMaybeRvcMap)
 
   private val s1_hits = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
     VecInit((0 until PortNumber).map { portIdx =>
@@ -307,15 +335,16 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     }).asUInt
   })
 
-  private val s1_maybeRvcMapVec = VecInit((0 until MaxFetchReqNum).map { i =>
-    VecInit((0 until PortNumber).map { j =>
+  // s1: merge the SRAM/MSHR aligned maps into the final fetch-coordinate map.
+  private val s1_alignedMaybeRvcMapVec = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
+    VecInit((0 until PortNumber).map { portIdx =>
       DataHoldBypass(
         Mux(
-          s1_mshrValidReg(i)(j),
-          s1_mshrMaybeRvcMapReg(i),
-          s1_sramShiftMaybeRvc(i)(j)
+          s1_mshrValidReg(reqIdx)(portIdx),
+          s1_mshrAlignedMaybeRvcMapReg(reqIdx),
+          s1_sramAlignedMaybeRvcMap(reqIdx)(portIdx)
         ),
-        RegNext(s0_fire) || s1_mshrValidReg(i)(j)
+        RegNext(s0_fire) || s1_mshrValidReg(reqIdx)(portIdx)
       )
     })
   })
@@ -415,9 +444,9 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
 
   io.toIfu.req.valid := s1_valid && s1_fetchFinish && !s1_flush
   io.toIfu.req.bits.maybeRvcMap :=
-    s1_maybeRvcMapVec.flatten.zip(s1_maybeRvcMaskVec.flatten).map { case (a, b) => a & b }.reduce(_ | _)
+    s1_alignedMaybeRvcMapVec.flatten.zip(s1_alignedMaybeRvcMaskVec.flatten).map { case (a, b) => a & b }.reduce(_ | _)
   io.toIfu.req.bits.firstRange := s1_firstBlockRange
-  io.toIfu.req.bits.totalRange := s1_totalBlockRange
+  io.toIfu.req.bits.totalRange := Mux(s1_twoFetchValid, s1_totalBlockRange, s1_firstBlockRange)
   io.toIfu.req.bits.info.zipWithIndex.foreach { case (req, i) =>
     req.valid                := s1_req(i).valid
     req.startVAddr           := s1_req(i).startVAddr

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -267,17 +267,17 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_shiftMshrMaybeRvc = Wire(Vec(MaxFetchReqNum, UInt(MaxInstNumPerBlock.W)))
   s1_shiftMshrMaybeRvc(0) := Mux(
     s1_mshrValid(0)(0),
-    s1_mshrMaybeRvcMap >> s1_shiftNum(0),
-    Cat(s1_mshrMaybeRvcMap, 0.U(1.W)) << s1_shiftNum(1)
+    (s1_mshrMaybeRvcMap >> s1_shiftNum(0)).asUInt,
+    (Cat(s1_mshrMaybeRvcMap, 0.U(1.W)) << s1_shiftNum(1)).asUInt
   )
   s1_shiftMshrMaybeRvc(1) := Mux(
     s1_mshrValid(1)(0),
     Mux(
       s1_shiftFlag,
-      s1_mshrMaybeRvcMap >> s1_shiftNum(2),
-      s1_mshrMaybeRvcMap << s1_shiftNum(2)
+      (s1_mshrMaybeRvcMap >> s1_shiftNum(2)).asUInt,
+      (s1_mshrMaybeRvcMap << s1_shiftNum(2)).asUInt
     ),
-    Cat(s1_mshrMaybeRvcMap, 0.U(2.W)) << s1_shiftNum(3)
+    (Cat(s1_mshrMaybeRvcMap, 0.U(2.W)) << s1_shiftNum(3)).asUInt
   )
 
   private val s1_mshrValidReg       = RegNext(s1_mshrValid)

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -23,6 +23,7 @@ import org.chipsalliance.cde.config.Parameters
 import utility.ChiselDB
 import utility.DataHoldBypass
 import utility.ValidHold
+import utility.UIntToMask
 import utility.XSPerfAccumulate
 import utility.XSPerfHistogram
 import xiangshan.L1CacheErrorInfo
@@ -112,6 +113,41 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s0_wayLookupEntry = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.entry))
   private val s0_exceptionInfo  = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.exceptionEntry))
   private val s0_wayMask        = VecInit(s0_wayLookupEntry.map(_.waymask))
+  private val s0_shiftNum       = Wire(Vec(MaxFetchLineNum, UInt(log2Ceil(MaxInstNumPerBlock).W)))
+  private val s0_shiftMaybeRvcMap = Wire(Vec(MaxFetchLineNum, UInt(MaxInstNumPerBlock.W)))
+  private val s0_firstBlockRange = Wire(UInt(MaxInstNumPerBlock.W))
+  private val s0_totalBlockRange = Wire(UInt(MaxInstNumPerBlock.W))
+  private val s0_shiftFlag      = Wire(Bool())
+  private val s0_takenCfiOffset = VecInit(s0_req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
+  private val s0_firstFetchSize = s0_takenCfiOffset(0) + 1.U(log2Ceil(MaxInstNumPerBlock).W)
+  // 我将移位分为两次进行
+  // shiftMaybeRvcMap(0)  := maybeRvcMap(0) >> s0_shiftNum(0)
+  s0_shiftNum(0)  := s0_req(0).startVAddr(log2Ceil(MaxInstNumPerBlock), 1)
+  // shiftMaybeRvcMap(1)  := Cat(maybeRvcMap(1), 0.U(1.W)) << s0_shiftNum(1)
+  s0_shiftNum(1)  := ~s0_shiftNum(0)
+  // shiftMaybeRvcMap(2)  := Mux(s0_shiftFlag, maybeRvcMap(2) >> s0_shiftNum(2), maybeRvcMap(2) << s0_shiftNum(2))
+  s0_shiftFlag    := s0_req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1) > s0_firstFetchSize
+  s0_shiftNum(2)  := Mux(
+    s0_shiftFlag,
+    s0_req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1) - s0_firstFetchSize,
+    s0_firstFetchSize - s0_req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1)
+  )
+  // shiftMaybeRvcMap(3)  := Cat(maybeRvcMap(3), 0.U(2.W)) << s0_shiftNum(3)
+  s0_shiftNum(3) := ~s0_req(1).startVAddr(log2Ceil(MaxInstNumPerBlock), 1) + s0_takenCfiOffset(0)
+  s0_firstBlockRange := UIntToMask(s0_firstFetchSize, MaxInstNumPerBlock)
+  s0_totalBlockRange := Mux(
+    s0_req(1).valid,
+    UIntToMask(s0_takenCfiOffset(1) + 1.U + s0_firstFetchSize, MaxInstNumPerBlock),
+    s0_firstBlockRange
+  )
+  s0_shiftMaybeRvcMap(0) := s0_wayLookupEntry(0).maybeRvcMap(0) >> s0_shiftNum(0)(1, 0)
+  s0_shiftMaybeRvcMap(1) := Cat(s0_wayLookupEntry(0).maybeRvcMap(1), 0.U(1.W)) << s0_shiftNum(1)(1, 0)
+  s0_shiftMaybeRvcMap(2) := Mux(
+    s0_shiftFlag,
+    s0_wayLookupEntry(1).maybeRvcMap(0) >> s0_shiftNum(2)(1, 0),
+    s0_wayLookupEntry(1).maybeRvcMap(0) << s0_shiftNum(2)(1, 0)
+  )
+  s0_shiftMaybeRvcMap(3) := Cat(s0_wayLookupEntry(1).maybeRvcMap(1), 0.U(2.W)) << s0_shiftNum(3)(1, 0)
 
   private val s0_dataSramReadConflict = {
     val reqValid = io.fromFtq.bits.req.map(_.valid).reduce(_ && _)
@@ -199,11 +235,26 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_req            = RegEnable(s0_req, s0_fire)
   private val s1_wayLookupEntry = RegEnable(s0_wayLookupEntry, s0_fire)
   private val s1_exceptionInfo  = RegEnable(s0_exceptionInfo, s0_fire)
+  private val s1_twoFetchValid  = RegEnable(s0_req(1).valid, s0_fire)
+  private val s1_shiftNum       = RegEnable(s0_shiftNum, s0_fire)
+  private val s1_shiftFlag      = RegEnable(s0_shiftFlag, s0_fire)
+  private val s1_shiftMaybeRvc  = RegEnable(s0_shiftMaybeRvcMap, s0_fire)
+  private val s1_firstBlockRange   = RegEnable(s0_firstBlockRange, s0_fire)
+  private val s1_totalBlockRange   = RegEnable(s0_totalBlockRange, s0_fire)
+  private val s1_sramShiftMaybeRvc = Wire(Vec(MaxFetchReqNum, Vec(PortNumber, UInt(MaxInstNumPerBlock.W))))
+  s1_sramShiftMaybeRvc(0)(0) := s1_shiftMaybeRvc(0) >> Cat(s1_shiftNum(0)(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W))
+  s1_sramShiftMaybeRvc(0)(1) := s1_shiftMaybeRvc(1) << Cat(s1_shiftNum(1)(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W))
+  s1_sramShiftMaybeRvc(1)(0) := Mux(
+    s1_shiftFlag,
+    s1_shiftMaybeRvc(2) >> Cat(s1_shiftNum(2)(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W)),
+    s1_shiftMaybeRvc(2) << Cat(s1_shiftNum(2)(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W))
+  )
+  s1_sramShiftMaybeRvc(1)(1) := s1_shiftMaybeRvc(3) << Cat(s1_shiftNum(3)(log2Ceil(MaxInstNumPerBlock) - 1, 2), 0.U(2.W))
+
 
   private val s1_wayMask     = VecInit(s1_wayLookupEntry.map(_.waymask))
   private val s1_isCrossLine = VecInit(s1_req.map(req => isCrossLine(req.startVAddr, req.endPosition)))
-  private val s1_takenCfiOffset =
-    VecInit(s1_req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
+  private val s1_takenCfiOffset = RegEnable(s0_takenCfiOffset, s0_fire)
 
   private val s1_pTag   = s1_wayLookupEntry(0).pTag
   private val s1_ftqIdx = s1_req(0).ftqIdx
@@ -248,12 +299,22 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     getBankValid(s1_mshrValid(i), s1_offset(i))
   })
   private val s1_mshrDatas       = fromMiss.bits.data.asTypeOf(Vec(DataBanks, UInt(ICacheDataBits.W)))
-  private val s1_mshrMaybeRvcMap = fromMiss.bits.maybeRvcMap.asTypeOf(Vec(DataBanks, UInt(MaxInstNumPerBank.W)))
+  private val s1_mshrMaybeRvcMap = fromMiss.bits.maybeRvcMap
+  private val s1_shiftMshrMaybeRvc = Wire(UInt(MaxInstNumPerBlock.W))
+  s1_shiftMshrMaybeRvc := Mux(
+    s1_mshrValid(0).reduce(_ || _),
+    Mux(s1_mshrValid(0)(0), s1_mshrMaybeRvcMap >> s1_shiftNum(0), Cat(s1_mshrMaybeRvcMap, 0.U(1.W)) << s1_shiftNum(1)),
+    Mux(
+      s1_mshrValid(1)(0),
+      Mux(s1_shiftFlag, s1_mshrMaybeRvcMap >> s1_shiftNum(2), s1_mshrMaybeRvcMap << s1_shiftNum(2)),
+      Cat(s1_mshrMaybeRvcMap, 0.U(2.W)) << s1_shiftNum(3)
+    )
+  )
 
   private val s1_mshrValidReg       = RegNext(s1_mshrValid)
   private val s1_bankMshrValidReg   = RegNext(s1_bankMshrValid)
   private val s1_mshrDatasReg       = RegNext(s1_mshrDatas)
-  private val s1_mshrMaybeRvcMapReg = RegNext(s1_mshrMaybeRvcMap)
+  private val s1_mshrMaybeRvcMapReg = RegNext(s1_shiftMshrMaybeRvc)
 
   private val s1_hits = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
     VecInit((0 until PortNumber).map { portIdx =>
@@ -277,24 +338,17 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     }).asUInt
   })
 
-  private val s1_maybeRvcMap = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
-    val sramMaybeRvcMap =
-      s1_wayLookupEntry(reqIdx).maybeRvcMap.asTypeOf(Vec(PortNumber, Vec(DataBanks, UInt(MaxInstNumPerBank.W))))
-
-    VecInit((0 until DataBanks).map { bankIdx =>
+  private val s1_maybeRvcMapVec = VecInit((0 until MaxFetchReqNum).map { i =>
+    VecInit((0 until PortNumber).map { j =>
       DataHoldBypass(
         Mux(
-          s1_bankMshrValidReg(reqIdx)(bankIdx),
-          s1_mshrMaybeRvcMapReg(bankIdx),
-          Mux(
-            s1_lineSel(reqIdx)(bankIdx),
-            sramMaybeRvcMap(1)(bankIdx),
-            sramMaybeRvcMap(0)(bankIdx)
-          )
+          s1_mshrValidReg(i)(j),
+          s1_mshrMaybeRvcMapReg,
+          s1_sramShiftMaybeRvc(i)(j)
         ),
-        s1_bankMshrValidReg(reqIdx)(bankIdx) || s1_bankSramValid(reqIdx)(bankIdx)
+        RegNext(s0_fire) || s1_mshrValidReg(i)(j)
       )
-    }).asUInt
+    })
   })
 
   private val s1_tlCorrupt = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
@@ -391,17 +445,18 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_exceptionOut = s1_exception || s1_tlException
 
   io.toIfu.req.valid := s1_valid && s1_fetchFinish && !s1_flush
-  io.toIfu.req.bits.zipWithIndex.foreach { case (req, i) =>
-    req.valid                := s1_req(i).valid
-    req.startVAddr           := s1_req(i).startVAddr
-    req.ftqIdx               := s1_req(i).ftqIdx
-    req.takenCfiOffset.valid := s1_req(i).taken
-    req.takenCfiOffset.bits  := s1_takenCfiOffset(i)
-    req.range                := Fill(FetchBlockInstNum, 1.U(1.W)) >> (~s1_takenCfiOffset(i)).asUInt
-    req.size                 := s1_takenCfiOffset(i) +& 1.U
-    req.data                 := s1_data(i)
-    req.maybeRvcMap          := s1_maybeRvcMap(i)
-    req.perf_isCrossLine     := s1_isCrossLine(i)
+  io.toIfu.req.bits.maybeRvcMap := ((s1_maybeRvcMapVec(0)(0) | s1_maybeRvcMapVec(0)(1)) & s1_firstBlockRange) |
+    ((s1_maybeRvcMapVec(1)(0) | s1_maybeRvcMapVec(1)(1)) & (s1_totalBlockRange & ~s1_firstBlockRange))
+  io.toIfu.req.bits.range  := s1_totalBlockRange
+  io.toIfu.req.bits.info.zipWithIndex.foreach { case (req, i) =>
+    req.valid            := s1_req(i).valid
+    req.startVAddr       := s1_req(i).startVAddr
+    req.ftqIdx           := s1_req(i).ftqIdx
+    req.takenCfiOffset   := s1_takenCfiOffset(i)
+    // req.range            := s1_totalBlockRange
+    req.size             := s1_takenCfiOffset(i) +& 1.U
+    req.data             := s1_data(i)
+    req.perf_isCrossLine := s1_isCrossLine(i)
 
     req.icacheMeta.exception          := s1_exceptionOut
     req.icacheMeta.pmpMmio            := s1_pmpMmio

--- a/src/main/scala/xiangshan/frontend/icache/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Parameters.scala
@@ -149,7 +149,8 @@ trait HasICacheParameters extends HasFrontendParameters // scalastyle:ignore num
   def DataSramWidth:         Int = ICacheDataBits + DataEccBits + DataPaddingBits
 
   // mainPipe
-  def EnableCorruptRefetch: Boolean = icacheParameters.EnableCorruptRefetch
+  def EnableCorruptRefetch:  Boolean = icacheParameters.EnableCorruptRefetch
+  def MaybeRvcFineShiftBits: Int     = 2
 
   // submodule enable
   def EnableCtrlUnit: Boolean = icacheParameters.EnableCtrlUnit

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -94,23 +94,19 @@ class FetchBlock(implicit p: Parameters) extends IfuBundle {
   }
 }
 class IfuData(implicit p: Parameters) extends IfuBundle with HasICacheParameters {
-  val index:       Vec[UInt] = Vec(FetchBlockInstNum, UInt(log2Ceil(FetchBlockInstNum).W))
+  val index:       Vec[UInt] = Vec(FetchBlockInstNum, UInt(log2Ceil(ICacheLineBytes / 2).W))
   val maybeRvcMap: UInt      = UInt(FetchBlockInstNum.W)
   val firstRange:  UInt      = UInt(FetchBlockInstNum.W)
   val totalRange:  UInt      = UInt(FetchBlockInstNum.W)
   val blockSel:    UInt      = UInt(FetchBlockInstNum.W)
 
   def fromICacheReq(req: MainPipeToIfuReq): IfuData = {
-    val reqStartOffset = req.info.map(_.startVAddr(5, 1))
-
-    val dupData = VecInit((0 until MaxFetchReqNum).map { i =>
-      Cat(req.info(i).data, req.info(i).data).asTypeOf(Vec(FetchBlockInstNum * 2, UInt(16.W)))
-    })
+    val reqStartOffset = req.info.map(_.startVAddr(log2Ceil(ICacheLineBytes / 2), 1))
 
     def getDataIndex(i: Int): (Bool, UInt, UInt) = {
       val fromReq0 = i.U < req.info(0).size
-      val req0Idx  = (reqStartOffset(0) +& i.U)(log2Ceil(FetchBlockInstNum * 2) - 1, 0)
-      val req1Idx  = (reqStartOffset(1) +& (i.U - req.info(0).size))(log2Ceil(FetchBlockInstNum * 2) - 1, 0)
+      val req0Idx  = (reqStartOffset(0) +& i.U)(log2Ceil(ICacheLineBytes / 2) - 1, 0)
+      val req1Idx  = (reqStartOffset(1) +& (i.U - req.info(0).size))(log2Ceil(ICacheLineBytes / 2) - 1, 0)
       (fromReq0, req0Idx, req1Idx)
     }
 

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -29,6 +29,7 @@ import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.frontend.ibuffer.IBufPtr
 import xiangshan.frontend.icache.HasICacheParameters
 import xiangshan.frontend.icache.MainPipeToIfuReq
+import xiangshan.frontend.icache.FetchBlocktoIfuReq
 
 /* ***
  * Naming:
@@ -68,19 +69,19 @@ class FetchBlock(implicit p: Parameters) extends IfuBundle {
   val ftqIdx:         FtqPtr      = new FtqPtr
   val startVAddr:     GuardedPc   = GuardedPc()
   val takenCfiOffset: Valid[UInt] = Valid(UInt(FetchBlockInstOffsetWidth.W))
-  val range:          UInt        = UInt(FetchBlockInstNum.W)
+  // val range:          UInt        = UInt(FetchBlockInstNum.W)
   val size:           UInt        = UInt(log2Ceil(FetchBlockInstNum + 1).W)
 
   val pcUpperBitsPlus1: UInt = UInt((GuardedVAddrBits - PcCutPoint).W)
 
   def pcUpperBits: UInt = startVAddr(GuardedVAddrBits - 1, PcCutPoint)
 
-  def fromICacheReq(req: MainPipeToIfuReq): FetchBlock = {
+  def fromICacheReq(req: FetchBlocktoIfuReq): FetchBlock = {
     valid            := req.valid
     ftqIdx           := req.ftqIdx
     startVAddr       := req.startVAddr
     takenCfiOffset   := req.takenCfiOffset
-    range            := req.range
+    // range            := req.range
     size             := req.size
     pcUpperBitsPlus1 := req.startVAddr(GuardedVAddrBits - 1, PcCutPoint) + 1.U
     this
@@ -92,38 +93,67 @@ class IfuData(implicit p: Parameters) extends IfuBundle with HasICacheParameters
   val range:       UInt      = UInt(FetchBlockInstNum.W)
   val blockSel:    UInt      = UInt(FetchBlockInstNum.W)
 
-  def fromICacheReq(req: Vec[MainPipeToIfuReq]): IfuData = {
-    val reqStartOffset = req.map(_.startVAddr(5, 1))
+  def fromICacheReq(req: MainPipeToIfuReq): IfuData = {
+    val reqStartOffset = req.info.map(_.startVAddr(5, 1))
 
-    val totalSize = req(0).size +& Mux(req(1).valid, req(1).size, 0.U.asTypeOf(req(1).size))
+    val totalSize = req.info(0).size +& Mux(req.info(1).valid, req.info(1).size, 0.U.asTypeOf(req.info(1).size))
 
     val dupData = VecInit((0 until MaxFetchReqNum).map { i =>
-      Cat(req(i).data, req(i).data).asTypeOf(Vec(FetchBlockInstNum * 2, UInt(16.W)))
+      Cat(req.info(i).data, req.info(i).data).asTypeOf(Vec(FetchBlockInstNum * 2, UInt(16.W)))
     })
-    val dupMaybeRvcMap = VecInit((0 until MaxFetchReqNum).map(i => Cat(req(i).maybeRvcMap, req(i).maybeRvcMap)))
 
     def getDataIndex(i: Int): (Bool, UInt, UInt) = {
-      val fromReq0 = i.U < req(0).size
+      val fromReq0 = i.U < req.info(0).size
       val req0Idx  = (reqStartOffset(0) +& i.U)(log2Ceil(FetchBlockInstNum * 2) - 1, 0)
-      val req1Idx  = (reqStartOffset(1) +& (i.U - req(0).size))(log2Ceil(FetchBlockInstNum * 2) - 1, 0)
+      val req1Idx  = (reqStartOffset(1) +& (i.U - req.info(0).size))(log2Ceil(FetchBlockInstNum * 2) - 1, 0)
       (fromReq0, req0Idx, req1Idx)
     }
 
     this.data := VecInit((0 until FetchBlockInstNum).map { i =>
       val (fromReq0, req0Idx, req1Idx) = getDataIndex(i)
-      Mux(fromReq0, dupData(0)(req0Idx), Mux(req(1).valid, dupData(1)(req1Idx), 0.U.asTypeOf(dupData(1)(req1Idx))))
+      Mux(fromReq0, dupData(0)(req0Idx), Mux(req.info(1).valid, dupData(1)(req1Idx), 0.U.asTypeOf(dupData(1)(req1Idx))))
     })
 
-    this.maybeRvcMap := VecInit((0 until FetchBlockInstNum).map { i =>
-      val (fromReq0, req0Idx, req1Idx) = getDataIndex(i)
-      Mux(fromReq0, dupMaybeRvcMap(0)(req0Idx), Mux(req(1).valid, dupMaybeRvcMap(1)(req1Idx), 0.U(1.W)))
-    }).asUInt
-
-    this.range    := VecInit((0 until FetchBlockInstNum).map(i => i.U < totalSize)).asUInt
-    this.blockSel := VecInit((0 until FetchBlockInstNum).map(i => req(1).valid && i.U >= req(0).size)).asUInt
+    this.maybeRvcMap := req.maybeRvcMap
+    this.range       := req.range
+    this.blockSel    :=
+      VecInit((0 until FetchBlockInstNum).map(i => req.info(1).valid && i.U >= req.info(0).size)).asUInt
 
     this
   }
+
+  // def fromICacheReq(req: Vec[MainPipeToIfuReq]): IfuData = {
+  //   val reqStartOffset = req.map(_.startVAddr(5, 1))
+  //
+  //   val totalSize = req(0).size +& Mux(req(1).valid, req(1).size, 0.U.asTypeOf(req(1).size))
+  //
+  //   val dupData = VecInit((0 until MaxFetchReqNum).map { i =>
+  //     Cat(req(i).data, req(i).data).asTypeOf(Vec(FetchBlockInstNum * 2, UInt(16.W)))
+  //   })
+  //   val dupMaybeRvcMap = VecInit((0 until MaxFetchReqNum).map(i => Cat(req(i).maybeRvcMap, req(i).maybeRvcMap)))
+  //
+  //   def getDataIndex(i: Int): (Bool, UInt, UInt) = {
+  //     val fromReq0 = i.U < req(0).size
+  //     val req0Idx  = (reqStartOffset(0) +& i.U)(log2Ceil(FetchBlockInstNum * 2) - 1, 0)
+  //     val req1Idx  = (reqStartOffset(1) +& (i.U - req(0).size))(log2Ceil(FetchBlockInstNum * 2) - 1, 0)
+  //     (fromReq0, req0Idx, req1Idx)
+  //   }
+  //
+  //   this.data := VecInit((0 until FetchBlockInstNum).map { i =>
+  //     val (fromReq0, req0Idx, req1Idx) = getDataIndex(i)
+  //     Mux(fromReq0, dupData(0)(req0Idx), Mux(req(1).valid, dupData(1)(req1Idx), 0.U.asTypeOf(dupData(1)(req1Idx))))
+  //   })
+  //
+  //   this.maybeRvcMap := VecInit((0 until FetchBlockInstNum).map { i =>
+  //     val (fromReq0, req0Idx, req1Idx) = getDataIndex(i)
+  //     Mux(fromReq0, dupMaybeRvcMap(0)(req0Idx), Mux(req(1).valid, dupMaybeRvcMap(1)(req1Idx), 0.U(1.W)))
+  //   }).asUInt
+  //
+  //   this.range    := VecInit((0 until FetchBlockInstNum).map(i => i.U < totalSize)).asUInt
+  //   this.blockSel := VecInit((0 until FetchBlockInstNum).map(i => req(1).valid && i.U >= req(0).size)).asUInt
+  //
+  //   this
+  // }
 }
 
 class InstSlot extends Bundle {

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -27,7 +27,7 @@ import xiangshan.frontend.Pc
 import xiangshan.frontend.bpu.BranchAttribute
 import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.frontend.ibuffer.IBufPtr
-import xiangshan.frontend.icache.FetchBlocktoIfuReq
+import xiangshan.frontend.icache.FetchBlockInfo
 import xiangshan.frontend.icache.HasICacheParameters
 import xiangshan.frontend.icache.MainPipeToIfuReq
 
@@ -60,9 +60,8 @@ class LastHalfEntry(implicit p: Parameters) extends IfuBundle {
 }
 
 class EndHalfRviInfo(implicit p: Parameters) extends IfuBundle {
-  val isHalfRvi: Bool      = Bool()
-  val pc:        GuardedPc = GuardedPc()
-  val data:      UInt      = UInt(16.W)
+  val pc:   GuardedPc = GuardedPc()
+  val data: UInt      = UInt(16.W)
 }
 
 class InstrIndexEntry(implicit p: Parameters) extends IfuBundle {
@@ -75,38 +74,36 @@ class FetchBlock(implicit p: Parameters) extends IfuBundle {
   val ftqIdx:         FtqPtr      = new FtqPtr
   val startVAddr:     GuardedPc   = GuardedPc()
   val takenCfiOffset: Valid[UInt] = Valid(UInt(FetchBlockInstOffsetWidth.W))
-  // val range:          UInt        = UInt(FetchBlockInstNum.W)
-  val size: UInt = UInt(log2Ceil(FetchBlockInstNum + 1).W)
+  val size:           UInt        = UInt(log2Ceil(FetchBlockInstNum + 1).W)
 
   val pcUpperBitsPlus1: UInt = UInt((GuardedVAddrBits - PcCutPoint).W)
 
   def pcUpperBits: UInt = startVAddr(GuardedVAddrBits - 1, PcCutPoint)
 
-  def fromICacheReq(req: FetchBlocktoIfuReq): FetchBlock = {
-    valid          := req.valid
-    ftqIdx         := req.ftqIdx
-    startVAddr     := req.startVAddr
-    takenCfiOffset := req.takenCfiOffset
-    // range            := req.range
+  def fromICacheReq(req: FetchBlockInfo): FetchBlock = {
+    valid            := req.valid
+    ftqIdx           := req.ftqIdx
+    startVAddr       := req.startVAddr
+    takenCfiOffset   := req.takenCfiOffset
     size             := req.size
     pcUpperBitsPlus1 := req.startVAddr(GuardedVAddrBits - 1, PcCutPoint) + 1.U
     this
   }
 }
 class IfuData(implicit p: Parameters) extends IfuBundle with HasICacheParameters {
-  val index:       Vec[UInt] = Vec(FetchBlockInstNum, UInt(log2Ceil(ICacheLineBytes / 2).W))
+  val index:       Vec[UInt] = Vec(FetchBlockInstNum, UInt(log2Ceil(ICacheLineBytes / instBytes).W))
   val maybeRvcMap: UInt      = UInt(FetchBlockInstNum.W)
   val firstRange:  UInt      = UInt(FetchBlockInstNum.W)
   val totalRange:  UInt      = UInt(FetchBlockInstNum.W)
   val blockSel:    UInt      = UInt(FetchBlockInstNum.W)
 
   def fromICacheReq(req: MainPipeToIfuReq): IfuData = {
-    val reqStartOffset = req.info.map(_.startVAddr(log2Ceil(ICacheLineBytes / 2), 1))
+    val reqStartOffset = req.info.map(_.startVAddr(log2Ceil(ICacheLineBytes / instBytes), 1))
 
     def getDataIndex(i: Int): (Bool, UInt, UInt) = {
       val fromReq0 = i.U < req.info(0).size
-      val req0Idx  = (reqStartOffset(0) +& i.U)(log2Ceil(ICacheLineBytes / 2) - 1, 0)
-      val req1Idx  = (reqStartOffset(1) +& (i.U - req.info(0).size))(log2Ceil(ICacheLineBytes / 2) - 1, 0)
+      val req0Idx  = (reqStartOffset(0) +& i.U)(log2Ceil(ICacheLineBytes / instBytes) - 1, 0)
+      val req1Idx  = (reqStartOffset(1) +& (i.U - req.info(0).size))(log2Ceil(ICacheLineBytes / instBytes) - 1, 0)
       (fromReq0, req0Idx, req1Idx)
     }
 
@@ -147,17 +144,17 @@ class Instruction(implicit p: Parameters) extends IfuBundle with HasICacheParame
 }
 
 class PredCheckRedirect(implicit p: Parameters) extends IfuBundle {
-  val target:       GuardedPc       = GuardedPc()
-  val misIdx:       Valid[UInt]     = Valid(UInt(log2Ceil(IBufferEnqueueWidth).W))
-  val taken:        Bool            = Bool()
-  val invalidTaken: Bool            = Bool()
-  val notCfiTaken:  Bool            = Bool()
-  val isRVC:        Bool            = Bool()
-  val blockSel:     Bool            = Bool()
-  val attribute:    BranchAttribute = new BranchAttribute
-  val mispredPc:    Pc              = Pc()
-  val endOffset:    UInt            = UInt(FetchBlockInstOffsetWidth.W)
-  val isCrossBlockInstr: Bool       = Bool()
+  val target:            GuardedPc       = GuardedPc()
+  val misIdx:            Valid[UInt]     = Valid(UInt(log2Ceil(IBufferEnqueueWidth).W))
+  val taken:             Bool            = Bool()
+  val invalidTaken:      Bool            = Bool()
+  val notCfiTaken:       Bool            = Bool()
+  val isRVC:             Bool            = Bool()
+  val blockSel:          Bool            = Bool()
+  val attribute:         BranchAttribute = new BranchAttribute
+  val mispredPc:         Pc              = Pc()
+  val endOffset:         UInt            = UInt(FetchBlockInstOffsetWidth.W)
+  val isCrossBlockInstr: Bool            = Bool()
 }
 
 /* ***** DB ***** */
@@ -186,9 +183,7 @@ class IfuRedirectInternal(implicit p: Parameters) extends IfuBundle {
   val instrCount:     UInt    = UInt(log2Ceil(FetchBlockInstNum + 1).W)
   val prevIBufEnqPtr: IBufPtr = new IBufPtr
   // A fallthrough does not always correspond to a half RVI instruction.
-  val isHalfInstr: Bool      = Bool()
-  val halfPc:      GuardedPc = GuardedPc()
-  val halfData:    UInt      = UInt(16.W)
+  val halfRviInfo: Valid[EndHalfRviInfo] = Valid(new EndHalfRviInfo)
 }
 
 class InstrCompactBundle(width: Int)(implicit p: Parameters) extends IfuBundle {

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -27,9 +27,9 @@ import xiangshan.frontend.Pc
 import xiangshan.frontend.bpu.BranchAttribute
 import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.frontend.ibuffer.IBufPtr
+import xiangshan.frontend.icache.FetchBlocktoIfuReq
 import xiangshan.frontend.icache.HasICacheParameters
 import xiangshan.frontend.icache.MainPipeToIfuReq
-import xiangshan.frontend.icache.FetchBlocktoIfuReq
 
 /* ***
  * Naming:
@@ -59,6 +59,12 @@ class LastHalfEntry(implicit p: Parameters) extends IfuBundle {
   val middlePC: Pc   = Pc()
 }
 
+class EndHalfRviInfo(implicit p: Parameters) extends IfuBundle {
+  val isHalfRvi: Bool       = Bool()
+  val pc:        PrunedAddr = PrunedAddr(VAddrBits)
+  val data:      UInt       = UInt(16.W)
+}
+
 class InstrIndexEntry(implicit p: Parameters) extends IfuBundle {
   val valid: Bool = Bool()
   val value: UInt = UInt(log2Ceil(ICacheLineBytes / 2).W)
@@ -70,17 +76,17 @@ class FetchBlock(implicit p: Parameters) extends IfuBundle {
   val startVAddr:     GuardedPc   = GuardedPc()
   val takenCfiOffset: Valid[UInt] = Valid(UInt(FetchBlockInstOffsetWidth.W))
   // val range:          UInt        = UInt(FetchBlockInstNum.W)
-  val size:           UInt        = UInt(log2Ceil(FetchBlockInstNum + 1).W)
+  val size: UInt = UInt(log2Ceil(FetchBlockInstNum + 1).W)
 
   val pcUpperBitsPlus1: UInt = UInt((GuardedVAddrBits - PcCutPoint).W)
 
   def pcUpperBits: UInt = startVAddr(GuardedVAddrBits - 1, PcCutPoint)
 
   def fromICacheReq(req: FetchBlocktoIfuReq): FetchBlock = {
-    valid            := req.valid
-    ftqIdx           := req.ftqIdx
-    startVAddr       := req.startVAddr
-    takenCfiOffset   := req.takenCfiOffset
+    valid          := req.valid
+    ftqIdx         := req.ftqIdx
+    startVAddr     := req.startVAddr
+    takenCfiOffset := req.takenCfiOffset
     // range            := req.range
     size             := req.size
     pcUpperBitsPlus1 := req.startVAddr(GuardedVAddrBits - 1, PcCutPoint) + 1.U
@@ -90,13 +96,12 @@ class FetchBlock(implicit p: Parameters) extends IfuBundle {
 class IfuData(implicit p: Parameters) extends IfuBundle with HasICacheParameters {
   val index:       Vec[UInt] = Vec(FetchBlockInstNum, UInt(log2Ceil(FetchBlockInstNum).W))
   val maybeRvcMap: UInt      = UInt(FetchBlockInstNum.W)
-  val range:       UInt      = UInt(FetchBlockInstNum.W)
+  val firstRange:  UInt      = UInt(FetchBlockInstNum.W)
+  val totalRange:  UInt      = UInt(FetchBlockInstNum.W)
   val blockSel:    UInt      = UInt(FetchBlockInstNum.W)
 
   def fromICacheReq(req: MainPipeToIfuReq): IfuData = {
     val reqStartOffset = req.info.map(_.startVAddr(5, 1))
-
-    val totalSize = req.info(0).size +& Mux(req.info(1).valid, req.info(1).size, 0.U.asTypeOf(req.info(1).size))
 
     val dupData = VecInit((0 until MaxFetchReqNum).map { i =>
       Cat(req.info(i).data, req.info(i).data).asTypeOf(Vec(FetchBlockInstNum * 2, UInt(16.W)))
@@ -109,55 +114,20 @@ class IfuData(implicit p: Parameters) extends IfuBundle with HasICacheParameters
       (fromReq0, req0Idx, req1Idx)
     }
 
-    // this.data := VecInit((0 until FetchBlockInstNum).map { i =>
-    //   val (fromReq0, req0Idx, req1Idx) = getDataIndex(i)
-    //   Mux(fromReq0, dupData(0)(req0Idx), Mux(req.info(1).valid, dupData(1)(req1Idx), 0.U.asTypeOf(dupData(1)(req1Idx))))
-    // })
     this.index := VecInit((0 until FetchBlockInstNum).map { i =>
       val (fromReq0, req0Idx, req1Idx) = getDataIndex(i)
       Mux(fromReq0, req0Idx, req1Idx)
     })
 
     this.maybeRvcMap := req.maybeRvcMap
-    this.range       := req.range
-    this.blockSel    :=
-      VecInit((0 until FetchBlockInstNum).map(i => req.info(1).valid && i.U >= req.info(0).size)).asUInt
+    this.firstRange  := req.firstRange
+    this.totalRange  := req.totalRange
+    this.blockSel :=
+      VecInit((0 until FetchBlockInstNum).map(i => req.info(1).valid && !firstRange(i))).asUInt
 
     this
   }
 
-  // def fromICacheReq(req: Vec[MainPipeToIfuReq]): IfuData = {
-  //   val reqStartOffset = req.map(_.startVAddr(5, 1))
-  //
-  //   val totalSize = req(0).size +& Mux(req(1).valid, req(1).size, 0.U.asTypeOf(req(1).size))
-  //
-  //   val dupData = VecInit((0 until MaxFetchReqNum).map { i =>
-  //     Cat(req(i).data, req(i).data).asTypeOf(Vec(FetchBlockInstNum * 2, UInt(16.W)))
-  //   })
-  //   val dupMaybeRvcMap = VecInit((0 until MaxFetchReqNum).map(i => Cat(req(i).maybeRvcMap, req(i).maybeRvcMap)))
-  //
-  //   def getDataIndex(i: Int): (Bool, UInt, UInt) = {
-  //     val fromReq0 = i.U < req(0).size
-  //     val req0Idx  = (reqStartOffset(0) +& i.U)(log2Ceil(FetchBlockInstNum * 2) - 1, 0)
-  //     val req1Idx  = (reqStartOffset(1) +& (i.U - req(0).size))(log2Ceil(FetchBlockInstNum * 2) - 1, 0)
-  //     (fromReq0, req0Idx, req1Idx)
-  //   }
-  //
-  //   this.data := VecInit((0 until FetchBlockInstNum).map { i =>
-  //     val (fromReq0, req0Idx, req1Idx) = getDataIndex(i)
-  //     Mux(fromReq0, dupData(0)(req0Idx), Mux(req(1).valid, dupData(1)(req1Idx), 0.U.asTypeOf(dupData(1)(req1Idx))))
-  //   })
-  //
-  //   this.maybeRvcMap := VecInit((0 until FetchBlockInstNum).map { i =>
-  //     val (fromReq0, req0Idx, req1Idx) = getDataIndex(i)
-  //     Mux(fromReq0, dupMaybeRvcMap(0)(req0Idx), Mux(req(1).valid, dupMaybeRvcMap(1)(req1Idx), 0.U(1.W)))
-  //   }).asUInt
-  //
-  //   this.range    := VecInit((0 until FetchBlockInstNum).map(i => i.U < totalSize)).asUInt
-  //   this.blockSel := VecInit((0 until FetchBlockInstNum).map(i => req(1).valid && i.U >= req(0).size)).asUInt
-  //
-  //   this
-  // }
 }
 
 class InstSlot extends Bundle {
@@ -176,7 +146,8 @@ class Instruction(implicit p: Parameters) extends IfuBundle with HasICacheParame
   val endOffset:         UInt = UInt(FetchBlockInstOffsetWidth.W)
   val isPrevEndHalfRvi:  Bool = Bool()
   val isCrossBlockInstr: Bool = Bool()
-  val index:             UInt = UInt(FetchBlockInstOffsetWidth.W)
+  // Compatible with miniConfig
+  val index: UInt = UInt(log2Ceil(ICacheLineBytes / 2).W)
 }
 
 class PredCheckRedirect(implicit p: Parameters) extends IfuBundle {

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -60,9 +60,9 @@ class LastHalfEntry(implicit p: Parameters) extends IfuBundle {
 }
 
 class EndHalfRviInfo(implicit p: Parameters) extends IfuBundle {
-  val isHalfRvi: Bool       = Bool()
-  val pc:        PrunedAddr = PrunedAddr(VAddrBits)
-  val data:      UInt       = UInt(16.W)
+  val isHalfRvi: Bool      = Bool()
+  val pc:        GuardedPc = GuardedPc()
+  val data:      UInt      = UInt(16.W)
 }
 
 class InstrIndexEntry(implicit p: Parameters) extends IfuBundle {

--- a/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Bundles.scala
@@ -88,7 +88,7 @@ class FetchBlock(implicit p: Parameters) extends IfuBundle {
   }
 }
 class IfuData(implicit p: Parameters) extends IfuBundle with HasICacheParameters {
-  val data:        Vec[UInt] = Vec(FetchBlockInstNum, UInt(16.W))
+  val index:       Vec[UInt] = Vec(FetchBlockInstNum, UInt(log2Ceil(FetchBlockInstNum).W))
   val maybeRvcMap: UInt      = UInt(FetchBlockInstNum.W)
   val range:       UInt      = UInt(FetchBlockInstNum.W)
   val blockSel:    UInt      = UInt(FetchBlockInstNum.W)
@@ -109,9 +109,13 @@ class IfuData(implicit p: Parameters) extends IfuBundle with HasICacheParameters
       (fromReq0, req0Idx, req1Idx)
     }
 
-    this.data := VecInit((0 until FetchBlockInstNum).map { i =>
+    // this.data := VecInit((0 until FetchBlockInstNum).map { i =>
+    //   val (fromReq0, req0Idx, req1Idx) = getDataIndex(i)
+    //   Mux(fromReq0, dupData(0)(req0Idx), Mux(req.info(1).valid, dupData(1)(req1Idx), 0.U.asTypeOf(dupData(1)(req1Idx))))
+    // })
+    this.index := VecInit((0 until FetchBlockInstNum).map { i =>
       val (fromReq0, req0Idx, req1Idx) = getDataIndex(i)
-      Mux(fromReq0, dupData(0)(req0Idx), Mux(req.info(1).valid, dupData(1)(req1Idx), 0.U.asTypeOf(dupData(1)(req1Idx))))
+      Mux(fromReq0, req0Idx, req1Idx)
     })
 
     this.maybeRvcMap := req.maybeRvcMap
@@ -172,6 +176,7 @@ class Instruction(implicit p: Parameters) extends IfuBundle with HasICacheParame
   val endOffset:         UInt = UInt(FetchBlockInstOffsetWidth.W)
   val isPrevEndHalfRvi:  Bool = Bool()
   val isCrossBlockInstr: Bool = Bool()
+  val index:             UInt = UInt(FetchBlockInstOffsetWidth.W)
 }
 
 class PredCheckRedirect(implicit p: Parameters) extends IfuBundle {
@@ -181,10 +186,11 @@ class PredCheckRedirect(implicit p: Parameters) extends IfuBundle {
   val invalidTaken: Bool            = Bool()
   val notCfiTaken:  Bool            = Bool()
   val isRVC:        Bool            = Bool()
-  val selectBlock:  Bool            = Bool()
+  val blockSel:     Bool            = Bool()
   val attribute:    BranchAttribute = new BranchAttribute
   val mispredPc:    Pc              = Pc()
   val endOffset:    UInt            = UInt(FetchBlockInstOffsetWidth.W)
+  val isCrossBlockInstr: Bool       = Bool()
 }
 
 /* ***** DB ***** */

--- a/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
@@ -116,6 +116,34 @@ trait IfuHelper extends HasIfuParameters with PreDecodeHelper {
     result
   }
 
+  def selectInstrData(
+      instr:              Instruction,
+      firstData:          Vec[UInt],
+      secondData:         Vec[UInt],
+      secondStartRviData: UInt
+  ): UInt =
+    Mux(
+      !instr.blockSel,
+      Mux(instr.isCrossBlockInstr, Cat(secondStartRviData, firstData(instr.index)(15, 0)), firstData(instr.index)),
+      secondData(instr.index)
+    )
+
+  def genBaseInstrData(
+      instrVec:           Vec[Instruction],
+      firstDataDup:       Vec[Vec[UInt]],
+      secondDataDup:      Vec[Vec[UInt]],
+      secondStartRviData: UInt
+  ): Vec[UInt] = {
+    require(instrVec.length == IBufferEnqueueWidth)
+    require(firstDataDup.length == 2)
+    require(secondDataDup.length == 2)
+
+    VecInit((0 until IBufferEnqueueWidth).map { i =>
+      val dupIdx = i / (IBufferEnqueueWidth / 2)
+      selectInstrData(instrVec(i), firstDataDup(dupIdx), secondDataDup(dupIdx), secondStartRviData)
+    })
+  }
+
   def alignData[T <: Data](indataVec: Vec[T], shiftNum: UInt, default: T): Vec[T] = {
     require(shiftNum.getWidth == 2)
     val dataVec = VecInit((0 until IBufferEnqueueWidth).map(i =>

--- a/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Helpers.scala
@@ -130,19 +130,13 @@ trait IfuHelper extends HasIfuParameters with PreDecodeHelper {
 
   def genBaseInstrData(
       instrVec:           Vec[Instruction],
-      firstDataDup:       Vec[Vec[UInt]],
-      secondDataDup:      Vec[Vec[UInt]],
+      firstData:          Vec[UInt],
+      secondData:         Vec[UInt],
       secondStartRviData: UInt
-  ): Vec[UInt] = {
-    require(instrVec.length == IBufferEnqueueWidth)
-    require(firstDataDup.length == 2)
-    require(secondDataDup.length == 2)
-
+  ): Vec[UInt] =
     VecInit((0 until IBufferEnqueueWidth).map { i =>
-      val dupIdx = i / (IBufferEnqueueWidth / 2)
-      selectInstrData(instrVec(i), firstDataDup(dupIdx), secondDataDup(dupIdx), secondStartRviData)
+      selectInstrData(instrVec(i), firstData, secondData, secondStartRviData)
     })
-  }
 
   def alignData[T <: Data](indataVec: Vec[T], shiftNum: UInt, default: T): Vec[T] = {
     require(shiftNum.getWidth == 2)

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -332,6 +332,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
       s1_alignedInstrVec(i).endOffset        := 0.U
     }
   }
+  // To facilitate compilation optimization and reduce the generation of redundant data.
+  s1_alignedInstrVec(IBufferEnqueueWidth - 1) := 0.U.asTypeOf(new Instruction)
 
   private val s1_alignedFoldPc =
     VecInit(s1_alignedInstrPcVec.map(i => XORFold(i(VAddrBits - 1, 1), MemPredPCWidth)))
@@ -373,9 +375,10 @@ class Ifu(implicit p: Parameters) extends IfuModule
     val alignedValid = s1_alignedInstrValid(i)
     val jalOffset    = getJalOffset(alignedInstr.data, alignedInstr.isRvc)
     val brOffset     = getBrOffset(alignedInstr.data, alignedInstr.isRvc)
+    val attribute    = BranchAttribute.decode(alignedInstr.data, alignedValid && s1_valid)
     s1_alignedPdInfoVec(i).valid       := alignedValid
     s1_alignedPdInfoVec(i).isRVC       := alignedInstr.isRvc
-    s1_alignedPdInfoVec(i).brAttribute := BranchAttribute.decode(alignedInstr.data, alignedValid && s1_valid)
+    s1_alignedPdInfoVec(i).brAttribute := Mux(alignedValid, attribute, BranchAttribute.None)
     s1_alignedJumpOffsetVec(i)         := Mux(s1_alignedPdInfoVec(i).isBr, brOffset, jalOffset)
   }
   /* --------------------------------------------------------------------------------------------------------------

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -131,7 +131,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   dontTouch(s0_fetchBlock)
 
-  private val s0_icacheData = Wire(new IfuData).fromICacheReq(io.fromICache.req.bits)
+  private val s0_ifuData    = Wire(new IfuData).fromICacheReq(io.fromICache.req.bits)
   private val s0_icacheMeta = VecInit(io.fromICache.req.bits.info.map(_.icacheMeta))
 
   s0_flushFromBpu := fromFtq.flushFromBpu.shouldFlushByStage3(s0_fetchBlock(0).ftqIdx, s0_valid)
@@ -146,7 +146,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   instrBoundary.io.req.valid               := s0_valid
   instrBoundary.io.req.fetchBlock          := s0_fetchBlock
-  instrBoundary.io.req.icacheData          := s0_icacheData
+  instrBoundary.io.req.ifuData             := s0_ifuData
   instrBoundary.io.req.firstInstrIsHalfRvi := s0_prevEndIsHalfRvi
   instrBoundary.io.req.totalEndPos         := s0_totalEndPos
 
@@ -174,6 +174,14 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s0_firstRange = VecInit(s0_rawInstrVec.map(instr => !instr.blockSel)).asUInt
   private val s0_firstRawInstrValid = s0_rawInstrValid & s0_firstRange
   private val s0_totalRawInstrValid = s0_rawInstrValid
+  private val s0_rawFirstDataDupWire  = VecInit(Seq.fill(2)(io.fromICache.req.bits.info(0).data))
+  private val s0_rawSecondDataDupWire = VecInit(Seq.fill(2)(io.fromICache.req.bits.info(1).data))
+  private val s0_firstEndIndex = Wire(UInt(FetchBlockInstOffsetWidth.W))
+  private val s0_secondEndIndex = Wire(UInt(FetchBlockInstOffsetWidth.W))
+  private val s0_secondStartIndex = Wire(UInt(FetchBlockInstOffsetWidth.W))
+  s0_firstEndIndex  := io.fromICache.req.bits.info(0).startVAddr(5, 1) + io.fromICache.req.bits.info(0).takenCfiOffset.bits
+  s0_secondEndIndex := io.fromICache.req.bits.info(1).startVAddr(5, 1) + io.fromICache.req.bits.info(1).takenCfiOffset.bits
+  s0_secondStartIndex := io.fromICache.req.bits.info(1).startVAddr(5, 1)
   /* --------------------------------------------------------------------------------------------------------------
      stage 1
      - cat half rvi instruction
@@ -213,7 +221,13 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_prevEndHalfRviData = RegInit(0.U(16.W))
   private val s1_prevEndHalfRviPc   = RegInit(0.U.asTypeOf(GuardedPc()))
 
-  private val s1_instrData    = RegEnable(s0_icacheData.data, s0_fire)
+  private val s1_firstICacheDataDup  = RegEnable(s0_rawFirstDataDupWire, s0_fire)
+  private val s1_secondICacheDataDup = RegEnable(s0_rawSecondDataDupWire, s0_fire)
+  private val s1_firstEndIndex = RegEnable(s0_firstEndIndex, s0_fire)
+  private val s1_secondEndIndex = RegEnable(s0_secondEndIndex, s0_fire)
+  private val s1_secondStartIndex = RegEnable(s0_secondStartIndex, s0_fire)
+  private val s1_rawFirstDataDup  = VecInit((0 until 2).map {i => cutICacheData(s1_firstICacheDataDup(i))})
+  private val s1_rawSecondDataDup = VecInit((0 until 2).map {i => cutICacheData(s1_secondICacheDataDup(i))})
   private val s1_icacheMetaIn = RegEnable(s0_icacheMeta, s0_fire)
   private val s1_instrVec     = s1_compactedInstrVec
 
@@ -272,29 +286,59 @@ class Ifu(implicit p: Parameters) extends IfuModule
     s1_firstEndHalfRviPc
   )
 
-  private val s1_firstEndHalfRviData = s1_instrData(s1_firstEndPos)
-  private val s1_totalEndHalfRviData = s1_instrData(s1_totalEndPos)
+  private val s1_firstEndHalfRviData = s1_rawFirstDataDup(0)(s1_firstEndIndex)(15, 0)
+  private val s1_secondEndHalfRviData = s1_rawSecondDataDup(0)(s1_secondEndIndex)(15, 0)
+  private val s1_totalEndHalfRviData = Mux(s1_fetchBlock(1).valid, s1_secondEndHalfRviData, s1_firstEndHalfRviData)
+  private val s1_secondStartRviData  = s1_rawSecondDataDup(0)(s1_secondStartIndex)(15, 0)
 
   // Patch instruction data
+  private val s1_baseInstrData = Wire(Vec(IBufferEnqueueWidth, UInt(32.W)))
+  for (i <- 0 until IBufferEnqueueWidth / 2) {
+    val index0 = s1_baseAlignedInstrVec(i).index
+    val index1 = s1_baseAlignedInstrVec(i + IBufferEnqueueWidth / 2).index
+    val blockSel0 = s1_baseAlignedInstrVec(i).blockSel
+    val isCrossBlock0 = s1_baseAlignedInstrVec(i).isCrossBlockInstr
+    val blockSel1 = s1_baseAlignedInstrVec(i + IBufferEnqueueWidth / 2).blockSel
+    val isCrossBlock1 = s1_baseAlignedInstrVec(i + IBufferEnqueueWidth / 2).isCrossBlockInstr
+    s1_baseInstrData(i) := Mux(
+      !blockSel0,
+      Mux(isCrossBlock0, Cat(s1_secondStartRviData, s1_rawFirstDataDup(0)(index0)(15, 0)), s1_rawFirstDataDup(0)(index0)),
+      s1_rawSecondDataDup(0)(index0)
+    )
+    s1_baseInstrData(i + IBufferEnqueueWidth / 2) := Mux(
+      !blockSel1,
+      Mux(isCrossBlock1, Cat(s1_secondStartRviData, s1_rawFirstDataDup(1)(index1)(15, 0)), s1_rawFirstDataDup(1)(index1)),
+      s1_rawSecondDataDup(1)(index1)
+    )
+  }
   private val s1_alignedInstrPcVec = WireDefault(s1_baseAlignedInstrPcVec)
   private val s1_alignedInstrVec   = WireDefault(s1_baseAlignedInstrVec)
-  for (i <- 0 until IfuAlignWidth) {
-    when(s1_alignShiftInstrNum === i.U) {
-      s1_alignedInstrPcVec(i) := Mux(s1_prevEndIsHalfRvi, s1_prevEndHalfRviPc, s1_baseAlignedInstrPcVec(i))
-      s1_alignedInstrVec(i).data := Mux(
-        s1_prevEndIsHalfRvi,
-        Cat(s1_baseAlignedInstrVec(i).data(15, 0), s1_prevEndHalfRviData),
-        s1_baseAlignedInstrVec(i).data
-      )
-      s1_alignedInstrVec(i).isPrevEndHalfRvi := s1_prevEndIsHalfRvi
-      s1_alignedInstrVec(i).endOffset        := Mux(s1_prevEndIsHalfRvi, 0.U, s1_baseAlignedInstrVec(i).endOffset)
-    }
-  }
 
   for (i <- 0 until IBufferEnqueueWidth) {
     s1_alignedInstrVec(i).valid        := s1_alignedInstrValid(i)
     s1_alignedInstrVec(i).isPredTaken  := s1_alignedPredTakenMask(i)
     s1_alignedInstrVec(i).invalidTaken := s1_alignedInvalidTakenMask(i)
+    s1_alignedInstrVec(i).data         := s1_baseInstrData(i)
+  }
+
+  for (i <- 0 until IfuAlignWidth) {
+    when(s1_alignShiftInstrNum === i.U) {
+      s1_alignedInstrPcVec(i) := Mux(s1_prevEndIsHalfRvi, s1_prevEndHalfRviPc, s1_baseAlignedInstrPcVec(i))
+      s1_alignedInstrVec(i).data := Mux(
+        s1_prevEndIsHalfRvi,
+        Cat(s1_baseInstrData(i)(15, 0), s1_prevEndHalfRviData),
+        s1_baseInstrData(i)
+      )
+      s1_alignedInstrVec(i).isPrevEndHalfRvi := s1_prevEndIsHalfRvi
+      s1_alignedInstrVec(i).endOffset := Mux(
+        s1_prevEndIsHalfRvi,
+        0.U,
+        Mux(!s1_baseAlignedInstrVec(i).blockSel && s1_baseAlignedInstrVec(i).isCrossBlockInstr,
+         0.U,
+         s1_baseAlignedInstrVec(i).endOffset
+        )
+      )
+    }
   }
 
   private val s1_alignedFoldPc =
@@ -402,6 +446,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   private val s2_blockSel     = VecInit(s2_expandedInstrVec.map(_.blockSel))
   private val s2_endOffsetVec = VecInit(s2_expandedInstrVec.map(_.endOffset))
+  private val s2_isCrossBlockInstr = VecInit(s2_expandedInstrVec.map(_.isCrossBlockInstr))
   dontTouch(s2_blockSel)
 
   private val s2_reqIsUncache    = RegEnable(s1_reqIsUncache, false.B, s1_fire)
@@ -497,7 +542,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   ) // for debug
   io.toIBuffer.bits.prevIBufEnqPtr := s2_prevIBufEnqPtr
   io.toIBuffer.bits.ftqPtr.zipWithIndex.foreach { case (ftqPtr, i) =>
-    ftqPtr := Mux(s2_blockSel(i), s2_fetchBlock(1).ftqIdx, s2_fetchBlock(0).ftqIdx)
+    ftqPtr := Mux(s2_blockSel(i) || s2_isCrossBlockInstr(i), s2_fetchBlock(1).ftqIdx, s2_fetchBlock(0).ftqIdx)
   }
 
   /* in s2, prevInstrCount equals to next cycle's IBuffer.numFromFetch without predChecker. "prev" means s1;
@@ -512,12 +557,13 @@ class Ifu(implicit p: Parameters) extends IfuModule
   )
 
   // Find the last entry based on the boundaries of compacted valid signals.
-  private val select = s2_blockSel
-  private val enq    = io.toIBuffer.bits.enqEnable
+  private val select = s2_blockSel.zip(s2_isCrossBlockInstr).map {
+    case (blockSel, isCrossBlock) => blockSel || isCrossBlock
+  }
+  private val enq = io.toIBuffer.bits.enqEnable
 
   private val s2_rvcIll             = VecInit(rvcExpanders.map(_.io.ill))
   private val s2_rvcException       = ExceptionType.fromRvcExpander((enq & s2_rvcIll.asUInt).orR, s2_valid)
-  private val s2_rvcExceptionOffset = PriorityEncoder(enq & s2_rvcIll.asUInt)
 
   io.toIBuffer.bits.isLastInFtqEntry := (0 until IBufferEnqueueWidth).map { i =>
     if (i == IBufferEnqueueWidth - 1) enq(i)
@@ -643,6 +689,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   uncacheRedirect.isHalfInstr    := uncacheNeedResend
   uncacheRedirect.halfPc         := uncachePc
   uncacheRedirect.halfData       := uncacheData(15, 0)
+
   /* *****************************************************************************
    * IFU Write-back Stage
    * - write back preDecode information to Ftq to update
@@ -671,13 +718,14 @@ class Ifu(implicit p: Parameters) extends IfuModule
     val b         = Wire(Valid(new FrontendRedirect))
     val ftqIdx    = VecInit(wbAlignFetchBlock.map(_.ftqIdx))
     val startAddr = VecInit(wbAlignFetchBlock.map(_.startVAddr.toUInt(VAddrBits - 1, 0)))
+    val select    = checkerRedirect.bits.blockSel || checkerRedirect.bits.isCrossBlockInstr
     val attribute = checkerRedirect.bits.attribute
     val canTrain = attribute.isDirect || attribute.isReturn ||
       checkerRedirect.bits.invalidTaken || checkerRedirect.bits.notCfiTaken
     b.valid          := wbValid && checkerRedirect.valid
     b.bits.canTrain  := canTrain
-    b.bits.ftqIdx    := Mux(checkerRedirect.bits.selectBlock, ftqIdx(1), ftqIdx(0))
-    b.bits.pc        := Mux(checkerRedirect.bits.selectBlock, startAddr(1), startAddr(0))
+    b.bits.ftqIdx    := Mux(select, ftqIdx(1), ftqIdx(0))
+    b.bits.pc        := Mux(select, startAddr(1), startAddr(0))
     b.bits.taken     := checkerRedirect.bits.taken
     b.bits.ftqOffset := checkerRedirect.bits.endOffset
     b.bits.isRVC     := checkerRedirect.bits.isRVC
@@ -690,19 +738,19 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   wbRedirect.valid := checkFlushWb.valid
   wbRedirect.isHalfInstr := Mux(
-    !checkerRedirect.bits.selectBlock,
+    !checkerRedirect.bits.blockSel,
     wbFirstEndIsHalfRvi,
     wbTotalEndIsHalfRvi
   ) && checkerRedirect.bits.invalidTaken
   wbRedirect.instrCount     := wbInstrCount
   wbRedirect.prevIBufEnqPtr := wbPrevIBufEnqPtr
   wbRedirect.halfPc := Mux(
-    !checkerRedirect.bits.selectBlock,
+    !checkerRedirect.bits.blockSel,
     wbFirstEndHalfRviPc,
     wbTotalEndHalfRviPc
   )
   wbRedirect.halfData := Mux(
-    !checkerRedirect.bits.selectBlock,
+    !checkerRedirect.bits.blockSel,
     wbFirstEndHalfRviData,
     wbTotalEndHalfRviData
   )
@@ -746,7 +794,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   perfAnalyzer.io.perfInfo.checkPerfInfo.taken(0)         := wbAlignFetchBlock(0).takenCfiOffset.valid
   perfAnalyzer.io.perfInfo.checkPerfInfo.taken(1)         := wbAlignFetchBlock(1).takenCfiOffset.valid
   perfAnalyzer.io.perfInfo.checkPerfInfo.misPred          := checkerRedirect.valid
-  perfAnalyzer.io.perfInfo.checkPerfInfo.selectBlock      := checkerRedirect.bits.selectBlock
+  perfAnalyzer.io.perfInfo.checkPerfInfo.selectBlock      := checkerRedirect.bits.blockSel
   perfAnalyzer.io.perfInfo.checkPerfInfo.misEndOffset     := checkerRedirect.bits.endOffset
   perfAnalyzer.io.perfInfo.checkPerfInfo.uncacheBubble    := s2_reqIsUncache && !s2_uncacheCanGo
 

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -233,8 +233,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_firstEndIndex       = RegEnable(s0_firstEndIndex, s0_fire)
   private val s1_secondEndIndex      = RegEnable(s0_secondEndIndex, s0_fire)
   private val s1_secondStartIndex    = RegEnable(s0_secondStartIndex, s0_fire)
-  private val s1_rawFirstDataDup     = VecInit((0 until 2).map(i => cutICacheData(s1_firstICacheDataDup(i))))
-  private val s1_rawSecondDataDup    = VecInit((0 until 2).map(i => cutICacheData(s1_secondICacheDataDup(i))))
+  private val s1_rawFirstDataDup     = VecInit(s1_firstICacheDataDup.map(cutICacheData(_)))
+  private val s1_rawSecondDataDup    = VecInit(s1_secondICacheDataDup.map(cutICacheData(_)))
 
   private val s1_icacheMetaIn = RegEnable(s0_icacheMeta, s0_fire)
   private val s1_instrVec     = s1_compactedInstrVec
@@ -289,7 +289,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_firstEndPos     = s1_fetchBlock(0).takenCfiOffset.bits
   private val s1_firstEndHalfRvi = Wire(new EndHalfRviInfo)
   s1_firstEndHalfRvi.isHalfRvi := s1_firstEndIsHalfRvi
-  s1_firstEndHalfRvi.pc        := s1_fetchBlock(0).startVAddr + (s1_firstEndPos << 1)
+  s1_firstEndHalfRvi.pc        := s1_fetchBlock(0).startVAddr + (s1_firstEndPos << 1).asUInt
   s1_firstEndHalfRvi.data      := s1_rawFirstDataDup(0)(s1_firstEndIndex)(15, 0)
 
   private val s1_secondEndHalfRviData = s1_rawSecondDataDup(0)(s1_secondEndIndex)(15, 0)

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -172,11 +172,11 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s0_hasException = s0_icacheMeta(0).exception.hasException
   private val s0_instrCount =
     Mux(s0_hasException, 1.U((log2Ceil(FetchBlockInstNum) + 1).W), PopCount(s0_instrEndMask.asUInt & s0_totalRange))
-  private val s0_rawFirstDataDupWire  = VecInit(Seq.fill(NumCacheDataDuplicate)(io.fromICache.req.bits.info(0).data))
-  private val s0_rawSecondDataDupWire = VecInit(Seq.fill(NumCacheDataDuplicate)(io.fromICache.req.bits.info(1).data))
-  private val s0_firstEndIndex        = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
-  private val s0_secondEndIndex       = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
-  private val s0_secondStartIndex     = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
+  private val s0_rawFirstData     = io.fromICache.req.bits.info(0).data
+  private val s0_rawSecondData    = io.fromICache.req.bits.info(1).data
+  private val s0_firstEndIndex    = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
+  private val s0_secondEndIndex   = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
+  private val s0_secondStartIndex = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
   s0_firstEndIndex := io.fromICache.req.bits.info(0).startVAddr(
     log2Ceil(ICacheLineBytes / 2),
     instOffsetBits
@@ -228,13 +228,13 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_prevEndHalfRviData = RegInit(0.U(16.W))
   private val s1_prevEndHalfRviPc   = RegInit(0.U.asTypeOf(GuardedPc()))
 
-  private val s1_firstICacheDataDup  = RegEnable(s0_rawFirstDataDupWire, s0_fire)
-  private val s1_secondICacheDataDup = RegEnable(s0_rawSecondDataDupWire, s0_fire)
-  private val s1_firstEndIndex       = RegEnable(s0_firstEndIndex, s0_fire)
-  private val s1_secondEndIndex      = RegEnable(s0_secondEndIndex, s0_fire)
-  private val s1_secondStartIndex    = RegEnable(s0_secondStartIndex, s0_fire)
-  private val s1_rawFirstDataDup     = VecInit(s1_firstICacheDataDup.map(cutICacheData(_)))
-  private val s1_rawSecondDataDup    = VecInit(s1_secondICacheDataDup.map(cutICacheData(_)))
+  private val s1_firstICacheData  = RegEnable(s0_rawFirstData, s0_fire)
+  private val s1_secondICacheData = RegEnable(s0_rawSecondData, s0_fire)
+  private val s1_firstEndIndex    = RegEnable(s0_firstEndIndex, s0_fire)
+  private val s1_secondEndIndex   = RegEnable(s0_secondEndIndex, s0_fire)
+  private val s1_secondStartIndex = RegEnable(s0_secondStartIndex, s0_fire)
+  private val s1_rawFirstData     = cutICacheData(s1_firstICacheData)
+  private val s1_rawSecondData    = cutICacheData(s1_secondICacheData)
 
   private val s1_icacheMetaIn = RegEnable(s0_icacheMeta, s0_fire)
   private val s1_instrVec     = s1_compactedInstrVec
@@ -290,9 +290,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_firstEndHalfRvi = Wire(new EndHalfRviInfo)
   s1_firstEndHalfRvi.isHalfRvi := s1_firstEndIsHalfRvi
   s1_firstEndHalfRvi.pc        := s1_fetchBlock(0).startVAddr + (s1_firstEndPos << 1).asUInt
-  s1_firstEndHalfRvi.data      := s1_rawFirstDataDup(0)(s1_firstEndIndex)(15, 0)
+  s1_firstEndHalfRvi.data      := s1_rawFirstData(s1_firstEndIndex)(15, 0)
 
-  private val s1_secondEndHalfRviData = s1_rawSecondDataDup(0)(s1_secondEndIndex)(15, 0)
+  private val s1_secondEndHalfRviData = s1_rawSecondData(s1_secondEndIndex)(15, 0)
   private val s1_totalEndHalfRvi      = Wire(new EndHalfRviInfo)
   s1_totalEndHalfRvi.isHalfRvi := s1_totalEndIsHalfRvi
   s1_totalEndHalfRvi.pc := Mux(
@@ -301,12 +301,12 @@ class Ifu(implicit p: Parameters) extends IfuModule
     s1_firstEndHalfRvi.pc
   )
   s1_totalEndHalfRvi.data := Mux(s1_fetchBlock(1).valid, s1_secondEndHalfRviData, s1_firstEndHalfRvi.data)
-  private val s1_secondStartRviData = s1_rawSecondDataDup(0)(s1_secondStartIndex)(15, 0)
+  private val s1_secondStartRviData = s1_rawSecondData(s1_secondStartIndex)(15, 0)
 
   private val s1_baseInstrData = genBaseInstrData(
     s1_baseAlignedInstrVec,
-    s1_rawFirstDataDup,
-    s1_rawSecondDataDup,
+    s1_rawFirstData,
+    s1_rawSecondData,
     s1_secondStartRviData
   )
   private val s1_alignedInstrPcVec = WireDefault(s1_baseAlignedInstrPcVec)
@@ -369,7 +369,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_useUncacheFetch = s1_valid && s1_icacheMeta(0).isUncache && s1_icacheMeta(0).exception.isNone
 
   private val s1_alignedPdInfoVec     = Wire(Vec(IBufferEnqueueWidth, new PreDecodeInfo))
-  private val s1_alignedJumpOffsetVec = Wire(Vec(IBufferEnqueueWidth, PrunedAddr(VAddrBits)))
+  private val s1_alignedJumpOffsetVec = Wire(Vec(IBufferEnqueueWidth, GuardedPc()))
   for (i <- 0 until IBufferEnqueueWidth) {
     val alignedInstr = s1_alignedInstrVec(i)
     val alignedValid = s1_alignedInstrValid(i)
@@ -572,12 +572,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // Other instructions in the same block may have pf or af set,
   // which is a side effect of the first instruction and actually not necessary.
   io.toIBuffer.bits.isBackendException := s2_icacheMeta(0).isBackendException
-<<<<<<< HEAD
   io.toIBuffer.bits.hasSatpFlush       := s2_icacheMeta(0).hasSatpFlush
   // if we have last half RV-I instruction, and has exception, we need to tell backend to caculate the correct pc
-=======
-  // if we have last half RV-I instruction, and has exception, we need to tell backend to calculate the correct pc
->>>>>>> 77b4563df (style(icache, ifu): clean up code, remove comments & encapsulate logic)
   io.toIBuffer.bits.exceptionCrossPage := s2_icacheMeta(0).exception.hasException && s2_prevEndIsHalfRvi
   // if icache respond with exception, it's marked on entire cacheline,
   // so the first enqueued instr should be marked with exception

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -328,6 +328,18 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // useUncacheFetch controls whether the instruction fetch operation follows the uncache control logic.
   private val s1_useUncacheFetch = s1_valid && s1_icacheMeta(0).isUncache && s1_icacheMeta(0).exception.isNone
 
+  private val s1_alignedPdInfoVec     = Wire(Vec(IBufferEnqueueWidth, new PreDecodeInfo))
+  private val s1_alignedJumpOffsetVec = Wire(Vec(IBufferEnqueueWidth, PrunedAddr(VAddrBits)))
+  for (i <- 0 until IBufferEnqueueWidth) {
+    val alignedInstr = s1_alignedInstrVec(i)
+    val alignedValid = s1_alignedInstrValid(i)
+    val jalOffset    = getJalOffset(alignedInstr.data, alignedInstr.isRvc)
+    val brOffset     = getBrOffset(alignedInstr.data, alignedInstr.isRvc)
+    s1_alignedPdInfoVec(i).valid       := alignedValid
+    s1_alignedPdInfoVec(i).isRVC       := alignedInstr.isRvc
+    s1_alignedPdInfoVec(i).brAttribute := BranchAttribute.decode(alignedInstr.data, alignedValid && s1_valid)
+    s1_alignedJumpOffsetVec(i)         := Mux(s1_alignedPdInfoVec(i).isBr, brOffset, jalOffset)
+  }
   /* --------------------------------------------------------------------------------------------------------------
      stage 2
      - expand instructions
@@ -356,12 +368,14 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s2_totalEndHalfRviPc   = RegEnable(s1_totalEndHalfRviPc, s1_fire)
   private val s2_totalEndHalfRviData = RegEnable(s1_totalEndHalfRviData, s1_fire)
 
-  private val s2_instrCount        = RegEnable(s1_instrCount, s1_fire)
-  private val s2_alignedInstrValid = RegEnable(s1_alignedInstrValid, s1_fire)
-  private val s2_icacheMeta        = RegEnable(s1_icacheMeta, s1_fire)
-  private val s2_alignedInstrVec   = RegEnable(s1_alignedInstrVec, s1_fire)
-  private val s2_alignedInstrPcVec = RegEnable(s1_alignedInstrPcVec, s1_fire)
-  private val s2_alignedFoldPc     = RegEnable(s1_alignedFoldPc, s1_fire)
+  private val s2_instrCount           = RegEnable(s1_instrCount, s1_fire)
+  private val s2_alignedInstrValid    = RegEnable(s1_alignedInstrValid, s1_fire)
+  private val s2_icacheMeta           = RegEnable(s1_icacheMeta, s1_fire)
+  private val s2_alignedInstrVec      = RegEnable(s1_alignedInstrVec, s1_fire)
+  private val s2_alignedInstrPcVec    = RegEnable(s1_alignedInstrPcVec, s1_fire)
+  private val s2_alignedFoldPc        = RegEnable(s1_alignedFoldPc, s1_fire)
+  private val s2_alignedPdInfoVec     = RegEnable(s1_alignedPdInfoVec, s1_fire)
+  private val s2_alignedJumpOffsetVec = RegEnable(s1_alignedJumpOffsetVec, s1_fire)
 
   s2_fire := io.toIBuffer.fire
   dontTouch(s2_fire)
@@ -387,17 +401,6 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s2_blockSel     = VecInit(s2_expandedInstrVec.map(_.blockSel))
   private val s2_endOffsetVec = VecInit(s2_expandedInstrVec.map(_.endOffset))
   dontTouch(s2_blockSel)
-
-  private val s2_alignedPdInfoVec     = Wire(Vec(IBufferEnqueueWidth, new PreDecodeInfo))
-  private val s2_alignedJumpOffsetVec = Wire(Vec(IBufferEnqueueWidth, GuardedPc()))
-  s2_alignedInstrVec.zipWithIndex.foreach { case (instr, i) =>
-    val jalOffset = getJalOffset(instr.data, instr.isRvc)
-    val brOffset  = getBrOffset(instr.data, instr.isRvc)
-    s2_alignedPdInfoVec(i).valid       := instr.valid
-    s2_alignedPdInfoVec(i).isRVC       := instr.isRvc
-    s2_alignedPdInfoVec(i).brAttribute := BranchAttribute.decode(instr.data, instr.valid && s2_valid)
-    s2_alignedJumpOffsetVec(i)         := Mux(s2_alignedPdInfoVec(i).isBr, brOffset, jalOffset)
-  }
 
   private val s2_reqIsUncache    = RegEnable(s1_reqIsUncache, false.B, s1_fire)
   private val s2_useUncacheFetch = RegEnable(s1_useUncacheFetch, s1_fire)

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -44,8 +44,6 @@ import xiangshan.frontend.InstrUncacheToIfuIO
 import xiangshan.frontend.PreDecodeInfo
 import xiangshan.frontend.bpu.BranchAttribute
 import xiangshan.frontend.ibuffer.IBufPtr
-import xiangshan.frontend.icache.PmpCheckBundle
-import xiangshan.mem.LoadStage.s0
 
 class Ifu(implicit p: Parameters) extends IfuModule
     with PreDecodeHelper
@@ -155,6 +153,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s0_rawInstrVec       = instrBoundary.io.resp.rawInstrVec
   private val s0_instrEndMask      = instrBoundary.io.resp.instrEndMask
   private val s0_rawInstrValid     = VecInit(s0_rawInstrVec.map(_.valid)).asUInt
+  private val s0_firstRange        = s0_ifuData.firstRange
+  private val s0_totalRange        = s0_ifuData.totalRange
 
   // When invalidTaken is true, we can not flush s2_prevLastIsHalfRvi because the fetch block after it is fall-through.
   when(backendRedirect) {
@@ -170,18 +170,22 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // When an exception occurs, forward the exception information immediately instead of
   // waiting for instruction concatenation to complete.
   private val s0_hasException = s0_icacheMeta(0).exception.hasException
-  private val s0_instrCount = Mux(s0_hasException, 1.U((log2Ceil(FetchBlockInstNum) + 1).W), PopCount(s0_instrEndMask))
-  private val s0_firstRange = VecInit(s0_rawInstrVec.map(instr => !instr.blockSel)).asUInt
-  private val s0_firstRawInstrValid = s0_rawInstrValid & s0_firstRange
-  private val s0_totalRawInstrValid = s0_rawInstrValid
-  private val s0_rawFirstDataDupWire  = VecInit(Seq.fill(2)(io.fromICache.req.bits.info(0).data))
-  private val s0_rawSecondDataDupWire = VecInit(Seq.fill(2)(io.fromICache.req.bits.info(1).data))
-  private val s0_firstEndIndex = Wire(UInt(FetchBlockInstOffsetWidth.W))
-  private val s0_secondEndIndex = Wire(UInt(FetchBlockInstOffsetWidth.W))
-  private val s0_secondStartIndex = Wire(UInt(FetchBlockInstOffsetWidth.W))
-  s0_firstEndIndex  := io.fromICache.req.bits.info(0).startVAddr(5, 1) + io.fromICache.req.bits.info(0).takenCfiOffset.bits
-  s0_secondEndIndex := io.fromICache.req.bits.info(1).startVAddr(5, 1) + io.fromICache.req.bits.info(1).takenCfiOffset.bits
-  s0_secondStartIndex := io.fromICache.req.bits.info(1).startVAddr(5, 1)
+  private val s0_instrCount =
+    Mux(s0_hasException, 1.U((log2Ceil(FetchBlockInstNum) + 1).W), PopCount(s0_instrEndMask.asUInt & s0_totalRange))
+  private val s0_rawFirstDataDupWire  = VecInit(Seq.fill(NumCacheDataDuplicate)(io.fromICache.req.bits.info(0).data))
+  private val s0_rawSecondDataDupWire = VecInit(Seq.fill(NumCacheDataDuplicate)(io.fromICache.req.bits.info(1).data))
+  private val s0_firstEndIndex        = Wire(UInt(FetchBlockInstOffsetWidth.W))
+  private val s0_secondEndIndex       = Wire(UInt(FetchBlockInstOffsetWidth.W))
+  private val s0_secondStartIndex     = Wire(UInt(FetchBlockInstOffsetWidth.W))
+  s0_firstEndIndex := io.fromICache.req.bits.info(0).startVAddr(
+    log2Ceil(ICacheLineBytes) - 1,
+    instOffsetBits
+  ) + io.fromICache.req.bits.info(0).takenCfiOffset.bits
+  s0_secondEndIndex := io.fromICache.req.bits.info(1).startVAddr(
+    log2Ceil(ICacheLineBytes) - 1,
+    instOffsetBits
+  ) + io.fromICache.req.bits.info(1).takenCfiOffset.bits
+  s0_secondStartIndex := io.fromICache.req.bits.info(1).startVAddr(log2Ceil(ICacheLineBytes) - 1, instOffsetBits)
   /* --------------------------------------------------------------------------------------------------------------
      stage 1
      - cat half rvi instruction
@@ -195,15 +199,19 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   private val s1_fetchBlock        = RegEnable(s0_fetchBlock, s0_fire)
   private val s1_totalEndPos       = RegEnable(s0_totalEndPos, s0_fire)
+  private val s1_rawInstrValid     = RegEnable(s0_rawInstrValid, s0_fire)
   private val s1_instrEndMask      = RegEnable(s0_instrEndMask, s0_fire)
+  private val s1_firstRange        = RegEnable(s0_firstRange, s0_fire)
+  private val s1_totalRange        = RegEnable(s0_totalRange, s0_fire)
   private val s1_compactedInstrVec = compact(s0_rawInstrVec, s0_fire)
   // The pre-calculated enqueue amount required when estimating whether the IBuffer can be enqueued.
-  private val s1_specInstrCount       = RegEnable(s0_instrCount, s0_fire)
-  private val s1_firstRange           = RegEnable(s0_firstRange, s0_fire)
-  private val s1_totalRawInstrValid   = RegEnable(s0_totalRawInstrValid, s0_fire)
-  private val s1_firstEndIsHalfRvi    = RegEnable(s0_firstEndIsHalfRvi, s0_fire)
-  private val s1_totalEndIsHalfRvi    = RegEnable(s0_totalEndIsHalfRvi, s0_fire)
-  private val s1_firstRawInstrValid   = s1_totalRawInstrValid & s1_firstRange
+  private val s1_specInstrCount    = RegEnable(s0_instrCount, s0_fire)
+  private val s1_firstEndIsHalfRvi = RegEnable(s0_firstEndIsHalfRvi, s0_fire)
+  private val s1_totalEndIsHalfRvi = RegEnable(s0_totalEndIsHalfRvi, s0_fire)
+  // Used to compute the sequence number of valid instructions.
+  private val s1_firstRawInstrValid = s1_rawInstrValid & s1_firstRange
+  private val s1_totalRawInstrValid = s1_rawInstrValid & s1_totalRange
+  // Used to compute the count of valid instructions within the fetch range.
   private val s1_firstRawInstrEndMask = s1_instrEndMask.asUInt & s1_firstRange
   private val s1_invalidTaken = VecInit(
     s1_fetchBlock(0).takenCfiOffset.valid && s1_firstEndIsHalfRvi,
@@ -215,7 +223,6 @@ class Ifu(implicit p: Parameters) extends IfuModule
     PopCount(s1_totalRawInstrValid) - 1.U
   )
 
-  dontTouch(s1_fetchBlock)
   private val s1_prevIBufEnqPtrDup  = RegInit(DuplicateInit(Seq("instr", "valid"), 0.U.asTypeOf(new IBufPtr)))
   private val s1_prevEndIsHalfRvi   = RegEnable(s0_prevEndIsHalfRvi, s0_fire)
   private val s1_prevEndHalfRviData = RegInit(0.U(16.W))
@@ -223,11 +230,12 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   private val s1_firstICacheDataDup  = RegEnable(s0_rawFirstDataDupWire, s0_fire)
   private val s1_secondICacheDataDup = RegEnable(s0_rawSecondDataDupWire, s0_fire)
-  private val s1_firstEndIndex = RegEnable(s0_firstEndIndex, s0_fire)
-  private val s1_secondEndIndex = RegEnable(s0_secondEndIndex, s0_fire)
-  private val s1_secondStartIndex = RegEnable(s0_secondStartIndex, s0_fire)
-  private val s1_rawFirstDataDup  = VecInit((0 until 2).map {i => cutICacheData(s1_firstICacheDataDup(i))})
-  private val s1_rawSecondDataDup = VecInit((0 until 2).map {i => cutICacheData(s1_secondICacheDataDup(i))})
+  private val s1_firstEndIndex       = RegEnable(s0_firstEndIndex, s0_fire)
+  private val s1_secondEndIndex      = RegEnable(s0_secondEndIndex, s0_fire)
+  private val s1_secondStartIndex    = RegEnable(s0_secondStartIndex, s0_fire)
+  private val s1_rawFirstDataDup     = VecInit((0 until 2).map(i => cutICacheData(s1_firstICacheDataDup(i))))
+  private val s1_rawSecondDataDup    = VecInit((0 until 2).map(i => cutICacheData(s1_secondICacheDataDup(i))))
+
   private val s1_icacheMetaIn = RegEnable(s0_icacheMeta, s0_fire)
   private val s1_instrVec     = s1_compactedInstrVec
 
@@ -278,39 +286,29 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_alignedPredTakenMask  = (s1_mergedPredTakenMask << s1_alignShiftValidNum).pad(IBufferEnqueueWidth)
   private val s1_alignedInvalidTakenMask = (s1_mergedInvalidTakenMask << s1_alignShiftValidNum).pad(IBufferEnqueueWidth)
 
-  private val s1_firstEndPos       = s1_fetchBlock(0).takenCfiOffset.bits
-  private val s1_firstEndHalfRviPc = s1_fetchBlock(0).startVAddr + (s1_firstEndPos << 1)
-  private val s1_totalEndHalfRviPc = Mux(
+  private val s1_firstEndPos     = s1_fetchBlock(0).takenCfiOffset.bits
+  private val s1_firstEndHalfRvi = Wire(new EndHalfRviInfo)
+  s1_firstEndHalfRvi.isHalfRvi := s1_firstEndIsHalfRvi
+  s1_firstEndHalfRvi.pc        := s1_fetchBlock(0).startVAddr + (s1_firstEndPos << 1)
+  s1_firstEndHalfRvi.data      := s1_rawFirstDataDup(0)(s1_firstEndIndex)(15, 0)
+
+  private val s1_secondEndHalfRviData = s1_rawSecondDataDup(0)(s1_secondEndIndex)(15, 0)
+  private val s1_totalEndHalfRvi      = Wire(new EndHalfRviInfo)
+  s1_totalEndHalfRvi.isHalfRvi := s1_totalEndIsHalfRvi
+  s1_totalEndHalfRvi.pc := Mux(
     s1_fetchBlock(1).valid,
     s1_fetchBlock(1).startVAddr + ((s1_fetchBlock(1).takenCfiOffset.bits) << 1),
-    s1_firstEndHalfRviPc
+    s1_firstEndHalfRvi.pc
   )
+  s1_totalEndHalfRvi.data := Mux(s1_fetchBlock(1).valid, s1_secondEndHalfRviData, s1_firstEndHalfRvi.data)
+  private val s1_secondStartRviData = s1_rawSecondDataDup(0)(s1_secondStartIndex)(15, 0)
 
-  private val s1_firstEndHalfRviData = s1_rawFirstDataDup(0)(s1_firstEndIndex)(15, 0)
-  private val s1_secondEndHalfRviData = s1_rawSecondDataDup(0)(s1_secondEndIndex)(15, 0)
-  private val s1_totalEndHalfRviData = Mux(s1_fetchBlock(1).valid, s1_secondEndHalfRviData, s1_firstEndHalfRviData)
-  private val s1_secondStartRviData  = s1_rawSecondDataDup(0)(s1_secondStartIndex)(15, 0)
-
-  // Patch instruction data
-  private val s1_baseInstrData = Wire(Vec(IBufferEnqueueWidth, UInt(32.W)))
-  for (i <- 0 until IBufferEnqueueWidth / 2) {
-    val index0 = s1_baseAlignedInstrVec(i).index
-    val index1 = s1_baseAlignedInstrVec(i + IBufferEnqueueWidth / 2).index
-    val blockSel0 = s1_baseAlignedInstrVec(i).blockSel
-    val isCrossBlock0 = s1_baseAlignedInstrVec(i).isCrossBlockInstr
-    val blockSel1 = s1_baseAlignedInstrVec(i + IBufferEnqueueWidth / 2).blockSel
-    val isCrossBlock1 = s1_baseAlignedInstrVec(i + IBufferEnqueueWidth / 2).isCrossBlockInstr
-    s1_baseInstrData(i) := Mux(
-      !blockSel0,
-      Mux(isCrossBlock0, Cat(s1_secondStartRviData, s1_rawFirstDataDup(0)(index0)(15, 0)), s1_rawFirstDataDup(0)(index0)),
-      s1_rawSecondDataDup(0)(index0)
-    )
-    s1_baseInstrData(i + IBufferEnqueueWidth / 2) := Mux(
-      !blockSel1,
-      Mux(isCrossBlock1, Cat(s1_secondStartRviData, s1_rawFirstDataDup(1)(index1)(15, 0)), s1_rawFirstDataDup(1)(index1)),
-      s1_rawSecondDataDup(1)(index1)
-    )
-  }
+  private val s1_baseInstrData = genBaseInstrData(
+    s1_baseAlignedInstrVec,
+    s1_rawFirstDataDup,
+    s1_rawSecondDataDup,
+    s1_secondStartRviData
+  )
   private val s1_alignedInstrPcVec = WireDefault(s1_baseAlignedInstrPcVec)
   private val s1_alignedInstrVec   = WireDefault(s1_baseAlignedInstrVec)
 
@@ -319,25 +317,19 @@ class Ifu(implicit p: Parameters) extends IfuModule
     s1_alignedInstrVec(i).isPredTaken  := s1_alignedPredTakenMask(i)
     s1_alignedInstrVec(i).invalidTaken := s1_alignedInvalidTakenMask(i)
     s1_alignedInstrVec(i).data         := s1_baseInstrData(i)
+    s1_alignedInstrVec(i).endOffset := Mux(
+      !s1_baseAlignedInstrVec(i).blockSel && s1_baseAlignedInstrVec(i).isCrossBlockInstr,
+      0.U,
+      s1_baseAlignedInstrVec(i).endOffset
+    )
   }
 
   for (i <- 0 until IfuAlignWidth) {
-    when(s1_alignShiftInstrNum === i.U) {
-      s1_alignedInstrPcVec(i) := Mux(s1_prevEndIsHalfRvi, s1_prevEndHalfRviPc, s1_baseAlignedInstrPcVec(i))
-      s1_alignedInstrVec(i).data := Mux(
-        s1_prevEndIsHalfRvi,
-        Cat(s1_baseInstrData(i)(15, 0), s1_prevEndHalfRviData),
-        s1_baseInstrData(i)
-      )
+    when((s1_alignShiftInstrNum === i.U) && s1_prevEndIsHalfRvi) {
+      s1_alignedInstrPcVec(i)                := s1_prevEndHalfRviPc
+      s1_alignedInstrVec(i).data             := Cat(s1_baseInstrData(i)(15, 0), s1_prevEndHalfRviData)
       s1_alignedInstrVec(i).isPrevEndHalfRvi := s1_prevEndIsHalfRvi
-      s1_alignedInstrVec(i).endOffset := Mux(
-        s1_prevEndIsHalfRvi,
-        0.U,
-        Mux(!s1_baseAlignedInstrVec(i).blockSel && s1_baseAlignedInstrVec(i).isCrossBlockInstr,
-         0.U,
-         s1_baseAlignedInstrVec(i).endOffset
-        )
-      )
+      s1_alignedInstrVec(i).endOffset        := 0.U
     }
   }
 
@@ -355,8 +347,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
     s1_prevEndHalfRviData := uncacheRedirect.halfData
     s1_prevEndHalfRviPc   := uncacheRedirect.halfPc
   }.elsewhen(s1_fire) {
-    s1_prevEndHalfRviData := s1_totalEndHalfRviData
-    s1_prevEndHalfRviPc   := s1_totalEndHalfRviPc
+    s1_prevEndHalfRviData := s1_totalEndHalfRvi.data
+    s1_prevEndHalfRviPc   := s1_totalEndHalfRvi.pc
   }
 
   when(backendRedirect) {
@@ -366,7 +358,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   }.elsewhen(uncacheRedirect.valid) {
     s1_prevIBufEnqPtrDup := uncacheRedirect.prevIBufEnqPtr + uncacheRedirect.instrCount
   }.elsewhen(s1_fire && !s1_icacheMeta(0).isUncache) {
-    s1_prevIBufEnqPtrDup := s1_prevIBufEnqPtrDup.head + s1_instrCount
+    s1_prevIBufEnqPtrDup := s1_prevIBufEnqPtrDup.head + s1_specInstrCount
   }
 
   // reqIsUncache is used to limit the number of fetch requests and enable special pre-decode configurations.
@@ -407,12 +399,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s2_prevEndHalfPc      = RegEnable(s1_prevEndHalfRviPc, s1_fire)
   private val s2_prevEndHalfRviData = RegEnable(s1_prevEndHalfRviData, s1_fire)
 
-  private val s2_firstEndIsHalfRvi   = RegEnable(s1_firstEndIsHalfRvi, s1_fire)
-  private val s2_firstEndHalfRviPc   = RegEnable(s1_firstEndHalfRviPc, s1_fire)
-  private val s2_firstEndHalfRviData = RegEnable(s1_firstEndHalfRviData, s1_fire)
-  private val s2_totalEndIsHalfRvi   = RegEnable(s1_totalEndIsHalfRvi, s1_fire)
-  private val s2_totalEndHalfRviPc   = RegEnable(s1_totalEndHalfRviPc, s1_fire)
-  private val s2_totalEndHalfRviData = RegEnable(s1_totalEndHalfRviData, s1_fire)
+  private val s2_firstEndHalfRvi = RegEnable(s1_firstEndHalfRvi, s1_fire)
+  private val s2_totalEndHalfRvi = RegEnable(s1_totalEndHalfRvi, s1_fire)
 
   private val s2_instrCount           = RegEnable(s1_instrCount, s1_fire)
   private val s2_alignedInstrValid    = RegEnable(s1_alignedInstrValid, s1_fire)
@@ -444,8 +432,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
     instr.data := expandedData
   }
 
-  private val s2_blockSel     = VecInit(s2_expandedInstrVec.map(_.blockSel))
-  private val s2_endOffsetVec = VecInit(s2_expandedInstrVec.map(_.endOffset))
+  private val s2_blockSel          = VecInit(s2_expandedInstrVec.map(_.blockSel))
+  private val s2_endOffsetVec      = VecInit(s2_expandedInstrVec.map(_.endOffset))
   private val s2_isCrossBlockInstr = VecInit(s2_expandedInstrVec.map(_.isCrossBlockInstr))
   dontTouch(s2_blockSel)
 
@@ -562,8 +550,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
   }
   private val enq = io.toIBuffer.bits.enqEnable
 
-  private val s2_rvcIll             = VecInit(rvcExpanders.map(_.io.ill))
-  private val s2_rvcException       = ExceptionType.fromRvcExpander((enq & s2_rvcIll.asUInt).orR, s2_valid)
+  private val s2_rvcIll       = VecInit(rvcExpanders.map(_.io.ill))
+  private val s2_rvcException = ExceptionType.fromRvcExpander((enq & s2_rvcIll.asUInt).orR, s2_valid)
 
   io.toIBuffer.bits.isLastInFtqEntry := (0 until IBufferEnqueueWidth).map { i =>
     if (i == IBufferEnqueueWidth - 1) enq(i)
@@ -581,8 +569,12 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // Other instructions in the same block may have pf or af set,
   // which is a side effect of the first instruction and actually not necessary.
   io.toIBuffer.bits.isBackendException := s2_icacheMeta(0).isBackendException
+<<<<<<< HEAD
   io.toIBuffer.bits.hasSatpFlush       := s2_icacheMeta(0).hasSatpFlush
   // if we have last half RV-I instruction, and has exception, we need to tell backend to caculate the correct pc
+=======
+  // if we have last half RV-I instruction, and has exception, we need to tell backend to calculate the correct pc
+>>>>>>> 77b4563df (style(icache, ifu): clean up code, remove comments & encapsulate logic)
   io.toIBuffer.bits.exceptionCrossPage := s2_icacheMeta(0).exception.hasException && s2_prevEndIsHalfRvi
   // if icache respond with exception, it's marked on entire cacheline,
   // so the first enqueued instr should be marked with exception
@@ -704,12 +696,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val wbPrevIBufEnqPtr  = RegEnable(s2_prevIBufEnqPtr, wbEnable)
   private val wbInstrCount      = RegEnable(PopCount(io.toIBuffer.bits.enqEnable), wbEnable)
 
-  private val wbFirstEndIsHalfRvi   = RegEnable(s2_firstEndIsHalfRvi, wbEnable)
-  private val wbFirstEndHalfRviPc   = RegEnable(s2_firstEndHalfRviPc, wbEnable)
-  private val wbFirstEndHalfRviData = RegEnable(s2_firstEndHalfRviData, wbEnable)
-  private val wbTotalEndIsHalfRvi   = RegEnable(s2_totalEndIsHalfRvi, wbEnable)
-  private val wbTotalEndHalfRviPc   = RegEnable(s2_totalEndHalfRviPc, wbEnable)
-  private val wbTotalEndHalfRviData = RegEnable(s2_totalEndHalfRviData, wbEnable)
+  private val wbFirstEndHalfRvi = RegEnable(s2_firstEndHalfRvi, wbEnable)
+  private val wbTotalEndHalfRvi = RegEnable(s2_totalEndHalfRvi, wbEnable)
 
   s2_wbNotFlush := wbAlignFetchBlock(0).ftqIdx === s2_fetchBlock(0).ftqIdx && s2_valid && wbValid
 
@@ -736,24 +724,18 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   toFtq.wbRedirect := Mux(wbValid, checkFlushWb, uncacheFlushWb)
 
-  wbRedirect.valid := checkFlushWb.valid
-  wbRedirect.isHalfInstr := Mux(
+  private val wbSelectedEndHalfRvi = Mux(
     !checkerRedirect.bits.blockSel,
-    wbFirstEndIsHalfRvi,
-    wbTotalEndIsHalfRvi
-  ) && checkerRedirect.bits.invalidTaken
+    wbFirstEndHalfRvi,
+    wbTotalEndHalfRvi
+  )
+
+  wbRedirect.valid          := checkFlushWb.valid
+  wbRedirect.isHalfInstr    := wbSelectedEndHalfRvi.isHalfRvi && checkerRedirect.bits.invalidTaken
   wbRedirect.instrCount     := wbInstrCount
   wbRedirect.prevIBufEnqPtr := wbPrevIBufEnqPtr
-  wbRedirect.halfPc := Mux(
-    !checkerRedirect.bits.blockSel,
-    wbFirstEndHalfRviPc,
-    wbTotalEndHalfRviPc
-  )
-  wbRedirect.halfData := Mux(
-    !checkerRedirect.bits.blockSel,
-    wbFirstEndHalfRviData,
-    wbTotalEndHalfRviData
-  )
+  wbRedirect.halfPc         := wbSelectedEndHalfRvi.pc
+  wbRedirect.halfData       := wbSelectedEndHalfRvi.data
 
   private val s1_icachePerfInfo = RegEnable(io.fromICache.perf, s0_fire)
   private val s2_icachePerfInfo = RegEnable(s1_icachePerfInfo, s1_fire)

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -26,6 +26,7 @@ import utility.UIntToMask
 import utility.ValidHold
 import utility.XORFold
 import utility.XSPerfAccumulate
+import utils.DuplicateInit
 import xiangshan.FrontendTdataDistributeIO
 import xiangshan.cache.mmu.HasTlbConst
 import xiangshan.cache.mmu.TlbRequestIO
@@ -207,7 +208,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   )
 
   dontTouch(s1_fetchBlock)
-  private val s1_prevIBufEnqPtr     = RegInit(0.U.asTypeOf(new IBufPtr))
+  private val s1_prevIBufEnqPtrDup  = RegInit(DuplicateInit(Seq("instr", "valid"), 0.U.asTypeOf(new IBufPtr)))
   private val s1_prevEndIsHalfRvi   = RegEnable(s0_prevEndIsHalfRvi, s0_fire)
   private val s1_prevEndHalfRviData = RegInit(0.U(16.W))
   private val s1_prevEndHalfRviPc   = RegInit(0.U.asTypeOf(GuardedPc()))
@@ -255,12 +256,13 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_mergedInvalidTakenMask = s1_invalidTakenMask(0) | s1_invalidTakenMask(1)
   dontTouch(s1_mergedInvalidTakenMask)
 
-  private val s1_alignShiftNum         = s1_prevIBufEnqPtr.value(1, 0)
-  private val s1_baseAlignedInstrVec   = align(s1_instrVec, s1_alignShiftNum)
+  private val s1_alignShiftInstrNum    = s1_prevIBufEnqPtrDup("instr").value(1, 0)
+  private val s1_alignShiftValidNum    = s1_prevIBufEnqPtrDup("valid").value(1, 0)
+  private val s1_baseAlignedInstrVec   = align(s1_instrVec, s1_alignShiftInstrNum)
   private val s1_baseAlignedInstrPcVec = VecInit(s1_baseAlignedInstrVec.map(instr => getInstrPc(instr, s1_fetchBlock)))
-  private val s1_alignedInstrValid     = (s1_instrValid << s1_alignShiftNum).pad(IBufferEnqueueWidth)
-  private val s1_alignedPredTakenMask  = (s1_mergedPredTakenMask << s1_alignShiftNum).pad(IBufferEnqueueWidth)
-  private val s1_alignedInvalidTakenMask = (s1_mergedInvalidTakenMask << s1_alignShiftNum).pad(IBufferEnqueueWidth)
+  private val s1_alignedInstrValid     = (s1_instrValid << s1_alignShiftValidNum).pad(IBufferEnqueueWidth)
+  private val s1_alignedPredTakenMask  = (s1_mergedPredTakenMask << s1_alignShiftValidNum).pad(IBufferEnqueueWidth)
+  private val s1_alignedInvalidTakenMask = (s1_mergedInvalidTakenMask << s1_alignShiftValidNum).pad(IBufferEnqueueWidth)
 
   private val s1_firstEndPos       = s1_fetchBlock(0).takenCfiOffset.bits
   private val s1_firstEndHalfRviPc = s1_fetchBlock(0).startVAddr + (s1_firstEndPos << 1)
@@ -277,7 +279,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_alignedInstrPcVec = WireDefault(s1_baseAlignedInstrPcVec)
   private val s1_alignedInstrVec   = WireDefault(s1_baseAlignedInstrVec)
   for (i <- 0 until IfuAlignWidth) {
-    when(s1_alignShiftNum === i.U) {
+    when(s1_alignShiftInstrNum === i.U) {
       s1_alignedInstrPcVec(i) := Mux(s1_prevEndIsHalfRvi, s1_prevEndHalfRviPc, s1_baseAlignedInstrPcVec(i))
       s1_alignedInstrVec(i).data := Mux(
         s1_prevEndIsHalfRvi,
@@ -314,13 +316,13 @@ class Ifu(implicit p: Parameters) extends IfuModule
   }
 
   when(backendRedirect) {
-    s1_prevIBufEnqPtr := 0.U.asTypeOf(new IBufPtr)
+    s1_prevIBufEnqPtrDup := 0.U.asTypeOf(new IBufPtr)
   }.elsewhen(wbRedirect.valid) {
-    s1_prevIBufEnqPtr := wbRedirect.prevIBufEnqPtr + wbRedirect.instrCount
+    s1_prevIBufEnqPtrDup := wbRedirect.prevIBufEnqPtr + wbRedirect.instrCount
   }.elsewhen(uncacheRedirect.valid) {
-    s1_prevIBufEnqPtr := uncacheRedirect.prevIBufEnqPtr + uncacheRedirect.instrCount
+    s1_prevIBufEnqPtrDup := uncacheRedirect.prevIBufEnqPtr + uncacheRedirect.instrCount
   }.elsewhen(s1_fire && !s1_icacheMeta(0).isUncache) {
-    s1_prevIBufEnqPtr := s1_prevIBufEnqPtr + s1_instrCount
+    s1_prevIBufEnqPtrDup := s1_prevIBufEnqPtrDup.head + s1_instrCount
   }
 
   // reqIsUncache is used to limit the number of fetch requests and enable special pre-decode configurations.
@@ -355,7 +357,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s2_fetchBlock  = RegEnable(s1_fetchBlock, s1_fire)
   dontTouch(s2_fetchBlock)
 
-  private val s2_prevIBufEnqPtr = RegEnable(s1_prevIBufEnqPtr, s1_fire)
+  private val s2_prevIBufEnqPtr = RegEnable(s1_prevIBufEnqPtrDup.head, s1_fire)
 
   private val s2_prevEndIsHalfRvi   = RegEnable(s1_prevEndIsHalfRvi, false.B, s1_fire)
   private val s2_prevEndHalfPc      = RegEnable(s1_prevEndHalfRviPc, s1_fire)

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -160,9 +160,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
   when(backendRedirect) {
     s0_prevEndIsHalfRvi := false.B
   }.elsewhen(wbRedirect.valid) {
-    s0_prevEndIsHalfRvi := wbRedirect.isHalfInstr
+    s0_prevEndIsHalfRvi := wbRedirect.halfRviInfo.valid
   }.elsewhen(uncacheRedirect.valid) {
-    s0_prevEndIsHalfRvi := uncacheRedirect.isHalfInstr
+    s0_prevEndIsHalfRvi := uncacheRedirect.halfRviInfo.valid
   }.elsewhen(s0_fire && !s0_icacheMeta(0).isUncache) {
     s0_prevEndIsHalfRvi := s0_totalEndIsHalfRvi
   }
@@ -174,18 +174,11 @@ class Ifu(implicit p: Parameters) extends IfuModule
     Mux(s0_hasException, 1.U((log2Ceil(FetchBlockInstNum) + 1).W), PopCount(s0_instrEndMask.asUInt & s0_totalRange))
   private val s0_rawFirstData     = io.fromICache.req.bits.info(0).data
   private val s0_rawSecondData    = io.fromICache.req.bits.info(1).data
-  private val s0_firstEndIndex    = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
-  private val s0_secondEndIndex   = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
-  private val s0_secondStartIndex = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
-  s0_firstEndIndex := io.fromICache.req.bits.info(0).startVAddr(
-    log2Ceil(ICacheLineBytes / 2),
-    instOffsetBits
-  ) + io.fromICache.req.bits.info(0).takenCfiOffset.bits
-  s0_secondEndIndex := io.fromICache.req.bits.info(1).startVAddr(
-    log2Ceil(ICacheLineBytes / 2),
-    instOffsetBits
-  ) + io.fromICache.req.bits.info(1).takenCfiOffset.bits
-  s0_secondStartIndex := io.fromICache.req.bits.info(1).startVAddr(log2Ceil(ICacheLineBytes / 2), instOffsetBits)
+  private val s0_firstEndIndex    = io.fromICache.req.bits.info(0).endIndex
+  private val s0_secondEndIndex   = io.fromICache.req.bits.info(1).endIndex
+  private val s0_secondStartIndex = Wire(UInt(log2Ceil(ICacheLineBytes / instBytes).W))
+  s0_secondStartIndex :=
+    io.fromICache.req.bits.info(1).startVAddr(log2Ceil(ICacheLineBytes / instBytes), instOffsetBits)
   /* --------------------------------------------------------------------------------------------------------------
      stage 1
      - cat half rvi instruction
@@ -224,9 +217,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   )
 
   private val s1_prevIBufEnqPtrDup  = RegInit(DuplicateInit(Seq("instr", "valid"), 0.U.asTypeOf(new IBufPtr)))
-  private val s1_prevEndIsHalfRvi   = RegEnable(s0_prevEndIsHalfRvi, s0_fire)
-  private val s1_prevEndHalfRviData = RegInit(0.U(16.W))
-  private val s1_prevEndHalfRviPc   = RegInit(0.U.asTypeOf(GuardedPc()))
+  private val s1_prevEndHalfRviInfo = RegInit(0.U.asTypeOf(Valid(new EndHalfRviInfo)))
 
   private val s1_firstICacheData  = RegEnable(s0_rawFirstData, s0_fire)
   private val s1_secondICacheData = RegEnable(s0_rawSecondData, s0_fire)
@@ -255,8 +246,13 @@ class Ifu(implicit p: Parameters) extends IfuModule
     1.U((log2Ceil(FetchBlockInstNum) + 1).W),
     Mux(s1_invalidTaken(0), s1_firstInstrCount, s1_specInstrCount)
   )
+  require(isPow2(FetchBlockInstNum), s"FetchBlockInstNum ($FetchBlockInstNum) must be a power of two")
   private val s1_instrValid =
-    Mux(s1_instrCount === FetchBlockInstNum.U, ~0.U(FetchBlockInstNum.W), UIntToMask(s1_instrCount, FetchBlockInstNum))
+    Mux(
+      s1_instrCount(log2Ceil(FetchBlockInstNum)),
+      Fill(FetchBlockInstNum, true.B),
+      UIntToMask(s1_instrCount(log2Ceil(FetchBlockInstNum) - 1, 0), FetchBlockInstNum)
+    )
 
   private val s1_predTakenMask = VecInit((0 until FetchPorts).map { i =>
     Mux(
@@ -287,20 +283,20 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s1_alignedInvalidTakenMask = (s1_mergedInvalidTakenMask << s1_alignShiftValidNum).pad(IBufferEnqueueWidth)
 
   private val s1_firstEndPos     = s1_fetchBlock(0).takenCfiOffset.bits
-  private val s1_firstEndHalfRvi = Wire(new EndHalfRviInfo)
-  s1_firstEndHalfRvi.isHalfRvi := s1_firstEndIsHalfRvi
-  s1_firstEndHalfRvi.pc        := s1_fetchBlock(0).startVAddr + (s1_firstEndPos << 1).asUInt
-  s1_firstEndHalfRvi.data      := s1_rawFirstData(s1_firstEndIndex)(15, 0)
+  private val s1_firstEndHalfRvi = Wire(Valid(new EndHalfRviInfo))
+  s1_firstEndHalfRvi.valid     := s1_firstEndIsHalfRvi
+  s1_firstEndHalfRvi.bits.pc   := s1_fetchBlock(0).startVAddr + (s1_firstEndPos << 1).asUInt
+  s1_firstEndHalfRvi.bits.data := s1_rawFirstData(s1_firstEndIndex)(15, 0)
 
   private val s1_secondEndHalfRviData = s1_rawSecondData(s1_secondEndIndex)(15, 0)
-  private val s1_totalEndHalfRvi      = Wire(new EndHalfRviInfo)
-  s1_totalEndHalfRvi.isHalfRvi := s1_totalEndIsHalfRvi
-  s1_totalEndHalfRvi.pc := Mux(
+  private val s1_totalEndHalfRvi      = Wire(Valid(new EndHalfRviInfo))
+  s1_totalEndHalfRvi.valid := s1_totalEndIsHalfRvi
+  s1_totalEndHalfRvi.bits.pc := Mux(
     s1_fetchBlock(1).valid,
     s1_fetchBlock(1).startVAddr + ((s1_fetchBlock(1).takenCfiOffset.bits) << 1),
-    s1_firstEndHalfRvi.pc
+    s1_firstEndHalfRvi.bits.pc
   )
-  s1_totalEndHalfRvi.data := Mux(s1_fetchBlock(1).valid, s1_secondEndHalfRviData, s1_firstEndHalfRvi.data)
+  s1_totalEndHalfRvi.bits.data := Mux(s1_fetchBlock(1).valid, s1_secondEndHalfRviData, s1_firstEndHalfRvi.bits.data)
   private val s1_secondStartRviData = s1_rawSecondData(s1_secondStartIndex)(15, 0)
 
   private val s1_baseInstrData = genBaseInstrData(
@@ -325,10 +321,10 @@ class Ifu(implicit p: Parameters) extends IfuModule
   }
 
   for (i <- 0 until IfuAlignWidth) {
-    when((s1_alignShiftInstrNum === i.U) && s1_prevEndIsHalfRvi) {
-      s1_alignedInstrPcVec(i)                := s1_prevEndHalfRviPc
-      s1_alignedInstrVec(i).data             := Cat(s1_baseInstrData(i)(15, 0), s1_prevEndHalfRviData)
-      s1_alignedInstrVec(i).isPrevEndHalfRvi := s1_prevEndIsHalfRvi
+    when((s1_alignShiftInstrNum === i.U) && s1_prevEndHalfRviInfo.valid) {
+      s1_alignedInstrPcVec(i)                := s1_prevEndHalfRviInfo.bits.pc
+      s1_alignedInstrVec(i).data             := Cat(s1_baseInstrData(i)(15, 0), s1_prevEndHalfRviInfo.bits.data)
+      s1_alignedInstrVec(i).isPrevEndHalfRvi := s1_prevEndHalfRviInfo.valid
       s1_alignedInstrVec(i).endOffset        := 0.U
     }
   }
@@ -340,17 +336,16 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   // backendRedirect has the highest priority
   when(backendRedirect) {
-    s1_prevEndHalfRviData := 0.U
-    s1_prevEndHalfRviPc   := 0.U.asTypeOf(GuardedPc())
+    s1_prevEndHalfRviInfo.bits := 0.U.asTypeOf(new EndHalfRviInfo)
   }.elsewhen(wbRedirect.valid) {
-    s1_prevEndHalfRviData := wbRedirect.halfData
-    s1_prevEndHalfRviPc   := wbRedirect.halfPc
+    s1_prevEndHalfRviInfo.bits := wbRedirect.halfRviInfo.bits
   }.elsewhen(uncacheRedirect.valid) {
-    s1_prevEndHalfRviData := uncacheRedirect.halfData
-    s1_prevEndHalfRviPc   := uncacheRedirect.halfPc
+    s1_prevEndHalfRviInfo.bits := uncacheRedirect.halfRviInfo.bits
   }.elsewhen(s1_fire) {
-    s1_prevEndHalfRviData := s1_totalEndHalfRvi.data
-    s1_prevEndHalfRviPc   := s1_totalEndHalfRvi.pc
+    s1_prevEndHalfRviInfo.bits := s1_totalEndHalfRvi.bits
+  }
+  when(s0_fire) {
+    s1_prevEndHalfRviInfo.valid := s0_prevEndIsHalfRvi
   }
 
   when(backendRedirect) {
@@ -396,14 +391,10 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val s2_fetchBlock  = RegEnable(s1_fetchBlock, s1_fire)
   dontTouch(s2_fetchBlock)
 
-  private val s2_prevIBufEnqPtr = RegEnable(s1_prevIBufEnqPtrDup.head, s1_fire)
-
-  private val s2_prevEndIsHalfRvi   = RegEnable(s1_prevEndIsHalfRvi, false.B, s1_fire)
-  private val s2_prevEndHalfPc      = RegEnable(s1_prevEndHalfRviPc, s1_fire)
-  private val s2_prevEndHalfRviData = RegEnable(s1_prevEndHalfRviData, s1_fire)
-
-  private val s2_firstEndHalfRvi = RegEnable(s1_firstEndHalfRvi, s1_fire)
-  private val s2_totalEndHalfRvi = RegEnable(s1_totalEndHalfRvi, s1_fire)
+  private val s2_prevIBufEnqPtr       = RegEnable(s1_prevIBufEnqPtrDup.head, s1_fire)
+  private val s2_prevEndIsHalfRviInfo = RegEnable(s1_prevEndHalfRviInfo, s1_fire)
+  private val s2_firstEndHalfRvi      = RegEnable(s1_firstEndHalfRvi, s1_fire)
+  private val s2_totalEndHalfRvi      = RegEnable(s1_totalEndHalfRvi, s1_fire)
 
   private val s2_instrCount           = RegEnable(s1_instrCount, s1_fire)
   private val s2_alignedInstrValid    = RegEnable(s1_alignedInstrValid, s1_fire)
@@ -459,7 +450,11 @@ class Ifu(implicit p: Parameters) extends IfuModule
     uncachePc   := 0.U.asTypeOf(GuardedPc())
   }.elsewhen(uncacheUnit.io.req.fire) {
     uncacheBusy := true.B
-    uncachePc   := Mux(s2_prevEndIsHalfRvi, s2_prevEndHalfPc, s2_alignedInstrPcVec(s2_alignShiftNum))
+    uncachePc := Mux(
+      s2_prevEndIsHalfRviInfo.valid,
+      s2_prevEndIsHalfRviInfo.bits.pc,
+      s2_alignedInstrPcVec(s2_alignShiftNum)
+    )
   }.elsewhen(uncacheUnit.io.resp.valid) {
     uncacheBusy := false.B
     // uncachePc := uncachePc
@@ -486,8 +481,9 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // not RVC, no exception, crossing page boundary
   private val uncacheNeedResend = uncacheUnit.io.resp.bits.needResend && uncacheUnit.io.resp.valid
 
-  private val s2_uncacheData = Mux(s2_prevEndIsHalfRvi, Cat(uncacheData(15, 0), s2_prevEndHalfRviData), uncacheData)
-  private val uncacheIsRvc   = s2_uncacheData(1, 0) =/= "b11".U
+  private val s2_uncacheData =
+    Mux(s2_prevEndIsHalfRviInfo.valid, Cat(uncacheData(15, 0), s2_prevEndIsHalfRviInfo.bits.data), uncacheData)
+  private val uncacheIsRvc = s2_uncacheData(1, 0) =/= "b11".U
   uncacheRvcExpander.io.in      := Mux(s2_reqIsUncache, s2_uncacheData, 0.U)
   uncacheRvcExpander.io.fsIsOff := io.csrFsIsOff
 
@@ -574,7 +570,7 @@ class Ifu(implicit p: Parameters) extends IfuModule
   io.toIBuffer.bits.isBackendException := s2_icacheMeta(0).isBackendException
   io.toIBuffer.bits.hasSatpFlush       := s2_icacheMeta(0).hasSatpFlush
   // if we have last half RV-I instruction, and has exception, we need to tell backend to caculate the correct pc
-  io.toIBuffer.bits.exceptionCrossPage := s2_icacheMeta(0).exception.hasException && s2_prevEndIsHalfRvi
+  io.toIBuffer.bits.exceptionCrossPage := s2_icacheMeta(0).exception.hasException && s2_prevEndIsHalfRviInfo.valid
   // if icache respond with exception, it's marked on entire cacheline,
   // so the first enqueued instr should be marked with exception
   // otherwise, we only have rvcException, so select its offset
@@ -615,14 +611,14 @@ class Ifu(implicit p: Parameters) extends IfuModule
   private val uncachePd           = 0.U.asTypeOf(Vec(FetchBlockInstNum, new PreDecodeInfo))
   private val uncacheMisEndOffset = Wire(Valid(UInt(FetchBlockInstOffsetWidth.W)))
   uncacheMisEndOffset.valid := s2_reqIsUncache
-  uncacheMisEndOffset.bits  := Mux(uncacheIsRvc || s2_prevEndIsHalfRvi || uncacheNeedResend, 0.U, 1.U)
+  uncacheMisEndOffset.bits  := Mux(uncacheIsRvc || s2_prevEndIsHalfRviInfo.valid || uncacheNeedResend, 0.U, 1.U)
 
   // Send mmioFlushWb back to FTQ 1 cycle after uncache fetch return
   // When backend redirect, mmioState reset after 1 cycle.
   // In this case, mask .valid to avoid overriding backend redirect
   private val uncacheTarget =
     Mux(
-      uncacheIsRvc || s2_prevEndIsHalfRvi || uncacheNeedResend,
+      uncacheIsRvc || s2_prevEndIsHalfRviInfo.valid || uncacheNeedResend,
       s2_fetchBlock(0).startVAddr + 2.U,
       s2_fetchBlock(0).startVAddr + 4.U
     )
@@ -649,14 +645,18 @@ class Ifu(implicit p: Parameters) extends IfuModule
       uncacheRvcExpander.io.out.bits
     )
 
-    io.toIBuffer.bits.pc(s2_alignShiftNum)                    := uncachePc.unGuard
-    io.toIBuffer.bits.isRvc(s2_alignShiftNum)                 := uncacheIsRvc
-    io.toIBuffer.bits.instrEndOffset(s2_alignShiftNum).offset := Mux(uncacheIsRvc || s2_prevEndIsHalfRvi, 0.U, 1.U)
+    io.toIBuffer.bits.pc(s2_alignShiftNum)    := uncachePc.unGuard
+    io.toIBuffer.bits.isRvc(s2_alignShiftNum) := uncacheIsRvc
+    io.toIBuffer.bits.instrEndOffset(s2_alignShiftNum).offset := Mux(
+      uncacheIsRvc || s2_prevEndIsHalfRviInfo.valid,
+      0.U,
+      1.U
+    )
 
     io.toIBuffer.bits.exceptionType := s2_icacheMeta(0).exception || uncacheException || uncacheRvcException
     // execption can happen in next page only when cross page.
     io.toIBuffer.bits.exceptionCrossPage :=
-      s2_prevEndIsHalfRvi && (s2_icacheMeta(0).exception.hasException || uncacheException.hasException)
+      s2_prevEndIsHalfRviInfo.valid && (s2_icacheMeta(0).exception.hasException || uncacheException.hasException)
     io.toIBuffer.bits.exceptionMask := VecInit.tabulate(IBufferEnqueueWidth) { i =>
       if (i < IfuAlignWidth) i.U === s2_alignShiftNum else false.B
     }
@@ -675,11 +675,11 @@ class Ifu(implicit p: Parameters) extends IfuModule
   // This fixes the edge case where instructions spanning both cache and uncache channels fell through
   // the cracks of the existing S1 (cache) and S2 (uncache) cross-page handling logic.
   uncacheRedirect.valid := s2_valid && io.toIBuffer.ready && s2_reqIsUncache && (s2_uncacheCanGo || uncacheNeedResend)
-  uncacheRedirect.instrCount     := Mux(uncacheNeedResend, 0.U, 1.U)
-  uncacheRedirect.prevIBufEnqPtr := s2_prevIBufEnqPtr
-  uncacheRedirect.isHalfInstr    := uncacheNeedResend
-  uncacheRedirect.halfPc         := uncachePc
-  uncacheRedirect.halfData       := uncacheData(15, 0)
+  uncacheRedirect.instrCount            := Mux(uncacheNeedResend, 0.U, 1.U)
+  uncacheRedirect.prevIBufEnqPtr        := s2_prevIBufEnqPtr
+  uncacheRedirect.halfRviInfo.valid     := uncacheNeedResend
+  uncacheRedirect.halfRviInfo.bits.pc   := uncachePc
+  uncacheRedirect.halfRviInfo.bits.data := uncacheData(15, 0)
 
   /* *****************************************************************************
    * IFU Write-back Stage
@@ -729,12 +729,11 @@ class Ifu(implicit p: Parameters) extends IfuModule
     wbTotalEndHalfRvi
   )
 
-  wbRedirect.valid          := checkFlushWb.valid
-  wbRedirect.isHalfInstr    := wbSelectedEndHalfRvi.isHalfRvi && checkerRedirect.bits.invalidTaken
-  wbRedirect.instrCount     := wbInstrCount
-  wbRedirect.prevIBufEnqPtr := wbPrevIBufEnqPtr
-  wbRedirect.halfPc         := wbSelectedEndHalfRvi.pc
-  wbRedirect.halfData       := wbSelectedEndHalfRvi.data
+  wbRedirect.valid             := checkFlushWb.valid
+  wbRedirect.instrCount        := wbInstrCount
+  wbRedirect.prevIBufEnqPtr    := wbPrevIBufEnqPtr
+  wbRedirect.halfRviInfo       := wbSelectedEndHalfRvi
+  wbRedirect.halfRviInfo.valid := wbSelectedEndHalfRvi.valid && checkerRedirect.bits.invalidTaken
 
   private val s1_icachePerfInfo = RegEnable(io.fromICache.perf, s0_fire)
   private val s2_icachePerfInfo = RegEnable(s1_icachePerfInfo, s1_fire)

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -174,18 +174,18 @@ class Ifu(implicit p: Parameters) extends IfuModule
     Mux(s0_hasException, 1.U((log2Ceil(FetchBlockInstNum) + 1).W), PopCount(s0_instrEndMask.asUInt & s0_totalRange))
   private val s0_rawFirstDataDupWire  = VecInit(Seq.fill(NumCacheDataDuplicate)(io.fromICache.req.bits.info(0).data))
   private val s0_rawSecondDataDupWire = VecInit(Seq.fill(NumCacheDataDuplicate)(io.fromICache.req.bits.info(1).data))
-  private val s0_firstEndIndex        = Wire(UInt(FetchBlockInstOffsetWidth.W))
-  private val s0_secondEndIndex       = Wire(UInt(FetchBlockInstOffsetWidth.W))
-  private val s0_secondStartIndex     = Wire(UInt(FetchBlockInstOffsetWidth.W))
+  private val s0_firstEndIndex        = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
+  private val s0_secondEndIndex       = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
+  private val s0_secondStartIndex     = Wire(UInt(log2Ceil(ICacheLineBytes / 2).W))
   s0_firstEndIndex := io.fromICache.req.bits.info(0).startVAddr(
-    log2Ceil(ICacheLineBytes) - 1,
+    log2Ceil(ICacheLineBytes / 2),
     instOffsetBits
   ) + io.fromICache.req.bits.info(0).takenCfiOffset.bits
   s0_secondEndIndex := io.fromICache.req.bits.info(1).startVAddr(
-    log2Ceil(ICacheLineBytes) - 1,
+    log2Ceil(ICacheLineBytes / 2),
     instOffsetBits
   ) + io.fromICache.req.bits.info(1).takenCfiOffset.bits
-  s0_secondStartIndex := io.fromICache.req.bits.info(1).startVAddr(log2Ceil(ICacheLineBytes) - 1, instOffsetBits)
+  s0_secondStartIndex := io.fromICache.req.bits.info(1).startVAddr(log2Ceil(ICacheLineBytes / 2), instOffsetBits)
   /* --------------------------------------------------------------------------------------------------------------
      stage 1
      - cat half rvi instruction

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -127,12 +127,12 @@ class Ifu(implicit p: Parameters) extends IfuModule
 
   io.fromICache.req.ready := s1_ready || s0_flush
 
-  private val s0_fetchBlock = VecInit(io.fromICache.req.bits.map(req => Wire(new FetchBlock).fromICacheReq(req)))
+  private val s0_fetchBlock = VecInit(io.fromICache.req.bits.info.map(req => Wire(new FetchBlock).fromICacheReq(req)))
 
   dontTouch(s0_fetchBlock)
 
   private val s0_icacheData = Wire(new IfuData).fromICacheReq(io.fromICache.req.bits)
-  private val s0_icacheMeta = VecInit(io.fromICache.req.bits.map(_.icacheMeta))
+  private val s0_icacheMeta = VecInit(io.fromICache.req.bits.info.map(_.icacheMeta))
 
   s0_flushFromBpu := fromFtq.flushFromBpu.shouldFlushByStage3(s0_fetchBlock(0).ftqIdx, s0_valid)
 

--- a/src/main/scala/xiangshan/frontend/ifu/InstrBoundary.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/InstrBoundary.scala
@@ -26,7 +26,7 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
       val valid:               Bool            = Bool()
       val firstInstrIsHalfRvi: Bool            = Bool()
       val fetchBlock:          Vec[FetchBlock] = Vec(MaxFetchReqNum, new FetchBlock)
-      val icacheData:          IfuData         = new IfuData
+      val ifuData:             IfuData         = new IfuData
       val totalEndPos:         UInt            = UInt(FetchBlockInstOffsetWidth.W)
     }
     class Resp(implicit p: Parameters) extends IfuBundle {
@@ -40,15 +40,15 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
   }
   val io: InstrBoundaryIO = IO(new InstrBoundaryIO)
 
-  private val data     = io.req.icacheData.data
-  private val range    = io.req.icacheData.range
-  private val maybeRvc = io.req.icacheData.maybeRvcMap
-  private val blockSel = io.req.icacheData.blockSel
+  private val index    = io.req.ifuData.index
+  private val range    = io.req.ifuData.range
+  private val maybeRvc = io.req.ifuData.maybeRvcMap
+  private val blockSel = io.req.ifuData.blockSel
 
   // We compute the boundaries of instructions in the first half of the fetch block directly, and compute the boundaries
   // of instructions in the latter half in two cases in parallel. Then we can choose the correct case according to
   // whether the last instruction in the first half is a 16-bit instruction or not.
-  private val boundary            = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(false.B)))
+  private val boundary = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(false.B)))
   private val latterHalfBoundary1 = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(false.B)))
   private val latterHalfBoundary2 = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(false.B)))
 
@@ -96,17 +96,18 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
       else isStart
     } && range(i)
 
-    instr.data := {
-      if (i == FetchBlockInstNum - 1)
-        Cat(0.U(16.W), data(i))
-      else
-        Cat(data(i + 1), data(i))
-    }
+    instr.index := index(i)
+    instr.data  := 0.U
 
     instr.isRvc := isStart && maybeRvc(i)
-    // Not involved in the instruction delimiting logic; timing impact should be controllable.
-    val fixedBlockSel = blockSel(i) || (crossBlockFallThrough && !maybeRvc(i))
-    instr.blockSel := fixedBlockSel
+    // After repeated and careful trade-offs, we decided to postpone the blockSel judgment for instructions that cross a FetchBlock.
+    // 1: If we set blockSel to 1 for such a crossing instruction here, we would need to adjust startOffset and endOffset accordingly – that is fine.
+    // 2: We need to fetch the corresponding instruction from the FetchBlock by index. The fetch logic reads 4 bytes sequentially.
+    // Even if we change blockSel to 1, no matter how we adjust the index, we would still have to combine isCrossBlockInstr and
+    // take data from FetchBlock0 and FetchBlock1 separately to assemble the instruction that spans two FetchBlocks.
+    // Why not extract the instruction data directly inside InstrBoundary? Logically it is possible, but hard to meet timing constraints.
+    // 3: Since we cannot resolve this cleanly in one place, we might as well compute the final result at the point of use by combining isCrossBlockInstr and blockSel.
+    instr.blockSel := blockSel(i)
 
     instr.isPredTaken       := false.B
     instr.invalidTaken      := false.B
@@ -114,7 +115,7 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
     instr.isCrossBlockInstr := crossBlockFallThrough && !maybeRvc(i)
 
     val startOffset = Mux(
-      fixedBlockSel,
+      blockSel(i),
       i.U(FetchBlockInstOffsetWidth.W) - io.req.fetchBlock(0).size,
       i.U(FetchBlockInstOffsetWidth.W)
     )

--- a/src/main/scala/xiangshan/frontend/ifu/InstrBoundary.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/InstrBoundary.scala
@@ -41,14 +41,13 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
   val io: InstrBoundaryIO = IO(new InstrBoundaryIO)
 
   private val index    = io.req.ifuData.index
-  private val range    = io.req.ifuData.range
   private val maybeRvc = io.req.ifuData.maybeRvcMap
   private val blockSel = io.req.ifuData.blockSel
 
   // We compute the boundaries of instructions in the first half of the fetch block directly, and compute the boundaries
   // of instructions in the latter half in two cases in parallel. Then we can choose the correct case according to
   // whether the last instruction in the first half is a 16-bit instruction or not.
-  private val boundary = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(false.B)))
+  private val boundary            = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(false.B)))
   private val latterHalfBoundary1 = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(false.B)))
   private val latterHalfBoundary2 = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(false.B)))
 
@@ -94,7 +93,7 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
       if (i == 0)
         io.req.firstInstrIsHalfRvi || isStart
       else isStart
-    } && range(i)
+    }
 
     instr.index := index(i)
     instr.data  := 0.U
@@ -125,15 +124,15 @@ class InstrBoundary(implicit p: Parameters) extends IfuModule with PreDecodeHelp
     instr
   }
 
-  io.resp.instrEndMask := boundary.zip(maybeRvc.asBools).zip(range.asBools).map { case ((boundary, isRvc), range) =>
-    (!boundary || (boundary && isRvc)) && range
+  io.resp.instrEndMask := boundary.zip(maybeRvc.asBools).map { case (boundary, isRvc) =>
+    !boundary || (boundary && isRvc)
   }
 
   private val firstEndPos = io.req.fetchBlock(0).takenCfiOffset.bits
-  io.resp.firstEndIsHalfRvi := range(firstEndPos) && boundary(firstEndPos) && !maybeRvc(firstEndPos)
+  io.resp.firstEndIsHalfRvi := boundary(firstEndPos) && !maybeRvc(firstEndPos)
 
   private val totalEndPos = io.req.totalEndPos
-  io.resp.totalEndIsHalfRvi := range(totalEndPos) && boundary(totalEndPos) && !maybeRvc(totalEndPos)
+  io.resp.totalEndIsHalfRvi := boundary(totalEndPos) && !maybeRvc(totalEndPos)
 
   // For differential test only. Will be optimized out in release
   private val boundDiff = WireInit(VecInit(Seq.fill(FetchBlockInstNum)(false.B)))

--- a/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
@@ -27,9 +27,10 @@ trait HasIfuParameters extends HasFrontendParameters {
 
   def ICacheLineBytes: Int = frontendParameters.icacheParameters.blockBytes
   // equal lower_result overflow bit
-  def PcCutPoint:    Int = ifuParameters.PcCutPoint.getOrElse((VAddrBits / 4) - 1)
-  def IfuAlignWidth: Int = frontendParameters.ibufferParameters.NumWriteBank
-  def IfuIdxWidth:   Int = log2Ceil(IBufferEnqueueWidth)
+  def PcCutPoint:            Int = ifuParameters.PcCutPoint.getOrElse((VAddrBits / 4) - 1)
+  def IfuAlignWidth:         Int = frontendParameters.ibufferParameters.NumWriteBank
+  def IfuIdxWidth:           Int = log2Ceil(IBufferEnqueueWidth)
+  def NumCacheDataDuplicate: Int = 2
 
   require(PcCutPoint > 0 && PcCutPoint < VAddrBits, s"PcCutPoint($PcCutPoint) must be in range (0, $VAddrBits)")
 }

--- a/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Parameters.scala
@@ -27,10 +27,8 @@ trait HasIfuParameters extends HasFrontendParameters {
 
   def ICacheLineBytes: Int = frontendParameters.icacheParameters.blockBytes
   // equal lower_result overflow bit
-  def PcCutPoint:            Int = ifuParameters.PcCutPoint.getOrElse((VAddrBits / 4) - 1)
-  def IfuAlignWidth:         Int = frontendParameters.ibufferParameters.NumWriteBank
-  def IfuIdxWidth:           Int = log2Ceil(IBufferEnqueueWidth)
-  def NumCacheDataDuplicate: Int = 2
+  def PcCutPoint:    Int = ifuParameters.PcCutPoint.getOrElse((VAddrBits / 4) - 1)
+  def IfuAlignWidth: Int = frontendParameters.ibufferParameters.NumWriteBank
 
   require(PcCutPoint > 0 && PcCutPoint < VAddrBits, s"PcCutPoint($PcCutPoint) must be in range (0, $VAddrBits)")
 }

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -141,10 +141,11 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   private val finalIsRVC        = instrVec(mispredIdx.bits).isRvc
   private val finalInvalidTaken = invalidTaken(mispredIdx.bits)
   private val finalNotCfiTaken  = notCfiTaken(mispredIdx.bits)
-  private val finalSelectBlock  = instrVec(mispredIdx.bits).blockSel
+  private val finalBlockSel     = instrVec(mispredIdx.bits).blockSel
   private val finalPc           = instrPcVec(mispredIdx.bits)
   private val finalAttribute    = pdInfoVec(mispredIdx.bits).brAttribute
   private val fixedTaken        = fixedTakenVec(mispredIdx.bits)
+  private val finalIsCrossBlockInstr = instrVec(mispredIdx.bits).isCrossBlockInstr
 
   // The actual end of the prediction block is the instruction before invalidTaken.
   private val endOffset = endOffsetVec(mispredIdx.bits)
@@ -161,7 +162,9 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   private val endOffsetNext        = RegEnable(endOffset, io.req.valid)
   private val finalPcNext          = RegEnable(finalPc, io.req.valid)
   private val fixedTakenNext       = RegEnable(fixedTaken, io.req.valid)
-  private val wbValid              = RegNext(io.req.valid, init = false.B)
+  private val finalBlockSelNext    = RegEnable(finalBlockSel, io.req.valid)
+  private val finalIsCrossBlockInstrNext = RegEnable(finalIsCrossBlockInstr, io.req.valid)
+  private val wbValid                    = RegNext(io.req.valid, init = false.B)
 
   private val fixedTarget = Mux(
     fixedIsJumpNext,
@@ -175,7 +178,8 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   io.resp.stage2Out.checkerRedirect.bits.taken        := fixedTakenNext
   io.resp.stage2Out.checkerRedirect.bits.isRVC        := finalIsRVCNext
   io.resp.stage2Out.checkerRedirect.bits.attribute    := Mux(invalidTakenNext, BranchAttribute.None, finalAttributeNext)
-  io.resp.stage2Out.checkerRedirect.bits.selectBlock  := finalSelectBlockNext
+  io.resp.stage2Out.checkerRedirect.bits.blockSel          := finalBlockSelNext
+  io.resp.stage2Out.checkerRedirect.bits.isCrossBlockInstr := finalIsCrossBlockInstrNext
   io.resp.stage2Out.checkerRedirect.bits.invalidTaken := invalidTakenNext
   io.resp.stage2Out.checkerRedirect.bits.notCfiTaken  := notCfiTakenNext
   io.resp.stage2Out.checkerRedirect.bits.mispredPc    := finalPcNext.unGuard
@@ -199,6 +203,6 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
     )
   )
 
-  io.resp.stage2Out.perfFaultType(0) := Mux(!finalSelectBlockNext, faultType, PreDecodeFaultType.NoFault)
-  io.resp.stage2Out.perfFaultType(1) := Mux(finalSelectBlockNext, faultType, PreDecodeFaultType.NoFault)
+  io.resp.stage2Out.perfFaultType(0) := Mux(!finalBlockSelNext, faultType, PreDecodeFaultType.NoFault)
+  io.resp.stage2Out.perfFaultType(1) := Mux(finalBlockSelNext, faultType, PreDecodeFaultType.NoFault)
 }

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -151,6 +151,7 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   private val endOffset = endOffsetVec(mispredIdx.bits)
 
   private val mispredIdxNext             = RegEnable(mispredIdx, io.req.valid)
+  private val fixedTakenNext             = RegEnable(fixedTaken, io.req.valid)
   private val finalIsRVCNext             = RegEnable(finalIsRVC, io.req.valid)
   private val finalAttributeNext         = RegEnable(finalAttribute, io.req.valid)
   private val invalidTakenNext           = RegEnable(finalInvalidTaken, io.req.valid)
@@ -174,7 +175,7 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   io.resp.stage2Out.checkerRedirect.valid          := mispredIdxNext.valid && wbValid
   io.resp.stage2Out.checkerRedirect.bits.target    := fixedTarget
   io.resp.stage2Out.checkerRedirect.bits.misIdx    := mispredIdxNext
-  io.resp.stage2Out.checkerRedirect.bits.taken     := fixedTakenNext
+  io.resp.stage2Out.checkerRedirect.bits.taken     := fixedTakenNext && mispredIdxNext.valid && wbValid
   io.resp.stage2Out.checkerRedirect.bits.isRVC     := finalIsRVCNext
   io.resp.stage2Out.checkerRedirect.bits.attribute := Mux(invalidTakenNext, BranchAttribute.None, finalAttributeNext)
   io.resp.stage2Out.checkerRedirect.bits.blockSel  := finalBlockSelNext

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -138,31 +138,30 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
       mispredIdx.valid &&
       (pdInfoVec(mispredIdx.bits).isJal || pdInfoVec(mispredIdx.bits).isBr)
 
-  private val finalIsRVC        = instrVec(mispredIdx.bits).isRvc
-  private val finalInvalidTaken = invalidTaken(mispredIdx.bits)
-  private val finalNotCfiTaken  = notCfiTaken(mispredIdx.bits)
-  private val finalBlockSel     = instrVec(mispredIdx.bits).blockSel
-  private val finalPc           = instrPcVec(mispredIdx.bits)
-  private val finalAttribute    = pdInfoVec(mispredIdx.bits).brAttribute
-  private val fixedTaken        = fixedTakenVec(mispredIdx.bits)
+  private val finalIsRVC             = instrVec(mispredIdx.bits).isRvc
+  private val finalInvalidTaken      = invalidTaken(mispredIdx.bits)
+  private val finalNotCfiTaken       = notCfiTaken(mispredIdx.bits)
+  private val finalBlockSel          = instrVec(mispredIdx.bits).blockSel
+  private val finalPc                = instrPcVec(mispredIdx.bits)
+  private val finalAttribute         = pdInfoVec(mispredIdx.bits).brAttribute
+  private val fixedTaken             = fixedTakenVec(mispredIdx.bits)
   private val finalIsCrossBlockInstr = instrVec(mispredIdx.bits).isCrossBlockInstr
 
   // The actual end of the prediction block is the instruction before invalidTaken.
   private val endOffset = endOffsetVec(mispredIdx.bits)
 
-  private val mispredIdxNext       = RegEnable(mispredIdx, io.req.valid)
-  private val finalIsRVCNext       = RegEnable(finalIsRVC, io.req.valid)
-  private val finalAttributeNext   = RegEnable(finalAttribute, io.req.valid)
-  private val invalidTakenNext     = RegEnable(finalInvalidTaken, io.req.valid)
-  private val notCfiTakenNext      = RegEnable(finalNotCfiTaken, io.req.valid)
-  private val finalSelectBlockNext = RegEnable(finalSelectBlock, io.req.valid)
-  private val jumpTargetsNext      = RegEnable(jumpTargets, io.req.valid)
-  private val seqTargetsNext       = RegEnable(seqTargets, io.req.valid)
-  private val fixedIsJumpNext      = RegEnable(fixedIsJump, io.req.valid)
-  private val endOffsetNext        = RegEnable(endOffset, io.req.valid)
-  private val finalPcNext          = RegEnable(finalPc, io.req.valid)
-  private val fixedTakenNext       = RegEnable(fixedTaken, io.req.valid)
-  private val finalBlockSelNext    = RegEnable(finalBlockSel, io.req.valid)
+  private val mispredIdxNext             = RegEnable(mispredIdx, io.req.valid)
+  private val finalIsRVCNext             = RegEnable(finalIsRVC, io.req.valid)
+  private val finalAttributeNext         = RegEnable(finalAttribute, io.req.valid)
+  private val invalidTakenNext           = RegEnable(finalInvalidTaken, io.req.valid)
+  private val notCfiTakenNext            = RegEnable(finalNotCfiTaken, io.req.valid)
+  private val jumpTargetsNext            = RegEnable(jumpTargets, io.req.valid)
+  private val seqTargetsNext             = RegEnable(seqTargets, io.req.valid)
+  private val fixedIsJumpNext            = RegEnable(fixedIsJump, io.req.valid)
+  private val endOffsetNext              = RegEnable(endOffset, io.req.valid)
+  private val finalPcNext                = RegEnable(finalPc, io.req.valid)
+  private val fixedTakenNext             = RegEnable(fixedTaken, io.req.valid)
+  private val finalBlockSelNext          = RegEnable(finalBlockSel, io.req.valid)
   private val finalIsCrossBlockInstrNext = RegEnable(finalIsCrossBlockInstr, io.req.valid)
   private val wbValid                    = RegNext(io.req.valid, init = false.B)
 
@@ -172,13 +171,13 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
     seqTargetsNext(mispredIdxNext.bits)
   )
 
-  io.resp.stage2Out.checkerRedirect.valid             := mispredIdxNext.valid && wbValid
-  io.resp.stage2Out.checkerRedirect.bits.target       := fixedTarget
-  io.resp.stage2Out.checkerRedirect.bits.misIdx       := mispredIdxNext
-  io.resp.stage2Out.checkerRedirect.bits.taken        := fixedTakenNext
-  io.resp.stage2Out.checkerRedirect.bits.isRVC        := finalIsRVCNext
-  io.resp.stage2Out.checkerRedirect.bits.attribute    := Mux(invalidTakenNext, BranchAttribute.None, finalAttributeNext)
-  io.resp.stage2Out.checkerRedirect.bits.blockSel          := finalBlockSelNext
+  io.resp.stage2Out.checkerRedirect.valid          := mispredIdxNext.valid && wbValid
+  io.resp.stage2Out.checkerRedirect.bits.target    := fixedTarget
+  io.resp.stage2Out.checkerRedirect.bits.misIdx    := mispredIdxNext
+  io.resp.stage2Out.checkerRedirect.bits.taken     := fixedTakenNext
+  io.resp.stage2Out.checkerRedirect.bits.isRVC     := finalIsRVCNext
+  io.resp.stage2Out.checkerRedirect.bits.attribute := Mux(invalidTakenNext, BranchAttribute.None, finalAttributeNext)
+  io.resp.stage2Out.checkerRedirect.bits.blockSel  := finalBlockSelNext
   io.resp.stage2Out.checkerRedirect.bits.isCrossBlockInstr := finalIsCrossBlockInstrNext
   io.resp.stage2Out.checkerRedirect.bits.invalidTaken := invalidTakenNext
   io.resp.stage2Out.checkerRedirect.bits.notCfiTaken  := notCfiTakenNext

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -151,7 +151,6 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   private val endOffset = endOffsetVec(mispredIdx.bits)
 
   private val mispredIdxNext             = RegEnable(mispredIdx, io.req.valid)
-  private val fixedTakenNext             = RegEnable(fixedTaken, io.req.valid)
   private val finalIsRVCNext             = RegEnable(finalIsRVC, io.req.valid)
   private val finalAttributeNext         = RegEnable(finalAttribute, io.req.valid)
   private val invalidTakenNext           = RegEnable(finalInvalidTaken, io.req.valid)

--- a/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/PredChecker.scala
@@ -179,9 +179,9 @@ class PredChecker(implicit p: Parameters) extends IfuModule {
   io.resp.stage2Out.checkerRedirect.bits.attribute := Mux(invalidTakenNext, BranchAttribute.None, finalAttributeNext)
   io.resp.stage2Out.checkerRedirect.bits.blockSel  := finalBlockSelNext
   io.resp.stage2Out.checkerRedirect.bits.isCrossBlockInstr := finalIsCrossBlockInstrNext
-  io.resp.stage2Out.checkerRedirect.bits.invalidTaken := invalidTakenNext
-  io.resp.stage2Out.checkerRedirect.bits.notCfiTaken  := notCfiTakenNext
-  io.resp.stage2Out.checkerRedirect.bits.mispredPc    := finalPcNext.unGuard
+  io.resp.stage2Out.checkerRedirect.bits.invalidTaken      := invalidTakenNext
+  io.resp.stage2Out.checkerRedirect.bits.notCfiTaken       := notCfiTakenNext
+  io.resp.stage2Out.checkerRedirect.bits.mispredPc         := finalPcNext.unGuard
   // FIXME: Not a reliable block-end marker; special cases may have only half a branch predicted.(invalidTaken)
   io.resp.stage2Out.checkerRedirect.bits.endOffset := endOffsetNext
 


### PR DESCRIPTION
~~This needs to wait until PR #6219 is merged.~~

1. Migrate the pre-decode logic to alleviate the timing pressure on the interface between the IFU and the IBuffer.
2. Shift the maybeRvc computation into the ICache to ease the interface timing pressure between the ICache and the IFU.
3. Register the ICache data for one cycle and adjust the valid instruction extraction logic to relieve the S0 stage pressure in the IFU.