### PR TITLE
feat(prefetch): add L3 prefetch path for stash prefetch

### DIFF
--- a/src/main/scala/xiangshan/DbEntry.scala
+++ b/src/main/scala/xiangshan/DbEntry.scala
@@ -7,7 +7,6 @@ import xiangshan.backend.ctrlblock.{DebugLsInfo, DebugMdpInfo}
 import xiangshan.cache.{DCacheBundle, HasDCacheParameters}
 import xiangshan.backend.fu.FuType
 import utility.MemReqSource
-import xiangshan.mem.prefetch.HasL1PrefetchHelper
 
 /** Mem */
 class LoadMissEntry(implicit p: Parameters) extends DCacheBundle {
@@ -60,11 +59,10 @@ class LoadInfoEntry(implicit p: Parameters) extends XSBundle{
   val exeLatency = UInt(64.W)
 }
 
-class StreamPFTraceInEntry(implicit p: Parameters) extends XSBundle with HasL1PrefetchHelper{
+class StreamPFTraceInEntry(implicit p: Parameters) extends XSBundle{
   val TriggerPC = UInt(VAddrBits.W)
   val TriggerVaddr = UInt(VAddrBits.W)
   val PFVaddr = UInt(VAddrBits.W)
-  val PFSink = UInt(SINK_BITS.W)
 }
 
 class StreamTrainTraceEntry(implicit p: Parameters) extends XSBundle with HasDCacheParameters{
@@ -76,7 +74,6 @@ class StreamTrainTraceEntry(implicit p: Parameters) extends XSBundle with HasDCa
   val Miss = Bool()
 }
 
-class StreamPFTraceOutEntry(implicit p: Parameters) extends XSBundle with HasL1PrefetchHelper{
+class StreamPFTraceOutEntry(implicit p: Parameters) extends XSBundle{
   val PFVaddr = UInt(VAddrBits.W)
-  val PFSink = UInt(SINK_BITS.W)
 }

--- a/src/main/scala/xiangshan/XSTile.scala
+++ b/src/main/scala/xiangshan/XSTile.scala
@@ -79,6 +79,10 @@ class XSTile()(implicit p: Parameters) extends LazyModule
         println("Connecting L1 prefetcher to L2!")
         recv := memBlock.l2_pf_sender_opt.get
       })
+      l2.l3_pf_recv_node.foreach(recv => {
+        println("Connecting L1 prefetcher L3 requests to L2!")
+        recv := memBlock.l3_pf_sender_opt.get
+      })
     case None =>
   }
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1142,7 +1142,9 @@ for(i <- 0 until reqNum) {
 
   val (mshr_penalty_sample, mshr_penalty) = TransactionLatencyCounter(GatedValidRegNextN(primary_fire, 2) && !release_entry, release_entry)
   XSPerfHistogram("miss_penalty", mshr_penalty, mshr_penalty_sample, 0, 20, 1, true, true)
-  XSPerfHistogram("miss_penalty", mshr_penalty, mshr_penalty_sample, 20, 100, 10, true, false)
+  XSPerfHistogram("miss_penalty", mshr_penalty, mshr_penalty_sample, 20, 100, 10, true, true)
+  XSPerfHistogram("miss_penalty", mshr_penalty, mshr_penalty_sample, 100, 1000, 50, true, true)
+  XSPerfHistogram("miss_penalty", mshr_penalty, mshr_penalty_sample, 1000, 5000, 200, true, false)
 
   val load_miss_begin = ParallelMux(
     primary_fire_vec
@@ -1152,12 +1154,16 @@ for(i <- 0 until reqNum) {
   val refill_finished = GatedValidRegNext(!w_grantlast && refill_done) && should_refill_data
   val (load_miss_penalty_sample, load_miss_penalty) = TransactionLatencyCounter(load_miss_begin, refill_finished) // not real refill finish time
   XSPerfHistogram("load_miss_penalty_to_use", load_miss_penalty, load_miss_penalty_sample, 0, 20, 1, true, true)
-  XSPerfHistogram("load_miss_penalty_to_use", load_miss_penalty, load_miss_penalty_sample, 20, 100, 10, true, false)
-  XSPerfHistogram("load_miss_penalty_to_use", load_miss_penalty, load_miss_penalty_sample, 100, 400, 30, true, false)
+  XSPerfHistogram("load_miss_penalty_to_use", load_miss_penalty, load_miss_penalty_sample, 20, 100, 10, true, true)
+  XSPerfHistogram("load_miss_penalty_to_use", load_miss_penalty, load_miss_penalty_sample, 100, 400, 30, true, true)
+  XSPerfHistogram("load_miss_penalty_to_use", load_miss_penalty, load_miss_penalty_sample, 400, 1000, 50, true, true)
+  XSPerfHistogram("load_miss_penalty_to_use", load_miss_penalty, load_miss_penalty_sample, 1000, 5000, 200, true, false)
 
   val (a_to_d_penalty_sample, a_to_d_penalty) = TransactionLatencyCounter(start_counting, GatedValidRegNext(io.mem_grant.fire && refill_done))
   XSPerfHistogram("a_to_d_penalty", a_to_d_penalty, a_to_d_penalty_sample, 0, 20, 1, true, true)
-  XSPerfHistogram("a_to_d_penalty", a_to_d_penalty, a_to_d_penalty_sample, 20, 100, 10, true, false)
+  XSPerfHistogram("a_to_d_penalty", a_to_d_penalty, a_to_d_penalty_sample, 20, 100, 10, true, true)
+  XSPerfHistogram("a_to_d_penalty", a_to_d_penalty, a_to_d_penalty_sample, 100, 1000, 50, true, true)
+  XSPerfHistogram("a_to_d_penalty", a_to_d_penalty, a_to_d_penalty_sample, 1000, 5000, 200, true, false)
 }
 
 class MissQueue(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DCacheModule

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -332,6 +332,8 @@ class MemBlockInlined()(implicit p: Parameters) extends LazyModule
   // NOTE: we currently only use one output port to L2 and L3 prefetch sender respectively
   val l2_pf_sender_opt = if (coreParams.prefetcher.nonEmpty)
     Some(BundleBridgeSource(() => new PrefetchRecv)) else None
+  val l3_pf_sender_opt = if (coreParams.prefetcher.nonEmpty)
+    Some(BundleBridgeSource(() => new PrefetchRecv)) else None
   val frontendBridge = LazyModule(new FrontendBridge)
   // interrupt sinks
   val clint_int_sink = IntSinkNode(IntSinkPortSimple(1, 2))
@@ -769,9 +771,14 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   outer.l2_pf_sender_opt.foreach(_.out.head._1.addr_valid := prefetcher.io.l1_pf_to_l2.addr_valid)
   outer.l2_pf_sender_opt.foreach(_.out.head._1.addr := prefetcher.io.l1_pf_to_l2.addr)
   outer.l2_pf_sender_opt.foreach(_.out.head._1.pf_source :=  prefetcher.io.l1_pf_to_l2.pf_source)
-  outer.l2_pf_sender_opt.foreach(_.out.head._1.l2_pf_en := prefetcher.io.l1_pf_to_l2.l2_pf_en)
+  outer.l2_pf_sender_opt.foreach(_.out.head._1.pf_en := prefetcher.io.l1_pf_to_l2.pf_en)
+  outer.l3_pf_sender_opt.foreach(_.out.head._1.addr_valid := prefetcher.io.l1_pf_to_l3.addr_valid)
+  outer.l3_pf_sender_opt.foreach(_.out.head._1.addr := prefetcher.io.l1_pf_to_l3.addr)
+  outer.l3_pf_sender_opt.foreach(_.out.head._1.pf_source :=  prefetcher.io.l1_pf_to_l3.pf_source)
+  outer.l3_pf_sender_opt.foreach(_.out.head._1.pf_en := prefetcher.io.l1_pf_to_l3.pf_en)
   XSPerfAccumulate("prefetch_fire_l1", l1_pf_req.fire)
   XSPerfAccumulate("prefetch_fire_l2", outer.l2_pf_sender_opt.map(_.out.head._1.addr_valid).getOrElse(false.B))
+  XSPerfAccumulate("prefetch_fire_l3", outer.l3_pf_sender_opt.map(_.out.head._1.addr_valid).getOrElse(false.B))
 
   /** prefetcher site in L2 */
   dtlb_reqs(L2toL1DTLBPortIndex) <> io.l2_tlb_req

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -33,15 +33,12 @@ trait HasL1PrefetchHelper extends HasCircularQueuePtrHelper with HasDCacheParame
   val HASH_TAG_WIDTH = VADDR_HASH_WIDTH + BLK_ADDR_RAW_WIDTH
 
   // capacity related
-  val MLP_SIZE = 32
   val MLP_L1_SIZE = 16
-  val MLP_L2L3_SIZE = MLP_SIZE - MLP_L1_SIZE
-
-  // prefetch sink related
-  val SINK_BITS = 2
-  def SINK_L1 = "b00".U
-  def SINK_L2 = "b01".U
-  def SINK_L3 = "b10".U
+  val MLP_L2_SIZE = 16
+  val MLP_L3_SIZE = 16
+  val MLP_L2_OFFSET = MLP_L1_SIZE
+  val MLP_L3_OFFSET = MLP_L1_SIZE + MLP_L2_SIZE
+  val MLP_SIZE = MLP_L1_SIZE + MLP_L2_SIZE + MLP_L3_SIZE
 
   // vaddr: |       region tag        |  region bits  | block offset |
   def get_region_tag(vaddr: UInt) = {
@@ -219,7 +216,6 @@ class MLPReqFilterBundle(implicit p: Parameters) extends XSBundle with HasL1Pref
   val region = UInt(REGION_TAG_BITS.W)
   val bit_vec = UInt(BIT_VEC_WITDH.W)
   val sent_vec = UInt(BIT_VEC_WITDH.W)
-  val sink = UInt(SINK_BITS.W)
   val is_vaddr = Bool()
   val source = new L1PrefetchSource()
   val debug_va_region = UInt(REGION_TAG_BITS.W)
@@ -230,7 +226,6 @@ class MLPReqFilterBundle(implicit p: Parameters) extends XSBundle with HasL1Pref
     region := index.U
     bit_vec := 0.U
     sent_vec := 0.U
-    sink := SINK_L1
     is_vaddr := false.B
     source.value := L1_HW_PREFETCH_NULL
     debug_va_region := 0.U
@@ -242,13 +237,8 @@ class MLPReqFilterBundle(implicit p: Parameters) extends XSBundle with HasL1Pref
     (tag === new_tag) && valid1 && valid2
   }
 
-  def update(update_bit_vec: UInt, update_sink: UInt) = {
+  def update(update_bit_vec: UInt) = {
     bit_vec := bit_vec | update_bit_vec
-    when(update_sink < sink) {
-      bit_vec := (bit_vec & ~sent_vec) | update_bit_vec
-      sink := update_sink
-    }
-
     assert(PopCount(update_bit_vec) >= 1.U, "valid bits in update vector should greater than one")
   }
 
@@ -290,7 +280,6 @@ class MLPReqFilterBundle(implicit p: Parameters) extends XSBundle with HasL1Pref
     res.region := x.region
     res.bit_vec := x.bit_vec
     res.sent_vec := 0.U
-    res.sink := x.sink
     res.is_vaddr := true.B
     res.source := x.source
     res.debug_va_region := x.region
@@ -318,7 +307,8 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
     val enable = Input(Bool())
     val flush = Input(Bool())
     val l1_prefetch_req = Flipped(ValidIO(new StreamPrefetchReqBundle))
-    val l2_l3_prefetch_req = Flipped(ValidIO(new StreamPrefetchReqBundle))
+    val l2_prefetch_req = Flipped(ValidIO(new StreamPrefetchReqBundle))
+    val l3_prefetch_req = Flipped(ValidIO(new StreamPrefetchReqBundle))
     val tlb_req = new TlbRequestIO(nRespDups = 2)
     val pmp_resp = Flipped(new PMPRespBundle())
     val l1_req = DecoupledIO(new L1PrefetchReq())
@@ -328,42 +318,55 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   })
 
   val l1_array = Reg(Vec(MLP_L1_SIZE, new MLPReqFilterBundle))
-  val l2_array = Reg(Vec(MLP_L2L3_SIZE, new MLPReqFilterBundle))
+  val l2_array = Reg(Vec(MLP_L2_SIZE, new MLPReqFilterBundle))
+  val l3_array = Reg(Vec(MLP_L3_SIZE, new MLPReqFilterBundle))
   val l1_valids = RegInit(VecInit(Seq.fill(MLP_L1_SIZE)(false.B)))
-  val l2_valids = RegInit(VecInit(Seq.fill(MLP_L2L3_SIZE)(false.B)))
+  val l2_valids = RegInit(VecInit(Seq.fill(MLP_L2_SIZE)(false.B)))
+  val l3_valids = RegInit(VecInit(Seq.fill(MLP_L3_SIZE)(false.B)))
 
   def _invalid(e: MLPReqFilterBundle, v: Bool): Unit = {
     v := false.B
     e.invalidate()
   }
 
-  def invalid_array(i: UInt, isL2: Boolean): Unit = {
-    if (isL2) {
-      _invalid(l2_array(i), l2_valids(i))
-    } else {
-      _invalid(l1_array(i), l1_valids(i))
+  private def updateFilterEntry(
+      entry: MLPReqFilterBundle,
+      valid: Bool,
+      alloc: Bool,
+      update: Bool,
+      req: MLPReqFilterBundle
+  ): Unit = {
+    when(alloc) {
+      valid := true.B
+      entry := req
+    }.elsewhen(update) {
+      entry.update(update_bit_vec = req.bit_vec)
     }
   }
 
-  def _reset(e: MLPReqFilterBundle, v: Bool, idx: Int): Unit = {
-    v := false.B
-    //only need to reset control signals for firendly area
-    // e.reset(idx)
-  }
-
-
-  def reset_array(i: Int, isL2: Boolean): Unit = {
-    if(isL2){
-      _reset(l2_array(i), l2_valids(i), i)
-    }else{
-      _reset(l1_array(i), l1_valids(i), i)
-    }
+  private def connectTlbReq(req: DecoupledIO[TlbReq], entry: MLPReqFilterBundle, valid: Bool): Unit = {
+    req.valid := valid
+    req.bits.vaddr := entry.get_tlb_va()
+    req.bits.cmd := TlbCmd.read
+    req.bits.isPrefetch := true.B
+    req.bits.size := 3.U
+    req.bits.kill := false.B
+    req.bits.no_translate := false.B
+    req.bits.fullva := 0.U
+    req.bits.checkfullva := false.B
+    req.bits.memidx := DontCare
+    req.bits.debug := DontCare
+    req.bits.hlvx := DontCare
+    req.bits.hyperinst := DontCare
+    req.bits.pmp_addr := DontCare
   }
 
   val l1_replacement = new ValidPseudoLRU(MLP_L1_SIZE)
-  val l2_replacement = new ValidPseudoLRU(MLP_L2L3_SIZE)
+  val l2_replacement = new ValidPseudoLRU(MLP_L2_SIZE)
+  val l3_replacement = new ValidPseudoLRU(MLP_L3_SIZE)
   val l1_tlb_req_arb = Module(new RRArbiterInit(new TlbReq, MLP_L1_SIZE))
-  val l2_tlb_req_arb = Module(new RRArbiterInit(new TlbReq, MLP_L2L3_SIZE))
+  val l2_tlb_req_arb = Module(new RRArbiterInit(new TlbReq, MLP_L2_SIZE))
+  val l3_tlb_req_arb = Module(new RRArbiterInit(new TlbReq, MLP_L3_SIZE))
   val l1_pf_req_arb = Module(new TwoLevelRRArbiter(new Bundle {
     val req = new L1PrefetchReq
     val debug_vaddr = UInt(VAddrBits.W)
@@ -371,14 +374,16 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   val l2_pf_req_arb = Module(new TwoLevelRRArbiter(new Bundle {
     val req = new L2PrefetchReq
     val debug_vaddr = UInt(VAddrBits.W)
-  }, MLP_L2L3_SIZE))
-  val l3_pf_req_arb = Module(new RRArbiterInit(new L3PrefetchReq, MLP_L2L3_SIZE))
+  }, MLP_L2_SIZE))
+  val l3_pf_req_arb = Module(new RRArbiterInit(new L3PrefetchReq, MLP_L3_SIZE))
 
   val l1_opt_replace_vec = VecInit(l1_array.zip(l1_valids).map{case (e, v) => e.may_be_replace(v)})
   val l2_opt_replace_vec = VecInit(l2_array.zip(l2_valids).map{case (e, v) => e.may_be_replace(v)})
+  val l3_opt_replace_vec = VecInit(l3_array.zip(l3_valids).map{case (e, v) => e.may_be_replace(v)})
   // if we have something to replace, then choose it, otherwise follow the plru manner
   val l1_real_replace_vec = Mux(Cat(l1_opt_replace_vec).orR, l1_opt_replace_vec, VecInit(Seq.fill(MLP_L1_SIZE)(true.B)))
-  val l2_real_replace_vec = Mux(Cat(l2_opt_replace_vec).orR, l2_opt_replace_vec, VecInit(Seq.fill(MLP_L2L3_SIZE)(true.B)))
+  val l2_real_replace_vec = Mux(Cat(l2_opt_replace_vec).orR, l2_opt_replace_vec, VecInit(Seq.fill(MLP_L2_SIZE)(true.B)))
+  val l3_real_replace_vec = Mux(Cat(l3_opt_replace_vec).orR, l3_opt_replace_vec, VecInit(Seq.fill(MLP_L3_SIZE)(true.B)))
 
   // l1 pf req enq
   // s0: hash tag match
@@ -414,15 +419,13 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   val s1_l1_update = s1_l1_valid && s1_l1_hit
   s0_l1_can_accept := !(s1_l1_valid && s1_l1_alloc && (s0_l1_region_hash === s1_l1_region_hash))
 
-  when(s1_l1_alloc) {
-    l1_valids(s1_l1_index) := true.B
-    l1_array(s1_l1_index) := s1_l1_prefetch_req
-  }.elsewhen(s1_l1_update) {
-    l1_array(s1_l1_index).update(
-      update_bit_vec = s1_l1_prefetch_req.bit_vec,
-      update_sink = s1_l1_prefetch_req.sink
-    )
-  }
+  updateFilterEntry(
+    l1_array(s1_l1_index),
+    l1_valids(s1_l1_index),
+    s1_l1_alloc,
+    s1_l1_update,
+    s1_l1_prefetch_req
+  )
 
   XSPerfAccumulate("s1_l1_enq_valid", s1_l1_valid)
   XSPerfAccumulate("s1_l1_enq_alloc", s1_l1_alloc)
@@ -430,18 +433,23 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   XSPerfAccumulate("l1_hash_conflict", s0_l1_valid && RegNext(s1_l1_valid) && (s0_l1_region =/= RegNext(s1_l1_region)) && (s0_l1_region_hash === RegNext(s1_l1_region_hash)))
   XSPerfAccumulate("s1_l1_enq_evict_useful_entry", s1_l1_alloc && l1_array(s1_l1_index).can_send_pf(l1_valids(s1_l1_index)))
 
-  // l2 l3 pf req enq
+  // l2 pf req enq
   // s0: hash tag match
+  val s0_l2_input_valid = io.l2_prefetch_req.valid
   val s0_l2_can_accept = Wire(Bool())
-  val s0_l2_valid = io.l2_l3_prefetch_req.valid && s0_l2_can_accept
-  val s0_l2_region = io.l2_l3_prefetch_req.bits.region
+  val s0_l2_valid = s0_l2_input_valid && s0_l2_can_accept
+  val s0_l2_region = io.l2_prefetch_req.bits.region
   val s0_l2_region_hash = region_hash_tag(s0_l2_region)
   val s0_l2_match_vec = l2_array.zip(l2_valids).map{ case (e, v) => e.tag_match(v, s0_l2_valid, s0_l2_region_hash) }
   val s0_l2_hit = VecInit(s0_l2_match_vec).asUInt.orR
-  val s0_l2_index = Wire(UInt(log2Up(MLP_L2L3_SIZE).W))
-  val s0_l2_prefetch_req = (new MLPReqFilterBundle).fromStreamPrefetchReqBundle(io.l2_l3_prefetch_req.bits)
+  val s0_l2_index = Wire(UInt(log2Up(MLP_L2_SIZE).W))
+  val s0_l2_prefetch_req = (new MLPReqFilterBundle).fromStreamPrefetchReqBundle(io.l2_prefetch_req.bits)
 
-  s0_l2_index := Mux(s0_l2_hit, OHToUInt(VecInit(s0_l2_match_vec).asUInt), l2_replacement.way(l2_real_replace_vec.reverse)._2)
+  s0_l2_index := Mux(
+    s0_l2_hit,
+    OHToUInt(VecInit(s0_l2_match_vec).asUInt),
+    l2_replacement.way(l2_real_replace_vec.reverse)._2
+  )
 
   when(s0_l2_valid) {
     l2_replacement.access(s0_l2_index)
@@ -450,8 +458,8 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   assert(!s0_l2_valid || PopCount(VecInit(s0_l2_match_vec)) <= 1.U, "req region should match no more than 1 entry")
 
   XSPerfAccumulate("s0_l2_enq_fire", s0_l2_valid)
-  XSPerfAccumulate("s0_l2_enq_valid", io.l2_l3_prefetch_req.valid)
-  XSPerfAccumulate("s0_l2_cannot_enq", io.l2_l3_prefetch_req.valid && !s0_l2_can_accept)
+  XSPerfAccumulate("s0_l2_enq_valid", s0_l2_input_valid)
+  XSPerfAccumulate("s0_l2_cannot_enq", s0_l2_input_valid && !s0_l2_can_accept)
 
   // s1: alloc or update
   val s1_l2_valid = RegNext(s0_l2_valid)
@@ -464,21 +472,88 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   val s1_l2_update = s1_l2_valid && s1_l2_hit
   s0_l2_can_accept := !(s1_l2_valid && s1_l2_alloc && (s0_l2_region_hash === s1_l2_region_hash))
 
-  when(s1_l2_alloc) {
-    l2_valids(s1_l2_index) := true.B
-    l2_array(s1_l2_index) := s1_l2_prefetch_req
-  }.elsewhen(s1_l2_update) {
-    l2_array(s1_l2_index).update(
-      update_bit_vec = s1_l2_prefetch_req.bit_vec,
-      update_sink = s1_l2_prefetch_req.sink
-    )
-  }
+  updateFilterEntry(
+    l2_array(s1_l2_index),
+    l2_valids(s1_l2_index),
+    s1_l2_alloc,
+    s1_l2_update,
+    s1_l2_prefetch_req
+  )
 
   XSPerfAccumulate("s1_l2_enq_valid", s1_l2_valid)
   XSPerfAccumulate("s1_l2_enq_alloc", s1_l2_alloc)
   XSPerfAccumulate("s1_l2_enq_update", s1_l2_update)
-  XSPerfAccumulate("l2_hash_conflict", s0_l2_valid && RegNext(s1_l2_valid) && (s0_l2_region =/= RegNext(s1_l2_region)) && (s0_l2_region_hash === RegNext(s1_l2_region_hash)))
-  XSPerfAccumulate("s1_l2_enq_evict_useful_entry", s1_l2_alloc && l2_array(s1_l2_index).can_send_pf(l2_valids(s1_l2_index)))
+  val l2_hash_conflict =
+    s0_l2_valid &&
+      RegNext(s1_l2_valid) &&
+      (s0_l2_region =/= RegNext(s1_l2_region)) &&
+      (s0_l2_region_hash === RegNext(s1_l2_region_hash))
+  XSPerfAccumulate("l2_hash_conflict", l2_hash_conflict)
+  XSPerfAccumulate(
+    "s1_l2_enq_evict_useful_entry",
+    s1_l2_alloc && l2_array(s1_l2_index).can_send_pf(l2_valids(s1_l2_index))
+  )
+
+  // l3 pf req enq
+  // s0: hash tag match
+  val s0_l3_input_valid = io.l3_prefetch_req.valid
+  val s0_l3_can_accept = Wire(Bool())
+  val s0_l3_valid = s0_l3_input_valid && s0_l3_can_accept
+  val s0_l3_region = io.l3_prefetch_req.bits.region
+  val s0_l3_region_hash = region_hash_tag(s0_l3_region)
+  val s0_l3_match_vec = l3_array.zip(l3_valids).map{ case (e, v) => e.tag_match(v, s0_l3_valid, s0_l3_region_hash) }
+  val s0_l3_hit = VecInit(s0_l3_match_vec).asUInt.orR
+  val s0_l3_index = Wire(UInt(log2Up(MLP_L3_SIZE).W))
+  val s0_l3_prefetch_req = (new MLPReqFilterBundle).fromStreamPrefetchReqBundle(io.l3_prefetch_req.bits)
+
+  s0_l3_index := Mux(
+    s0_l3_hit,
+    OHToUInt(VecInit(s0_l3_match_vec).asUInt),
+    l3_replacement.way(l3_real_replace_vec.reverse)._2
+  )
+
+  when(s0_l3_valid) {
+    l3_replacement.access(s0_l3_index)
+  }
+
+  assert(!s0_l3_valid || PopCount(VecInit(s0_l3_match_vec)) <= 1.U, "req region should match no more than 1 entry")
+
+  XSPerfAccumulate("s0_l3_enq_fire", s0_l3_valid)
+  XSPerfAccumulate("s0_l3_enq_valid", s0_l3_input_valid)
+  XSPerfAccumulate("s0_l3_cannot_enq", s0_l3_input_valid && !s0_l3_can_accept)
+
+  // s1: alloc or update
+  val s1_l3_valid = RegNext(s0_l3_valid)
+  val s1_l3_region = RegEnable(s0_l3_region, s0_l3_valid)
+  val s1_l3_region_hash = RegEnable(s0_l3_region_hash, s0_l3_valid)
+  val s1_l3_hit = RegEnable(s0_l3_hit, s0_l3_valid)
+  val s1_l3_index = RegEnable(s0_l3_index, s0_l3_valid)
+  val s1_l3_prefetch_req = RegEnable(s0_l3_prefetch_req, s0_l3_valid)
+  val s1_l3_alloc = s1_l3_valid && !s1_l3_hit
+  val s1_l3_update = s1_l3_valid && s1_l3_hit
+  s0_l3_can_accept := !(s1_l3_valid && s1_l3_alloc && (s0_l3_region_hash === s1_l3_region_hash))
+
+  updateFilterEntry(
+    l3_array(s1_l3_index),
+    l3_valids(s1_l3_index),
+    s1_l3_alloc,
+    s1_l3_update,
+    s1_l3_prefetch_req
+  )
+
+  XSPerfAccumulate("s1_l3_enq_valid", s1_l3_valid)
+  XSPerfAccumulate("s1_l3_enq_alloc", s1_l3_alloc)
+  XSPerfAccumulate("s1_l3_enq_update", s1_l3_update)
+  val l3_hash_conflict =
+    s0_l3_valid &&
+      RegNext(s1_l3_valid) &&
+      (s0_l3_region =/= RegNext(s1_l3_region)) &&
+      (s0_l3_region_hash === RegNext(s1_l3_region_hash))
+  XSPerfAccumulate("l3_hash_conflict", l3_hash_conflict)
+  XSPerfAccumulate(
+    "s1_l3_enq_evict_useful_entry",
+    s1_l3_alloc && l3_array(s1_l3_index).can_send_pf(l3_valids(s1_l3_index))
+  )
 
   // stream pf debug db here
   // Hit:
@@ -501,7 +576,6 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
     log_data.TriggerPC := io.l1_prefetch_req.bits.trigger_pc
     log_data.TriggerVaddr := io.l1_prefetch_req.bits.trigger_va
     log_data.PFVaddr := Cat(s0_l1_region, i.U(REGION_BITS.W), 0.U(log2Up(dcacheParameters.blockBytes).W))
-    log_data.PFSink := s0_l1_prefetch_req.sink
 
     stream_pf_trace_debug_table.log(
       data = log_data,
@@ -512,20 +586,42 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
     )
   }
   for (i <- 0 until BIT_VEC_WITDH) {
-    // l2 l3 enq log
+    // l2 enq log
     val hit_entry = l2_array(s0_l2_index)
     val new_req = Mux(
       s0_l2_hit,
-      io.l2_l3_prefetch_req.bits.bit_vec & ~(hit_entry.bit_vec),
-      io.l2_l3_prefetch_req.bits.bit_vec
+      io.l2_prefetch_req.bits.bit_vec & ~(hit_entry.bit_vec),
+      io.l2_prefetch_req.bits.bit_vec
     )
-    val log_enable = s0_l2_valid && new_req(i) && isFromStream(io.l2_l3_prefetch_req.bits.source.value)
+    val log_enable = s0_l2_valid && new_req(i) && isFromStream(io.l2_prefetch_req.bits.source.value)
     val log_data = Wire(new StreamPFTraceInEntry)
 
-    log_data.TriggerPC := io.l2_l3_prefetch_req.bits.trigger_pc
-    log_data.TriggerVaddr := io.l2_l3_prefetch_req.bits.trigger_va
+    log_data.TriggerPC := io.l2_prefetch_req.bits.trigger_pc
+    log_data.TriggerVaddr := io.l2_prefetch_req.bits.trigger_va
     log_data.PFVaddr := Cat(s0_l2_region, i.U(REGION_BITS.W), 0.U(log2Up(dcacheParameters.blockBytes).W))
-    log_data.PFSink := s0_l2_prefetch_req.sink
+
+    stream_pf_trace_debug_table.log(
+      data = log_data,
+      en = log_enable,
+      site = "StreamPFTrace",
+      clock = clock,
+      reset = reset
+    )
+  }
+  for (i <- 0 until BIT_VEC_WITDH) {
+    // l3 enq log
+    val hit_entry = l3_array(s0_l3_index)
+    val new_req = Mux(
+      s0_l3_hit,
+      io.l3_prefetch_req.bits.bit_vec & ~(hit_entry.bit_vec),
+      io.l3_prefetch_req.bits.bit_vec
+    )
+    val log_enable = s0_l3_valid && new_req(i) && isFromStream(io.l3_prefetch_req.bits.source.value)
+    val log_data = Wire(new StreamPFTraceInEntry)
+
+    log_data.TriggerPC := io.l3_prefetch_req.bits.trigger_pc
+    log_data.TriggerVaddr := io.l3_prefetch_req.bits.trigger_va
+    log_data.PFVaddr := Cat(s0_l3_region, i.U(REGION_BITS.W), 0.U(log2Up(dcacheParameters.blockBytes).W))
 
     stream_pf_trace_debug_table.log(
       data = log_data,
@@ -538,7 +634,9 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
 
   // tlb req
   // s0: arb all tlb reqs
-  val s0_tlb_fire_vec = VecInit(l1_tlb_req_arb.io.in.map(_.fire) ++ l2_tlb_req_arb.io.in.map(_.fire))
+  val s0_tlb_fire_vec = VecInit(
+    l1_tlb_req_arb.io.in.map(_.fire) ++ l2_tlb_req_arb.io.in.map(_.fire) ++ l3_tlb_req_arb.io.in.map(_.fire)
+  )
   val s1_tlb_fire_vec = GatedValidRegNext(s0_tlb_fire_vec)
   val s2_tlb_fire_vec = GatedValidRegNext(s1_tlb_fire_vec)
   val s3_tlb_fire_vec = GatedValidRegNext(s2_tlb_fire_vec)
@@ -547,41 +645,34 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   })
   for(i <- 0 until MLP_L1_SIZE) {
     val l1_evict = s1_l1_alloc && (s1_l1_index === i.U)
-    l1_tlb_req_arb.io.in(i).valid := l1_valids(i) && l1_array(i).is_vaddr && not_tlbing_vec(i) && !l1_evict
-    l1_tlb_req_arb.io.in(i).bits.vaddr := l1_array(i).get_tlb_va()
-    l1_tlb_req_arb.io.in(i).bits.cmd := TlbCmd.read
-    l1_tlb_req_arb.io.in(i).bits.isPrefetch := true.B
-    l1_tlb_req_arb.io.in(i).bits.size := 3.U
-    l1_tlb_req_arb.io.in(i).bits.kill := false.B
-    l1_tlb_req_arb.io.in(i).bits.no_translate := false.B
-    l1_tlb_req_arb.io.in(i).bits.fullva := 0.U
-    l1_tlb_req_arb.io.in(i).bits.checkfullva := false.B
-    l1_tlb_req_arb.io.in(i).bits.memidx := DontCare
-    l1_tlb_req_arb.io.in(i).bits.debug := DontCare
-    l1_tlb_req_arb.io.in(i).bits.hlvx := DontCare
-    l1_tlb_req_arb.io.in(i).bits.hyperinst := DontCare
-    l1_tlb_req_arb.io.in(i).bits.pmp_addr  := DontCare
+    connectTlbReq(
+      l1_tlb_req_arb.io.in(i),
+      l1_array(i),
+      l1_valids(i) && l1_array(i).is_vaddr && not_tlbing_vec(i) && !l1_evict
+    )
   }
-  for(i <- 0 until MLP_L2L3_SIZE) {
+  for(i <- 0 until MLP_L2_SIZE) {
     val l2_evict = s1_l2_alloc && (s1_l2_index === i.U)
-    l2_tlb_req_arb.io.in(i).valid := l2_valids(i) && l2_array(i).is_vaddr && not_tlbing_vec(i + MLP_L1_SIZE) && !l2_evict
-    l2_tlb_req_arb.io.in(i).bits.vaddr := l2_array(i).get_tlb_va()
-    l2_tlb_req_arb.io.in(i).bits.cmd := TlbCmd.read
-    l2_tlb_req_arb.io.in(i).bits.isPrefetch := true.B
-    l2_tlb_req_arb.io.in(i).bits.size := 3.U
-    l2_tlb_req_arb.io.in(i).bits.kill := false.B
-    l2_tlb_req_arb.io.in(i).bits.no_translate := false.B
-    l2_tlb_req_arb.io.in(i).bits.fullva := 0.U
-    l2_tlb_req_arb.io.in(i).bits.checkfullva := false.B
-    l2_tlb_req_arb.io.in(i).bits.memidx := DontCare
-    l2_tlb_req_arb.io.in(i).bits.debug := DontCare
-    l2_tlb_req_arb.io.in(i).bits.hlvx := DontCare
-    l2_tlb_req_arb.io.in(i).bits.hyperinst := DontCare
-    l2_tlb_req_arb.io.in(i).bits.pmp_addr  := DontCare
+    val l2_need_tlb = l2_valids(i) && l2_array(i).is_vaddr
+    connectTlbReq(
+      l2_tlb_req_arb.io.in(i),
+      l2_array(i),
+      l2_need_tlb && not_tlbing_vec(i + MLP_L2_OFFSET) && !l2_evict
+    )
   }
-  val tlb_req_arb = Module(new RRArbiterInit(new TlbReq, 2))
+  for(i <- 0 until MLP_L3_SIZE) {
+    val l3_evict = s1_l3_alloc && (s1_l3_index === i.U)
+    val l3_need_tlb = l3_valids(i) && l3_array(i).is_vaddr
+    connectTlbReq(
+      l3_tlb_req_arb.io.in(i),
+      l3_array(i),
+      l3_need_tlb && not_tlbing_vec(i + MLP_L3_OFFSET) && !l3_evict
+    )
+  }
+  val tlb_req_arb = Module(new RRArbiterInit(new TlbReq, 3))
   tlb_req_arb.io.in(0) <> l1_tlb_req_arb.io.out
   tlb_req_arb.io.in(1) <> l2_tlb_req_arb.io.out
+  tlb_req_arb.io.in(2) <> l3_tlb_req_arb.io.out
   assert(PopCount(s0_tlb_fire_vec) <= 1.U, "s0_tlb_fire_vec should be one-hot or empty")
 
   // s1: send out the req
@@ -589,8 +680,9 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   val s1_tlb_req_bits = RegEnable(tlb_req_arb.io.out.bits, tlb_req_arb.io.out.valid)
   val s1_tlb_req_index = RegEnable(OHToUInt(s0_tlb_fire_vec.asUInt), tlb_req_arb.io.out.valid)
   val s1_l1_tlb_evict = s1_l1_alloc && (s1_l1_index === s1_tlb_req_index)
-  val s1_l2_tlb_evict = s1_l2_alloc && ((s1_l2_index + MLP_L1_SIZE.U) === s1_tlb_req_index)
-  val s1_tlb_evict = s1_l1_tlb_evict || s1_l2_tlb_evict
+  val s1_l2_tlb_evict = s1_l2_alloc && ((s1_l2_index + MLP_L2_OFFSET.U) === s1_tlb_req_index)
+  val s1_l3_tlb_evict = s1_l3_alloc && ((s1_l3_index + MLP_L3_OFFSET.U) === s1_tlb_req_index)
+  val s1_tlb_evict = s1_l1_tlb_evict || s1_l2_tlb_evict || s1_l3_tlb_evict
   io.tlb_req.req.valid := s1_tlb_req_valid && !s1_tlb_evict
   io.tlb_req.req.bits := s1_tlb_req_bits
   io.tlb_req.req_kill := false.B
@@ -604,8 +696,9 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   val s2_tlb_resp = io.tlb_req.resp.bits
   val s2_tlb_update_index = RegEnable(s1_tlb_req_index, s1_tlb_req_valid)
   val s2_l1_tlb_evict = s1_l1_alloc && (s1_l1_index === s2_tlb_update_index)
-  val s2_l2_tlb_evict = s1_l2_alloc && ((s1_l2_index + MLP_L1_SIZE.U) === s2_tlb_update_index)
-  val s2_tlb_evict = s2_l1_tlb_evict || s2_l2_tlb_evict
+  val s2_l2_tlb_evict = s1_l2_alloc && ((s1_l2_index + MLP_L2_OFFSET.U) === s2_tlb_update_index)
+  val s2_l3_tlb_evict = s1_l3_alloc && ((s1_l3_index + MLP_L3_OFFSET.U) === s2_tlb_update_index)
+  val s2_tlb_evict = s2_l1_tlb_evict || s2_l2_tlb_evict || s2_l3_tlb_evict
 
   // s3: get pmp response form PMPChecker
   val s3_tlb_resp_valid = RegNext(s2_tlb_resp_valid)
@@ -624,25 +717,44 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
     // pmp access fault
     s3_pmp_resp.ld
   )
-  when(s3_tlb_resp_valid && !s3_tlb_evict) {
-    when(s3_tlb_update_index < MLP_L1_SIZE.U) {
-      l1_array(s3_tlb_update_index).is_vaddr := s3_tlb_resp.miss
+  val s3_paddr_region = Cat(
+    0.U((VAddrBits - PAddrBits).W),
+    s3_tlb_resp.paddr.head(s3_tlb_resp.paddr.head.getWidth - 1, REGION_TAG_OFFSET)
+  )
+  val s3_tlb_update_valid = s3_tlb_resp_valid && !s3_tlb_evict
+  val s3_update_l1 = s3_tlb_update_index < MLP_L1_SIZE.U
+  val s3_update_l2 = s3_tlb_update_index >= MLP_L2_OFFSET.U && s3_tlb_update_index < MLP_L3_OFFSET.U
+  val s3_update_l3 = s3_tlb_update_index >= MLP_L3_OFFSET.U
+  val s3_l2_update_index = s3_tlb_update_index - MLP_L2_OFFSET.U
+  val s3_l3_update_index = s3_tlb_update_index - MLP_L3_OFFSET.U
 
-      when(!s3_tlb_resp.miss) {
-        l1_array(s3_tlb_update_index).region := Cat(0.U((VAddrBits - PAddrBits).W), s3_tlb_resp.paddr.head(s3_tlb_resp.paddr.head.getWidth - 1, REGION_TAG_OFFSET))
-        when(s3_drop) {
-          invalid_array(s3_tlb_update_index, false)
-        }
+  when(s3_tlb_update_valid && s3_update_l1) {
+    l1_array(s3_tlb_update_index).is_vaddr := s3_tlb_resp.miss
+
+    when(!s3_tlb_resp.miss) {
+      l1_array(s3_tlb_update_index).region := s3_paddr_region
+      when(s3_drop) {
+        _invalid(l1_array(s3_tlb_update_index), l1_valids(s3_tlb_update_index))
       }
-    }.otherwise {
-      val inner_index = s3_tlb_update_index - MLP_L1_SIZE.U
-      l2_array(inner_index).is_vaddr := s3_tlb_resp.miss
+    }
+  }
+  when(s3_tlb_update_valid && s3_update_l2) {
+    l2_array(s3_l2_update_index).is_vaddr := s3_tlb_resp.miss
 
-      when(!s3_tlb_resp.miss) {
-        l2_array(inner_index).region := Cat(0.U((VAddrBits - PAddrBits).W), s3_tlb_resp.paddr.head(s3_tlb_resp.paddr.head.getWidth - 1, REGION_TAG_OFFSET))
-        when(s3_drop) {
-          invalid_array(inner_index, true)
-        }
+    when(!s3_tlb_resp.miss) {
+      l2_array(s3_l2_update_index).region := s3_paddr_region
+      when(s3_drop) {
+        _invalid(l2_array(s3_l2_update_index), l2_valids(s3_l2_update_index))
+      }
+    }
+  }
+  when(s3_tlb_update_valid && s3_update_l3) {
+    l3_array(s3_l3_update_index).is_vaddr := s3_tlb_resp.miss
+
+    when(!s3_tlb_resp.miss) {
+      l3_array(s3_l3_update_index).region := s3_paddr_region
+      when(s3_drop) {
+        _invalid(l3_array(s3_l3_update_index), l3_valids(s3_l3_update_index))
       }
     }
   }
@@ -675,8 +787,7 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
     val evict = s1_l1_alloc && (s1_l1_index === i.U)
     val issue_forward_sent_vec = Mux(s1_pf_valid && s1_l1_pf_chosen_oh(i), s1_l1_pf_candidate_oh, 0.U)
     val forward_sent_vec = l1_array(i).sent_vec | issue_forward_sent_vec
-    l1_pf_req_arb.io.in(i).valid := l1_array(i).can_send_pf(l1_valids(i), forward_sent_vec) &&
-      l1_array(i).sink === SINK_L1 && !evict
+    l1_pf_req_arb.io.in(i).valid := l1_array(i).can_send_pf(l1_valids(i), forward_sent_vec) && !evict
     l1_pf_req_arb.io.in(i).bits.req.paddr := l1_array(i).get_pf_paddr(forward_sent_vec)
     l1_pf_req_arb.io.in(i).bits.req.vaddr := l1_array(i).get_pf_vaddr(forward_sent_vec)
     l1_pf_req_arb.io.in(i).bits.req.confidence := l1_array(i).confidence
@@ -725,23 +836,19 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   XSPerfAccumulate("s1_pf_fire", s1_pf_fire)
 
   // l2 pf
-  val s1_l2_pf_valid = Wire(Bool())
-  val s1_l2_pf_chosen_oh = RegInit(0.U(MLP_L2L3_SIZE.W))
+  val s1_l2_pf_valid = RegNext(l2_pf_req_arb.io.out.valid)
+  val s1_l2_pf_fire = s1_l2_pf_valid && io.l2_pf_addr.ready
+  val s1_l2_pf_chosen_oh = RegInit(0.U(MLP_L2_SIZE.W))
   val s1_l2_pf_candidate_oh = RegInit(0.U(BIT_VEC_WITDH.W))
 
-  val s1_l3_pf_valid = Wire(Bool())
-  val s1_l3_pf_fire = Wire(Bool())
-  val s1_l3_pf_chosen_oh = RegInit(0.U(MLP_L2L3_SIZE.W))
-  val s1_l3_pf_candidate_oh = RegInit(0.U(BIT_VEC_WITDH.W))
-
   // s0: generate prefetch req paddr per entry, arb them, sent out
-  for(i <- 0 until MLP_L2L3_SIZE) {
+  l2_pf_req_arb.io.out.ready := io.l2_pf_addr.ready
+
+  for(i <- 0 until MLP_L2_SIZE) {
     val evict = s1_l2_alloc && (s1_l2_index === i.U)
-    val issue_forward_sent_vec = Mux(s1_l2_pf_valid && s1_l2_pf_chosen_oh(i), s1_l2_pf_candidate_oh, 0.U) |
-      Mux(s1_l3_pf_valid && s1_l3_pf_chosen_oh(i), s1_l3_pf_candidate_oh, 0.U)
+    val issue_forward_sent_vec = Mux(s1_l2_pf_valid && s1_l2_pf_chosen_oh(i), s1_l2_pf_candidate_oh, 0.U)
     val forward_sent_vec = l2_array(i).sent_vec | issue_forward_sent_vec
-    l2_pf_req_arb.io.in(i).valid := l2_array(i).can_send_pf(l2_valids(i), forward_sent_vec) &&
-      (l2_array(i).sink === SINK_L2) && !evict
+    l2_pf_req_arb.io.in(i).valid := l2_array(i).can_send_pf(l2_valids(i), forward_sent_vec) && !evict
     l2_pf_req_arb.io.in(i).bits.req.addr := l2_array(i).get_pf_paddr(forward_sent_vec)
     l2_pf_req_arb.io.in(i).bits.req.source := MuxLookup(l2_array(i).source.value, MemReqSource.Prefetch2L2Unknown.id.U)(Seq(
       L1_HW_PREFETCH_STRIDE -> MemReqSource.Prefetch2L2Stride.id.U,
@@ -751,9 +858,6 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   }
 
   // s1: send out to l2 and update sent_vec
-  s1_l2_pf_valid := RegNext(l2_pf_req_arb.io.out.valid)
-  val s1_l2_pf_fire = s1_l2_pf_valid && io.l2_pf_addr.ready
-
   when(l2_pf_req_arb.io.out.valid) {
     s1_l2_pf_chosen_oh := l2_pf_req_arb.io.chosenOH
     s1_l2_pf_candidate_oh := get_candidate_oh(l2_pf_req_arb.io.out.bits.req.addr)
@@ -761,11 +865,9 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   io.l2_pf_addr.valid := s1_l2_pf_valid
   io.l2_pf_addr.bits := RegEnable(l2_pf_req_arb.io.out.bits.req, l2_pf_req_arb.io.out.valid)
 
-  l2_pf_req_arb.io.out.ready := io.l2_pf_addr.ready
-  for (i <- 0 until MLP_L2L3_SIZE) {
+  for (i <- 0 until MLP_L2_SIZE) {
     val evict = s1_l2_alloc && (s1_l2_index === i.U)
-    val issue_sent_vec = Mux(s1_l2_pf_fire && s1_l2_pf_chosen_oh(i), s1_l2_pf_candidate_oh, 0.U) |
-      Mux(s1_l3_pf_fire && s1_l3_pf_chosen_oh(i), s1_l3_pf_candidate_oh, 0.U)
+    val issue_sent_vec = Mux(s1_l2_pf_fire && s1_l2_pf_chosen_oh(i), s1_l2_pf_candidate_oh, 0.U)
     when(issue_sent_vec.orR && !evict) {
       l2_array(i).sent_vec := l2_array(i).sent_vec | issue_sent_vec
     }
@@ -775,9 +877,7 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   val l1_debug_data = Wire(new StreamPFTraceOutEntry)
   val l2_debug_data = Wire(new StreamPFTraceOutEntry)
   l1_debug_data.PFVaddr := l1_pf_req_arb.io.out.bits.debug_vaddr
-  l1_debug_data.PFSink := SINK_L1
   l2_debug_data.PFVaddr := l2_pf_req_arb.io.out.bits.debug_vaddr
-  l2_debug_data.PFSink := SINK_L2
 
   stream_out_debug_table.log(
     data = l1_debug_data,
@@ -795,27 +895,27 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   )
 
   // last level cache pf
+  val s1_l3_pf_valid = RegNext(l3_pf_req_arb.io.out.valid)
+  val s1_l3_pf_fire = s1_l3_pf_valid && io.l3_pf_addr.ready
+  val s1_l3_pf_chosen_oh = RegInit(0.U(MLP_L3_SIZE.W))
+  val s1_l3_pf_candidate_oh = RegInit(0.U(BIT_VEC_WITDH.W))
+
   // s0: generate prefetch req paddr per entry, arb them, sent out
   l3_pf_req_arb.io.out.ready := io.l3_pf_addr.ready
 
-  for(i <- 0 until MLP_L2L3_SIZE) {
-    val evict = s1_l2_alloc && (s1_l2_index === i.U)
-    val issue_forward_sent_vec = Mux(s1_l2_pf_valid && s1_l2_pf_chosen_oh(i), s1_l2_pf_candidate_oh, 0.U) |
-      Mux(s1_l3_pf_valid && s1_l3_pf_chosen_oh(i), s1_l3_pf_candidate_oh, 0.U)
-    val forward_sent_vec = l2_array(i).sent_vec | issue_forward_sent_vec
-    l3_pf_req_arb.io.in(i).valid := l2_array(i).can_send_pf(l2_valids(i), forward_sent_vec) &&
-      (l2_array(i).sink === SINK_L3) && !evict
-    l3_pf_req_arb.io.in(i).bits.addr := l2_array(i).get_pf_paddr(forward_sent_vec)
-    l3_pf_req_arb.io.in(i).bits.source := MuxLookup(l2_array(i).source.value, MemReqSource.Prefetch2L3Unknown.id.U)(Seq(
+  for(i <- 0 until MLP_L3_SIZE) {
+    val evict = s1_l3_alloc && (s1_l3_index === i.U)
+    val issue_forward_sent_vec = Mux(s1_l3_pf_valid && s1_l3_pf_chosen_oh(i), s1_l3_pf_candidate_oh, 0.U)
+    val forward_sent_vec = l3_array(i).sent_vec | issue_forward_sent_vec
+    l3_pf_req_arb.io.in(i).valid := l3_array(i).can_send_pf(l3_valids(i), forward_sent_vec) && !evict
+    l3_pf_req_arb.io.in(i).bits.addr := l3_array(i).get_pf_paddr(forward_sent_vec)
+    l3_pf_req_arb.io.in(i).bits.source := MuxLookup(l3_array(i).source.value, MemReqSource.Prefetch2L3Unknown.id.U)(Seq(
       L1_HW_PREFETCH_STRIDE -> MemReqSource.Prefetch2L3Stride.id.U,
       L1_HW_PREFETCH_STREAM -> MemReqSource.Prefetch2L3Stream.id.U
     ))
   }
 
   // s1: send out to l3 and update sent_vec
-  s1_l3_pf_valid := RegNext(l3_pf_req_arb.io.out.valid)
-  s1_l3_pf_fire := s1_l3_pf_valid && io.l3_pf_addr.ready
-
   when(l3_pf_req_arb.io.out.valid) {
     s1_l3_pf_chosen_oh := UIntToOH(l3_pf_req_arb.io.chosen)
     s1_l3_pf_candidate_oh := get_candidate_oh(l3_pf_req_arb.io.out.bits.addr)
@@ -823,27 +923,61 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   io.l3_pf_addr.valid := s1_l3_pf_valid
   io.l3_pf_addr.bits := RegEnable(l3_pf_req_arb.io.out.bits, l3_pf_req_arb.io.out.valid)
 
+  for (i <- 0 until MLP_L3_SIZE) {
+    val evict = s1_l3_alloc && (s1_l3_index === i.U)
+    val issue_sent_vec = Mux(s1_l3_pf_fire && s1_l3_pf_chosen_oh(i), s1_l3_pf_candidate_oh, 0.U)
+    when(issue_sent_vec.orR && !evict) {
+      l3_array(i).sent_vec := l3_array(i).sent_vec | issue_sent_vec
+    }
+  }
+
   // reset meta to avoid muti-hit problem
-  for(i <- 0 until MLP_SIZE) {
-    if(i < MLP_L1_SIZE) {
-      when(RegNext(io.flush)) {
-        reset_array(i, false)
-      }
-    }else {
-      when(RegNext(io.flush)) {
-        reset_array(i - MLP_L1_SIZE, true)
-      }
+  for(i <- 0 until MLP_L1_SIZE) {
+    when(RegNext(io.flush)) {
+      l1_valids(i) := false.B
+    }
+  }
+  for(i <- 0 until MLP_L2_SIZE) {
+    when(RegNext(io.flush)) {
+      l2_valids(i) := false.B
+    }
+  }
+  for(i <- 0 until MLP_L3_SIZE) {
+    when(RegNext(io.flush)) {
+      l3_valids(i) := false.B
     }
   }
 
   XSPerfAccumulate("l2_prefetche_queue_busby", io.l2PfqBusy)
   XSPerfHistogram("filter_active", PopCount(VecInit(
     l1_array.zip(l1_valids).map{ case (e, v) => e.can_send_pf(v) } ++
-    l2_array.zip(l2_valids).map{ case (e, v) => e.can_send_pf(v) }
+    l2_array.zip(l2_valids).map{ case (e, v) => e.can_send_pf(v) } ++
+    l3_array.zip(l3_valids).map{ case (e, v) => e.can_send_pf(v) }
     ).asUInt), true.B, 0, MLP_SIZE, 1)
-  XSPerfHistogram("l1_filter_active", PopCount(VecInit(l1_array.zip(l1_valids).map{ case (e, v) => e.can_send_pf(v)}).asUInt), true.B, 0, MLP_L1_SIZE, 1)
-  XSPerfHistogram("l2_filter_active", PopCount(VecInit(l2_array.zip(l2_valids).map{ case (e, v) => e.can_send_pf(v) && (e.sink === SINK_L2)}).asUInt), true.B, 0, MLP_L2L3_SIZE, 1)
-  XSPerfHistogram("l3_filter_active", PopCount(VecInit(l2_array.zip(l2_valids).map{ case (e, v) => e.can_send_pf(v) && (e.sink === SINK_L3)}).asUInt), true.B, 0, MLP_L2L3_SIZE, 1)
+  XSPerfHistogram(
+    "l1_filter_active",
+    PopCount(VecInit(l1_array.zip(l1_valids).map{ case (e, v) => e.can_send_pf(v)}).asUInt),
+    true.B,
+    0,
+    MLP_L1_SIZE,
+    1
+  )
+  XSPerfHistogram(
+    "l2_filter_active",
+    PopCount(VecInit(l2_array.zip(l2_valids).map{ case (e, v) => e.can_send_pf(v)}).asUInt),
+    true.B,
+    0,
+    MLP_L2_SIZE,
+    1
+  )
+  XSPerfHistogram(
+    "l3_filter_active",
+    PopCount(VecInit(l3_array.zip(l3_valids).map{ case (e, v) => e.can_send_pf(v)}).asUInt),
+    true.B,
+    0,
+    MLP_L3_SIZE,
+    1
+  )
 }
 
 class L1Prefetcher(implicit p: Parameters) extends BasePrefecher with HasStreamPrefetchHelper with HasStridePrefetchHelper {
@@ -906,14 +1040,17 @@ class L1Prefetcher(implicit p: Parameters) extends BasePrefecher with HasStreamP
     stride_meta_array.io.l1_prefetch_req.bits
   )
 
-  val stream_pf_valid2 = stream_bit_vec_array.io.l2_l3_prefetch_req.valid && stream_pf_ctrl.enable && streamEnable
-  val stride_pf_valid2 = stride_meta_array.io.l2_l3_prefetch_req.valid && stride_pf_ctrl.enable && strideEnable
-  pf_queue_filter.io.l2_l3_prefetch_req.valid := stream_pf_valid2 || stride_pf_valid2
-  pf_queue_filter.io.l2_l3_prefetch_req.bits := Mux(
+  val stream_pf_valid2 = stream_bit_vec_array.io.l2_prefetch_req.valid && stream_pf_ctrl.enable && streamEnable
+  val stride_pf_valid2 = stride_meta_array.io.l2_prefetch_req.valid && stride_pf_ctrl.enable && strideEnable
+  pf_queue_filter.io.l2_prefetch_req.valid := stream_pf_valid2 || stride_pf_valid2
+  pf_queue_filter.io.l2_prefetch_req.bits := Mux(
     stream_pf_valid2,
-    stream_bit_vec_array.io.l2_l3_prefetch_req.bits,
-    stride_meta_array.io.l2_l3_prefetch_req.bits
+    stream_bit_vec_array.io.l2_prefetch_req.bits,
+    stride_meta_array.io.l2_prefetch_req.bits
   )
+  pf_queue_filter.io.l3_prefetch_req.valid :=
+    stream_bit_vec_array.io.l3_prefetch_req.valid && stream_pf_ctrl.enable && streamEnable
+  pf_queue_filter.io.l3_prefetch_req.bits := stream_bit_vec_array.io.l3_prefetch_req.bits
 
   io.l1_req.valid := pf_queue_filter.io.l1_req.valid && io.enable
   io.l1_req.bits := pf_queue_filter.io.l1_req.bits

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -705,8 +705,10 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   val s3_tlb_resp = RegEnable(s2_tlb_resp, s2_tlb_resp_valid)
   val s3_tlb_update_index = RegEnable(s2_tlb_update_index, s2_tlb_resp_valid)
   val s3_l1_tlb_evict = s1_l1_alloc && (s1_l1_index === s3_tlb_update_index)
-  val s3_l2_tlb_evict = s1_l2_alloc && ((s1_l2_index + MLP_L1_SIZE.U) === s3_tlb_update_index)
-  val s3_tlb_evict = RegNext(s2_tlb_evict) || s3_l1_tlb_evict || s3_l2_tlb_evict
+  val s3_l2_tlb_evict = s1_l2_alloc && ((s1_l2_index + MLP_L2_OFFSET.U) === s3_tlb_update_index)
+  val s3_l3_tlb_evict = s1_l3_alloc && ((s1_l3_index + MLP_L3_OFFSET.U) === s3_tlb_update_index)
+  val s3_alloc_evict = s3_l1_tlb_evict || s3_l2_tlb_evict || s3_l3_tlb_evict
+  val s3_tlb_evict = RegNext(s2_tlb_evict) || s3_alloc_evict
   val s3_pmp_resp = io.pmp_resp
   val s3_update_valid = s3_tlb_resp_valid && !s3_tlb_evict && !s3_tlb_resp.miss
   val s3_drop = s3_update_valid && (
@@ -762,6 +764,7 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
 
   XSPerfAccumulate("s3_tlb_resp_valid", s3_tlb_resp_valid)
   XSPerfAccumulate("s3_tlb_resp_evict", s3_tlb_resp_valid && s3_tlb_evict)
+  XSPerfAccumulate("s3_tlb_resp_alloc_evict", s3_tlb_resp_valid && s3_alloc_evict)
   XSPerfAccumulate("s3_tlb_resp_miss", s3_tlb_resp_valid && !s3_tlb_evict && s3_tlb_resp.miss)
   XSPerfAccumulate("s3_tlb_resp_updated", s3_update_valid)
   XSPerfAccumulate("s3_tlb_resp_page_fault", s3_update_valid && s3_tlb_resp.excp.head.pf.ld)
@@ -821,6 +824,10 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   val in_pmem = PmemRanges.map(_.cover(s1_pf_bits.req.paddr)).reduce(_ || _)
   io.l1_req.valid := s1_pf_valid && in_pmem && io.enable
   io.l1_req.bits := s1_pf_bits.req
+  assert(
+    !io.l1_req.valid || io.l1_req.bits.paddr(PAGE_OFFSET - 1, 0) === io.l1_req.bits.vaddr(PAGE_OFFSET - 1, 0),
+    "L1 prefetch request paddr/vaddr page offset mismatch"
+  )
 
   l1_pf_req_arb.io.out.ready := s1_pf_can_go || !s1_pf_valid
 

--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -269,7 +269,7 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
 
   val l1_depth_const = Constantin.createRecord(s"streamL1Depth${p(XSCoreParamsKey).HartId}", initValue = 64)
   val l2_depth_const = Constantin.createRecord(s"streamL2Depth${p(XSCoreParamsKey).HartId}", initValue = 640)
-  val l3_depth_const = Constantin.createRecord(s"streamL3Depth${p(XSCoreParamsKey).HartId}", initValue = 960) // l3 is not useful
+  val l3_depth_const = Constantin.createRecord(s"streamL3Depth${p(XSCoreParamsKey).HartId}", initValue = 960) 
 
   val l1_depth = Wire(UInt(DEPTH_BITS.W))
   val l2_depth = Wire(UInt(DEPTH_BITS.W))
@@ -425,7 +425,7 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
   val s4_pf_l2_bits = RegEnable(s3_pf_l2_bits, s3_pf_l2_valid)
   val s4_pf_l3_bits = RegEnable(s3_pf_l3_bits, s3_pf_l2_valid)
 
-  val enable_l3_pf = Constantin.createRecord(s"enableL3StreamPrefetch${p(XSCoreParamsKey).HartId}", initValue = false)
+  val enable_l3_pf = Constantin.createRecord(s"enableL3StreamPrefetch${p(XSCoreParamsKey).HartId}", initValue = true)
   // s5: send the l3 prefetch req out
   val s5_pf_l3_valid = GatedValidRegNext(s4_pf_l2_valid) && enable_l3_pf
   val s5_pf_l3_bits = RegEnable(s4_pf_l3_bits, s4_pf_l2_valid)

--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -117,7 +117,6 @@ class StreamBitVectorBundle(implicit p: Parameters) extends XSBundle with HasStr
 class StreamPrefetchReqBundle(implicit p: Parameters) extends XSBundle with HasStreamPrefetchHelper {
   val region = UInt(REGION_TAG_BITS.W)
   val bit_vec = UInt(BIT_VEC_WITDH.W)
-  val sink = UInt(SINK_BITS.W)
   val source = new L1PrefetchSource()
   val confidence = UInt(1.W)
   // debug usage
@@ -125,10 +124,9 @@ class StreamPrefetchReqBundle(implicit p: Parameters) extends XSBundle with HasS
   val trigger_va = UInt(VAddrBits.W)
 
   // align prefetch vaddr and width to region
-  def getStreamPrefetchReqBundle(valid: Bool, vaddr: UInt, width: Int, decr_mode: Bool, sink: UInt, source: UInt, confidence: UInt, t_pc: UInt, t_va: UInt): StreamPrefetchReqBundle = {
+  def getStreamPrefetchReqBundle(valid: Bool, vaddr: UInt, width: Int, decr_mode: Bool, source: UInt, confidence: UInt, t_pc: UInt, t_va: UInt): StreamPrefetchReqBundle = {
     val res = Wire(new StreamPrefetchReqBundle)
     res.region := get_region_tag(vaddr)
-    res.sink := sink
     res.source.value := source
     res.confidence := confidence
 
@@ -145,7 +143,6 @@ class StreamPrefetchReqBundle(implicit p: Parameters) extends XSBundle with HasS
 
     assert(!valid || PopCount(res.bit_vec) <= width.U, "actual prefetch block number should less than or equals to WIDTH_CACHE_BLOCKS")
     assert(!valid || PopCount(res.bit_vec) >= 1.U, "at least one block should be included")
-    assert(sink <= SINK_L3, "invalid sink")
     for(i <- 0 until BIT_VEC_WITDH) {
       when(decr_mode) {
         when(i.U > region_bits) {
@@ -175,7 +172,8 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
     val confidence = Input(UInt(1.W))
     val train_req = Flipped(DecoupledIO(new TrainReqBundle))
     val l1_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
-    val l2_l3_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
+    val l2_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
+    val l3_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
 
     // Stride send lookup req here
     val stream_lookup_req  = Flipped(ValidIO(UInt(VAddrBits.W)))
@@ -382,7 +380,6 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
     vaddr = s2_l1_vaddr,
     width = WIDTH_CACHE_BLOCKS,
     decr_mode = s2_decr_mode,
-    sink = SINK_L1,
     source = L1_HW_PREFETCH_STREAM,
     confidence = io.confidence,
     t_pc = s2_pc,
@@ -393,7 +390,6 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
     vaddr = s2_l2_vaddr,
     width = L2_WIDTH_CACHE_BLOCKS,
     decr_mode = s2_decr_mode,
-    sink = SINK_L2,
     source = L1_HW_PREFETCH_STREAM,
     confidence = io.confidence,
     t_pc = s2_pc,
@@ -404,7 +400,6 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
     vaddr = s2_l3_vaddr,
     width = L3_WIDTH_CACHE_BLOCKS,
     decr_mode = s2_decr_mode,
-    sink = SINK_L3,
     source = L1_HW_PREFETCH_STREAM,
     confidence = io.confidence,
     t_pc = s2_pc,
@@ -437,12 +432,18 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
 
   io.l1_prefetch_req.valid := s3_pf_l1_valid
   io.l1_prefetch_req.bits := s3_pf_l1_bits
-  io.l2_l3_prefetch_req.valid := s4_pf_l2_valid || s5_pf_l3_valid
-  io.l2_l3_prefetch_req.bits := Mux(s4_pf_l2_valid, s4_pf_l2_bits, s5_pf_l3_bits)
+  io.l2_prefetch_req.valid := s4_pf_l2_valid
+  io.l2_prefetch_req.bits := s4_pf_l2_bits
+  io.l3_prefetch_req.valid := s5_pf_l3_valid
+  io.l3_prefetch_req.bits := s5_pf_l3_bits
 
   XSPerfAccumulate("s4_pf_sent", s4_pf_l2_valid)
-  XSPerfAccumulate("s5_pf_sent", !s4_pf_l2_valid && s5_pf_l3_valid)
-  XSPerfAccumulate("pf_sent", PopCount(Seq(io.l1_prefetch_req.valid, io.l2_l3_prefetch_req.valid)))
+  XSPerfAccumulate("stream_l3_candidate", s5_pf_l3_valid)
+  XSPerfAccumulate("s5_pf_sent", s5_pf_l3_valid)
+  XSPerfAccumulate(
+    "pf_sent",
+    PopCount(Seq(io.l1_prefetch_req.valid, io.l2_prefetch_req.valid, io.l3_prefetch_req.valid))
+  )
 
   // Stride lookup starts here
   // S0: Stride send req

--- a/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StreamPrefetcher.scala
@@ -269,7 +269,7 @@ class StreamBitVectorArray(implicit p: Parameters) extends XSModule with HasStre
 
   val l1_depth_const = Constantin.createRecord(s"streamL1Depth${p(XSCoreParamsKey).HartId}", initValue = 64)
   val l2_depth_const = Constantin.createRecord(s"streamL2Depth${p(XSCoreParamsKey).HartId}", initValue = 640)
-  val l3_depth_const = Constantin.createRecord(s"streamL3Depth${p(XSCoreParamsKey).HartId}", initValue = 640) // l3 is not useful
+  val l3_depth_const = Constantin.createRecord(s"streamL3Depth${p(XSCoreParamsKey).HartId}", initValue = 960) // l3 is not useful
 
   val l1_depth = Wire(UInt(DEPTH_BITS.W))
   val l2_depth = Wire(UInt(DEPTH_BITS.W))

--- a/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1StridePrefetcher.scala
@@ -144,7 +144,7 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
     val confidence = Input(UInt(1.W))
     val train_req = Flipped(DecoupledIO(new TrainReqBundle))
     val l1_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
-    val l2_l3_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
+    val l2_prefetch_req = ValidIO(new StreamPrefetchReqBundle)
     // query Stream component to see if a stream pattern has already been detected
     val stream_lookup_req  = ValidIO(UInt(VAddrBits.W))
     val stream_lookup_resp = Input(Bool())
@@ -240,7 +240,6 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
     vaddr = s2_l1_pf_vaddr,
     width = STRIDE_WIDTH_BLOCKS,
     decr_mode = s2_decr_mode,
-    sink = SINK_L1,
     source = L1_HW_PREFETCH_STRIDE,
     confidence = io.confidence,
     // TODO: add stride debug db, not useful for now
@@ -252,7 +251,6 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
     vaddr = s2_l2_pf_vaddr,
     width = STRIDE_WIDTH_BLOCKS,
     decr_mode = s2_decr_mode,
-    sink = SINK_L2,
     source = L1_HW_PREFETCH_STRIDE,
     confidence = io.confidence,
     // TODO: add stride debug db, not useful for now
@@ -271,10 +269,10 @@ class StrideMetaArray(implicit p: Parameters) extends XSModule with HasStridePre
 
   io.l1_prefetch_req.valid := s3_valid && io.enable
   io.l1_prefetch_req.bits := s3_l1_pf_req_bits
-  io.l2_l3_prefetch_req.valid := s4_valid && io.enable
-  io.l2_l3_prefetch_req.bits := s4_l2_pf_req_bits
+  io.l2_prefetch_req.valid := s4_valid && io.enable
+  io.l2_prefetch_req.bits := s4_l2_pf_req_bits
 
-  XSPerfAccumulate("pf_valid", PopCount(Seq(io.l1_prefetch_req.valid, io.l2_l3_prefetch_req.valid)))
+  XSPerfAccumulate("pf_valid", PopCount(Seq(io.l1_prefetch_req.valid, io.l2_prefetch_req.valid)))
   XSPerfAccumulate("l1_pf_valid", s3_valid)
   XSPerfAccumulate("l2_pf_valid", s4_valid)
   XSPerfAccumulate("detect_stream", io.stream_lookup_resp)

--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
@@ -98,6 +98,7 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
     // prefetch req sender
     val l1_pf_to_l1 = DecoupledIO(new L1PrefetchReq())
     val l1_pf_to_l2 = Output(new xscache.coupledL2.PrefetchRecv())
+    val l1_pf_to_l3 = Output(new xscache.coupledL2.PrefetchRecv())
   })
 
   def isLoadAccess(uop: DynInst): Bool = FuType.isLoad(uop.fuType) || FuType.isVLoad(uop.fuType)
@@ -324,7 +325,12 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
   io.l1_pf_to_l2.addr_valid := l2_pf_req.valid
   io.l1_pf_to_l2.addr := l2_pf_req.bits.addr
   io.l1_pf_to_l2.pf_source := l2_pf_req.bits.source
-  io.l1_pf_to_l2.l2_pf_en := RegNextN(io.pfCtrlFromCSR.l2_pf_enable, L2_PF_REG_CNT, Some(true.B))
+  io.l1_pf_to_l2.pf_en := RegNextN(io.pfCtrlFromCSR.l2_pf_enable, L2_PF_REG_CNT, Some(true.B))
+
+  io.l1_pf_to_l3.addr_valid := l3_pf_req.valid
+  io.l1_pf_to_l3.addr := l3_pf_req.bits.addr
+  io.l1_pf_to_l3.pf_source := l3_pf_req.bits.source
+  io.l1_pf_to_l3.pf_en := RegNextN(io.pfCtrlFromCSR.l2_pf_enable, L3_PF_REG_CNT, Some(true.B))
 
   val l2_trace = Wire(new LoadPfDbBundle)
   l2_trace.paddr := l2_pf_req.bits.addr


### PR DESCRIPTION
- Split stream-generated L2 and L3 prefetch requests before they
  enter the multi-level prefetch filter, so L3 requests get their
  own filter entries, TLB arbitration, sent-vector tracking, and
  output path instead of sharing the L2/L3 pipeline with a sink
  selector.
- Replace the shared L2/L3 filter array in MutiLevelPrefetchFilter
  with dedicated 16-entry L2 and L3 arrays, each with its own RR
  arbiter and PLRU replacement.
- Remove the sink field from stream prefetch request bundles and
  debug DB entries; L2 and L3 destinations are now separate valid
  interfaces (l2_prefetch_req / l3_prefetch_req).
- Pass the L3 prefetch bridge through PrefetcherWrapper, MemBlock,
  and XSTile so XSCache receives it independently from the L2 path.
- Bump the XSCache submodule for the matching stash support: the
  coupledL2 stash prefetch path issues CHI StashOnceShared TXREQs
  with a dedicated TxnID namespace, and openLLC handles
  StashOnceShared refills including the MemUnit bypass-data path
  that previously could leak a RefillBuf entry.
- Raise the L3 stream prefetch depth to 960 (was 640); L3 prefetch
  follows the existing L2 prefetch CSR enable (pf_en), so no new
  standalone control is added.