### PR TITLE
fix(extLLC): route traffic directly through ExtLLC

### DIFF
--- a/src/main/scala/top/ExternalLLC.scala
+++ b/src/main/scala/top/ExternalLLC.scala
@@ -1,12 +1,16 @@
 package top
 
 import chisel3._
+import chisel3.util._
 import chisel3.experimental.dataview._
 import coupledL2.tl2chi.PortIO
 import freechips.rocketchip.amba.axi4._
-import freechips.rocketchip.diplomacy.{AddressSet, IdRange, LazyModule, LazyModuleImp, ValName}
+import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
 import org.chipsalliance.cde.config.{Field, Parameters}
 import system.HasSoCParameter
+import utility.ResetGen
 import utils.VerilogAXI4Record
 
 case object UseExternalLLCKey extends Field[Boolean](false)
@@ -20,6 +24,8 @@ object ExternalLLCAddressMap {
 object ExternalLLCAxiParams {
   val VisibleIdBits = 6
   val DdrcIdBits = 14
+  val PeriIdBits = 2
+  val IMSICIdBits = 11
 }
 
 // Match OpenNCB's forced-INCR memory AXI behavior expected by XiangShan AXI4 slaves.
@@ -58,16 +64,133 @@ object AXI4ForceIncr {
   def apply()(implicit p: Parameters, valName: ValName): AXI4Node = LazyModule(new AXI4ForceIncr()).node
 }
 
+/**
+  * ExtLLC exposes IMSIC as one 128-bit HN-I AXI master. XiangShan keeps one
+  * 32-bit IMSIC AXI slave per hart, so retain ExtLLC's dedicated HN-I path and
+  * split requests by the architectural IMSIC address ranges here.
+  */
+class ExternalLLCIMSICXbar()(implicit override val p: Parameters) extends LazyModule with HasSoCParameter {
+  private val inputDataBytes = 16
+  private val imsicParams = soc.IMSICParams
+  private val sgStrideWidth = imsicParams.intFileMemWidth + log2Ceil(1 + imsicParams.geilen)
+
+  val masterNode = AXI4MasterNode(Seq(AXI4MasterPortParameters(
+    Seq(AXI4MasterParameters(
+      name = "extllc-imsic",
+      id = IdRange(0, 1 << ExternalLLCAxiParams.IMSICIdBits)
+    ))
+  )))
+
+  private val imsicRangesByHart = Seq.tabulate(NumCores) { hart =>
+    Seq(
+      AddressSet(
+        imsicParams.mAddr + (hart.toLong << imsicParams.intFileMemWidth),
+        (1L << imsicParams.intFileMemWidth) - 1
+      ),
+      AddressSet(
+        imsicParams.sgAddr + (hart.toLong << sgStrideWidth),
+        (1L << sgStrideWidth) - 1
+      )
+    )
+  }
+
+  val imsicSlaveNodes = imsicRangesByHart.map { ranges =>
+    AXI4SlaveNode(Seq(AXI4SlavePortParameters(
+      Seq(AXI4SlaveParameters(
+        address = ranges,
+        regionType = RegionType.UNCACHED,
+        supportsWrite = TransferSizes(1, inputDataBytes),
+        supportsRead = TransferSizes(1, inputDataBytes)
+      )),
+      beatBytes = 4
+    )))
+  }
+
+  private val errorDevice = LazyModule(new TLError(
+    params = DevNullParams(
+      address = Seq(AddressSet(0x0L, 0x7fffffffL)).flatMap { range =>
+        imsicRangesByHart.flatten.foldLeft(Seq(range)) { case (remaining, imsicRange) =>
+          remaining.flatMap(_.subtract(imsicRange))
+        }
+      },
+      maxAtomic = 1,
+      maxTransfer = inputDataBytes
+    ),
+    beatBytes = 4
+  ))
+
+  private val xbar = TLXbar()
+  xbar :=
+    TLFIFOFixer() :=
+    TLWidthWidget(inputDataBytes) :=
+    AXI4ToTL() :=
+    AXI4UserYanker(Some(1)) :=
+    AXI4Fragmenter() :=
+    AXI4Buffer() :=
+    AXI4Buffer() :=
+    AXI4IdIndexer(1) :=
+    masterNode
+
+  imsicSlaveNodes.foreach { node =>
+    node :=
+      AXI4Buffer() :=
+      AXI4Buffer() :=
+      AXI4Buffer() :=
+      AXI4IdIndexer(idBits = 2) :=
+      AXI4UserYanker() :=
+      AXI4Deinterleaver(64) :=
+      TLToAXI4() :=
+      TLSourceShrinker(64) :=
+      TLBuffer.chainNode(2) :=
+      xbar
+  }
+  errorDevice.node := xbar
+
+  lazy val module = new ExternalLLCIMSICXbarImp(this)
+}
+
+class ExternalLLCIMSICXbarImp(wrapper: ExternalLLCIMSICXbar)(implicit override val p: Parameters)
+  extends LazyRawModuleImp(wrapper) {
+  val io = IO(new Bundle {
+    val clock = Input(Clock())
+    val reset = Input(AsyncReset())
+    val s_axi = Flipped(new VerilogAXI4Record(wrapper.masterNode.out.head._2.bundle))
+    val m_axi = Vec(wrapper.NumCores, new VerilogAXI4Record(wrapper.imsicSlaveNodes.head.in.head._2.bundle))
+  })
+
+  val resetSync = withClockAndReset(io.clock, io.reset) { ResetGen() }
+  // Assert reset directly so the AXI buffers are initialized before the first
+  // clock edge; ResetGen still synchronizes the release.
+  val adapterReset = (io.reset.asBool || resetSync.asBool).asAsyncReset
+  childClock := io.clock
+  childReset := adapterReset
+
+  io.s_axi.viewAs[AXI4Bundle] <> wrapper.masterNode.out.head._1
+
+  io.m_axi.zip(wrapper.imsicSlaveNodes).foreach { case (axi, node) =>
+    axi.viewAs[AXI4Bundle] <> node.in.head._1
+  }
+}
+
 class ExternalLLC()(implicit override val p: Parameters) extends LazyModule with HasSoCParameter {
   val ddrcAXI4Node = AXI4MasterNode(Seq(AXI4MasterPortParameters(
     Seq(AXI4MasterParameters(
-      name = "external-llc",
+      name = "extllc-ddrc",
       id = IdRange(0, 1 << ExternalLLCAxiParams.DdrcIdBits),
       aligned = true,
       maxFlight = Some(1)
     ))
   )))
+  val periAXI4Node = AXI4MasterNode(Seq(AXI4MasterPortParameters(
+    Seq(AXI4MasterParameters(
+      name = "extllc-peri",
+      id = IdRange(0, 1 << ExternalLLCAxiParams.PeriIdBits),
+      aligned = true,
+      maxFlight = Some(1)
+    ))
+  )))
   val axi4node = AXI4IdentityNode()
+  val imsicXbar = LazyModule(new ExternalLLCIMSICXbar())
 
   axi4node :=
     AXI4UserYanker(Some(1)) :=
@@ -84,24 +207,46 @@ class ExternalLLCImp(wrapper: ExternalLLC)(implicit override val p: Parameters) 
     val clock = Input(Clock())
     val reset = Input(Bool())
     val rn = Vec(NumCores, Flipped(new PortIO))
+    val rnNodeId = Output(Vec(NumCores, UInt(11.W)))
+    val imsic = Vec(NumCores, new VerilogAXI4Record(wrapper.imsicXbar.imsicSlaveNodes.head.in.head._2.bundle))
   })
 
   val (axi, edge) = wrapper.ddrcAXI4Node.out.head
