### PR TITLE
perf(ubtb): use resolve+fast train

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -184,12 +184,11 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   }
 
   private val fastTrain = Wire(Valid(new FastTrain))
-  fastTrain.valid                := s3_valid
-  fastTrain.bits.startPc         := s3_startPc.get.unGuard
-  fastTrain.bits.finalPrediction := s3_prediction
-  fastTrain.bits.abtbMeta        := s3_abtbMeta
-  fastTrain.bits.utageMeta       := s3_utageMeta
-  fastTrain.bits.hasOverride     := s3_override
+  fastTrain.valid        := s3_valid
+  fastTrain.bits.startPc := s3_startPc.get.unGuard
+  fastTrain.bits.branch.fromPrediction(s3_prediction, s3_override)
+  fastTrain.bits.abtbMeta  := s3_abtbMeta
+  fastTrain.bits.utageMeta := s3_utageMeta
 
   predictors.foreach { p =>
     p.io.startPc   := s0_startPc.get

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -231,6 +231,7 @@ class BranchInfo(implicit p: Parameters) extends BpuBundle with HalfAlignHelper 
 
   val debug_realCfiPc: Option[UInt] = Option.when(!env.FPGAPlatform)(UInt(VAddrBits.W))
 
+  // backend resolve train s1/s3 predictor
   def fromResolve(resolve: Resolve): Unit = {
     this.taken       := resolve.taken
     this.target      := resolve.target
@@ -245,6 +246,17 @@ class BranchInfo(implicit p: Parameters) extends BpuBundle with HalfAlignHelper 
         resolve.debug_isRVC.get
       )
     }
+  }
+
+  // s3 prediction train s1 predictor
+  def fromPrediction(prediction: Prediction, hasOverride: Bool): Unit = {
+    this.taken       := prediction.taken
+    this.target      := prediction.target.unGuard // s1 training does not need guard bit
+    this.cfiPosition := prediction.cfiPosition
+    this.attribute   := prediction.attribute
+    this.mispredict  := hasOverride
+    // not available
+    this.debug_realCfiPc.foreach(_ := DontCare)
   }
 }
 
@@ -284,11 +296,10 @@ class Train(NumStartPcVecDup: Int = 1)(implicit p: Parameters) extends BpuTrain 
 
 // use s3 prediction to train s1 predictors
 class FastTrain(implicit p: Parameters) extends BpuBundle {
-  val startPc:         Pc            = Pc()
-  val finalPrediction: Prediction    = new Prediction
-  val hasOverride:     Bool          = Bool()
-  val abtbMeta:        AheadBtbMeta  = new AheadBtbMeta
-  val utageMeta:       MicroTageMeta = new MicroTageMeta
+  val startPc:   Pc            = Pc()
+  val branch:    BranchInfo    = new BranchInfo
+  val abtbMeta:  AheadBtbMeta  = new AheadBtbMeta
+  val utageMeta: MicroTageMeta = new MicroTageMeta
 }
 
 // metadata for commit training (e.g. ras)

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
@@ -263,10 +263,10 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
 
   // A taken final prediction can allocate/correct an entry. A not-taken
   // prediction only updates counters of the conditional entries that hit.
-  private val t1_trainTaken           = t1_train.finalPrediction.taken
-  private val t1_trainPosition        = t1_train.finalPrediction.cfiPosition
-  private val t1_trainAttribute       = t1_train.finalPrediction.attribute
-  private val t1_trainTarget          = t1_train.finalPrediction.target
+  private val t1_trainTaken           = t1_train.branch.taken
+  private val t1_trainPosition        = t1_train.branch.cfiPosition
+  private val t1_trainAttribute       = t1_train.branch.attribute
+  private val t1_trainTarget          = t1_train.branch.target
   private val t1_trainTargetLowerBits = getTargetLowerBits(t1_trainTarget)
 
   private val t1_condMask           = t1_meta.entries.map(e => e.hit && e.attribute.isConditional)

--- a/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
@@ -37,7 +37,6 @@ class MicroBtb(implicit p: Parameters) extends BasePredictor with HasMicroBtbPar
 
   println(f"MicroBtb:")
   println(f"  Size(full-assoc): $NumEntries")
-  println(f"  Use fast-train: $UseFastTrain")
   println(f"  Replacer: $Replacer")
   println(f"  Address fields:")
   addrFields.show(indent = 4)
@@ -107,29 +106,18 @@ class MicroBtb(implicit p: Parameters) extends BasePredictor with HasMicroBtbPar
    * - check if hits t1 stage
    * - calculate hit flags
    */
