### PR TITLE
fix(TLB): canonicalize PMM addresses for only-stage-2 translation

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -71,14 +71,9 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   val flush_pipe = io.flushPipe
   val redirect = io.redirect
   val EffectiveVa = Wire(Vec(Width, UInt(XLEN.W)))
+  val pmm = WireInit(VecInit(Seq.fill(Width)(0.U(2.W))))
   val req_in = req
   val req_out = Reg(Vec(Width, new TlbReq))
-  for (i <- 0 until Width) {
-    when (req(i).fire) {
-      req_out(i) := req(i).bits
-      req_out(i).fullva := EffectiveVa(i)
-    }
-  }
   val req_out_v = (0 until Width).map(i => ValidHold(req_in(i).fire && !req_in(i).bits.kill, resp(i).fire, flush_pipe(i)))
 
   val isHyperInst = (0 until Width).map(i => req_out_v(i) && req_out(i).hyperinst)
@@ -166,37 +161,34 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   )
 
   (0 until Width).foreach{i =>
-
-    val pmm = WireInit(0.U(2.W))
-
     when (ifetch || req(i).bits.hlvx) {
-      pmm := 0.U
+      pmm(i) := 0.U
     } .elsewhen (premode(i) === ModeM) {
-      pmm := csr.pmm.mseccfg
+      pmm(i) := csr.pmm.mseccfg
     } .elsewhen (Mux(virt_in || req_in(i).bits.hyperinst, csr.priv.vmxr || csr.priv.mxr, csr.priv.mxr)) {
-      pmm := 0.U
+      pmm(i) := 0.U
     } .elsewhen (!(virt_in || req_in(i).bits.hyperinst) && premode(i) === ModeS) {
-      pmm := csr.pmm.menvcfg
+      pmm(i) := csr.pmm.menvcfg
     } .elsewhen ((virt_in || req_in(i).bits.hyperinst) && premode(i) === ModeS) {
-      pmm := csr.pmm.henvcfg
+      pmm(i) := csr.pmm.henvcfg
     } .elsewhen (req_in(i).bits.hyperinst && csr.priv.imode === ModeU) {
-      pmm := csr.pmm.hstatus
+      pmm(i) := csr.pmm.hstatus
     } .elsewhen (premode(i) === ModeU) {
-      pmm := csr.pmm.senvcfg
+      pmm(i) := csr.pmm.senvcfg
     }
 
     when (prevmEnable(i) || (pres2xlateEnable(i) && csr.vsatp.mode =/= 0.U)) {
-      when (pmm === PMLEN7) {
+      when (pmm(i) === PMLEN7) {
         EffectiveVa(i) := SignExt(req_in(i).bits.fullva(56, 0), XLEN)
-      } .elsewhen (pmm === PMLEN16) {
+      } .elsewhen (pmm(i) === PMLEN16) {
         EffectiveVa(i) := SignExt(req_in(i).bits.fullva(47, 0), XLEN)
       } .otherwise {
         EffectiveVa(i) := req_in(i).bits.fullva
       }
     } .otherwise {
-      when (pmm === PMLEN7) {
+      when (pmm(i) === PMLEN7) {
         EffectiveVa(i) := ZeroExt(req_in(i).bits.fullva(56, 0), XLEN)
-      } .elsewhen (pmm === PMLEN16) {
+      } .elsewhen (pmm(i) === PMLEN16) {
         EffectiveVa(i) := ZeroExt(req_in(i).bits.fullva(47, 0), XLEN)
       } .otherwise {
         EffectiveVa(i) := req_in(i).bits.fullva
@@ -235,6 +227,31 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     }
   }
 
+  def effectiveVpn(currentVaddr: UInt, maskedFullva: UInt): UInt = {
+    if (VAddrBits > 48) {
+      Cat(maskedFullva(VAddrBits - 1, 48), currentVaddr(47, offLen))
+    } else {
+      get_pn(currentVaddr)
+    }
+  }
+
+  val rawInVpn = req_in.map(req => get_pn(req.bits.vaddr))
+  val effectiveInVpn = (0 until Width).map(i => effectiveVpn(req_in(i).bits.vaddr, EffectiveVa(i)))
+  val useEffectiveVpnIn = (0 until Width).map(i => !ifetch && req_in_s2xlate(i) === onlyStage2 && pmm(i) === PMLEN16)
+  val inVpn = (0 until Width).map(i => Mux(useEffectiveVpnIn(i), effectiveInVpn(i), rawInVpn(i)))
+
+  val rawOutVpn = req_out.map(req => get_pn(req.vaddr))
+  val effectiveOutVpn = (0 until Width).map(i => effectiveVpn(req_out(i).vaddr, req_out(i).fullva))
+  val useEffectiveVpnOut = RegInit(VecInit(Seq.fill(Width)(false.B)))
+  for (i <- 0 until Width) {
+    when (req(i).fire) {
+      req_out(i) := req(i).bits
+      req_out(i).fullva := EffectiveVa(i)
+      useEffectiveVpnOut(i) := useEffectiveVpnIn(i)
+    }
+  }
+  val outVpn = (0 until Width).map(i => Mux(useEffectiveVpnOut(i), effectiveOutVpn(i), rawOutVpn(i)))
+
   val refill = ptw.resp.fire && !(ptw.resp.bits.getGpa) && !need_gpa && !maybe_need_gpa_not_allow_refill && !flush_mmu
   // prevent ptw refill when: 1) it's a getGpa request; 2) l1tlb is in need_gpa state; 3) mmu is being flushed.
 
@@ -243,7 +260,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   entries.io.base_connect(sfence, csr, csr.satp)
   if (q.outReplace) { io.replace <> entries.io.replace }
   for (i <- 0 until Width) {
-    entries.io.r_req_apply(io.requestor(i).req.valid, get_pn(req_in(i).bits.vaddr), i, req_in_s2xlate(i))
+    entries.io.r_req_apply(io.requestor(i).req.valid, inVpn(i), i, req_in_s2xlate(i))
     entries.io.w_apply(refill, ptw.resp.bits)
     // TODO: RegNext enable:req.valid
     resp(i).bits.debug.isFirstIssue := RegEnable(req(i).bits.debug.isFirstIssue, req(i).valid)
@@ -287,10 +304,10 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   /************************  main body above | method/log/perf below ****************************/
   def TLBRead(i: Int) = {
     val (e_hit, e_ppn, e_perm, e_g_perm, e_s2xlate, e_pbmt, e_g_pbmt) = entries.io.r_resp_apply(i)
-    val (p_hit, p_ppn, p_pbmt, p_perm, p_gvpn, p_g_pbmt, p_g_perm, p_s2xlate, p_s1_level, p_s1_isLeaf, p_s1_isFakePte, p_hit_fast) = ptw_resp_bypass(get_pn(req_in(i).bits.vaddr), req_in_s2xlate(i))
+    val (p_hit, p_ppn, p_pbmt, p_perm, p_gvpn, p_g_pbmt, p_g_perm, p_s2xlate, p_s1_level, p_s1_isLeaf, p_s1_isFakePte, p_hit_fast) = ptw_resp_bypass(inVpn(i), req_in_s2xlate(i))
     val enable = portTranslateEnable(i)
     val isOnlys2xlate = req_out_s2xlate(i) === onlyStage2
-    val need_gpa_req_match = need_gpa_vpn === get_pn(req_out(i).vaddr) && need_gpa_s2xlate === req_out_s2xlate(i)
+    val need_gpa_req_match = need_gpa_vpn === outVpn(i) && need_gpa_s2xlate === req_out_s2xlate(i)
     val isitlb = TlbCmd.isExec(req_out(i).cmd)
     val isPrefetch = req_out(i).isPrefetch
     val currentRedirect = req_out(i).debug.robIdx.needFlush(redirect)
@@ -310,7 +327,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
         maybe_need_gpa_not_allow_refill := true.B
         need_gpa_wire := true.B
         need_gpa := true.B
-        need_gpa_vpn := get_pn(req_out(i).vaddr)
+        need_gpa_vpn := outVpn(i)
         need_gpa_s2xlate := req_out_s2xlate(i)
         resp_gpa_refill := false.B
         need_gpa_robidx := req_out(i).debug.robIdx
@@ -538,12 +555,12 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       (csr.hgatp.mode === 0.U) -> onlyStage1
     ))
 
-    val ptw_just_back = ptw.resp.fire && req_s2xlate === ptw.resp.bits.s2xlate && ptw.resp.bits.hit(get_pn(req_out(idx).vaddr), csr.satp.asid, csr.vsatp.asid, csr.hgatp.vmid, allType = true)
+    val ptw_just_back = ptw.resp.fire && req_s2xlate === ptw.resp.bits.s2xlate && ptw.resp.bits.hit(outVpn(idx), csr.satp.asid, csr.vsatp.asid, csr.hgatp.vmid, allType = true)
     // TODO: RegNext enable: ptw.resp.valid ? req.valid
     val ptw_resp_bits_reg = RegEnable(ptw.resp.bits, ptw.resp.valid)
-    val ptw_already_back = GatedValidRegNext(ptw.resp.fire) && req_s2xlate === ptw_resp_bits_reg.s2xlate && ptw_resp_bits_reg.hit(get_pn(req_out(idx).vaddr), csr.satp.asid, csr.vsatp.asid, csr.hgatp.vmid, allType = true)
+    val ptw_already_back = GatedValidRegNext(ptw.resp.fire) && req_s2xlate === ptw_resp_bits_reg.s2xlate && ptw_resp_bits_reg.hit(outVpn(idx), csr.satp.asid, csr.vsatp.asid, csr.hgatp.vmid, allType = true)
     val ptw_getGpa = req_need_gpa && hitVec(idx)
-    val need_gpa_req_match = need_gpa_vpn === get_pn(req_out(idx).vaddr) && need_gpa_s2xlate === req_s2xlate
+    val need_gpa_req_match = need_gpa_vpn === outVpn(idx) && need_gpa_s2xlate === req_s2xlate
 
     io.ptw.req(idx).valid := false.B;
     io.tlbreplay(idx) := false.B;
@@ -565,7 +582,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       io.tlbreplay(idx) := true.B
     }
 
-    io.ptw.req(idx).bits.vpn := get_pn(req_out(idx).vaddr)
+    io.ptw.req(idx).bits.vpn := outVpn(idx)
     io.ptw.req(idx).bits.s2xlate := req_s2xlate
     io.ptw.req(idx).bits.getGpa := ptw_getGpa
     io.ptw.req(idx).bits.memidx := req_out(idx).memidx
@@ -578,7 +595,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
 
     // miss request entries
     val req_need_gpa = hasGpf(idx)
-    val miss_req_vpn = get_pn(req_out(idx).vaddr)
+    val miss_req_vpn = outVpn(idx)
     val miss_req_memidx = req_out(idx).memidx
     val miss_req_s2xlate = Wire(UInt(2.W))
     miss_req_s2xlate := MuxCase(noS2xlate, Seq(
@@ -606,7 +623,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       val s2xlate = io.ptw.resp.bits.s2xlate
       resp(idx).valid := true.B
       resp(idx).bits.miss := false.B
-      val vpn = get_pn(req_out(idx).vaddr)
+      val vpn = outVpn(idx)
       val s1_ppn = stage1.genPPN(vpn)(ppnLen - 1, 0)
       val s2_gvpn = Mux(s2xlate === onlyStage2, vpn, s1_ppn)
       val s2_ppn = stage2.genPPNS2(s2_gvpn)(ppnLen - 1, 0)
@@ -622,7 +639,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
         (stage1.isFakePte() && csr.vsatp.mode === Sv48) -> 3.U,
         (!stage1.isFakePte()) -> (stage1.entry.level.get - 1.U),
       ))
-      val s1_gpaddr_offset = Mux(stage1.isLeaf(), get_off(req_out(idx).vaddr), Cat(getVpnn(get_pn(req_out(idx).vaddr), vpn_idx), 0.U(log2Up(XLEN/8).W)))
+      val s1_gpaddr_offset = Mux(stage1.isLeaf(), get_off(req_out(idx).vaddr), Cat(getVpnn(outVpn(idx), vpn_idx), 0.U(log2Up(XLEN/8).W)))
       val s1_gpaddr = Cat(stage1.genGVPN(vpn), s1_gpaddr_offset)
 
       for (d <- 0 until nRespDups) {
@@ -742,7 +759,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
         difftest.valid := false.B
       }
       difftest.index := TLBDiffId(p(XSCoreParamsKey).HartId).U
-      difftest.vpn := RegEnable(get_pn(req_in(i).bits.vaddr), req_in(i).valid)
+      difftest.vpn := RegEnable(inVpn(i), req_in(i).valid)
       difftest.ppn := get_pn(io.requestor(i).resp.bits.paddr(0))
       difftest.satp := Cat(csr.satp.mode, csr.satp.asid, csr.satp.ppn)
       difftest.vsatp := Cat(csr.vsatp.mode, csr.vsatp.asid, csr.vsatp.ppn)

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -227,13 +227,16 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     }
   }
 
