### PR TITLE
fix(StoreMisalignBuffer): prevent vector misaligned store from getting stuck in s_block

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -225,7 +225,7 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
     io.sqControl.toStoreMisalignBuffer.uop.uopIdx === req.uop.uopIdx
 
   io.sqControl.toStoreQueue.crossPageWithHit := sameSqPtr && isCrossPage
-  io.sqControl.toStoreQueue.crossPageCanDeq := !isCrossPage || bufferState === s_block || (req.isvec && bufferState === s_wb)
+  io.sqControl.toStoreQueue.crossPageCanDeq := !isCrossPage || bufferState === s_block
   io.sqControl.toStoreQueue.paddr := Cat(splitStoreResp(1).paddr(splitStoreResp(1).paddr.getWidth - 1, 3), 0.U(3.W))
 
   io.sqControl.toStoreQueue.withSamePtr := sameSqPtr && sameUop && req.isvec && robMatch && isCrossPage


### PR DESCRIPTION
### Problem
For cross-page vector misaligned stores, `crossPageCanDeq` was raised during SMS `s_wb`. This allowed StoreQueue to dequeue the entry and raise `doDeq` while SMS was still in `s_wb`. Since `doDeq` is only handled in `s_block`, SMS entered `s_block` on the following cycle after vector writeback, but the SQ entry had already been dequeued and would not raise another `doDeq`. SMS then remained stuck in `s_block`.

### Fix
Only raise `crossPageCanDeq` when SMS is in `s_block`. This aligns StoreQueue's `doDeq` with the state in which SMS consumes it, preventing the vector misaligned-store state machine from getting stuck.