### PR TITLE
feat(difftest): snapshot rename tables before commit

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -399,13 +399,6 @@ class CSRSpecialIO(implicit p: Parameters) extends XSBundle {
   val interrupt = Output(Bool())
 }
 
-class DiffCommitIO(implicit p: Parameters) extends XSBundle {
-  val isCommit = Bool()
-  val commitValid = Vec(CommitWidth * MaxUopSize, Bool())
-
-  val info = Vec(CommitWidth * MaxUopSize, new RabCommitInfo)
-}
-
 class RobCommitInfo(implicit p: Parameters) extends RobCommitEntryBundle
 
 class RobCommitIO(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -632,7 +632,21 @@ class CtrlBlockImp(
   rat.io.hartId := io.fromTop.hartId
   rat.io.redirect := s1_s3_redirect.valid
   rat.io.rabCommits := rob.io.rabCommits
-  rat.io.diffCommits.foreach(_ := rob.io.diffCommits.get)
+  rat.io.diffRatCommitRobIdx.foreach(_ := rob.io.diffRatCommitRobIdx.get)
+  rat.io.renameUpdates.foreach { updates =>
+    updates.zip(rename.io.out).foreach { case (update, renameOut) =>
+      update.valid := renameOut.fire && !s1_s3_redirect.valid
+      update.bits.robIdx := renameOut.bits.robIdx
+      update.bits.lastUop := renameOut.bits.lastUop
+      update.bits.ldest := renameOut.bits.ldest
+      update.bits.pdest := renameOut.bits.pdest
+      update.bits.rfWen := renameOut.bits.rfWen
+      update.bits.fpWen := renameOut.bits.fpWen
+      update.bits.vecWen := renameOut.bits.vecWen
+      update.bits.v0Wen := renameOut.bits.v0Wen
+      update.bits.vlWen := renameOut.bits.vlWen
+    }
+  }
   rat.io.intRenamePorts := rename.io.intRenamePorts
   rat.io.fpRenamePorts := rename.io.fpRenamePorts
   rat.io.vecRenamePorts := rename.io.vecRenamePorts

--- a/src/main/scala/xiangshan/backend/rename/RenameTable.scala
+++ b/src/main/scala/xiangshan/backend/rename/RenameTable.scala
@@ -25,6 +25,7 @@ import utility.ParallelPriorityMux
 import utility.GatedValidRegNext
 import utility.XSError
 import xiangshan._
+import xiangshan.backend.rob.{DiffRatRenameUpdate, DiffRatStateBuffer, DiffRatStateParams, RobPtr}
 
 abstract class RegType
 case object Reg_I extends RegType
@@ -50,6 +51,7 @@ class RenameTable(reg_t: RegType)(implicit p: Parameters) extends XSModule with 
   // params alias
   private val numVecRegSrc = backendParams.numVecRegSrc
   private val numVecRatPorts = numVecRegSrc
+  private val diffRatParams = DiffRatStateParams()
 
   val readPortsNum = reg_t match {
     case Reg_I => 2
@@ -59,11 +61,11 @@ class RenameTable(reg_t: RegType)(implicit p: Parameters) extends XSModule with 
     case Reg_Vl => 1
   }
   val rdataNums = reg_t match {
-    case Reg_I => 32
-    case Reg_F => 32
-    case Reg_V => 31 // no v0
-    case Reg_V0 => 1 // v0
-    case Reg_Vl => 1 // vl
+    case Reg_I => diffRatParams.intEntries
+    case Reg_F => diffRatParams.fpEntries
+    case Reg_V => diffRatParams.vecEntries
+    case Reg_V0 => diffRatParams.v0Entries
+    case Reg_Vl => diffRatParams.vlEntries
   }
   val renameTableWidth = reg_t match {
     case Reg_I => log2Ceil(IntLogicRegs)
@@ -72,7 +74,6 @@ class RenameTable(reg_t: RegType)(implicit p: Parameters) extends XSModule with 
     case Reg_V0 => log2Ceil(V0LogicRegs)
     case Reg_Vl => log2Ceil(VlLogicRegs)
   }
-
   val io = IO(new Bundle {
     val redirect = Input(Bool())
     val readPorts = Vec(readPortsNum * RenameWidth, new RatReadPort(renameTableWidth))
@@ -81,22 +82,13 @@ class RenameTable(reg_t: RegType)(implicit p: Parameters) extends XSModule with 
     val old_pdest = Vec(RabCommitWidth, Output(UInt(PhyRegIdxWidth.W)))
     val need_free = Vec(RabCommitWidth, Output(Bool()))
     val snpt = Input(new SnapshotPort)
-    val diffWritePorts = if (backendParams.basicDebugEn) Some(Vec(RabCommitWidth * MaxUopSize, Input(new RatWritePort(renameTableWidth)))) else None
+    val diffRatBase = if (backendParams.basicDebugEn) Some(Vec(rdataNums, Output(UInt(PhyRegIdxWidth.W)))) else None
     val debug_rdata = if (backendParams.debugEn) Some(Vec(rdataNums, Output(UInt(PhyRegIdxWidth.W)))) else None
-    val diff_rdata = if (backendParams.basicDebugEn) Some(Vec(rdataNums, Output(UInt(PhyRegIdxWidth.W)))) else None
     val debug_v0 = if (backendParams.debugEn) reg_t match {
       case Reg_V0 => Some(Output(UInt(PhyRegIdxWidth.W)))
       case _ => None
     } else None
-    val diff_v0 = if (backendParams.debugEn) reg_t match {
-      case Reg_V0 => Some(Output(UInt(PhyRegIdxWidth.W)))
-      case _ => None
-    } else None
     val debug_vl = if (backendParams.debugEn) reg_t match {
-      case Reg_Vl => Some(Output(UInt(PhyRegIdxWidth.W)))
-      case _ => None
-    } else None
-    val diff_vl = if (backendParams.debugEn) reg_t match {
       case Reg_Vl => Some(Output(UInt(PhyRegIdxWidth.W)))
       case _ => None
     } else None
@@ -182,29 +174,13 @@ class RenameTable(reg_t: RegType)(implicit p: Parameters) extends XSModule with 
   }
   io.debug_v0.foreach(_ := arch_table(0))
   io.debug_vl.foreach(_ := arch_table(0))
-  if (env.EnableDifftest || env.AlwaysBasicDiff) {
-    val difftest_table = RegInit(rename_table_init)
-    val difftest_table_next = WireDefault(difftest_table)
-
-    for (w <- io.diffWritePorts.get) {
-      when(w.wen) {
-        difftest_table_next(w.addr) := w.data
-      }
+  // spec_table_next is the recovered speculative base before this cycle's rename updates.
+  // Reusing it keeps Difftest aligned with the functional checkpoint, redirect, and walk recovery path.
+  io.diffRatBase.foreach { base =>
+    reg_t match {
+      case Reg_V => base := VecInit(spec_table_next.drop(diffRatParams.v0Entries).take(rdataNums))
+      case _ => base := VecInit(spec_table_next.take(rdataNums))
     }
-    difftest_table := difftest_table_next
-
-    io.diff_rdata.foreach{ x => reg_t match {
-        case Reg_V => x := difftest_table.drop(1).take(rdataNums)
-        case _ => x := difftest_table.take(rdataNums)
-      }
-    }
-    io.diff_v0.foreach(_ := difftest_table(0))
-    io.diff_vl.foreach(_ := difftest_table(0))
-  }
-  else {
-    io.diff_rdata.foreach(_ := 0.U.asTypeOf(io.debug_rdata.get))
-    io.diff_v0.foreach(_ := 0.U)
-    io.diff_vl.foreach(_ := 0.U)
   }
 }
 
@@ -213,12 +189,15 @@ class RenameTableWrapper(implicit p: Parameters) extends XSModule {
   // params alias
   private val numVecRegSrc = backendParams.numVecRegSrc
   private val numVecRatPorts = numVecRegSrc
+  private val diffRatParams = DiffRatStateParams()
 
   val io = IO(new Bundle() {
     val hartId = Input(UInt(8.W))
     val redirect = Input(Bool())
     val rabCommits = Input(new RabCommitIO)
-    val diffCommits = if (backendParams.basicDebugEn) Some(Input(new DiffCommitIO)) else None
+    val renameUpdates =
+      if (backendParams.basicDebugEn) Some(Input(Vec(diffRatParams.renameWidth, Valid(new DiffRatRenameUpdate)))) else None
+    val diffRatCommitRobIdx = if (backendParams.basicDebugEn) Some(Input(Valid(new RobPtr))) else None
     val intReadPorts = Vec(RenameWidth, Vec(2, new RatReadPort(IntLogicRegs)))
     val intRenamePorts = Vec(RenameWidth, Input(new RatWritePort(IntLogicRegs)))
     val fpReadPorts = Vec(RenameWidth, Vec(3, new RatReadPort(FpLogicRegs)))
@@ -239,14 +218,14 @@ class RenameTableWrapper(implicit p: Parameters) extends XSModule {
     val snpt = Input(new SnapshotPort)
 
     // for debug assertions
-    val debug_int_rat = if (backendParams.debugEn) Some(Vec(32, Output(UInt(PhyRegIdxWidth.W)))) else None
-    val debug_fp_rat  = if (backendParams.debugEn) Some(Vec(32, Output(UInt(PhyRegIdxWidth.W)))) else None
-    val debug_vec_rat = if (backendParams.debugEn) Some(Vec(31, Output(UInt(PhyRegIdxWidth.W)))) else None
-    val debug_v0_rat  = if (backendParams.debugEn) Some(Vec(1,Output(UInt(PhyRegIdxWidth.W)))) else None
-    val debug_vl_rat  = if (backendParams.debugEn) Some(Vec(1,Output(UInt(PhyRegIdxWidth.W)))) else None
+    val debug_int_rat = if (backendParams.debugEn) Some(Vec(diffRatParams.intEntries, Output(UInt(PhyRegIdxWidth.W)))) else None
+    val debug_fp_rat  = if (backendParams.debugEn) Some(Vec(diffRatParams.fpEntries, Output(UInt(PhyRegIdxWidth.W)))) else None
+    val debug_vec_rat = if (backendParams.debugEn) Some(Vec(diffRatParams.vecEntries, Output(UInt(PhyRegIdxWidth.W)))) else None
+    val debug_v0_rat  = if (backendParams.debugEn) Some(Vec(diffRatParams.v0Entries, Output(UInt(PhyRegIdxWidth.W)))) else None
+    val debug_vl_rat  = if (backendParams.debugEn) Some(Vec(diffRatParams.vlEntries, Output(UInt(PhyRegIdxWidth.W)))) else None
 
     // for difftest
-    val diff_vl_rat  = if (backendParams.basicDebugEn) Some(Vec(1,Output(UInt(PhyRegIdxWidth.W)))) else None
+    val diff_vl_rat = if (backendParams.basicDebugEn) Some(Vec(diffRatParams.vlEntries, Output(UInt(PhyRegIdxWidth.W)))) else None
   })
 
   val intRat = Module(new RenameTable(Reg_I))
@@ -254,13 +233,24 @@ class RenameTableWrapper(implicit p: Parameters) extends XSModule {
   val vecRat = Module(new RenameTable(Reg_V))
   val v0Rat  = Module(new RenameTable(Reg_V0))
   val vlRat  = Module(new RenameTable(Reg_Vl))
+  val diffRatBuffer = if (backendParams.basicDebugEn) Some(Module(new DiffRatStateBuffer)) else None
+
+  diffRatBuffer.foreach { rat =>
+    rat.io.diffRatBase.intRat := intRat.io.diffRatBase.get
+    rat.io.diffRatBase.fpRat := fpRat.io.diffRatBase.get
+    rat.io.diffRatBase.vecRat := vecRat.io.diffRatBase.get
+    rat.io.diffRatBase.v0Rat := v0Rat.io.diffRatBase.get
+    rat.io.diffRatBase.vlRat := vlRat.io.diffRatBase.get
+    rat.io.renameUpdates := io.renameUpdates.get
+    rat.io.commitRobIdx := io.diffRatCommitRobIdx.get
+  }
 
   io.debug_int_rat .foreach(_ := intRat.io.debug_rdata.get)
   if (env.AlwaysBasicDiff || env.EnableDifftest) {
     // Delay of RenameTable should be same as PhyRegFile
     val difftest = DifftestModule(new DiffArchIntRenameTable(IntPhyRegs), delay = 2)
     difftest.coreid := io.hartId
-    difftest.value := intRat.io.diff_rdata.get
+    difftest.value := diffRatBuffer.get.io.diffRat.intRat
   }
   intRat.io.readPorts <> io.intReadPorts.flatten
   intRat.io.redirect := io.redirect
@@ -287,20 +277,12 @@ class RenameTableWrapper(implicit p: Parameters) extends XSModule {
       spec.data := rename.data
     }
   }
-  if (backendParams.basicDebugEn) {
-    for ((diff, i) <- intRat.io.diffWritePorts.get.zipWithIndex) {
-      diff.wen := io.diffCommits.get.isCommit && io.diffCommits.get.commitValid(i) && io.diffCommits.get.info(i).rfWen
-      diff.addr := io.diffCommits.get.info(i).ldest
-      diff.data := io.diffCommits.get.info(i).pdest
-    }
-  }
-
   // debug read ports for difftest
   io.debug_fp_rat.foreach(_ := fpRat.io.debug_rdata.get)
   if (env.AlwaysBasicDiff || env.EnableDifftest) {
     val difftest = DifftestModule(new DiffArchFpRenameTable(FpPhyRegs), delay = 2)
     difftest.coreid := io.hartId
-    difftest.value := fpRat.io.diff_rdata.get
+    difftest.value := diffRatBuffer.get.io.diffRat.fpRat
   }
   fpRat.io.readPorts <> io.fpReadPorts.flatten
   fpRat.io.redirect := io.redirect
@@ -324,21 +306,13 @@ class RenameTableWrapper(implicit p: Parameters) extends XSModule {
       spec.data := rename.data
     }
   }
-  if (backendParams.basicDebugEn) {
-    for ((diff, i) <- fpRat.io.diffWritePorts.get.zipWithIndex) {
-      diff.wen := io.diffCommits.get.isCommit && io.diffCommits.get.commitValid(i) && io.diffCommits.get.info(i).fpWen
-      diff.addr := io.diffCommits.get.info(i).ldest
-      diff.data := io.diffCommits.get.info(i).pdest
-    }
-  }
-
   if (env.AlwaysBasicDiff || env.EnableDifftest) {
     // Split each 128-bit vector reg into two 64-bit regs (lo, hi), so convert index to (2*index, 2*index+1)
     val splitVecPregs = 2 * (V0PhyRegs + VfPhyRegs)
     val difftest = DifftestModule(new DiffArchVecRenameTable(splitVecPregs), delay = 2)
     difftest.coreid := io.hartId
     // When merge v0Rat and vecRat, the index of vecRats should starts from V0PhyRegs
-    val vecRats = v0Rat.io.diff_rdata.get ++ vecRat.io.diff_rdata.get.map(_ + V0PhyRegs.U)
+    val vecRats = diffRatBuffer.get.io.diffRat.v0Rat ++ diffRatBuffer.get.io.diffRat.vecRat.map(_ + V0PhyRegs.U)
     difftest.value := VecInit(vecRats.flatMap { r =>
       val splitDest = (r << 1).asUInt
       Seq(splitDest, splitDest + 1.U)
@@ -372,14 +346,6 @@ class RenameTableWrapper(implicit p: Parameters) extends XSModule {
       spec.data := rename.data
     }
   }
-  if (backendParams.basicDebugEn) {
-    for ((diff, i) <- vecRat.io.diffWritePorts.get.zipWithIndex) {
-      diff.wen := io.diffCommits.get.isCommit && io.diffCommits.get.commitValid(i) && io.diffCommits.get.info(i).vecWen
-      diff.addr := io.diffCommits.get.info(i).ldest
-      diff.data := io.diffCommits.get.info(i).pdest
-    }
-  }
-
   // debug read ports for difftest
   io.debug_v0_rat.foreach(_ := v0Rat.io.debug_rdata.get)
   v0Rat.io.readPorts <> io.v0ReadPorts
@@ -407,17 +373,9 @@ class RenameTableWrapper(implicit p: Parameters) extends XSModule {
       spec.data := rename.data
     }
   }
-  if (backendParams.basicDebugEn) {
-    for ((diff, i) <- v0Rat.io.diffWritePorts.get.zipWithIndex) {
-      diff.wen := io.diffCommits.get.isCommit && io.diffCommits.get.commitValid(i) && io.diffCommits.get.info(i).v0Wen
-      diff.addr := io.diffCommits.get.info(i).ldest
-      diff.data := io.diffCommits.get.info(i).pdest
-    }
-  }
-
   // debug read ports for difftest
   io.debug_vl_rat.foreach(_ := vlRat.io.debug_rdata.get)
-  io.diff_vl_rat.foreach(_ := vlRat.io.diff_rdata.get)
+  io.diff_vl_rat.foreach(_ := diffRatBuffer.get.io.diffRat.vlRat)
   vlRat.io.readPorts <> io.vlReadPorts
   vlRat.io.redirect := io.redirect
   vlRat.io.snpt := io.snpt
@@ -441,13 +399,6 @@ class RenameTableWrapper(implicit p: Parameters) extends XSModule {
       spec.wen := true.B
       spec.addr := rename.addr
       spec.data := rename.data
-    }
-  }
-  if (backendParams.basicDebugEn) {
-    for ((diff, i) <- vlRat.io.diffWritePorts.get.zipWithIndex) {
-      diff.wen := io.diffCommits.get.isCommit && io.diffCommits.get.commitValid(i) && io.diffCommits.get.info(i).vlWen
-      diff.addr := io.diffCommits.get.info(i).ldest
-      diff.data := io.diffCommits.get.info(i).pdest
     }
   }
 }

--- a/src/main/scala/xiangshan/backend/rob/DiffRatStateBuffer.scala
+++ b/src/main/scala/xiangshan/backend/rob/DiffRatStateBuffer.scala
@@ -1,0 +1,173 @@
+/***************************************************************************************
+ * Copyright (c) 2026 Beijing Institute of Open Source Chip (BOSC)
+ * Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * XiangShan is licensed under Mulan PSL v2.
+ ***************************************************************************************/
+
+package xiangshan.backend.rob
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+import xiangshan._
+
+case class DiffRatStateParams()(implicit p: Parameters) {
+  private val coreParams = p(XSCoreParamsKey)
+
+  val intEntries: Int = 32
+  val fpEntries: Int = 32
+  val vecEntries: Int = 31
+  val v0Entries: Int = 1
+  val vlEntries: Int = 1
+  val robEntries: Int = coreParams.RobSize
+  val renameWidth: Int = coreParams.RenameWidth
+
+  require(Seq(intEntries, fpEntries, vecEntries, v0Entries, vlEntries).forall(_ > 0))
+  require(coreParams.IntLogicRegs >= intEntries)
+  require(coreParams.FpLogicRegs >= fpEntries)
+  require(coreParams.VecLogicRegs >= vecEntries + v0Entries)
+  require(coreParams.V0LogicRegs >= v0Entries)
+  require(coreParams.VlLogicRegs >= vlEntries)
+  require(robEntries > 0)
+  require(renameWidth > 0)
+
+  val totalEntries: Int = intEntries + fpEntries + vecEntries + v0Entries + vlEntries
+  // Keep the two circular ROB pointer generations distinct in snapshot storage.
+  val storageEntries: Int = robEntries * 2
+  val bankBits: Int = log2Ceil(renameWidth max 2)
+  val slotBits: Int = log2Ceil(storageEntries)
+}
+
+class DiffRatState(val params: DiffRatStateParams)(implicit p: Parameters) extends XSBundle {
+  val intRat = Vec(params.intEntries, UInt(PhyRegIdxWidth.W))
+  val fpRat = Vec(params.fpEntries, UInt(PhyRegIdxWidth.W))
+  val vecRat = Vec(params.vecEntries, UInt(PhyRegIdxWidth.W))
+  val v0Rat = Vec(params.v0Entries, UInt(PhyRegIdxWidth.W))
+  val vlRat = Vec(params.vlEntries, UInt(PhyRegIdxWidth.W))
+}
+
+class DiffRatRenameUpdate(implicit p: Parameters) extends XSBundle {
+  val robIdx = new RobPtr
+  val lastUop = Bool()
+  val ldest = UInt(LogicRegsWidth.W)
+  val pdest = UInt(PhyRegIdxWidth.W)
+  val rfWen = Bool()
+  val fpWen = Bool()
+  val vecWen = Bool()
+  val v0Wen = Bool()
+  val vlWen = Bool()
+}
+
+object DiffRatState {
+  def init(params: DiffRatStateParams)(implicit p: Parameters): DiffRatState = {
+    val state = Wire(new DiffRatState(params))
+    val pregWidth = state.v0Rat.head.getWidth
+    state.intRat := VecInit.fill(params.intEntries)(0.U(pregWidth.W))
+    state.fpRat := VecInit.tabulate(params.fpEntries)(_.U(pregWidth.W))
+    state.vecRat := VecInit.tabulate(params.vecEntries)(i => (i + params.v0Entries).U(pregWidth.W))
+    state.v0Rat := VecInit.tabulate(params.v0Entries)(_.U(pregWidth.W))
+    state.vlRat := VecInit.tabulate(params.vlEntries)(_.U(pregWidth.W))
+    state
+  }
+}
+
+class DiffRatStateBuffer(implicit p: Parameters) extends XSModule {
+  private val params = DiffRatStateParams()
+  private val stateWidth = params.totalEntries * PhyRegIdxWidth
+
+  val io = IO(new Bundle {
+    val diffRatBase = Input(new DiffRatState(params))
+    val renameUpdates = Input(Vec(params.renameWidth, Valid(new DiffRatRenameUpdate)))
+    val commitRobIdx = Input(Valid(new RobPtr))
+    val diffRat = Output(new DiffRatState(params))
+  })
+
+  private def slotOf(ptr: RobPtr): UInt = {
+    val generationOffset = Mux(ptr.flag, params.robEntries.U(params.slotBits.W), 0.U(params.slotBits.W))
+    (Cat(0.U(1.W), ptr.value) +& generationOffset)(params.slotBits - 1, 0)
+  }
+
+  val laneRat = Wire(Vec(params.renameWidth + 1, new DiffRatState(params)))
+  laneRat.head := io.diffRatBase
+
+  for (lane <- 0 until params.renameWidth) {
+    val req = io.renameUpdates(lane)
+    val prev = laneRat(lane)
+    val next = laneRat(lane + 1)
+
+    for (reg <- 0 until params.intEntries) {
+      val hit = req.valid && req.bits.rfWen && req.bits.ldest === reg.U
+      next.intRat(reg) := Mux(hit, req.bits.pdest, prev.intRat(reg))
+    }
+    for (reg <- 0 until params.fpEntries) {
+      val hit = req.valid && req.bits.fpWen && req.bits.ldest === reg.U
+      next.fpRat(reg) := Mux(hit, req.bits.pdest, prev.fpRat(reg))
+    }
+    for (reg <- 0 until params.vecEntries) {
+      val hit = req.valid && req.bits.vecWen && req.bits.ldest === (reg + params.v0Entries).U
+      next.vecRat(reg) := Mux(hit, req.bits.pdest, prev.vecRat(reg))
+    }
+    for (reg <- 0 until params.v0Entries) {
+      val hit = req.valid && req.bits.v0Wen && req.bits.ldest === reg.U
+      next.v0Rat(reg) := Mux(hit, req.bits.pdest, prev.v0Rat(reg))
+    }
+    for (reg <- 0 until params.vlEntries) {
+      val hit = req.valid && req.bits.vlWen && req.bits.ldest === reg.U
+      next.vlRat(reg) := Mux(hit, req.bits.pdest, prev.vlRat(reg))
+    }
+  }
+
+  val stateBanks = Seq.tabulate(params.renameWidth) { bank =>
+    SyncReadMem(params.storageEntries, UInt(stateWidth.W), SyncReadMem.ReadFirst)
+      .suggestName(s"diff_rat_state_bank_$bank")
+  }
+  val stateWriteValid = VecInit(io.renameUpdates.map(req => req.valid && req.bits.lastUop))
+  val stateWriteSlots = io.renameUpdates.map(req => slotOf(req.bits.robIdx))
+  val stateWriteData = laneRat.tail.map(_.asUInt)
+  val stateBankTags = Mem(params.storageEntries, UInt(params.bankBits.W))
+  val stateSlotValid = RegInit(VecInit.fill(params.storageEntries)(false.B))
+
+  // ROB compression means last-uop state slots are not necessarily consecutive.
+  // Give each rename lane a dedicated bank and retain the selected lane per ROB slot.
+  for {
+    older <- 0 until params.renameWidth
+    younger <- older + 1 until params.renameWidth
+  } {
+    assert(
+      !(stateWriteValid(older) && stateWriteValid(younger) &&
+        stateWriteSlots(older) === stateWriteSlots(younger)),
+      "two rename lanes write the same diff RAT slot"
+    )
+  }
+  for (lane <- 0 until params.renameWidth) {
+    when(stateWriteValid(lane)) {
+      stateBanks(lane).write(stateWriteSlots(lane), stateWriteData(lane))
+      stateBankTags.write(stateWriteSlots(lane), lane.U)
+      stateSlotValid(stateWriteSlots(lane)) := true.B
+    }
+  }
+
+  val readSlot = slotOf(io.commitRobIdx.bits)
+  val readRequestValid = io.commitRobIdx.valid && stateSlotValid(readSlot)
+  val readWriteConflict = VecInit.tabulate(params.renameWidth) { lane =>
+    stateWriteValid(lane) && stateWriteSlots(lane) === readSlot
+  }.asUInt.orR
+  assert(!io.commitRobIdx.valid || stateSlotValid(readSlot), "diff RAT commit reads an invalid state")
+  assert(!io.commitRobIdx.valid || !readWriteConflict, "diff RAT state is read and written in the same cycle")
+
+  when(io.commitRobIdx.valid) {
+    stateSlotValid(readSlot) := false.B
+  }
+
+  val bankReadData = VecInit(stateBanks.map(_.read(readSlot, readRequestValid)))
+  val readValid = RegNext(readRequestValid, false.B)
+  val readBankOH = RegEnable(UIntToOH(stateBankTags.read(readSlot), params.renameWidth), readRequestValid)
+  val readState = Mux1H(readBankOH, bankReadData).asTypeOf(new DiffRatState(params))
+  val committedRat = RegInit(DiffRatState.init(params))
+
+  when(readValid) {
+    committedRat := readState
+  }
+  io.diffRat := Mux(readValid, readState, committedRat)
+}

--- a/src/main/scala/xiangshan/backend/rob/Rab.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rab.scala
@@ -53,7 +53,6 @@ class RenameBuffer(size: Int)(implicit p: Parameters) extends XSModule with HasC
     val enqPtrVec = Output(Vec(RenameWidth, new RenameBufferPtr))
 
     val commits = Output(new RabCommitIO)
-    val diffCommits = if (backendParams.basicDebugEn) Some(Output(new DiffCommitIO)) else None
 
     val status = Output(new Bundle {
       val walkEnd = Bool()
@@ -89,13 +88,6 @@ class RenameBuffer(size: Int)(implicit p: Parameters) extends XSModule with HasC
 
   private val walkPtrSnapshots = SnapshotGenerator(enqPtr, io.snpt.snptEnq, io.snpt.snptDeq, io.redirect.valid, io.snpt.flushVec)
 
-  val vcfgPtrOH = RegInit(1.U(size.W))
-  val vcfgPtrOHShift = CircularShift(vcfgPtrOH)
-  // may shift [0, 2) steps
-  val vcfgPtrOHVec = VecInit.tabulate(2)(vcfgPtrOHShift.left)
-
-  val diffPtr = RegInit(0.U.asTypeOf(new RenameBufferPtr))
-  val diffPtrNext = Wire(new RenameBufferPtr)
   // Regs
   val renameBuffer = Reg(Vec(size, new RenameBufferEntry))
   val renameBufferEntries = VecInit((0 until size) map (i => renameBuffer(i)))
@@ -162,16 +154,6 @@ class RenameBuffer(size: Int)(implicit p: Parameters) extends XSModule with HasC
 
   val walkCandidates   = VecInit(walkPtrOHVec.map(sel => Mux1H(sel, renameBufferEntries)))
   val commitCandidates = VecInit(deqPtrOHVec.map(sel => Mux1H(sel, renameBufferEntries)))
-  val vcfgCandidates   = VecInit(vcfgPtrOHVec.map(sel => Mux1H(sel, renameBufferEntries)))
-
-  // update diff pointer
-  diffPtrNext := diffPtr + newCommitSize
-  diffPtr := diffPtrNext
-
-  // update vcfg pointer
-  // TODO: do not use diffPtrNext here
-  vcfgPtrOH := diffPtrNext.toOH
-
   // update enq pointer
   val enqPtrNext = Mux(
     state === s_walk && stateNext === s_idle,
@@ -278,14 +260,6 @@ class RenameBuffer(size: Int)(implicit p: Parameters) extends XSModule with HasC
         x.lreg := RegEnable(io.commits.info(i).ldest, valid)
         x.preg := RegEnable(io.commits.info(i).pdest, valid)
     }
-  }
-
-  // for difftest
-  io.diffCommits.foreach(_ := 0.U.asTypeOf(new DiffCommitIO))
-  io.diffCommits.foreach(_.isCommit := true.B)
-  for(i <- 0 until RabCommitWidth * MaxUopSize) {
-    io.diffCommits.foreach(_.commitValid(i) := i.U < newCommitSize)
-    io.diffCommits.foreach(_.info(i) := renameBufferEntries((diffPtr + i.U).value).info)
   }
 
   XSError(isBefore(enqPtr, deqPtr) && !isFull(enqPtr, deqPtr), "\ndeqPtr is older than enqPtr!\n")

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -79,7 +79,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       val traceCommitInfo = new TraceBundle(hasIaddr = false, CommitWidth, IretireWidthInPipe)
     }
     val rabCommits = Output(new RabCommitIO)
-    val diffCommits = if (backendParams.basicDebugEn) Some(Output(new DiffCommitIO)) else None
+    val diffRatCommitRobIdx = if (backendParams.basicDebugEn) Some(Output(Valid(new RobPtr))) else None
     val isVsetFlushPipe = Output(Bool())
     val lsq = new RobLsqIO
     val robDeqPtr = Output(new RobPtr)
@@ -369,7 +369,6 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
 
   // pipe rab commits for better timing and area
   io.rabCommits := RegNext(rab.io.commits)
-  io.diffCommits.foreach(_ := rab.io.diffCommits.get)
 
   /**
    * connection of [[vtypeBuffer]]
@@ -603,6 +602,16 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   }.elsewhen(handleVlsExcp){
     deqVlsExceptionCommitSize := deqPtrEntry.realDestSize
     deqVlsExceptionNeedCommit := true.B
+  }
+
+  io.diffRatCommitRobIdx.foreach { commitRobIdx =>
+    val hasCommit = io.commits.isCommit && io.commits.commitValid.asUInt.orR
+    val newestCommit = PriorityMuxDefault(
+      io.commits.commitValid.zip(io.commits.robIdx).reverse,
+      deqPtr
+    )
+    commitRobIdx.valid := hasCommit || deqVlsExceptionNeedCommit
+    commitRobIdx.bits := Mux(deqVlsExceptionNeedCommit, deqPtr, newestCommit)
   }
 
   XSDebug(deqHasException && exceptionDataRead.bits.singleStep, "Debug Mode: Deq has singlestep exception\n")


### PR DESCRIPTION
## Summary

- Replace the 390-entry RAB diff-commit window and the corresponding wide RAT write ports with incremental per-instruction rename-table snapshots.
- Apply at most `RenameWidth` updates per cycle to a combined int/fp/vec/v0/vl candidate and store one snapshot when an instruction's last uop is renamed.
- Give each rename lane a fixed snapshot bank and retain the producing bank per ROB slot. Commit therefore reads one snapshot without relying on consecutive ROB slots, which is unsafe across ROB compression and recovery.
- Keep the architectural RAB commit/walk path unchanged and widen its size counters so the full buffer size is representable.