### PR TITLE
fix(Berti): remove unreliable PC override in PrefetcherWrapper

### DIFF
--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherWrapper.scala
@@ -271,11 +271,6 @@ class PrefetcherWrapper(implicit p: Parameters) extends PrefetchModule {
         source.bits.miss || isFromBerti(source.bits.metaSource)
       ) && !source.bits.isHwPrefetch // && isLoadAccess(source.bits.uop)
       pf.io.ld_in(i).bits := source.bits
-      pf.io.ld_in(i).bits.pc := Mux(
-        io.trainSource.s3_ptrChasing(i),
-        s2_loadPcVec(i),
-        s3_loadPcVec(i)
-      )
     }
 
     for (i <- 0 until ST_TRAIN_WIDTH) {


### PR DESCRIPTION
**Context**

I work in the computer architecture department at Universidad de Murcia, co-creator of the Berti prefetcher. While porting Berti to OpenXiangShan, the prefetcher showed near-zero prefetch coverage across almost the entire benchmark suite. Only fd-spmv showed partial learning.

**The problem**

Berti separates two events in time for the same load: the access, when the load executes and records that this PC touched this address, and the search, much later on refill after a cache miss, when it looks up what else this same PC has seen to compute deltas and issue prefetches. For the search to find what the access stored, the PC must be exactly the same at both moments.

```scala
pf.io.ld_in(i).bits := source.bits                  // route A

pf.io.ld_in(i).bits.uop.pc := Mux(                  // route B
  io.trainSource.s3_ptrChasing(i),
  s2_loadPcVec(i),
  s3_loadPcVec(i)
)
```

In `PrefetcherWrapper.scala`, `uop.pc` was being overwritten for all prefetchers through a `Mux` (route B, a PC reconstructed from a lane-indexed shift register) instead of leaving the uop's own `pc` field, which travels attached to the instruction (route A). Route B assumes the same instruction stays in the same lane every cycle with no stall or replay, which does not always hold, so it can end up carrying another instruction's PC.

**Historical origin**

Route B was added in 2022 for one narrow case: pointer-chasing loads reach certain stages one cycle early, and `s3_ptrChasing` corrected that skew. That signal is now hardcoded to `false` in the current codebase, with an existing comment from XiangShan developers saying the logic should be removed, so the correction it was built for is already inert. In July 2025 `PrefetcherWrapper.scala` was created and reused route B for SMS and Stride. In November 2025 Berti was wired in following the same connection pattern, without accounting for how Berti's access/search timing differs from theirs.

**Why SMS and Stride are unaffected**

They only use the PC as an index into their own table within a single event. An occasionally mismatched PC just lands the entry in a different bucket, with no cross-time comparison to break.

**Why Berti is affected**

Berti's refill-time search reads `uop.pc` directly from the MSHR (route A, untouched by this override), while access-time training went through the overridden route B. The loads that matter most to Berti, the ones that miss and stay in flight longest, are also the most likely to desync between the two routes.

**Evidence**

Real execution traces, percentage of refill-time searches whose PC matched an entry actually written during training:

| Benchmark | % matching PC |
|---|---|
| fd-vvadd | 5% |
| fd-median | 6% |
| fd-multiply | 5% |
| fd-spmv | 20% |

Local trace replay on fd-vvadd. With PCs as they came from the trace, FIND = 0, matching production behavior. Aligning only the search PC with the training PC, with no other variable changed, FIND = 267 out of 413.

**Fix**

Remove the `Mux` override. `uop.pc` is left as route A delivers it, so access-time and refill-time PCs are always the same value. Only affects Berti's connection; SMS/Stride wiring and `Berti.scala` are untouched.

**Results**

IPC speedup vs no-prefetch baseline, Berti Only configuration, before and after this fix (11-benchmark suite):

| Benchmark | Before fix | After fix |
|---|---|---|
| chase | 1.000 | 1.000 |
| fd-median | 1.000 | 1.037 |
| fd-multiply | 1.000 | 1.000 |
| fd-spmv | 1.010 | 1.049 |
| fd-vvadd | 1.000 | 1.004 |
| multistride | 1.000 | 1.003 |
| stream | 1.000 | 1.005 |
| stride+3 | 1.000 | 1.011 |
| stride+4 | 1.000 | 0.989 |
| stride+7 | 1.000 | 1.007 |
| stride+8 | 1.000 | 0.989 |
| **Geomean** | **1.001** | **1.008** |

**Scope**

This PR only fixes the samePC issue. We are developing other fixes independently, including a correction for an arithmetic bug in the timeliness check and a revision of the HistoryTable/DeltaTable sizing. We are also working on a version closer to the original Berti design, including multiple prefetch candidates per cycle (multi-delta search), which will be submitted once it is stable enough for review.