-  def effectiveVpn(currentVaddr: UInt, maskedFullva: UInt): UInt = {
+  def effectiveVaddr(currentVaddr: UInt, maskedFullva: UInt): UInt = {
     if (VAddrBits > 48) {
-      Cat(maskedFullva(VAddrBits - 1, 48), currentVaddr(47, offLen))
+      Cat(maskedFullva(VAddrBits - 1, 48), currentVaddr(47, 0))
     } else {
-      get_pn(currentVaddr)
+      currentVaddr
     }
   }
+
+  def effectiveVpn(currentVaddr: UInt, maskedFullva: UInt): UInt =
+    get_pn(effectiveVaddr(currentVaddr, maskedFullva))
 
   val rawInVpn = req_in.map(req => get_pn(req.bits.vaddr))
   val effectiveInVpn = (0 until Width).map(i => effectiveVpn(req_in(i).bits.vaddr, EffectiveVa(i)))
@@ -251,6 +254,9 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     }
   }
   val outVpn = (0 until Width).map(i => Mux(useEffectiveVpnOut(i), effectiveOutVpn(i), rawOutVpn(i)))
+
+  def onlyStage2Gpaddr(idx: Int, currentVaddr: UInt): UInt =
+    Mux(useEffectiveVpnOut(idx), effectiveVaddr(currentVaddr, req_out(idx).fullva), currentVaddr)
 
   val refill = ptw.resp.fire && !(ptw.resp.bits.getGpa) && !need_gpa && !maybe_need_gpa_not_allow_refill && !flush_mmu
   // prevent ptw refill when: 1) it's a getGpa request; 2) l1tlb is in need_gpa state; 3) mmu is being flushed.
