### PR TITLE
timing(ICache): fix timing of 2-fetch related logic

### DIFF
--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -19,8 +19,8 @@ import chisel3._
 import chisel3.util._
 import ftq.BpuFlushInfo
 import ftq.FtqPtr
+import ftq.FtqToMainPipeBundle
 import ftq.FtqToPrefetchBundle
-import ftq.FtqToWayLookupBundle
 import org.chipsalliance.cde.config.Parameters
 import utility.InstSeqNum
 import utility.XSError
@@ -104,18 +104,16 @@ class FtqFetchRequest(implicit p: Parameters) extends FrontendBundle with HasICa
   def startVAddr:          PrunedAddr      = vAddr(0)
   def nextLineVAddr:       PrunedAddr      = vAddr(1)
   val takenCfiOffset:      Valid[UInt]     = Valid(UInt(CfiPositionWidth.W))
-  val isCrossLine:         Bool            = Bool()
   val ftqIdx:              FtqPtr          = new FtqPtr
-  val bankSel:             Vec[UInt]       = Vec(PortNumber, UInt(DataBanks.W))
   val vSetIdx:             Vec[UInt]       = Vec(PortNumber, UInt(idxBits.W))
   val hasBackendException: Bool            = Bool()
 }
 
 class FtqToICacheIO(implicit p: Parameters) extends FrontendBundle {
-  val toPrefetch:    DecoupledIO[FtqToPrefetchBundle]  = Decoupled(new FtqToPrefetchBundle)
-  val toWayLookup:   DecoupledIO[FtqToWayLookupBundle] = Decoupled(new FtqToWayLookupBundle)
-  val flushFromBpu:  BpuFlushInfo                      = new BpuFlushInfo
-  val redirectFlush: Bool                              = Output(Bool())
+  val toPrefetch:    DecoupledIO[FtqToPrefetchBundle] = Decoupled(new FtqToPrefetchBundle)
+  val toMainPipe:    DecoupledIO[FtqToMainPipeBundle] = Decoupled(new FtqToMainPipeBundle)
+  val flushFromBpu:  BpuFlushInfo                     = new BpuFlushInfo
+  val redirectFlush: Bool                             = Output(Bool())
 }
 
 class ICacheToIfuIO(implicit p: Parameters) extends FrontendBundle with HasICacheParameters {

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -222,9 +222,8 @@ class FrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBase(
 
   // ICache-Ftq
   icache.io.fromFtq <> ftq.io.toICache
-  ftq.io.fromICache.fromPrefetch  := icache.io.toFtq.fromPrefetch
-  ftq.io.fromICache.fromWayLookup := icache.io.toFtq.fromWayLookup
-  icache.io.flush                 := DontCare
+  ftq.io.fromICache.fromMainPipe := icache.io.toFtq.fromMainPipe
+  icache.io.flush                := DontCare
 
   // Ifu-ICache
   ifu.io.fromICache <> icache.io.toIfu

--- a/src/main/scala/xiangshan/frontend/TwoFetch.scala
+++ b/src/main/scala/xiangshan/frontend/TwoFetch.scala
@@ -17,12 +17,9 @@ package xiangshan.frontend
 
 import chisel3._
 import chisel3.util._
-import ftq.FtqBundle
 import ftq.FtqPrefetchReq
-import icache.HasICacheParameters
 import icache.MetaInfo
 import icache.PrefetchReqBundle
-import org.chipsalliance.cde.config.Parameters
 import utils.EnumUInt
 
 // As 2-prefetch / 2-fetch support is spread across Ftq/Ifu/ICache,
@@ -148,9 +145,4 @@ object TwoPrefetchCase {
      */
     def Interleave: UInt = 8.U(width.W)
   }
-}
-
-class TwoFetchInfo(implicit p: Parameters) extends FtqBundle with HasICacheParameters {
-  val isMmio:  Bool      = Bool()
-  val wayMask: Vec[UInt] = Vec(PortNumber, UInt(nWays.W))
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -28,7 +28,6 @@ import xiangshan.frontend.bpu.BpuPerfMeta
 import xiangshan.frontend.bpu.BranchAttribute
 import xiangshan.frontend.bpu.BranchInfo
 import xiangshan.frontend.icache.ICacheCacheLineHelper
-import xiangshan.frontend.icache.ICacheDataHelper
 import xiangshan.frontend.icache.PrefetchReqBundle
 
 class FtqEntry(implicit p: Parameters) extends FtqBundle {
@@ -110,7 +109,7 @@ class FtqToPrefetchBundle(implicit p: Parameters) extends FtqBundle {
   val twoPrefetchCase: TwoPrefetchCase        = new TwoPrefetchCase
 }
 
-class FtqToWayLookupBundle(implicit p: Parameters) extends FtqBundle {
+class FtqToMainPipeBundle(implicit p: Parameters) extends FtqBundle {
   val req: Vec[FtqFetchRequest] = Vec(MaxFetchReqNum, new FtqFetchRequest)
 }
 
@@ -133,26 +132,21 @@ class FtqPrefetchReq(implicit p: Parameters) extends FtqBundle with ICacheCacheL
   }
 }
 
-class FtqFetchReq(implicit p: Parameters) extends FtqBundle with ICacheDataHelper with ICacheCacheLineHelper {
-  val startVAddr:     PrunedAddr = PrunedAddr(VAddrBits)
-  val nextLineVAddr:  PrunedAddr = PrunedAddr(VAddrBits)
-  val takenCfiOffset: UInt       = UInt(CfiPositionWidth.W)
-  val isCrossLine:    Bool       = Bool()
-  val bankSel:        Vec[UInt]  = Vec(PortNumber, UInt(DataBanks.W))
-  val vSetIdx:        Vec[UInt]  = Vec(PortNumber, UInt(idxBits.W))
-  val size:           UInt       = UInt((log2Ceil(FetchBlockInstNum) + 1).W)
-  val vPageNumber:    UInt       = UInt((VAddrBits - PageOffsetWidth).W)
+class FtqFetchReq(implicit p: Parameters) extends FtqBundle with ICacheCacheLineHelper {
+  val startVAddr:     PrunedAddr  = PrunedAddr(VAddrBits)
+  val nextLineVAddr:  PrunedAddr  = PrunedAddr(VAddrBits)
+  val takenCfiOffset: Valid[UInt] = Valid(UInt(CfiPositionWidth.W))
+  val vSetIdx:        Vec[UInt]   = Vec(PortNumber, UInt(idxBits.W))
+  val size:           UInt        = UInt((log2Ceil(FetchBlockInstNum) + 1).W)
+  val vPageNumber:    UInt        = UInt((VAddrBits - PageOffsetWidth).W)
 
   def fromFtqEntry(entry: FtqEntry): FtqFetchReq = {
-    val (isCrossLine, bankSel) = getBankSel(startVAddr, takenCfiOffset)
-    startVAddr       := entry.startPc
-    nextLineVAddr    := entry.startPc + blockBytes.U
-    takenCfiOffset   := entry.takenCfiOffset.bits
-    this.isCrossLine := isCrossLine
-    this.bankSel     := bankSel
-    vSetIdx          := VecInit(get_idx(startVAddr), get_idx(nextLineVAddr))
-    size             := entry.takenCfiOffset.bits +& 1.U
-    vPageNumber      := entry.startPc(VAddrBits - 1, PageOffsetWidth)
+    startVAddr     := entry.startPc
+    nextLineVAddr  := entry.startPc + blockBytes.U
+    takenCfiOffset := entry.takenCfiOffset
+    vSetIdx        := VecInit(get_idx(startVAddr), get_idx(startVAddr) + 1.U)
+    size           := entry.takenCfiOffset.bits +& 1.U
+    vPageNumber    := entry.startPc(VAddrBits - 1, PageOffsetWidth)
     this
   }
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -59,6 +59,7 @@ import xiangshan.frontend.bpu.BranchInfo
 import xiangshan.frontend.bpu.HalfAlignHelper
 import xiangshan.frontend.icache.ICacheCacheLineHelper
 import xiangshan.frontend.icache.ICacheToFtqIO
+import xiangshan.frontend.icache.TwoFetchFailReason
 
 class Ftq(implicit p: Parameters) extends FtqModule
     with HalfAlignHelper
@@ -218,8 +219,8 @@ class Ftq(implicit p: Parameters) extends FtqModule
     val twoPrefetchValid = io.toICache.toPrefetch.bits.twoPrefetchCase.valid
     pfPtr := Mux(twoPrefetchValid, pfPtr + 2.U, pfPtr + 1.U)
   }
-  when(io.toICache.toWayLookup.fire) {
-    fetchPtr := Mux(io.fromICache.fromWayLookup.realTwoFetchValid, fetchPtr + 2.U, fetchPtr + 1.U)
+  when(io.toICache.toMainPipe.fire) {
+    fetchPtr := Mux(io.fromICache.fromMainPipe.realTwoFetchValid, fetchPtr + 2.U, fetchPtr + 1.U)
   }
 
   // TODO: wait for Ifu/ICache to remove bpu s2 flush
@@ -278,6 +279,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
     req.startVAddr       := prefetchReq(i).startVAddr
     req.nextLineVAddr    := req.startVAddr + blockBytes.U
     req.isCrossLine      := prefetchReq(i).isCrossLine
+    req.takenCfiOffset   := prefetchReq(i).takenCfiOffset
     req.ftqIdx           := pfPtr(i)
     req.backendException := Mux(backendExceptionPtr === pfPtr(i), backendException, ExceptionType.None)
     req.isSoftPrefetch   := false.B
@@ -300,16 +302,14 @@ class Ftq(implicit p: Parameters) extends FtqModule
       backendExceptionPtr === fetchPtr(0) || backendExceptionPtr === fetchPtr(1)
     ))
 
-  io.toICache.toWayLookup.valid := bpuPtr(0) > fetchPtr(0) && !redirect.valid &&
+  io.toICache.toMainPipe.valid := bpuPtr(0) > fetchPtr(0) && !redirect.valid &&
     distanceBetween(fetchPtr(0), commitPtr(0)) < (FtqSize - 1).U
-  io.toICache.toWayLookup.bits.req.zipWithIndex.foreach { case (req, i) =>
+  io.toICache.toMainPipe.bits.req.zipWithIndex.foreach { case (req, i) =>
     req.valid               := (if (i == 0) true.B else rawTwoFetchValid)
     req.startVAddr          := fetchReq(i).startVAddr
     req.nextLineVAddr       := fetchReq(i).nextLineVAddr
-    req.takenCfiOffset      := entryQueue(fetchPtr(i).value).takenCfiOffset
-    req.isCrossLine         := fetchReq(i).isCrossLine
+    req.takenCfiOffset      := fetchReq(i).takenCfiOffset
     req.ftqIdx              := fetchPtr(i)
-    req.bankSel             := fetchReq(i).bankSel
     req.vSetIdx             := fetchReq(i).vSetIdx
     req.hasBackendException := backendException.hasException && backendExceptionPtr === fetchPtr(i)
   }
@@ -688,30 +688,26 @@ class Ftq(implicit p: Parameters) extends FtqModule
   )
   XSPerfAccumulate(
     "total_fetch",
-    io.toICache.toWayLookup.fire
+    io.toICache.toMainPipe.fire
   )
   XSPerfAccumulate(
     "1fetch",
-    io.toICache.toWayLookup.fire && !io.fromICache.fromWayLookup.realTwoFetchValid
+    io.toICache.toMainPipe.fire && !io.fromICache.fromMainPipe.realTwoFetchValid
   )
   XSPerfAccumulate(
     "2fetch",
-    io.toICache.toWayLookup.fire && io.fromICache.fromWayLookup.realTwoFetchValid
+    io.toICache.toMainPipe.fire && io.fromICache.fromMainPipe.realTwoFetchValid
   )
   XSPerfSeqAccumulate(
     "2fetch_fail_reason",
-    io.toICache.toWayLookup.fire && !io.fromICache.fromWayLookup.realTwoFetchValid,
+    io.toICache.toMainPipe.fire && !io.fromICache.fromMainPipe.realTwoFetchValid,
     Seq(
       ("fb_not_enough", distanceBetween(bpuPtr(0), fetchPtr(0)) <= 3.U),
       ("fb1_exception", backendException.hasException && backendExceptionPtr === fetchPtr(0)),
       ("fb2_exception", backendException.hasException && backendExceptionPtr === fetchPtr(1)),
       ("total_size", (fetchReq(0).size +& fetchReq(1).size) > FetchBlockInstNum.U),
-      ("page_conflict", fetchReq(0).vPageNumber =/= fetchReq(1).vPageNumber),
-      ("can_not_serve_two_meta", io.fromICache.fromWayLookup.perf_canNotServeTwoMeta),
-      ("sram_conflict", io.fromICache.fromWayLookup.perf_dataSramReadConflict),
-      ("has_mmio", io.fromICache.fromWayLookup.perf_hasMmio),
-      ("has_itlb_exception", io.fromICache.fromWayLookup.perf_hasItlbException)
-    ),
+      ("page_conflict", fetchReq(0).vPageNumber =/= fetchReq(1).vPageNumber)
+    ) ++ TwoFetchFailReason.getValidSeq(io.fromICache.fromMainPipe.perf_twoFetchFailReason),
     withPriority = true
   )
 }

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -20,6 +20,7 @@ import chisel3.util._
 import freechips.rocketchip.tilelink.TLBundleA
 import freechips.rocketchip.tilelink.TLEdgeOut
 import org.chipsalliance.cde.config.Parameters
