### PR TITLE
fix(WriteBuffer): read-write conflict on the same entry caused an error

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/WriteBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/WriteBuffer.scala
@@ -31,7 +31,7 @@ import xiangshan.XSModule
  * 3. Written SRAM entries undergo write comparison - only differing data triggers re-write
  * 4. Entries with saturation counters support counter updates
  * 5. Single-write-multiple-read (SWMR) port configuration
- * 6. Bypass write data to read port when empty
+ * Write requests are non-backpressured. A miss on a full row overwrites a dirty victim.
  * @param gen The type of the write request bundle
  * @param numEntries The number of entries in the write buffer
  * @param numPorts The number of write ports
@@ -56,10 +56,13 @@ class WriteBuffer[T <: WriteReqBundle](
   require(numPorts >= 1)
   require(numPorts <= numEntries)
   class WriteBufferIO extends Bundle {
-    val write:     Vec[DecoupledIO[T]] = Vec(numPorts, Flipped(DecoupledIO(gen)))
-    val read:      Vec[DecoupledIO[T]] = Vec(numPorts, DecoupledIO(gen))
-    val takenMask: Option[Vec[Bool]]   = Option.when(hasCnt)(Vec(numPorts, Input(Bool())))
-    val flush:     Option[Bool]        = Option.when(hasFlush)(Input(Bool()))
+    val write: Vec[ValidIO[T]]     = Vec(numPorts, Flipped(Valid(gen)))
+    val read:  Vec[DecoupledIO[T]] = Vec(numPorts, DecoupledIO(gen))
+    val full:  Vec[Bool]           = Output(Vec(numPorts, Bool()))
+    // A full miss overwrites a pending dirty entry.
+    val overwrite: Vec[Bool]         = Output(Vec(numPorts, Bool()))
+    val takenMask: Option[Vec[Bool]] = Option.when(hasCnt)(Vec(numPorts, Input(Bool())))
+    val flush:     Option[Bool]      = Option.when(hasFlush)(Input(Bool()))
   }
   val io: WriteBufferIO = IO(new WriteBufferIO)
 
@@ -97,7 +100,6 @@ class WriteBuffer[T <: WriteReqBundle](
   private val readReadyVec = WireInit(VecInit(Seq.fill(numPorts)(false.B)))
   private val emptyVec     = WireInit(VecInit(Seq.fill(numPorts)(false.B)))
   private val fullVec      = WireInit(VecInit(Seq.fill(numPorts)(false.B)))
-  private val writeFlowVec = WireInit(VecInit(Seq.fill(numPorts)(false.B)))
   // Replace is to prioritize replacing the entry of the same port as setIdx
   private val victimSameSetIdx = WireInit(VecInit.fill(numPorts)(0.U.asTypeOf(Valid(UInt(log2Ceil(numEntries).W)))))
 
@@ -226,6 +228,7 @@ class WriteBuffer[T <: WriteReqBundle](
     XSPerfAccumulate(f"${namePrefix}_port${portIdx}_hit_written", writeValid && hitWritten)
     XSPerfAccumulate(f"${namePrefix}_port${portIdx}_hit", writeValid && hit)
     XSPerfAccumulate(f"${namePrefix}_port${portIdx}_not_hit", writeValid && !hit)
+    io.overwrite(portIdx) := writeValid && fullVec(portIdx) && !hit
 
   }
 
@@ -236,11 +239,11 @@ class WriteBuffer[T <: WriteReqBundle](
     readValidVec(nRows) := dirty(nRows)
     emptyVec(nRows)     := !readValidVec(nRows).reduce(_ || _)
     fullVec(nRows)      := readValidVec(nRows).reduce(_ && _)
+    io.full(nRows)      := fullVec(nRows)
     val readIdx = PriorityEncoder(readValidVec(nRows))
 
-    io.write(nRows).ready := !fullVec(nRows)
-    io.read(nRows).valid  := !emptyVec(nRows)
-    io.read(nRows).bits   := DontCare
+    io.read(nRows).valid := !emptyVec(nRows)
+    io.read(nRows).bits  := DontCare
 
     when(readReadyVec(nRows) && !emptyVec(nRows)) {
       io.read(nRows).bits   := entries(nRows)(readIdx)

--- a/src/main/scala/xiangshan/frontend/bpu/WriteBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/WriteBuffer.scala
@@ -116,7 +116,7 @@ class WriteBuffer[T <: WriteReqBundle](
   // and flush overrides both at the end of the next-state calculation.
   for (rowIdx <- 0 until numPorts) {
     val drainIdx = PriorityEncoder(dirty(rowIdx))
-    when(io.read(rowIdx).ready && dirty(rowIdx).reduce(_ || _)) {
+    when(io.read(rowIdx).fire) {
       nextDirty(rowIdx)(drainIdx) := false.B
     }
   }

--- a/src/main/scala/xiangshan/frontend/bpu/WriteBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/WriteBuffer.scala
@@ -86,7 +86,10 @@ class WriteBuffer[T <: WriteReqBundle](
 
   private val dirty   = RegInit(VecInit(Seq.fill(numPorts)(VecInit(Seq.fill(numEntries)(false.B)))))
   private val entries = RegInit(VecInit(Seq.fill(numPorts)(VecInit(Seq.fill(numEntries)(0.U.asTypeOf(gen.cloneType))))))
-  private val shadowValid = RegInit(VecInit(Seq.fill(numPorts)(VecInit(Seq.fill(numEntries)(false.B)))))
+  private val shadowValid     = RegInit(VecInit(Seq.fill(numPorts)(VecInit(Seq.fill(numEntries)(false.B)))))
+  private val nextDirty       = WireInit(dirty)
+  private val nextEntries     = WireInit(entries)
+  private val nextShadowValid = WireInit(shadowValid)
 
   private val writePortValid = VecInit(Seq.fill(numPorts)(false.B))
   private val writePortBits  = VecInit(Seq.fill(numPorts)(0.U.asTypeOf(gen.cloneType)))
@@ -108,6 +111,15 @@ class WriteBuffer[T <: WriteReqBundle](
   dontTouch(readValidVec)
   dontTouch(replacerWay)
   dontTouch(emptyVec)
+
+  // Apply drain first. Write requests below override it when they update the same slot,
+  // and flush overrides both at the end of the next-state calculation.
+  for (rowIdx <- 0 until numPorts) {
+    val drainIdx = PriorityEncoder(dirty(rowIdx))
+    when(io.read(rowIdx).ready && dirty(rowIdx).reduce(_ || _)) {
+      nextDirty(rowIdx)(drainIdx) := false.B
+    }
+  }
 
   writePortValid.zipWithIndex.foreach { case (writeValid, portIdx) =>
     val setIdxHitVec = entries(portIdx).zip(shadowValid(portIdx)).map { case (entry, valid) =>
@@ -181,11 +193,11 @@ class WriteBuffer[T <: WriteReqBundle](
       )
       // if this write port !hit need to write a new entry
       when(!hit) {
-        entries(portIdx)(victim)     := io.write(portIdx).bits
-        shadowValid(portIdx)(victim) := true.B
-        dirty(portIdx)(victim)       := true.B
-        writeTouchVec(portIdx).valid := true.B
-        writeTouchVec(portIdx).bits  := victim
+        nextEntries(portIdx)(victim)     := io.write(portIdx).bits
+        nextShadowValid(portIdx)(victim) := true.B
+        nextDirty(portIdx)(victim)       := true.B
+        writeTouchVec(portIdx).valid     := true.B
+        writeTouchVec(portIdx).bits      := victim
       }
 
       // if hit need to update the entry
@@ -195,14 +207,15 @@ class WriteBuffer[T <: WriteReqBundle](
         val mergedEntry =
           if (hasWayMask) mergeSameWay(entries(rowIdx)(hitIdx), io.write(portIdx).bits) else io.write(portIdx).bits
         when(hitNotWritten) {
-          entries(rowIdx)(hitIdx)     := mergedEntry
-          shadowValid(rowIdx)(hitIdx) := true.B
+          nextEntries(rowIdx)(hitIdx)     := mergedEntry
+          nextShadowValid(rowIdx)(hitIdx) := true.B
+          nextDirty(rowIdx)(hitIdx)       := true.B
         }.elsewhen(hitWritten) {
           val entryChange = entries(rowIdx)(hitIdx).asUInt =/= mergedEntry.asUInt
           when(entryChange) {
-            dirty(rowIdx)(hitIdx)       := true.B
-            entries(rowIdx)(hitIdx)     := mergedEntry
-            shadowValid(rowIdx)(hitIdx) := true.B
+            nextDirty(rowIdx)(hitIdx)       := true.B
+            nextEntries(rowIdx)(hitIdx)     := mergedEntry
+            nextShadowValid(rowIdx)(hitIdx) := true.B
           }
         }
       }
@@ -216,11 +229,11 @@ class WriteBuffer[T <: WriteReqBundle](
           // and write other entry information
           val writePortTaken = takenMask(portIdx)
           val updateCnt      = entries(rowIdx)(hitIdx).cnt.get.getUpdate(writePortTaken)
-          temporarily.cnt.get         := updateCnt.asTypeOf(temporarily.cnt.get)
-          entries(rowIdx)(hitIdx)     := temporarily
-          shadowValid(rowIdx)(hitIdx) := true.B
+          temporarily.cnt.get             := updateCnt.asTypeOf(temporarily.cnt.get)
+          nextEntries(rowIdx)(hitIdx)     := temporarily
+          nextShadowValid(rowIdx)(hitIdx) := true.B
           // Counter updates make the shadow entry differ from SRAM again.
-          dirty(rowIdx)(hitIdx) := true.B
+          nextDirty(rowIdx)(hitIdx) := true.B
         }
       }
     }
@@ -246,8 +259,7 @@ class WriteBuffer[T <: WriteReqBundle](
     io.read(nRows).bits  := DontCare
 
     when(readReadyVec(nRows) && !emptyVec(nRows)) {
-      io.read(nRows).bits   := entries(nRows)(readIdx)
-      dirty(nRows)(readIdx) := false.B
+      io.read(nRows).bits := entries(nRows)(readIdx)
     }
     val touchWays = Seq(writeTouchVec(nRows)) ++ hitTouchVec(nRows).filter(_.valid == true.B).take(numPorts)
     replacerWay(nRows) := replacer.way
@@ -255,7 +267,7 @@ class WriteBuffer[T <: WriteReqBundle](
     when(flush) {
       // Discard all pending SRAM writes while retaining the shadow entries.
       for (i <- 0 until numEntries) {
-        dirty(nRows)(i) := false.B
+        nextDirty(nRows)(i) := false.B
       }
     }
     XSPerfAccumulate(f"${namePrefix}_port${nRows}_is_full", writePortValid(nRows) && fullVec(nRows))
@@ -267,4 +279,8 @@ class WriteBuffer[T <: WriteReqBundle](
       numEntries
     )
   }
+
+  dirty       := nextDirty
+  entries     := nextEntries
+  shadowValid := nextShadowValid
 }

--- a/src/main/scala/xiangshan/frontend/bpu/WriteBuffer.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/WriteBuffer.scala
@@ -81,9 +81,9 @@ class WriteBuffer[T <: WriteReqBundle](
     merged
   }
 
-  private val needWrite = RegInit(VecInit(Seq.fill(numPorts)(VecInit(Seq.fill(numEntries)(false.B)))))
+  private val dirty   = RegInit(VecInit(Seq.fill(numPorts)(VecInit(Seq.fill(numEntries)(false.B)))))
   private val entries = RegInit(VecInit(Seq.fill(numPorts)(VecInit(Seq.fill(numEntries)(0.U.asTypeOf(gen.cloneType))))))
-  private val valids  = RegInit(VecInit(Seq.fill(numPorts)(VecInit(Seq.fill(numEntries)(false.B)))))
+  private val shadowValid = RegInit(VecInit(Seq.fill(numPorts)(VecInit(Seq.fill(numEntries)(false.B)))))
 
   private val writePortValid = VecInit(Seq.fill(numPorts)(false.B))
   private val writePortBits  = VecInit(Seq.fill(numPorts)(0.U.asTypeOf(gen.cloneType)))
@@ -108,7 +108,7 @@ class WriteBuffer[T <: WriteReqBundle](
   dontTouch(emptyVec)
 
   writePortValid.zipWithIndex.foreach { case (writeValid, portIdx) =>
-    val setIdxHitVec = entries(portIdx).zip(valids(portIdx)).map { case (entry, valid) =>
+    val setIdxHitVec = entries(portIdx).zip(shadowValid(portIdx)).map { case (entry, valid) =>
       writeValid && valid && writePortBits(portIdx).setIdx === entry.setIdx
     }
     XSError(
@@ -146,7 +146,7 @@ class WriteBuffer[T <: WriteReqBundle](
     // maintain hitMask for each write port
     val hitMask = VecInit.fill(numPorts)(VecInit.fill(numEntries)(false.B))
     for (p <- 0 until numPorts; e <- 0 until numEntries) {
-      hitMask(p)(e) := writeValid && valids(p)(e) &&
+      hitMask(p)(e) := writeValid && shadowValid(p)(e) &&
         writePortBits(portIdx).setIdx === entries(p)(e).setIdx &&
         writePortBits(portIdx).tag.getOrElse(0.U) === entries(p)(e).tag.getOrElse(0.U)
     }
@@ -162,14 +162,14 @@ class WriteBuffer[T <: WriteReqBundle](
 
     val rowIdx        = OHToUInt(hitRowsVec) // hitRow's idx
     val hitIdx        = hitRowIdxVec(rowIdx) // hit entry's idx
-    val hitNotWritten = hit && needWrite(rowIdx)(hitIdx)
-    val hitWritten    = hit && !needWrite(rowIdx)(hitIdx)
+    val hitNotWritten = hit && dirty(rowIdx)(hitIdx)
+    val hitWritten    = hit && !dirty(rowIdx)(hitIdx)
     dontTouch(hitRowsVec)
     dontTouch(hitRowIdxVec)
 
     when(writeValid) {
       // if the entry is not written, it is useful
-      val notUsefulVec = needWrite(portIdx).map(!_)
+      val notUsefulVec = dirty(portIdx).map(!_)
       val notUseful    = notUsefulVec.reduce(_ || _)
       val notUsefulIdx = PriorityEncoder(notUsefulVec)
       val victim = Mux(
@@ -180,8 +180,8 @@ class WriteBuffer[T <: WriteReqBundle](
       // if this write port !hit need to write a new entry
       when(!hit) {
         entries(portIdx)(victim)     := io.write(portIdx).bits
-        valids(portIdx)(victim)      := true.B
-        needWrite(portIdx)(victim)   := true.B
+        shadowValid(portIdx)(victim) := true.B
+        dirty(portIdx)(victim)       := true.B
         writeTouchVec(portIdx).valid := true.B
         writeTouchVec(portIdx).bits  := victim
       }
@@ -193,14 +193,14 @@ class WriteBuffer[T <: WriteReqBundle](
         val mergedEntry =
           if (hasWayMask) mergeSameWay(entries(rowIdx)(hitIdx), io.write(portIdx).bits) else io.write(portIdx).bits
         when(hitNotWritten) {
-          entries(rowIdx)(hitIdx) := mergedEntry
-          valids(rowIdx)(hitIdx)  := true.B
+          entries(rowIdx)(hitIdx)     := mergedEntry
+          shadowValid(rowIdx)(hitIdx) := true.B
         }.elsewhen(hitWritten) {
           val entryChange = entries(rowIdx)(hitIdx).asUInt =/= mergedEntry.asUInt
           when(entryChange) {
-            needWrite(rowIdx)(hitIdx) := true.B
-            entries(rowIdx)(hitIdx)   := mergedEntry
-            valids(rowIdx)(hitIdx)    := true.B
+            dirty(rowIdx)(hitIdx)       := true.B
+            entries(rowIdx)(hitIdx)     := mergedEntry
+            shadowValid(rowIdx)(hitIdx) := true.B
           }
         }
       }
@@ -214,11 +214,11 @@ class WriteBuffer[T <: WriteReqBundle](
           // and write other entry information
           val writePortTaken = takenMask(portIdx)
           val updateCnt      = entries(rowIdx)(hitIdx).cnt.get.getUpdate(writePortTaken)
-          temporarily.cnt.get     := updateCnt.asTypeOf(temporarily.cnt.get)
-          entries(rowIdx)(hitIdx) := temporarily
-          valids(rowIdx)(hitIdx)  := true.B
-          // If the write port hit a written entry, update the needWrite
-          needWrite(rowIdx)(hitIdx) := true.B
+          temporarily.cnt.get         := updateCnt.asTypeOf(temporarily.cnt.get)
+          entries(rowIdx)(hitIdx)     := temporarily
+          shadowValid(rowIdx)(hitIdx) := true.B
+          // Counter updates make the shadow entry differ from SRAM again.
+          dirty(rowIdx)(hitIdx) := true.B
         }
       }
     }
@@ -233,7 +233,7 @@ class WriteBuffer[T <: WriteReqBundle](
   for (nRows <- 0 until numPorts) {
     val replacer = ReplacementPolicy.fromString("plru", numEntries)
     readReadyVec(nRows) := io.read(nRows).ready
-    readValidVec(nRows) := needWrite(nRows)
+    readValidVec(nRows) := dirty(nRows)
     emptyVec(nRows)     := !readValidVec(nRows).reduce(_ || _)
     fullVec(nRows)      := readValidVec(nRows).reduce(_ && _)
     val readIdx = PriorityEncoder(readValidVec(nRows))
@@ -243,16 +243,16 @@ class WriteBuffer[T <: WriteReqBundle](
     io.read(nRows).bits   := DontCare
 
     when(readReadyVec(nRows) && !emptyVec(nRows)) {
-      io.read(nRows).bits       := entries(nRows)(readIdx)
-      needWrite(nRows)(readIdx) := false.B
+      io.read(nRows).bits   := entries(nRows)(readIdx)
+      dirty(nRows)(readIdx) := false.B
     }
     val touchWays = Seq(writeTouchVec(nRows)) ++ hitTouchVec(nRows).filter(_.valid == true.B).take(numPorts)
     replacerWay(nRows) := replacer.way
     replacer.access(touchWays)
     when(flush) {
-      // Reset the write buffer needWrite when flush is true
+      // Discard all pending SRAM writes while retaining the shadow entries.
       for (i <- 0 until numEntries) {
-        needWrite(nRows)(i) := false.B
+        dirty(nRows)(i) := false.B
       }
     }
     XSPerfAccumulate(f"${namePrefix}_port${nRows}_is_full", writePortValid(nRows) && fullVec(nRows))

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtbBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtbBank.scala
@@ -78,7 +78,7 @@ class AheadBtbBank(bandIdx: Int)(implicit p: Parameters) extends AheadBtbModule 
     nameSuffix = s"abtbBank$bandIdx"
   ))
 
-  // writeReq is a ValidIO, it means that the new request will be dropped if the buffer is full
+  // WriteBuffer accepts every pulse; a full miss overwrites an older dirty entry.
   writeBuffer.io.write.head.valid := io.writeReq.valid
   writeBuffer.io.write.head.bits  := io.writeReq.bits
 
@@ -103,7 +103,7 @@ class AheadBtbBank(bandIdx: Int)(implicit p: Parameters) extends AheadBtbModule 
 
   XSPerfAccumulate("read", sram.io.r.req.fire)
   XSPerfAccumulate("write", sram.io.w.req.fire)
-  XSPerfAccumulate("write_buffer_full", !writeBuffer.io.write.head.ready)
-  XSPerfAccumulate("write_buffer_full_drop_write", !writeBuffer.io.write.head.ready && io.writeReq.valid)
+  XSPerfAccumulate("write_buffer_full", writeBuffer.io.full.head)
+  XSPerfAccumulate("write_buffer_overwrite", writeBuffer.io.overwrite.head)
   XSPerfAccumulate("need_reset_ctr", io.writeResp.valid && io.writeResp.bits.needResetCtr)
 }

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/IttageTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/IttageTable.scala
@@ -271,11 +271,11 @@ class IttageTable(
       bank.io.r.req.valid && buffer.io.read.head.valid
     }).asUInt.orR
   )
-  private val targetBankReady = writeBuffers
+  private val updateOverwrite = writeBuffers
     .zip(updateBankMask.asBools)
-    .map { case (buffer, sel) => buffer.io.write.head.ready && sel }
+    .map { case (buffer, sel) => buffer.io.overwrite.head && sel }
     .reduce(_ || _)
-  XSPerfAccumulate("ittage_table_update_drop", io.update.valid && !targetBankReady)
+  XSPerfAccumulate("ittage_table_update_overwrite", io.update.valid && updateOverwrite)
 
   if (debug) {
     val u    = io.update

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbInternalBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbInternalBank.scala
@@ -194,9 +194,7 @@ class MainBtbInternalBank(
   counterWriteBuffer.io.enq.bits.wayMask  := writeCounter.req.bits.wayMask
   counterWriteBuffer.io.enq.bits.counters := writeCounter.req.bits.counters
 
-  private val perf_entryDropWrite = (0 until NumWay).map { i =>
-    writeEntry.req.valid && writeEntry.req.bits.wayMask(i) && !entryWriteBuffer.io.write(i).ready
-  }.reduce(_ || _)
+  private val perfEntryOverwrite = entryWriteBuffer.io.overwrite.reduce(_ || _)
 
   XSPerfAccumulate(
     "multihit_write_conflict",
@@ -209,7 +207,7 @@ class MainBtbInternalBank(
     !counterWriteBuffer.io.enq.ready && counterWriteBuffer.io.enq.valid
   )
   XSPerfAccumulate(
-    "entry_writebuffer_drop_write",
-    perf_entryDropWrite
+    "entry_writebuffer_overwrite",
+    perfEntryOverwrite
   )
 }

--- a/src/main/scala/xiangshan/frontend/bpu/tage/TageTable.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/TageTable.scala
@@ -233,7 +233,7 @@ class TageTable(
   )
   XSPerfAccumulate(s"tage_write_total_${tableIdx}", Mux(io.writeReq.valid, PopCount(io.writeReq.bits.wayMask), 0.U))
   XSPerfAccumulate(
-    "drop_write",
-    PopCount(entryWriteBuffers.flatMap(writePorts => writePorts.io.write.map(p => p.valid && !p.ready)))
+    "overwrite",
+    PopCount(entryWriteBuffers.flatMap(_.io.overwrite))
   )
 }


### PR DESCRIPTION
This Pr
1. rename valids/needWrite to shadowValid/dirty
2. WriteBuffer overwrites on full, the write interface is changed from DecoupledIO to ValidIO, and ABTB, ITTAGE, MBTB, and TAGE counters are updated accordingly
3. a write hit sets the slot to dirty, but within the same cycle, after the SRAM latches that slot, a subsequent unconditional assignment clears the dirty bit. 
    - The SRAM latches old data A
    - A new request in the same cycle updates the shadow register to B and sets the dirty bit
    - The dequeue logic then clears the dirty bit
    - Result: B remains in the shadow register but is never written back to the SRAM
        