### PR TITLE
ci(perf-trigger): use fixed length short sha for SPEC dir

### DIFF
--- a/.github/workflows/perf-template.yml
+++ b/.github/workflows/perf-template.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Set env
         id: set_env
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
+          SHORT_SHA=$(git rev-parse --short=9 HEAD)
           DATE=$(git show -s --format=%cd --date=format:%y%m%d HEAD)
           echo "SCRIPTS_HOME=/nfs/home/share/ci-workloads/env-scripts" >> $GITHUB_ENV
           echo "SHORT_SHA=${SHORT_SHA}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The perf trigger workflow uses the abbreviated commit sha to build SPEC_DIR. The default abbreviation length from git rev-parse --short can change when the repository object set changes.

Use an explicit short sha length so rerunning the same commit maps to the same SPEC result directory and can reuse existing emu and checkpoint results.