### PR TITLE
feat(vector): new vector float-point multiplier/alu support by using scalar fp functionUnit in Yunsuan

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -489,7 +489,7 @@ case class XSCoreParameters
       IssueBlockParams(Seq(
         ExeUnitParams(
           "VFEX0",
-          Seq(VialuCfg, VfcvtCfg, VmoveCfg, VfmaCfg, VimacCfg),
+          Seq(VialuCfg, VfaluCfg, VfcvtCfg, VmoveCfg, VfmulCfg, VimacCfg),
           Seq(VfWB(port = 3, 0), IntWB(port = 4, 1), FpWB(port = 6, 0)),
           Seq(Seq(VfRD(0, 0), IntRD(0, 2), FpRD(12, 1)), Seq(VfRD(1, 0)), Seq(VfRD(2, 0))),
           vlRD = VlRD(0, 0),
@@ -500,7 +500,7 @@ case class XSCoreParameters
       IssueBlockParams(Seq(
         ExeUnitParams(
           "VFEX1",
-          Seq(VialuCfg, VfmaCfg, VidivCfg),
+          Seq(VialuCfg, VfaluCfg, VfmulCfg, VidivCfg),
           Seq(VfWB(port = 4, 0)),
           Seq(Seq(VfRD(3, 0), IntRD(2, 2), FpRD(13, 1)), Seq(VfRD(4, 0)), Seq(VfRD(5, 0))),
           vlRD = VlRD(1, 0),

--- a/src/main/scala/xiangshan/backend/BackendParams.scala
+++ b/src/main/scala/xiangshan/backend/BackendParams.scala
@@ -726,7 +726,7 @@ object BackendV2SchdParams {
       IssueBlockParams(Seq(
         ExeUnitParams(
           "VFEX0",
-          Seq(VialuCfg, VfaluCfg, VfmaCfg, VimacCfg, VppuCfg, VipuCfg, VfcvtCfg, VSetRvfWvfCfg, VmoveCfg),
+          Seq(VialuCfg, VfaluCfg, VfmulCfg, VimacCfg, VppuCfg, VipuCfg, VfcvtCfg, VSetRvfWvfCfg, VmoveCfg),
           Seq(VfWB(port = 0, 0), V0WB(port = 0, 0), IntWB(port = 7, 0), FpWB(port = 6, 0)),
           Seq(Seq(VfRD(0, 0), IntRD(11, 0), FpRD(9, 0)), Seq(VfRD(1, 0)), Seq(VfRD(2, 0)), Seq(V0RD(0, 0))),
           vlWB = VlWB(port = vfSchdVlWbPort, 0),
@@ -736,7 +736,7 @@ object BackendV2SchdParams {
       IssueBlockParams(Seq(
         ExeUnitParams(
           "VFEX1",
-          Seq(VialuCfg, VfaluCfg, VfmaCfg, VfdivCfg, VidivCfg),
+          Seq(VialuCfg, VfaluCfg, VfmulCfg, VfdivCfg, VidivCfg),
           Seq(VfWB(port = 1, 0), V0WB(port = 1, 0), FpWB(port = 7, 0)),
           Seq(Seq(VfRD(3, 0), IntRD(12, 0), FpRD(10, 0)), Seq(VfRD(4, 0)), Seq(VfRD(5, 0)), Seq(V0RD(1, 0))),
           vlRD = VlRD(1, 0),

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -895,6 +895,7 @@ object Bundles {
     val isDstMask = Bool() // vvm, vvvm, mmm
     val isOpMask  = Bool() // vmand, vmnand
     val isMove    = Bool() // vmv.s.x, vmv.v.v, vmv.v.x, vmv.v.i
+    val isReverse = Bool() // reverse operand order for vector arithmetic
 
     val isDependOldVd = Bool() // some instruction's computation depends on oldvd
     val isWritePartVd = Bool() // some instruction's computation writes part of vd, such as vredsum

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -890,7 +890,6 @@ object Bundles {
     val nf        = Nf()
     val veew      = VEew()
 
-    val isReverse = Bool() // vrsub, vrdiv
     val isExt     = Bool()
     val isNarrow  = Bool()
     val isDstMask = Bool() // vvm, vvvm, mmm

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -1055,7 +1055,7 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
   decodedInst.vpu.vm := inst.VM
   decodedInst.vpu.nf := inst.NF
   decodedInst.vpu.veew := inst.WIDTH
-  decodedInst.vpu.isReverse := needReverseInsts.map(_ === inst.ALL).reduce(_ || _)
+  // decodedInst.vpu.isReverse := needReverseInsts.map(_ === inst.ALL).reduce(_ || _)
   decodedInst.vpu.isExt := vextInsts.map(_ === inst.ALL).reduce(_ || _)
   val isNarrow = narrowInsts.map(_ === inst.ALL).reduce(_ || _)
   val isDstMask = maskDstInsts.map(_ === inst.ALL).reduce(_ || _)

--- a/src/main/scala/xiangshan/backend/decode/opcode/Opcode.scala
+++ b/src/main/scala/xiangshan/backend/decode/opcode/Opcode.scala
@@ -75,7 +75,8 @@ object Opcode {
   object VFMacOpcodes extends Opcodes.FMacOpcode {
     override def getLat(opcode: Opcode): Int = {
       require(this.all.contains(opcode))
-      2
+      // FMacOpcode.getOpNum is bit 5; OP3 is encoded as one.
+      if (opcode.encode(5).rawString == "1") 3 else 2
     }
   }
 

--- a/src/main/scala/xiangshan/backend/decode/opcode/Opcode.scala
+++ b/src/main/scala/xiangshan/backend/decode/opcode/Opcode.scala
@@ -72,7 +72,12 @@ object Opcode {
   val FMacOpcodes       = opcodes.FMacOpcode
   val VFMiscOpcodes     = opcodes.VFMiscOpcode
   val VFCvtOpcodes      = opcodes.VFCvtOpcode
-  val VFMacOpcodes      = opcodes.VFMacOpcode
+  object VFMacOpcodes extends Opcodes.FMacOpcode {
+    override def getLat(opcode: Opcode): Int = {
+      require(this.all.contains(opcode))
+      2
+    }
+  }
 
   // Todo: remove these
   def X = BitPat("b0_0000_0000")
@@ -1105,6 +1110,13 @@ object Opcode {
   object FAluOpcodes extends Opcodes.FMacOpcode
   object VFRedOpcodes extends Opcodes.VFRedOpcode
   object VFDivOpcodes extends Opcodes.VFDivOpcode
+
+  object VFAluOpcodes extends Opcodes.FMacOpcode {
+    override def getLat(opcode: Opcode): Int = {
+      require(this.all.contains(opcode))
+      1
+    }
+  }
 
   trait VSetOpcodes extends Opcodes {
     // vtype is from imm

--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -168,7 +168,7 @@ case class FuConfig (
 
   def needVecCtrl: Boolean = {
     import FuType._
-    Seq(vipu, vialuF, vimac, vidiv, vppu, vfalu, vmove, vfma, vfdiv, vfcvt, vldu, vstu, vsha256ms, vsha256c).contains(fuType)
+    Seq(vipu, vialuF, vimac, vidiv, vppu, vfalu, vmove, vfmul, vfdiv, vfcvt, vldu, vstu, vsha256ms, vsha256c).contains(fuType)
   }
 
   def needUncertainWakeup: Boolean = {
@@ -198,10 +198,12 @@ case class FuConfig (
 
   def isVecArith: Boolean = fuType == FuType.vialuF || fuType == FuType.vimac ||
                             fuType == FuType.vppu || fuType == FuType.vipu ||
-                            fuType == FuType.vfalu || fuType == FuType.vfma ||
+                            fuType == FuType.vfalu || fuType == FuType.vfmul ||
                             fuType == FuType.vfdiv || fuType == FuType.vfcvt ||
                             fuType == FuType.vidiv || fuType == FuType.vmove ||
                             fuType == FuType.vsha256ms || fuType == FuType.vsha256c
+
+  def isVfmul: Boolean = fuType == FuType.vfmul
 
   def isVecMem: Boolean = fuType == FuType.vldu || fuType == FuType.vstu ||
                           fuType == FuType.vsegldu || fuType == FuType.vsegstu ||
@@ -716,15 +718,16 @@ object FuConfig {
   val VfaluCfg = FuConfig (
     name = "vfalu",
     fuType = FuType.vfalu,
-    fuGen = (p: Parameters, cfg: FuConfig) => Module(new VFAlu(cfg)(p).suggestName("Vfalu")),
+    fuGen = null,
     srcData = Seq(
       Seq(VecData(), VecData(), VecData()), // vs1, vs2, vd_old
+      Seq(FpData(),  VecData(), VecData()), // fs1, vs2, vd_old
     ),
     piped = true,
     writeVecRf = true,
     writeV0Rf = true,
-    writeFpRf = true,
     writeFflags = true,
+    needWidenOut = true,
     latency = CertainLatency(1),
     vlWakeUp = true,
     maskWakeUp = true,
@@ -736,10 +739,10 @@ object FuConfig {
     readVType = true,
   )
 
-  val VfmaCfg = FuConfig (
-    name = "vfma",
-    fuType = FuType.vfma,
-    fuGen = (p: Parameters, cfg: FuConfig) => Module(new VFMA(cfg)(p).suggestName("Vfma")),
+  val VfmulCfg = FuConfig (
+    name = "vfmul",
+    fuType = FuType.vfmul,
+    fuGen = null,
     srcData = Seq(
       Seq(VecData(), VecData(), VecData()), // vs1, vs2, vd_old
       Seq(FpData(),  VecData(), VecData()), // fs1, vs2, vd_old
@@ -749,7 +752,7 @@ object FuConfig {
     writeV0Rf = true,
     writeFflags = true,
     needWidenOut = true,
-    latency = CertainLatency(3),
+    latency = CertainLatency(2),
     vlWakeUp = true,
     maskWakeUp = true,
     destDataBits = 128,
@@ -766,6 +769,7 @@ object FuConfig {
     fuGen = (p: Parameters, cfg: FuConfig) => Module(new VFDivSqrt(cfg)(p).suggestName("Vfdiv")),
     srcData = Seq(
       Seq(VecData(), VecData(), VecData()), // vs1, vs2, vd_old
+      Seq(FpData(),  VecData(), VecData()), // fs1, vs2, vd_old
     ),
     piped = false,
     writeVecRf = true,
@@ -1018,13 +1022,13 @@ object FuConfig {
     NJmpCfg, LinkCfg, BrhCfg, I2fCfg, FcmpCfg, I2vCfg, F2vCfg, CsrCfg, AluCfg, MulCfg, DivCfg, FenceCfg, BkuCfg,
     VSetCfg, VSetRvfWvfCfg, VSetRiWvfCfg, VSetRiWiCfg,
     LduCfg, StaCfg, StdCfg, HyldaCfg, HystaCfg, FakeHystaCfg, MouCfg, MoudCfg,
-    VialuCfg, VimacCfg, VidivCfg, VppuCfg, VipuCfg, VmoveCfg, VfaluCfg, VfmaCfg, VfdivCfg, VfcvtCfg, VSha256msCfg, VSha256cCfg,
+    VialuCfg, VimacCfg, VidivCfg, VppuCfg, VipuCfg, VmoveCfg, VfaluCfg, VfmulCfg, VfdivCfg, VfcvtCfg, VSha256msCfg, VSha256cCfg,
     FaluCfg, FmulCfg, FdivCfg, FcvtCfg,
     VStdCfg, VlduCfg, VstuCfg, VseglduCfg, VsegstuCfg
   )
 
   def VecArithFuConfigs = Seq(
-    VialuCfg, VimacCfg, VppuCfg, VipuCfg, VfaluCfg, VmoveCfg, VfmaCfg, VfcvtCfg, VfdivCfg
+    VialuCfg, VimacCfg, VppuCfg, VipuCfg, VfaluCfg, VmoveCfg, VfmulCfg, VfcvtCfg, VfdivCfg
   )
 
   def needUncertainWakeupFuConfigs = Seq(

--- a/src/main/scala/xiangshan/backend/fu/FuType.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuType.scala
@@ -47,7 +47,7 @@ object FuType extends ChiselOHEnum {
   val vidiv = addType(name = "vidiv")
   val vfalu = addType(name = "vfalu")
   val vmove = addType(name = "vmove")
-  val vfma = addType(name = "vfma")
+  val vfmul = addType(name = "vfmul")
   val vfdiv = addType(name = "vfdiv")
   val vfcvt = addType(name = "vfcvt")
   val vset = addType(name = "vset")
@@ -115,7 +115,7 @@ object FuType extends ChiselOHEnum {
   val fpArithAll = Seq(falu, fcvt, fmul, fDivSqrt, f2v, fcmp)
   val scalaMemAll = Seq(ldu, stu, mou)
   val vecOPI = Seq(vipu, vialuF, vppu, vimac, vidiv)
-  val vecOPF = Seq(vfalu, vfma, vfdiv, vfcvt)
+  val vecOPF = Seq(vfalu, vfmul, vfdiv, vfcvt)
   val vecVSET = Seq(vset)
   val vecArith = vecOPI ++ vecOPF
   val vecMem = Seq(vldu, vstu, vsegldu, vsegstu)
@@ -124,7 +124,7 @@ object FuType extends ChiselOHEnum {
   val vecAll = vecVSET ++ vecArithOrMem ++ vecMove
   val fpOP = fpArithAll ++ Seq(i2f, i2v)
   val scalaNeedFrm = Seq(i2f, fmul, fDivSqrt)
-  val vectorNeedFrm = Seq(vfalu, vfma, vfdiv, vfcvt)
+  val vectorNeedFrm = Seq(vfalu, vfmul, vfdiv, vfcvt)
   val blockBackCompress = Seq(brh, njmp)
 
   def X = BitPat.N(num) // Todo: Don't Care
@@ -201,7 +201,7 @@ object FuType extends ChiselOHEnum {
 
   def isVecOPF(fuType: UInt): Bool = FuTypeOrR(fuType, vecOPF)
 
-  def isVecOPFFma(fuType: UInt): Bool = FuTypeOrR(fuType, vfma)
+  def isVecOPFFmul(fuType: UInt): Bool = FuTypeOrR(fuType, vfmul)
 
   def isVArithMem(fuType: UInt): Bool = FuTypeOrR(fuType, vecArithOrMem) // except vset
 
@@ -246,7 +246,7 @@ object FuType extends ChiselOHEnum {
     vidiv -> "vidiv",
     vfalu -> "vfalu",
     vmove -> "vmove",
-    vfma -> "vfma",
+    vfmul -> "vfmul",
     vfdiv -> "vfdiv",
     vfcvt -> "vfcvt"
   )

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -144,11 +144,21 @@ class FuncUnitFmulOutputToFalu(implicit p: Parameters) extends XSBundle {
   val debug_seqNum = OptionWrapper(backendParams.debugEn, InstSeqNum())
 }
 
+class FuncUnitVfmulOutputToVfalu(implicit p: Parameters) extends XSBundle {
+  val vfalucfg = FuConfig.VfaluCfg
+  val fuType = FuType()
+  val ctrl = new FuncUnitCtrlInput(vfalucfg)
+  val data = new FuncUnitDataInput(vfalucfg)
+  val perfDebugInfo = OptionWrapper(backendParams.debugEn, new PerfDebugInfo())
+  val debug_seqNum = OptionWrapper(backendParams.debugEn, InstSeqNum())
+}
+
 class FuncUnitIO(cfg: FuConfig)(implicit p: Parameters) extends XSBundle {
   val flush = Flipped(ValidIO(new Redirect))
   val in = Flipped(DecoupledIO(new FuncUnitInput(cfg)))
   val out = DecoupledIO(new FuncUnitOutput(cfg))
   val outToFaluFromFmul = OptionWrapper(cfg.isFmul, Valid(new FuncUnitFmulOutputToFalu))
+  val outToVfaluFromVfmul = OptionWrapper(cfg.isVfmul, Valid(new FuncUnitVfmulOutputToVfalu))
   val outValidAhead3Cycle = OptionWrapper(FuConfig.needUncertainWakeupFuConfigs.contains(cfg), Output(Bool()))
   val outRFWenAhead3Cycle = OptionWrapper(cfg.isCsr, Output(Bool()))
   val outPdestAhead3Cycle = OptionWrapper(cfg.isCsr, Output(UInt(PhyRegIdxWidth.W)))
@@ -238,6 +248,7 @@ trait HasPipelineReg { this: FuncUnit =>
   val latdiff :Int = cfg.latency.extraLatencyVal.getOrElse(0)
   val preLat :Int = latency - latdiff
   val fmulTofaluLatencyVal :Int = cfg.latency.fmulTofaluLatencyVal.getOrElse(0)
+  val vfmul2VfaluLatencyVal = fmulTofaluLatencyVal
   require(latency >= 0 && latdiff >=0)
 
   def pipelineReg(init: FuncUnitInput , valid:Bool, ready: Bool,latency: Int, flush:ValidIO[Redirect]): (Seq[FuncUnitInput],Seq[Bool],Seq[Bool])={
@@ -318,6 +329,21 @@ trait HasPipelineReg { this: FuncUnit =>
     outToFaluFromFmul.bits.ctrl := fmulTofaluCtrl
     outToFaluFromFmul.bits.perfDebugInfo.foreach(_ := fmulTofaluPerfVec.last.get)
     outToFaluFromFmul.bits.debug_seqNum.foreach(_ := fmulTofaluSeqNumVec.last.get)
+    io.out.valid := fixValidVec.last && !RegNextN(io.in.valid && FuOpType.FMacOpcodes.isOP3(io.in.bits.ctrl.fuOpType), cfg.latency.latencyVal.get)
+  } else if (cfg.isVfmul) {
+    val outToVfaluFromVfmul = io.outToVfaluFromVfmul.get
+    val (vfmul2VfaluPipeReg: Seq[FuncUnitInput], vfmul2VfaluValidVecThisFu, vfmul2VfaluRdyVec) = pipelineReg(io.in.bits, io.in.valid && FuOpType.FMacOpcodes.isOP3(io.in.bits.ctrl.fuOpType), true.B, vfmul2VfaluLatencyVal, io.flush)
+    val vfmul2VfaluValidVec = io.in.bits.validPipe.get.zip(vfmul2VfaluValidVecThisFu).map(x => x._1 && x._2)
+    val vfmul2VfaluCtrl = ctrlVec(vfmul2VfaluLatencyVal)
+    val vfmul2VfaluPerfVec = vfmul2VfaluPipeReg.map(_.perfDebugInfo)
+    val vfmul2VfaluSeqNumVec = vfmul2VfaluPipeReg.map(_.debug_seqNum)
+
+    io.in.ready := fixRdyVec.head && vfmul2VfaluRdyVec.head
+    outToVfaluFromVfmul.valid := vfmul2VfaluValidVec.last
+    outToVfaluFromVfmul.bits.fuType := FuType.vfalu.U
+    outToVfaluFromVfmul.bits.ctrl := vfmul2VfaluCtrl
+    outToVfaluFromVfmul.bits.perfDebugInfo.foreach(_ := vfmul2VfaluPerfVec.last.get)
+    outToVfaluFromVfmul.bits.debug_seqNum.foreach(_ := vfmul2VfaluSeqNumVec.last.get)
     io.out.valid := fixValidVec.last && !RegNextN(io.in.valid && FuOpType.FMacOpcodes.isOP3(io.in.bits.ctrl.fuOpType), cfg.latency.latencyVal.get)
   } else {
     io.out.valid := fixValidVec.last

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -144,21 +144,11 @@ class FuncUnitFmulOutputToFalu(implicit p: Parameters) extends XSBundle {
   val debug_seqNum = OptionWrapper(backendParams.debugEn, InstSeqNum())
 }
 
-class FuncUnitVfmulOutputToVfalu(implicit p: Parameters) extends XSBundle {
-  val vfalucfg = FuConfig.VfaluCfg
-  val fuType = FuType()
-  val ctrl = new FuncUnitCtrlInput(vfalucfg)
-  val data = new FuncUnitDataInput(vfalucfg)
-  val perfDebugInfo = OptionWrapper(backendParams.debugEn, new PerfDebugInfo())
-  val debug_seqNum = OptionWrapper(backendParams.debugEn, InstSeqNum())
-}
-
 class FuncUnitIO(cfg: FuConfig)(implicit p: Parameters) extends XSBundle {
   val flush = Flipped(ValidIO(new Redirect))
   val in = Flipped(DecoupledIO(new FuncUnitInput(cfg)))
   val out = DecoupledIO(new FuncUnitOutput(cfg))
   val outToFaluFromFmul = OptionWrapper(cfg.isFmul, Valid(new FuncUnitFmulOutputToFalu))
-  val outToVfaluFromVfmul = OptionWrapper(cfg.isVfmul, Valid(new FuncUnitVfmulOutputToVfalu))
   val outValidAhead3Cycle = OptionWrapper(FuConfig.needUncertainWakeupFuConfigs.contains(cfg), Output(Bool()))
   val outRFWenAhead3Cycle = OptionWrapper(cfg.isCsr, Output(Bool()))
   val outPdestAhead3Cycle = OptionWrapper(cfg.isCsr, Output(UInt(PhyRegIdxWidth.W)))
@@ -248,7 +238,6 @@ trait HasPipelineReg { this: FuncUnit =>
   val latdiff :Int = cfg.latency.extraLatencyVal.getOrElse(0)
   val preLat :Int = latency - latdiff
   val fmulTofaluLatencyVal :Int = cfg.latency.fmulTofaluLatencyVal.getOrElse(0)
-  val vfmul2VfaluLatencyVal = fmulTofaluLatencyVal
   require(latency >= 0 && latdiff >=0)
 
   def pipelineReg(init: FuncUnitInput , valid:Bool, ready: Bool,latency: Int, flush:ValidIO[Redirect]): (Seq[FuncUnitInput],Seq[Bool],Seq[Bool])={
@@ -329,21 +318,6 @@ trait HasPipelineReg { this: FuncUnit =>
     outToFaluFromFmul.bits.ctrl := fmulTofaluCtrl
     outToFaluFromFmul.bits.perfDebugInfo.foreach(_ := fmulTofaluPerfVec.last.get)
     outToFaluFromFmul.bits.debug_seqNum.foreach(_ := fmulTofaluSeqNumVec.last.get)
-    io.out.valid := fixValidVec.last && !RegNextN(io.in.valid && FuOpType.FMacOpcodes.isOP3(io.in.bits.ctrl.fuOpType), cfg.latency.latencyVal.get)
-  } else if (cfg.isVfmul) {
-    val outToVfaluFromVfmul = io.outToVfaluFromVfmul.get
-    val (vfmul2VfaluPipeReg: Seq[FuncUnitInput], vfmul2VfaluValidVecThisFu, vfmul2VfaluRdyVec) = pipelineReg(io.in.bits, io.in.valid && FuOpType.FMacOpcodes.isOP3(io.in.bits.ctrl.fuOpType), true.B, vfmul2VfaluLatencyVal, io.flush)
-    val vfmul2VfaluValidVec = io.in.bits.validPipe.get.zip(vfmul2VfaluValidVecThisFu).map(x => x._1 && x._2)
-    val vfmul2VfaluCtrl = ctrlVec(vfmul2VfaluLatencyVal)
-    val vfmul2VfaluPerfVec = vfmul2VfaluPipeReg.map(_.perfDebugInfo)
-    val vfmul2VfaluSeqNumVec = vfmul2VfaluPipeReg.map(_.debug_seqNum)
-
-    io.in.ready := fixRdyVec.head && vfmul2VfaluRdyVec.head
-    outToVfaluFromVfmul.valid := vfmul2VfaluValidVec.last
-    outToVfaluFromVfmul.bits.fuType := FuType.vfalu.U
-    outToVfaluFromVfmul.bits.ctrl := vfmul2VfaluCtrl
-    outToVfaluFromVfmul.bits.perfDebugInfo.foreach(_ := vfmul2VfaluPerfVec.last.get)
-    outToVfaluFromVfmul.bits.debug_seqNum.foreach(_ := vfmul2VfaluSeqNumVec.last.get)
     io.out.valid := fixValidVec.last && !RegNextN(io.in.valid && FuOpType.FMacOpcodes.isOP3(io.in.bits.ctrl.fuOpType), cfg.latency.latencyVal.get)
   } else {
     io.out.valid := fixValidVec.last

--- a/src/main/scala/xiangshan/backend/fu/vector/VecPipedFuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/VecPipedFuncUnit.scala
@@ -35,8 +35,6 @@ trait VecFuncUnitAlias { this: FuncUnit =>
   protected val isExt     = vecCtrl.isExt
   protected val isDstMask = vecCtrl.isDstMask
   protected val isMove    = vecCtrl.isMove
-  // swap vs1 and vs2, used by vrsub, etc
-  protected val isReverse = vecCtrl.isReverse
 
   protected val sew8  = vecCtrl.sew8
   protected val sew16 = vecCtrl.sew16

--- a/src/main/scala/xiangshan/backend/fu/vector/VecSrcTypeModule.scala
+++ b/src/main/scala/xiangshan/backend/fu/vector/VecSrcTypeModule.scala
@@ -9,7 +9,6 @@ class VecSrcTypeModuleIO extends Bundle {
   val in = Input(new Bundle {
     val fuOpType  : UInt = OpType()
     val vsew      : UInt = VSew()
-    val isReverse : Bool = Bool() // vrsub, vrdiv
     val isExt     : Bool = Bool()
     val isDstMask : Bool = Bool() // vvm, vvvm, mmm
     val isMove    : Bool = Bool() // vmv.s.x, vmv.v.v, vmv.v.x, vmv.v.i

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VCVTWrapper.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VCVTWrapper.scala
@@ -74,7 +74,7 @@ class VCVTWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFun
       mod.narrowSrc2 := narrowVs2Vec(i)
       mod.narrowSrc1 := narrowVs1Vec(i)
       mod.opType := opType.ex0
-      mod.rm := in.frm.get
+      mod.rm := frm
       mod.inSew1H := cvtInSew1H(i).ex0
       mod.outSew1H := cvtOutSew1H(i).ex0
       mod.cvt64UseWidenSrc2 := cvt64UseWidenSrc2(i).ex0

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFALU.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFALU.scala
@@ -1,510 +1,510 @@
-package xiangshan.backend.fu.wrapper
-
-import org.chipsalliance.cde.config.Parameters
-import chisel3._
-import chisel3.util._
-import xiangshan.backend.fu.FuConfig
-import xiangshan.backend.fu.vector.Bundles.{VLmul, VSew}
-import xiangshan.backend.fu.vector.utils.VecDataSplitModule
-import xiangshan.backend.fu.vector.{Mgu, Mgtu, VecInfo, VecPipedFuncUnit}
-import xiangshan.ExceptionNO
-import yunsuan.encoding.Opcode.Opcodes.{VFMiscOpcode, VFMacOpcode, VFRedOpcode}
-import yunsuan.vector.{LZD, VectorFloatAdder}
-
-class VFAlu(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg) {
-  // params alias
-  private val dataWidth = cfg.destDataBits
-  private val dataWidthOfDataModule = 64
-  private val numVecModule = dataWidth / dataWidthOfDataModule
-
-  private def isVectorMisc(op: UInt): Bool = VFMiscOpcode.isVfCompare(op) || VFMiscOpcode.isFclass(op)
-
-  // io alias
-  private implicit val opcode: UInt = fuOpType
-  private val resWiden = VFMacOpcode.isResWiden(opcode)
-  private val opbWiden = VFMacOpcode.isOpbWiden(opcode)
-  private val inIsVfRedOrdered = VFRedOpcode.isVfRedOrdered(opcode)
-  private val inIsVfWRedOrdered = VFRedOpcode.isVfWRedOrdered(opcode)
-
-  // modules
-  private val vfalus = Seq.fill(numVecModule)(Module(new VectorFloatAdder))
-  private val vs2Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
-  private val vs1Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
-  private val oldVdSplit  = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
-  private val mgu = Module(new Mgu(dataWidth))
-  private val mgtu = Module(new Mgtu(dataWidth))
-
-  /**
-    * In connection of [[vs2Split]], [[vs1Split]] and [[oldVdSplit]]
-    */
-  vs2Split.io.inVecData := vs2
-  vs1Split.io.inVecData := vs1
-  oldVdSplit.io.inVecData := oldVd
-
-  /**
-    * [[vfalus]]'s in connection
-    */
-  // Vec(vs2(31,0), vs2(63,32), vs2(95,64), vs2(127,96)) ==>
-  // Vec(
-  //   Cat(vs2(95,64),  vs2(31,0)),
-  //   Cat(vs2(127,96), vs2(63,32)),
-  // )
-  private val resultData = Wire(Vec(numVecModule,UInt(dataWidthOfDataModule.W)))
-  private val fflagsData = Wire(Vec(numVecModule,UInt(20.W)))
-  private val srcMaskRShiftForReduction = Wire(UInt((8 * numVecModule).W))
-  // for reduction
-  val isFirstGroupUop = vuopIdx === 0.U ||
-    (vuopIdx === 1.U && (vlmul === VLmul.m4 || vlmul === VLmul.m8)) ||
-    ((vuopIdx === 2.U || vuopIdx === 3.U) && vlmul === VLmul.m8)
-  val maskRshiftWidthForReduction = Wire(UInt(6.W))
-  maskRshiftWidthForReduction := Mux(inIsVfRedOrdered,
-    vuopIdx,
-    Mux1H(Seq(
-      (vsew === VSew.e16) -> (vuopIdx(1, 0) << 4),
-      (vsew === VSew.e32) -> (vuopIdx(1, 0) << 3),
-      (vsew === VSew.e64) -> (vuopIdx(1, 0) << 2),
-    ))
-  )
-  val vlMaskForReduction = (~(Fill(VLEN, 1.U) << vl)).asUInt
-  srcMaskRShiftForReduction := ((srcMask & vlMaskForReduction) >> maskRshiftWidthForReduction)(8 * numVecModule - 1, 0)
-  val existMask = (srcMask & vlMaskForReduction).orR
-  val existMaskReg = RegEnable(existMask, io.in.fire)
-
-
-  def genMaskForReduction(inmask: UInt, sew: UInt, i: Int): UInt = {
-    val f64MaskNum = dataWidth / 64 * 2
-    val f32MaskNum = dataWidth / 32 * 2
-    val f16MaskNum = dataWidth / 16 * 2
-    val f64Mask = inmask(f64MaskNum - 1, 0)
-    val f32Mask = inmask(f32MaskNum - 1, 0)
-    val f16Mask = inmask(f16MaskNum - 1, 0)
-    // vs2 reordered, so mask use high bits
-    val f64FirstFoldMaskUnorder = Mux1H(
-      Seq(
-        vecCtrl.fpu.isFoldTo1_2 -> Cat(0.U(3.W), f64Mask(0), 0.U(3.W), f64Mask(1)),
-      )
-    )
-    val f64FirstFoldMaskOrder = Mux1H(
-      Seq(
-        vecCtrl.fpu.isFoldTo1_2 -> Cat(0.U(3.W), f64Mask(1), 0.U(3.W), f64Mask(0))
-      )
-    )
-    val f32FirstFoldMaskUnorder = Mux1H(
-      Seq(
-        vecCtrl.fpu.isFoldTo1_2 -> Cat(0.U(2.W), f32Mask(1), f32Mask(0), 0.U(2.W), f32Mask(3), f32Mask(2)),
-        vecCtrl.fpu.isFoldTo1_4 -> Cat(0.U(3.W), f32Mask(0), 0.U(3.W), f32Mask(1)),
-      )
-    )
-    val f32FirstFoldMaskOrder = Mux1H(
-      Seq(
-        vecCtrl.fpu.isFoldTo1_2 -> Cat(0.U(2.W), f32Mask(3), f32Mask(2), 0.U(2.W), f32Mask(1), f32Mask(0)),
-        vecCtrl.fpu.isFoldTo1_4 -> Cat(0.U(3.W), f32Mask(1), 0.U(3.W), f32Mask(0)),
-      )
-    )
-    val f16FirstFoldMaskUnorder = Mux1H(
-      Seq(
-        vecCtrl.fpu.isFoldTo1_2 -> Cat(f16Mask(3,0), f16Mask(7,4)),
-        vecCtrl.fpu.isFoldTo1_4 -> Cat(0.U(2.W), f16Mask(1), f16Mask(0), 0.U(2.W), f16Mask(3), f16Mask(2)),
-        vecCtrl.fpu.isFoldTo1_8 -> Cat(0.U(3.W), f16Mask(0), 0.U(3.W), f16Mask(1)),
-      )
-    )
-    val f16FirstFoldMaskOrder = Mux1H(
-      Seq(
-        vecCtrl.fpu.isFoldTo1_2 -> Cat(f16Mask(7,4), f16Mask(3,0)),
-        vecCtrl.fpu.isFoldTo1_4 -> Cat(0.U(2.W), f16Mask(3), f16Mask(2), 0.U(2.W), f16Mask(1), f16Mask(0)),
-        vecCtrl.fpu.isFoldTo1_8 -> Cat(0.U(3.W), f16Mask(1), 0.U(3.W), f16Mask(0)),
-      )
-    )
-    val f64FoldMask = Mux1H(
-      Seq(
-        vecCtrl.fpu.isFoldTo1_2 -> "b00010001".U,
-      )
-    )
-    val f32FoldMask = Mux1H(
-      Seq(
-        vecCtrl.fpu.isFoldTo1_2 -> "b00110011".U,
-        vecCtrl.fpu.isFoldTo1_4 -> "b00010001".U,
-      )
-    )
-    val f16FoldMask = Mux1H(
-      Seq(
-        vecCtrl.fpu.isFoldTo1_2 -> "b11111111".U,
-        vecCtrl.fpu.isFoldTo1_4 -> "b00110011".U,
-        vecCtrl.fpu.isFoldTo1_8 -> "b00010001".U,
-      )
-    )
-    // low 4 bits for vs2(fp_a), high 4 bits for vs1(fp_b),
-    val isFold = vecCtrl.fpu.isFoldTo1_2 || vecCtrl.fpu.isFoldTo1_4 || vecCtrl.fpu.isFoldTo1_8
-    val f64FirstNotFoldMask = Cat(0.U(3.W), f64Mask(i + 2), 0.U(3.W), f64Mask(i))
-    val f32FirstNotFoldMask = Cat(0.U(2.W), f32Mask(i * 2 + 5, i * 2 + 4), 0.U(2.W), Cat(f32Mask(i * 2 + 1, i * 2)))
-    val f16FirstNotFoldMask = Cat(f16Mask(i * 4 + 11, i * 4 + 8), f16Mask(i * 4 + 3, i * 4))
-    val f64MaskI = Mux(inIsVfRedOrdered,
-      Mux(isFold, f64FirstFoldMaskOrder, f64FirstNotFoldMask),
-      Mux(isFirstGroupUop,
-        Mux(isFold, f64FirstFoldMaskUnorder, f64FirstNotFoldMask),
-        Mux(isFold, f64FoldMask, Fill(8, 1.U))))
-    val f32MaskI = Mux(inIsVfRedOrdered,
-      Mux(isFold, f32FirstFoldMaskOrder, f32FirstNotFoldMask),
-      Mux(isFirstGroupUop,
-        Mux(isFold, f32FirstFoldMaskUnorder, f32FirstNotFoldMask),
-        Mux(isFold, f32FoldMask, Fill(8, 1.U))))
-    val f16MaskI = Mux(inIsVfRedOrdered,
-      Mux(isFold, f16FirstFoldMaskOrder, f16FirstNotFoldMask),
-      Mux(isFirstGroupUop,
-        Mux(isFold, f16FirstFoldMaskUnorder, f16FirstNotFoldMask),
-        Mux(isFold, f16FoldMask, Fill(8, 1.U))))
-    val outMask = Mux1H(
-      Seq(
-        (sew === 3.U) -> f64MaskI,
-        (sew === 2.U) -> f32MaskI,
-        (sew === 1.U) -> f16MaskI,
-      )
-    )
-    Mux(inIsVfRedOrdered, outMask(0), outMask)
-  }
-  def genMaskForMerge(inmask:UInt, sew:UInt, i:Int): UInt = {
-    val f64MaskNum = dataWidth / 64
-    val f32MaskNum = dataWidth / 32
-    val f16MaskNum = dataWidth / 16
-    val f64Mask = inmask(f64MaskNum-1,0)
-    val f32Mask = inmask(f32MaskNum-1,0)
-    val f16Mask = inmask(f16MaskNum-1,0)
-    val f64MaskI = Cat(0.U(3.W),f64Mask(i))
-    val f32MaskI = Cat(0.U(2.W),f32Mask(2*i+1,2*i))
-    val f16MaskI = f16Mask(4*i+3,4*i)
-    val outMask = Mux1H(
-      Seq(
-        (sew === 3.U) -> f64MaskI,
-        (sew === 2.U) -> f32MaskI,
-        (sew === 1.U) -> f16MaskI,
-      )
-    )
-    outMask
-  }
-  def genMaskForRedFFlag(sew:UInt): UInt = {
-    val default = "b11111111".U
-    val f64FoldMask = Mux(outVecCtrl.fpu.isFoldTo1_2, "b00000001".U, default)
-    val f32Fold = outVecCtrl.fpu.isFoldTo1_2 || outVecCtrl.fpu.isFoldTo1_4
-    val f32FoldMask = Mux1H(
-      Seq(
-        outVecCtrl.fpu.isFoldTo1_2 -> "b00000011".U,
-        outVecCtrl.fpu.isFoldTo1_4 -> "b00000001".U,
-      )
-    )
-    val f16Fold = outVecCtrl.fpu.isFoldTo1_2 || outVecCtrl.fpu.isFoldTo1_4 || outVecCtrl.fpu.isFoldTo1_8
-    val f16FoldMask = Mux1H(
-      Seq(
-        outVecCtrl.fpu.isFoldTo1_2 -> "b00001111".U,
-        outVecCtrl.fpu.isFoldTo1_4 -> "b00000011".U,
-        outVecCtrl.fpu.isFoldTo1_8 -> "b00000001".U,
-      )
-    )
-    Mux1H(
-      Seq(
-        (sew === 3.U) -> f64FoldMask,
-        (sew === 2.U) -> Mux(f32Fold, f32FoldMask, default),
-        (sew === 1.U) -> Mux(f16Fold, f16FoldMask, default),
-      )
-    )
-  }
-  val srcMaskRShift = Wire(UInt((4 * numVecModule).W))
-  val maskRshiftWidth = Wire(UInt(6.W))
-  maskRshiftWidth := Mux1H(
-    Seq(
-      (vsew === VSew.e16) -> (vuopIdx(2,0) << 3),
-      (vsew === VSew.e32) -> (vuopIdx(2,0) << 2),
-      (vsew === VSew.e64) -> (vuopIdx(2,0) << 1),
-    )
-  )
-  srcMaskRShift := (srcMask >> maskRshiftWidth)(4 * numVecModule - 1, 0)
-  val fp_aIsFpCanonicalNAN = Wire(Vec(numVecModule,Bool()))
-  val fp_bIsFpCanonicalNAN = Wire(Vec(numVecModule,Bool()))
-  val inIsFold = Wire(UInt(3.W))
-  inIsFold := Cat(vecCtrl.fpu.isFoldTo1_8, vecCtrl.fpu.isFoldTo1_4, vecCtrl.fpu.isFoldTo1_2)
-  vfalus.zipWithIndex.foreach {
-    case (mod, i) =>
-      mod.io.fire             := io.in.valid
-      mod.io.fp_a             := vs2Split.io.outVec64b(i)
-      mod.io.fp_b             := vs1Split.io.outVec64b(i)
-      mod.io.widen_a          := Cat(vs2Split.io.outVec32b(i+numVecModule), vs2Split.io.outVec32b(i))
-      mod.io.widen_b          := Cat(vs1Split.io.outVec32b(i+numVecModule), vs1Split.io.outVec32b(i))
-      mod.io.frs1             := 0.U     // already vf -> vv
-      mod.io.is_frs1          := false.B // already vf -> vv
-      mod.io.mask             := genMaskForMerge(inmask = srcMaskRShift, sew = vsew, i = i)
-      mod.io.maskForReduction := genMaskForReduction(inmask = srcMaskRShiftForReduction, sew = vsew, i = i)
-      mod.io.uop_idx          := vuopIdx(0)
-      mod.io.is_vec           := true.B // Todo
-      mod.io.round_mode       := rm
-      mod.io.fp_format        := Mux(resWiden, vsew + 1.U, vsew)
-      mod.io.opb_widening     := opbWiden
-      mod.io.res_widening     := resWiden
-      mod.io.op_code          := opcode
-      mod.io.is_vfwredosum    := inIsVfWRedOrdered
-      mod.io.is_fold          := inIsFold
-      mod.io.vs2_fold         := vs2      // for better timing
-      resultData(i)           := mod.io.fp_result
-      fflagsData(i)           := mod.io.fflags
-      fp_aIsFpCanonicalNAN(i) := vecCtrl.fpu.isFpToVecInst & (
-          ((vsew === VSew.e32) & (!vs2Split.io.outVec64b(i).head(32).andR)) |
-          ((vsew === VSew.e16) & (!vs2Split.io.outVec64b(i).head(48).andR))
-        )
-      fp_bIsFpCanonicalNAN(i) := vecCtrl.fpu.isFpToVecInst & (
-          ((vsew === VSew.e32) & (!vs1Split.io.outVec64b(i).head(32).andR)) |
-          ((vsew === VSew.e16) & (!vs1Split.io.outVec64b(i).head(48).andR))
-        )
-      mod.io.fp_aIsFpCanonicalNAN := fp_aIsFpCanonicalNAN(i)
-      mod.io.fp_bIsFpCanonicalNAN := fp_bIsFpCanonicalNAN(i)
-  }
-  val outVuopidx = outVecCtrl.vuopIdx(2, 0) // for vfadd max vuopidx=7
-  val numOfUopVFRED = Wire(UInt(4.W))
-  val numofUopVFREDReg = RegEnable(numOfUopVFRED, io.in.fire)
-  val vs1Reg = RegEnable(vs1, io.in.fire)
-  val outFuOpType = outCtrl.fuOpType
-  val outIsDstMask = VFMiscOpcode.isDstMask(outFuOpType)
-  val outIsVfRedUnordered = VFRedOpcode.isVfRedUnordered(outFuOpType)
-  val outIsVfRedUnComp = VFRedOpcode.isVfRedUnComp(outFuOpType)
-  val outIsVfRedUnSum = VFRedOpcode.isVfredusum(outFuOpType)
-  val outIsVfRedOrdered = VFRedOpcode.isVfRedOrdered(outFuOpType)
-  val outIsVfWRedOrdered = VFRedOpcode.isVfWRedOrdered(outFuOpType)
-  val outIsVfredosumNoWiden = VFRedOpcode.isVfredosumNoWiden(outFuOpType)
-
-  val isLastUopRed = outIsVfRedUnordered && outLastUop
-  val resultDataUInt = Mux(isLastUopRed && !existMaskReg, vs1Reg, resultData.asUInt)
-  val cmpResultWidth = dataWidth / 16
-  val cmpResult = Wire(Vec(cmpResultWidth, Bool()))
-  for (i <- 0 until cmpResultWidth) {
-    if(i == 0) {
-      cmpResult(i) := resultDataUInt(0)
-    }
-    else if(i < dataWidth / 64) {
-      cmpResult(i) := Mux1H(
-        Seq(
-          (outVecCtrl.vsew === 1.U) -> resultDataUInt(i*16),
-          (outVecCtrl.vsew === 2.U) -> resultDataUInt(i*32),
-          (outVecCtrl.vsew === 3.U) -> resultDataUInt(i*64)
-        )
-      )
-    }
-    else if(i < dataWidth / 32) {
-      cmpResult(i) := Mux1H(
-        Seq(
-          (outVecCtrl.vsew === 1.U) -> resultDataUInt(i * 16),
-          (outVecCtrl.vsew === 2.U) -> resultDataUInt(i * 32),
-          (outVecCtrl.vsew === 3.U) -> false.B
-        )
-      )
-    }
-    else if(i <  dataWidth / 16) {
-      cmpResult(i) := Mux(outVecCtrl.vsew === 1.U, resultDataUInt(i*16), false.B)
-    }
-  }
-  val outCtrl_s0 = ctrlVec.head
-  val outVecCtrl_s0 = ctrlVec.head.vpu.get
-  val outIsVectorMisc_s0 = isVectorMisc(outCtrl_s0.fuOpType)
-  val outIsVectorMisc = isVectorMisc(outFuOpType)
-  val outIsVfRedOrdered_s0 = VFRedOpcode.isVfRedOrdered(outCtrl_s0.fuOpType)
-  val outIsReduction = VFRedOpcode.isVfReduction(outFuOpType)
-  val outIsReduction_s0 = VFRedOpcode.isVfReduction(outCtrl_s0.fuOpType)
-  val outResWiden_s0 = VFMacOpcode.isResWiden(outCtrl_s0.fuOpType) && !outIsVectorMisc_s0
-  val outResWiden = VFMacOpcode.isResWiden(outFuOpType)
-  val outResWidenFix = outResWiden && !outIsVectorMisc
-  val outEew_s0 = Mux(outResWiden_s0, outVecCtrl_s0.vsew + 1.U, outVecCtrl_s0.vsew)
-  val outEew = Mux(outResWidenFix, outVecCtrl.vsew + 1.U, outVecCtrl.vsew)
-  val vlMax_s0 = ((VLEN/8).U >> outEew_s0).asUInt
-  val vlMax = ((VLEN/8).U >> outEew).asUInt
-  val outVlmulFix = Mux(outResWidenFix, outVecCtrl.vlmul + 1.U, outVecCtrl.vlmul)
-  val lmulAbs = Mux(outVlmulFix(2), (~outVlmulFix(1,0)).asUInt + 1.U, outVlmulFix(1,0))
-  //  vfmv_f_s need vl=1, reduction last uop need vl=1, other uop need vl=vlmax
-  numOfUopVFRED := {
-    // addTime include add frs1
-    val addTime = MuxLookup(outVecCtrl_s0.vlmul, 1.U(4.W))(Seq(
-      VLmul.m2 -> 2.U,
-      VLmul.m4 -> 4.U,
-      VLmul.m8 -> 8.U,
-    ))
-    val foldLastVlmul = MuxLookup(outVecCtrl_s0.vsew, "b000".U)(Seq(
-      VSew.e16 -> VLmul.mf8,
-      VSew.e32 -> VLmul.mf4,
-      VSew.e64 -> VLmul.mf2,
-    ))
-    // lmul < 1, foldTime = vlmul - foldFastVlmul
-    // lmul >= 1, foldTime = 0.U - foldFastVlmul
-    val foldTime = Mux(outVecCtrl_s0.vlmul(2), outVecCtrl_s0.vlmul, 0.U) - foldLastVlmul
-    addTime + foldTime
-  }
-  val reductionVl = Mux((outVecCtrl_s0.vuopIdx ===  numOfUopVFRED - 1.U) || outIsVfRedOrdered_s0, 1.U, vlMax_s0)
-  val outVl_s0       = dataVec.head.vl.get
-  val outVlFix_s0 = Mux(outIsReduction_s0, reductionVl, outVl_s0)
-  val outVlFix = RegEnable(outVlFix_s0,io.in.fire)
-
-  val vlMaxAllUop = Wire(outVl.cloneType)
-  vlMaxAllUop := Mux(outVecCtrl.vlmul(2), vlMax >> lmulAbs, vlMax << lmulAbs).asUInt
-  val vlMaxThisUop = Mux(outVecCtrl.vlmul(2), vlMax >> lmulAbs, vlMax).asUInt
-  val vlSetThisUop = Mux(outVlFix > outVuopidx*vlMaxThisUop, outVlFix - outVuopidx*vlMaxThisUop, 0.U)
-  val vlThisUop = Wire(UInt(4.W))
-  vlThisUop := Mux(vlSetThisUop < vlMaxThisUop, vlSetThisUop, vlMaxThisUop)
-  val vlMaskRShift = Wire(UInt((4 * numVecModule).W))
-  vlMaskRShift := Fill(4 * numVecModule, 1.U(1.W)) >> ((4 * numVecModule).U - vlThisUop)
-
-  val outVuopidxForRed = outVecCtrl.vuopIdx(2, 0) // lmul=8 sew=16, (4+2+1)(vector)+(1+1+1)(fold)+(1)(scala) max vuopIdx=10
-  val outIsFisrtGroup = outVuopidxForRed === 0.U ||
-    (outVuopidxForRed === 1.U && (outVlmul === VLmul.m4 || outVlmul === VLmul.m8)) ||
-    ((outVuopidxForRed === 2.U || outVuopidxForRed === 3.U) && outVlmul === VLmul.m8)
-  val firstNeedFFlags = outIsFisrtGroup  && outIsVfRedUnComp
-  val lastNeedFFlags = outVecCtrl.lastUop && outIsVfRedUnComp
-  private val needNoMask = outIsReduction
-  val maskToMgu = Mux(needNoMask, allMaskTrue, outSrcMask)
-  val allFFlagsEn = Wire(Vec(4*numVecModule,Bool()))
-  val outSrcMaskRShift = Wire(UInt((4*numVecModule).W))
-  outSrcMaskRShift := (maskToMgu >> (outVecCtrl.vuopIdx(2,0) * vlMax))(4*numVecModule-1,0)
-  val f16FFlagsEn = outSrcMaskRShift
-  val f32FFlagsEn = Wire(Vec(numVecModule,UInt(4.W)))
-  val f64FFlagsEn = Wire(Vec(numVecModule, UInt(4.W)))
-  val f16VlMaskEn = vlMaskRShift
-  val f32VlMaskEn = Wire(Vec(numVecModule, UInt(4.W)))
-  val f64VlMaskEn = Wire(Vec(numVecModule, UInt(4.W)))
-  for (i <- 0 until numVecModule){
-    f32FFlagsEn(i) := Cat(Fill(2, 0.U), outSrcMaskRShift(2*i+1,2*i))
-    f64FFlagsEn(i) := Cat(Fill(3, 0.U), outSrcMaskRShift(i))
-    f32VlMaskEn(i) := Cat(Fill(2, 0.U), vlMaskRShift(2 * i + 1, 2 * i))
-    f64VlMaskEn(i) := Cat(Fill(3, 0.U), vlMaskRShift(i))
-  }
-  val fflagsEn= Mux1H(
-    Seq(
-      (outEew === 1.U) -> f16FFlagsEn.asUInt,
-      (outEew === 2.U) -> f32FFlagsEn.asUInt,
-      (outEew === 3.U) -> f64FFlagsEn.asUInt
-    )
-  )
-  val vlMaskEn = Mux1H(
-    Seq(
-      (outEew === 1.U) -> f16VlMaskEn.asUInt,
-      (outEew === 2.U) -> f32VlMaskEn.asUInt,
-      (outEew === 3.U) -> f64VlMaskEn.asUInt
-    )
-  )
-  val fflagsRedMask = genMaskForRedFFlag(outVecCtrl.vsew)
-
-  if (backendParams.debugEn){
-    dontTouch(allFFlagsEn)
-    dontTouch(fflagsRedMask)
-  }
-  // use srcMask(XLEN-1, 0) because float format hasn't fp8
-  val allVmZero = RegEnable(LZD(Reverse(srcMask(XLEN-1, 0))) >= outVl_s0, io.in.fire)
-  allFFlagsEn := Mux(outIsReduction,
-    Cat(
-      Fill(4*numVecModule - 1, firstNeedFFlags || outIsVfRedUnSum && !outVecCtrl.lastUop) & fflagsRedMask(4*numVecModule - 1, 1),
-      !allVmZero && (lastNeedFFlags || firstNeedFFlags || outIsVfRedOrdered || outIsVfRedUnSum)
-    ),
-    fflagsEn & vlMaskEn
-  ).asTypeOf(allFFlagsEn)
-
-  val allFFlags = fflagsData.asTypeOf(Vec( 4*numVecModule,UInt(5.W)))
-  val outFFlags = allFFlagsEn.zip(allFFlags).map{
-    case(en,fflags) => Mux(en, fflags, 0.U(5.W))
-  }.reduce(_ | _)
-
-
-  val cmpResultOldVd = Wire(UInt(cmpResultWidth.W))
-  val cmpResultOldVdRshiftWidth = Wire(UInt(6.W))
-  cmpResultOldVdRshiftWidth := Mux1H(
-    Seq(
-      (outVecCtrl.vsew === VSew.e16) -> (outVecCtrl.vuopIdx(2, 0) << 3),
-      (outVecCtrl.vsew === VSew.e32) -> (outVecCtrl.vuopIdx(2, 0) << 2),
-      (outVecCtrl.vsew === VSew.e64) -> (outVecCtrl.vuopIdx(2, 0) << 1),
-    )
-  )
-  cmpResultOldVd := (outOldVd >> cmpResultOldVdRshiftWidth)(4*numVecModule-1,0)
-  val cmpResultForMgu = Wire(Vec(cmpResultWidth, Bool()))
-  private val maxVdIdx = 8
-  private val elementsInOneUop = Mux1H(
-    Seq(
-      (outEew === 1.U) -> (cmpResultWidth).U(4.W),
-      (outEew === 2.U) -> (cmpResultWidth / 2).U(4.W),
-      (outEew === 3.U) -> (cmpResultWidth / 4).U(4.W),
-    )
-  )
-  private val vdIdx = outVecCtrl.vuopIdx(2, 0)
-  private val elementsComputed = Mux1H(Seq.tabulate(maxVdIdx)(i => (vdIdx === i.U) -> (elementsInOneUop * i.U)))
-  for (i <- 0 until cmpResultWidth) {
-    val cmpResultWithVmask = Mux(outSrcMaskRShift(i), cmpResult(i), Mux(outVecCtrl.vma, true.B, cmpResultOldVd(i)))
-    cmpResultForMgu(i) := Mux(elementsComputed +& i.U >= outVl, true.B, cmpResultWithVmask)
-  }
-  val outIsFold = outVecCtrl.fpu.isFoldTo1_2 || outVecCtrl.fpu.isFoldTo1_4 || outVecCtrl.fpu.isFoldTo1_8
-  val outOldVdForREDO = Mux1H(Seq(
-    (outVecCtrl.vsew === VSew.e16) -> (outOldVd >> 16),
-    (outVecCtrl.vsew === VSew.e32) -> (outOldVd >> 32),
-    (outVecCtrl.vsew === VSew.e64) -> (outOldVd >> 64),
-  ))
-  val outOldVdForWREDO = Mux(
-    !outIsFold,
-    Mux(outVecCtrl.vsew === VSew.e16, Cat(outOldVd(VLEN-1-16,16), 0.U(32.W)), Cat(outOldVd(VLEN-1-32,32), 0.U(64.W))),
-    Mux(outVecCtrl.vsew === VSew.e16,
-      // Divide vuopIdx by 8 and the remainder is 1
-      Mux(outVecCtrl.vuopIdx(2,0) === 1.U, outOldVd, outOldVd >> 16),
-      // Divide vuopIdx by 4 and the remainder is 1
-      Mux(outVecCtrl.vuopIdx(1,0) === 1.U, outOldVd, outOldVd >> 32)
-    ),
-  )
-  val outOldVdForRED = Mux(outIsVfredosumNoWiden, outOldVdForREDO, outOldVdForWREDO)
-  val numOfUopVFREDOSUM = {
-    val uvlMax = MuxLookup(outVecCtrl.vsew, 0.U)(Seq(
-      VSew.e16 -> 8.U,
-      VSew.e32 -> 4.U,
-      VSew.e64 -> 2.U,
-    ))
-    val vlMax = Mux(outVecCtrl.vlmul(2), uvlMax >> (-outVecCtrl.vlmul)(1, 0), uvlMax << outVecCtrl.vlmul(1, 0)).asUInt
-    vlMax
-  }
-  val isLastUopForREDO = outVecCtrl.lastUop
-  val isOutOldVdForREDO = (outIsVfredosumNoWiden && outIsFold) || outIsVfWRedOrdered && !isLastUopForREDO
-  val taIsFalseForVFREDO = outIsVfRedOrdered && (outVecCtrl.vuopIdx =/= numOfUopVFREDOSUM - 1.U)
-  val notModifyVd = outVl === 0.U
-  mgu.io.in.vd := Mux(outIsDstMask, Cat(0.U((dataWidth / 16 * 15).W), cmpResultForMgu.asUInt), resultDataUInt)
-  mgu.io.in.oldVd := Mux(isOutOldVdForREDO, outOldVdForRED, outOldVd)
-  mgu.io.in.mask := maskToMgu
-  mgu.io.in.info.ta := Mux(taIsFalseForVFREDO, false.B, outVecCtrl.vta)
-  mgu.io.in.info.ma := outVecCtrl.vma
-  mgu.io.in.info.vl := outVlFix
-  mgu.io.in.info.vlmul := outVecCtrl.vlmul
-  mgu.io.in.info.valid := Mux(notModifyVd, false.B, io.in.valid)
-  mgu.io.in.info.vstart := outVecCtrl.vstart
-  mgu.io.in.info.eew :=  RegEnable(outEew_s0,io.in.fire)
-  mgu.io.in.info.vsew := outVecCtrl.vsew
-  mgu.io.in.info.vdIdx := RegEnable(
-    Mux(outIsReduction_s0, 0.U, outVecCtrl_s0.vuopIdx),
-    io.in.fire
-  )
-  mgu.io.in.info.narrow := outVecCtrl.isNarrow
-  mgu.io.in.info.dstMask := outIsDstMask
-  mgu.io.in.isIndexedVls := false.B
-  mgtu.io.in.vd := Mux(outIsDstMask, mgu.io.out.vd, resultDataUInt)
-  mgtu.io.in.vl := outVl
-  // when dest is mask, the result need to be masked by mgtu
-  io.out.bits.res.data := Mux(notModifyVd, outOldVd, Mux(outIsDstMask, mgtu.io.out.vd, mgu.io.out.vd))
-  io.out.bits.res.fflags.get := Mux(notModifyVd, 0.U(5.W), outFFlags)
-  io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := mgu.io.out.illegal
-}
-
-class VFMgu(vlen:Int)(implicit p: Parameters) extends Module{
-  val io = IO(new VFMguIO(vlen))
-
-  val vd = io.in.vd
-  val oldvd = io.in.oldVd
-  val mask = io.in.mask
-  val vsew = io.in.info.eew
-  val num16bits = vlen / 16
-
-}
-
-class VFMguIO(vlen: Int)(implicit p: Parameters) extends Bundle {
-  val in = new Bundle {
-    val vd = Input(UInt(vlen.W))
-    val oldVd = Input(UInt(vlen.W))
-    val mask = Input(UInt(vlen.W))
-    val info = Input(new VecInfo)
-  }
-  val out = new Bundle {
-    val vd = Output(UInt(vlen.W))
-  }
-}
+//package xiangshan.backend.fu.wrapper
+//
+//import org.chipsalliance.cde.config.Parameters
+//import chisel3._
+//import chisel3.util._
+//import xiangshan.backend.fu.FuConfig
+//import xiangshan.backend.fu.vector.Bundles.{VLmul, VSew}
+//import xiangshan.backend.fu.vector.utils.VecDataSplitModule
+//import xiangshan.backend.fu.vector.{Mgu, Mgtu, VecInfo, VecPipedFuncUnit}
+//import xiangshan.ExceptionNO
+//import yunsuan.encoding.Opcode.Opcodes.{VFMiscOpcode, VFMacOpcode, VFRedOpcode}
+//import yunsuan.vector.{LZD, VectorFloatAdder}
+//
+//class VFAlu(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg) {
+//  // params alias
+//  private val dataWidth = cfg.destDataBits
+//  private val dataWidthOfDataModule = 64
+//  private val numVecModule = dataWidth / dataWidthOfDataModule
+//
+//  private def isVectorMisc(op: UInt): Bool = VFMiscOpcode.isVfCompare(op) || VFMiscOpcode.isFclass(op)
+//
+//  // io alias
+//  private implicit val opcode: UInt = fuOpType
+//  private val resWiden = VFMacOpcode.isResWiden(opcode)
+//  private val opbWiden = VFMacOpcode.isOpbWiden(opcode)
+//  private val inIsVfRedOrdered = VFRedOpcode.isVfRedOrdered(opcode)
+//  private val inIsVfWRedOrdered = VFRedOpcode.isVfWRedOrdered(opcode)
+//
+//  // modules
+//  private val vfalus = Seq.fill(numVecModule)(Module(new VectorFloatAdder))
+//  private val vs2Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+//  private val vs1Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+//  private val oldVdSplit  = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+//  private val mgu = Module(new Mgu(dataWidth))
+//  private val mgtu = Module(new Mgtu(dataWidth))
+//
+//  /**
+//    * In connection of [[vs2Split]], [[vs1Split]] and [[oldVdSplit]]
+//    */
+//  vs2Split.io.inVecData := vs2
+//  vs1Split.io.inVecData := vs1
+//  oldVdSplit.io.inVecData := oldVd
+//
+//  /**
+//    * [[vfalus]]'s in connection
+//    */
+//  // Vec(vs2(31,0), vs2(63,32), vs2(95,64), vs2(127,96)) ==>
+//  // Vec(
+//  //   Cat(vs2(95,64),  vs2(31,0)),
+//  //   Cat(vs2(127,96), vs2(63,32)),
+//  // )
+//  private val resultData = Wire(Vec(numVecModule,UInt(dataWidthOfDataModule.W)))
+//  private val fflagsData = Wire(Vec(numVecModule,UInt(20.W)))
+//  private val srcMaskRShiftForReduction = Wire(UInt((8 * numVecModule).W))
+//  // for reduction
+//  val isFirstGroupUop = vuopIdx === 0.U ||
+//    (vuopIdx === 1.U && (vlmul === VLmul.m4 || vlmul === VLmul.m8)) ||
+//    ((vuopIdx === 2.U || vuopIdx === 3.U) && vlmul === VLmul.m8)
+//  val maskRshiftWidthForReduction = Wire(UInt(6.W))
+//  maskRshiftWidthForReduction := Mux(inIsVfRedOrdered,
+//    vuopIdx,
+//    Mux1H(Seq(
+//      (vsew === VSew.e16) -> (vuopIdx(1, 0) << 4),
+//      (vsew === VSew.e32) -> (vuopIdx(1, 0) << 3),
+//      (vsew === VSew.e64) -> (vuopIdx(1, 0) << 2),
+//    ))
+//  )
+//  val vlMaskForReduction = (~(Fill(VLEN, 1.U) << vl)).asUInt
+//  srcMaskRShiftForReduction := ((srcMask & vlMaskForReduction) >> maskRshiftWidthForReduction)(8 * numVecModule - 1, 0)
+//  val existMask = (srcMask & vlMaskForReduction).orR
+//  val existMaskReg = RegEnable(existMask, io.in.fire)
+//
+//
+//  def genMaskForReduction(inmask: UInt, sew: UInt, i: Int): UInt = {
+//    val f64MaskNum = dataWidth / 64 * 2
+//    val f32MaskNum = dataWidth / 32 * 2
+//    val f16MaskNum = dataWidth / 16 * 2
+//    val f64Mask = inmask(f64MaskNum - 1, 0)
+//    val f32Mask = inmask(f32MaskNum - 1, 0)
+//    val f16Mask = inmask(f16MaskNum - 1, 0)
+//    // vs2 reordered, so mask use high bits
+//    val f64FirstFoldMaskUnorder = Mux1H(
+//      Seq(
+//        vecCtrl.fpu.isFoldTo1_2 -> Cat(0.U(3.W), f64Mask(0), 0.U(3.W), f64Mask(1)),
+//      )
+//    )
+//    val f64FirstFoldMaskOrder = Mux1H(
+//      Seq(
+//        vecCtrl.fpu.isFoldTo1_2 -> Cat(0.U(3.W), f64Mask(1), 0.U(3.W), f64Mask(0))
+//      )
+//    )
+//    val f32FirstFoldMaskUnorder = Mux1H(
+//      Seq(
+//        vecCtrl.fpu.isFoldTo1_2 -> Cat(0.U(2.W), f32Mask(1), f32Mask(0), 0.U(2.W), f32Mask(3), f32Mask(2)),
+//        vecCtrl.fpu.isFoldTo1_4 -> Cat(0.U(3.W), f32Mask(0), 0.U(3.W), f32Mask(1)),
+//      )
+//    )
+//    val f32FirstFoldMaskOrder = Mux1H(
+//      Seq(
+//        vecCtrl.fpu.isFoldTo1_2 -> Cat(0.U(2.W), f32Mask(3), f32Mask(2), 0.U(2.W), f32Mask(1), f32Mask(0)),
+//        vecCtrl.fpu.isFoldTo1_4 -> Cat(0.U(3.W), f32Mask(1), 0.U(3.W), f32Mask(0)),
+//      )
+//    )
+//    val f16FirstFoldMaskUnorder = Mux1H(
+//      Seq(
+//        vecCtrl.fpu.isFoldTo1_2 -> Cat(f16Mask(3,0), f16Mask(7,4)),
+//        vecCtrl.fpu.isFoldTo1_4 -> Cat(0.U(2.W), f16Mask(1), f16Mask(0), 0.U(2.W), f16Mask(3), f16Mask(2)),
+//        vecCtrl.fpu.isFoldTo1_8 -> Cat(0.U(3.W), f16Mask(0), 0.U(3.W), f16Mask(1)),
+//      )
+//    )
+//    val f16FirstFoldMaskOrder = Mux1H(
+//      Seq(
+//        vecCtrl.fpu.isFoldTo1_2 -> Cat(f16Mask(7,4), f16Mask(3,0)),
+//        vecCtrl.fpu.isFoldTo1_4 -> Cat(0.U(2.W), f16Mask(3), f16Mask(2), 0.U(2.W), f16Mask(1), f16Mask(0)),
+//        vecCtrl.fpu.isFoldTo1_8 -> Cat(0.U(3.W), f16Mask(1), 0.U(3.W), f16Mask(0)),
+//      )
+//    )
+//    val f64FoldMask = Mux1H(
+//      Seq(
+//        vecCtrl.fpu.isFoldTo1_2 -> "b00010001".U,
+//      )
+//    )
+//    val f32FoldMask = Mux1H(
+//      Seq(
+//        vecCtrl.fpu.isFoldTo1_2 -> "b00110011".U,
+//        vecCtrl.fpu.isFoldTo1_4 -> "b00010001".U,
+//      )
+//    )
+//    val f16FoldMask = Mux1H(
+//      Seq(
+//        vecCtrl.fpu.isFoldTo1_2 -> "b11111111".U,
+//        vecCtrl.fpu.isFoldTo1_4 -> "b00110011".U,
+//        vecCtrl.fpu.isFoldTo1_8 -> "b00010001".U,
+//      )
+//    )
+//    // low 4 bits for vs2(fp_a), high 4 bits for vs1(fp_b),
+//    val isFold = vecCtrl.fpu.isFoldTo1_2 || vecCtrl.fpu.isFoldTo1_4 || vecCtrl.fpu.isFoldTo1_8
+//    val f64FirstNotFoldMask = Cat(0.U(3.W), f64Mask(i + 2), 0.U(3.W), f64Mask(i))
+//    val f32FirstNotFoldMask = Cat(0.U(2.W), f32Mask(i * 2 + 5, i * 2 + 4), 0.U(2.W), Cat(f32Mask(i * 2 + 1, i * 2)))
+//    val f16FirstNotFoldMask = Cat(f16Mask(i * 4 + 11, i * 4 + 8), f16Mask(i * 4 + 3, i * 4))
+//    val f64MaskI = Mux(inIsVfRedOrdered,
+//      Mux(isFold, f64FirstFoldMaskOrder, f64FirstNotFoldMask),
+//      Mux(isFirstGroupUop,
+//        Mux(isFold, f64FirstFoldMaskUnorder, f64FirstNotFoldMask),
+//        Mux(isFold, f64FoldMask, Fill(8, 1.U))))
+//    val f32MaskI = Mux(inIsVfRedOrdered,
+//      Mux(isFold, f32FirstFoldMaskOrder, f32FirstNotFoldMask),
+//      Mux(isFirstGroupUop,
+//        Mux(isFold, f32FirstFoldMaskUnorder, f32FirstNotFoldMask),
+//        Mux(isFold, f32FoldMask, Fill(8, 1.U))))
+//    val f16MaskI = Mux(inIsVfRedOrdered,
+//      Mux(isFold, f16FirstFoldMaskOrder, f16FirstNotFoldMask),
+//      Mux(isFirstGroupUop,
+//        Mux(isFold, f16FirstFoldMaskUnorder, f16FirstNotFoldMask),
+//        Mux(isFold, f16FoldMask, Fill(8, 1.U))))
+//    val outMask = Mux1H(
+//      Seq(
+//        (sew === 3.U) -> f64MaskI,
+//        (sew === 2.U) -> f32MaskI,
+//        (sew === 1.U) -> f16MaskI,
+//      )
+//    )
+//    Mux(inIsVfRedOrdered, outMask(0), outMask)
+//  }
+//  def genMaskForMerge(inmask:UInt, sew:UInt, i:Int): UInt = {
+//    val f64MaskNum = dataWidth / 64
+//    val f32MaskNum = dataWidth / 32
+//    val f16MaskNum = dataWidth / 16
+//    val f64Mask = inmask(f64MaskNum-1,0)
+//    val f32Mask = inmask(f32MaskNum-1,0)
+//    val f16Mask = inmask(f16MaskNum-1,0)
+//    val f64MaskI = Cat(0.U(3.W),f64Mask(i))
+//    val f32MaskI = Cat(0.U(2.W),f32Mask(2*i+1,2*i))
+//    val f16MaskI = f16Mask(4*i+3,4*i)
+//    val outMask = Mux1H(
+//      Seq(
+//        (sew === 3.U) -> f64MaskI,
+//        (sew === 2.U) -> f32MaskI,
+//        (sew === 1.U) -> f16MaskI,
+//      )
+//    )
+//    outMask
+//  }
+//  def genMaskForRedFFlag(sew:UInt): UInt = {
+//    val default = "b11111111".U
+//    val f64FoldMask = Mux(outVecCtrl.fpu.isFoldTo1_2, "b00000001".U, default)
+//    val f32Fold = outVecCtrl.fpu.isFoldTo1_2 || outVecCtrl.fpu.isFoldTo1_4
+//    val f32FoldMask = Mux1H(
+//      Seq(
+//        outVecCtrl.fpu.isFoldTo1_2 -> "b00000011".U,
+//        outVecCtrl.fpu.isFoldTo1_4 -> "b00000001".U,
+//      )
+//    )
+//    val f16Fold = outVecCtrl.fpu.isFoldTo1_2 || outVecCtrl.fpu.isFoldTo1_4 || outVecCtrl.fpu.isFoldTo1_8
+//    val f16FoldMask = Mux1H(
+//      Seq(
+//        outVecCtrl.fpu.isFoldTo1_2 -> "b00001111".U,
+//        outVecCtrl.fpu.isFoldTo1_4 -> "b00000011".U,
+//        outVecCtrl.fpu.isFoldTo1_8 -> "b00000001".U,
+//      )
+//    )
+//    Mux1H(
+//      Seq(
+//        (sew === 3.U) -> f64FoldMask,
+//        (sew === 2.U) -> Mux(f32Fold, f32FoldMask, default),
+//        (sew === 1.U) -> Mux(f16Fold, f16FoldMask, default),
+//      )
+//    )
+//  }
+//  val srcMaskRShift = Wire(UInt((4 * numVecModule).W))
+//  val maskRshiftWidth = Wire(UInt(6.W))
+//  maskRshiftWidth := Mux1H(
+//    Seq(
+//      (vsew === VSew.e16) -> (vuopIdx(2,0) << 3),
+//      (vsew === VSew.e32) -> (vuopIdx(2,0) << 2),
+//      (vsew === VSew.e64) -> (vuopIdx(2,0) << 1),
+//    )
+//  )
+//  srcMaskRShift := (srcMask >> maskRshiftWidth)(4 * numVecModule - 1, 0)
+//  val fp_aIsFpCanonicalNAN = Wire(Vec(numVecModule,Bool()))
+//  val fp_bIsFpCanonicalNAN = Wire(Vec(numVecModule,Bool()))
+//  val inIsFold = Wire(UInt(3.W))
+//  inIsFold := Cat(vecCtrl.fpu.isFoldTo1_8, vecCtrl.fpu.isFoldTo1_4, vecCtrl.fpu.isFoldTo1_2)
+//  vfalus.zipWithIndex.foreach {
+//    case (mod, i) =>
+//      mod.io.fire             := io.in.valid
+//      mod.io.fp_a             := vs2Split.io.outVec64b(i)
+//      mod.io.fp_b             := vs1Split.io.outVec64b(i)
+//      mod.io.widen_a          := Cat(vs2Split.io.outVec32b(i+numVecModule), vs2Split.io.outVec32b(i))
+//      mod.io.widen_b          := Cat(vs1Split.io.outVec32b(i+numVecModule), vs1Split.io.outVec32b(i))
+//      mod.io.frs1             := 0.U     // already vf -> vv
+//      mod.io.is_frs1          := false.B // already vf -> vv
+//      mod.io.mask             := genMaskForMerge(inmask = srcMaskRShift, sew = vsew, i = i)
+//      mod.io.maskForReduction := genMaskForReduction(inmask = srcMaskRShiftForReduction, sew = vsew, i = i)
+//      mod.io.uop_idx          := vuopIdx(0)
+//      mod.io.is_vec           := true.B // Todo
+//      mod.io.round_mode       := rm
+//      mod.io.fp_format        := Mux(resWiden, vsew + 1.U, vsew)
+//      mod.io.opb_widening     := opbWiden
+//      mod.io.res_widening     := resWiden
+//      mod.io.op_code          := opcode
+//      mod.io.is_vfwredosum    := inIsVfWRedOrdered
+//      mod.io.is_fold          := inIsFold
+//      mod.io.vs2_fold         := vs2      // for better timing
+//      resultData(i)           := mod.io.fp_result
+//      fflagsData(i)           := mod.io.fflags
+//      fp_aIsFpCanonicalNAN(i) := vecCtrl.fpu.isFpToVecInst & (
+//          ((vsew === VSew.e32) & (!vs2Split.io.outVec64b(i).head(32).andR)) |
+//          ((vsew === VSew.e16) & (!vs2Split.io.outVec64b(i).head(48).andR))
+//        )
+//      fp_bIsFpCanonicalNAN(i) := vecCtrl.fpu.isFpToVecInst & (
+//          ((vsew === VSew.e32) & (!vs1Split.io.outVec64b(i).head(32).andR)) |
+//          ((vsew === VSew.e16) & (!vs1Split.io.outVec64b(i).head(48).andR))
+//        )
+//      mod.io.fp_aIsFpCanonicalNAN := fp_aIsFpCanonicalNAN(i)
+//      mod.io.fp_bIsFpCanonicalNAN := fp_bIsFpCanonicalNAN(i)
+//  }
+//  val outVuopidx = outVecCtrl.vuopIdx(2, 0) // for vfadd max vuopidx=7
+//  val numOfUopVFRED = Wire(UInt(4.W))
+//  val numofUopVFREDReg = RegEnable(numOfUopVFRED, io.in.fire)
+//  val vs1Reg = RegEnable(vs1, io.in.fire)
+//  val outFuOpType = outCtrl.fuOpType
+//  val outIsDstMask = VFMiscOpcode.isDstMask(outFuOpType)
+//  val outIsVfRedUnordered = VFRedOpcode.isVfRedUnordered(outFuOpType)
+//  val outIsVfRedUnComp = VFRedOpcode.isVfRedUnComp(outFuOpType)
+//  val outIsVfRedUnSum = VFRedOpcode.isVfredusum(outFuOpType)
+//  val outIsVfRedOrdered = VFRedOpcode.isVfRedOrdered(outFuOpType)
+//  val outIsVfWRedOrdered = VFRedOpcode.isVfWRedOrdered(outFuOpType)
+//  val outIsVfredosumNoWiden = VFRedOpcode.isVfredosumNoWiden(outFuOpType)
+//
+//  val isLastUopRed = outIsVfRedUnordered && outLastUop
+//  val resultDataUInt = Mux(isLastUopRed && !existMaskReg, vs1Reg, resultData.asUInt)
+//  val cmpResultWidth = dataWidth / 16
+//  val cmpResult = Wire(Vec(cmpResultWidth, Bool()))
+//  for (i <- 0 until cmpResultWidth) {
+//    if(i == 0) {
+//      cmpResult(i) := resultDataUInt(0)
+//    }
+//    else if(i < dataWidth / 64) {
+//      cmpResult(i) := Mux1H(
+//        Seq(
+//          (outVecCtrl.vsew === 1.U) -> resultDataUInt(i*16),
+//          (outVecCtrl.vsew === 2.U) -> resultDataUInt(i*32),
+//          (outVecCtrl.vsew === 3.U) -> resultDataUInt(i*64)
+//        )
+//      )
+//    }
+//    else if(i < dataWidth / 32) {
+//      cmpResult(i) := Mux1H(
+//        Seq(
+//          (outVecCtrl.vsew === 1.U) -> resultDataUInt(i * 16),
+//          (outVecCtrl.vsew === 2.U) -> resultDataUInt(i * 32),
+//          (outVecCtrl.vsew === 3.U) -> false.B
+//        )
+//      )
+//    }
+//    else if(i <  dataWidth / 16) {
+//      cmpResult(i) := Mux(outVecCtrl.vsew === 1.U, resultDataUInt(i*16), false.B)
+//    }
+//  }
+//  val outCtrl_s0 = ctrlVec.head
+//  val outVecCtrl_s0 = ctrlVec.head.vpu.get
+//  val outIsVectorMisc_s0 = isVectorMisc(outCtrl_s0.fuOpType)
+//  val outIsVectorMisc = isVectorMisc(outFuOpType)
+//  val outIsVfRedOrdered_s0 = VFRedOpcode.isVfRedOrdered(outCtrl_s0.fuOpType)
+//  val outIsReduction = VFRedOpcode.isVfReduction(outFuOpType)
+//  val outIsReduction_s0 = VFRedOpcode.isVfReduction(outCtrl_s0.fuOpType)
+//  val outResWiden_s0 = VFMacOpcode.isResWiden(outCtrl_s0.fuOpType) && !outIsVectorMisc_s0
+//  val outResWiden = VFMacOpcode.isResWiden(outFuOpType)
+//  val outResWidenFix = outResWiden && !outIsVectorMisc
+//  val outEew_s0 = Mux(outResWiden_s0, outVecCtrl_s0.vsew + 1.U, outVecCtrl_s0.vsew)
+//  val outEew = Mux(outResWidenFix, outVecCtrl.vsew + 1.U, outVecCtrl.vsew)
+//  val vlMax_s0 = ((VLEN/8).U >> outEew_s0).asUInt
+//  val vlMax = ((VLEN/8).U >> outEew).asUInt
+//  val outVlmulFix = Mux(outResWidenFix, outVecCtrl.vlmul + 1.U, outVecCtrl.vlmul)
+//  val lmulAbs = Mux(outVlmulFix(2), (~outVlmulFix(1,0)).asUInt + 1.U, outVlmulFix(1,0))
+//  //  vfmv_f_s need vl=1, reduction last uop need vl=1, other uop need vl=vlmax
+//  numOfUopVFRED := {
+//    // addTime include add frs1
+//    val addTime = MuxLookup(outVecCtrl_s0.vlmul, 1.U(4.W))(Seq(
+//      VLmul.m2 -> 2.U,
+//      VLmul.m4 -> 4.U,
+//      VLmul.m8 -> 8.U,
+//    ))
+//    val foldLastVlmul = MuxLookup(outVecCtrl_s0.vsew, "b000".U)(Seq(
+//      VSew.e16 -> VLmul.mf8,
+//      VSew.e32 -> VLmul.mf4,
+//      VSew.e64 -> VLmul.mf2,
+//    ))
+//    // lmul < 1, foldTime = vlmul - foldFastVlmul
+//    // lmul >= 1, foldTime = 0.U - foldFastVlmul
+//    val foldTime = Mux(outVecCtrl_s0.vlmul(2), outVecCtrl_s0.vlmul, 0.U) - foldLastVlmul
+//    addTime + foldTime
+//  }
+//  val reductionVl = Mux((outVecCtrl_s0.vuopIdx ===  numOfUopVFRED - 1.U) || outIsVfRedOrdered_s0, 1.U, vlMax_s0)
+//  val outVl_s0       = dataVec.head.vl.get
+//  val outVlFix_s0 = Mux(outIsReduction_s0, reductionVl, outVl_s0)
+//  val outVlFix = RegEnable(outVlFix_s0,io.in.fire)
+//
+//  val vlMaxAllUop = Wire(outVl.cloneType)
+//  vlMaxAllUop := Mux(outVecCtrl.vlmul(2), vlMax >> lmulAbs, vlMax << lmulAbs).asUInt
+//  val vlMaxThisUop = Mux(outVecCtrl.vlmul(2), vlMax >> lmulAbs, vlMax).asUInt
+//  val vlSetThisUop = Mux(outVlFix > outVuopidx*vlMaxThisUop, outVlFix - outVuopidx*vlMaxThisUop, 0.U)
+//  val vlThisUop = Wire(UInt(4.W))
+//  vlThisUop := Mux(vlSetThisUop < vlMaxThisUop, vlSetThisUop, vlMaxThisUop)
+//  val vlMaskRShift = Wire(UInt((4 * numVecModule).W))
+//  vlMaskRShift := Fill(4 * numVecModule, 1.U(1.W)) >> ((4 * numVecModule).U - vlThisUop)
+//
+//  val outVuopidxForRed = outVecCtrl.vuopIdx(2, 0) // lmul=8 sew=16, (4+2+1)(vector)+(1+1+1)(fold)+(1)(scala) max vuopIdx=10
+//  val outIsFisrtGroup = outVuopidxForRed === 0.U ||
+//    (outVuopidxForRed === 1.U && (outVlmul === VLmul.m4 || outVlmul === VLmul.m8)) ||
+//    ((outVuopidxForRed === 2.U || outVuopidxForRed === 3.U) && outVlmul === VLmul.m8)
+//  val firstNeedFFlags = outIsFisrtGroup  && outIsVfRedUnComp
+//  val lastNeedFFlags = outVecCtrl.lastUop && outIsVfRedUnComp
+//  private val needNoMask = outIsReduction
+//  val maskToMgu = Mux(needNoMask, allMaskTrue, outSrcMask)
+//  val allFFlagsEn = Wire(Vec(4*numVecModule,Bool()))
+//  val outSrcMaskRShift = Wire(UInt((4*numVecModule).W))
+//  outSrcMaskRShift := (maskToMgu >> (outVecCtrl.vuopIdx(2,0) * vlMax))(4*numVecModule-1,0)
+//  val f16FFlagsEn = outSrcMaskRShift
+//  val f32FFlagsEn = Wire(Vec(numVecModule,UInt(4.W)))
+//  val f64FFlagsEn = Wire(Vec(numVecModule, UInt(4.W)))
+//  val f16VlMaskEn = vlMaskRShift
+//  val f32VlMaskEn = Wire(Vec(numVecModule, UInt(4.W)))
+//  val f64VlMaskEn = Wire(Vec(numVecModule, UInt(4.W)))
+//  for (i <- 0 until numVecModule){
+//    f32FFlagsEn(i) := Cat(Fill(2, 0.U), outSrcMaskRShift(2*i+1,2*i))
+//    f64FFlagsEn(i) := Cat(Fill(3, 0.U), outSrcMaskRShift(i))
+//    f32VlMaskEn(i) := Cat(Fill(2, 0.U), vlMaskRShift(2 * i + 1, 2 * i))
+//    f64VlMaskEn(i) := Cat(Fill(3, 0.U), vlMaskRShift(i))
+//  }
+//  val fflagsEn= Mux1H(
+//    Seq(
+//      (outEew === 1.U) -> f16FFlagsEn.asUInt,
+//      (outEew === 2.U) -> f32FFlagsEn.asUInt,
+//      (outEew === 3.U) -> f64FFlagsEn.asUInt
+//    )
+//  )
+//  val vlMaskEn = Mux1H(
+//    Seq(
+//      (outEew === 1.U) -> f16VlMaskEn.asUInt,
+//      (outEew === 2.U) -> f32VlMaskEn.asUInt,
+//      (outEew === 3.U) -> f64VlMaskEn.asUInt
+//    )
+//  )
+//  val fflagsRedMask = genMaskForRedFFlag(outVecCtrl.vsew)
+//
+//  if (backendParams.debugEn){
+//    dontTouch(allFFlagsEn)
+//    dontTouch(fflagsRedMask)
+//  }
+//  // use srcMask(XLEN-1, 0) because float format hasn't fp8
+//  val allVmZero = RegEnable(LZD(Reverse(srcMask(XLEN-1, 0))) >= outVl_s0, io.in.fire)
+//  allFFlagsEn := Mux(outIsReduction,
+//    Cat(
+//      Fill(4*numVecModule - 1, firstNeedFFlags || outIsVfRedUnSum && !outVecCtrl.lastUop) & fflagsRedMask(4*numVecModule - 1, 1),
+//      !allVmZero && (lastNeedFFlags || firstNeedFFlags || outIsVfRedOrdered || outIsVfRedUnSum)
+//    ),
+//    fflagsEn & vlMaskEn
+//  ).asTypeOf(allFFlagsEn)
+//
+//  val allFFlags = fflagsData.asTypeOf(Vec( 4*numVecModule,UInt(5.W)))
+//  val outFFlags = allFFlagsEn.zip(allFFlags).map{
+//    case(en,fflags) => Mux(en, fflags, 0.U(5.W))
+//  }.reduce(_ | _)
+//
+//
+//  val cmpResultOldVd = Wire(UInt(cmpResultWidth.W))
+//  val cmpResultOldVdRshiftWidth = Wire(UInt(6.W))
+//  cmpResultOldVdRshiftWidth := Mux1H(
+//    Seq(
+//      (outVecCtrl.vsew === VSew.e16) -> (outVecCtrl.vuopIdx(2, 0) << 3),
+//      (outVecCtrl.vsew === VSew.e32) -> (outVecCtrl.vuopIdx(2, 0) << 2),
+//      (outVecCtrl.vsew === VSew.e64) -> (outVecCtrl.vuopIdx(2, 0) << 1),
+//    )
+//  )
+//  cmpResultOldVd := (outOldVd >> cmpResultOldVdRshiftWidth)(4*numVecModule-1,0)
+//  val cmpResultForMgu = Wire(Vec(cmpResultWidth, Bool()))
+//  private val maxVdIdx = 8
+//  private val elementsInOneUop = Mux1H(
+//    Seq(
+//      (outEew === 1.U) -> (cmpResultWidth).U(4.W),
+//      (outEew === 2.U) -> (cmpResultWidth / 2).U(4.W),
+//      (outEew === 3.U) -> (cmpResultWidth / 4).U(4.W),
+//    )
+//  )
+//  private val vdIdx = outVecCtrl.vuopIdx(2, 0)
+//  private val elementsComputed = Mux1H(Seq.tabulate(maxVdIdx)(i => (vdIdx === i.U) -> (elementsInOneUop * i.U)))
+//  for (i <- 0 until cmpResultWidth) {
+//    val cmpResultWithVmask = Mux(outSrcMaskRShift(i), cmpResult(i), Mux(outVecCtrl.vma, true.B, cmpResultOldVd(i)))
+//    cmpResultForMgu(i) := Mux(elementsComputed +& i.U >= outVl, true.B, cmpResultWithVmask)
+//  }
+//  val outIsFold = outVecCtrl.fpu.isFoldTo1_2 || outVecCtrl.fpu.isFoldTo1_4 || outVecCtrl.fpu.isFoldTo1_8
+//  val outOldVdForREDO = Mux1H(Seq(
+//    (outVecCtrl.vsew === VSew.e16) -> (outOldVd >> 16),
+//    (outVecCtrl.vsew === VSew.e32) -> (outOldVd >> 32),
+//    (outVecCtrl.vsew === VSew.e64) -> (outOldVd >> 64),
+//  ))
+//  val outOldVdForWREDO = Mux(
+//    !outIsFold,
+//    Mux(outVecCtrl.vsew === VSew.e16, Cat(outOldVd(VLEN-1-16,16), 0.U(32.W)), Cat(outOldVd(VLEN-1-32,32), 0.U(64.W))),
+//    Mux(outVecCtrl.vsew === VSew.e16,
+//      // Divide vuopIdx by 8 and the remainder is 1
+//      Mux(outVecCtrl.vuopIdx(2,0) === 1.U, outOldVd, outOldVd >> 16),
+//      // Divide vuopIdx by 4 and the remainder is 1
+//      Mux(outVecCtrl.vuopIdx(1,0) === 1.U, outOldVd, outOldVd >> 32)
+//    ),
+//  )
+//  val outOldVdForRED = Mux(outIsVfredosumNoWiden, outOldVdForREDO, outOldVdForWREDO)
+//  val numOfUopVFREDOSUM = {
+//    val uvlMax = MuxLookup(outVecCtrl.vsew, 0.U)(Seq(
+//      VSew.e16 -> 8.U,
+//      VSew.e32 -> 4.U,
+//      VSew.e64 -> 2.U,
+//    ))
+//    val vlMax = Mux(outVecCtrl.vlmul(2), uvlMax >> (-outVecCtrl.vlmul)(1, 0), uvlMax << outVecCtrl.vlmul(1, 0)).asUInt
+//    vlMax
+//  }
+//  val isLastUopForREDO = outVecCtrl.lastUop
+//  val isOutOldVdForREDO = (outIsVfredosumNoWiden && outIsFold) || outIsVfWRedOrdered && !isLastUopForREDO
+//  val taIsFalseForVFREDO = outIsVfRedOrdered && (outVecCtrl.vuopIdx =/= numOfUopVFREDOSUM - 1.U)
+//  val notModifyVd = outVl === 0.U
+//  mgu.io.in.vd := Mux(outIsDstMask, Cat(0.U((dataWidth / 16 * 15).W), cmpResultForMgu.asUInt), resultDataUInt)
+//  mgu.io.in.oldVd := Mux(isOutOldVdForREDO, outOldVdForRED, outOldVd)
+//  mgu.io.in.mask := maskToMgu
+//  mgu.io.in.info.ta := Mux(taIsFalseForVFREDO, false.B, outVecCtrl.vta)
+//  mgu.io.in.info.ma := outVecCtrl.vma
+//  mgu.io.in.info.vl := outVlFix
+//  mgu.io.in.info.vlmul := outVecCtrl.vlmul
+//  mgu.io.in.info.valid := Mux(notModifyVd, false.B, io.in.valid)
+//  mgu.io.in.info.vstart := outVecCtrl.vstart
+//  mgu.io.in.info.eew :=  RegEnable(outEew_s0,io.in.fire)
+//  mgu.io.in.info.vsew := outVecCtrl.vsew
+//  mgu.io.in.info.vdIdx := RegEnable(
+//    Mux(outIsReduction_s0, 0.U, outVecCtrl_s0.vuopIdx),
+//    io.in.fire
+//  )
+//  mgu.io.in.info.narrow := outVecCtrl.isNarrow
+//  mgu.io.in.info.dstMask := outIsDstMask
+//  mgu.io.in.isIndexedVls := false.B
+//  mgtu.io.in.vd := Mux(outIsDstMask, mgu.io.out.vd, resultDataUInt)
+//  mgtu.io.in.vl := outVl
+//  // when dest is mask, the result need to be masked by mgtu
+//  io.out.bits.res.data := Mux(notModifyVd, outOldVd, Mux(outIsDstMask, mgtu.io.out.vd, mgu.io.out.vd))
+//  io.out.bits.res.fflags.get := Mux(notModifyVd, 0.U(5.W), outFFlags)
+//  io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := mgu.io.out.illegal
+//}
+//
+//class VFMgu(vlen:Int)(implicit p: Parameters) extends Module{
+//  val io = IO(new VFMguIO(vlen))
+//
+//  val vd = io.in.vd
+//  val oldvd = io.in.oldVd
+//  val mask = io.in.mask
+//  val vsew = io.in.info.eew
+//  val num16bits = vlen / 16
+//
+//}
+//
+//class VFMguIO(vlen: Int)(implicit p: Parameters) extends Bundle {
+//  val in = new Bundle {
+//    val vd = Input(UInt(vlen.W))
+//    val oldVd = Input(UInt(vlen.W))
+//    val mask = Input(UInt(vlen.W))
+//    val info = Input(new VecInfo)
+//  }
+//  val out = new Bundle {
+//    val vd = Output(UInt(vlen.W))
+//  }
+//}

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFAluWrapper.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFAluWrapper.scala
@@ -9,10 +9,28 @@ import xiangshan.backend.decode.opcode.Opcode.VFMacOpcodes.isFmul
 import xiangshan.backend.fu.vector.Bundles.VSew
 import xiangshan.backend.fu.vector.utils.VecDataSplitModule
 import xiangshan.backend.vector.fu.Func._
-import xiangshan.backend.vector.fu.{VecFixLatFunc, VecFuConfig}
+import xiangshan.backend.vector.fu.{Func, VecFixLatFunc, VecFuConfig}
 import yunsuan.vector.Common.{Fflags, VSew}
 import yunsuan.vector.vfalu.VectorFALU
 import yunsuan.vector.vfmul.{VFMul2VFALUCtrlBundle, VFMul2VFALUOutput}
+
+object VFAluWrapper {
+  /**
+    * The S1 product is not a register-file result.  It carries the complete
+    * OP3 context into VFALU so its S1 result can use the normal vector
+    * writeback and merge path.
+    */
+  class VFMulForward(cfg: VecFuConfig)(implicit p: Parameters) extends XSBundle {
+    val mul = Vec(cfg.destDataBits / 64, new VFMul2VFALUOutput)
+    val addend = Vec(cfg.destDataBits / 64, UInt(64.W))
+    val isSub = Bool()
+    val ctrlOpcode = UInt(6.W)
+    val frm = UInt(3.W)
+    val ctrl = new Func.InCtrl(cfg)
+    val data = new Func.InData(cfg)
+    val debug = Option.when(backendParams.debugEn)(new xiangshan.backend.vector.VecRegionModule.DebugBundle)
+  }
+}
 
 class VFAluWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFunc(cfg) {
 
@@ -25,15 +43,16 @@ class VFAluWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFu
   private val zeroFflagsE8 = VecInit(Seq.fill(vlenb)(zeroFflags))
   private val zeroNarrowFflagsE8 = VecInit(Seq.fill(vlenb / 2)(zeroFflags))
 
-  private val ex0opcode = fuOpType
-  private val ex0NextOpcode = ex0Next.bits.ctrl.opcode
-  private val ex0vsew = ex0ctrl.vtype.get.vsew
-  private val isOP3 = makePipeReg(VFMacOpcodes.isOP3(ex0NextOpcode), pipeRegValids)
-  //  private val resSew = Wire(Vec(normalLatency + 1, UInt(ex0vsew.getWidth.W)))
+  // VectorFALU S0 accepts the VFMUL S1 product.  Keep the original uop
+  // alongside it so MergeUnit observes the matching oldVd/vl/vtype context.
+  private val op3Fire_s0 = in.fromVfmul.get.valid
+  private val op3Fire_s1 = RegInit(false.B)
+  op3Fire_s1 := op3Fire_s0
+  private val op3Context_s0 = in.fromVfmul.get.bits
+  private val op3Context_s1 = RegEnable(op3Context_s0, op3Fire_s0)
 
-  //  for (i <- 0 to cfg.latency) {
-  //    resSew(i) := ex(i).bits.ctrl.vtype.get.vsew
-  //  }
+  out.op3OutContext.get.valid := op3Fire_s1 && !op3Context_s0.ctrl.robIdx.needFlush(in.flush)
+  out.op3OutContext.get.bits := op3Context_s1
 
   private val vfalus = Seq.fill(numVecModule)(Module(new VectorFALU)) // WARNING: Don't change this module. MUST USE VectorFloatMultiplier
 //  val fromVfmul = IO(Output(Valid(Vec(numVecModule, new FuncUnitFaluInputFromFmul))))
@@ -49,18 +68,16 @@ class VFAluWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFu
   private val resultData = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
   private val fflagsData = Wire(Vec(numVecModule, Vec(vlenb / numVecModule, Fflags())))
 
-  //  val outToFaluFromFmul = out.outToVfaluFromVfmul.get
-
   vfalus.zipWithIndex.foreach {
     case (mod, i) =>
-      mod.io.fire               := ex(0).valid
-      mod.io.in.opcode          := ex0opcode
-      mod.io.in.fpA             := vs2Split.io.outVec64b(i)
-      mod.io.in.fpB             := vs1Split.io.outVec64b(i)
-      mod.io.in.fpAAppend       := 0.U
-      mod.io.in.roundMode       := frm
-      mod.io.in.inCtrlFromVFMul := 0.U.asTypeOf(new VFMul2VFALUCtrlBundle)
-      mod.io.in.isSubFromVFMul  := false.B
+      mod.io.fire               := op3Fire_s0 || ex(0).valid
+      mod.io.in.opcode          := Mux(op3Fire_s0, op3Context_s0.ctrlOpcode,            fuOpType                               )
+      mod.io.in.fpA             := Mux(op3Fire_s0, op3Context_s0.mul(i).fpA,            vs2Split.io.outVec64b(i)               )
+      mod.io.in.fpB             := Mux(op3Fire_s0, op3Context_s0.addend(i),             vs1Split.io.outVec64b(i)               )
+      mod.io.in.fpAAppend       := Mux(op3Fire_s0, op3Context_s0.mul(i).fpAAppend,      0.U                                    )
+      mod.io.in.roundMode       := Mux(op3Fire_s0, op3Context_s0.frm,                   frm                                    )
+      mod.io.in.inCtrlFromVFMul := Mux(op3Fire_s0, op3Context_s0.mul(i).FMULToFADDCtrl, 0.U.asTypeOf(new VFMul2VFALUCtrlBundle))
+      mod.io.in.isSubFromVFMul  := Mux(op3Fire_s0, op3Context_s0.isSub,                 false.B                                )
 
       resultData(i) := mod.io.out.fpResult
       fflagsData(i) := mod.io.out.fflagsVec
@@ -90,6 +107,24 @@ class VFAluWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFu
     vecData.fflagsE8.get := fflagsData.asTypeOf(Vec(vlenb, Fflags()))
   }
 
-  out.ex(cfg.latency).valid := ex(cfg.latency).valid
+  when (op3Fire_s1) {
+    out.ex(cfg.latency).bits.ctrl.robIdx     :=  op3Context_s1.ctrl.robIdx
+    out.ex(cfg.latency).bits.ctrl.pdest      :=  op3Context_s1.ctrl.pdest
+    out.ex(cfg.latency).bits.ctrl.pdestV0   .zip(op3Context_s1.ctrl.pdestV0  ).foreach { case (sink, source) => sink := source }
+    out.ex(cfg.latency).bits.ctrl.pdestVl   .zip(op3Context_s1.ctrl.pdestVl  ).foreach { case (sink, source) => sink := source }
+    out.ex(cfg.latency).bits.ctrl.rfWen     .zip(op3Context_s1.ctrl.rfWen    ).foreach { case (sink, source) => sink := source }
+    out.ex(cfg.latency).bits.ctrl.fpWen     .zip(op3Context_s1.ctrl.fpWen    ).foreach { case (sink, source) => sink := source }
+    out.ex(cfg.latency).bits.ctrl.vecWen    .zip(op3Context_s1.ctrl.vecWen   ).foreach { case (sink, source) => sink := source }
+    out.ex(cfg.latency).bits.ctrl.v0Wen     .zip(op3Context_s1.ctrl.v0Wen    ).foreach { case (sink, source) => sink := source }
+    out.ex(cfg.latency).bits.ctrl.vlWen     .zip(op3Context_s1.ctrl.vlWen    ).foreach { case (sink, source) => sink := source }
+    out.ex(cfg.latency).bits.ctrl.flushPipe .zip(op3Context_s1.ctrl.flushPipe).foreach { case (sink, source) => sink := source }
+    out.ex(cfg.latency).bits.ctrl.fflagsWen .zip(op3Context_s1.ctrl.fflagsWen).foreach { case (sink, source) => sink := source }
+    out.ex(cfg.latency).bits.debug          .zip(op3Context_s1.debug         ).foreach { case (sink, source) => sink := source }
+  }
 
+  // The normal VFALU input and an OP3 product reserve the same S0.  The
+  // issue-side writeback reservation prevents this collision.
+  assert(!(op3Fire_s0 && ex(0).valid), "VFALU received OP2 and OP3 work in the same S0")
+  assert(!(op3Fire_s1 && ex(cfg.latency).valid), "VFALU produced OP2 and OP3 results in the same cycle")
+  out.ex(cfg.latency).valid := Mux(op3Fire_s1, out.op3OutContext.get.valid, ex(cfg.latency).valid)
 }

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFAluWrapper.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFAluWrapper.scala
@@ -72,8 +72,8 @@ class VFAluWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFu
     case (mod, i) =>
       mod.io.fire               := op3Fire_s0 || ex(0).valid
       mod.io.in.opcode          := Mux(op3Fire_s0, op3Context_s0.ctrlOpcode,            fuOpType                               )
-      mod.io.in.fpA             := Mux(op3Fire_s0, op3Context_s0.mul(i).fpA,            vs2Split.io.outVec64b(i)               )
-      mod.io.in.fpB             := Mux(op3Fire_s0, op3Context_s0.addend(i),             vs1Split.io.outVec64b(i)               )
+      mod.io.in.fpA             := Mux(op3Fire_s0, op3Context_s0.mul(i).fpA,            Mux(ex0ctrl.isReverse, vs1Split.io.outVec64b(i), vs2Split.io.outVec64b(i)))
+      mod.io.in.fpB             := Mux(op3Fire_s0, op3Context_s0.addend(i),             Mux(ex0ctrl.isReverse, vs2Split.io.outVec64b(i), vs1Split.io.outVec64b(i)))
       mod.io.in.fpAAppend       := Mux(op3Fire_s0, op3Context_s0.mul(i).fpAAppend,      0.U                                    )
       mod.io.in.roundMode       := Mux(op3Fire_s0, op3Context_s0.frm,                   frm                                    )
       mod.io.in.inCtrlFromVFMul := Mux(op3Fire_s0, op3Context_s0.mul(i).FMULToFADDCtrl, 0.U.asTypeOf(new VFMul2VFALUCtrlBundle))

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFAluWrapper.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFAluWrapper.scala
@@ -1,0 +1,95 @@
+package xiangshan.backend.fu.wrapper
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+import xiangshan._
+import xiangshan.backend.decode.opcode.Opcode.VFMacOpcodes
+import xiangshan.backend.decode.opcode.Opcode.VFMacOpcodes.isFmul
+import xiangshan.backend.fu.vector.Bundles.VSew
+import xiangshan.backend.fu.vector.utils.VecDataSplitModule
+import xiangshan.backend.vector.fu.Func._
+import xiangshan.backend.vector.fu.{VecFixLatFunc, VecFuConfig}
+import yunsuan.vector.Common.{Fflags, VSew}
+import yunsuan.vector.vfalu.VectorFALU
+import yunsuan.vector.vfmul.{VFMul2VFALUCtrlBundle, VFMul2VFALUOutput}
+
+class VFAluWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFunc(cfg) {
+
+  private val dataWidth = cfg.destDataBits
+  private val dataWidthOfDataModule = 64
+  private val numVecModule = dataWidth / dataWidthOfDataModule
+
+  private val vlenb = VLEN / 8
+  private val zeroFflags = 0.U.asTypeOf(Fflags())
+  private val zeroFflagsE8 = VecInit(Seq.fill(vlenb)(zeroFflags))
+  private val zeroNarrowFflagsE8 = VecInit(Seq.fill(vlenb / 2)(zeroFflags))
+
+  private val ex0opcode = fuOpType
+  private val ex0NextOpcode = ex0Next.bits.ctrl.opcode
+  private val ex0vsew = ex0ctrl.vtype.get.vsew
+  private val isOP3 = makePipeReg(VFMacOpcodes.isOP3(ex0NextOpcode), pipeRegValids)
+  //  private val resSew = Wire(Vec(normalLatency + 1, UInt(ex0vsew.getWidth.W)))
+
+  //  for (i <- 0 to cfg.latency) {
+  //    resSew(i) := ex(i).bits.ctrl.vtype.get.vsew
+  //  }
+
+  private val vfalus = Seq.fill(numVecModule)(Module(new VectorFALU)) // WARNING: Don't change this module. MUST USE VectorFloatMultiplier
+//  val fromVfmul = IO(Output(Valid(Vec(numVecModule, new FuncUnitFaluInputFromFmul))))
+
+  private val vs2Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+  private val vs1Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+  private val oldVdSplit = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+
+  vs2Split.io.inVecData := ex0vs2
+  vs1Split.io.inVecData := ex0vs1
+  oldVdSplit.io.inVecData := ex0oldVd
+
+  private val resultData = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
+  private val fflagsData = Wire(Vec(numVecModule, Vec(vlenb / numVecModule, Fflags())))
+
+  //  val outToFaluFromFmul = out.outToVfaluFromVfmul.get
+
+  vfalus.zipWithIndex.foreach {
+    case (mod, i) =>
+      mod.io.fire               := ex(0).valid
+      mod.io.in.opcode          := ex0opcode
+      mod.io.in.fpA             := vs2Split.io.outVec64b(i)
+      mod.io.in.fpB             := vs1Split.io.outVec64b(i)
+      mod.io.in.fpAAppend       := 0.U
+      mod.io.in.roundMode       := frm
+      mod.io.in.inCtrlFromVFMul := 0.U.asTypeOf(new VFMul2VFALUCtrlBundle)
+      mod.io.in.isSubFromVFMul  := false.B
+
+      resultData(i) := mod.io.out.fpResult
+      fflagsData(i) := mod.io.out.fflagsVec
+  }
+
+  private def zeroVecData(vecData: VecSpecialData): Unit = {
+    vecData.normal := 0.U
+    vecData.narrow := 0.U
+    vecData.maskE8 := 0.U
+    vecData.maskE16 := 0.U
+    vecData.maskE32 := 0.U
+    vecData.maskE64 := 0.U
+    vecData.isWiden.foreach(_ := false.B)
+    vecData.isNarrow.foreach(_ := false.B)
+    vecData.vxsatE8.foreach(_ := 0.U.asTypeOf(vecData.vxsatE8.get))
+    vecData.narrowVxsatE8.foreach(_ := 0.U.asTypeOf(vecData.narrowVxsatE8.get))
+    vecData.fflagsE8.foreach(_ := zeroFflagsE8)
+    vecData.narrowFflagsE8.foreach(_ := zeroNarrowFflagsE8)
+  }
+
+  for (i <- 0 to cfg.latency) {
+    out.ex(i).bits.data.vec.foreach(zeroVecData)
+  }
+
+  out.ex(cfg.latency).bits.data.vec.foreach { vecData =>
+    vecData.normal := Cat(resultData.reverse)
+    vecData.fflagsE8.get := fflagsData.asTypeOf(Vec(vlenb, Fflags()))
+  }
+
+  out.ex(cfg.latency).valid := ex(cfg.latency).valid
+
+}

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFMA.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFMA.scala
@@ -1,165 +1,165 @@
-package xiangshan.backend.fu.wrapper
-
-import org.chipsalliance.cde.config.Parameters
-import chisel3._
-import chisel3.util._
-import utility.XSError
-import xiangshan.backend.fu.FuConfig
-import xiangshan.backend.fu.vector.Bundles.VSew
-import xiangshan.backend.fu.vector.utils.VecDataSplitModule
-import xiangshan.backend.fu.vector.{Mgu, VecPipedFuncUnit}
-import xiangshan.ExceptionNO
-import yunsuan.vector.VectorFloatFMA
-import xiangshan.backend.decode.opcode.Opcode.VFMacOpcodes
-
-class VFMA(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg) {
-  import VFMacOpcodes._
-
-  // params alias
-  private val dataWidth = cfg.destDataBits
-  private val dataWidthOfDataModule = 64
-  private val numVecModule = dataWidth / dataWidthOfDataModule
-
-  // io alias
-  private val opcode: UInt = fuOpType
-  private val resWiden  = isResWiden(opcode)
-
-  // modules
-  private val vfmas = Seq.fill(numVecModule)(Module(new VectorFloatFMA))
-  private val vs2Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
-  private val vs1Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
-  private val oldVdSplit  = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
-  private val mgu = Module(new Mgu(dataWidth))
-
-  /**
-    * In connection of [[vs2Split]], [[vs1Split]] and [[oldVdSplit]]
-    */
-  vs2Split.io.inVecData := vs2
-  vs1Split.io.inVecData := vs1
-  oldVdSplit.io.inVecData := oldVd
-
-  /**
-    * [[vfmas]]'s in connection
-    */
-  // Vec(vs2(31,0), vs2(63,32), vs2(95,64), vs2(127,96)) ==>
-  // Vec(
-  //   Cat(vs2(95,64),  vs2(31,0)),
-  //   Cat(vs2(127,96), vs2(63,32)),
-  // )
-  private val vs2GroupedVec: Vec[UInt] = VecInit(vs2Split.io.outVec32b.zipWithIndex.groupBy(_._2 % 2).map(x => x._1 -> x._2.map(_._1)).values.map(x => Cat(x.reverse)).toSeq)
-  private val vs1GroupedVec: Vec[UInt] = VecInit(vs1Split.io.outVec32b.zipWithIndex.groupBy(_._2 % 2).map(x => x._1 -> x._2.map(_._1)).values.map(x => Cat(x.reverse)).toSeq)
-  private val resultData = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
-  private val fflagsData = Wire(Vec(numVecModule, UInt(20.W)))
-  val fp_aIsFpCanonicalNAN = Wire(Vec(numVecModule, Bool()))
-  val fp_bIsFpCanonicalNAN = Wire(Vec(numVecModule, Bool()))
-  val fp_cIsFpCanonicalNAN = Wire(Vec(numVecModule, Bool()))
-  vfmas.zipWithIndex.foreach {
-    case (mod, i) =>
-      mod.io.fire         := io.in.valid
-      mod.io.fp_a         := vs2Split.io.outVec64b(i)
-      mod.io.fp_b         := vs1Split.io.outVec64b(i)
-      mod.io.fp_c         := oldVdSplit.io.outVec64b(i)
-      mod.io.widen_a      := Cat(vs2Split.io.outVec32b(i+numVecModule), vs2Split.io.outVec32b(i))
-      mod.io.widen_b      := Cat(vs1Split.io.outVec32b(i+numVecModule), vs1Split.io.outVec32b(i))
-      mod.io.frs1         := 0.U     // already vf -> vv
-      mod.io.is_frs1      := false.B // already vf -> vv
-      mod.io.uop_idx      := vuopIdx(0)
-      mod.io.is_vec       := true.B // Todo
-      mod.io.round_mode   := rm
-      mod.io.fp_format    := Mux(resWiden, vsew + 1.U, vsew)
-      mod.io.res_widening := resWiden
-      mod.io.op_code      := opcode
-      resultData(i) := mod.io.fp_result
-      fflagsData(i) := mod.io.fflags
-      fp_aIsFpCanonicalNAN(i) := vecCtrl.fpu.isFpToVecInst & (
-        ((vsew === VSew.e32) & (!vs2Split.io.outVec64b(i).head(32).andR)) |
-          ((vsew === VSew.e16) & (!vs2Split.io.outVec64b(i).head(48).andR))
-        )
-      fp_bIsFpCanonicalNAN(i) := vecCtrl.fpu.isFpToVecInst & (
-        ((vsew === VSew.e32) & (!vs1Split.io.outVec64b(i).head(32).andR)) |
-          ((vsew === VSew.e16) & (!vs1Split.io.outVec64b(i).head(48).andR))
-        )
-      fp_cIsFpCanonicalNAN(i) := !isFmul(opcode) & vecCtrl.fpu.isFpToVecInst & (
-        ((vsew === VSew.e32) & (!oldVdSplit.io.outVec64b(i).head(32).andR)) |
-          ((vsew === VSew.e16) & (!oldVdSplit.io.outVec64b(i).head(48).andR))
-        )
-      mod.io.fp_aIsFpCanonicalNAN := fp_aIsFpCanonicalNAN(i)
-      mod.io.fp_bIsFpCanonicalNAN := fp_bIsFpCanonicalNAN(i)
-      mod.io.fp_cIsFpCanonicalNAN := fp_cIsFpCanonicalNAN(i)
-  }
-
-  val outFuOpType = outCtrl.fuOpType
-  val outWiden = isResWiden(outCtrl.fuOpType)
-  val outEew = Mux(outWiden, outVecCtrl.vsew + 1.U, outVecCtrl.vsew)
-  val outVuopidx = outVecCtrl.vuopIdx(2, 0)
-  val vlMax = ((VLEN / 8).U >> outEew).asUInt
-  val outVlmulFix = Mux(outWiden, outVecCtrl.vlmul + 1.U, outVecCtrl.vlmul)
-  val lmulAbs = Mux(outVlmulFix(2), (~outVlmulFix(1, 0)).asUInt + 1.U, outVlmulFix(1, 0))
-  val outVlFix = Mux(outVecCtrl.fpu.isFpToVecInst, 1.U, outVl)
-  val vlMaxAllUop = Wire(outVl.cloneType)
-  vlMaxAllUop := Mux(outVecCtrl.vlmul(2), vlMax >> lmulAbs, vlMax << lmulAbs).asUInt
-  val vlMaxThisUop = Mux(outVecCtrl.vlmul(2), vlMax >> lmulAbs, vlMax).asUInt
-  val vlSetThisUop = Mux(outVlFix > outVuopidx * vlMaxThisUop, outVlFix - outVuopidx * vlMaxThisUop, 0.U)
-  val vlThisUop = Wire(UInt(4.W))
-  vlThisUop := Mux(vlSetThisUop < vlMaxThisUop, vlSetThisUop, vlMaxThisUop)
-  val vlMaskRShift = Wire(UInt((4 * numVecModule).W))
-  vlMaskRShift := Fill(4 * numVecModule, 1.U(1.W)) >> ((4 * numVecModule).U - vlThisUop)
-
-  private val needNoMask = outVecCtrl.fpu.isFpToVecInst
-  val maskToMgu = Mux(needNoMask, allMaskTrue, outSrcMask)
-  val allFFlagsEn = Wire(Vec(4 * numVecModule, Bool()))
-  val outSrcMaskRShift = Wire(UInt((4 * numVecModule).W))
-  outSrcMaskRShift := (maskToMgu >> (outVecCtrl.vuopIdx(2, 0) * vlMax))(4 * numVecModule - 1, 0)
-  val f16FFlagsEn = outSrcMaskRShift
-  val f32FFlagsEn = Wire(Vec(numVecModule, UInt(4.W)))
-  val f64FFlagsEn = Wire(Vec(numVecModule, UInt(4.W)))
-  val f16VlMaskEn = vlMaskRShift
-  val f32VlMaskEn = Wire(Vec(numVecModule, UInt(4.W)))
-  val f64VlMaskEn = Wire(Vec(numVecModule, UInt(4.W)))
-  for (i <- 0 until numVecModule) {
-    f32FFlagsEn(i) := Cat(Fill(2, 0.U), outSrcMaskRShift(2 * i + 1, 2 * i))
-    f64FFlagsEn(i) := Cat(Fill(3, 0.U), outSrcMaskRShift(i))
-    f32VlMaskEn(i) := Cat(Fill(2, 0.U), vlMaskRShift(2 * i + 1, 2 * i))
-    f64VlMaskEn(i) := Cat(Fill(3, 0.U), vlMaskRShift(i))
-  }
-  val fflagsEn = Mux1H(
-    Seq(
-      (outEew === 1.U) -> f16FFlagsEn.asUInt,
-      (outEew === 2.U) -> f32FFlagsEn.asUInt,
-      (outEew === 3.U) -> f64FFlagsEn.asUInt
-    )
-  )
-  val vlMaskEn = Mux1H(
-    Seq(
-      (outEew === 1.U) -> f16VlMaskEn.asUInt,
-      (outEew === 2.U) -> f32VlMaskEn.asUInt,
-      (outEew === 3.U) -> f64VlMaskEn.asUInt
-    )
-  )
-  allFFlagsEn := (fflagsEn & vlMaskEn).asTypeOf(allFFlagsEn)
-
-  val allFFlags = fflagsData.asTypeOf(Vec(4 * numVecModule, UInt(5.W)))
-  val outFFlags = allFFlagsEn.zip(allFFlags).map {
-    case (en, fflags) => Mux(en, fflags, 0.U(5.W))
-  }.reduce(_ | _)
-  io.out.bits.res.fflags.get := outFFlags
-
-  val resultDataUInt = resultData.asUInt
-  mgu.io.in.vd := resultDataUInt
-  mgu.io.in.oldVd := outOldVd
-  mgu.io.in.mask := maskToMgu
-  mgu.io.in.info.ta := outVecCtrl.vta
-  mgu.io.in.info.ma := outVecCtrl.vma
-  mgu.io.in.info.vl := Mux(outVecCtrl.fpu.isFpToVecInst, 1.U, outVl)
-  mgu.io.in.info.vlmul := outVecCtrl.vlmul
-  mgu.io.in.info.valid := io.out.valid
-  mgu.io.in.info.vstart := Mux(outVecCtrl.fpu.isFpToVecInst, 0.U, outVecCtrl.vstart)
-  mgu.io.in.info.eew := outEew
-  mgu.io.in.info.vsew := outVecCtrl.vsew
-  mgu.io.in.info.vdIdx := outVecCtrl.vuopIdx
-  mgu.io.in.info.narrow := outVecCtrl.isNarrow
-  mgu.io.in.info.dstMask := outVecCtrl.isDstMask
-  mgu.io.in.isIndexedVls := false.B
-  io.out.bits.res.data := mgu.io.out.vd
-  io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := mgu.io.out.illegal
-}
+//package xiangshan.backend.fu.wrapper
+//
+//import org.chipsalliance.cde.config.Parameters
+//import chisel3._
+//import chisel3.util._
+//import utility.XSError
+//import xiangshan.backend.fu.FuConfig
+//import xiangshan.backend.fu.vector.Bundles.VSew
+//import xiangshan.backend.fu.vector.utils.VecDataSplitModule
+//import xiangshan.backend.fu.vector.{Mgu, VecPipedFuncUnit}
+//import xiangshan.ExceptionNO
+//import yunsuan.vector.VectorFloatFMA
+//import xiangshan.backend.decode.opcode.Opcode.VFMacOpcodes
+//
+//class VFMA(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg) {
+//  import VFMacOpcodes._
+//
+//  // params alias
+//  private val dataWidth = cfg.destDataBits
+//  private val dataWidthOfDataModule = 64
+//  private val numVecModule = dataWidth / dataWidthOfDataModule
+//
+//  // io alias
+//  private val opcode: UInt = fuOpType
+//  private val resWiden  = isResWiden(opcode)
+//
+//  // modules
+//  private val vfmas = Seq.fill(numVecModule)(Module(new VectorFloatFMA))
+//  private val vs2Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+//  private val vs1Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+//  private val oldVdSplit  = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+//  private val mgu = Module(new Mgu(dataWidth))
+//
+//  /**
+//    * In connection of [[vs2Split]], [[vs1Split]] and [[oldVdSplit]]
+//    */
+//  vs2Split.io.inVecData := vs2
+//  vs1Split.io.inVecData := vs1
+//  oldVdSplit.io.inVecData := oldVd
+//
+//  /**
+//    * [[vfmas]]'s in connection
+//    */
+//  // Vec(vs2(31,0), vs2(63,32), vs2(95,64), vs2(127,96)) ==>
+//  // Vec(
+//  //   Cat(vs2(95,64),  vs2(31,0)),
+//  //   Cat(vs2(127,96), vs2(63,32)),
+//  // )
+//  private val vs2GroupedVec: Vec[UInt] = VecInit(vs2Split.io.outVec32b.zipWithIndex.groupBy(_._2 % 2).map(x => x._1 -> x._2.map(_._1)).values.map(x => Cat(x.reverse)).toSeq)
+//  private val vs1GroupedVec: Vec[UInt] = VecInit(vs1Split.io.outVec32b.zipWithIndex.groupBy(_._2 % 2).map(x => x._1 -> x._2.map(_._1)).values.map(x => Cat(x.reverse)).toSeq)
+//  private val resultData = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
+//  private val fflagsData = Wire(Vec(numVecModule, UInt(20.W)))
+//  val fp_aIsFpCanonicalNAN = Wire(Vec(numVecModule, Bool()))
+//  val fp_bIsFpCanonicalNAN = Wire(Vec(numVecModule, Bool()))
+//  val fp_cIsFpCanonicalNAN = Wire(Vec(numVecModule, Bool()))
+//  vfmas.zipWithIndex.foreach {
+//    case (mod, i) =>
+//      mod.io.fire         := io.in.valid
+//      mod.io.fp_a         := vs2Split.io.outVec64b(i)
+//      mod.io.fp_b         := vs1Split.io.outVec64b(i)
+//      mod.io.fp_c         := oldVdSplit.io.outVec64b(i)
+//      mod.io.widen_a      := Cat(vs2Split.io.outVec32b(i+numVecModule), vs2Split.io.outVec32b(i))
+//      mod.io.widen_b      := Cat(vs1Split.io.outVec32b(i+numVecModule), vs1Split.io.outVec32b(i))
+//      mod.io.frs1         := 0.U     // already vf -> vv
+//      mod.io.is_frs1      := false.B // already vf -> vv
+//      mod.io.uop_idx      := vuopIdx(0)
+//      mod.io.is_vec       := true.B // Todo
+//      mod.io.round_mode   := rm
+//      mod.io.fp_format    := Mux(resWiden, vsew + 1.U, vsew)
+//      mod.io.res_widening := resWiden
+//      mod.io.op_code      := opcode
+//      resultData(i) := mod.io.fpResult
+//      fflagsData(i) := mod.io.fflags
+//      fp_aIsFpCanonicalNAN(i) := vecCtrl.fpu.isFpToVecInst & (
+//        ((vsew === VSew.e32) & (!vs2Split.io.outVec64b(i).head(32).andR)) |
+//          ((vsew === VSew.e16) & (!vs2Split.io.outVec64b(i).head(48).andR))
+//        )
+//      fp_bIsFpCanonicalNAN(i) := vecCtrl.fpu.isFpToVecInst & (
+//        ((vsew === VSew.e32) & (!vs1Split.io.outVec64b(i).head(32).andR)) |
+//          ((vsew === VSew.e16) & (!vs1Split.io.outVec64b(i).head(48).andR))
+//        )
+//      fp_cIsFpCanonicalNAN(i) := !isFmul(opcode) & vecCtrl.fpu.isFpToVecInst & (
+//        ((vsew === VSew.e32) & (!oldVdSplit.io.outVec64b(i).head(32).andR)) |
+//          ((vsew === VSew.e16) & (!oldVdSplit.io.outVec64b(i).head(48).andR))
+//        )
+//      mod.io.fp_aIsFpCanonicalNAN := fp_aIsFpCanonicalNAN(i)
+//      mod.io.fp_bIsFpCanonicalNAN := fp_bIsFpCanonicalNAN(i)
+//      mod.io.fp_cIsFpCanonicalNAN := fp_cIsFpCanonicalNAN(i)
+//  }
+//
+//  val outFuOpType = outCtrl.fuOpType
+//  val outWiden = isResWiden(outCtrl.fuOpType)
+//  val outEew = Mux(outWiden, outVecCtrl.vsew + 1.U, outVecCtrl.vsew)
+//  val outVuopidx = outVecCtrl.vuopIdx(2, 0)
+//  val vlMax = ((VLEN / 8).U >> outEew).asUInt
+//  val outVlmulFix = Mux(outWiden, outVecCtrl.vlmul + 1.U, outVecCtrl.vlmul)
+//  val lmulAbs = Mux(outVlmulFix(2), (~outVlmulFix(1, 0)).asUInt + 1.U, outVlmulFix(1, 0))
+//  val outVlFix = Mux(outVecCtrl.fpu.isFpToVecInst, 1.U, outVl)
+//  val vlMaxAllUop = Wire(outVl.cloneType)
+//  vlMaxAllUop := Mux(outVecCtrl.vlmul(2), vlMax >> lmulAbs, vlMax << lmulAbs).asUInt
+//  val vlMaxThisUop = Mux(outVecCtrl.vlmul(2), vlMax >> lmulAbs, vlMax).asUInt
+//  val vlSetThisUop = Mux(outVlFix > outVuopidx * vlMaxThisUop, outVlFix - outVuopidx * vlMaxThisUop, 0.U)
+//  val vlThisUop = Wire(UInt(4.W))
+//  vlThisUop := Mux(vlSetThisUop < vlMaxThisUop, vlSetThisUop, vlMaxThisUop)
+//  val vlMaskRShift = Wire(UInt((4 * numVecModule).W))
+//  vlMaskRShift := Fill(4 * numVecModule, 1.U(1.W)) >> ((4 * numVecModule).U - vlThisUop)
+//
+//  private val needNoMask = outVecCtrl.fpu.isFpToVecInst
+//  val maskToMgu = Mux(needNoMask, allMaskTrue, outSrcMask)
+//  val allFFlagsEn = Wire(Vec(4 * numVecModule, Bool()))
+//  val outSrcMaskRShift = Wire(UInt((4 * numVecModule).W))
+//  outSrcMaskRShift := (maskToMgu >> (outVecCtrl.vuopIdx(2, 0) * vlMax))(4 * numVecModule - 1, 0)
+//  val f16FFlagsEn = outSrcMaskRShift
+//  val f32FFlagsEn = Wire(Vec(numVecModule, UInt(4.W)))
+//  val f64FFlagsEn = Wire(Vec(numVecModule, UInt(4.W)))
+//  val f16VlMaskEn = vlMaskRShift
+//  val f32VlMaskEn = Wire(Vec(numVecModule, UInt(4.W)))
+//  val f64VlMaskEn = Wire(Vec(numVecModule, UInt(4.W)))
+//  for (i <- 0 until numVecModule) {
+//    f32FFlagsEn(i) := Cat(Fill(2, 0.U), outSrcMaskRShift(2 * i + 1, 2 * i))
+//    f64FFlagsEn(i) := Cat(Fill(3, 0.U), outSrcMaskRShift(i))
+//    f32VlMaskEn(i) := Cat(Fill(2, 0.U), vlMaskRShift(2 * i + 1, 2 * i))
+//    f64VlMaskEn(i) := Cat(Fill(3, 0.U), vlMaskRShift(i))
+//  }
+//  val fflagsEn = Mux1H(
+//    Seq(
+//      (outEew === 1.U) -> f16FFlagsEn.asUInt,
+//      (outEew === 2.U) -> f32FFlagsEn.asUInt,
+//      (outEew === 3.U) -> f64FFlagsEn.asUInt
+//    )
+//  )
+//  val vlMaskEn = Mux1H(
+//    Seq(
+//      (outEew === 1.U) -> f16VlMaskEn.asUInt,
+//      (outEew === 2.U) -> f32VlMaskEn.asUInt,
+//      (outEew === 3.U) -> f64VlMaskEn.asUInt
+//    )
+//  )
+//  allFFlagsEn := (fflagsEn & vlMaskEn).asTypeOf(allFFlagsEn)
+//
+//  val allFFlags = fflagsData.asTypeOf(Vec(4 * numVecModule, UInt(5.W)))
+//  val outFFlags = allFFlagsEn.zip(allFFlags).map {
+//    case (en, fflags) => Mux(en, fflags, 0.U(5.W))
+//  }.reduce(_ | _)
+//  io.out.bits.res.fflags.get := outFFlags
+//
+//  val resultDataUInt = resultData.asUInt
+//  mgu.io.in.vd := resultDataUInt
+//  mgu.io.in.oldVd := outOldVd
+//  mgu.io.in.mask := maskToMgu
+//  mgu.io.in.info.ta := outVecCtrl.vta
+//  mgu.io.in.info.ma := outVecCtrl.vma
+//  mgu.io.in.info.vl := Mux(outVecCtrl.fpu.isFpToVecInst, 1.U, outVl)
+//  mgu.io.in.info.vlmul := outVecCtrl.vlmul
+//  mgu.io.in.info.valid := io.out.valid
+//  mgu.io.in.info.vstart := Mux(outVecCtrl.fpu.isFpToVecInst, 0.U, outVecCtrl.vstart)
+//  mgu.io.in.info.eew := outEew
+//  mgu.io.in.info.vsew := outVecCtrl.vsew
+//  mgu.io.in.info.vdIdx := outVecCtrl.vuopIdx
+//  mgu.io.in.info.narrow := outVecCtrl.isNarrow
+//  mgu.io.in.info.dstMask := outVecCtrl.isDstMask
+//  mgu.io.in.isIndexedVls := false.B
+//  io.out.bits.res.data := mgu.io.out.vd
+//  io.out.bits.ctrl.exceptionVec(ExceptionNO.illegalInstr) := mgu.io.out.illegal
+//}

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFMacWrapper.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFMacWrapper.scala
@@ -1,123 +1,123 @@
-package xiangshan.backend.fu.wrapper
-
-import chisel3._
-import chisel3.util._
-import org.chipsalliance.cde.config.Parameters
-import xiangshan.backend.decode.opcode.Opcode.VFMacOpcodes
-import xiangshan.backend.fu.vector.utils.VecDataSplitModule
-import xiangshan.backend.vector.fu.Func._
-import xiangshan.backend.vector.fu.{VecFixLatFunc, VecFuConfig}
-import yunsuan.vector.Common.VSew
-import yunsuan.vector.VectorFMA.VectorFMA
-
-class VFMacWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFunc(cfg) {
-
-  private val dataWidth = cfg.destDataBits
-  private val dataWidthOfDataModule = 64
-  private val numVecModule = dataWidth / dataWidthOfDataModule
-
-  private val vs2Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
-  private val vs1Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
-  private val oldVdSplit = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
-  private val vfmas = Seq.fill(numVecModule)(Module(new VectorFMA))
-
-  private val ex0NextOpcode = ex0Next.bits.ctrl.opcode
-  private val ex0NextSew = VFMacOpcodes.getFormat(ex0NextOpcode)
-  private val ex0VfmaInfo = ex0data.vfma.get
-
-  private val sel16 = makePipeReg(ex0NextSew === VSew.e16, pipeRegValids)
-  private val sel32 = makePipeReg(ex0NextSew === VSew.e32, pipeRegValids)
-  private val sel64 = makePipeReg(ex0NextSew === VSew.e64, pipeRegValids)
-  private val isWiden    = makePipeReg(VFMacOpcodes.isResWiden (ex0NextOpcode), pipeRegValids)
-  private val isVfmul    = makePipeReg(VFMacOpcodes.isFmul     (ex0NextOpcode), pipeRegValids)
-  private val isVfmacc   = makePipeReg(VFMacOpcodes.isFmacc    (ex0NextOpcode), pipeRegValids)
-  private val isVfnmacc  = makePipeReg(VFMacOpcodes.isFnmacc   (ex0NextOpcode), pipeRegValids)
-  private val isVfmsac   = makePipeReg(VFMacOpcodes.isFmsac    (ex0NextOpcode), pipeRegValids)
-  private val isVfnmsac  = makePipeReg(VFMacOpcodes.isFnmsac   (ex0NextOpcode), pipeRegValids)
-  private val isVfmadd   = makePipeReg(VFMacOpcodes.isFmadd    (ex0NextOpcode), pipeRegValids)
-  private val isVfnmadd  = makePipeReg(VFMacOpcodes.isFnmadd   (ex0NextOpcode), pipeRegValids)
-  private val isVfmsub   = makePipeReg(VFMacOpcodes.isFmsub    (ex0NextOpcode), pipeRegValids)
-  private val isVfnmsub  = makePipeReg(VFMacOpcodes.isFnmsub   (ex0NextOpcode), pipeRegValids)
-
-  private val ex0frm = in.frm.get
-
-  vs2Split.io.inVecData := ex0vs2
-  vs1Split.io.inVecData := ex0vs1
-  oldVdSplit.io.inVecData := ex0oldVd
-
-  private val vs2Vec = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
-  private val vs1Vec = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
-  private val oldVdVec = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
-  private val vs2WidenVec = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
-  private val vs1WidenVec = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
-
-  for (i <- 0 until numVecModule) {
-    vs2Vec(i) := vs2Split.io.outVec64b(i)
-    vs1Vec(i) := vs1Split.io.outVec64b(i)
-    oldVdVec(i) := oldVdSplit.io.outVec64b(i)
-    vs2WidenVec(i) := Mux(ex0uopIdx(0), vs2Split.io.outVec32b(i + numVecModule), vs2Split.io.outVec32b(i)).pad(dataWidthOfDataModule)
-    vs1WidenVec(i) := Mux(ex0uopIdx(0), vs1Split.io.outVec32b(i + numVecModule), vs1Split.io.outVec32b(i)).pad(dataWidthOfDataModule)
-  }
-
-  vfmas.zipWithIndex.foreach {
-    case (mod, i) =>
-      mod.in.ex0.valid := ex(0).valid
-      mod.in.ex1Valid := ex(1).valid
-      mod.in.ex2Valid := ex(2).valid
-      mod.in.ex0.bits.ctrl.isVfmul := isVfmul.ex0
-      mod.in.ex0.bits.ctrl.isVfmacc := isVfmacc.ex0
-      mod.in.ex0.bits.ctrl.isVfnmacc := isVfnmacc.ex0
-      mod.in.ex0.bits.ctrl.isVfmsac := isVfmsac.ex0
-      mod.in.ex0.bits.ctrl.isVfnmsac := isVfnmsac.ex0
-      mod.in.ex0.bits.ctrl.isVfmadd := isVfmadd.ex0
-      mod.in.ex0.bits.ctrl.isVfnmadd := isVfnmadd.ex0
-      mod.in.ex0.bits.ctrl.isVfmsub := isVfmsub.ex0
-      mod.in.ex0.bits.ctrl.isVfnmsub := isVfnmsub.ex0
-      mod.in.ex0.bits.ctrl.round_mode := ex0frm
-      mod.in.ex0.bits.ctrl.sel16 := sel16.ex0
-      mod.in.ex0.bits.ctrl.sel32 := sel32.ex0
-      mod.in.ex0.bits.ctrl.sel64 := sel64.ex0
-      mod.in.ex0.bits.ctrl.res_widening := isWiden.ex0
-
-      mod.in.ex0.bits.data.fp_a := vs2Vec(i)
-      mod.in.ex0.bits.data.fp_b := vs1Vec(i)
-      mod.in.ex0.bits.data.fp_c := oldVdVec(i)
-      mod.in.ex0.bits.data.widen_a := vs2WidenVec(i)
-      mod.in.ex0.bits.data.widen_b := vs1WidenVec(i)
-      mod.in.ex0.bits.data.fp_aIsFpCanonicalNAN := ex0VfmaInfo.fpAIsFpCanonicalNAN(i)
-      mod.in.ex0.bits.data.fp_bIsFpCanonicalNAN := ex0VfmaInfo.fpBIsFpCanonicalNAN(i)
-      mod.in.ex0.bits.data.fp_cIsFpCanonicalNAN := ex0VfmaInfo.fpCIsFpCanonicalNAN(i)
-  }
-
-  out.ex.indices.filterNot(stageIdx => stageIdx == 3).foreach { stageIdx =>
-    out.ex(stageIdx).bits.data.vec.foreach {
-      case vecData =>
-        vecData.normal := 0.U.asTypeOf(vecData.normal)
-        vecData.narrow := 0.U.asTypeOf(vecData.narrow)
-        vecData.maskE8 := 0.U.asTypeOf(vecData.maskE8)
-        vecData.maskE16 := 0.U.asTypeOf(vecData.maskE16)
-        vecData.maskE32 := 0.U.asTypeOf(vecData.maskE32)
-        vecData.maskE64 := 0.U.asTypeOf(vecData.maskE64)
-        vecData.isWiden.get := isWiden.ex(stageIdx)
-        vecData.vxsatE8.foreach(_ := 0.U.asTypeOf(vecData.vxsatE8.get))
-        vecData.narrowVxsatE8.foreach(_ := 0.U.asTypeOf(vecData.narrowVxsatE8.get))
-        vecData.fflagsE8.foreach(_ := 0.U.asTypeOf(vecData.fflagsE8.get))
-        vecData.narrowFflagsE8.foreach(_ := 0.U.asTypeOf(vecData.narrowFflagsE8.get))
-    }
-  }
-
-  out.ex(3).bits.data.vec.foreach {
-    case vecData =>
-      vecData.normal := Cat(vfmas.map(_.out.fp_result).reverse)
-      vecData.narrow := 0.U.asTypeOf(vecData.narrow)
-      vecData.maskE8 := 0.U.asTypeOf(vecData.maskE8)
-      vecData.maskE16 := 0.U.asTypeOf(vecData.maskE16)
-      vecData.maskE32 := 0.U.asTypeOf(vecData.maskE32)
-      vecData.maskE64 := 0.U.asTypeOf(vecData.maskE64)
-      vecData.isWiden.get := isWiden.ex3
-      vecData.vxsatE8.foreach(_ := 0.U.asTypeOf(vecData.vxsatE8.get))
-      vecData.narrowVxsatE8.foreach(_ := 0.U.asTypeOf(vecData.narrowVxsatE8.get))
-      vecData.fflagsE8.foreach(_ := VecInit(vfmas.flatMap(_.out.fflags)))
-      vecData.narrowFflagsE8.foreach(_ := 0.U.asTypeOf(vecData.narrowFflagsE8.get))
-  }
-}
+//package xiangshan.backend.fu.wrapper
+//
+//import chisel3._
+//import chisel3.util._
+//import org.chipsalliance.cde.config.Parameters
+//import xiangshan.backend.decode.opcode.Opcode.VFMacOpcodes
+//import xiangshan.backend.fu.vector.utils.VecDataSplitModule
+//import xiangshan.backend.vector.fu.Func._
+//import xiangshan.backend.vector.fu.{VecFixLatFunc, VecFuConfig}
+//import yunsuan.vector.Common.VSew
+//import yunsuan.vector.VectorFMA.VectorFMA
+//
+//class VFMacWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFunc(cfg) {
+//
+//  private val dataWidth = cfg.destDataBits
+//  private val dataWidthOfDataModule = 64
+//  private val numVecModule = dataWidth / dataWidthOfDataModule
+//
+//  private val vs2Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+//  private val vs1Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+//  private val oldVdSplit = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+//  private val vfmas = Seq.fill(numVecModule)(Module(new VectorFMA))
+//
+//  private val ex0NextOpcode = ex0Next.bits.ctrl.opcode
+//  private val ex0NextSew = VFMacOpcodes.getFormat(ex0NextOpcode)
+//  private val ex0VfmaInfo = ex0data.vfmul.get
+//
+//  private val sel16 = makePipeReg(ex0NextSew === VSew.e16, pipeRegValids)
+//  private val sel32 = makePipeReg(ex0NextSew === VSew.e32, pipeRegValids)
+//  private val sel64 = makePipeReg(ex0NextSew === VSew.e64, pipeRegValids)
+//  private val isWiden    = makePipeReg(VFMacOpcodes.isResWiden (ex0NextOpcode), pipeRegValids)
+//  private val isVfmul    = makePipeReg(VFMacOpcodes.isFmul     (ex0NextOpcode), pipeRegValids)
+//  private val isVfmacc   = makePipeReg(VFMacOpcodes.isFmacc    (ex0NextOpcode), pipeRegValids)
+//  private val isVfnmacc  = makePipeReg(VFMacOpcodes.isFnmacc   (ex0NextOpcode), pipeRegValids)
+//  private val isVfmsac   = makePipeReg(VFMacOpcodes.isFmsac    (ex0NextOpcode), pipeRegValids)
+//  private val isVfnmsac  = makePipeReg(VFMacOpcodes.isFnmsac   (ex0NextOpcode), pipeRegValids)
+//  private val isVfmadd   = makePipeReg(VFMacOpcodes.isFmadd    (ex0NextOpcode), pipeRegValids)
+//  private val isVfnmadd  = makePipeReg(VFMacOpcodes.isFnmadd   (ex0NextOpcode), pipeRegValids)
+//  private val isVfmsub   = makePipeReg(VFMacOpcodes.isFmsub    (ex0NextOpcode), pipeRegValids)
+//  private val isVfnmsub  = makePipeReg(VFMacOpcodes.isFnmsub   (ex0NextOpcode), pipeRegValids)
+//
+//  private val ex0frm = in.frm.get
+//
+//  vs2Split.io.inVecData := ex0vs2
+//  vs1Split.io.inVecData := ex0vs1
+//  oldVdSplit.io.inVecData := ex0oldVd
+//
+//  private val vs2Vec = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
+//  private val vs1Vec = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
+//  private val oldVdVec = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
+//  private val vs2WidenVec = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
+//  private val vs1WidenVec = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
+//
+//  for (i <- 0 until numVecModule) {
+//    vs2Vec(i) := vs2Split.io.outVec64b(i)
+//    vs1Vec(i) := vs1Split.io.outVec64b(i)
+//    oldVdVec(i) := oldVdSplit.io.outVec64b(i)
+//    vs2WidenVec(i) := Mux(ex0uopIdx(0), vs2Split.io.outVec32b(i + numVecModule), vs2Split.io.outVec32b(i)).pad(dataWidthOfDataModule)
+//    vs1WidenVec(i) := Mux(ex0uopIdx(0), vs1Split.io.outVec32b(i + numVecModule), vs1Split.io.outVec32b(i)).pad(dataWidthOfDataModule)
+//  }
+//
+//  vfmas.zipWithIndex.foreach {
+//    case (mod, i) =>
+//      mod.in.ex0.valid := ex(0).valid
+//      mod.in.ex1Valid := ex(1).valid
+//      mod.in.ex2Valid := ex(2).valid
+//      mod.in.ex0.bits.ctrl.isVfmul := isVfmul.ex0
+//      mod.in.ex0.bits.ctrl.isVfmacc := isVfmacc.ex0
+//      mod.in.ex0.bits.ctrl.isVfnmacc := isVfnmacc.ex0
+//      mod.in.ex0.bits.ctrl.isVfmsac := isVfmsac.ex0
+//      mod.in.ex0.bits.ctrl.isVfnmsac := isVfnmsac.ex0
+//      mod.in.ex0.bits.ctrl.isVfmadd := isVfmadd.ex0
+//      mod.in.ex0.bits.ctrl.isVfnmadd := isVfnmadd.ex0
+//      mod.in.ex0.bits.ctrl.isVfmsub := isVfmsub.ex0
+//      mod.in.ex0.bits.ctrl.isVfnmsub := isVfnmsub.ex0
+//      mod.in.ex0.bits.ctrl.round_mode := ex0frm
+//      mod.in.ex0.bits.ctrl.sel16 := sel16.ex0
+//      mod.in.ex0.bits.ctrl.sel32 := sel32.ex0
+//      mod.in.ex0.bits.ctrl.sel64 := sel64.ex0
+//      mod.in.ex0.bits.ctrl.res_widening := isWiden.ex0
+//
+//      mod.in.ex0.bits.data.fp_a := vs2Vec(i)
+//      mod.in.ex0.bits.data.fp_b := vs1Vec(i)
+//      mod.in.ex0.bits.data.fp_c := oldVdVec(i)
+//      mod.in.ex0.bits.data.widen_a := vs2WidenVec(i)
+//      mod.in.ex0.bits.data.widen_b := vs1WidenVec(i)
+//      mod.in.ex0.bits.data.fp_aIsFpCanonicalNAN := ex0VfmaInfo.fpAIsFpCanonicalNAN(i)
+//      mod.in.ex0.bits.data.fp_bIsFpCanonicalNAN := ex0VfmaInfo.fpBIsFpCanonicalNAN(i)
+//      mod.in.ex0.bits.data.fp_cIsFpCanonicalNAN := ex0VfmaInfo.fpCIsFpCanonicalNAN(i)
+//  }
+//
+//  out.ex.indices.filterNot(stageIdx => stageIdx == 3).foreach { stageIdx =>
+//    out.ex(stageIdx).bits.data.vec.foreach {
+//      case vecData =>
+//        vecData.normal := 0.U.asTypeOf(vecData.normal)
+//        vecData.narrow := 0.U.asTypeOf(vecData.narrow)
+//        vecData.maskE8 := 0.U.asTypeOf(vecData.maskE8)
+//        vecData.maskE16 := 0.U.asTypeOf(vecData.maskE16)
+//        vecData.maskE32 := 0.U.asTypeOf(vecData.maskE32)
+//        vecData.maskE64 := 0.U.asTypeOf(vecData.maskE64)
+//        vecData.isWiden.get := isWiden.ex(stageIdx)
+//        vecData.vxsatE8.foreach(_ := 0.U.asTypeOf(vecData.vxsatE8.get))
+//        vecData.narrowVxsatE8.foreach(_ := 0.U.asTypeOf(vecData.narrowVxsatE8.get))
+//        vecData.fflagsE8.foreach(_ := 0.U.asTypeOf(vecData.fflagsE8.get))
+//        vecData.narrowFflagsE8.foreach(_ := 0.U.asTypeOf(vecData.narrowFflagsE8.get))
+//    }
+//  }
+//
+//  out.ex(3).bits.data.vec.foreach {
+//    case vecData =>
+//      vecData.normal := Cat(vfmas.map(_.out.fpResult).reverse)
+//      vecData.narrow := 0.U.asTypeOf(vecData.narrow)
+//      vecData.maskE8 := 0.U.asTypeOf(vecData.maskE8)
+//      vecData.maskE16 := 0.U.asTypeOf(vecData.maskE16)
+//      vecData.maskE32 := 0.U.asTypeOf(vecData.maskE32)
+//      vecData.maskE64 := 0.U.asTypeOf(vecData.maskE64)
+//      vecData.isWiden.get := isWiden.ex3
+//      vecData.vxsatE8.foreach(_ := 0.U.asTypeOf(vecData.vxsatE8.get))
+//      vecData.narrowVxsatE8.foreach(_ := 0.U.asTypeOf(vecData.narrowVxsatE8.get))
+//      vecData.fflagsE8.foreach(_ := VecInit(vfmas.flatMap(_.out.fflags)))
+//      vecData.narrowFflagsE8.foreach(_ := 0.U.asTypeOf(vecData.narrowFflagsE8.get))
+//  }
+//}

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFMulWrapper.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFMulWrapper.scala
@@ -1,0 +1,102 @@
+package xiangshan.backend.fu.wrapper
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+import xiangshan._
+import xiangshan.backend.decode.opcode.Opcode.VFMacOpcodes
+import xiangshan.backend.decode.opcode.Opcode.VFMacOpcodes.isFmul
+import xiangshan.backend.fu.vector.Bundles.VSew
+import xiangshan.backend.fu.vector.utils.VecDataSplitModule
+import xiangshan.backend.vector.fu.Func._
+import xiangshan.backend.vector.fu.{VecFixLatFunc, VecFuConfig}
+import yunsuan.vector.Common.{Fflags, VSew}
+import yunsuan.vector.vfmul.{VectorFMUL, VFMul2VFALUOutput}
+import yunsuan.vector.vfmul.utils.VFAlgoUtils
+
+class VFMulWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFunc(cfg) {
+
+  private val dataWidth = cfg.destDataBits
+  private val dataWidthOfDataModule = 64
+  private val numVecModule = dataWidth / dataWidthOfDataModule
+  private val normalLatency = 2
+  require(cfg.latency >= normalLatency)
+
+  private val vlenb = VLEN / 8
+  private val zeroFflags = 0.U.asTypeOf(Fflags())
+  private val zeroFflagsE8 = VecInit(Seq.fill(vlenb)(zeroFflags))
+  private val zeroNarrowFflagsE8 = VecInit(Seq.fill(vlenb / 2)(zeroFflags))
+
+  private val ex0opcode = fuOpType
+  private val ex0NextOpcode = ex0Next.bits.ctrl.opcode
+  private val ex0vsew = ex0ctrl.vtype.get.vsew
+  private val isFmul = makePipeReg(VFMacOpcodes.isFmul(ex0NextOpcode), pipeRegValids)
+  private val isOP3 = makePipeReg(VFMacOpcodes.isOP3(ex0NextOpcode), pipeRegValids)
+//  private val resSew = Wire(Vec(normalLatency + 1, UInt(ex0vsew.getWidth.W)))
+
+//  for (i <- 0 to cfg.latency) {
+//    resSew(i) := ex(i).bits.ctrl.vtype.get.vsew
+//  }
+
+  private val vfmuls = Seq.fill(numVecModule)(Module(new VectorFMUL)) // WARNING: Don't change this module. MUST USE VectorFloatMultiplier
+  val toVfalu = IO(Output(Valid(Vec(numVecModule, new VFMul2VFALUOutput))))
+
+  private val vs2Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+  private val vs1Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+  private val oldVdSplit = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+
+  vs2Split.io.inVecData := ex0vs2
+  vs1Split.io.inVecData := ex0vs1
+  oldVdSplit.io.inVecData := ex0oldVd
+
+  private val resultData = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
+  private val fflagsData = Wire(Vec(numVecModule, Vec(vlenb / numVecModule, Fflags())))
+
+//  val outToFaluFromFmul = out.outToVfaluFromVfmul.get
+
+  vfmuls.zipWithIndex.foreach {
+    case (mod, i) =>
+      mod.io.fire             := ex(0).valid
+      mod.io.in.isFMUL        := isFmul.ex0
+      mod.io.in.isNeg         := false.B
+      mod.io.in.fp_fmt        := VFMacOpcodes.getDataType(ex0opcode)
+      mod.io.in.fp_a          := vs2Split.io.outVec64b(i)
+      mod.io.in.fp_b          := vs1Split.io.outVec64b(i)
+      mod.io.in.round_mode    := frm
+
+      toVfalu.bits(i) := mod.io.outToFADD
+
+      resultData(i) := mod.io.out.fpResult
+      fflagsData(i) := mod.io.out.fflagsVec
+  }
+  toVfalu.valid := ex(1).valid
+
+  private def zeroVecData(vecData: VecSpecialData): Unit = {
+    vecData.normal := 0.U
+    vecData.narrow := 0.U
+    vecData.maskE8 := 0.U
+    vecData.maskE16 := 0.U
+    vecData.maskE32 := 0.U
+    vecData.maskE64 := 0.U
+    vecData.isWiden.foreach(_ := false.B)
+    vecData.isNarrow.foreach(_ := false.B)
+    vecData.vxsatE8.foreach(_ := 0.U.asTypeOf(vecData.vxsatE8.get))
+    vecData.narrowVxsatE8.foreach(_ := 0.U.asTypeOf(vecData.narrowVxsatE8.get))
+    vecData.fflagsE8.foreach(_ := zeroFflagsE8)
+    vecData.narrowFflagsE8.foreach(_ := zeroNarrowFflagsE8)
+  }
+
+  for (i <- 0 to cfg.latency) {
+    out.ex(i).bits.data.vec.foreach(zeroVecData)
+  }
+
+  out.ex(normalLatency).bits.data.vec.foreach { vecData =>
+    vecData.normal := Cat(resultData.reverse)
+    vecData.fflagsE8.get := fflagsData.asTypeOf(Vec(vlenb, Fflags()))
+  }
+
+  out.ex(normalLatency).valid := ex(normalLatency).valid &&
+    ex(normalLatency).bits.ctrl.latency === normalLatency.U &&
+    isFmul.ex(normalLatency)
+
+}

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFMulWrapper.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFMulWrapper.scala
@@ -32,6 +32,12 @@ class VFMulWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFu
   private val ex0vsew = ex0ctrl.vtype.get.vsew
   private val isFmul = makePipeReg(VFMacOpcodes.isFmul(ex0NextOpcode), pipeRegValids)
   private val isOP3 = makePipeReg(VFMacOpcodes.isOP3(ex0NextOpcode), pipeRegValids)
+  private val op3MulUsesOldVd =
+    VFMacOpcodes.isFmadd(ex0opcode) || VFMacOpcodes.isFnmadd(ex0opcode) ||
+    VFMacOpcodes.isFmsub(ex0opcode) || VFMacOpcodes.isFnmsub(ex0opcode)
+  private val op3NegProduct =
+    VFMacOpcodes.isFnmadd(ex0opcode) || VFMacOpcodes.isFnmsub(ex0opcode) ||
+    VFMacOpcodes.isFnmacc(ex0opcode) || VFMacOpcodes.isFnmsac(ex0opcode)
 //  private val resSew = Wire(Vec(normalLatency + 1, UInt(ex0vsew.getWidth.W)))
 
 //  for (i <- 0 to cfg.latency) {
@@ -52,16 +58,14 @@ class VFMulWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFu
   private val resultData = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
   private val fflagsData = Wire(Vec(numVecModule, Vec(vlenb / numVecModule, Fflags())))
 
-//  val outToFaluFromFmul = out.outToVfaluFromVfmul.get
-
   vfmuls.zipWithIndex.foreach {
     case (mod, i) =>
       mod.io.fire             := ex(0).valid
       mod.io.in.isFMUL        := isFmul.ex0
-      mod.io.in.isNeg         := false.B
+      mod.io.in.isNeg         := op3NegProduct
       mod.io.in.fp_fmt        := VFMacOpcodes.getDataType(ex0opcode)
-      mod.io.in.fp_a          := vs2Split.io.outVec64b(i)
-      mod.io.in.fp_b          := vs1Split.io.outVec64b(i)
+      mod.io.in.fp_a          := vs1Split.io.outVec64b(i)
+      mod.io.in.fp_b          := Mux(op3MulUsesOldVd, oldVdSplit.io.outVec64b(i), vs2Split.io.outVec64b(i))
       mod.io.in.round_mode    := frm
 
       toVfalu.bits(i) := mod.io.outToFADD
@@ -69,7 +73,9 @@ class VFMulWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFu
       resultData(i) := mod.io.out.fpResult
       fflagsData(i) := mod.io.out.fflagsVec
   }
-  toVfalu.valid := ex(1).valid
+  // VectorFMUL S1 is the unrounded product consumed by the vector adder.
+  // OP2 multiplication must never enter this path.
+  toVfalu.valid := ex(1).valid && isOP3.ex(1)
 
   private def zeroVecData(vecData: VecSpecialData): Unit = {
     vecData.normal := 0.U

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VFMulWrapper.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VFMulWrapper.scala
@@ -27,33 +27,26 @@ class VFMulWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFu
   private val zeroFflagsE8 = VecInit(Seq.fill(vlenb)(zeroFflags))
   private val zeroNarrowFflagsE8 = VecInit(Seq.fill(vlenb / 2)(zeroFflags))
 
-  private val ex0opcode = fuOpType
   private val ex0NextOpcode = ex0Next.bits.ctrl.opcode
-  private val ex0vsew = ex0ctrl.vtype.get.vsew
   private val isFmul = makePipeReg(VFMacOpcodes.isFmul(ex0NextOpcode), pipeRegValids)
   private val isOP3 = makePipeReg(VFMacOpcodes.isOP3(ex0NextOpcode), pipeRegValids)
-  private val op3MulUsesOldVd =
-    VFMacOpcodes.isFmadd(ex0opcode) || VFMacOpcodes.isFnmadd(ex0opcode) ||
-    VFMacOpcodes.isFmsub(ex0opcode) || VFMacOpcodes.isFnmsub(ex0opcode)
-  private val op3NegProduct =
-    VFMacOpcodes.isFnmadd(ex0opcode) || VFMacOpcodes.isFnmsub(ex0opcode) ||
-    VFMacOpcodes.isFnmacc(ex0opcode) || VFMacOpcodes.isFnmsac(ex0opcode)
-//  private val resSew = Wire(Vec(normalLatency + 1, UInt(ex0vsew.getWidth.W)))
-
-//  for (i <- 0 to cfg.latency) {
-//    resSew(i) := ex(i).bits.ctrl.vtype.get.vsew
-//  }
+  private val dataType = makePipeReg(VFMacOpcodes.getDataType(ex0NextOpcode), pipeRegValids)
+  private val op3MulUsesOldVd = VFMacOpcodes.isFmadd(ex0NextOpcode) || VFMacOpcodes.isFnmadd(ex0NextOpcode) ||
+    VFMacOpcodes.isFmsub(ex0NextOpcode) || VFMacOpcodes.isFnmsub(ex0NextOpcode)
+  private val op3NegProduct = makePipeReg(
+    VFMacOpcodes.isFnmadd(ex0NextOpcode) || VFMacOpcodes.isFnmsub(ex0NextOpcode) ||
+      VFMacOpcodes.isFnmacc(ex0NextOpcode) || VFMacOpcodes.isFnmsac(ex0NextOpcode),
+    pipeRegValids)
 
   private val vfmuls = Seq.fill(numVecModule)(Module(new VectorFMUL)) // WARNING: Don't change this module. MUST USE VectorFloatMultiplier
   val toVfalu = IO(Output(Valid(Vec(numVecModule, new VFMul2VFALUOutput))))
 
-  private val vs2Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
   private val vs1Split = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
-  private val oldVdSplit = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
+  private val fpBSplit = Module(new VecDataSplitModule(dataWidth, dataWidthOfDataModule))
 
-  vs2Split.io.inVecData := ex0vs2
+  private val fpBIn = makePipeReg(Mux(op3MulUsesOldVd, ex0NextOldVd, ex0NextVs2), pipeRegValids)
   vs1Split.io.inVecData := ex0vs1
-  oldVdSplit.io.inVecData := ex0oldVd
+  fpBSplit.io.inVecData := fpBIn.ex0
 
   private val resultData = Wire(Vec(numVecModule, UInt(dataWidthOfDataModule.W)))
   private val fflagsData = Wire(Vec(numVecModule, Vec(vlenb / numVecModule, Fflags())))
@@ -62,10 +55,10 @@ class VFMulWrapper(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFu
     case (mod, i) =>
       mod.io.fire             := ex(0).valid
       mod.io.in.isFMUL        := isFmul.ex0
-      mod.io.in.isNeg         := op3NegProduct
-      mod.io.in.fp_fmt        := VFMacOpcodes.getDataType(ex0opcode)
+      mod.io.in.isNeg         := op3NegProduct.ex0
+      mod.io.in.fp_fmt        := dataType.ex0
       mod.io.in.fp_a          := vs1Split.io.outVec64b(i)
-      mod.io.in.fp_b          := Mux(op3MulUsesOldVd, oldVdSplit.io.outVec64b(i), vs2Split.io.outVec64b(i))
+      mod.io.in.fp_b          := fpBSplit.io.outVec64b(i)
       mod.io.in.round_mode    := frm
 
       toVfalu.bits(i) := mod.io.outToFADD

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VPPU.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VPPU.scala
@@ -51,7 +51,6 @@ class VPPU(cfg: FuConfig)(implicit p: Parameters) extends VecPipedFuncUnit(cfg) 
     */
   typeMod.io.in.fuOpType := fuOpType
   typeMod.io.in.vsew := vsew
-  typeMod.io.in.isReverse := isReverse
   typeMod.io.in.isExt := isExt
   typeMod.io.in.isDstMask := vecCtrl.isDstMask
   typeMod.io.in.isMove := isMove

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1378,7 +1378,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   XSPerfAccumulate("waitAtmCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.mou.U)
 
   XSPerfAccumulate("waitVfaluCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.vfalu.U)
-  XSPerfAccumulate("waitVfmaCycle" , deqNotWritebacked && deqHeadInfoFuType === FuType.vfma.U)
+  XSPerfAccumulate("waitVfmulCycle" , deqNotWritebacked && deqHeadInfoFuType === FuType.vfmul.U)
   XSPerfAccumulate("waitVfdivCycle", deqNotWritebacked && deqHeadInfoFuType === FuType.vfdiv.U)
 
   val vfalufuop = Seq() // Todo: vector pma

--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeChannels.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeChannels.scala
@@ -392,19 +392,23 @@ object DecodeChannelOutput {
 
   def fromVecChannelUop(vuop: VecDecodeChannelOutputUop): DecodeChannelOutput = {
     val uop = Wire(new DecodeChannelOutput)
+    // VFALU can reverse its inputs after register-file reads. Keeping the
+    // scalar in src1 is required because only that issue port reads FPRs.
+    val reverseVfalu = vuop.src12Rev && vuop.fuType === FuType.vfalu.U
+    val swapSrc12 = vuop.src12Rev && !reverseVfalu
 
     uop.fuType := vuop.fuType
     uop.opcode := vuop.opcode
     uop.isVset := vuop.isVset
 
-    uop.src1Ren := Mux(vuop.src12Rev, vuop.renameInfo.src2Ren, vuop.renameInfo.src1Ren)
-    uop.src1Type := Mux(vuop.src12Rev, vuop.renameInfo.src2Type, vuop.renameInfo.src1Type)
-    uop.src2Ren := Mux(vuop.src12Rev, vuop.renameInfo.src1Ren,vuop.renameInfo.src2Ren)
-    uop.src2Type := Mux(vuop.src12Rev, vuop.renameInfo.src1Type,vuop.renameInfo.src2Type)
+    uop.src1Ren := Mux(swapSrc12, vuop.renameInfo.src2Ren, vuop.renameInfo.src1Ren)
+    uop.src1Type := Mux(swapSrc12, vuop.renameInfo.src2Type, vuop.renameInfo.src1Type)
+    uop.src2Ren := Mux(swapSrc12, vuop.renameInfo.src1Ren,vuop.renameInfo.src2Ren)
+    uop.src2Type := Mux(swapSrc12, vuop.renameInfo.src1Type,vuop.renameInfo.src2Type)
     uop.src3Ren := vuop.renameInfo.readVdAsSrc || vuop.vdDepElim =/= VdDepElim.Always
     uop.src3Type.value := DecodeSrcType.VP
-    uop.lsrc1 := Mux(vuop.src12Rev, vuop.src.src2, vuop.src.src1)
-    uop.lsrc2 := Mux(vuop.src12Rev, vuop.src.src1, vuop.src.src2)
+    uop.lsrc1 := Mux(swapSrc12, vuop.src.src2, vuop.src.src1)
+    uop.lsrc2 := Mux(swapSrc12, vuop.src.src1, vuop.src.src2)
     uop.lsrc3 := vuop.src.dest
     uop.vlRen := vuop.renameInfo.vlRen
     uop.v0Ren := vuop.v0Ren
@@ -441,7 +445,7 @@ object DecodeChannelOutput {
     uop.uopIdx := vuop.uopIdx
     uop.isFirstUop := vuop.isFirstUop
     uop.isLastUop := vuop.isLastUop
-    uop.src12Rev := vuop.src12Rev
+    uop.src12Rev := reverseVfalu
 
     uop.isJR := false.B
     uop.isJ := false.B

--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeFields/VecDecodeChannel/FuTypeField.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeFields/VecDecodeChannel/FuTypeField.scala
@@ -73,7 +73,8 @@ object FuTypeField {
       case _: Opcode.FDivOpcodes.type => FuType.fDivSqrt
       case _: Opcode.FCvtOpcodes.type => FuType.fcvt
       case _: Opcode.FMiscOpcodes.type => FuType.fcmp
-      case _: Opcode.VFMacOpcodes.type => FuType.vfma
+      case _: Opcode.VFAluOpcodes.type => FuType.vfalu
+      case _: Opcode.VFMacOpcodes.type => FuType.vfmul
       case _: Opcode.VFDivOpcodes.type => FuType.vfdiv
       case _: Opcode.VFCvtOpcodes.type => FuType.vfcvt
       case _: Opcode.VFMiscOpcodes.type => FuType.vfalu

--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeStage.scala
@@ -178,7 +178,6 @@ class DecodeStageImp(
         bits.vpu.vl := 0.U // Todo: remove it
         bits.vpu.nf := 0.U // Todo: remove it
         bits.vpu.veew := 0.U // Todo: remove it
-        bits.vpu.isReverse := 0.U // Todo: remove it
         bits.vpu.isExt := 0.U // Todo: remove it
         bits.vpu.isNarrow := 0.U // Todo: remove it
         bits.vpu.isDstMask := 0.U // Todo: remove it

--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeStage.scala
@@ -183,6 +183,7 @@ class DecodeStageImp(
         bits.vpu.isDstMask := 0.U // Todo: remove it
         bits.vpu.isOpMask := 0.U // Todo: remove it
         bits.vpu.isMove := 0.U // Todo: remove it
+        bits.vpu.isReverse := uopInfo.src12Rev
         bits.vpu.isDependOldVd := 0.U // Todo: remove it
         bits.vpu.isWritePartVd := 0.U // Todo: remove it
         bits.vpu.isVleff := false.B // Todo: remove it

--- a/src/main/scala/xiangshan/backend/vector/Decoder/Split/SplitTable.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/Split/SplitTable.scala
@@ -2,7 +2,7 @@ package xiangshan.backend.vector.Decoder.Split
 
 import chisel3.util.BitPat
 import xiangshan.backend.decode.isa.Instructions._
-import xiangshan.backend.decode.opcode.Opcode.{Opcode, VMoveOpcodes, _}
+import xiangshan.backend.decode.opcode.Opcode._
 import xiangshan.backend.vector.Decoder.DecodePatterns.SewLmulPattern
 import xiangshan.backend.vector.Decoder.InstPattern.{VecArithInstPattern, VecInstPattern, VecIntVVVPattern}
 import xiangshan.backend.vector.Decoder.RVVDecodeUtil
@@ -958,41 +958,41 @@ object SplitTable {
     )
 
     val opf00Table = SeqMap[BitPat, SeqMap[SewLmulPattern, Seq[Opcode]]](
-      VFADD_VV -> dup(null, vfadd_fp16, vfadd_fp32, vfadd_fp64)(_.S1v),
-      VFADD_VF -> dup(null, vfadd_fp16, vfadd_fp32, vfadd_fp64)(_.S1f),
-      VFSUB_VV -> dup(null, vfsub_fp16, vfsub_fp32, vfsub_fp64)(_.S1v),
-      VFSUB_VF -> dup(null, vfsub_fp16, vfsub_fp32, vfsub_fp64)(_.S1f),
-      VFMIN_VV -> dup(null, vfmin_fp16, vfmin_fp32, vfmin_fp64)(_.S1v),
-      VFMIN_VF -> dup(null, vfmin_fp16, vfmin_fp32, vfmin_fp64)(_.S1f),
-      VFMAX_VV -> dup(null, vfmax_fp16, vfmax_fp32, vfmax_fp64)(_.S1v),
-      VFMAX_VF -> dup(null, vfmax_fp16, vfmax_fp32, vfmax_fp64)(_.S1f),
+      VFADD_VV -> dup(null, VFAluOpcodes.vfadd_fp16, VFAluOpcodes.vfadd_fp32, VFAluOpcodes.vfadd_fp64)(_.S1v),
+      VFADD_VF -> dup(null, VFAluOpcodes.vfadd_fp16, VFAluOpcodes.vfadd_fp32, VFAluOpcodes.vfadd_fp64)(_.S1f),
+      VFSUB_VV -> dup(null, VFAluOpcodes.vfsub_fp16, VFAluOpcodes.vfsub_fp32, VFAluOpcodes.vfsub_fp64)(_.S1v),
+      VFSUB_VF -> dup(null, VFAluOpcodes.vfsub_fp16, VFAluOpcodes.vfsub_fp32, VFAluOpcodes.vfsub_fp64)(_.S1f),
+      VFMIN_VV -> dup(null, VFAluOpcodes.vfmin_fp16, VFAluOpcodes.vfmin_fp32, VFAluOpcodes.vfmin_fp64)(_.S1v),
+      VFMIN_VF -> dup(null, VFAluOpcodes.vfmin_fp16, VFAluOpcodes.vfmin_fp32, VFAluOpcodes.vfmin_fp64)(_.S1f),
+      VFMAX_VV -> dup(null, VFAluOpcodes.vfmax_fp16, VFAluOpcodes.vfmax_fp32, VFAluOpcodes.vfmax_fp64)(_.S1v),
+      VFMAX_VF -> dup(null, VFAluOpcodes.vfmax_fp16, VFAluOpcodes.vfmax_fp32, VFAluOpcodes.vfmax_fp64)(_.S1f),
 
       VFREDUSUM_VS -> redu(
         null, null,
-        vfredusum_fp16, vfadd_fp16.copy().S1v,
-        vfredusum_fp32, vfadd_fp32.copy().S1v,
-        vfredusum_fp64, vfadd_fp64.copy().S1v,
+        vfredusum_fp16, VFAluOpcodes.vfadd_fp16.copy().S1v,
+        vfredusum_fp32, VFAluOpcodes.vfadd_fp32.copy().S1v,
+        vfredusum_fp64, VFAluOpcodes.vfadd_fp64.copy().S1v,
       ),
       VFREDOSUM_VS -> dup(null, vfredosum_fp16, vfredosum_fp32, vfredosum_fp64)(_ + Src2Mask),
       VFREDMIN_VS -> redu(
         null, null,
-        vfredmin_fp16, vfmin_fp16.copy().S1v,
-        vfredmin_fp32, vfmin_fp32.copy().S1v,
-        vfredmin_fp64, vfmin_fp64.copy().S1v,
+        vfredmin_fp16, VFAluOpcodes.vfmin_fp16.copy().S1v,
+        vfredmin_fp32, VFAluOpcodes.vfmin_fp32.copy().S1v,
+        vfredmin_fp64, VFAluOpcodes.vfmin_fp64.copy().S1v,
       ),
       VFREDMAX_VS -> redu(
         null, null,
-        vfredmax_fp16, vfmax_fp16.copy().S1v,
-        vfredmax_fp32, vfmax_fp32.copy().S1v,
-        vfredmax_fp64, vfmax_fp64.copy().S1v,
+        vfredmax_fp16, VFAluOpcodes.vfmax_fp16.copy().S1v,
+        vfredmax_fp32, VFAluOpcodes.vfmax_fp32.copy().S1v,
+        vfredmax_fp64, VFAluOpcodes.vfmax_fp64.copy().S1v,
       ),
 
-      VFSGNJ_VV  -> dup(null, vfsgnj_fp16, vfsgnj_fp32, vfsgnj_fp64)(_.S1v),
-      VFSGNJ_VF  -> dup(null, vfsgnj_fp16, vfsgnj_fp32, vfsgnj_fp64)(_.S1f),
-      VFSGNJN_VV -> dup(null, vfsgnjn_fp16, vfsgnjn_fp32, vfsgnjn_fp64)(_.S1v),
-      VFSGNJN_VF -> dup(null, vfsgnjn_fp16, vfsgnjn_fp32, vfsgnjn_fp64)(_.S1f),
-      VFSGNJX_VV -> dup(null, vfsgnjx_fp16, vfsgnjx_fp32, vfsgnjx_fp64)(_.S1v),
-      VFSGNJX_VF -> dup(null, vfsgnjx_fp16, vfsgnjx_fp32, vfsgnjx_fp64)(_.S1f),
+      VFSGNJ_VV  -> dup(null, VFAluOpcodes.vfsgnj_fp16, VFAluOpcodes.vfsgnj_fp32, VFAluOpcodes.vfsgnj_fp64)(_.S1v),
+      VFSGNJ_VF  -> dup(null, VFAluOpcodes.vfsgnj_fp16, VFAluOpcodes.vfsgnj_fp32, VFAluOpcodes.vfsgnj_fp64)(_.S1f),
+      VFSGNJN_VV -> dup(null, VFAluOpcodes.vfsgnjn_fp16, VFAluOpcodes.vfsgnjn_fp32, VFAluOpcodes.vfsgnjn_fp64)(_.S1v),
+      VFSGNJN_VF -> dup(null, VFAluOpcodes.vfsgnjn_fp16, VFAluOpcodes.vfsgnjn_fp32, VFAluOpcodes.vfsgnjn_fp64)(_.S1f),
+      VFSGNJX_VV -> dup(null, VFAluOpcodes.vfsgnjx_fp16, VFAluOpcodes.vfsgnjx_fp32, VFAluOpcodes.vfsgnjx_fp64)(_.S1v),
+      VFSGNJX_VF -> dup(null, VFAluOpcodes.vfsgnjx_fp16, VFAluOpcodes.vfsgnjx_fp32, VFAluOpcodes.vfsgnjx_fp64)(_.S1f),
 
       VFSLIDE1UP_VF    -> dup(null, vslide1up_e16, vslide1up_e32, vslide1up_e64)(_.S1f),
       VFSLIDE1DOWN_VF  -> dup(null, vslide1down_e16, vslide1down_e32, vslide1down_e64)(_.S1f),
@@ -1073,7 +1073,7 @@ object SplitTable {
       VFRDIV_VF         -> dup(null, vfdiv_fp16, vfdiv_fp32, vfdiv_fp64)(_.S1f.rev),
       VFMUL_VV          -> dup(null, vfmul_fp16, vfmul_fp32, vfmul_fp64)(_.S1v),
       VFMUL_VF          -> dup(null, vfmul_fp16, vfmul_fp32, vfmul_fp64)(_.S1f),
-      VFRSUB_VF         -> dup(null, vfsub_fp16, vfsub_fp32, vfsub_fp64)(_.S1f.rev),
+      VFRSUB_VF         -> dup(null, VFAluOpcodes.vfsub_fp16, VFAluOpcodes.vfsub_fp32, VFAluOpcodes.vfsub_fp64)(_.S1f.rev),
 
       VFMADD_VV         -> dup(null, vfmadd_fp16, vfmadd_fp32, vfmadd_fp64)(_.S1v),
       VFMADD_VF         -> dup(null, vfmadd_fp16, vfmadd_fp32, vfmadd_fp64)(_.S1f),
@@ -1094,14 +1094,14 @@ object SplitTable {
     )
 
     val opf11Table = SeqMap[BitPat, SeqMap[SewLmulPattern, Seq[Opcode]]](
-      VFWADD_VV         -> dupF2W(null, vfwadd_fp16, vfwadd_fp32)(_.S1v),
-      VFWADD_VF         -> dupF2W(null, vfwadd_fp16, vfwadd_fp32)(_.S1f),
-      VFWSUB_VV         -> dupF2W(null, vfwsub_fp16, vfwsub_fp32)(_.S1v),
-      VFWSUB_VF         -> dupF2W(null, vfwsub_fp16, vfwsub_fp32)(_.S1f),
-      VFWADD_WV         -> dupF2W(null, vfwadd_w_fp16, vfwadd_w_fp32)(_.S1v),
-      VFWADD_WF         -> dupF2W(null, vfwadd_w_fp16, vfwadd_w_fp32)(_.S1f),
-      VFWSUB_WV         -> dupF2W(null, vfwsub_w_fp16, vfwsub_w_fp32)(_.S1v),
-      VFWSUB_WF         -> dupF2W(null, vfwsub_w_fp16, vfwsub_w_fp32)(_.S1f),
+      VFWADD_VV         -> dupF2W(null, VFAluOpcodes.vfwadd_fp16, VFAluOpcodes.vfwadd_fp32)(_.S1v),
+      VFWADD_VF         -> dupF2W(null, VFAluOpcodes.vfwadd_fp16, VFAluOpcodes.vfwadd_fp32)(_.S1f),
+      VFWSUB_VV         -> dupF2W(null, VFAluOpcodes.vfwsub_fp16, VFAluOpcodes.vfwsub_fp32)(_.S1v),
+      VFWSUB_VF         -> dupF2W(null, VFAluOpcodes.vfwsub_fp16, VFAluOpcodes.vfwsub_fp32)(_.S1f),
+      VFWADD_WV         -> dupF2W(null, VFAluOpcodes.vfwadd_w_fp16, VFAluOpcodes.vfwadd_w_fp32)(_.S1v),
+      VFWADD_WF         -> dupF2W(null, VFAluOpcodes.vfwadd_w_fp16, VFAluOpcodes.vfwadd_w_fp32)(_.S1f),
+      VFWSUB_WV         -> dupF2W(null, VFAluOpcodes.vfwsub_w_fp16, VFAluOpcodes.vfwsub_w_fp32)(_.S1v),
+      VFWSUB_WF         -> dupF2W(null, VFAluOpcodes.vfwsub_w_fp16, VFAluOpcodes.vfwsub_w_fp32)(_.S1f),
       VFWMUL_VV         -> dupF2W(null, vfwmul_fp16, vfwmul_fp32)(_.S1v),
       VFWMUL_VF         -> dupF2W(null, vfwmul_fp16, vfwmul_fp32)(_.S1f),
       VFWMACC_VV        -> dupF2W(null, vfwmacc_fp16, vfwmacc_fp32)(_.S1v),
@@ -1114,8 +1114,8 @@ object SplitTable {
       VFWNMSAC_VF       -> dupF2W(null, vfwnmsac_fp16, vfwnmsac_fp32)(_.S1f),
       // to do
       VFWREDUSUM_VS     -> (
-        fwredu(_.e16)(vfwadd_fp16, vfwadd_w_fp16, vfwredusum_fp16) ++
-        fwredu(_.e32)(vfwadd_fp32, vfwadd_w_fp32, vfwredusum_fp32)
+        fwredu(_.e16)(VFAluOpcodes.vfwadd_fp16, VFAluOpcodes.vfwadd_w_fp16, vfwredusum_fp16) ++
+        fwredu(_.e32)(VFAluOpcodes.vfwadd_fp32, VFAluOpcodes.vfwadd_w_fp32, vfwredusum_fp32)
       ),
       VFWREDOSUM_VS     -> (
         fwredosum(_.e16)(vfwredosum_fp16) ++

--- a/src/main/scala/xiangshan/backend/vector/Exu.scala
+++ b/src/main/scala/xiangshan/backend/vector/Exu.scala
@@ -426,6 +426,7 @@ object Exu {
 
     def <#=:(sink: Func.InCtrl): Unit = {
       sink.opcode                      := this.ctrl.opcode
+      sink.isReverse                   := this.ctrl.isReverse
       sink.latency                     := this.ctrl.latency
       sink.robIdx                      := this.ctrl.robIdx
       sink.uopIdx                      := this.ctrl.uopIdx
@@ -522,6 +523,7 @@ object Exu {
 
     val fuType    = FuType()
     val opcode    = Opcode()
+    val isReverse = Bool()
     val latency   = Latency()
 
     val gpWen     = Option.when(param.needGpWen)(Bool())
@@ -553,6 +555,7 @@ object Exu {
       this.uopIdx := deq.uopIdx
       this.fuType := deq.fuType
       this.opcode := deq.opcode
+      this.isReverse := deq.isReverse
       this.latency := deq.latency
 
       this.gpWen.foreach(_ := deq.gpWen)

--- a/src/main/scala/xiangshan/backend/vector/Exu.scala
+++ b/src/main/scala/xiangshan/backend/vector/Exu.scala
@@ -12,6 +12,7 @@ import xiangshan.backend.datapath.DataConfig._
 import xiangshan.backend.datapath.RdConfig.IntRD
 import xiangshan.backend.datapath.WbConfig.WbConfig
 import xiangshan.backend.decode.opcode.{Latency, Opcode}
+import xiangshan.backend.decode.opcode.Opcode.VFMacOpcodes
 import xiangshan.backend.fu.FuType
 import xiangshan.backend.fu.fpu.Bundles.{Fflags, Frm}
 import xiangshan.backend.fu.wrapper.{VFAluWrapper, VFMulWrapper}
@@ -30,11 +31,18 @@ import yunsuan.vector.v2.MergeUnit
 class Exu(val param: ExuParam)(implicit val p: Parameters) extends Module with HasXSParameter {
   override def desiredName: String = param.name
 
+  // OP3 is dispatched to VFMUL but writes back through VFALU one cycle
+  // later than a pure multiply.  Keep an EX3 context slot without changing
+  // either unit's native output capacity.
+  private val hasVfmacPipe = param.fuConfigs.exists(_.name == "vfalu") && param.fuConfigs.exists(_.name == "vfmul")
+  private val mul2aluLatency = if (hasVfmacPipe) 1 else 0
   val latencyMax: Int = param.fuConfigs.map(_.latency).max
   val vlenb = VLEN / 8
   // The width of the number of e8 elem in VLEN bits
   val byteElemWidth = log2Ceil(vlenb)
+  // EX3 is context-only for OP3.  No FU has an out.ex(3) result slot.
   private val numOfMgu = if (param.hasVStd) 0 else latencyMax + 1
+  private val numOfOut = latencyMax + 1
   private val numOfEx = latencyMax + 1
 
   val in = IO(Input(new Exu.In(param)))
@@ -42,6 +50,9 @@ class Exu(val param: ExuParam)(implicit val p: Parameters) extends Module with H
 
   val bypass: BypassNetwork = Module(new BypassNetwork()(param, p))
   val fus: Seq[Func] = param.fuConfigs.map(cfg => cfg.fuGen2(p, cfg))
+  private val vfaluWrappers = fus.collect { case fu: VFAluWrapper => fu }
+  private val vfmulWrappers = fus.collect { case fu: VFMulWrapper => fu }
+  require(vfaluWrappers.size <= 1 && vfmulWrappers.size <= 1, s"${param.name} supports one VFALU/VFMUL pair")
   private val nonFixedLatFus: Seq[VecNonFixedLatFunc] = fus.collect { case fu: VecNonFixedLatFunc => fu }
   val mgus: Seq[MergeUnit] = Seq.fill(numOfMgu)(Module(new MergeUnit()))
 
@@ -103,10 +114,95 @@ class Exu(val param: ExuParam)(implicit val p: Parameters) extends Module with H
       fu.in.vxrm.zip(in.vxrm).foreach { case (sink, source) => sink := source }
   }
 
+  // VFMUL S1 and its matching EX1 uop are sampled in the same cycle, then
+  // held for one cycle before entering VFALU S0.  This registered boundary
+  // gives OP3 its decoded latency of three cycles; VFMUL never contributes
+  // writeback data or flags for OP3.
+  (vfaluWrappers.headOption, vfmulWrappers.headOption) match {
+    case (Some(vfalu), Some(vfmul)) =>
+      val source = ex(mul2aluLatency)
+      implicit val op = source.bits.ctrl.opcode
+      val addendIsVs2 = VFMacOpcodes.isFmadd || VFMacOpcodes.isFnmadd || VFMacOpcodes.isFmsub || VFMacOpcodes.isFnmsub
+      val isSub = VFMacOpcodes.isFnmadd || VFMacOpcodes.isFmsub || VFMacOpcodes.isFnmacc || VFMacOpcodes.isFmsac
+      val sourceFrm = source.bits.ctrl.frm.map(instFrm =>
+        Mux(instFrm === VecFrm.DYN, in.frm.get, instFrm)
+      ).getOrElse(0.U)
+      val forward = Wire(Valid(new VFAluWrapper.VFMulForward(vfalu.cfg)))
+      val forwardS1Valid = RegInit(false.B)
+      val forwardS1 = Reg(new VFAluWrapper.VFMulForward(vfalu.cfg))
+
+      forward.valid := vfmul.toVfalu.valid && source.valid && VFMacOpcodes.isOP3 &&
+                       !source.bits.ctrl.robIdx.needFlush(in.flush)
+      forward.bits.mul := vfmul.toVfalu.bits
+      for (i <- forward.bits.addend.indices) {
+        val addend = Mux(addendIsVs2, source.bits.data.src(1), source.bits.data.src(2))
+        forward.bits.addend(i) := addend(64 * (i + 1) - 1, 64 * i)
+      }
+      forward.bits.isSub := isSub
+      forward.bits.ctrlOpcode := VFMacOpcodes.getCtrlOpcode
+      forward.bits.frm := sourceFrm
+      forward.bits.ctrl <#=: source.bits
+      forward.bits.data <#=: source.bits
+      forward.bits.debug.foreach(_ := source.bits.debug.get)
+
+      forwardS1Valid := forward.valid
+      when (forward.valid) {
+        forwardS1 := forward.bits
+      }
+
+      vfalu.in.fromVfmul.get.valid := forwardS1Valid && !forwardS1.ctrl.robIdx.needFlush(in.flush)
+      vfalu.in.fromVfmul.get.bits := forwardS1
+    case (Some(vfalu), None) =>
+      vfalu.in.fromVfmul.get.valid := false.B
+      vfalu.in.fromVfmul.get.bits := 0.U.asTypeOf(vfalu.in.fromVfmul.get.bits)
+    case (None, Some(_)) =>
+      require(requirement = false, s"${param.name} has VFMUL but no VFALU for OP3 forwarding")
+    case (None, None) =>
+  }
+
+  val resultContexts = ex.indices.map { i =>
+    val context = Wire(chiselTypeOf(ex(i).bits))
+    context := ex(i).bits
+    if (i == 1) {
+      vfaluWrappers.headOption.foreach { vfalu =>
+        val op3 = vfalu.out.op3OutContext.get
+        val op3Ctrl = op3.bits.ctrl
+        when (op3.valid) {
+          context.ctrl.robIdx      :=  op3Ctrl.robIdx
+          context.ctrl.uopIdx      :=  op3Ctrl.uopIdx
+          context.ctrl.fuType      :=  FuType.vfalu.U
+          context.ctrl.opcode      :=  op3Ctrl.opcode
+          context.ctrl.latency     :=  op3Ctrl.latency
+          context.ctrl.gpWen      .zip(op3Ctrl.rfWen    ).foreach { case (sink, source) => sink := source }
+          context.ctrl.fpWen      .zip(op3Ctrl.fpWen    ).foreach { case (sink, source) => sink := source }
+          context.ctrl.vpWen      .zip(op3Ctrl.vecWen   ).foreach { case (sink, source) => sink := source }
+          context.ctrl.pdest       :=  op3Ctrl.pdest
+          context.ctrl.v0Wen      .zip(op3Ctrl.v0Wen    ).foreach { case (sink, source) => sink := source }
+          context.ctrl.vlWen      .zip(op3Ctrl.vlWen    ).foreach { case (sink, source) => sink := source }
+          context.ctrl.pdestV0    .zip(op3Ctrl.pdestV0  ).foreach { case (sink, source) => sink := source }
+          context.ctrl.pdestVl    .zip(op3Ctrl.pdestVl  ).foreach { case (sink, source) => sink := source }
+          context.ctrl.fflagsWen  .zip(op3Ctrl.fflagsWen).foreach { case (sink, source) => sink := source }
+          context.ctrl.flushPipe  .zip(op3Ctrl.flushPipe).foreach { case (sink, source) => sink := source }
+          context.ctrl.vm         .zip(op3Ctrl.vm       ).foreach { case (sink, source) => sink := source }
+          context.ctrl.vtype      .zip(op3Ctrl.vtype    ).foreach { case (sink, source) => sink := source }
+          context.ctrl.oldVType   .zip(op3Ctrl.oldVType ).foreach { case (sink, source) => sink := source }
+          context.data.src :=  op3.bits.data.src
+          context.data.v0 .zip(op3.bits.data.v0).foreach { case (sink, source) => sink := source }
+          context.data.vl .zip(op3.bits.data.vl).foreach { case (sink, source) => sink := source }
+          context.data.imm.foreach(_ := op3.bits.data.imm)
+          context.data.pc.zip(op3.bits.data.pc).foreach { case (sink, source) => sink := source }
+          context.debug.zip(op3.bits.debug).foreach { case (sink, source) => sink := source }
+        }
+      }
+    }
+    context
+  }
+
   mgus.zipWithIndex.foreach {
     case (mgu, i) =>
-      val vl = ex(i).bits.data.vl.get.suggestName(s"ex${i}_vl")
-      val vsew = ex(i).bits.ctrl.vtype.get.vsew
+      val context = resultContexts(i)
+      val vl = context.data.vl.get.suggestName(s"ex${i}_vl")
+      val vsew = context.ctrl.vtype.get.vsew
       val isWiden = Mux1H(fus.flatMap(_.out.ex.lift(i)).map(validIO =>
         validIO.valid -> validIO.bits.data.vec.get.isWiden.getOrElse(false.B)
       )).suggestName(s"ex${i}_isWiden")
@@ -115,23 +211,23 @@ class Exu(val param: ExuParam)(implicit val p: Parameters) extends Module with H
       )).suggestName(s"ex${i}_isNarrow")
       val resSew = Mux(isWiden, vsew + 1.U, vsew).suggestName(s"ex${i}_resSew")
       val eewOH = UIntToOH(resSew, SewOH.width).suggestName(s"ex${i}_eewOH")
-      val vdIdx = Mux(isNarrow, ex(i).bits.ctrl.uopIdx >> 1, ex(i).bits.ctrl.uopIdx)
+      val vdIdx = Mux(isNarrow, context.ctrl.uopIdx >> 1, context.ctrl.uopIdx).asUInt
       val vlMapVdIdx = elemIdxMapVdIdx(vl, eewOH)(3, 0) // 4 bits 0~8
       val end = elemIdxMapElemE8Idx(vl, eewOH)
       val vd = Mux1H(fus.flatMap(_.out.ex.lift(i)).map { validIO =>
         val vecData = validIO.bits.data.vec.get
-        val oldVd = ex(i).bits.data.src(2)
+        val oldVd = context.data.src(2)
         val narrowVd = Mux(
-          ex(i).bits.ctrl.uopIdx(0),
+          context.ctrl.uopIdx(0),
           Cat(vecData.narrow, oldVd(VLEN / 2 - 1, 0)),
           Cat(oldVd(VLEN - 1, VLEN / 2), vecData.narrow)
         )
         validIO.valid -> Mux(vecData.isNarrow.getOrElse(false.B), narrowVd, vecData.normal)
       }).suggestName(s"ex${i}_vd")
 
-      mgu.in.ctrl.vma := ex(i).bits.ctrl.vtype.get.vma
-      mgu.in.ctrl.vta := ex(i).bits.ctrl.vtype.get.vta
-      mgu.in.data.mask := Fill(vlenb, ex(i).bits.ctrl.vm.get) | ex(i).bits.data.v0.get // Todo: use vlenb v0
+      mgu.in.ctrl.vma := context.ctrl.vtype.get.vma
+      mgu.in.ctrl.vta := context.ctrl.vtype.get.vta
+      mgu.in.data.mask := Fill(vlenb, context.ctrl.vm.get) | context.data.v0.get // Todo: use vlenb v0
       // since vstart is always 0 for vector arith instruction, begin is always 0
       mgu.in.data.begin := 0.U
       mgu.in.data.end := Mux1H(Seq(
@@ -139,11 +235,11 @@ class Exu(val param: ExuParam)(implicit val p: Parameters) extends Module with H
         (vdIdx === vlMapVdIdx) -> end,
         (vdIdx < vlMapVdIdx) -> vlenb.U,
       ))
-      mgu.in.data.oldVd := ex(i).bits.data.src(2).toByteVec
+      mgu.in.data.oldVd := context.data.src(2).toByteVec
       mgu.in.data.vd := vd.toByteVec
   }
 
-  val outFuUopEx = Wire(Vec(latencyMax + 1, ValidIO(new Exu.OutUop(param))))
+  val outFuUopEx = Wire(Vec(numOfOut, ValidIO(new Exu.OutUop(param))))
   outFuUopEx.zipWithIndex.foreach {
     case (out: ValidIO[Exu.OutUop], i) =>
       val fuOuts: Seq[ValidIO[Func.OutUop]] = fus.flatMap(_.out.ex.lift(i))
@@ -380,8 +476,8 @@ object Exu {
       this.toRob.flushPipe.foreach(_ := Mux1H(fuOutValidOH, fuOuts.map(_.bits.ctrl.flushPipe.getOrElse(false.B))))
       this.toRob.replay.foreach(_ := Mux1H(fuOutValidOH, fuOuts.map(_.bits.ctrl.replay.getOrElse(false.B))))
       this.toRob.redirect.foreach(x => x := Mux1H(fuOutValidOH, fuOuts.map(_.bits.data.redirect.getOrElse(0.U.asTypeOf(x)))))
-//      this.toRob.fflags.foreach(x => x := Mux1H(fuOutValidOH, fuOuts.map(_.bits.data.fflags.getOrElse(0.U.asTypeOf(x)))))
-//      this.toRob.vxsat.foreach(x => x := Mux1H(fuOutValidOH, fuOuts.map(_.bits.data.vxsat.getOrElse(0.U.asTypeOf(x)))))
+      //      this.toRob.fflags.foreach(x => x := Mux1H(fuOutValidOH, fuOuts.map(_.bits.data.fflags.getOrElse(0.U.asTypeOf(x)))))
+      //      this.toRob.vxsat.foreach(x => x := Mux1H(fuOutValidOH, fuOuts.map(_.bits.data.vxsat.getOrElse(0.U.asTypeOf(x)))))
       this.toRob.exceptionVec := ExceptSparseVec.mux1h(fuOutValidOH, fuOuts.map(_.bits.ctrl.exceptionVec))
       this.toRob.debug.foreach(_ := Mux1H(fuOutValidOH, fuOuts.map(_.bits.debug.get)))
 

--- a/src/main/scala/xiangshan/backend/vector/Exu.scala
+++ b/src/main/scala/xiangshan/backend/vector/Exu.scala
@@ -64,15 +64,16 @@ class Exu(val param: ExuParam)(implicit val p: Parameters) extends Module with H
   inEx.valid := in.uop.valid
   inEx.bits :<#= in.uop.bits
   inEx.bits.fuSel := VecInit(param.fuConfigs.map(_.fuSel2(in.uop.bits)))
+  inEx.bits.data.src := bypass.out.src
 
   ex.zip(inEx +: ex).zipWithIndex.foreach {
     case ((sink: ValidIO[Exu.ExStage], source: ValidIO[Exu.ExStage]), stageIdx) =>
       sink.valid := source.valid && !source.bits.ctrl.robIdx.needFlush(in.flush)
       when(source.valid) {
         sink.bits := source.bits
-        if (stageIdx == 0) {
-          sink.bits.data.src := bypass.out.src
-        }
+        // if (stageIdx == 0) {
+        //   sink.bits.data.src := bypass.out.src
+        // }
       }
   }
 

--- a/src/main/scala/xiangshan/backend/vector/Exu.scala
+++ b/src/main/scala/xiangshan/backend/vector/Exu.scala
@@ -14,6 +14,7 @@ import xiangshan.backend.datapath.WbConfig.WbConfig
 import xiangshan.backend.decode.opcode.{Latency, Opcode}
 import xiangshan.backend.fu.FuType
 import xiangshan.backend.fu.fpu.Bundles.{Fflags, Frm}
+import xiangshan.backend.fu.wrapper.{VFAluWrapper, VFMulWrapper}
 import xiangshan.backend.vector.Decoder.DecodeFields.VecDecodeChannel.{Frm => VecFrm}
 import xiangshan.backend.fu.vector.Bundles.{VType, Vxrm, _}
 import xiangshan.backend.regfile.PregParams
@@ -354,7 +355,6 @@ object Exu {
       sink.v0          .foreach(x => x := this.data.v0.get)
       sink.pc          .foreach(x => x := this.data.pc.get)
       sink.imm                         := this.data.imm.getOrElse(0.U)
-      sink.vfma       .foreach(x => x := this.data.vfma.get)
     }
 
     def <#=:(sink: Func.InUop) : Unit = {
@@ -490,7 +490,6 @@ object Exu {
     val vl  = Option.when(param.readVlRf)(Vl())
     val imm = Option.when(param.needImm)(UInt(param.immWidth.W))
     val pc  = Option.when(param.needPc)(UInt(VAddrData().dataWidth.W))
-    val vfma = Option.when(param.fuConfigs.exists(_.fuType == FuType.vfma))(new Func.VFMacInfo)
   }
 
   class InBypassCtrl(val param: ExuParam)(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/vector/IssuePipe.scala
+++ b/src/main/scala/xiangshan/backend/vector/IssuePipe.scala
@@ -207,11 +207,6 @@ class IssuePipe(
   }
 
   //to do
-  is2Next.bits.data.vfma.foreach { vfma =>
-    vfma.fpAIsFpCanonicalNAN.foreach(_ := false.B)
-    vfma.fpBIsFpCanonicalNAN.foreach(_ := false.B)
-    vfma.fpCIsFpCanonicalNAN.foreach(_ := false.B)
-  }
   is2Next.bits.data.v0.foreach(_ := 0.U)
   is2Next.bits.data.vl.foreach(_ := in.is2VlRdDataNext.head.data)
 

--- a/src/main/scala/xiangshan/backend/vector/LatDecoder.scala
+++ b/src/main/scala/xiangshan/backend/vector/LatDecoder.scala
@@ -32,7 +32,7 @@ class LatDecoder(opcodesSeq: Seq[Opcodes]) extends Module {
 
 object LatDecoder {
   def apply(fuType: UInt, opcode: UInt): UInt = {
-    val mod = Module(new LatDecoder(Seq(FMacOpcodes, VIAluOpcodes, VFMacOpcodes, VMoveOpcodes, VFCvtOpcodes, VIMacOpcodes)))
+    val mod = Module(new LatDecoder(Seq(FMacOpcodes, VIAluOpcodes, VFAluOpcodes, VFMacOpcodes, VMoveOpcodes, VFCvtOpcodes, VIMacOpcodes)))
     mod.in.fuType := fuType
     mod.in.opcode := opcode
     mod.out.lat

--- a/src/main/scala/xiangshan/backend/vector/VecIssueQueue.scala
+++ b/src/main/scala/xiangshan/backend/vector/VecIssueQueue.scala
@@ -915,6 +915,7 @@ object VecIssueQueue {
     // from decode
     val fuType    = FuType()
     val opcode    = FuOpType()
+    val isReverse = Bool()
 
     val vm        = Bool()
     val vtype     = VType()
@@ -959,6 +960,7 @@ object VecIssueQueue {
     def fromDispatchOutUop(source: DispatchOutUop): Unit = {
       this.fuType := source.fuType
       this.opcode := source.fuOpType
+      this.isReverse := source.vpu.isReverse
 
       this.vm := source.vm
       this.vtype := source.vtype
@@ -1002,6 +1004,7 @@ object VecIssueQueue {
     def fromRegionInUop(source: RegionInUop): Unit = {
       this.fuType := source.fuType
       this.opcode := source.fuOpType
+      this.isReverse := source.vpu.map(_.isReverse).getOrElse(false.B)
 
       this.vm := source.vm.getOrElse(false.B)
       this.vtype := source.vtype.getOrElse(0.U.asTypeOf(this.vtype))
@@ -1049,6 +1052,7 @@ object VecIssueQueue {
 
     val fuType       = FuType()
     val opcode       = Opcode()
+    val isReverse    = Bool()
 
     val robIdx       = new RobPtr
     val uopIdx       = UopIdx()
@@ -1093,6 +1097,7 @@ object VecIssueQueue {
     def fromEntry(entry: Entry): Unit = {
       this.fuType := entry.payload.fuType
       this.opcode := entry.payload.opcode
+      this.isReverse := entry.payload.isReverse
       this.vm.foreach(_ := entry.payload.vm.get)
       this.robIdx := entry.status.robIdx
       this.uopIdx := entry.status.uopIdx
@@ -1218,6 +1223,7 @@ object VecIssueQueue {
   class Payload(implicit p: Parameters, param: IssueParam) extends XSBundle {
     val fuType    = FuType()
     val opcode    = FuOpType()
+    val isReverse = Bool()
     val vm        = Option.when(param.needVM)(Bool())
     val vtype     = Option.when(param.readVType)(VType())
     val oldVType  = Option.when(param.readOldVType)(VType())
@@ -1246,6 +1252,7 @@ object VecIssueQueue {
     def fromEnq(enq: Enq): Unit = {
       this.fuType := enq.fuType
       this.opcode := enq.opcode
+      this.isReverse := enq.isReverse
       this.vm.foreach(_ := enq.vm)
       this.vtype.foreach(_ := enq.vtype)
       this.oldVType.foreach(_ := enq.oldVType)

--- a/src/main/scala/xiangshan/backend/vector/fu/Func.scala
+++ b/src/main/scala/xiangshan/backend/vector/fu/Func.scala
@@ -115,7 +115,6 @@ object Func {
     val vl        = Option.when(cfg.readVl)(Vl())
     val imm       = UInt(cfg.destDataBits.W)
     val pc        = Option.when(cfg.needPc)(UInt(VAddrData().dataWidth.W))
-    val vfma      = Option.when(cfg.fuType == FuType.vfma)(new VFMacInfo)
   }
 
   class OutCtrl(cfg: VecFuConfig)(implicit p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/vector/fu/Func.scala
+++ b/src/main/scala/xiangshan/backend/vector/fu/Func.scala
@@ -10,6 +10,7 @@ import xiangshan.backend.decode.opcode.Latency
 import xiangshan.backend.fu.FuType
 import xiangshan.backend.fu.fpu.Bundles.Frm
 import xiangshan.backend.fu.vector.Bundles._
+import xiangshan.backend.fu.wrapper.VFAluWrapper
 import xiangshan.backend.rob.RobPtr
 import xiangshan.backend.vector.VecRegionModule
 import xiangshan.mem.{SqPtr, StoreQueueDataWrite}
@@ -70,10 +71,12 @@ object Func {
     val ex = Vec(cfg.latency + 1, ValidIO(new InUop))
     val frm = Option.when(cfg.needSrcFrm)(Frm())
     val vxrm = Option.when(cfg.needSrcVxrm)(Vxrm())
+    val fromVfmul = Option.when(cfg.isVfalu)(ValidIO(new VFAluWrapper.VFMulForward(cfg)))
   }
 
   class Out(implicit val cfg: VecFuConfig, p: Parameters) extends XSBundle {
     val ex = Vec(cfg.latency + 1, ValidIO(new OutUop))
+    val op3OutContext = Option.when(cfg.isVfalu)(ValidIO(new VFAluWrapper.VFMulForward(cfg)))
   }
 
   class InUop(implicit val cfg: VecFuConfig, p: Parameters) extends XSBundle {

--- a/src/main/scala/xiangshan/backend/vector/fu/Func.scala
+++ b/src/main/scala/xiangshan/backend/vector/fu/Func.scala
@@ -93,6 +93,7 @@ object Func {
 
   class InCtrl(cfg: VecFuConfig)(implicit p: Parameters) extends XSBundle {
     val opcode    = FuOpType()
+    val isReverse = Bool()
     val latency   = Latency()
     val robIdx    = new RobPtr
     val uopIdx    = UopIdx()

--- a/src/main/scala/xiangshan/backend/vector/fu/VecFuConfig.scala
+++ b/src/main/scala/xiangshan/backend/vector/fu/VecFuConfig.scala
@@ -184,9 +184,11 @@ case class VecFuConfig (
 
   def isVecArith: Boolean = fuType == FuType.vialuF || fuType == FuType.vimac ||
                             fuType == FuType.vppu || fuType == FuType.vipu ||
-                            fuType == FuType.vfalu || fuType == FuType.vfma ||
+                            fuType == FuType.vfalu || fuType == FuType.vfmul ||
                             fuType == FuType.vfdiv || fuType == FuType.vfcvt ||
                             fuType == FuType.vidiv || fuType == FuType.vmove
+
+  def isVfmul: Boolean = fuType == FuType.vfmul
 
   def isVecMem: Boolean = fuType == FuType.vldu || fuType == FuType.vstu ||
                           fuType == FuType.vsegldu || fuType == FuType.vsegstu ||
@@ -289,8 +291,8 @@ object VecFuConfig {
   val VppuCfg = VecFuConfig.fromFuConfig(FuConfig.VppuCfg)
   val VipuCfg = VecFuConfig.fromFuConfig(FuConfig.VipuCfg)
   val VmoveCfg = VecFuConfig.fromFuConfig(FuConfig.VmoveCfg, (p: Parameters, cfg: VecFuConfig) => Module(new VMove(cfg)(p).suggestName("Vmove")))
-  val VfaluCfg = VecFuConfig.fromFuConfig(FuConfig.VfaluCfg)
-  val VfmaCfg  = VecFuConfig.fromFuConfig(FuConfig.VfmaCfg,  (p: Parameters, cfg: VecFuConfig) => Module(new VFMacWrapper(cfg)(p).suggestName("Vfma")))
+  val VfaluCfg = VecFuConfig.fromFuConfig(FuConfig.VfaluCfg, (p: Parameters, cfg: VecFuConfig) => Module(new VFAluWrapper(cfg)(p).suggestName("Vfalu")))
+  val VfmulCfg = VecFuConfig.fromFuConfig(FuConfig.VfmulCfg, (p: Parameters, cfg: VecFuConfig) => Module(new VFMulWrapper(cfg)(p).suggestName("Vfmul")))
   val VfdivCfg = VecFuConfig.fromFuConfig(FuConfig.VfdivCfg)
   val VfcvtCfg = VecFuConfig.fromFuConfig(FuConfig.VfcvtCfg, (p: Parameters, cfg: VecFuConfig) => Module(new VCVTWrapper(cfg)(p).suggestName("Vfcvt")))
   val VSha256msCfg = VecFuConfig.fromFuConfig(FuConfig.VSha256msCfg)
@@ -338,7 +340,7 @@ object VecFuConfig {
     VipuCfg,
     VmoveCfg,
     VfaluCfg,
-    VfmaCfg,
+    VfmulCfg,
     VfdivCfg,
     VfcvtCfg,
     VSha256msCfg,

--- a/src/main/scala/xiangshan/backend/vector/fu/VecFuConfig.scala
+++ b/src/main/scala/xiangshan/backend/vector/fu/VecFuConfig.scala
@@ -190,6 +190,8 @@ case class VecFuConfig (
 
   def isVfmul: Boolean = fuType == FuType.vfmul
 
+  def isVfalu: Boolean = fuType == FuType.vfalu
+
   def isVecMem: Boolean = fuType == FuType.vldu || fuType == FuType.vstu ||
                           fuType == FuType.vsegldu || fuType == FuType.vsegstu ||
                           name == "vstd"

--- a/src/main/scala/xiangshan/backend/vector/fu/VecFunc.scala
+++ b/src/main/scala/xiangshan/backend/vector/fu/VecFunc.scala
@@ -20,6 +20,11 @@ trait VecFuncAlias { this: Func =>
   protected def ex0oldVd = ex0data.src(2)
   protected def ex0vl = ex0data.vl.get
 
+  protected def ex0NextData = ex0Next.bits.data
+  protected def ex0NextVs1 = ex0NextData.src(0)
+  protected def ex0NextVs2 = ex0NextData.src(1)
+  protected def ex0NextOldVd = ex0NextData.src(2)
+
   protected def vxrm = in.vxrm.get
   protected def frm = in.frm.get
 

--- a/src/main/scala/xiangshan/backend/vector/fu/VecFunc.scala
+++ b/src/main/scala/xiangshan/backend/vector/fu/VecFunc.scala
@@ -21,6 +21,7 @@ trait VecFuncAlias { this: Func =>
   protected def ex0vl = ex0data.vl.get
 
   protected def vxrm = in.vxrm.get
+  protected def frm = in.frm.get
 
   protected def ex0vma = ex0ctrl.vtype.get.vma
   protected def ex0vta = ex0ctrl.vtype.get.vta


### PR DESCRIPTION
Add a new vector floating-point multiplier and ALU. Use corresponding scalar function units to implement this new feature, because then we can give vfmul a 3-cycle latency, vfalu a 2-cycle latency, and give vf mul-and-add/accumulate instructions a 4-cycle latency by bypassing it from vfmul to vfalu.