### PR TITLE
fix(L1PF, LSQ): reject stale TLB updates and nonphysical store wakeups

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -343,6 +343,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     // store address execute
     (0 until StorePipelineWidth).map(w => {
       storeAddrWakeupVec(i)(w) := io.storeAddrWakeup(w).valid &&
+        io.storeAddrWakeup(w).bits.sqIdx.withInPhysicalQueue(io.sqDeqPtr) &&
         blockSqIdx(i) === io.storeAddrWakeup(w).bits.sqIdx
     })
     storeAddrInSameCycleVec(i) := storeAddrWakeupVec(i).asUInt.orR // for better timing

--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -611,7 +611,9 @@ class MutiLevelPrefetchFilter(implicit p: Parameters) extends XSModule with HasL
   val s3_tlb_resp_valid = RegNext(s2_tlb_resp_valid)
   val s3_tlb_resp = RegEnable(s2_tlb_resp, s2_tlb_resp_valid)
   val s3_tlb_update_index = RegEnable(s2_tlb_update_index, s2_tlb_resp_valid)
-  val s3_tlb_evict = RegNext(s2_tlb_evict)
+  val s3_l1_tlb_evict = s1_l1_alloc && (s1_l1_index === s3_tlb_update_index)
+  val s3_l2_tlb_evict = s1_l2_alloc && ((s1_l2_index + MLP_L1_SIZE.U) === s3_tlb_update_index)
+  val s3_tlb_evict = RegNext(s2_tlb_evict) || s3_l1_tlb_evict || s3_l2_tlb_evict
   val s3_pmp_resp = io.pmp_resp
   val s3_update_valid = s3_tlb_resp_valid && !s3_tlb_evict && !s3_tlb_resp.miss
   val s3_drop = s3_update_valid && (


### PR DESCRIPTION
Fixed bugs exposed by errors reported from some benchmarks when running spec06 virtualization checkpoints. Two commits correspond to two different bugs. The L1PF issue caused difftest error and passes after the fix. The LSQ issue caused hangs, but after discussion with @weidingliu , it was found to be a performance bug; the real root cause lies in the back‑end module where the OG1 ready condition is incorrect, causing the ROB‑head load to be issued from IQ and reach DataPath but blocked at OG1 and never enter LoadUnit（this should be fixed later）. However, the bug addressed by this commit still needs to be fixed. After the fix, the hang no longer occurs.