+import utils.EnumUInt
 import xiangshan.SoftIfetchPrefetchBundle
 import xiangshan.backend.fu.PMPReqBundle
 import xiangshan.backend.fu.PMPRespBundle
@@ -28,7 +29,6 @@ import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.FetchRequestBundle
 import xiangshan.frontend.FtqFetchRequest
 import xiangshan.frontend.PrunedAddr
-import xiangshan.frontend.TwoFetchInfo
 import xiangshan.frontend.ftq.FtqPtr
 import xiangshan.frontend.ifu.IfuBundle
 
@@ -240,8 +240,11 @@ class MainPipeToIfuIO(implicit p: Parameters) extends ICacheBundle {
 }
 
 class WayLookupToMainPipeBundle(implicit p: Parameters) extends ICacheBundle {
-  val req:           Vec[FtqFetchRequest] = Vec(FetchPorts, new FtqFetchRequest)
-  val wayLookupInfo: Vec[WayLookupBundle] = Vec(FetchPorts, new WayLookupBundle)
+  val wayLookupInfo: Vec[Valid[WayLookupBundle]] = Vec(FetchPorts, Valid(new WayLookupBundle))
+}
+
+class MainPipeToWayLookupBundle(implicit p: Parameters) extends ICacheBundle {
+  val realTwoFetchValid: Bool = Bool()
 }
 
 /* ***** PrefetchPipe ***** */
