### PR TITLE
fix(MMU, COVE) : remove test code for mpt and bitmap

### DIFF
--- a/src/main/resources/config/Default.yml
+++ b/src/main/resources/config/Default.yml
@@ -85,5 +85,3 @@ CVMParams:
   HasDelayNoencryption: false
 
 EnableBitmapCheck: true
-
-EnableBitmapCheckDefault: false

--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -504,8 +504,7 @@ class CVMCompile extends Config((site, here, up) => {
     HasDelayNoencryption = false
   )
   case XSTileKey => up(XSTileKey).map(_.copy(
-    HasBitmapCheck = true,
-    HasBitmapCheckDefault = false))
+    HasBitmapCheck = true))
 })
 
 class CVMTestCompile extends Config((site, here, up) => {
@@ -515,8 +514,7 @@ class CVMTestCompile extends Config((site, here, up) => {
     HasDelayNoencryption = true
   )
   case XSTileKey => up(XSTileKey).map(_.copy(
-    HasBitmapCheck =true,
-    HasBitmapCheckDefault = true))
+    HasBitmapCheck =true))
 })
 
 class MinimalAliasDebugConfig(n: Int = 1) extends Config(

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -60,7 +60,6 @@ case class YamlConfig(
   CHIAddrWidth: Option[Int],
   CVMParams: Option[CVMParameters],
   EnableBitmapCheck: Option[Boolean],
-  EnableBitmapCheckDefault: Option[Boolean],
 )
 
 object YamlParser {

--- a/src/main/scala/top/YamlParser.scala
+++ b/src/main/scala/top/YamlParser.scala
@@ -208,11 +208,6 @@ object YamlParser {
         case XSTileKey => up(XSTileKey).map(_.copy(HasBitmapCheck = enable))
       })
     }
-    yamlConfig.EnableBitmapCheckDefault.foreach { enable =>
-      newConfig = newConfig.alter((site, here, up) => {
-        case XSTileKey => up(XSTileKey).map(_.copy(HasBitmapCheckDefault = enable))
-      })
-    }
     newConfig
   }
 }

--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -54,11 +54,7 @@ case class XSCoreParameters
   ELEN: Int = 64,
   HSXLEN: Int = 64,
   HasMptCheck: Boolean = false, //enable mpt
-  HasMptCheckDefault: Boolean = false, // hardwired testing code: fake 2M MPT table
-  HasMptCheckDefault4k: Boolean = false, // hardwired testing code: fake 4k MPT table
-  HasMptInodeOpt: Boolean = false, // hardwired testing code: skip mpt check for non-leaf ptw nodes
   HasBitmapCheck: Boolean = true,
-  HasBitmapCheckDefault: Boolean = false,
   HasMExtension: Boolean = true,
   HasCExtension: Boolean = true,
   HasHExtension: Boolean = true,
