### PR TITLE
fix(StoreQueue): use the real forward mask for s2FullOverlap

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
@@ -594,7 +594,9 @@ abstract class PhysicalStoreQueueBase(implicit p: Parameters) extends LSQModule 
       )
       val s2OutMask            = ParallelLookUp(s2ByteSelectOffset, s2SelectMask) & s2LoadMaskEnd
 
-      val s2FullOverlap        = s2SelectDataEntry.byteStart <= s2LoadStart && s2SelectDataEntry.byteEnd >= s2LoadEnd
+      // byteStart/byteEnd only bound the store's 16B span, not the bytes it actually holds, so a
+      // store that partially covers the load's bank looks fully overlapped. Check the real mask.
+      val s2FullOverlap        = s2OutMask === s2LoadMaskEnd
       // First condition: access extends beyond the lower log2Ceil(VLEN/8) bits.
       // Second condition: higher bits of the virtual address within the page offset are non-zero, indicating a potential cross-page access.
       val s2Cross4KPage        = s2SelectDataEntry.byteEnd(VWordOffset) && s2SelectDataEntry.vaddr(pageOffset - 1, VWordOffset).andR && s2ForwardValid


### PR DESCRIPTION
fix(StoreQueue): use the real forward mask for s2FullOverlap

Hello, here is a pull request for a bug I found.

Fixes #6229

## Problem

A misaligned load that crosses a 16B (VWord) boundary and whose lower half partially overlaps an
in-flight store misses store-to-load forwarding on the bytes the store does not hold, and commits
stale data.

`s2FullOverlap` in `NewStoreQueue.scala` gates the fast forward path:

```scala
val s2FullOverlap = s2SelectDataEntry.byteStart <= s2LoadStart && s2SelectDataEntry.byteEnd >= s2LoadEnd
```

`byteStart`/`byteEnd` only bound the store's 16B span, not the bytes it actually holds. A store that
partially covers the load's bank therefore reads as fully overlapped, so `s2SafeForward` stays true,
the forward shortcut is taken, and the uncovered bytes fall through to the DCache stale while the
store value is still in the SQ/sbuffer. This is the residual case #6003 (the cross-16B fix for #5998)
did not cover. #6229 reports it with a scalar `ld`; it reproduces identically with a vector
`vle32.v`.

## Fix

Compare the real post-rotation mask, which already reflects the bytes the store holds:

```scala
val s2FullOverlap = s2OutMask === s2LoadMaskEnd
```

The overlap is full only when the forwarded mask covers every byte the load needs.

## Minimal reproducer

The trigger needs a `vse32.v` at LMUL2, a `vle32.v` at LMUL2 whose base is not 16B aligned and
crosses a 64B line, and a second in-flight vector load. Removing any one of the three makes it pass.

```asm
    vsetvli x0, t1, e32, m2, tu, mu   # SEW32, LMUL2, vl=8
    la      t2, buf                   # buf is 64B aligned
    addi    a4, t2, 60                # load base: crosses the 64B line at buf+64
    addi    s6, t2, 76                # store base: overlaps the load's upper register

    vmv.v.i v16, -1                   # pre-fill buf[0..127] with 0xffffffff (stale marker)
    vse32.v v16, (t2)                 # (repeat to fill the four 32B words of buf)

    vid.v   v8
    vadd.vi v8, v8, 1                 # v8 = 1,2,3,4,5,6,7,8
    vse32.v v8, (s6)                  # STORE 1..8 at buf+76, still in flight
    vle32.v v6, (s6)                  # second in-flight vector load
    vle32.v v0, (a4)                  # line-crossing load; its upper register maps to the store
```

The load whose upper register maps to `buf+76..91` should read the store's first four elements
`[1,2,3,4]`. Before the fix it gets element 0 forwarded and the rest stale: `[1, 0xffffffff,
0xffffffff, 0xffffffff]`, where the reference returns `[1,2,3,4]`. The full generated program shows
the same shape on a `v1` at instruction 1790: reference `[0x7fc00000, 0x26d20000, 0x7fc00000,
0x3a720000]`, hardware `[0x7fc00000, 0xb8b75dc4, 0x48791e57, 0xa62221b7]`, element 0 matching and the
rest reading pre-store memory.
with no divergence.

Assisted-by: Claude:claude-opus-5 [Claude Code]