### PR TITLE
fix(Berti): avoid unsigned underflow in timeliness comparison

### DIFF
--- a/src/main/scala/xiangshan/mem/prefetch/Berti.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/Berti.scala
@@ -61,6 +61,10 @@ trait HasBertiHelper extends HasCircularQueuePtrHelper with HasDCacheParameters 
   def HtLineOffsetWidth: Int = DCacheLineOffset
   def DtPcTagWidth: Int = 10
   def DtCntWidth: Int = 4
+  // Width of the global timestamp (currTime and tsp). Wide enough that the elapsed
+  // distance (currTime - tsp) never exceeds 2^TimestampWidth in practice, avoiding
+  // aliasing from a double counter wrap. (latency keeps LATENCY_WIDTH bits.)
+  def TimestampWidth: Int = 32
 
   def useByteAddr: Boolean = bertiParams.use_byte_addr
   def usePLRU: Boolean = bertiParams.ht_replacement_policy == "plru"
@@ -169,7 +173,7 @@ class HistoryTable()(implicit p: Parameters) extends BertiModule {
   class Entry()(implicit p: Parameters) extends BertiBundle {
     val pcTag = UInt(HtPcTagWidth.W)
     val baseVAddr = UInt(HtLineVAddrWidth.W)
-    val tsp = UInt(LATENCY_WIDTH.W)
+    val tsp = UInt(TimestampWidth.W)
 
     def alloc(_pcTag: UInt, _baseVAddr: UInt, _tsp: UInt): Unit = {
       pcTag := _pcTag
@@ -201,7 +205,7 @@ class HistoryTable()(implicit p: Parameters) extends BertiModule {
   val entries = Reg(Vec(HtSetSize, Vec(HtWaySize, new Entry)))
   val valids = RegInit(0.U.asTypeOf(Vec(HtSetSize, Vec(HtWaySize, Bool()))))
   val decrModes = RegInit(0.U.asTypeOf(Vec(HtSetSize, Bool())))
-  val currTime = GTimer()
+  val currTime = GTimer()(TimestampWidth - 1, 0)
   // PLRU: replace record
   val replacer = Option.when(usePLRU)(ReplacementPolicy.fromString("setplru", HtWaySize, HtSetSize))
   // FIFO: for FIFO replace policy
@@ -266,8 +270,8 @@ class HistoryTable()(implicit p: Parameters) extends BertiModule {
     when(matchVec.orR){
       val hitWay = OHToUInt(matchVec)
       val pair = getDelta(getTrainBaseAddr2HT(vaddr), entries(set)(hitWay).baseVAddr)
-      stat_find_delta := latency =/= 0.U && (currTime - latency > entries(set)(hitWay).tsp)
-      res.valid := latency =/= 0.U && (currTime - latency > entries(set)(hitWay).tsp) && pair._1
+      stat_find_delta := latency =/= 0.U && (currTime - entries(set)(hitWay).tsp > latency)
+      res.valid := latency =/= 0.U && (currTime - entries(set)(hitWay).tsp > latency) && pair._1
       res.pc := pc
       res.delta := pair._2
       replacer.get.access(set, hitWay)
@@ -312,7 +316,7 @@ class HistoryTable()(implicit p: Parameters) extends BertiModule {
     val tag = getTag(pc)
     val way = learnPtrs.get(set).value
     val pair = getDelta(getTrainBaseAddr2HT(vaddr), entries(set)(way).baseVAddr)
-    stat_find_delta := valids(set)(way) && latency =/= 0.U && tag === entries(set)(way).pcTag && (currTime - latency > entries(set)(way).tsp)
+    stat_find_delta := valids(set)(way) && latency =/= 0.U && tag === entries(set)(way).pcTag && (currTime - entries(set)(way).tsp > latency)
     res.pc := pc
     res.valid := stat_find_delta && pair._1
     when (decrModes(set) ^ pair._2(pair._2.getWidth-1)){


### PR DESCRIPTION
**Context**

I work in the computer architecture department at Universidad de Murcia, co-creator of the Berti prefetcher. While diagnosing why Berti showed near-zero prefetch coverage on OpenXiangShan (see PR #6319 for the main cause), we also found a separate arithmetic bug in the timeliness check that is worth fixing on its own, independent of that issue.

**The problem**

The timeliness gate decides whether a stored history entry is recent enough to be useful, by comparing the elapsed time since it was written against the observed miss latency. The comparison was written as:

```scala
currTime - latency > tsp
```

`currTime`, `tsp`, and `latency` are all unsigned. When `latency` is greater than `currTime` (which happens whenever a load's latency exceeds how long the global counter has been running, typically near reset or right after the counter wraps), the subtraction `currTime - latency` underflows. The result wraps around to a very large unsigned value, so the comparison is satisfied almost unconditionally, and the gate accepts deltas that are not actually timely.

**Fix**

Reordering the subtraction avoids the underflow entirely:

```scala
currTime - tsp > latency
```

`tsp` is always less than or equal to `currTime` by construction (an entry cannot be written in the future), so `currTime - tsp` never underflows. If the counter itself wraps around, the wraparound cancels out identically on both sides of the comparison, so it still measures the real elapsed distance correctly.

Example with a 16-bit counter that has just wrapped:

```
currTime = 5, tsp = 65530, latency = 8
currTime - tsp = 5 - 65530 (mod 65536) = 11
11 > 8  ->  correctly resolves as timely (11 real cycles elapsed)
```

Alongside the reorder, the timestamp field itself (`tsp` and `currTime`) is widened from `LATENCY_WIDTH` to a dedicated `TimestampWidth` (32 bits), to reduce how often the counter wraps in the first place.

**Results**

IPC speedup vs no-prefetch baseline, Berti Only configuration, before and after this fix (11-benchmark suite):

| Benchmark | Before fix | After fix |
|---|---|---|
| chase | 1.000 | 1.000 |
| fd-median | 1.000 | 1.000 |
| fd-multiply | 1.000 | 1.000 |
| fd-spmv | 1.010 | 1.010 |
| fd-vvadd | 1.000 | 1.000 |
| multistride | 1.000 | 1.000 |
| stream | 1.000 | 1.000 |
| stride+3 | 1.000 | 1.000 |
| stride+4 | 1.000 | 1.000 |
| stride+7 | 1.000 | 1.000 |
| stride+8 | 1.000 | 1.000 |
| **Geomean** | **1.001** | **1.001** |

No measurable IPC change on this suite, this fix is included for correctness on its own merits. Without it, the timeliness gate can silently misjudge deltas whenever the global counter wraps around a load's outstanding latency, which may not surface on this short-running suite but can affect longer executions.
