### PR TITLE
timing(Ftq,ICache): fix meta read port timing

### DIFF
--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -88,16 +88,6 @@ class FetchRequestBundle(implicit p: Parameters) extends FrontendBundle with ICa
       p" offset: ${takenCfiOffset.bits}\n"
 }
 
-class FtqPrefetchRequest(implicit p: Parameters) extends FrontendBundle with ICacheCacheLineHelper {
-  val startVAddr:         PrunedAddr    = PrunedAddr(VAddrBits)
-  val nextCachelineVAddr: PrunedAddr    = PrunedAddr(VAddrBits)
-  val ftqIdx:             FtqPtr        = new FtqPtr
-  val takenCfiOffset:     UInt          = UInt(CfiPositionWidth.W)
-  val backendException:   ExceptionType = new ExceptionType
-
-  def crossCacheline: Bool = super.isCrossLine(this.startVAddr, this.takenCfiOffset)
-}
-
 class FtqFetchRequest(implicit p: Parameters) extends FrontendBundle with HasICacheParameters {
   val valid:               Bool            = Bool()
   val vAddr:               Vec[PrunedAddr] = Vec(PortNumber, PrunedAddr(VAddrBits))

--- a/src/main/scala/xiangshan/frontend/TwoFetch.scala
+++ b/src/main/scala/xiangshan/frontend/TwoFetch.scala
@@ -42,6 +42,19 @@ class TwoPrefetchCase extends Bundle {
       )
     )
 
+  // timing optimization:
+  // To avoid introducing a very wide adder on the meta SRAM read path,
+  // vSetIdx(1) comes from vSetIdx(0) + 1.U rather than get_idx(nextLineVAddr).
+  def selectMetaSetIdx(reqVec: Vec[PrefetchReqBundle]): Vec[UInt] =
+    MuxCase(
+      // unable to do 2-prefetch, or isSameLine or isOverlap1, both use req1's start and nextLine
+      reqVec(0).vSetIdx,
+      Seq(
+        isOverlap2   -> reqVec(1).vSetIdx,
+        isInterleave -> VecInit(reqVec(0).vSetIdx(0), reqVec(1).vSetIdx(0))
+      )
+    )
+
   // select isCrossLine flag to read ICacheMetaArray
   def selectIsCrossLine(reqVec: Vec[PrefetchReqBundle]): Bool =
     MuxCase(

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -127,7 +127,7 @@ class FtqPrefetchReq(implicit p: Parameters) extends FtqBundle with ICacheCacheL
     startVAddr    := entry.startPc
     nextLineVAddr := entry.startPc + blockBytes.U
     isCrossLine   := super.isCrossLine(startVAddr, entry.endPosition)
-    vSetIdx       := VecInit(get_idx(startVAddr), get_idx(nextLineVAddr))
+    vSetIdx       := VecInit(get_idx(startVAddr), get_idx(startVAddr) + 1.U)
     this
   }
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -279,6 +279,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
   io.toICache.toPrefetch.bits.req.zipWithIndex.foreach { case (req, i) =>
     req.startVAddr       := prefetchReq(i).startVAddr
     req.nextLineVAddr    := prefetchReq(i).nextLineVAddr
+    req.vSetIdx          := prefetchReq(i).vSetIdx
     req.isCrossLine      := prefetchReq(i).isCrossLine
     req.ftqIdx           := pfPtr(i)
     req.backendException := Mux(backendExceptionPtr === pfPtr(i), backendException, ExceptionType.None)

--- a/src/main/scala/xiangshan/frontend/icache/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Bundles.scala
@@ -251,6 +251,7 @@ class MainPipeToWayLookupBundle(implicit p: Parameters) extends ICacheBundle {
 class PrefetchReqBundle(implicit p: Parameters) extends ICacheBundle {
   val startVAddr:       PrunedAddr    = PrunedAddr(VAddrBits)
   val nextLineVAddr:    PrunedAddr    = PrunedAddr(VAddrBits)
+  val vSetIdx:          Vec[UInt]     = Vec(PortNumber, UInt(idxBits.W))
   val isCrossLine:      Bool          = Bool()
   val ftqIdx:           FtqPtr        = new FtqPtr
   val backendException: ExceptionType = new ExceptionType
@@ -259,6 +260,7 @@ class PrefetchReqBundle(implicit p: Parameters) extends ICacheBundle {
   def fromSoftPrefetch(req: SoftIfetchPrefetchBundle): PrefetchReqBundle = {
     startVAddr       := req.vaddr
     nextLineVAddr    := DontCare
+    vSetIdx          := VecInit(get_idx(startVAddr), 0.U(idxBits.W))
     isCrossLine      := false.B
     ftqIdx           := DontCare
     backendException := ExceptionType.None

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -90,7 +90,7 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   private val s0_twoPrefetchCase  = io.fromFtq.bits.twoPrefetchCase
 
   private val s0_readMetaVAddr  = s0_twoPrefetchCase.selectMetaVAddr(s0_req)
-  private val s0_readMetaSetIdx = VecInit(s0_readMetaVAddr.map(get_idx))
+  private val s0_readMetaSetIdx = s0_twoPrefetchCase.selectMetaSetIdx(s0_req)
   private val s0_readDoubleLine = s0_twoPrefetchCase.selectIsCrossLine(s0_req)
 
   fromBpuS0Flush := !s0_isSoftPrefetch && io.flushFromBpu.shouldFlushByStage3(s0_ftqIdx, s0_valid)


### PR DESCRIPTION
To avoid introducing a very wide adder on the meta SRAM read path, `vSetIdx(1)` comes from `vSetIdx(0) + 1.U` rather than `get_idx(nextLineVAddr)`.