@@ -404,10 +410,11 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       // By the way, frontend handles the cross page instruction fetch by itself, so TLB doesn't need to do anything extra.
       // Also, the fullva of iTLB is not used and always zero. crossPageVaddr should never use fullva in iTLB.
       val crossPageVaddr = Mux(isitlb || req_out(i).fullva(12) =/= vaddr(12), req_out(i).vaddr, req_out(i).fullva)
+      val onlyStage2Gpa = onlyStage2Gpaddr(i, crossPageVaddr)
       val gpaddr_offset = Mux(isLeaf(d), get_off(crossPageVaddr), Cat(getVpnn(get_pn(crossPageVaddr), vpn_idx), 0.U(log2Up(XLEN/8).W)))
       val gpaddr = Cat(gvpn(d), gpaddr_offset)
       resp(i).bits.paddr(d) := Mux(enable, paddr, notTranslatePaddr)
-      resp(i).bits.gpaddr(d) := Mux(r_s2xlate(d) === onlyStage2, crossPageVaddr, gpaddr)
+      resp(i).bits.gpaddr(d) := Mux(r_s2xlate(d) === onlyStage2, onlyStage2Gpa, gpaddr)
     }
 
     XSDebug(req_out_v(i), p"(${i.U}) hit:${hit} miss:${miss} ppn:${Hexadecimal(ppn(0))} perm:${perm(0)}\n")
