### PR TITLE
fix(LoadUnit): retire prefetch.i instead of killing it at S1

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -600,8 +600,8 @@ class LoadUnitS1(param: ExeUnitParams)(
   
   val isUnalignTail = LoadEntrance.isUnalignTail(entrance)
 
-  val kill = !pipeIn.valid || io.kill || isSwInstrPrefetch ||
-             robIdx.needFlush(redirect) || robIdx.needFlush(redirectNext) || 
+  val kill = !pipeIn.valid || io.kill ||
+             robIdx.needFlush(redirect) || robIdx.needFlush(redirectNext) ||
              (robIdx.needFlush(redirectNextNext) && isUnalignTail)
 
   /**


### PR DESCRIPTION
fix(LoadUnit): retire prefetch.i instead of killing it at S1

Hello, here is a pull request for a bug I found.

A software instruction prefetch (prefetch.i) owns a ROB entry that expects one
writeback, but LoadUnitS1 killed it via the isSwInstrPrefetch term of kill, so it
never reached S3 where software prefetches write back. The ROB head then hung on
it forever. Software data prefetches (prefetch.r/prefetch.w) are not killed at S1
and retire correctly.

Remove the isSwInstrPrefetch term from the S1 kill so prefetch.i flows to S3 and
retires as a clean no-op. It still fires the frontend prefetch in S1 and never
touches the data cache (noQuery/noDCacheAccess force no TLB/PMP fault), so there is
no register write and no trap.

Fixes #5960

Assisted-by: Claude:claude-opus-4-8 [Claude Code]