-  val wrapperBlackBox = Module(new ExternalLLCWrapper(edge.bundle))
+  val (peri, periEdge) = wrapper.periAXI4Node.out.head
+  val imsicXbar = wrapper.imsicXbar.module
+  val wrapperBlackBox = Module(new ExternalLLCWrapper(
+    edge.bundle,
+    periEdge.bundle,
+    wrapper.imsicXbar.masterNode.out.head._2.bundle
+  ))
 
   wrapperBlackBox.io.clock := io.clock
   wrapperBlackBox.io.reset := io.reset
   wrapperBlackBox.io.rn <> io.rn
+  io.rnNodeId := wrapperBlackBox.io.rnNodeId
   axi <> wrapperBlackBox.io.ddrc.viewAs[AXI4Bundle]
+  peri <> wrapperBlackBox.io.peri.viewAs[AXI4Bundle]
+
+  imsicXbar.io.clock := io.clock
+  imsicXbar.io.reset := io.reset.asAsyncReset
+  wrapperBlackBox.io.imsic <> imsicXbar.io.s_axi
+  io.imsic.zip(imsicXbar.io.m_axi).foreach { case (out, in) => out <> in }
 }
 
-class ExternalLLCWrapper(ddrcParams: AXI4BundleParameters)(implicit val p: Parameters) extends BlackBox
+class ExternalLLCWrapper(
+  ddrcParams: AXI4BundleParameters,
+  periParams: AXI4BundleParameters,
+  imsicParams: AXI4BundleParameters
+)(implicit val p: Parameters) extends BlackBox
   with HasSoCParameter {
   val io = IO(new Bundle {
     val clock = Input(Clock())
     val reset = Input(Bool())
 
     val rn = Vec(NumCores, Flipped(new PortIO))
+    val rnNodeId = Output(Vec(NumCores, UInt(11.W)))
     val ddrc = new VerilogAXI4Record(ddrcParams)
+    val peri = new VerilogAXI4Record(periParams)
+    val imsic = new VerilogAXI4Record(imsicParams)
   })
 }

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -138,7 +138,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     LazyModule(new ExternalLLC())
   }
 