@@ -644,7 +651,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
 
       for (d <- 0 until nRespDups) {
         resp(idx).bits.paddr(d) := Mux(s2xlate === onlyStage2 || s2xlate === allStage, s2_paddr, s1_paddr)
-        resp(idx).bits.gpaddr(d) := Mux(s2xlate === onlyStage2, req_out(idx).vaddr, s1_gpaddr)
+        resp(idx).bits.gpaddr(d) := Mux(s2xlate === onlyStage2, onlyStage2Gpaddr(idx, req_out(idx).vaddr), s1_gpaddr)
         pbmt_check(idx, d, io.ptw.resp.bits.s1.entry.pbmt, io.ptw.resp.bits.s2.entry.pbmt, s2xlate)
         perm_check(stage1, req_out(idx).cmd, idx, d, stage2, req_out(idx).hlvx, s2xlate)
       }

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadMisalignBuffer.scala
@@ -323,7 +323,11 @@ class LoadMisalignBuffer(implicit p: Parameters) extends XSModule
       lowAddrLoad.fullva := req.fullva
       highAddrLoad.uop := req.uop
       highAddrLoad.uop.exceptionVec(loadAddrMisaligned) := false.B
-      highAddrLoad.fullva := req.fullva
+      highAddrLoad.fullva := (if (VAddrBits > 48) {
+        Cat(req.fullva(XLEN - 1, VAddrBits), highAddrLoad.vaddr)
+      } else {
+        req.fullva
+      })
 
       switch (alignedType(1, 0)) {
         is (LB) {

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreMisalignBuffer.scala
@@ -367,8 +367,14 @@ class StoreMisalignBuffer(implicit p: Parameters) extends XSModule
       curPtr := 0.U
       lowAddrStore.uop := req.uop
       lowAddrStore.uop.exceptionVec(storeAddrMisaligned) := false.B
+      lowAddrStore.fullva := req.fullva
       highAddrStore.uop := req.uop
       highAddrStore.uop.exceptionVec(storeAddrMisaligned) := false.B
+      highAddrStore.fullva := (if (VAddrBits > 48) {
+        Cat(req.fullva(XLEN - 1, VAddrBits), highAddrStore.vaddr)
+      } else {
+        req.fullva
+      })
 
       switch (alignedType(1, 0)) {
         is (SB) {

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -779,12 +779,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   s0_out.vaddr         := Mux(s0_nc_with_data, s0_sel_src.vaddr, s0_dcache_vaddr)
   // A split load may advance to the next page. Keep that fragment's low bits while
   // preserving the PMM-normalized high bits returned by the TLB.
-  val s0_mabuf_fullva = if (VAddrBits > 48) {
-    Cat(s0_tlb_fullva(XLEN - 1, 48), s0_out.vaddr(47, 0))
-  } else {
-    s0_tlb_fullva
-  }
-  s0_out.fullva        := Mux(s0_sel_src.frm_mabuf, s0_mabuf_fullva, s0_tlb_fullva)
+  s0_out.fullva        := s0_tlb_fullva
   s0_out.mask          := s0_sel_src.mask
   s0_out.uop           := s0_sel_src.uop
   s0_out.isFirstIssue  := s0_sel_src.isFirstIssue
@@ -1015,7 +1010,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   s1_out                   := s1_in
   s1_out.vaddr             := s1_vaddr
-  s1_out.fullva            := Mux(s1_in.isFrmMisAlignBuf, s1_in.fullva, io.tlb.resp.bits.fullva)
+  s1_out.fullva            := io.tlb.resp.bits.fullva
   s1_out.vaNeedExt         := io.tlb.resp.bits.excp(0).vaNeedExt
   s1_out.isHyper           := io.tlb.resp.bits.excp(0).isHyper
   s1_out.paddr             := s1_paddr_dup_lsu

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -777,7 +777,14 @@ class LoadUnit(implicit p: Parameters) extends XSModule
   // TODO: prefetch need writeback to loadQueueFlag
   s0_out               := DontCare
   s0_out.vaddr         := Mux(s0_nc_with_data, s0_sel_src.vaddr, s0_dcache_vaddr)
-  s0_out.fullva        := Mux(s0_sel_src.frm_mabuf, s0_out.vaddr, s0_tlb_fullva)
+  // A split load may advance to the next page. Keep that fragment's low bits while
+  // preserving the PMM-normalized high bits returned by the TLB.
+  val s0_mabuf_fullva = if (VAddrBits > 48) {
+    Cat(s0_tlb_fullva(XLEN - 1, 48), s0_out.vaddr(47, 0))
+  } else {
+    s0_tlb_fullva
+  }
+  s0_out.fullva        := Mux(s0_sel_src.frm_mabuf, s0_mabuf_fullva, s0_tlb_fullva)
   s0_out.mask          := s0_sel_src.mask
   s0_out.uop           := s0_sel_src.uop
   s0_out.isFirstIssue  := s0_sel_src.isFirstIssue
@@ -1008,7 +1015,7 @@ class LoadUnit(implicit p: Parameters) extends XSModule
 
   s1_out                   := s1_in
   s1_out.vaddr             := s1_vaddr
-  s1_out.fullva            := Mux(s1_in.isFrmMisAlignBuf, s1_in.vaddr, io.tlb.resp.bits.fullva)
+  s1_out.fullva            := Mux(s1_in.isFrmMisAlignBuf, s1_in.fullva, io.tlb.resp.bits.fullva)
   s1_out.vaNeedExt         := io.tlb.resp.bits.excp(0).vaNeedExt
   s1_out.isHyper           := io.tlb.resp.bits.excp(0).isHyper
   s1_out.paddr             := s1_paddr_dup_lsu

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -188,12 +188,16 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   s0_is128bit := Mux(s0_use_flow_ma, io.misalign_stin.bits.is128bit, is128Bit(s0_vecstin.alignedType) || s0_misalignWith16Byte)
 
   s0_fullva := Mux(
-    s0_use_flow_rs,
-    s0_stin.src(0) + SignExt(s0_stin.uop.imm(11,0), XLEN),
+    s0_use_flow_ma,
+    if (VAddrBits > 48) io.misalign_stin.bits.fullva else s0_vaddr,
     Mux(
-      s0_use_flow_vec,
-      s0_vecstin.vaddr,
-      s0_vaddr
+      s0_use_flow_rs,
+      s0_stin.src(0) + SignExt(s0_stin.uop.imm(11,0), XLEN),
+      Mux(
+        s0_use_flow_vec,
+        s0_vecstin.vaddr,
+        s0_vaddr
+      )
     )
   )
 
@@ -304,7 +308,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s1_isHyper   = io.tlb.resp.bits.excp(0).isHyper
   val s1_paddr     = io.tlb.resp.bits.paddr(0)
   val s1_gpaddr    = io.tlb.resp.bits.gpaddr(0)
-  val s1_fullva    = Mux(s1_frm_mabuf, s1_out.vaddr, io.tlb.resp.bits.fullva)
+  val s1_fullva    = io.tlb.resp.bits.fullva
   val s1_isForVSnonLeafPTE   = io.tlb.resp.bits.isForVSnonLeafPTE
   val s1_tlb_miss  = io.tlb.resp.bits.miss && io.tlb.resp.valid && s1_valid
   val s1_tlb_hit   = !io.tlb.resp.bits.miss && io.tlb.resp.valid && s1_valid


### PR DESCRIPTION
Fixes #6215 

Normalize the only-stage-2 PMLEN16 VPN consistently across lookup, PTW, replay, and GPA tracking; canonicalize returned GPAs on both TLB-hit and PTW-response paths; preserve normalized full-VA upper bits across split-load fragments.

This PR uses the PMM-normalized VPN consistently for TLB lookup, PTW bypass/replay, miss handling, need_gpa matching, and DiffTest reporting.

The changes are limited to onlyStage2 translations using PMLEN16 under Sv48x4. iTLB accesses and all other translation modes retain their existing behavior.