### PR TITLE
fix(RegCache): reserve in-flight write destinations to prevent slot reuse

### DIFF
--- a/src/main/scala/xiangshan/backend/regcache/RegCache.scala
+++ b/src/main/scala/xiangshan/backend/regcache/RegCache.scala
@@ -119,6 +119,21 @@ class RegCache()(implicit p: Parameters, params: BackendParams) extends XSModule
     w.addr := rcIdx
   }
 
+  // a chosen slot stays reserved until its write lands, 3 cycles later
+  def buildReserved(sel: Vec[UInt], size: Int): Vec[Bool] = {
+    val z  = VecInit(Seq.fill(sel.length)(0.U(sel.head.getWidth.W)))
+    val g1 = RegNext(sel, z)
+    val g2 = RegNext(g1, z)
+    val gens = sel ++ g1 ++ g2
+    val mask = Wire(Vec(size, Bool()))
+    for (e <- 0 until size) {
+      mask(e) := gens.map(_ === e.U).reduce(_ || _)
+    }
+    mask
+  }
+  IntRegCacheAgeTimer.io.reserved := buildReserved(IntRegCacheRepRCIdx, IntRegCacheSize)
+  MemRegCacheAgeTimer.io.reserved := buildReserved(MemRegCacheRepRCIdx, MemRegCacheSize)
+
   if (params.basicDebugEn) {
     io.diffRcIdx.get.zipWithIndex.foreach { case (x, i) =>
       when(x.wen) {

--- a/src/main/scala/xiangshan/backend/regcache/RegCacheAgeTimer.scala
+++ b/src/main/scala/xiangshan/backend/regcache/RegCacheAgeTimer.scala
@@ -43,6 +43,8 @@ class RegCacheAgeTimer
     val readPorts = Vec(numReadPorts, new RCAgeTimerReadPort(addrWidth))
     val writePorts = Vec(numWritePorts, new RCAgeTimerWritePort(addrWidth))
     val validInfo = Vec(numEntries, Input(Bool()))
+    // slots already chosen as a write destination whose write has not landed yet
+    val reserved = Vec(numEntries, Input(Bool()))
     val ageInfo = Vec(numEntries, Vec(numEntries, Output(Bool())))
   })
 
@@ -79,7 +81,11 @@ class RegCacheAgeTimer
       true.B
     else if (row < col) {
       val res = Wire(Bool())
-      when (io.validInfo(row) && !io.validInfo(col)) {
+      when (io.reserved(row) && !io.reserved(col)) {
+        res := false.B
+      }.elsewhen (!io.reserved(row) && io.reserved(col)) {
+        res := true.B
+      }.elsewhen (io.validInfo(row) && !io.validInfo(col)) {
         res := false.B
       }.elsewhen (!io.validInfo(row) && io.validInfo(col)) {
         res := true.B


### PR DESCRIPTION
fix(RegCache): reserve in-flight write destinations to prevent slot reuse

Hello, here is a pull request for a bug I found.

`f25e75d9` added `ageTimerExtra` to the register-cache age timer to "avoid replacing the
same item in multiple consecutive cycles when reg cache is full". That heuristic reduces
the reuse but does not remove it, and the residual reuse is a correctness hazard, not just
a cache-efficiency one.

The age detector picks the oldest slots as write destinations every cycle and the write
lands three cycles later (`delayToWakeupQueueRCIdx = RegNextN(_, 3)`), but the age timer
marks a slot used only when its write lands. During the three-cycle gap the same oldest
slot is chosen again for a later producer, so two producers write one slot on consecutive
cycles. The read path takes the slot index the wakeup queue set at wakeup and does not
re-check the tag at read time (`DataPath` reads `issue.bits.rcIdx` directly), so the
earlier producer's consumer reads the later producer's value.

This marks the in-flight selections as reserved and treats a reserved slot as strictly
youngest in the age timer, so a chosen slot is not re-chosen until its write completes. It
deterministically prevents what the `ageTimerExtra` heuristic only made less likely. The
cache is already sized for exactly this: IntRegCache 24 = 4 * 6 write ports, MemRegCache
12 = 4 * 3.

### Note for reviewers

The reserve is unconditional: it reserves every age-detector pick, whether or not a
producer takes it. Measured cycle impact was zero, so I kept the simpler form, but you may
prefer gating it on the wakeup queue's `rfWen`.

Assisted-by: Claude:claude-opus-4-8 [Claude Code]
