### PR TITLE
refactor(Frontend): replace takenCfiOffset with endPosition

### DIFF
--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -103,7 +103,9 @@ class FtqFetchRequest(implicit p: Parameters) extends FrontendBundle with HasICa
   val vAddr:               Vec[PrunedAddr] = Vec(PortNumber, PrunedAddr(VAddrBits))
   def startVAddr:          PrunedAddr      = vAddr(0)
   def nextLineVAddr:       PrunedAddr      = vAddr(1)
-  val takenCfiOffset:      Valid[UInt]     = Valid(UInt(CfiPositionWidth.W))
+  val taken:               Bool            = Bool()
+  val endPosition:         UInt            = UInt(CfiPositionWidth.W)
+  val bankSel:             Vec[UInt]       = Vec(PortNumber, UInt(DataBanks.W))
   val ftqIdx:              FtqPtr          = new FtqPtr
   val vSetIdx:             Vec[UInt]       = Vec(PortNumber, UInt(idxBits.W))
   val hasBackendException: Bool            = Bool()

--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -682,8 +682,8 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   XSPerfHistogram(
     "fetchBlockSize",
     Mux(
-      io.toFtq.prediction.bits.takenCfiOffset.valid,
-      io.toFtq.prediction.bits.takenCfiOffset.bits,
+      io.toFtq.prediction.bits.taken,
+      getFtqOffset(io.toFtq.prediction.bits.startPc, io.toFtq.prediction.bits.endPosition),
       FetchBlockInstNum.U
     ),
     io.toFtq.prediction.fire,

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -195,18 +195,19 @@ class BpuCtrl extends Bundle {
 }
 
 // Bpu -> Ftq
-class BpuPrediction(implicit p: Parameters) extends BpuBundle with HalfAlignHelper {
-  val startPc:        PrunedAddr  = PrunedAddr(VAddrBits)
-  val target:         PrunedAddr  = PrunedAddr(VAddrBits)
-  val takenCfiOffset: Valid[UInt] = Valid(UInt(CfiPositionWidth.W))
+class BpuPrediction(implicit p: Parameters) extends BpuBundle {
+  val startPc:     PrunedAddr = PrunedAddr(VAddrBits)
+  val target:      PrunedAddr = PrunedAddr(VAddrBits)
+  val taken:       Bool       = Bool()
+  val endPosition: UInt       = UInt(CfiPositionWidth.W)
   // override valid
   val s3Override: Bool = Bool()
 
   def fromStage(startPc: PrunedAddr, prediction: Prediction): Unit = {
-    this.startPc              := startPc
-    this.takenCfiOffset.valid := prediction.taken
-    this.takenCfiOffset.bits  := getFtqOffset(startPc, prediction.cfiPosition)
-    this.target               := prediction.target
+    this.startPc     := startPc
+    this.target      := prediction.target
+    this.taken       := prediction.taken
+    this.endPosition := prediction.cfiPosition
   }
 }
 

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -28,11 +28,13 @@ import xiangshan.frontend.bpu.BpuPerfMeta
 import xiangshan.frontend.bpu.BranchAttribute
 import xiangshan.frontend.bpu.BranchInfo
 import xiangshan.frontend.icache.ICacheCacheLineHelper
+import xiangshan.frontend.icache.ICacheDataHelper
 import xiangshan.frontend.icache.PrefetchReqBundle
 
 class FtqEntry(implicit p: Parameters) extends FtqBundle {
-  val startPc:        PrunedAddr  = PrunedAddr(VAddrBits)
-  val takenCfiOffset: Valid[UInt] = Valid(UInt(CfiPositionWidth.W))
+  val startPc:     PrunedAddr = PrunedAddr(VAddrBits)
+  val taken:       Bool       = Bool()
+  val endPosition: UInt       = UInt(CfiPositionWidth.W)
 }
 
 class MetaEntry(implicit p: Parameters) extends FtqBundle {
@@ -114,39 +116,41 @@ class FtqToMainPipeBundle(implicit p: Parameters) extends FtqBundle {
 }
 
 class FtqPrefetchReq(implicit p: Parameters) extends FtqBundle with ICacheCacheLineHelper {
-  val startVAddr:     PrunedAddr = PrunedAddr(VAddrBits)
-  val nextLineVAddr:  PrunedAddr = PrunedAddr(VAddrBits)
-  val takenCfiOffset: UInt       = UInt(CfiPositionWidth.W)
-  val isCrossLine:    Bool       = Bool()
-  val vSetIdx:        Vec[UInt]  = Vec(MaxPrefetchReqNum, UInt(idxBits.W))
-  val vPageNumber:    UInt       = UInt((VAddrBits - PageOffsetWidth).W)
+  val startVAddr:    PrunedAddr = PrunedAddr(VAddrBits)
+  val nextLineVAddr: PrunedAddr = PrunedAddr(VAddrBits)
+  val isCrossLine:   Bool       = Bool()
+  val vSetIdx:       Vec[UInt]  = Vec(PortNumber, UInt(idxBits.W))
+
+  def vPageNumber: UInt = startVAddr(VAddrBits - 1, PageOffsetWidth)
 
   def fromFtqEntry(entry: FtqEntry): FtqPrefetchReq = {
-    startVAddr     := entry.startPc
-    nextLineVAddr  := entry.startPc + blockBytes.U
-    takenCfiOffset := entry.takenCfiOffset.bits
-    isCrossLine    := isCrossLine(startVAddr, takenCfiOffset)
-    vSetIdx        := VecInit(get_idx(startVAddr), get_idx(nextLineVAddr))
-    vPageNumber    := entry.startPc(VAddrBits - 1, PageOffsetWidth)
+    startVAddr    := entry.startPc
+    nextLineVAddr := entry.startPc + blockBytes.U
+    isCrossLine   := super.isCrossLine(startVAddr, entry.endPosition)
+    vSetIdx       := VecInit(get_idx(startVAddr), get_idx(nextLineVAddr))
     this
   }
 }
 
-class FtqFetchReq(implicit p: Parameters) extends FtqBundle with ICacheCacheLineHelper {
-  val startVAddr:     PrunedAddr  = PrunedAddr(VAddrBits)
-  val nextLineVAddr:  PrunedAddr  = PrunedAddr(VAddrBits)
-  val takenCfiOffset: Valid[UInt] = Valid(UInt(CfiPositionWidth.W))
-  val vSetIdx:        Vec[UInt]   = Vec(PortNumber, UInt(idxBits.W))
-  val size:           UInt        = UInt((log2Ceil(FetchBlockInstNum) + 1).W)
-  val vPageNumber:    UInt        = UInt((VAddrBits - PageOffsetWidth).W)
+class FtqFetchReq(implicit p: Parameters) extends FtqBundle with ICacheDataHelper {
+  val startVAddr:    PrunedAddr = PrunedAddr(VAddrBits)
+  val nextLineVAddr: PrunedAddr = PrunedAddr(VAddrBits)
+  val taken:         Bool       = Bool()
+  val endPosition:   UInt       = UInt(CfiPositionWidth.W)
+  val bankSel:       Vec[UInt]  = Vec(PortNumber, UInt(DataBanks.W))
+  val vSetIdx:       Vec[UInt]  = Vec(PortNumber, UInt(idxBits.W))
+
+  def size: UInt = (endPosition +& 1.U) - startVAddr(FetchBlockAlignWidth - 1, instOffsetBits)
+
+  def vPageNumber: UInt = startVAddr(VAddrBits - 1, PageOffsetWidth)
 
   def fromFtqEntry(entry: FtqEntry): FtqFetchReq = {
-    startVAddr     := entry.startPc
-    nextLineVAddr  := entry.startPc + blockBytes.U
-    takenCfiOffset := entry.takenCfiOffset
-    vSetIdx        := VecInit(get_idx(startVAddr), get_idx(startVAddr) + 1.U)
-    size           := entry.takenCfiOffset.bits +& 1.U
-    vPageNumber    := entry.startPc(VAddrBits - 1, PageOffsetWidth)
+    startVAddr    := entry.startPc
+    nextLineVAddr := entry.startPc + blockBytes.U
+    taken         := entry.taken
+    endPosition   := entry.endPosition
+    bankSel       := getBankSel(startVAddr, endPosition)
+    vSetIdx       := VecInit(get_idx(startVAddr), get_idx(startVAddr) + 1.U)
     this
   }
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -57,7 +57,7 @@ import xiangshan.frontend.bpu.BpuTrain
 import xiangshan.frontend.bpu.BranchAttribute
 import xiangshan.frontend.bpu.BranchInfo
 import xiangshan.frontend.bpu.HalfAlignHelper
-import xiangshan.frontend.icache.ICacheCacheLineHelper
+import xiangshan.frontend.icache.ICacheDataHelper
 import xiangshan.frontend.icache.ICacheToFtqIO
 import xiangshan.frontend.icache.TwoFetchFailReason
 
@@ -67,7 +67,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
     with HasCircularQueuePtrHelper
     with IfuRedirectReceiver
     with BackendRedirectReceiver
-    with ICacheCacheLineHelper {
+    with ICacheDataHelper {
 
   class FtqIO extends FtqBundle {
     val fromBpu: BpuToFtqIO = Flipped(new BpuToFtqIO)
@@ -192,8 +192,9 @@ class Ftq(implicit p: Parameters) extends FtqModule
   }
 
   when((prediction.fire || bpuS3Redirect) && !redirect.valid) {
-    entryQueue(predictionPtr.value).startPc        := prediction.bits.startPc
-    entryQueue(predictionPtr.value).takenCfiOffset := prediction.bits.takenCfiOffset
+    entryQueue(predictionPtr.value).startPc     := prediction.bits.startPc
+    entryQueue(predictionPtr.value).taken       := prediction.bits.taken
+    entryQueue(predictionPtr.value).endPosition := prediction.bits.endPosition
   }
 
   private val s3PerfQueue = WireInit(perfQueue)
@@ -277,9 +278,8 @@ class Ftq(implicit p: Parameters) extends FtqModule
   io.toICache.toPrefetch.valid := bpuPtr(0) > pfPtr(0) && !redirect.valid
   io.toICache.toPrefetch.bits.req.zipWithIndex.foreach { case (req, i) =>
     req.startVAddr       := prefetchReq(i).startVAddr
-    req.nextLineVAddr    := req.startVAddr + blockBytes.U
+    req.nextLineVAddr    := prefetchReq(i).nextLineVAddr
     req.isCrossLine      := prefetchReq(i).isCrossLine
-    req.takenCfiOffset   := prefetchReq(i).takenCfiOffset
     req.ftqIdx           := pfPtr(i)
     req.backendException := Mux(backendExceptionPtr === pfPtr(i), backendException, ExceptionType.None)
     req.isSoftPrefetch   := false.B
@@ -308,7 +308,9 @@ class Ftq(implicit p: Parameters) extends FtqModule
     req.valid               := (if (i == 0) true.B else rawTwoFetchValid)
     req.startVAddr          := fetchReq(i).startVAddr
     req.nextLineVAddr       := fetchReq(i).nextLineVAddr
-    req.takenCfiOffset      := fetchReq(i).takenCfiOffset
+    req.taken               := fetchReq(i).taken
+    req.endPosition         := fetchReq(i).endPosition
+    req.bankSel             := fetchReq(i).bankSel
     req.ftqIdx              := fetchPtr(i)
     req.vSetIdx             := fetchReq(i).vSetIdx
     req.hasBackendException := backendException.hasException && backendExceptionPtr === fetchPtr(i)

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -252,7 +252,6 @@ class PrefetchReqBundle(implicit p: Parameters) extends ICacheBundle {
   val startVAddr:       PrunedAddr    = PrunedAddr(VAddrBits)
   val nextLineVAddr:    PrunedAddr    = PrunedAddr(VAddrBits)
   val isCrossLine:      Bool          = Bool()
-  val takenCfiOffset:   UInt          = UInt(CfiPositionWidth.W)
   val ftqIdx:           FtqPtr        = new FtqPtr
   val backendException: ExceptionType = new ExceptionType
   val isSoftPrefetch:   Bool          = Bool()
@@ -260,8 +259,7 @@ class PrefetchReqBundle(implicit p: Parameters) extends ICacheBundle {
   def fromSoftPrefetch(req: SoftIfetchPrefetchBundle): PrefetchReqBundle = {
     startVAddr       := req.vaddr
     nextLineVAddr    := DontCare
-    isCrossLine      := false.B // prefetch only one line for a prefetch.i instruction
-    takenCfiOffset   := 0.U
+    isCrossLine      := false.B
     ftqIdx           := DontCare
     backendException := ExceptionType.None
     isSoftPrefetch   := true.B
@@ -278,8 +276,6 @@ class PrefetchReqBundle(implicit p: Parameters) extends ICacheBundle {
  */
 class WayLookupEntry(implicit p: Parameters) extends ICacheBundle {
   val vSetIdx:     Vec[UInt] = Vec(PortNumber, UInt(idxBits.W))
-  val bankSel:     Vec[UInt] = Vec(PortNumber, UInt(DataBanks.W))
-  val isCrossLine: Bool      = Bool()
   val waymask:     Vec[UInt] = Vec(PortNumber, UInt(nWays.W))
   val maybeRvcMap: Vec[UInt] = Vec(PortNumber, UInt(MaxInstNumPerBlock.W))
   val metaCodes:   Vec[UInt] = Vec(PortNumber, UInt(MetaEccBits.W))

--- a/src/main/scala/xiangshan/frontend/icache/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Helpers.scala
@@ -19,6 +19,7 @@ import chisel3._
 import chisel3.util._
 import xiangshan.frontend.PrunedAddr
 import xiangshan.frontend.PrunedAddrInit
+import xiangshan.frontend.bpu.HasBpuParameters
 
 trait ICacheEccHelper extends HasICacheParameters {
   // per-port
@@ -110,7 +111,7 @@ trait ICacheMetaHelper extends HasICacheParameters {
     getWaymask(reqPTag, VecInit(entries.map(_.bits.meta.phyTag)), VecInit(entries.map(_.valid)))
 }
 
-trait ICacheDataHelper extends HasICacheParameters {
+trait ICacheDataHelper extends HasICacheParameters with ICacheCacheLineHelper {
   def getBankIdx(blkOffset: UInt): UInt =
     (blkOffset >> rowOffBits).asUInt
 
@@ -131,20 +132,30 @@ trait ICacheDataHelper extends HasICacheParameters {
     )
   }
 
-  def getBankSel(startPc: PrunedAddr, takenCfiOffset: UInt): (Bool, Vec[UInt]) = {
-    val blockOffset        = startPc(blockOffBits - 1, 0)
-    val blockEndOffsetTemp = blockOffset +& Cat(takenCfiOffset, 0.U(instOffsetBits.W))
-    val blockEndOffset     = blockEndOffsetTemp(blockOffBits - 1, 0)
-    val isCrossLine        = blockEndOffsetTemp(blockOffBits)
-    val bankIdxLow         = getBankIdx(blockOffset)
-    val bankIdxHigh        = getBankIdx(blockEndOffset)
-    val bankSel = VecInit(
+  def getBankSel(startPc: PrunedAddr, endPosition: UInt): Vec[UInt] = {
+    val bankIdxLow = startPc(blockOffBits - 1, rowOffBits)
+    val (isCrossLine, bankIdxHigh) =
+      if (useHalfAlignFastPath) {
+        (
+          super.isCrossLine(startPc, endPosition),
+          Cat(
+            startPc(blockOffBits - 1) ^ endPosition(CfiPositionWidth - 1),
+            endPosition(CfiPositionWidth - 2, rowOffBits - instOffsetBits)
+          )
+        )
+      } else {
+        val (crossLine, endLineOffset) = getFetchBlockEndLineOffset(startPc, endPosition)
+        (
+          crossLine,
+          endLineOffset(blockOffBits - instOffsetBits - 1, rowOffBits - instOffsetBits)
+        )
+      }
+    VecInit(
       // first line: if in same line, select [low, high], else select [low, end]
       VecInit((0 until DataBanks).map(i => (i.U >= bankIdxLow) && (isCrossLine || i.U <= bankIdxHigh))).asUInt,
       // second line: if in same line, select nothing, else select [start, high]
       VecInit((0 until DataBanks).map(i => (i.U <= bankIdxHigh) && isCrossLine)).asUInt
     )
-    (isCrossLine, bankSel)
   }
 
   def getLineSel(blkOffset: UInt): Vec[Bool] = {
@@ -238,12 +249,26 @@ trait ICacheMissUpdateHelper extends HasICacheParameters with ICacheEccHelper wi
     })
 }
 
-trait ICacheCacheLineHelper extends HasICacheParameters {
-  def isCrossLine(startVAddr: PrunedAddr, takenCfiOffset: UInt): Bool = {
+trait ICacheCacheLineHelper extends HasICacheParameters with HasBpuParameters {
+  protected def useHalfAlignFastPath: Boolean =
+    FetchBlockSize == blockBytes && FetchBlockAlignSize == FetchBlockSize / 2
+
+  def getFetchBlockEndLineOffset(startPc: PrunedAddr, endPosition: UInt): (Bool, UInt) = {
     require(FetchBlockSize <= blockBytes, "Cannot fetch more than one cache line in a fetch block")
-    val startBlockOffset = startVAddr(blockOffBits - 1, instOffsetBits)
-    val endBlockOffset   = startBlockOffset +& takenCfiOffset
-    // if overflow, must be cross line
-    endBlockOffset(blockOffBits - instOffsetBits)
+    val endOffset              = endPosition - startPc(FetchBlockAlignWidth - 1, instOffsetBits)
+    val startLineOffset        = startPc(blockOffBits - 1, instOffsetBits)
+    val endLineOffsetWithCarry = startLineOffset +& endOffset
+    val isCrossLine            = endLineOffsetWithCarry(blockOffBits - instOffsetBits)
+    val endLineOffset          = endLineOffsetWithCarry(blockOffBits - instOffsetBits - 1, 0)
+    (isCrossLine, endLineOffset)
   }
+
+  def isCrossLine(startPc: PrunedAddr, endPosition: UInt): Bool =
+    // Fast path for the default configuration: 64B fetch block, 32B half-align.
+    if (useHalfAlignFastPath) {
+      startPc(blockOffBits - 1) && endPosition(CfiPositionWidth - 1)
+    } else {
+      // Generic fallback for other align sizes.
+      getFetchBlockEndLineOffset(startPc, endPosition)._1
+    }
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -30,6 +30,7 @@ import xiangshan.cache.mmu.Pbmt
 import xiangshan.cache.mmu.TlbCmd
 import xiangshan.frontend.ExceptionType
 import xiangshan.frontend.PrunedAddr
+import xiangshan.frontend.bpu.HalfAlignHelper
 import xiangshan.frontend.ftq.BpuFlushInfo
 import xiangshan.frontend.ftq.FtqToMainPipeBundle
 
@@ -37,7 +38,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
     with ICacheEccHelper
     with ICacheAddrHelper
     with ICacheDataHelper
-    with ICacheMissUpdateHelper {
+    with ICacheMissUpdateHelper
+    with HalfAlignHelper {
 
   class ICacheMainPipeIO(implicit p: Parameters) extends ICacheBundle {
     val hartId: UInt = Input(UInt(hartIdLen.W))
@@ -119,7 +121,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
       req1LineIdx <- 0 until MaxFetchReqNum
     } yield {
       val bankOverlap =
-        (s0_wayLookupEntry(0).bankSel(req0LineIdx) & s0_wayLookupEntry(1).bankSel(req1LineIdx)).orR
+        (io.fromFtq.bits.req(0).bankSel(req0LineIdx) & io.fromFtq.bits.req(1).bankSel(req1LineIdx)).orR
       val sameWay =
         s0_wayLookupEntry(0).waymask(req0LineIdx) === s0_wayLookupEntry(1).waymask(req1LineIdx)
       val differentSet =
@@ -181,7 +183,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   toData.valid := s0_valid && s1_ready && !s0_flush
   toData.bits.zipWithIndex.foreach { case (readReq, i) =>
     readReq.valid        := s0_req(i).valid
-    readReq.bits.bankSel := s0_wayLookupEntry(i).bankSel
+    readReq.bits.bankSel := s0_req(i).bankSel
     readReq.bits.waymask := s0_wayMask(i)
     readReq.bits.vSetIdx := s0_req(i).vSetIdx
   }
@@ -199,7 +201,9 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s1_exceptionInfo  = RegEnable(s0_exceptionInfo, s0_fire)
 
   private val s1_wayMask     = VecInit(s1_wayLookupEntry.map(_.waymask))
-  private val s1_isCrossLine = VecInit(s1_wayLookupEntry.map(_.isCrossLine))
+  private val s1_isCrossLine = VecInit(s1_req.map(req => isCrossLine(req.startVAddr, req.endPosition)))
+  private val s1_takenCfiOffset =
+    VecInit(s1_req.map(req => getFtqOffset(req.startVAddr, req.endPosition)))
 
   private val s1_pTag   = s1_wayLookupEntry(0).pTag
   private val s1_ftqIdx = s1_req(0).ftqIdx
@@ -383,15 +387,16 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
 
   io.toIfu.req.valid := s1_valid && s1_fetchFinish && !s1_flush
   io.toIfu.req.bits.zipWithIndex.foreach { case (req, i) =>
-    req.valid            := s1_req(i).valid
-    req.startVAddr       := s1_req(i).startVAddr
-    req.ftqIdx           := s1_req(i).ftqIdx
-    req.takenCfiOffset   := s1_req(i).takenCfiOffset
-    req.range            := Fill(FetchBlockInstNum, 1.U(1.W)) >> (~s1_req(i).takenCfiOffset.bits).asUInt
-    req.size             := s1_req(i).takenCfiOffset.bits +& 1.U
-    req.data             := s1_data(i)
-    req.maybeRvcMap      := s1_maybeRvcMap(i)
-    req.perf_isCrossLine := s1_isCrossLine(i)
+    req.valid                := s1_req(i).valid
+    req.startVAddr           := s1_req(i).startVAddr
+    req.ftqIdx               := s1_req(i).ftqIdx
+    req.takenCfiOffset.valid := s1_req(i).taken
+    req.takenCfiOffset.bits  := s1_takenCfiOffset(i)
+    req.range                := Fill(FetchBlockInstNum, 1.U(1.W)) >> (~s1_takenCfiOffset(i)).asUInt
+    req.size                 := s1_takenCfiOffset(i) +& 1.U
+    req.data                 := s1_data(i)
+    req.maybeRvcMap          := s1_maybeRvcMap(i)
+    req.perf_isCrossLine     := s1_isCrossLine(i)
 
     req.icacheMeta.exception          := s1_exceptionOut
     req.icacheMeta.pmpMmio            := s1_pmpMmio
@@ -417,7 +422,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
   private val s2_wayLookupEntry = RegEnable(s1_wayLookupEntry, s1_fire)
   private val s2_pTag           = RegEnable(s1_pTag, s1_fire)
   private val s2_wayMask        = RegEnable(s1_wayMask, s1_fire)
-  private val s2_req            = RegEnable(s1_req, s1_fire)
+  private val s2_vAddr          = RegEnable(VecInit(s1_req.map(_.vAddr)), s1_fire)
   private val s2_sramDatas      = RegEnable(s1_sramDatas, s1_fire)
   private val s2_sramCodes      = RegEnable(s1_sramCodes, s1_fire)
   private val s2_offset         = RegEnable(s1_offset, s1_fire)
@@ -471,7 +476,7 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
 
       val info = Wire(Valid(new CorruptedInfo))
       info.valid        := metaCorrupt(portIdx) || dataCorrupt(portIdx)
-      info.bits.vAddr   := s2_req(reqIdx).vAddr(portIdx)
+      info.bits.vAddr   := s2_vAddr(reqIdx)(portIdx)
       info.bits.wayMask := s2_wayMask(reqIdx)(portIdx)
       info.bits.isMeta  := metaCorrupt(portIdx)
       info.bits.isData  := dataCorrupt(portIdx)

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -33,8 +33,7 @@ import xiangshan.frontend.ftq.FtqToPrefetchBundle
 class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
     with ICacheAddrHelper
     with ICacheMetaHelper
-    with ICacheMissUpdateHelper
-    with ICacheDataHelper {
+    with ICacheMissUpdateHelper {
 
   class ICachePrefetchPipeIO(implicit p: Parameters) extends ICacheBundle {
     // control
@@ -292,8 +291,6 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
   // Disallow enqueuing wayLookup when SRAM write occurs.
   toWayLookup.zipWithIndex.foreach { case (port, i) =>
-    val (isCrossLine, bankSel) = getBankSel(s1_req(i).startVAddr, s1_req(i).takenCfiOffset)
-
     port.valid :=
       // tlb/meta ready
       ((s1_state === S1FsmState.EnqWay) || ((s1_state === S1FsmState.Idle) && tlbFinish)) &&
@@ -308,8 +305,6 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
 
     port.bits.ftqIdx            := s1_req(i).ftqIdx
     port.bits.entry.vSetIdx     := VecInit(get_idx(s1_req(i).startVAddr), get_idx(s1_req(i).nextLineVAddr))
-    port.bits.entry.bankSel     := bankSel
-    port.bits.entry.isCrossLine := isCrossLine
     port.bits.entry.waymask     := VecInit(s1_reqMetaInfo(i).map(_.waymask))
     port.bits.entry.pTag        := s1_pTag
     port.bits.entry.maybeRvcMap := VecInit(s1_reqMetaInfo(i).map(_.maybeRvcMap))


### PR DESCRIPTION
This PR replaces `takenCfiOffset` with `endPosition` in all frontend modules except the IFU. However, all `takenCfiOffset` usages will be removed later.

Whether the fetch block ends with a taken branch instruction or by fall-through, `endPosition` can consistently represent the semantic meaning of “the end position of the fetch block.”

And there are some benefits about timing:
1. The prediction sent from the BPU to the FTQ no longer needs to compute `takenCfiOffset`; instead, it can store `endPosition` directly in the FTQ.
2. When calculating `isCrossLine` and `bankSel`, an extra addition is no longer needed.