-  private val t0_fire        = Wire(Bool())
-  private val t0_startPc     = Wire(Pc())
-  private val t0_actualTaken = Wire(Bool())
-  private val t0_position    = Wire(UInt(CfiPositionWidth.W))
-  private val t0_fullTarget  = Wire(Pc())
-  private val t0_attribute   = Wire(new BranchAttribute)
+  private val t0_useFast    = io.fastTrain.get.valid
+  private val t0_useResolve = io.stageCtrl.t0_fire && io.train.mispredictBranch.valid
 
-  if (UseFastTrain) {
-    t0_fire        := io.fastTrain.get.valid && io.enable
-    t0_startPc     := io.fastTrain.get.bits.startPc
-    t0_actualTaken := io.fastTrain.get.bits.finalPrediction.taken
-    t0_position    := io.fastTrain.get.bits.finalPrediction.cfiPosition
-    t0_fullTarget  := io.fastTrain.get.bits.finalPrediction.target.unGuard
-    t0_attribute   := io.fastTrain.get.bits.finalPrediction.attribute
-  } else {
-    // FIXME: not sure if first mispredict is the best, maybe first taken?
-    t0_fire        := io.stageCtrl.t0_fire && io.train.mispredictBranch.valid && io.enable
-    t0_startPc     := io.train.startPc
-    t0_actualTaken := io.train.mispredictBranch.bits.taken
-    t0_position    := io.train.mispredictBranch.bits.cfiPosition
-    t0_fullTarget  := io.train.mispredictBranch.bits.target
-    t0_attribute   := io.train.mispredictBranch.bits.attribute
-  }
+  // resolve's mispredict has higher priority
+  private val t0_fire    = (t0_useFast || t0_useResolve) && io.enable
+  private val t0_startPc = Mux(t0_useResolve, io.train.startPc, io.fastTrain.get.bits.startPc)
+  private val t0_branch  = Mux(t0_useResolve, io.train.mispredictBranch.bits, io.fastTrain.get.bits.branch)
+
+  private val t0_actualTaken = t0_branch.taken
+  private val t0_position    = t0_branch.cfiPosition
+  private val t0_fullTarget  = t0_branch.target
+  private val t0_attribute   = t0_branch.attribute
 
   private val t0_tag         = getTag(t0_startPc)
   private val t0_target      = getEntryTarget(t0_fullTarget)

--- a/src/main/scala/xiangshan/frontend/bpu/ubtb/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ubtb/Parameters.scala
@@ -24,8 +24,6 @@ case class MicroBtbParameters(
     TargetWidth:    Int = 22, // 2B aligned
     UsefulCntWidth: Int = 2,
     Replacer:       String = "plru",
-    // use s3 prediction to train ubtb
-    UseFastTrain: Boolean = true,
     // enable carry and borrow fix for target, so jumps around 2^(TargetWidth+1) boundary will not cause misprediction
     // mainBtb should handle this case, so performance affect should be slight, and, bad for timing
     EnableTargetFix: Boolean = false
@@ -40,6 +38,5 @@ trait HasMicroBtbParameters extends HasBpuParameters {
   def UsefulCntWidth: Int    = ubtbParameters.UsefulCntWidth
   def Replacer:       String = ubtbParameters.Replacer
 
-  def UseFastTrain:    Boolean = ubtbParameters.UseFastTrain
   def EnableTargetFix: Boolean = ubtbParameters.EnableTargetFix
 }

--- a/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
@@ -249,7 +249,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
   private val t0_trainRead              = VecInit(tables.map(_.train.t0_read))
   private val t0_foldedPathHistForTrain = t0_trainMeta.foldedPathHistForTrain
   private val t0_trainStartPc           = t0_train.startPc
-  private val finalPrediction           = t0_train.finalPrediction
+  private val finalPrediction           = t0_train.branch
 
   private val t0_hasHitMisPredVec  = Wire(Vec(NumAheadBtbPredictionEntries, Bool()))
   private val t0_missHitMisPredVec = Wire(Vec(NumAheadBtbPredictionEntries, Bool()))


### PR DESCRIPTION
The original design use resolve or fast train only (controlled by EnableFastTrain compile-time parameter)

Consider the following predict-execute flow:
s1 miss -> s3 miss -> resolve (s3 train) -> redirect -> s1 still miss -> s3 hit (s1 train) -> s1 hit

There will be an extra s1 miss after the first redirect caused by mispredict.

This commit use resolve as high priorty train source, the ideal flow will become: s1 miss -> s3 miss -> resolve(s1/3 train) -> redirect -> s1 hit -> s3 hit (s1 train again)

Hopefully this will reduce some override bubble