### PR TITLE
fix(MemBlock): misalign vec elements within a uop are strictly ordered

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -1471,7 +1471,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
 
   // For vector, when there is a store across pages with the same uop in storeMisalignBuffer, storequeue needs to mark this item as committed.
   // TODO FIXME Can vecMbCommit be removed?
-  when(io.maControl.toStoreQueue.withSamePtr && allvalid(rdataPtrExt(0).value)) {
+  when(io.maControl.toStoreQueue.withSamePtr) {
     vecMbCommit(rdataPtrExt(0).value) := true.B
   }
 

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -184,7 +184,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   val s0_rs_cross16Bytes = s0_addr_Up_low(4) =/= s0_addr_low(4)
   val s0_misalignWith16Byte = !s0_rs_cross16Bytes && !s0_addr_aligned && !s0_use_flow_prf
   val s0_misalignNeedReplay = s0_rs_cross16Bytes && !(s0_uop.sqIdx === io.sqCommitPtr ||
-    s0_uop.robIdx === io.sqCommitRobIdx && s0_uop.uopIdx === io.sqCommitUopIdx || s0_vecIsFirstActiveElement && s0_use_flow_vec)
+    s0_uop.robIdx === io.sqCommitRobIdx && s0_uop.uopIdx === io.sqCommitUopIdx) || !s0_vecIsFirstActiveElement && s0_use_flow_vec
   s0_is128bit := Mux(s0_use_flow_ma, io.misalign_stin.bits.is128bit, is128Bit(s0_vecstin.alignedType) || s0_misalignWith16Byte)
 
   s0_fullva := Mux(

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -453,16 +453,15 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
   // allocated
   when(doEnqueue){ // if enqueue need to been cancelled, it will be false, so this have high priority
     allocated := true.B
-    isFirstActive := true.B
   }.elsewhen(needCancel) { // redirect
     allocated := false.B
-    isFirstActive := false.B
   }.elsewhen(splitFinish && (activeIssue || inActiveIssue)){ //dequeue
     allocated := false.B
-    isFirstActive := false.B
   }
 
-  when(io.out.fire) {
+  when(doEnqueue) {
+    isFirstActive := true.B
+  }. elsewhen(io.out.fire) {
     isFirstActive := false.B
   }
 


### PR DESCRIPTION
Because cross-page unaligned accesses need to be stored in the StoreMisalignBuffer, the MergeBuffer cannot commit the entire uop. Therefore, we need to ensure that before any unaligned element within the uop is executed, there are no other elements left unexecuted.

In the previous related fix, I incorrectly implemented the replay logic, and this is corrected here.