@@ -583,11 +579,7 @@ trait HasXSParameter {
   val xLen = XLEN
   assert(!(HasMptCheck == true && HasBitmapCheck == true), "Conflicts: MPT and Bitmap can't be used together")
   def HasMptCheck = coreParams.HasMptCheck && !coreParams.HasBitmapCheck
-  def HasMptCheckDefault = coreParams.HasMptCheckDefault
-  def HasMptCheckDefault4k = coreParams.HasMptCheckDefault4k
-  def HasMptInodeOpt = coreParams.HasMptInodeOpt
   def HasBitmapCheck = coreParams.HasBitmapCheck
-  def HasBitmapCheckDefault = coreParams.HasBitmapCheckDefault
 
   /** prefetch config */
   def prefetcherSeq = coreParams.prefetcher

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/MachineLevel.scala
@@ -24,15 +24,9 @@ trait MachineLevel { self: NewCSR =>
   // Machine level Custom Read/Write
   val mbmc = if (HasBitmapCheck) Some(Module(new CSRModule("Mbmc", new MbmcBundle) {
     val mbmc_lock = reg.BME.asBool
-    if (!HasBitmapCheckDefault) {
-      reg.BME := Mux(wen && !mbmc_lock, wdata.BME, reg.BME)
-      reg.CMODE := Mux(wen, wdata.CMODE, reg.CMODE)
-      reg.BMA := Mux(wen && !mbmc_lock, wdata.BMA, reg.BMA)
-    } else {
-      reg.BME := 1.U
-      reg.CMODE := 0.U
-      reg.BMA := BMAField.TestBMA
-    }
+    reg.BME := Mux(wen && !mbmc_lock, wdata.BME, reg.BME)
+    reg.CMODE := Mux(wen, wdata.CMODE, reg.CMODE)
+    reg.BMA := Mux(wen && !mbmc_lock, wdata.BMA, reg.BMA)
     reg.BCLEAR := Mux(reg.BCLEAR.asBool, 0.U, Mux(wen && wdata.BCLEAR.asBool, 1.U, 0.U))
     reg.KEYIDEN := Mux(wen, wdata.KEYIDEN, reg.KEYIDEN)
   })
@@ -40,30 +34,18 @@ trait MachineLevel { self: NewCSR =>
 
   val mmpt = if (HasMptCheck) Some(Module(new CSRModule("Mmpt", new MmptBundle) {
     val ppnMask = ZeroExt(Fill(PPNLengthMpt, 1.U(1.W)).take(PAddrBits - PageOffsetWidth), PPNLengthMpt)
-    if (!HasMptCheckDefault) {
-      when(wen) {
-        reg.SDID := wdata.SDID
-        reg.PPN := wdata.PPN & ppnMask
-        reg.optOutInNode := wdata.optOutInNode
-        when(wdata.MODE.isLegal) {
-          reg.MODE := wdata.MODE
-        }.otherwise {
-          reg.MODE := reg.MODE
-        }
+    when(wen) {
+      reg.SDID := wdata.SDID
+      reg.PPN := wdata.PPN & ppnMask
+      reg.optOutInNode := wdata.optOutInNode
+      when(wdata.MODE.isLegal) {
+        reg.MODE := wdata.MODE
       }.otherwise {
-        reg := reg
+        reg.MODE := reg.MODE
       }
-    } else {
-      reg.SDID := 0.U.asTypeOf(reg.SDID)
-      reg.PPN := "h00000080000".U(PPNLengthMpt.W) & ppnMask //for testing, will be removed later
-      if (HasMptInodeOpt) {
-        reg.optOutInNode := 1.U.asTypeOf(reg.optOutInNode)
-      } else {
-        reg.optOutInNode := 0.U.asTypeOf(reg.optOutInNode)
-      }
-      reg.MODE := 2.U.asTypeOf(reg.MODE)
+    }.otherwise {
+      reg := reg
     }
-
   })
     .setAddr(Mmpt)) else None
 

--- a/src/main/scala/xiangshan/cache/mmu/BitmapCheck.scala
+++ b/src/main/scala/xiangshan/cache/mmu/BitmapCheck.scala
@@ -145,13 +145,7 @@ class Bitmap(implicit p: Parameters) extends XSModule with HasPtwConst {
   val mem_arb = Module(new RRArbiterInit(new bitmapEntry(), l2tlbParams.llptwsize+2))
 
   val bitmapdata = Wire(Vec(blockBits / XLEN, UInt(XLEN.W)))
-  if (HasBitmapCheckDefault) {
-    for (i <- 0 until blockBits / XLEN) {
-      bitmapdata(i) := 0.U
-    }
-  } else {
-    bitmapdata := io.mem.resp.bits.value.asTypeOf(Vec(blockBits / XLEN, UInt(XLEN.W)))
-  }
+  bitmapdata := io.mem.resp.bits.value.asTypeOf(Vec(blockBits / XLEN, UInt(XLEN.W)))
 
   for (i <- 0 until l2tlbParams.llptwsize+2) {
     mem_arb.io.in(i).bits := entries(i)

--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -216,6 +216,11 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   val tlbCounter = RegInit(0.U(log2Ceil(MissQueueSize + 1).W))
   val reqVec = WireInit(VecInit(Seq.fill(PtwWidth)(false.B)))
   val respVec = WireInit(VecInit(Seq.fill(PtwWidth)(false.B)))
+  val arb1MptOnly = if (HasMptCheck) {
+    arb1.io.out.bits.mptOnly.get && mptEn.get
+  } else {
+    false.B
+  }
 
   for (i <- 0 until PtwWidth) {
     when (io.tlb(i).req(0).fire) {
@@ -237,7 +242,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
     mpt_arb.get.io.in(mptOnlyPort).bits.id := arb1.io.chosen // b101 + bx //tlb id to mptc id
     mpt_arb.get.io.in(mptOnlyPort).bits.mptOnly := true.B // used for l2tlb return control logic
     mpt_arb.get.io.in(mptOnlyPort).bits.reqPA := arb1.io.out.bits.vpn // for mpt only vpn is ppn
-    mpt_arb.get.io.in(mptOnlyPort).valid := arb1.io.out.fire && (arb1.io.out.bits.mptOnly.get) // valid when mptOnly and
+    mpt_arb.get.io.in(mptOnlyPort).valid := arb1.io.out.fire && arb1MptOnly // valid when mptOnly and
     // s2xlate is dont care, it has nothing to do with mpt
   }
 
@@ -249,7 +254,7 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   ptw.io.llptw.ready := arb2.io.in(InArbPTWPort).ready
   block_decoupled(missQueue.io.out, arb2.io.in(InArbMissQueuePort), Mux(missQueue.io.out.bits.isLLptw, !llptw.io.in.ready, !ptw.io.req.ready))
 
-  arb2.io.in(InArbTlbPort).valid := arb1.io.out.fire && (if (HasMptCheck) !(arb1.io.out.bits.mptOnly.get) else true.B)
+  arb2.io.in(InArbTlbPort).valid := arb1.io.out.fire && !arb1MptOnly
   // not mpt only req will go to l2tlb,mptOnly goes to mptc directly
   arb2.io.in(InArbTlbPort).bits.req_info.vpn := arb1.io.out.bits.vpn
   arb2.io.in(InArbTlbPort).bits.req_info.s2xlate := arb1.io.out.bits.s2xlate
@@ -260,9 +265,12 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   // 1. arb1 and arb2 are both comb logic, so ready can work just the same cycle
   // 2. arb1 can send one req at most in a cycle, so do not need to write
   //    "tlbCounter <= (MissQueueSize - 2).U"
-  arb1.io.out.ready := arb2.io.in(InArbTlbPort).ready && tlbCounter < MissQueueSize.U &&
-    (if (HasMptCheck) (mpt_arb.get.io.in(mptOnlyPort).ready) else true.B)
-  //arb1 out is ready when arb2 and mptc are both ready
+  val arb1TargetReady = if (HasMptCheck) {
+    Mux(arb1MptOnly, mpt_arb.get.io.in(mptOnlyPort).ready, arb2.io.in(InArbTlbPort).ready)
+  } else {
+    arb2.io.in(InArbTlbPort).ready
+  }
+  arb1.io.out.ready := tlbCounter < MissQueueSize.U && arb1TargetReady
   arb2.io.in(InArbHPTWPort).valid := hptw_req_arb.io.out.valid
   arb2.io.in(InArbHPTWPort).bits.req_info.vpn := hptw_req_arb.io.out.bits.gvpn
   arb2.io.in(InArbHPTWPort).bits.req_info.s2xlate := onlyStage2

--- a/src/main/scala/xiangshan/cache/mmu/MptChecker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MptChecker.scala
@@ -89,6 +89,7 @@ class MptOutputSwitchBox(implicit p: Parameters) extends XSModule with MPTCacheP
   val mptOutDataReg = Reg(new MptTlbRespBundle())
   val mptOutMptOnly = RegInit(false.B)
   val mptOutReqPA   = Reg(UInt(ppnLen.W))
+  val mptEn = io.csr.mmpt.mode =/= 0.U
 
   val flush = io.sfence.valid || io.csr.satp.changed || io.csr.vsatp.changed || io.csr.hgatp.changed ||
     io.csr.priv.virt_changed || (if (HasMptCheck) io.csr.mmpt.changed else false.B)
@@ -135,7 +136,7 @@ class MptOutputSwitchBox(implicit p: Parameters) extends XSModule with MPTCacheP
           nextState := s_send_l1_tlb
         }
       }.elsewhen(io.mergeArb.valid) { // normal mode, two modes are mutually exclusive
-        when(io.mergeArb.bits.fault) {
+        when(io.mergeArb.bits.fault || !mptEn) {
           io.l1TLB.valid := true.B
           when(io.l1TLB.ready) {
             io.mergeArb.ready := true.B

--- a/src/main/scala/xiangshan/cache/mmu/MptChecker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MptChecker.scala
@@ -1209,11 +1209,13 @@ class MptChecker(implicit p: Parameters) extends XSModule with HasPtwConst {
   mptMissQueueInst.csr <> io.csr
   mptMissQueueInst.sfence <> io.sfence
 
+  val mptEn = io.csr.mmpt.mode =/= 0.U
+
   mptCacheInst.req.bits.mptOnly := io.req.bits.mptOnly // need some fix
   mptCacheInst.req.bits.reqPA   := io.req.bits.reqPA
   mptCacheInst.req.bits.source  := io.req.bits.id
-  mptCacheInst.req.valid        := io.req.valid
-  io.req.ready                  := mptCacheInst.req.ready
+  mptCacheInst.req.valid        := io.req.valid && mptEn
+  io.req.ready                  := mptEn && mptCacheInst.req.ready
 
   val mptReturn = Wire(new MptRespBundle())
   mptReturn.mptPerm := Mux(mptMissQueueInst.resp.valid, mptMissQueueInst.resp.bits.perm, mptCacheInst.respHit.bits.perm)
@@ -1245,7 +1247,7 @@ class MptChecker(implicit p: Parameters) extends XSModule with HasPtwConst {
     mptCacheInst.respHit.bits.permIsNAPOT
   )
 
-  io.resp.valid := mptMissQueueInst.resp.valid || mptCacheInst.respHit.valid
+  io.resp.valid := mptEn && (mptMissQueueInst.resp.valid || mptCacheInst.respHit.valid)
   io.resp.bits <> mptReturn
 
   mptMissQueueInst.refill <> mptTWInst.refill
@@ -1255,8 +1257,8 @@ class MptChecker(implicit p: Parameters) extends XSModule with HasPtwConst {
   mptMissQueueInst.missCache.bits.hitAddr  := mptCacheInst.respMiss.bits.ppn
   mptMissQueueInst.missCache.bits.source   := mptCacheInst.respMiss.bits.source
   mptMissQueueInst.missCache.bits.pa       := mptCacheInst.respMiss.bits.pa
-  mptMissQueueInst.missCache.valid         := mptCacheInst.respMiss.valid
-  mptCacheInst.respMiss.ready              := mptMissQueueInst.missCache.ready
+  mptMissQueueInst.missCache.valid         := mptCacheInst.respMiss.valid && mptEn
+  mptCacheInst.respMiss.ready              := Mux(mptEn, mptMissQueueInst.missCache.ready, true.B)
   // cache refill io
   mptCacheInst.refill <> mptTWInst.refill
   // MptMissQueue-twio
@@ -1274,21 +1276,4 @@ class MptChecker(implicit p: Parameters) extends XSModule with HasPtwConst {
   mptTWInst.pmp.resp <> io.pmp.resp
   io.pmp.req <> mptTWInst.pmp.req
 
-  val mptDiabledFakedRespValid = RegInit(false.B)
-  val mptDiabledFakedMptOnly   = RegInit(false.B)
-  when(io.csr.mmpt.mode === 0.U) {
-    mptCacheInst.req.valid := false.B // mptmode  return 111
-
-    io.req.ready := true.B
-    when(io.req.fire) {
-      mptDiabledFakedRespValid := true.B
-      mptDiabledFakedMptOnly   := io.req.bits.mptOnly
-    }
-    io.resp.valid        := mptDiabledFakedRespValid
-    io.resp.bits.mptOnly := mptDiabledFakedMptOnly
-    when(io.resp.fire) {
-      mptDiabledFakedRespValid := false.B
-      mptDiabledFakedMptOnly   := false.B
-    }
-  }
 }

--- a/src/main/scala/xiangshan/cache/mmu/MptChecker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MptChecker.scala
@@ -269,46 +269,6 @@ class MptEntry(implicit p: Parameters) extends XSBundle with MPTCacheParam {
 
   def getAddr(offset: UInt): UInt =
     this.data.getAddr(offset)
-
-  def genFake(level: UInt): Unit = {
-    this.N         := false.B
-    this.data.data := "h802F4".U
-    this.L         := false.B
-    this.V         := true.B
-    switch(level) {
-      is("b1000".U) {
-        this.N         := false.B
-        this.data.data := "h802F4".U
-        this.L         := false.B
-        this.V         := true.B
-      }
-      is("b0100".U) {
-        this.N         := false.B
-        this.data.data := "h802F5".U
-        this.L         := false.B
-        this.V         := true.B
-      }
-      is("b0010".U) {
-        if (HasMptCheckDefault4k) {
-          this.N         := false.B
-          this.data.data := "h802F6".U
-          this.L         := false.B
-          this.V         := true.B
-        } else {
-          this.N         := false.B
-          this.data.data := "hFFFFFFFFFFFF".U
-          this.L         := true.B
-          this.V         := true.B
-        }
-      }
-      is("b0001".U) {
-        this.N         := false.B
-        this.data.data := "hFFFFFFFFFFFF".U
-        this.L         := true.B
-        this.V         := true.B
-      }
-    }
-  }
 }
 
 class MptCacheTag(tagLen: Int, isSp: Boolean = false)(implicit p: Parameters) extends XSBundle with MPTCacheParam {
@@ -1102,11 +1062,8 @@ class MPTTableWalker(implicit p: Parameters) extends XSModule with MPTCacheParam
   val pmpCheckLevel = RegEnable(nextPmpCheckLevel, "b1000".U(mptLevelLenOH.W), setPmpCheckLevel)
 
   val mpteResp = Wire(new MptEntry())
-  if (HasMptCheckDefault) {
-    mpteResp.genFake(level)
-  } else {
-    mpteResp.apply(mem.resp.bits) // mem mpte mpteData
-  }
+
+  mpteResp.apply(mem.resp.bits) // mem mpte mpteData
 
   val mpteData = Reg(new MptData())
   // Stores the returned permissions/lower-level address, or the incoming request address entry;
@@ -1141,10 +1098,9 @@ class MPTTableWalker(implicit p: Parameters) extends XSModule with MPTCacheParam
   // should be safer than just := memAddr
 
   // accessFault logic
-  val pmpFail = if (HasMptCheckDefault) false.B else (!isLeafMpte) && (io.pmp.resp.ld || io.pmp.resp.mmio)
+  val pmpFail = (!isLeafMpte) && (io.pmp.resp.ld || io.pmp.resp.mmio)
   // PMP delay unknown
-  val entryError = if (HasMptCheckDefault) false.B else
-    mpteInvalid || rsvZeroError0 || rsvZeroError1 || rsvZeroError2 || ((!isLeafMpte) && level === 1.U)
+  val entryError = mpteInvalid || rsvZeroError0 || rsvZeroError1 || rsvZeroError2 || ((!isLeafMpte) && level === 1.U)
   // level == 0 non leaf, zero = / = 0,pmp fail,invalid casue accessFault
   val accessFault = entryError || pmpFail // pmp fail also cause accessFault
   io.refill.bits.level := Mux(pmpFail, pmpCheckLevel, level) // pmpFail return next level,else cur level

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -609,7 +609,11 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
         vs_finish := true.B
       }.otherwise{
         if (HasMptCheck) {
-          s_mpt_check := true.B // mem_addr_update checks pmp, next is mpt or mem access state
+          when(mptEn && checkIntermediateNode) {
+            s_mpt_check := true.B
+          }.otherwise {
+            s_mem_req := false.B
+          }
         }else{
           s_mem_req := false.B
         } // that is not intended for mpt
@@ -1666,7 +1670,11 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
     when(!(find_pte || accessFaultMpt)) {
       level := levelNext
       if (HasMptCheck) {
-        s_mpt_check := true.B // mem_addr_update checks pmp, next is mpt or mem access state
+        when(mptEn && checkIntermediateNode) {
+          s_mpt_check := true.B
+        }.otherwise {
+          s_mem_req := false.B
+        }
       } else {
         s_mem_req := false.B
       }


### PR DESCRIPTION
MPT and Bitmap use hardwired pseudo page table to run CI test. Those codes are now redundant, since we have collected enough performance data.