### PR TITLE
fix(extLLC): route physical targets to external LLC

### DIFF
--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -511,7 +511,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
             Option.when(useExternalLLC)(externalLLCControlRange -> llcRouteId)
           dontTouch(coreCHI)
           bind(
-            route(coreCHI, chiRouteMap),
+            route(coreCHI, chiRouteMap, Option.when(useExternalLLC)(llcRouteId)),
             Map(mmioRouteId -> mmioLogger.io.up, llcRouteId -> llcLogger.io.up)
           )
           chi_mmioBridge_opt(i).get.module.io.chi.connect(mmioLogger.io.down)


### PR DESCRIPTION
Use the external LLC output as TargetBinder's default return route so physical node IDs stay intact on response and data traffic. Keep request routing address based and explicit MMIO routes unchanged.

Update OpenLLC with optional default return-route support.