### PR TITLE
fix(Rename): fix vl free-list leak that permanently stalls rename

### DIFF
--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -291,6 +291,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     fl.io.redirect := io.redirect.valid
     fl.io.walk := io.rabCommits.isWalk
   }
+  vlFreeList.io.walk := io.vlCommits.isWalk
   // only when all free list and dispatch1 has enough space can we do allocation
   // when lsqEnqCtrl recover finish, it can allocate freelist.
   // when isWalk, freelist can definitely allocate
@@ -298,10 +299,10 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   fpFreeList.io.doAllocate := intFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && io.toLsqEnqCtrl.canAccept && dispatchCanAcc || io.rabCommits.isWalk
   vecFreeList.io.doAllocate := intFreeList.io.canAllocate && fpFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && io.toLsqEnqCtrl.canAccept && dispatchCanAcc || io.rabCommits.isWalk
   v0FreeList.io.doAllocate := intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && vlFreeList.io.canAllocate && io.toLsqEnqCtrl.canAccept && dispatchCanAcc || io.rabCommits.isWalk
-  vlFreeList.io.doAllocate := intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && io.toLsqEnqCtrl.canAccept && dispatchCanAcc || io.rabCommits.isWalk
+  vlFreeList.io.doAllocate := intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && io.toLsqEnqCtrl.canAccept && dispatchCanAcc || io.vlCommits.isWalk
 
   //           dispatch1 ready ++ float point free list ready ++ int free list ready ++ vec free list ready     ++ not walk
-  val canOut = dispatchCanAcc && fpFreeList.io.canAllocate && intFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !io.rabCommits.isWalk && io.toLsqEnqCtrl.canAccept
+  val canOut = dispatchCanAcc && fpFreeList.io.canAllocate && intFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !io.rabCommits.isWalk && !io.vlCommits.isWalk && io.toLsqEnqCtrl.canAccept
 
   val isLastFtqVec = io.in.map(_.bits.isLastInFtqEntry)
   val isFusionVec = io.isFusionVec
@@ -576,7 +577,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     // Assign performance counters
     uops(i).debug.foreach(_.perfDebugInfo.renameTime := GTimer())
 
-    io.out(i).valid := io.in(i).valid && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !io.rabCommits.isWalk && io.toLsqEnqCtrl.canAccept
+    io.out(i).valid := io.in(i).valid && intFreeList.io.canAllocate && fpFreeList.io.canAllocate && vecFreeList.io.canAllocate && v0FreeList.io.canAllocate && vlFreeList.io.canAllocate && !io.rabCommits.isWalk && !io.vlCommits.isWalk && io.toLsqEnqCtrl.canAccept
     io.out(i).bits := uops(i)
     // dirty code
     if (i == 0) {
@@ -603,7 +604,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     fpSpecWen(i)  := needFpDest(i)  && fpFreeList.io.canAllocate  && fpFreeList.io.doAllocate  && !io.rabCommits.isWalk && !io.redirect.valid
     vecSpecWen(i) := needVecDest(i) && vecFreeList.io.canAllocate && vecFreeList.io.doAllocate && !io.rabCommits.isWalk && !io.redirect.valid
     v0SpecWen(i) := needV0Dest(i) && v0FreeList.io.canAllocate && v0FreeList.io.doAllocate && !io.rabCommits.isWalk && !io.redirect.valid
-    vlSpecWen(i) := needVlDest(i) && vlFreeList.io.canAllocate && vlFreeList.io.doAllocate && !io.rabCommits.isWalk && !io.redirect.valid
+    vlSpecWen(i) := needVlDest(i) && vlFreeList.io.canAllocate && vlFreeList.io.doAllocate && !io.rabCommits.isWalk && !io.vlCommits.isWalk && !io.redirect.valid
 
 
     if (i < RabCommitWidth) {

--- a/src/main/scala/xiangshan/backend/rob/VTypeBuffer.scala
+++ b/src/main/scala/xiangshan/backend/rob/VTypeBuffer.scala
@@ -175,9 +175,9 @@ class VTypeBuffer(size: Int)(implicit p: Parameters) extends XSModule with HasCi
   private val walkSize     = RegInit(0.U(size.U.getWidth.W))
   private val spclWalkSize = RegInit(0.U(size.U.getWidth.W))
 
-  private val commitSizeNext   = Wire(UInt(RabCommitWidth.U.getWidth.W))
-  private val walkSizeNext     = Wire(UInt(RabCommitWidth.U.getWidth.W))
-  private val spclWalkSizeNext = Wire(UInt(RabCommitWidth.U.getWidth.W))
+  private val commitSizeNext   = Wire(UInt(size.U.getWidth.W))
+  private val walkSizeNext     = Wire(UInt(size.U.getWidth.W))
+  private val spclWalkSizeNext = Wire(UInt(size.U.getWidth.W))
 
   private val newCommitSize   = io.fromRob.commitSize
   private val newWalkSize     = io.fromRob.walkSize


### PR DESCRIPTION
fix(Rename): fix vl free-list leak that permanently stalls rename

Hello, here is a pull request for a bug I found.

## Problem

The vl rename free list leaks one physical register every time a control-flow
redirect fires while a vl-writing instruction is in flight and survives the
redirect (so it is not flushed and commits normally). After about 17 such
redirects the 31-entry vl free list is empty, rename can no longer allocate a
vl destination, and the core stops committing. There is no trap, no exception,
and no architectural exit: the program hangs (or trips `rob_commit_stuck` on
builds that assert it).

Root cause: the vl free list takes its walk requests from `io.vlCommits`
(RegNext of the VTypeBuffer commits) but its walk state from
`io.rabCommits.isWalk`, one cycle out of phase, so a vl walk-request that
outlives the RAB walk is dropped and the vl free-list head rolls back past a
surviving vl uop.

## Fix

Two commits, both feeding the same leak:
- `fix(Rename)`: drive the vl free-list walk state, its allocate gate, and the
  rename accept/specWen gates from `io.vlCommits.isWalk`, the same stream as its
  walk requests. The int/fp/vec/v0 free lists are untouched.
- `fix(VTypeBuffer)`: widen the `commitSizeNext`/`walkSizeNext`/`spclWalkSizeNext`
  wires from `RabCommitWidth` (4 bits) to the buffer size, so the walk accounting
  no longer truncates past 15 in-flight vtype entries (a second latent path to
  the same leak).

Assisted-by: Claude:claude-opus-4-8 [Claude Code]