### PR TITLE
fix(core): frontend pc canonical check

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -102,7 +102,7 @@ class CfiUpdateInfo(implicit p: Parameters) extends XSBundle with HasBPUParamete
   val TOSW = new RASPtr
   val TOSR = new RASPtr
   val NOS = new RASPtr
-  val topAddr = UInt(VAddrBits.W)
+  val topAddr = UInt((VAddrBits + 1).W)
   // val hist = new ShiftingGlobalHistory
   val folded_hist = new AllFoldedHistories(foldedGHistInfos)
   val afhob = new AllAheadFoldedHistoryOldestBits(foldedGHistInfos)
@@ -115,7 +115,7 @@ class CfiUpdateInfo(implicit p: Parameters) extends XSBundle with HasBPUParamete
   val jr_hit = Bool() // if in ftb entry
   val sc_hit = Bool() // if used in ftb entry, invalid if !br_hit
   val predTaken = Bool()
-  val target = UInt(VAddrBits.W)
+  val target = UInt((VAddrBits + 1).W)
   val taken = Bool()
   val isMisPred = Bool()
   val shift = UInt((log2Ceil(numBr)+1).W)

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -877,7 +877,7 @@ object Bundles {
   }
 
   class ExceptionInfo(implicit p: Parameters) extends XSBundle {
-    val pc = UInt(VAddrData().dataWidth.W)
+    val pc = UInt((VAddrData().dataWidth + 1).W)
     val instr = UInt(32.W)
     val commitType = CommitType()
     val exceptionVec = ExceptionVec()

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -34,7 +34,7 @@ import xiangshan.backend.fu.vector.Bundles.{VType, Vl}
 import xiangshan.backend.fu.wrapper.CSRToDecode
 import xiangshan.backend.rename.{Rename, RenameTableWrapper, SnapshotGenerator}
 import xiangshan.backend.rob.{Rob, RobCSRIO, RobCoreTopDownIO, RobDebugRollingIO, RobLsqIO, RobPtr}
-import xiangshan.frontend.{FtqPtr, FtqRead, Ftq_RF_Components}
+import xiangshan.frontend.{FtqPcMemEntry, FtqPtr, FtqRead}
 import xiangshan.mem.{LqPtr, LsqEnqIO, SqPtr}
 import xiangshan.backend.issue.{FpScheduler, IntScheduler, MemScheduler, VfScheduler}
 import xiangshan.backend.trace._
@@ -95,7 +95,7 @@ class CtrlBlockImp(
   val rename = Module(new Rename)
   val redirectGen = Module(new RedirectGenerator)
   private def hasRen: Boolean = true
-  private val pcMem = Module(new SyncDataModuleTemplate(new Ftq_RF_Components, FtqSize, numPcMemRead, 1, "BackendPC", hasRen = hasRen))
+  private val pcMem = Module(new SyncDataModuleTemplate(new FtqPcMemEntry, FtqSize, numPcMemRead, 1, "BackendPC", hasRen = hasRen))
   private val rob = wrapper.rob.module
   private val memCtrl = Module(new MemCtrl(params))
 
@@ -326,7 +326,7 @@ class CtrlBlockImp(
 
   redirectGen.io.loadReplay.bits.cfiUpdate.pc := loadRedirectPcRead
   val load_target = loadRedirectPcRead
-  redirectGen.io.loadReplay.bits.cfiUpdate.target := load_target
+  redirectGen.io.loadReplay.bits.cfiUpdate.target := SignExt(load_target, VAddrBits + 1)
 
   redirectGen.io.robFlush := s1_robFlushRedirect
 
@@ -373,7 +373,7 @@ class CtrlBlockImp(
   private val s5_csrIsTrap = DelayN(rob.io.exception.valid, 4)
   private val s5_trapTargetFromCsr = io.robio.csr.trapTarget
 
-  val flushTarget = Mux(s5_csrIsTrap, s5_trapTargetFromCsr.pc, s2_robFlushPc)
+  val flushTarget = Mux(s5_csrIsTrap, s5_trapTargetFromCsr.pc, SignExt(s2_robFlushPc, XLEN))
   val s5_trapTargetIAF = Mux(s5_csrIsTrap, s5_trapTargetFromCsr.raiseIAF, false.B)
   val s5_trapTargetIPF = Mux(s5_csrIsTrap, s5_trapTargetFromCsr.raiseIPF, false.B)
   val s5_trapTargetIGPF = Mux(s5_csrIsTrap, s5_trapTargetFromCsr.raiseIGPF, false.B)

--- a/src/main/scala/xiangshan/backend/ctrlblock/RedirectGenerator.scala
+++ b/src/main/scala/xiangshan/backend/ctrlblock/RedirectGenerator.scala
@@ -33,7 +33,10 @@ class RedirectGenerator(implicit p: Parameters) extends XSModule
   val robFlush = io.robFlush
   val oldestExuRedirect = Wire(chiselTypeOf(io.oldestExuRedirect))
   oldestExuRedirect := io.oldestExuRedirect
-  oldestExuRedirect.bits.fullTarget := Cat(io.oldestExuRedirect.bits.fullTarget.head(XLEN - VAddrBits), io.oldestExuRedirect.bits.cfiUpdate.target)
+  oldestExuRedirect.bits.fullTarget := Cat(
+    io.oldestExuRedirect.bits.fullTarget.head(XLEN - VAddrBits - 1),
+    io.oldestExuRedirect.bits.cfiUpdate.target
+  )
   when(!io.oldestExuRedirectIsCSR){
     oldestExuRedirect.bits.cfiUpdate.backendIAF := io.instrAddrTransType.checkAccessFault(oldestExuRedirect.bits.fullTarget)
     oldestExuRedirect.bits.cfiUpdate.backendIPF := io.instrAddrTransType.checkPageFault(oldestExuRedirect.bits.fullTarget)

--- a/src/main/scala/xiangshan/backend/datapath/PcTargetMem.scala
+++ b/src/main/scala/xiangshan/backend/datapath/PcTargetMem.scala
@@ -7,7 +7,7 @@ import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import utility._
 import xiangshan._
 import xiangshan.backend.datapath.DataConfig.VAddrData
-import xiangshan.frontend.{FtqPtr, FtqToCtrlIO, Ftq_RF_Components}
+import xiangshan.frontend.{FtqPcMemEntry, FtqPtr, FtqToCtrlIO}
 
 class PcTargetMem(params: BackendParams)(implicit p: Parameters) extends LazyModule {
   override def shouldBeInlined: Boolean = false
@@ -24,7 +24,7 @@ class PcTargetMemImp(override val wrapper: PcTargetMem)(implicit p: Parameters, 
   private val readValid = io.toDataPath.fromDataPathValid
 
   private def hasRen: Boolean = true
-  private val targetMem = Module(new SyncDataModuleTemplate(new Ftq_RF_Components, FtqSize, numTargetMemRead, 1, hasRen = hasRen))
+  private val targetMem = Module(new SyncDataModuleTemplate(new FtqPcMemEntry, FtqSize, numTargetMemRead, 1, hasRen = hasRen))
   private val targetPCVec : Vec[UInt] = Wire(Vec(params.numTargetReadPort, UInt(VAddrData().dataWidth.W)))
   private val pcVec       : Vec[UInt] = Wire(Vec(params.numPcMemReadPort, UInt(VAddrData().dataWidth.W)))
 

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/CSREvent.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSREvents/CSREvent.scala
@@ -99,10 +99,10 @@ trait CSREventBase {
 
     val bareAddr   = ZeroExt(addr(PAddrWidth - 1, 0), XLEN)
     // When enable virtual memory, the higher bit should fill with the msb of address of Sv39/Sv48/Sv57
-    val sv39Addr   = SignExt(addr.take(39), XLEN)
-    val sv39x4Addr = ZeroExt(addr.take(39 + 2), XLEN)
-    val sv48Addr   = SignExt(addr.take(48), XLEN)
-    val sv48x4Addr = ZeroExt(addr.take(48 + 2), XLEN)
+    val sv39Addr   = SignExt(addr.take(40), XLEN)
+    val sv39x4Addr = ZeroExt(addr.take(40 + 2), XLEN)
+    val sv48Addr   = SignExt(addr.take(49), XLEN)
+    val sv48x4Addr = ZeroExt(addr.take(49 + 2), XLEN)
 
     val trapAddr = Mux1H(Seq(
       isBare   -> bareAddr,
@@ -118,7 +118,7 @@ trait CSREventBase {
 
 class TrapEntryEventInput(implicit val p: Parameters) extends Bundle with HasXSParameter {
   val causeNO = Input(new CauseBundle)
-  val trapPc = Input(UInt(VaddrMaxWidth.W))
+  val trapPc = Input(UInt((VaddrMaxWidth+1).W))
   val trapPcGPA = Input(UInt(PAddrBitsMax.W))
   val trapInst = Input(ValidIO(UInt(InstWidth.W)))
   val fetchMalTval = Input(UInt(XLEN.W))

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -136,7 +136,7 @@ class NewCSR(implicit val p: Parameters) extends Module
     })
     val fromRob = Input(new Bundle {
       val trap = ValidIO(new Bundle {
-        val pc = UInt(VaddrMaxWidth.W)
+        val pc = UInt((VaddrMaxWidth+1).W)
         val pcGPA = UInt(PAddrBitsMax.W)
         val instr = UInt(InstWidth.W)
         val trapVec = UInt(64.W)

--- a/src/main/scala/xiangshan/backend/fu/wrapper/BranchUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/BranchUnit.scala
@@ -11,7 +11,7 @@ import xiangshan.{RedirectLevel, SelImm, XSModule}
 
 class AddrAddModule(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle {
-    val pcExtend = Input(UInt((VAddrBits + 1).W))
+    val pcExtend = Input(UInt((VAddrBits + 2).W))
     val taken = Input(Bool())
     val isRVC = Input(Bool())
     val imm = Input(UInt(32.W)) // branch inst only support 12 bits immediate num
@@ -21,7 +21,7 @@ class AddrAddModule(implicit p: Parameters) extends XSModule {
   val immMinWidth = FuConfig.BrhCfg.immType.map(x => SelImm.getImmUnion(x).len).max
   print(s"[Branch]: immMinWidth = $immMinWidth\n")
   io.target := SignExt(Mux(io.taken,
-    io.pcExtend + SignExt(io.imm(immMinWidth + 2, 0), VAddrBits + 1),
+    io.pcExtend + SignExt(io.imm(immMinWidth + 2, 0), VAddrBits + 2),
     io.pcExtend + (io.nextPcOffset << instOffsetBits).asUInt
   ), XLEN)
 }
@@ -35,8 +35,8 @@ class BranchUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
   dataModule.io.pred_taken := io.in.bits.ctrl.predictInfo.get.taken
 
   val pcExtend = Mux(io.instrAddrTransType.get.shouldBeSext,
-    SignExt(io.in.bits.data.pc.get, VAddrBits + 1),
-    ZeroExt(io.in.bits.data.pc.get, VAddrBits + 1)
+    SignExt(io.in.bits.data.pc.get, VAddrBits + 2),
+    ZeroExt(io.in.bits.data.pc.get, VAddrBits + 2)
   )
   addModule.io.pcExtend := pcExtend
   addModule.io.imm := io.in.bits.data.imm // imm
@@ -50,7 +50,7 @@ class BranchUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
   io.out.bits.res.data := 0.U
   io.out.bits.res.redirect.get match {
     case redirect =>
-      redirect.valid := io.out.valid && (dataModule.io.mispredict || redirect.bits.cfiUpdate.hasBackendFault)
+      redirect.valid := io.out.valid && dataModule.io.mispredict
       redirect.bits := 0.U.asTypeOf(io.out.bits.res.redirect.get.bits)
       redirect.bits.level := RedirectLevel.flushAfter
       redirect.bits.robIdx := io.in.bits.ctrl.robIdx
@@ -62,9 +62,9 @@ class BranchUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
       redirect.bits.cfiUpdate.predTaken := dataModule.io.pred_taken
       redirect.bits.cfiUpdate.target := addModule.io.target
       redirect.bits.cfiUpdate.pc := io.in.bits.data.pc.get
-      redirect.bits.cfiUpdate.backendIAF := io.instrAddrTransType.get.checkAccessFault(addModule.io.target)
-      redirect.bits.cfiUpdate.backendIPF := io.instrAddrTransType.get.checkPageFault(addModule.io.target)
-      redirect.bits.cfiUpdate.backendIGPF := io.instrAddrTransType.get.checkGuestPageFault(addModule.io.target)
+      redirect.bits.cfiUpdate.backendIAF := false.B
+      redirect.bits.cfiUpdate.backendIPF := false.B
+      redirect.bits.cfiUpdate.backendIGPF := false.B
   }
   connect0LatencyCtrlSingal
 }

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -466,15 +466,15 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       resp(idx).bits.isForVSnonLeafPTE := false.B
       resp(idx).bits.excp(nDups).pf.ld := RegNext(prepf) && isLd
       resp(idx).bits.excp(nDups).pf.st := RegNext(prepf) && isSt
-      resp(idx).bits.excp(nDups).pf.instr := false.B
+      resp(idx).bits.excp(nDups).pf.instr := RegNext(prepf) && isInst
 
       resp(idx).bits.excp(nDups).gpf.ld := RegNext(pregpf) && isLd
       resp(idx).bits.excp(nDups).gpf.st := RegNext(pregpf) && isSt
-      resp(idx).bits.excp(nDups).gpf.instr := false.B
+      resp(idx).bits.excp(nDups).gpf.instr := RegNext(pregpf) && isInst
 
       resp(idx).bits.excp(nDups).af.ld := RegNext(preaf) && TlbCmd.isRead(cmd)
       resp(idx).bits.excp(nDups).af.st := RegNext(preaf) && TlbCmd.isWrite(cmd)
-      resp(idx).bits.excp(nDups).af.instr := false.B
+      resp(idx).bits.excp(nDups).af.instr := RegNext(preaf) && isInst
 
       resp(idx).bits.excp(nDups).vaNeedExt := false.B
       // overwrite miss & gpaddr when exception related to high address truncation happens

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -199,7 +199,16 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
 
     val pf48 = SignExt(EffectiveVa(i)(47, 0), XLEN) =/= EffectiveVa(i)
     val pf39 = SignExt(EffectiveVa(i)(38, 0), XLEN) =/= EffectiveVa(i)
-    val gpf48 = EffectiveVa(i)(XLEN - 1, 48 + 2) =/= 0.U
+    val gpf48 = Mux(
+      // ITLB uses fullva SignExt-ed from 50bit pc,
+      // it can wrongly SignExt a canonical Sv48x4 address into a non-canonical one,
+      // so here we check if EffectiveVa(49) is 0:
+      //   if it is, then an pc overflow happened, a gpf should be raised.
+      //   otherwise, EffectiveVa(63..50) is SignExt-ed from EffectiveVa(49) and we should ignore it.
+      TlbCmd.isExec(req_in(i).bits.cmd),
+      EffectiveVa(i)(XLEN - 1, 48 + 2) =/= 0.U && EffectiveVa(i)(48 + 2 - 1) === 0.U,
+      EffectiveVa(i)(XLEN - 1, 48 + 2) =/= 0.U,
+    )
     val gpf39 = EffectiveVa(i)(XLEN - 1, 39 + 2) =/= 0.U
     val af = EffectiveVa(i)(XLEN - 1, PAddrBits) =/= 0.U
     when (req(i).valid && req(i).bits.checkfullva) {

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -461,7 +461,6 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
 
     // when pf and gpf can't happens simultaneously
     val hasPf = (ldPf || ldUpdate || stPf || stUpdate || instrPf || instrUpdate) && s1_valid && !af && !isFakePte && !isNonLeaf
-    // Only lsu need check related to high address truncation
     when (RegNext(prepf || pregpf || preaf)) {
       resp(idx).bits.isForVSnonLeafPTE := false.B
       resp(idx).bits.excp(nDups).pf.ld := RegNext(prepf) && isLd
@@ -479,7 +478,13 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       resp(idx).bits.excp(nDups).vaNeedExt := false.B
       // overwrite miss & gpaddr when exception related to high address truncation happens
       resp(idx).bits.miss := false.B
-      resp(idx).bits.gpaddr(nDups) := req_out(idx).fullva
+      // Instruction fetch only provides a VAddrBits+1-bit va (from the PC), which the frontend
+      // can only sign-extend to XLEN since the current translation mode is unavailable there.
+      // However, sequential fetch may overflow the PC into the invalid bit[50]=1 region under Sv48x4,
+      // in such case, do sign-extension would wrongly set bits [63:51]=1.
+      // Zero-extend instead to report the correct unsigned gpaddr on guest page faults
+      // DTLB requests carry a full XLEN va, so keeping it as-is.
+      resp(idx).bits.gpaddr(nDups) := Mux(isInst, ZeroExt(req_out(idx).fullva(VAddrBits, 0), XLEN), req_out(idx).fullva)
     } .otherwise {
       // isForVSnonLeafPTE is used only when gpf happens and it caused by a G-stage translation which supports VS-stage translation
       // it will be sent to CSR in order to modify the m/htinst.

--- a/src/main/scala/xiangshan/frontend/BPU.scala
+++ b/src/main/scala/xiangshan/frontend/BPU.scala
@@ -108,7 +108,8 @@ trait BPUUtils extends HasXSParameter {
   }
 
   def getFallThroughAddr(start: UInt, carry: Bool, pft: UInt) = {
-    val higher = start.head(VAddrBits - log2Ceil(PredictWidth) - instOffsetBits)
+    val higher = SignExt(start, VAddrBits + 1)
+      .head(VAddrBits + 1 - log2Ceil(PredictWidth) - instOffsetBits)
     Cat(Mux(carry, higher + 1.U, higher), pft, 0.U(instOffsetBits.W))
   }
 
@@ -206,9 +207,9 @@ abstract class BasePredictor(implicit p: Parameters) extends XSModule
     SegmentedAddrNext(s2_pc, s2_fire, Some("s3_pc"))
   }
 
-  io.out.s1.pc := s1_pc_dup
-  io.out.s2.pc := s2_pc_dup.map(_.getAddr())
-  io.out.s3.pc := s3_pc_dup.map(_.getAddr())
+  io.out.s1.pc := s1_pc_dup.map(SignExt(_, VAddrBits + 1))
+  io.out.s2.pc := s2_pc_dup.map(pc => SignExt(pc.getAddr(), VAddrBits + 1))
+  io.out.s3.pc := s3_pc_dup.map(pc => SignExt(pc.getAddr(), VAddrBits + 1))
 
   val perfEvents: Seq[(String, UInt)] = Seq()
 
@@ -286,7 +287,7 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
   val s1_ready_dup, s2_ready_dup, s3_ready_dup                                  = dup_wire(Bool())
   val s1_components_ready_dup, s2_components_ready_dup, s3_components_ready_dup = dup_wire(Bool())
 
-  val s0_pc_dup = dup(WireInit(0.U(VAddrBits.W)))
+  val s0_pc_dup = dup(WireInit(0.U((VAddrBits + 1).W)))
   val s0_pc_reg_dup = s0_pc_dup.zip(s0_stall_dup).map { case (s0_pc, s0_stall) =>
     RegEnable(s0_pc, !s0_stall)
   }
@@ -353,7 +354,13 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
   def getHist(ptr: CGHPtr): UInt = (Cat(ghv_wire.asUInt, ghv_wire.asUInt) >> (ptr.value + 1.U))(HistoryLength - 1, 0)
   s0_ghist := getHist(s0_ghist_ptr_dup(0))
 
-  val resp = predictors.io.out
+  val resp = WireInit(predictors.io.out)
+  // pc is (VAddrBits + 1) in width, but each predictor can only predict VAddrBits,
+  // the extra 1 bit is for ITLB to do the canonical check, and is initially from fall-through, redirect target, etc..
+  // so here we need to override resp.sx.pc to actual pipeline pc.
+  resp.s1.pc := VecInit(predictors.io.out.s1.pc.map(pc => Cat(s1_pc(VAddrBits), pc(VAddrBits - 1, 0))))
+  resp.s2.pc := VecInit(predictors.io.out.s2.pc.map(pc => Cat(s2_pc(VAddrBits), pc(VAddrBits - 1, 0))))
+  resp.s3.pc := VecInit(predictors.io.out.s3.pc.map(pc => Cat(s3_pc(VAddrBits), pc(VAddrBits - 1, 0))))
 
   val toFtq_fire = io.bpu_to_ftq.resp.valid && io.bpu_to_ftq.resp.ready
 
@@ -453,7 +460,7 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
     s1_valid_dup(2) && s2_components_ready_dup(2) && s2_ready_dup(2) ||
       s2_fire_dup(2) && s2_redirect_dup(2) ||
       s3_fire_dup(2) && s3_redirect_dup(2)
-  io.bpu_to_ftq.resp.bits                              := predictors.io.out
+  io.bpu_to_ftq.resp.bits                              := resp
   io.bpu_to_ftq.resp.bits.last_stage_spec_info.histPtr := s3_ghist_ptr_dup(2)
 
   val full_pred_diff        = WireInit(false.B)
@@ -596,7 +603,7 @@ class Predictor(implicit p: Parameters) extends XSModule with HasBPUConst with H
 
   class PreviousPredInfo extends Bundle {
     val hit         = Vec(numDup, Bool())
-    val target      = Vec(numDup, UInt(VAddrBits.W))
+    val target      = Vec(numDup, UInt((VAddrBits + 1).W))
     val lastBrPosOH = Vec(numDup, Vec(numBr + 1, Bool()))
     val taken       = Vec(numDup, Bool())
     val takenMask   = Vec(numDup, Vec(numBr, Bool()))

--- a/src/main/scala/xiangshan/frontend/FTB.scala
+++ b/src/main/scala/xiangshan/frontend/FTB.scala
@@ -879,7 +879,10 @@ class FTB(implicit p: Parameters) extends BasePredictor with FTBParams with BPUU
 
   val ftb_write_fallThrough = ftb_write.entry.getFallThrough(write_pc)
   when(write_valid) {
-    assert(write_pc + (FetchWidth * 4).U >= ftb_write_fallThrough, s"FTB write_entry fallThrough address error!")
+    assert(
+      SignExt(write_pc, VAddrBits + 1) + (FetchWidth * 4).U >= ftb_write_fallThrough,
+      s"FTB write_entry fallThrough address error!"
+    )
   }
 
   XSDebug("req_v=%b, req_pc=%x, ready=%b (resp at next cycle)\n", io.s0_fire(0), s0_pc_dup(0), ftbBank.io.req_pc.ready)

--- a/src/main/scala/xiangshan/frontend/FauFTB.scala
+++ b/src/main/scala/xiangshan/frontend/FauFTB.scala
@@ -179,7 +179,7 @@ class FauFTB(implicit p: Parameters) extends BasePredictor with FauFTBParams {
   val uftb_write_fallThrough = u_s1_ftb_entry.getFallThrough(uftb_write_pc)
   when(u_s1_valid && u_s1_hit) {
     assert(
-      uftb_write_pc + (FetchWidth * 4).U >= uftb_write_fallThrough,
+      SignExt(uftb_write_pc, VAddrBits + 1) + (FetchWidth * 4).U >= uftb_write_fallThrough,
       s"FauFTB write entry fallThrough address error!"
     )
   }

--- a/src/main/scala/xiangshan/frontend/Frontend.scala
+++ b/src/main/scala/xiangshan/frontend/Frontend.scala
@@ -231,7 +231,7 @@ class FrontendInlinedImp(outer: FrontendInlined) extends LazyModuleImp(outer)
   io.backend.fromIfu := ifu.io.toBackend
   io.frontendInfo.bpuInfo <> ftq.io.bpuInfo
 
-  val checkPcMem = Reg(Vec(FtqSize, new Ftq_RF_Components))
+  val checkPcMem = Reg(Vec(FtqSize, new FtqPcMemEntry))
   when(ftq.io.toBackend.pc_mem_wen) {
     checkPcMem(ftq.io.toBackend.pc_mem_waddr) := ftq.io.toBackend.pc_mem_wdata
   }

--- a/src/main/scala/xiangshan/frontend/FrontendBundle.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendBundle.scala
@@ -33,9 +33,9 @@ class FrontendTopDownBundle(implicit p: Parameters) extends XSBundle {
 class FetchRequestBundle(implicit p: Parameters) extends XSBundle with HasICacheParameters {
 
   // fast path: Timing critical
-  val startAddr     = UInt(VAddrBits.W)
-  val nextlineStart = UInt(VAddrBits.W)
-  val nextStartAddr = UInt(VAddrBits.W)
+  val startAddr     = UInt((VAddrBits + 1).W)
+  val nextlineStart = UInt((VAddrBits + 1).W)
+  val nextStartAddr = UInt((VAddrBits + 1).W)
   // slow path
   val ftqIdx    = new FtqPtr
   val ftqOffset = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
@@ -66,8 +66,8 @@ class FetchRequestBundle(implicit p: Parameters) extends XSBundle with HasICache
 }
 
 class FtqICacheInfo(implicit p: Parameters) extends XSBundle with HasICacheParameters {
-  val startAddr      = UInt(VAddrBits.W)
-  val nextlineStart  = UInt(VAddrBits.W)
+  val startAddr      = UInt((VAddrBits + 1).W)
+  val nextlineStart  = UInt((VAddrBits + 1).W)
   val ftqIdx         = new FtqPtr
   def crossCacheline = startAddr(blockOffBits - 1) === 1.U
   def fromFtqPcBundle(b: Ftq_RF_Components) = {
@@ -98,7 +98,7 @@ class PredecodeWritebackBundle(implicit p: Parameters) extends XSBundle {
   val ftqOffset  = UInt(log2Ceil(PredictWidth).W)
   val misOffset  = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
   val cfiOffset  = ValidUndirectioned(UInt(log2Ceil(PredictWidth).W))
-  val target     = UInt(VAddrBits.W)
+  val target     = UInt((VAddrBits + 1).W)
   val jalTarget  = UInt(VAddrBits.W)
   val instrRange = Vec(PredictWidth, Bool())
 }
@@ -543,10 +543,10 @@ class FullBranchPrediction(val isNotS3: Boolean)(implicit p: Parameters) extends
 
   val slot_valids = Vec(totalSlot, Bool())
 
-  val targets         = Vec(totalSlot, UInt(VAddrBits.W))
-  val jalr_target     = UInt(VAddrBits.W) // special path for indirect predictors
+  val targets         = Vec(totalSlot, UInt((VAddrBits + 1).W))
+  val jalr_target     = UInt((VAddrBits + 1).W) // special path for indirect predictors and RAS
   val offsets         = Vec(totalSlot, UInt(log2Ceil(PredictWidth).W))
-  val fallThroughAddr = UInt(VAddrBits.W)
+  val fallThroughAddr = UInt((VAddrBits + 1).W)
   val fallThroughErr  = Bool()
   val multiHit        = Bool()
 
@@ -649,8 +649,9 @@ class FullBranchPrediction(val isNotS3: Boolean)(implicit p: Parameters) extends
       last_stage_pc:    Option[Tuple2[UInt, Bool]] = None,
       last_stage_entry: Option[Tuple2[FTBEntry, Bool]] = None
   ) = {
-    slot_valids          := entry.brSlots.map(_.valid) :+ entry.tailSlot.valid
-    targets              := entry.getTargetVec(pc, last_stage_pc) // Use previous stage pc for better timing
+    slot_valids := entry.brSlots.map(_.valid) :+ entry.tailSlot.valid
+    // Keep FTB target generation at VAddrBits and extend only when entering the full prediction path.
+    targets              := VecInit(entry.getTargetVec(pc, last_stage_pc).map(SignExt(_, VAddrBits + 1)))
     jalr_target          := targets.last
     offsets              := entry.getOffsetVec
     is_jal               := entry.tailSlot.valid && entry.isJal
@@ -663,8 +664,12 @@ class FullBranchPrediction(val isNotS3: Boolean)(implicit p: Parameters) extends
 
     val startLower        = Cat(0.U(1.W), pc(instOffsetBits + log2Ceil(PredictWidth) - 1, instOffsetBits))
     val endLowerwithCarry = Cat(entry.carry, entry.pftAddr)
-    fallThroughErr  := startLower >= endLowerwithCarry || endLowerwithCarry > (startLower + PredictWidth.U)
-    fallThroughAddr := Mux(fallThroughErr, pc + (FetchWidth * 4).U, entry.getFallThrough(pc, last_stage_entry))
+    fallThroughErr := startLower >= endLowerwithCarry || endLowerwithCarry > (startLower + PredictWidth.U)
+    fallThroughAddr := Mux(
+      fallThroughErr,
+      SignExt(pc, VAddrBits + 1) + (FetchWidth * 4).U,
+      entry.getFallThrough(pc, last_stage_entry)
+    )
   }
 
   def display(cond: Bool): Unit =
@@ -679,13 +684,13 @@ class SpeculativeInfo(implicit p: Parameters) extends XSBundle
   val TOSW    = new RASPtr
   val TOSR    = new RASPtr
   val NOS     = new RASPtr
-  val topAddr = UInt(VAddrBits.W)
+  val topAddr = UInt((VAddrBits + 1).W)
 }
 
 //
 class BranchPredictionBundle(val isNotS3: Boolean)(implicit p: Parameters) extends XSBundle
     with HasBPUConst with BPUUtils {
-  val pc          = Vec(numDup, UInt(VAddrBits.W))
+  val pc          = Vec(numDup, UInt((VAddrBits + 1).W))
   val valid       = Vec(numDup, Bool())
   val hasRedirect = Vec(numDup, Bool())
   val ftq_idx     = new FtqPtr

--- a/src/main/scala/xiangshan/frontend/IFU.scala
+++ b/src/main/scala/xiangshan/frontend/IFU.scala
@@ -87,7 +87,7 @@ class NewIFUIO(implicit p: Parameters) extends XSBundle {
 // the middle of an RVI inst
 class LastHalfInfo(implicit p: Parameters) extends XSBundle {
   val valid    = Bool()
-  val middlePC = UInt(VAddrBits.W)
+  val middlePC = UInt((VAddrBits + 1).W)
   def matchThisBlock(startAddr: UInt) = valid && middlePC === startAddr
 }
 
@@ -100,11 +100,11 @@ class IfuToPreDecode(implicit p: Parameters) extends XSBundle {
 class IfuToPredChecker(implicit p: Parameters) extends XSBundle {
   val ftqOffset  = Valid(UInt(log2Ceil(PredictWidth).W))
   val jumpOffset = Vec(PredictWidth, UInt(XLEN.W))
-  val target     = UInt(VAddrBits.W)
+  val target     = UInt((VAddrBits + 1).W)
   val instrRange = Vec(PredictWidth, Bool())
   val instrValid = Vec(PredictWidth, Bool())
   val pds        = Vec(PredictWidth, new PreDecodeInfo)
-  val pc         = Vec(PredictWidth, UInt(VAddrBits.W))
+  val pc         = Vec(PredictWidth, UInt((VAddrBits + 1).W))
   val fire_in    = Bool()
 }
 
@@ -303,7 +303,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
     .elsewhen(f0_fire && !f0_flush)(f1_valid := true.B)
     .elsewhen(f1_fire)(f1_valid := false.B)
 
-  val f1_pc_high       = f1_ftq_req.startAddr(VAddrBits - 1, PcCutPoint)
+  val f1_pc_high       = f1_ftq_req.startAddr(VAddrBits, PcCutPoint)
   val f1_pc_high_plus1 = f1_pc_high + 1.U
 
   /**
@@ -365,8 +365,9 @@ class NewIFU(implicit p: Parameters) extends XSModule
   // TODO: addr compare may be timing critical
   val f2_icache_all_resp_wire =
     fromICache.valid &&
-      fromICache.bits.vaddr(0) === f2_ftq_req.startAddr &&
-      (fromICache.bits.doubleline && fromICache.bits.vaddr(1) === f2_ftq_req.nextlineStart || !f2_doubleLine)
+      fromICache.bits.vaddr(0) === f2_ftq_req.startAddr(VAddrBits - 1, 0) &&
+      (fromICache.bits.doubleline &&
+        fromICache.bits.vaddr(1) === f2_ftq_req.nextlineStart(VAddrBits - 1, 0) || !f2_doubleLine)
   val f2_icache_all_resp_reg = RegInit(false.B)
 
   icacheRespAllValid := f2_icache_all_resp_reg || f2_icache_all_resp_wire
@@ -600,7 +601,7 @@ class NewIFU(implicit p: Parameters) extends XSModule
     * Half snpc(i) is larger than pc(i) by 4. Using pc to calculate half snpc may be a good choice.
     ***********************************************************************
     */
-  val f3_half_snpc = Wire(Vec(PredictWidth, UInt(VAddrBits.W)))
+  val f3_half_snpc = Wire(Vec(PredictWidth, UInt((VAddrBits + 1).W)))
   for (i <- 0 until PredictWidth) {
     if (i == (PredictWidth - 2)) {
       f3_half_snpc(i) := CatPC(f3_pc_last_lower_result_plus2, f3_pc_high, f3_pc_high_plus1)
@@ -872,13 +873,13 @@ class NewIFU(implicit p: Parameters) extends XSModule
   io.iTLBInter.req.valid                   := (mmio_state === m_sendTLB) && f3_req_is_mmio
   io.iTLBInter.req.bits.size               := 3.U
   io.iTLBInter.req.bits.vaddr              := f3_resend_vaddr
-  io.iTLBInter.req.bits.debug.pc           := f3_resend_vaddr
+  io.iTLBInter.req.bits.debug.pc           := SignExt(f3_resend_vaddr, XLEN)
   io.iTLBInter.req.bits.cmd                := TlbCmd.exec
   io.iTLBInter.req.bits.isPrefetch         := false.B
   io.iTLBInter.req.bits.kill               := false.B // IFU use itlb for mmio, doesn't need sync, set it to false
   io.iTLBInter.req.bits.no_translate       := false.B
-  io.iTLBInter.req.bits.fullva             := 0.U
-  io.iTLBInter.req.bits.checkfullva        := false.B
+  io.iTLBInter.req.bits.fullva             := SignExt(f3_resend_vaddr, XLEN)
+  io.iTLBInter.req.bits.checkfullva        := true.B
   io.iTLBInter.req.bits.hyperinst          := DontCare
   io.iTLBInter.req.bits.hlvx               := DontCare
   io.iTLBInter.req.bits.memidx             := DontCare
@@ -1103,8 +1104,8 @@ class NewIFU(implicit p: Parameters) extends XSModule
   val wb_instr_range         = RegEnable(io.toIbuffer.bits.enqEnable, wb_enable)
 
   val wb_pc_lower_result = RegEnable(f3_pc_lower_result, wb_enable)
-  val wb_pc_high         = RegEnable(f3_pc_high, wb_enable)
-  val wb_pc_high_plus1   = RegEnable(f3_pc_high_plus1, wb_enable)
+  val wb_pc_high         = RegEnable(f3_pc_high(VAddrBits - PcCutPoint - 1, 0), wb_enable)
+  val wb_pc_high_plus1   = RegEnable(f3_pc_high_plus1(VAddrBits - PcCutPoint - 1, 0), wb_enable)
   val wb_pc              = CatPC(wb_pc_lower_result, wb_pc_high, wb_pc_high_plus1)
 
   // val wb_pc             = RegEnable(f3_pc, wb_enable)

--- a/src/main/scala/xiangshan/frontend/ITTAGE.scala
+++ b/src/main/scala/xiangshan/frontend/ITTAGE.scala
@@ -596,7 +596,7 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
   s2_tageTarget := Mux1H(Seq(
     (provided && !(providerNull && altProvided), providerCatTarget),
     (altProvided && providerNull, altproviderCatTarget),
-    (!provided, baseTarget)
+    (!provided, baseTarget(VAddrBits - 1, 0))
   ))
   s2_provided          := provided
   s2_provider          := providerInfo.tableIdx
@@ -614,7 +614,7 @@ class ITTage(implicit p: Parameters) extends BaseITTage {
     fp & s3_tageTarget <-
       io.out.s3.full_pred zip s3_tageTarget_dup
   )
-    yield fp.jalr_target := s3_tageTarget
+    yield fp.jalr_target := SignExt(s3_tageTarget, VAddrBits + 1)
 
   resp_meta.provider.valid    := s3_provided
   resp_meta.provider.bits     := s3_provider

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -64,8 +64,8 @@ object FtqPtr {
 }
 
 class Ftq_RF_Components(implicit p: Parameters) extends XSBundle with BPUUtils {
-  val startAddr     = UInt(VAddrBits.W)
-  val nextLineAddr  = UInt(VAddrBits.W)
+  val startAddr     = UInt((VAddrBits + 1).W)
+  val nextLineAddr  = UInt((VAddrBits + 1).W)
   val isNextMask    = Vec(PredictWidth, Bool())
   val fallThruError = Bool()
   // val carry = Bool()
@@ -90,6 +90,20 @@ class Ftq_RF_Components(implicit p: Parameters) extends XSBundle with BPUUtils {
   }
   override def toPrintable: Printable =
     p"startAddr:${Hexadecimal(startAddr)}"
+}
+
+// Ftq_RF_Components keeps an extra bit for canonical check, backend pcMem does not need that
+class FtqPcMemEntry(implicit p: Parameters) extends Ftq_RF_Components {
+  override val startAddr    = UInt(VAddrBits.W)
+  override val nextLineAddr = UInt(VAddrBits.W)
+
+  def fromFtqPcBundle(b: Ftq_RF_Components) = {
+    startAddr     := b.startAddr(VAddrBits - 1, 0)
+    nextLineAddr  := b.nextLineAddr(VAddrBits - 1, 0)
+    isNextMask    := b.isNextMask
+    fallThruError := b.fallThruError
+    this
+  }
 }
 
 class Ftq_pd_Entry(implicit p: Parameters) extends XSBundle {
@@ -207,7 +221,7 @@ class FtqToCtrlIO(implicit p: Parameters) extends XSBundle with HasBackendRedire
   // write to backend pc mem
   val pc_mem_wen   = Output(Bool())
   val pc_mem_waddr = Output(UInt(log2Ceil(FtqSize).W))
-  val pc_mem_wdata = Output(new Ftq_RF_Components)
+  val pc_mem_wdata = Output(new FtqPcMemEntry)
   // newest target
   val newest_entry_en     = Output(Bool())
   val newest_entry_target = Output(UInt(VAddrBits.W))
@@ -649,8 +663,9 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   ftb_entry_mem.io.wdata(0) := io.fromBpu.resp.bits.last_stage_ftb_entry
 
   // multi-write
-  val update_target = Reg(Vec(FtqSize, UInt(VAddrBits.W))) // could be taken target or fallThrough //TODO: remove this
-  val newest_entry_target          = Reg(UInt(VAddrBits.W))
+  val update_target =
+    Reg(Vec(FtqSize, UInt((VAddrBits + 1).W))) // could be taken target or fallThrough //TODO: remove this
+  val newest_entry_target          = Reg(UInt((VAddrBits + 1).W))
   val newest_entry_target_modified = RegInit(false.B)
   val newest_entry_ptr             = Reg(new FtqPtr)
   val newest_entry_ptr_modified    = RegInit(false.B)
@@ -831,7 +846,7 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val toIfuPcBundle                  = Wire(new Ftq_RF_Components)
   val entry_is_to_send               = WireInit(entry_fetch_status(ifuPtr.value) === f_to_send)
   val entry_ftq_offset               = WireInit(cfiIndex_vec(ifuPtr.value))
-  val entry_next_addr                = Wire(UInt(VAddrBits.W))
+  val entry_next_addr                = Wire(UInt((VAddrBits + 1).W))
 
   val pc_mem_ifu_ptr_rdata   = VecInit(Seq.fill(copyNum)(RegNext(ftq_pc_mem.io.ifuPtr_rdata)))
   val pc_mem_ifu_plus1_rdata = VecInit(Seq.fill(copyNum)(RegNext(ftq_pc_mem.io.ifuPtrPlus1_rdata)))
@@ -1157,13 +1172,13 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   // to backend pc mem / target
   io.toBackend.pc_mem_wen   := RegNext(last_cycle_bpu_in)
   io.toBackend.pc_mem_waddr := RegEnable(last_cycle_bpu_in_idx, last_cycle_bpu_in)
-  io.toBackend.pc_mem_wdata := RegEnable(bpu_in_bypass_buf_for_ifu, last_cycle_bpu_in)
+  io.toBackend.pc_mem_wdata.fromFtqPcBundle(RegEnable(bpu_in_bypass_buf_for_ifu, last_cycle_bpu_in))
 
   // num cycle is fixed
   val newest_entry_en: Bool = RegNext(last_cycle_bpu_in || backendRedirect.valid || ifuRedirectToBpu.valid)
   io.toBackend.newest_entry_en     := RegNext(newest_entry_en)
   io.toBackend.newest_entry_ptr    := RegEnable(newest_entry_ptr, newest_entry_en)
-  io.toBackend.newest_entry_target := RegEnable(newest_entry_target, newest_entry_en)
+  io.toBackend.newest_entry_target := RegEnable(newest_entry_target, newest_entry_en)(VAddrBits - 1, 0)
 
   // *********************************************************************
   // **************************** wb from exu ****************************
@@ -1462,10 +1477,10 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   io.toBpu.update.valid := commit_valid && do_commit
   val update = io.toBpu.update.bits
   update.false_hit   := commit_hit === h_false_hit
-  update.pc          := commit_pc_bundle.startAddr
+  update.pc          := commit_pc_bundle.startAddr(VAddrBits - 1, 0)
   update.meta        := commit_meta
   update.cfi_idx     := commit_cfi
-  update.full_target := commit_target
+  update.full_target := commit_target(VAddrBits - 1, 0)
   update.from_stage  := commit_stage
   update.spec_info   := commit_spec_meta
   XSError(commit_valid && do_commit && debug_cfi, "\ncommit cfi can be non c_commited\n")
@@ -1474,11 +1489,11 @@ class Ftq(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHelpe
   val update_ftb_entry = update.ftb_entry
 
   val ftbEntryGen = Module(new FTBEntryGen).io
-  ftbEntryGen.start_addr     := commit_pc_bundle.startAddr
+  ftbEntryGen.start_addr     := commit_pc_bundle.startAddr(VAddrBits - 1, 0)
   ftbEntryGen.old_entry      := commit_ftb_entry
   ftbEntryGen.pd             := commit_pd
   ftbEntryGen.cfiIndex       := commit_cfi
-  ftbEntryGen.target         := commit_target
+  ftbEntryGen.target         := commit_target(VAddrBits - 1, 0)
   ftbEntryGen.hit            := commit_real_hit
   ftbEntryGen.mispredict_vec := commit_mispredict
 

--- a/src/main/scala/xiangshan/frontend/NewFtq.scala
+++ b/src/main/scala/xiangshan/frontend/NewFtq.scala
@@ -92,13 +92,13 @@ class Ftq_RF_Components(implicit p: Parameters) extends XSBundle with BPUUtils {
     p"startAddr:${Hexadecimal(startAddr)}"
 }
 
-// Ftq_RF_Components keeps an extra bit for canonical check, backend pcMem does not need that
 class FtqPcMemEntry(implicit p: Parameters) extends Ftq_RF_Components {
-  override val startAddr    = UInt(VAddrBits.W)
+  // Ftq_RF_Components keeps an extra bit on nextLineAddr for canonical check,
+  // backend pcMem / targetMem does not need that, override here to reduce area
   override val nextLineAddr = UInt(VAddrBits.W)
 
   def fromFtqPcBundle(b: Ftq_RF_Components) = {
-    startAddr     := b.startAddr(VAddrBits - 1, 0)
+    startAddr     := b.startAddr
     nextLineAddr  := b.nextLineAddr(VAddrBits - 1, 0)
     isNextMask    := b.isNextMask
     fallThruError := b.fallThruError

--- a/src/main/scala/xiangshan/frontend/PreDecode.scala
+++ b/src/main/scala/xiangshan/frontend/PreDecode.scala
@@ -333,7 +333,11 @@ class PredCheckerResp(implicit p: Parameters) extends XSBundle with HasPdConst {
   }
   // to Ftq write back port (stage 2)
   val stage2Out = new Bundle {
-    val fixedTarget   = Vec(PredictWidth, UInt(VAddrBits.W))
+    // fixedTarget is pc+offset, so needs an extra bit for ITLB to do canonical-check
+    val fixedTarget = Vec(PredictWidth, UInt((VAddrBits + 1).W))
+    // jalTarget is used only to train FTB, keep VAddrBits to save area,
+    // FTB might generate fetch block with wrong target the next time,
+    // but predecode will find predTarget =/= fixedTarget and generates a redirect, so this is fine.
     val jalTarget     = Vec(PredictWidth, UInt(VAddrBits.W))
     val fixedMissPred = Vec(PredictWidth, Bool())
     val faultType     = Vec(PredictWidth, new CheckInfo)
@@ -395,7 +399,7 @@ class PredChecker(implicit p: Parameters) extends XSModule with HasPdConst {
   })
 
   val jumpTargets = VecInit(pds.zipWithIndex.map { case (pd, i) =>
-    (pc(i) + jumpOffset(i)).asTypeOf(UInt(VAddrBits.W))
+    (SignExt(pc(i), XLEN) + jumpOffset(i))(VAddrBits, 0)
   })
   val seqTargets = VecInit((0 until PredictWidth).map(i => pc(i) + Mux(pds(i).isRVC || !instrValid(i), 2.U, 4.U)))
 

--- a/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
+++ b/src/main/scala/xiangshan/frontend/icache/IPrefetch.scala
@@ -29,8 +29,8 @@ abstract class IPrefetchBundle(implicit p: Parameters) extends ICacheBundle
 abstract class IPrefetchModule(implicit p: Parameters) extends ICacheModule
 
 class IPrefetchReq(implicit p: Parameters) extends IPrefetchBundle {
-  val startAddr:        UInt   = UInt(VAddrBits.W)
-  val nextlineStart:    UInt   = UInt(VAddrBits.W)
+  val startAddr:        UInt   = UInt((VAddrBits + 1).W)
+  val nextlineStart:    UInt   = UInt((VAddrBits + 1).W)
   val ftqIdx:           FtqPtr = new FtqPtr
   val isSoftPrefetch:   Bool   = Bool()
   val backendException: UInt   = UInt(ExceptionType.width.W)
@@ -45,8 +45,8 @@ class IPrefetchReq(implicit p: Parameters) extends IPrefetchBundle {
   }
 
   def fromSoftPrefetch(req: SoftIfetchPrefetchBundle): IPrefetchReq = {
-    this.startAddr      := req.vaddr
-    this.nextlineStart  := req.vaddr + (1 << blockOffBits).U
+    this.startAddr      := SignExt(req.vaddr, VAddrBits + 1)
+    this.nextlineStart  := SignExt(req.vaddr, VAddrBits + 1) + (1 << blockOffBits).U
     this.ftqIdx         := DontCare
     this.isSoftPrefetch := true.B
     this
@@ -171,13 +171,16 @@ class IPrefetchPipe(implicit p: Parameters) extends IPrefetchModule with HasICac
   private val itlb_finish = tlb_valid_latch(0) && (!s1_doubleline || tlb_valid_latch(1))
 
   (0 until PortNumber).foreach { i =>
+    val vaddr = Mux(s1_need_itlb(i), s1_req_vaddr(i), s0_req_vaddr(i))
     toITLB(i).valid             := s1_need_itlb(i) || (s0_valid && (if (i == 0) true.B else s0_doubleline))
     toITLB(i).bits              := DontCare
     toITLB(i).bits.size         := 3.U
-    toITLB(i).bits.vaddr        := Mux(s1_need_itlb(i), s1_req_vaddr(i), s0_req_vaddr(i))
-    toITLB(i).bits.debug.pc     := Mux(s1_need_itlb(i), s1_req_vaddr(i), s0_req_vaddr(i))
+    toITLB(i).bits.vaddr        := vaddr
+    toITLB(i).bits.debug.pc     := SignExt(vaddr, XLEN)
     toITLB(i).bits.cmd          := TlbCmd.exec
     toITLB(i).bits.no_translate := false.B
+    toITLB(i).bits.checkfullva  := true.B
+    toITLB(i).bits.fullva       := SignExt(vaddr, XLEN)
   }
   fromITLB.foreach(_.ready := true.B)
   io.itlb.foreach(_.req_kill := false.B)

--- a/src/main/scala/xiangshan/frontend/newRAS.scala
+++ b/src/main/scala/xiangshan/frontend/newRAS.scala
@@ -36,7 +36,7 @@ import xiangshan._
 import xiangshan.frontend._
 
 class RASEntry()(implicit p: Parameters) extends XSBundle {
-  val retAddr = UInt(VAddrBits.W)
+  val retAddr = UInt((VAddrBits + 1).W)
   val ctr     = UInt(RasCtrSize.W) // layer of nested call functions
   def =/=(that: RASEntry) = this.retAddr =/= that.retAddr || this.ctr =/= that.ctr
 }
@@ -109,7 +109,7 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
     val io = IO(new Bundle {
       val spec_push_valid = Input(Bool())
       val spec_pop_valid  = Input(Bool())
-      val spec_push_addr  = Input(UInt(VAddrBits.W))
+      val spec_push_addr  = Input(UInt((VAddrBits + 1).W))
       // for write bypass between s2 and s3
 
       val s2_fire        = Input(Bool())
@@ -118,13 +118,13 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
       val s3_meta        = Input(new RASInternalMeta)
       val s3_missed_pop  = Input(Bool())
       val s3_missed_push = Input(Bool())
-      val s3_pushAddr    = Input(UInt(VAddrBits.W))
-      val spec_pop_addr  = Output(UInt(VAddrBits.W))
+      val s3_pushAddr    = Input(UInt((VAddrBits + 1).W))
+      val spec_pop_addr  = Output(UInt((VAddrBits + 1).W))
 
       val commit_valid      = Input(Bool())
       val commit_push_valid = Input(Bool())
       val commit_pop_valid  = Input(Bool())
-      val commit_push_addr  = Input(UInt(VAddrBits.W))
+      val commit_push_addr  = Input(UInt((VAddrBits + 1).W))
       val commit_meta_TOSW  = Input(new RASPtr)
       // for debug purpose only
       val commit_meta_ssp = Input(UInt(log2Up(RasSize).W))
@@ -137,7 +137,7 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
       val redirect_meta_TOSW = Input(new RASPtr)
       val redirect_meta_TOSR = Input(new RASPtr)
       val redirect_meta_NOS  = Input(new RASPtr)
-      val redirect_callAddr  = Input(UInt(VAddrBits.W))
+      val redirect_callAddr  = Input(UInt((VAddrBits + 1).W))
 
       val ssp  = Output(UInt(log2Up(RasSize).W))
       val sctr = Output(UInt(RasCtrSize.W))
@@ -723,7 +723,7 @@ class RAS(implicit p: Parameters) extends BasePredictor with HasCircularQueuePtr
   stack.redirect_meta_TOSW := recover_cfi.TOSW
   stack.redirect_meta_TOSR := recover_cfi.TOSR
   stack.redirect_meta_NOS  := recover_cfi.NOS
-  stack.redirect_callAddr  := recover_cfi.pc + Mux(recover_cfi.pd.isRVC, 2.U, 4.U)
+  stack.redirect_callAddr  := SignExt(recover_cfi.pc, VAddrBits + 1) + Mux(recover_cfi.pd.isRVC, 2.U, 4.U)
 
   val updateValid = RegNext(io.update.valid, init = false.B)
   val update      = Wire(new BranchPredictionUpdate)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueRAW.scala
@@ -355,7 +355,7 @@ class LoadQueueRAW(implicit p: Parameters) extends XSModule
     redirect.bits.stFtqOffset := stFtqOffset(i)
     redirect.bits.satpFlush   := false.B
     redirect.bits.level       := RedirectLevel.flush
-    redirect.bits.cfiUpdate.target := rollbackLqWb(i).bits.pc
+    redirect.bits.cfiUpdate.target := SignExt(rollbackLqWb(i).bits.pc, VAddrBits + 1)
     redirect.bits.debug_runahead_checkpoint_id := rollbackLqWb(i).bits.debugInfo.runahead_checkpoint_id
     redirect
   })

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -572,7 +572,7 @@ class LoadQueueUncache(implicit p: Parameters) extends XSModule
     redirect.bits.ftqOffset   := reqSelUops(i).ftqOffset
     redirect.bits.level       := RedirectLevel.flush
     redirect.bits.satpFlush   := false.B
-    redirect.bits.cfiUpdate.target := reqSelUops(i).pc // TODO: check if need pc
+    redirect.bits.cfiUpdate.target := SignExt(reqSelUops(i).pc, VAddrBits + 1) // TODO: check if need pc
     redirect.bits.debug_runahead_checkpoint_id := reqSelUops(i).debugInfo.runahead_checkpoint_id
     redirect
   })

--- a/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/HybridUnit.scala
@@ -1214,7 +1214,7 @@ class HybridUnit(implicit p: Parameters) extends XSModule
   io.ldu_io.rollback.bits.ftqOffset   := s3_out.bits.uop.ftqOffset
   io.ldu_io.rollback.bits.satpFlush   := false.B
   io.ldu_io.rollback.bits.level       := Mux(s3_rep_frm_fetch, RedirectLevel.flush, RedirectLevel.flushAfter)
-  io.ldu_io.rollback.bits.cfiUpdate.target := s3_out.bits.uop.pc
+  io.ldu_io.rollback.bits.cfiUpdate.target := SignExt(s3_out.bits.uop.pc, VAddrBits + 1)
   io.ldu_io.rollback.bits.debug_runahead_checkpoint_id := s3_out.bits.uop.debugInfo.runahead_checkpoint_id
   /* <------- DANGEROUS: Don't change sequence here ! -------> */
   io.ldu_io.lsq.ldin.bits.uop := s3_out.bits.uop

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -1681,7 +1681,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   io.rollback.bits.ftqOffset   := s3_out.bits.uop.ftqOffset
   io.rollback.bits.satpFlush   := false.B
   io.rollback.bits.level       := Mux(s3_rep_frm_fetch || s3_frm_mis_flush, RedirectLevel.flush, RedirectLevel.flushAfter)
-  io.rollback.bits.cfiUpdate.target := s3_out.bits.uop.pc
+  io.rollback.bits.cfiUpdate.target := SignExt(s3_out.bits.uop.pc, VAddrBits + 1)
   io.rollback.bits.debug_runahead_checkpoint_id := s3_out.bits.uop.debugInfo.runahead_checkpoint_id
   /* <------- DANGEROUS: Don't change sequence here ! -------> */
 


### PR DESCRIPTION
According to spec, when accessing a non-canonical virtual address (i.e. `bit[63..39]` differs from `bit[38]` in Sv39 mode), a (guest) page fault should be raised. This is not easy to be checked as frontend stores only VAddrBits of pc.

In https://github.com/OpenXiangShan/XiangShan/pull/3003, we checked this in backend, and captured any non-canonical address targeting by a jump/branch.

However, this fix does not account for the case where the PC increments sequentially until it overflows the boundary. E.g. fetching a fall-through block from `0x3f_ffff_fffe` to `0x40_0000_001c` should raise a page fault at non-canonical address `0x40_0000_0000`.

For current 50bit VAddrBits, violation of Sv39,39x4,48 can be captured simply by utilizing ITLB's `checkfullva` port, but for Sv48x4, we need an extra bit.

This PR adds an extra bit to the following producer -> ITLB datapath:

- IFU MMIO fetch resend_vaddr (`= pc + 2 (size of half RVI)`) -> ITLB
- IFU predChecker fixedTarget (`= pc + offset decoded from inst`) -> ifuWbRedirect target -> BPU pc -> FTQ pcMem -> IPrefetch -> ITLB
- BPU fallThrough (`= pc + 32 (size of fetch block)`) -> prediction target -> BPU pc -> ...
- RAS topAddr (`= pc of call instruction + (if isRVC 2 else 4)`) -> prediction target -> BPU pc -> ...
- SoftPrefetch nextLineStart (`= pc + 64 (size of cache line)`) -> IPrefetch -> ITLB

and to the the exception datapath for xepc/xtval generation:

- Ftq -> pcMem -> CtrlBlock (robFlushPc) -> csrio.exception -> TrapEvent genTrapVA

Fixes https://github.com/OpenXiangShan/XiangShan/issues/6264

Also:
- add necessary SignExt to the unchanged datapath. E.g. backend load-replay redirect target, bpu predictor results.
- enable TLB high address truncation checking logic for instr.
- fix TLB Sv48x4 checking for frontend fullva (SignExt-ed from 50bit to 64bit), use bit[49] to distinguish between a signed extension and an overflow.
- fix CSR trapVA generation, use the guard bit as sign bit to do SignExt, to distinguish between a canonical singed extension and a non-canonical one.
- fix BranchUnit target generation, to prevent an overflowed Sv48x4 va to be signed-extended.

Tested with OpenXiangShan/nexus-am#79 and OpenXiangShan/nexus-am#80, Sv39/48/39x4/48x4 passed, Sv57 not supported by XiangShan. ([stdout.log](https://github.com/user-attachments/files/30406403/stdout.log))