-  val chi_mmioBridge_opt = Seq.fill(NumCores)(Option.when(enableCHI)(
+  val chi_mmioBridge_opt = Seq.fill(NumCores)(Option.when(enableCHI && !useExternalLLC)(
     LazyModule(new OpenNCB()(p.alter((site, here, up) => {
       case NCBParametersKey => new NCBParameters(
         outstandingDepth            = 32,
@@ -295,6 +295,7 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 
   chi_extllc_opt.foreach { externalLLC =>
     misc.soc_xbar.get := externalLLC.axi4node
+    misc.soc_xbar.get := externalLLC.periAXI4Node
   }
 
   chi_mmioBridge_opt.foreach { e =>
@@ -400,16 +401,21 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 
     io.pll0_ctrl <> misc.module.pll0_ctrl
 
-    val imsic_axi4 = Option.when(NumCores == 1)(imsic_bus_tops.head.axi4.map { x =>
+    val imsic_axi4 = Option.when(!useExternalLLC && NumCores == 1)(imsic_bus_tops.head.axi4.map { x =>
       IO(Flipped(new VerilogAXI4Record(x.elts.head.params.copy(addrBits = 32))))
     }).flatten
-    val imsic_axi4s = Option.when(NumCores > 1)(imsic_bus_tops.head.axi4.map { x =>
+    val imsic_axi4s = Option.when(!useExternalLLC && NumCores > 1)(imsic_bus_tops.head.axi4.map { x =>
       IO(Vec(NumCores, Flipped(new VerilogAXI4Record(x.elts.head.params.copy(addrBits = 32)))))
     }).flatten
     imsic_bus_tops.zipWithIndex.foreach { case (imsic_bus_top, i) =>
       imsic_bus_top.axi4.foreach { x =>
-        val imsic_axi4_port = if (NumCores == 1) imsic_axi4.get else imsic_axi4s.get(i)
-        imsic_axi4_port.viewAs[AXI4Bundle] <> x.elements.head._2
+        chi_extllc_opt match {
+          case Some(externalLLC) =>
+            externalLLC.module.io.imsic(i).viewAs[AXI4Bundle] <> x.elements.head._2
+          case None =>
+            val imsic_axi4_port = if (NumCores == 1) imsic_axi4.get else imsic_axi4s.get(i)
+            imsic_axi4_port.viewAs[AXI4Bundle] <> x.elements.head._2
+        }
       }
       imsic_bus_top.tl_m.foreach { x =>
         val imsic_m_tl = IO(chiselTypeOf(x.getWrappedValue))
@@ -495,7 +501,17 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
     }
 
     withClockAndReset(io.clock, io.reset) {
-      if (enableCHI) {
+      if (enableCHI && useExternalLLC) {
+        for ((core, i) <- core_with_l2.zipWithIndex) {
+          val coreCHI = core.module.io.chi.get
+          val extLLCLogger = CHILogger(s"L2[${i}]_ExtLLC", true)
+          val extLLCRN = chi_extllc_opt.get.module.io.rn(i)
+          dontTouch(coreCHI)
+          coreCHI <> extLLCLogger.io.up
+          extLLCRN <> extLLCLogger.io.down
+          require(coreCHI.getWidth == extLLCRN.getWidth)
+        }
+      } else if (enableCHI) {
         val llcRouteId = NumCores * 2
         for ((core, i) <- core_with_l2.zipWithIndex) {
           val coreCHI = core.module.io.chi.get
@@ -503,24 +519,16 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
           val llcLogger = CHILogger(s"L2[${i}]_LLC", true)
           val mmioRouteId = NumCores + i
           val lowAddressRange = AddressSet(0x0L, 0x00007fffffffL)
-          val externalLLCControlRange = ExternalLLCAddressMap.Control
-          val mmioRanges = if (useExternalLLC) lowAddressRange.subtract(externalLLCControlRange) else Seq(lowAddressRange)
           val chiRouteMap = Map[AddressSet, Int]() ++
-            mmioRanges.map(_ -> mmioRouteId) ++
-            AddressSet(0x0L, 0xffffffffffffL).subtract(lowAddressRange).map(_ -> llcRouteId) ++
-            Option.when(useExternalLLC)(externalLLCControlRange -> llcRouteId)
+            Seq(lowAddressRange -> mmioRouteId) ++
+            AddressSet(0x0L, 0xffffffffffffL).subtract(lowAddressRange).map(_ -> llcRouteId)
           dontTouch(coreCHI)
           bind(
             route(coreCHI, chiRouteMap),
             Map(mmioRouteId -> mmioLogger.io.up, llcRouteId -> llcLogger.io.up)
           )
           chi_mmioBridge_opt(i).get.module.io.chi.connect(mmioLogger.io.down)
-          val llcRN = chi_extllc_opt match {
-            case Some(externalLLC) =>
-              externalLLC.module.io.rn(i)
-            case None =>
-              chi_openllc_opt.get.io.rn(i)
-          }
+          val llcRN = chi_openllc_opt.get.io.rn(i)
           llcRN <> llcLogger.io.down
           require(llcLogger.io.down.getWidth == llcRN.getWidth)
           require(coreCHI.getWidth == llcLogger.io.up.getWidth)
@@ -574,7 +582,11 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
 
     core_with_l2.zipWithIndex.foreach { case (tile, i) =>
       tile.module.io.nodeID.foreach { case nodeID =>
-        nodeID := i.U
+        if (useExternalLLC) {
+          nodeID := chi_extllc_opt.get.module.io.rnNodeId(i)
+        } else {
+          nodeID := i.U
+        }
         dontTouch(nodeID)
       }
     }


### PR DESCRIPTION
Connect each CoupleL2 CHI port directly to its ExtLLC RN and preserve physical RN node IDs at the CHI boundary. Requests now use ExtLLC routing instead of the OpenLLC route/bind path.

Connect the ExtLLC HN-D peripheral and HN-I IMSIC AXI paths to XSTop. Adapt the shared 128-bit IMSIC master to the per-hart 32-bit AXI ports.