### PR TITLE
fix(tlb): add a mask to the robidx of need_gpa to avoid X

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -109,6 +109,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   val maybe_need_gpa_not_allow_refill = WireInit(false.B)
   val need_clear_need_gpa = RegInit(false.B)
   val need_gpa_robidx = Reg(new RobPtr)
+  val need_gpa_robidx_valid = RegInit(false.B)
   val need_gpa_vpn = Reg(UInt(vpnLen.W))
   val resp_gpa_gvpn = Reg(UInt(ptePPNLen.W))
   val resp_gpa_refill = RegInit(false.B)
@@ -290,10 +291,11 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     val lastCycleRedirect = req_out(i).debug.robIdx.needFlush(RegNext(redirect))
 
     need_clear_need_gpa := false.B
-    when (!isitlb && need_gpa_robidx.needFlush(redirect) || isitlb && flush_pipe(i) || need_clear_need_gpa){
+    when (!isitlb && need_gpa_robidx_valid && need_gpa_robidx.needFlush(redirect) || isitlb && flush_pipe(i) || need_clear_need_gpa){
       need_gpa := false.B
       resp_gpa_refill := false.B
       need_gpa_vpn := 0.U
+      need_gpa_robidx_valid := false.B
     }.elsewhen (req_out_v(i) && !p_hit && !(resp_gpa_refill && need_gpa_vpn_hit) && !isOnlys2xlate && hasGpf(i) && need_gpa === false.B && !io.requestor(i).req_kill && !isPrefetch && !currentRedirect && !lastCycleRedirect) {
       when(canGetGpa(i)) {
         maybe_need_gpa_not_allow_refill := true.B
@@ -302,6 +304,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
         need_gpa_vpn := get_pn(req_out(i).vaddr)
         resp_gpa_refill := false.B
         need_gpa_robidx := req_out(i).debug.robIdx
+        need_gpa_robidx_valid := true.B
         when (p_hit_fast) {
           need_clear_need_gpa := true.B
         }


### PR DESCRIPTION
## Background

  `need_gpa_robidx` is an uninitialized register and is only meaningful after
  the TLB starts tracking a GPA request.

  Previously, the redirect clear path evaluated:

  ```scala
  need_gpa_robidx.needFlush(redirect)
  ```
  even when no GPA request had captured a valid ROB index. In X-propagation
  simulation, an asserted redirect could therefore propagate the unknown ROB
  index through needFlush into GPA replay/clear control.

  ## Changes

  - Add a reset-initialized need_gpa_robidx_valid bit.
  - Set the valid bit when capturing need_gpa_robidx for a GPA request.
  - Gate the redirect flush check with need_gpa_robidx_valid.
  - Clear the valid bit when the GPA tracking state is cleared.

  This makes the inactive state explicit:

  need_gpa_robidx_valid = 0
  => need_gpa_robidx does not participate in redirect comparison

  and prevents an uninitialized ROB index from affecting GPA control signals.