@@ -249,6 +252,7 @@ class PrefetchReqBundle(implicit p: Parameters) extends ICacheBundle {
   val startVAddr:       PrunedAddr    = PrunedAddr(VAddrBits)
   val nextLineVAddr:    PrunedAddr    = PrunedAddr(VAddrBits)
   val isCrossLine:      Bool          = Bool()
+  val takenCfiOffset:   UInt          = UInt(CfiPositionWidth.W)
   val ftqIdx:           FtqPtr        = new FtqPtr
   val backendException: ExceptionType = new ExceptionType
   val isSoftPrefetch:   Bool          = Bool()
@@ -257,6 +261,7 @@ class PrefetchReqBundle(implicit p: Parameters) extends ICacheBundle {
     startVAddr       := req.vaddr
     nextLineVAddr    := DontCare
     isCrossLine      := false.B // prefetch only one line for a prefetch.i instruction
+    takenCfiOffset   := 0.U
     ftqIdx           := DontCare
     backendException := ExceptionType.None
     isSoftPrefetch   := true.B
@@ -273,6 +278,8 @@ class PrefetchReqBundle(implicit p: Parameters) extends ICacheBundle {
  */
 class WayLookupEntry(implicit p: Parameters) extends ICacheBundle {
   val vSetIdx:     Vec[UInt] = Vec(PortNumber, UInt(idxBits.W))
+  val bankSel:     Vec[UInt] = Vec(PortNumber, UInt(DataBanks.W))
+  val isCrossLine: Bool      = Bool()
   val waymask:     Vec[UInt] = Vec(PortNumber, UInt(nWays.W))
   val maybeRvcMap: Vec[UInt] = Vec(PortNumber, UInt(MaxInstNumPerBlock.W))
   val metaCodes:   Vec[UInt] = Vec(PortNumber, UInt(MetaEccBits.W))
@@ -419,21 +426,22 @@ class WayLookupPerfInfo(implicit p: Parameters) extends ICacheBundle {
   val empty: Bool = Bool()
 }
 
-class PrefetchToFtqBundle(implicit p: Parameters) extends ICacheBundle {
-  val ftqIdx:       FtqPtr                   = new FtqPtr
-  val twoFetchInfo: Vec[Valid[TwoFetchInfo]] = Vec(2, Valid(new TwoFetchInfo))
-}
-
 class ICacheToFtqIO(implicit p: Parameters) extends ICacheBundle {
-  val fromPrefetch:  Valid[PrefetchToFtqBundle] = Valid(new PrefetchToFtqBundle)
-  val fromWayLookup: WayLookupToFtqBundle       = Output(new WayLookupToFtqBundle)
+  val fromMainPipe: MainPipeToFtqBundle = Output(new MainPipeToFtqBundle)
 }
 
-class WayLookupToFtqBundle(implicit p: Parameters) extends ICacheBundle {
+object TwoFetchFailReason extends EnumUInt(4) {
+  def NoMeta:           UInt = 0.U(width.W)
+  def DataConflict:     UInt = 1.U(width.W)
+  def HasMmio:          UInt = 2.U(width.W)
+  def HasItlbException: UInt = 3.U(width.W)
+
+  def apply(noMeta: Bool, dataConflict: Bool, hasMmio: Bool, hasItlbException: Bool): UInt =
+    PriorityEncoder(Seq(noMeta, dataConflict, hasMmio, hasItlbException))
+}
+
+class MainPipeToFtqBundle(implicit p: Parameters) extends ICacheBundle {
   val realTwoFetchValid: Bool = Bool()
 
-  val perf_canNotServeTwoMeta:   Bool = Bool()
-  val perf_dataSramReadConflict: Bool = Bool()
-  val perf_hasMmio:              Bool = Bool()
-  val perf_hasItlbException:     Bool = Bool()
+  val perf_twoFetchFailReason: UInt = TwoFetchFailReason()
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheDataArray.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheDataArray.scala
@@ -35,22 +35,16 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheModule with ICacheDa
   /* *** read *** */
   private val r0_valid = io.read.req.valid
   private val r0_req   = io.read.req.bits
-  dontTouch(r0_req)
 
   io.read.req.ready := banks.map(_.io.read.req.ready).reduce(_ && _)
 
   // Save req->(bank, way) ownership to route SRAM response back per-req in the next cycle.
   private val r0_reqPerBankWayMask = Wire(Vec(MaxFetchReqNum, Vec(DataBanks, UInt(nWays.W))))
-  dontTouch(r0_reqPerBankWayMask)
 
   banks.zipWithIndex.foreach { case (bank, bankIdx) =>
     val reqReadBankValid = Wire(Vec(MaxFetchReqNum, Bool())).suggestName(s"bank_${bankIdx}_reqReadBankValid")
     val reqReadSetIdx    = Wire(Vec(MaxFetchReqNum, UInt(idxBits.W))).suggestName(s"bank_${bankIdx}_reqReadSetIdx")
     val reqReadWayValid  = Wire(Vec(MaxFetchReqNum, UInt(nWays.W))).suggestName(s"bank_${bankIdx}_reqReadWayValid")
-
-    dontTouch(reqReadBankValid)
-    dontTouch(reqReadSetIdx)
-    dontTouch(reqReadWayValid)
 
     (0 until MaxFetchReqNum).foreach { i =>
       val lineSelOH = Cat(r0_req(i).bits.bankSel(1)(bankIdx), r0_req(i).bits.bankSel(0)(bankIdx))
@@ -67,9 +61,6 @@ class ICacheDataArray(implicit p: Parameters) extends ICacheModule with ICacheDa
 
     val perWayReadValid  = Wire(Vec(nWays, Bool())).suggestName(s"bank_${bankIdx}_perWayReadValid")
     val perWayReadSetIdx = Wire(Vec(nWays, UInt(idxBits.W))).suggestName(s"bank_${bankIdx}_perWayReadSetIdx")
-
-    dontTouch(perWayReadValid)
-    dontTouch(perWayReadSetIdx)
 
     (0 until nWays).foreach { wayIdx =>
       val reqSel = VecInit((0 until MaxFetchReqNum).map(reqIdx => reqReadWayValid(reqIdx)(wayIdx)))

--- a/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
@@ -176,8 +176,6 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   prefetcher.io.fromFtq.bits        := io.fromFtq.toPrefetch.bits
   prefetcher.io.fromFtq.bits.req(0) := Mux(softPrefetchValid, softPrefetch, io.fromFtq.toPrefetch.bits.req(0))
   io.fromFtq.toPrefetch.ready       := prefetcher.io.fromFtq.ready && !softPrefetchValid
-  io.toFtq.fromPrefetch             := prefetcher.io.toFtq
-  io.toFtq.fromWayLookup            := wayLookup.io.toFtq
 
   missUnit.io.hartId := io.hartId
   missUnit.io.fencei := io.fencei
@@ -194,11 +192,13 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   mainPipe.io.eccEnable    := eccEnable
   mainPipe.io.hartId       := io.hartId
   mainPipe.io.missResp     := missUnit.io.resp
+  mainPipe.io.fromFtq <> io.fromFtq.toMainPipe
   mainPipe.io.fromWayLookup <> wayLookup.io.toMainPipe
+  io.toFtq.fromMainPipe := mainPipe.io.toFtq
 
   wayLookup.io.flush        := io.fromFtq.redirectFlush
   wayLookup.io.flushFromBpu := io.fromFtq.flushFromBpu
-  wayLookup.io.fromFtq <> io.fromFtq.toWayLookup
+  wayLookup.io.fromMainPipe := mainPipe.io.toWayLookup
   wayLookup.io.write <> prefetcher.io.wayLookupWrite
   wayLookup.io.update := missUnit.io.resp
 
@@ -212,7 +212,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   io.itlbFlushPipe := prefetcher.io.itlbFlushPipe
 
   // notify IFU that Icache pipeline is available
-  io.toIfu.fetchReady := wayLookup.io.fromFtq.ready
+  io.toIfu.fetchReady := io.fromFtq.toMainPipe.ready
 
   // send final accepted fetch bundle
   io.toIfu.req <> mainPipe.io.toIfu.req

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -31,6 +31,7 @@ import xiangshan.cache.mmu.TlbCmd
 import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.ftq.BpuFlushInfo
+import xiangshan.frontend.ftq.FtqToMainPipeBundle
 
 class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     with ICacheEccHelper
@@ -45,7 +46,10 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     val dataRead:      DataReadBundle                         = new DataReadBundle
     val metaFlush:     MetaFlushBundle                        = new MetaFlushBundle
     val replacerTouch: ReplacerTouchBundle                    = new ReplacerTouchBundle
+    val fromFtq:       DecoupledIO[FtqToMainPipeBundle]       = Flipped(DecoupledIO(new FtqToMainPipeBundle))
     val fromWayLookup: DecoupledIO[WayLookupToMainPipeBundle] = Flipped(DecoupledIO(new WayLookupToMainPipeBundle))
+    val toWayLookup:   MainPipeToWayLookupBundle              = Output(new MainPipeToWayLookupBundle)
+    val toFtq:         MainPipeToFtqBundle                    = Output(new MainPipeToFtqBundle)
     val missReq:       DecoupledIO[MissReqBundle]             = DecoupledIO(new MissReqBundle)
     val missResp:      Valid[MissRespBundle]                  = Flipped(ValidIO(new MissRespBundle))
     val eccEnable:     Bool                                   = Input(Bool())
@@ -98,20 +102,75 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
    */
 
   /** s0 control */
-  private val s0_valid = io.fromWayLookup.valid
-  private val s0_req   = io.fromWayLookup.bits.req
+  private val s0_valid = io.fromFtq.valid && io.fromWayLookup.valid
+  private val s0_req   = WireDefault(io.fromFtq.bits.req)
 
   private val s0_ftqIdx = s0_req(0).ftqIdx
 
-  private val s0_wayLookupEntry = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.entry))
-  private val s0_exceptionInfo  = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.exceptionEntry))
+  private val s0_wayLookupEntry = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.entry))
+  private val s0_exceptionInfo  = VecInit(io.fromWayLookup.bits.wayLookupInfo.map(_.bits.exceptionEntry))
   private val s0_wayMask        = VecInit(s0_wayLookupEntry.map(_.waymask))
+
+  private val s0_dataSramReadConflict = {
+    val reqValid = io.fromFtq.bits.req.map(_.valid).reduce(_ && _)
+    // Each request may read its current line or next line, so check all four cross-request line pairs.
+    val linePairConflict = for {
+      req0LineIdx <- 0 until MaxFetchReqNum
+      req1LineIdx <- 0 until MaxFetchReqNum
+    } yield {
+      val bankOverlap =
+        (s0_wayLookupEntry(0).bankSel(req0LineIdx) & s0_wayLookupEntry(1).bankSel(req1LineIdx)).orR
+      val sameWay =
+        s0_wayLookupEntry(0).waymask(req0LineIdx) === s0_wayLookupEntry(1).waymask(req1LineIdx)
+      val differentSet =
+        s0_wayLookupEntry(0).vSetIdx(req0LineIdx) =/= s0_wayLookupEntry(1).vSetIdx(req1LineIdx)
+
+      bankOverlap && sameWay && differentSet
+    }
+
+    reqValid && linePairConflict.reduce(_ || _)
+  }
+
+  private val s0_hasMmio          = s0_wayLookupEntry.map(_.isMmio).reduce(_ || _)
+  private val s0_hasItlbException = s0_exceptionInfo.map(_.itlbException.hasException).reduce(_ || _)
+  private val s0_realTwoFetchValid = io.fromFtq.bits.req(1).valid && io.fromWayLookup.bits.wayLookupInfo(1).valid &&
+    !s0_dataSramReadConflict && !s0_hasMmio && !s0_hasItlbException
+
+  s0_req(1).valid := s0_realTwoFetchValid
 
   s0_flush := io.flush || io.flushFromBpu.shouldFlushByStage3(s0_ftqIdx, s0_valid)
 
-  io.fromWayLookup.ready := toData.ready && s1_ready && !s0_flush
+  private val s0_canAccept = toData.ready && s1_ready
+  io.fromFtq.ready       := s0_canAccept && io.fromWayLookup.valid && !s0_flush
+  io.fromWayLookup.ready := s0_canAccept && io.fromFtq.valid && !s0_flush
 
-  s0_fire := io.fromWayLookup.fire
+  io.toWayLookup.realTwoFetchValid := s0_realTwoFetchValid
+  io.toFtq.realTwoFetchValid       := s0_realTwoFetchValid
+
+  io.toFtq.perf_twoFetchFailReason :=
+    TwoFetchFailReason(
+      !io.fromWayLookup.bits.wayLookupInfo(1).valid,
+      s0_dataSramReadConflict,
+      s0_hasMmio,
+      s0_hasItlbException
+    )
+
+  s0_fire := io.fromFtq.fire
+
+  if (!env.FPGAPlatform) {
+    (0 until MaxFetchReqNum).foreach { i =>
+      when(s0_fire && s0_req(i).valid) {
+        assert(
+          s0_wayLookupEntry(i).debug_ftqIdx.get === s0_req(i).ftqIdx,
+          "ICache MainPipe: wayLookupEntry ftqIdx mismatch"
+        )
+        assert(
+          s0_wayLookupEntry(i).debug_startVAddr.get === s0_req(i).startVAddr,
+          "ICache MainPipe: wayLookupEntry startVAddr mismatch"
+        )
+      }
+    }
+  }
 
   /**
     ******************************************************************************
@@ -122,7 +181,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   toData.valid := s0_valid && s1_ready && !s0_flush
   toData.bits.zipWithIndex.foreach { case (readReq, i) =>
     readReq.valid        := s0_req(i).valid
-    readReq.bits.bankSel := s0_req(i).bankSel
+    readReq.bits.bankSel := s0_wayLookupEntry(i).bankSel
     readReq.bits.waymask := s0_wayMask(i)
     readReq.bits.vSetIdx := s0_req(i).vSetIdx
   }
@@ -139,7 +198,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_wayLookupEntry = RegEnable(s0_wayLookupEntry, s0_fire)
   private val s1_exceptionInfo  = RegEnable(s0_exceptionInfo, s0_fire)
 
-  private val s1_wayMask = VecInit(s1_wayLookupEntry.map(_.waymask))
+  private val s1_wayMask     = VecInit(s1_wayLookupEntry.map(_.waymask))
+  private val s1_isCrossLine = VecInit(s1_wayLookupEntry.map(_.isCrossLine))
 
   private val s1_pTag   = s1_wayLookupEntry(0).pTag
   private val s1_ftqIdx = s1_req(0).ftqIdx
@@ -160,7 +220,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
 
   private val s1_sramRespValid = RegNext(s0_fire)
   private val s1_lineValid = VecInit((0 until MaxFetchReqNum).map { i =>
-    VecInit(s1_req(i).valid, s1_req(i).valid && s1_req(i).isCrossLine)
+    VecInit(s1_req(i).valid, s1_req(i).valid && s1_isCrossLine(i))
   })
   private val s1_sramValid = VecInit((0 until MaxFetchReqNum).map { i =>
     VecInit(s1_lineValid(i).map(s1_sramRespValid && _))
@@ -180,8 +240,6 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     )
   })
 
-  dontTouch(s1_mshrValid)
-
   private val s1_bankMshrValid = VecInit((0 until MaxFetchReqNum).map { i =>
     getBankValid(s1_mshrValid(i), s1_offset(i))
   })
@@ -196,8 +254,6 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
       )
     })
   })
-
-  dontTouch(s1_hits)
 
   private val s1_data = VecInit((0 until MaxFetchReqNum).map { reqIdx =>
     VecInit((0 until DataBanks).map { bankIdx =>
@@ -255,8 +311,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     io.replacerTouch.req(i).bits.vSetIdx := s1_req(0).vSetIdx(i)                      // FIXME
     io.replacerTouch.req(i).bits.way     := OHToUInt(s1_wayLookupEntry(0).waymask(i)) // FIXME
   }
-  io.replacerTouch.req(0).valid := RegNext(s0_fire) && s1_sramHits(0)(0)                          // FIXME
-  io.replacerTouch.req(1).valid := RegNext(s0_fire) && s1_sramHits(0)(1) && s1_req(0).isCrossLine // FIXME
+  io.replacerTouch.req(0).valid := RegNext(s0_fire) && s1_sramHits(0)(0)                      // FIXME
+  io.replacerTouch.req(1).valid := RegNext(s0_fire) && s1_sramHits(0)(1) && s1_isCrossLine(0) // FIXME
 
   /* *** PMP check (to be removed) *** */
   // if itlb has exception, pAddr can be invalid, therefore pmp check can be skipped do not do this now for timing
@@ -271,7 +327,6 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_exception = s1_exceptionInfo(0).itlbException || s1_pmpException
 
   private val s1_vAddr = VecInit(s1_req.flatMap(req => req.vAddr))
-  dontTouch(s1_vAddr)
 
   /* *** Fetch when miss or corrupt *** */
   // do not fetch if is mmio
@@ -310,7 +365,6 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   XSPerfAccumulate("to_missUnit_stall", toMiss.valid && !toMiss.ready)
 
   private val s1_fetchFinish = !s1_shouldFetch.reduce(_ || _)
-  dontTouch(s1_fetchFinish)
 
   private val s1_portValid = VecInit(s1_lineValid.flatten)
 
@@ -337,7 +391,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     req.size             := s1_req(i).takenCfiOffset.bits +& 1.U
     req.data             := s1_data(i)
     req.maybeRvcMap      := s1_maybeRvcMap(i)
-    req.perf_isCrossLine := s1_req(i).isCrossLine
+    req.perf_isCrossLine := s1_isCrossLine(i)
 
     req.icacheMeta.exception          := s1_exceptionOut
     req.icacheMeta.pmpMmio            := s1_pmpMmio
@@ -369,6 +423,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s2_offset         = RegEnable(s1_offset, s1_fire)
   private val s2_bankSramValid  = RegEnable(s1_bankSramValid, s1_fire)
   private val s2_sramHits       = RegEnable(s1_sramHits, s1_fire)
+  private val s2_isCrossLine    = RegEnable(s1_isCrossLine, s1_fire)
 
   // make corrupt-related info as a bundle for easier selection
   private class CorruptedInfo extends Bundle {
@@ -385,14 +440,14 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
       s2_wayLookupEntry(reqIdx).metaCodes,
       s2_wayMask(reqIdx),
       eccEnable,
-      s2_req(reqIdx).isCrossLine
+      s2_isCrossLine(reqIdx)
     )
 
     val dataCorrupt = checkDataEcc(
       s2_sramDatas(reqIdx),
       s2_sramCodes(reqIdx),
       eccEnable,
-      getBankSel(s2_offset(reqIdx), s2_valid, s2_req(reqIdx).isCrossLine),
+      getBankSel(s2_offset(reqIdx), s2_valid, s2_isCrossLine(reqIdx)),
       s2_bankSramValid(reqIdx),
       s2_sramHits(reqIdx)
     )
@@ -405,7 +460,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
      */
     when(s2_valid) {
       assert(
-        !(!s2_req(reqIdx).isCrossLine && (metaCorrupt(1) || dataCorrupt(1))),
+        !(!s2_isCrossLine(reqIdx) && (metaCorrupt(1) || dataCorrupt(1))),
         "meta or data corrupt detected on line 1 but s2_isCrossLine is false.B"
       )
     }
@@ -498,7 +553,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   accessTrace.vAddr      := s1_vAddr(0).toUInt
   accessTrace.pAddr      := getPAddrFromPTag(s1_vAddr(0), s1_pTag).toUInt
   accessTrace.wayMask    := s1_wayMask(0)
-  accessTrace.crossLine  := s1_req(0).isCrossLine
+  accessTrace.crossLine  := s1_isCrossLine(0)
   accessTrace.waitRefill := perf_waitRefill
   accessTrace.exception  := s1_exceptionOut
   accessTrace.pmpMmio    := s1_pmpMmio

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -43,7 +43,6 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     val flush:       Bool = Input(Bool())
 
     val fromFtq:       DecoupledIO[FtqToPrefetchBundle] = Flipped(Decoupled(new FtqToPrefetchBundle))
-    val toFtq:         Valid[PrefetchToFtqBundle]       = Valid(new PrefetchToFtqBundle)
     val flushFromBpu:  BpuFlushInfo                     = Flipped(new BpuFlushInfo)
     val itlb:          TlbRequestIO                     = new TlbRequestIO
     val itlbFlushPipe: Bool                             = Output(Bool())
@@ -293,6 +292,8 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
   // Disallow enqueuing wayLookup when SRAM write occurs.
   toWayLookup.zipWithIndex.foreach { case (port, i) =>
+    val (isCrossLine, bankSel) = getBankSel(s1_req(i).startVAddr, s1_req(i).takenCfiOffset)
+
     port.valid :=
       // tlb/meta ready
       ((s1_state === S1FsmState.EnqWay) || ((s1_state === S1FsmState.Idle) && tlbFinish)) &&
@@ -307,6 +308,8 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
     port.bits.ftqIdx            := s1_req(i).ftqIdx
     port.bits.entry.vSetIdx     := VecInit(get_idx(s1_req(i).startVAddr), get_idx(s1_req(i).nextLineVAddr))
+    port.bits.entry.bankSel     := bankSel
+    port.bits.entry.isCrossLine := isCrossLine
     port.bits.entry.waymask     := VecInit(s1_reqMetaInfo(i).map(_.waymask))
     port.bits.entry.pTag        := s1_pTag
     port.bits.entry.maybeRvcMap := VecInit(s1_reqMetaInfo(i).map(_.maybeRvcMap))
@@ -356,15 +359,6 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
   // merge pmp mmio and itlb pbmt
   s1_isMmio := s1_pmpMmio || Pbmt.isUncache(s1_itlbPbmt)
-
-  io.toFtq.valid                             := s1_fire && !s1_isSoftPrefetch
-  io.toFtq.bits.ftqIdx                       := s1_ftqIdx
-  io.toFtq.bits.twoFetchInfo(0).valid        := true.B
-  io.toFtq.bits.twoFetchInfo(0).bits.isMmio  := s1_isMmio
-  io.toFtq.bits.twoFetchInfo(0).bits.wayMask := VecInit(s1_reqMetaInfo(0).map(_.waymask))
-  io.toFtq.bits.twoFetchInfo(1).valid        := s1_twoPrefetchCase.valid
-  io.toFtq.bits.twoFetchInfo(1).bits.isMmio  := s1_isMmio
-  io.toFtq.bits.twoFetchInfo(1).bits.wayMask := VecInit(s1_reqMetaInfo(1).map(_.waymask))
 
   /**
     ******************************************************************************

--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -26,7 +26,6 @@ import utility.XSPerfHistogram
 import utility.XSPerfSeqAccumulate
 import xiangshan.frontend.ftq.BpuFlushInfo
 import xiangshan.frontend.ftq.FtqPtr
-import xiangshan.frontend.ftq.FtqToWayLookupBundle
 
 class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     with ICacheMissUpdateHelper
@@ -36,10 +35,8 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     val flush:        Bool         = Input(Bool())
     val flushFromBpu: BpuFlushInfo = Input(new BpuFlushInfo)
 
-    val fromFtq: DecoupledIO[FtqToWayLookupBundle] = Flipped(Decoupled(new FtqToWayLookupBundle))
-    val toFtq:   WayLookupToFtqBundle              = Output(new WayLookupToFtqBundle)
-
-    val toMainPipe: DecoupledIO[WayLookupToMainPipeBundle] = DecoupledIO(new WayLookupToMainPipeBundle)
+    val toMainPipe:   DecoupledIO[WayLookupToMainPipeBundle] = DecoupledIO(new WayLookupToMainPipeBundle)
+    val fromMainPipe: MainPipeToWayLookupBundle              = Input(new MainPipeToWayLookupBundle)
 
     val write: Vec[DecoupledIO[WayLookupWriteBundle]] = Vec(FetchPorts, Flipped(DecoupledIO(new WayLookupWriteBundle)))
 
@@ -70,11 +67,9 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
 
   private val numValidEntries = distanceBetween(writePtr, readPtr)
   private val numFreeEntries  = WayLookupSize.U - numValidEntries
-  dontTouch(numValidEntries)
-  dontTouch(numFreeEntries)
 
   // NOTE: May be unportable, we have bp3 == pf2 now, and WayLookup is written in pf1,
-  // so the tailing 0 (already bypassed to if1) or 1 (if1 stall, stored here) entries might be flushed by bp3,
+  // so up to one tail entry still in WayLookup might be flushed by bp3,
   // therefore, when shouldFlushByStage3, we need to move back writePtr by 0 (empty) or 1.
   // If in future we have bp4 (or even more) flush, this might not be enough.
   // NOTE: With 2-prefetch, writePtr - 2.U still does not need to be flushed,
@@ -97,7 +92,8 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     readPtr.value := 0.U
     readPtr.flag  := false.B
   }.elsewhen(io.toMainPipe.fire) {
-    readPtr := readPtr + Mux(io.toFtq.realTwoFetchValid, 2.U, 1.U)
+    val deqCnt = Mux(io.fromMainPipe.realTwoFetchValid, 2.U, 1.U)
+    readPtr := readPtr + deqCnt
   }
 
   when(io.flush) {
@@ -110,9 +106,6 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
   // we can store only the first exception encountered, as exceptions must trigger a redirection (and thus a flush)
   private val exceptionEntry = RegInit(0.U.asTypeOf(Valid(new WayLookupExceptionEntry)))
   private val exceptionPtr   = RegInit(ICacheWayLookupPtr(false.B, 0.U))
-  private val exceptionHit = VecInit((0 until MaxFetchReqNum).map { i =>
-    exceptionPtr === (readPtr + i.U) && exceptionEntry.valid
-  })
 
   when(io.flush || bpuS3FlushValid && exceptionPtr === bpuS3FlushPtr) {
     // When flushed by bp3
@@ -139,63 +132,23 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
   private val updateStall = VecInit((0 until MaxFetchReqNum).map(i => entryUpdate((readPtr + i.U).value)))
 
   /* *** read *** */
-  private val secondWriteValid = if (FetchPorts == 1) false.B else io.write(1).valid
-  private val fetchReq         = io.fromFtq.bits.req
-
-  private val canDeq       = !empty && !updateStall(0)
-  private val canDeqSecond = numValidEntries > 1.U && !updateStall(0) && !updateStall(1)
+  private val canDeq    = !empty && !updateStall(0)
+  private val canDeqTwo = numValidEntries > 1.U && !updateStall(0) && !updateStall(1)
 
   private val fetchReqEntry = VecInit((0 until MaxFetchReqNum).map(i => entries((readPtr + i.U).value)))
   private val fetchReqExceptionEntry = VecInit((0 until MaxFetchReqNum).map { i =>
-    Mux(exceptionHit(i), exceptionEntry.bits, 0.U.asTypeOf(new WayLookupExceptionEntry))
+    Mux(
+      exceptionEntry.valid && exceptionPtr === (readPtr + i.U),
+      exceptionEntry.bits,
+      0.U.asTypeOf(new WayLookupExceptionEntry)
+    )
   })
 
-  private val isDataSramReadConflict = (0 until DataBanks).map { bankIdx =>
-    val reqReadInfo = (0 until MaxFetchReqNum).map { i =>
-      val lineSelOH = Cat(fetchReq(i).bankSel(1)(bankIdx), fetchReq(i).bankSel(0)(bankIdx))
-      val readValid = lineSelOH.orR && fetchReq(i).valid
-      val wayMask   = Mux1H(lineSelOH, fetchReqEntry(i).waymask) & Fill(nWays, readValid)
-      val setIdx    = Mux1H(lineSelOH, fetchReq(i).vSetIdx)
-      (readValid, wayMask, setIdx)
-    }
-
-    reqReadInfo.map(_._1).reduce(_ && _) &&    // read same bank
-    reqReadInfo(0)._2 === reqReadInfo(1)._2 && // read same way
-    reqReadInfo(0)._3 =/= reqReadInfo(1)._3    // read different set
-  }.reduce(_ || _)
-
-  private val hasMmio          = fetchReqEntry.map(_.isMmio).reduce(_ || _)
-  private val hasItlbException = exceptionHit.reduce(_ || _)
-
-  private val realTwoFetchValid = fetchReq(1).valid && canDeqSecond &&
-    !isDataSramReadConflict && !hasMmio && !hasItlbException
-
-  io.toFtq.realTwoFetchValid         := realTwoFetchValid
-  io.toFtq.perf_canNotServeTwoMeta   := !canDeqSecond
-  io.toFtq.perf_dataSramReadConflict := isDataSramReadConflict
-  io.toFtq.perf_hasMmio              := hasMmio
-  io.toFtq.perf_hasItlbException     := hasItlbException
-
-  io.fromFtq.ready := io.toMainPipe.ready && canDeq && !io.flush
-
-  io.toMainPipe.valid             := io.fromFtq.valid && canDeq && !io.flush
-  io.toMainPipe.bits.req          := fetchReq
-  io.toMainPipe.bits.req(1).valid := realTwoFetchValid
-
+  io.toMainPipe.valid := canDeq && !io.flush
   io.toMainPipe.bits.wayLookupInfo.zipWithIndex.foreach { case (info, i) =>
-    info.entry          := fetchReqEntry(i)
-    info.exceptionEntry := fetchReqExceptionEntry(i)
-  }
-
-  if (!env.FPGAPlatform) {
-    when(io.toMainPipe.fire) {
-      assert(io.toMainPipe.bits.wayLookupInfo(0).entry.debug_ftqIdx.get === fetchReq(0).ftqIdx)
-      assert(io.toMainPipe.bits.wayLookupInfo(0).entry.debug_startVAddr.get === fetchReq(0).startVAddr)
-      when(realTwoFetchValid) {
-        assert(io.toMainPipe.bits.wayLookupInfo(1).entry.debug_ftqIdx.get === fetchReq(1).ftqIdx)
-        assert(io.toMainPipe.bits.wayLookupInfo(1).entry.debug_startVAddr.get === fetchReq(1).startVAddr)
-      }
-    }
+    info.valid               := (if (i == 0) true.B else canDeqTwo)
+    info.bits.entry          := fetchReqEntry(i)
+    info.bits.exceptionEntry := fetchReqExceptionEntry(i)
   }
 
   /**


### PR DESCRIPTION
wait #6044 


This PR:
1. Stores `bankSel` and `isCrossLine` in `wayLookup` to avoid introducing their computation into the critical handshake path between `Ftq` and `MainPipe`.
2. Moves the decision logic for `realTwoFetchValid` from `wayLookup` to `MainPipe`’s `s0`, and routes the `ready` signal from `MainPipe` to `Ftq` directly instead of passing through `WayLookup`.