### PR TITLE
feat(NTL): support RISC-V zihintntl in decode and DCache

### DIFF
--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -363,7 +363,7 @@ object Bundles {
     val uopIdx = UopIdx()
     val lastUop = Bool()
     val isNtlHint = Bool()
-    val ntl = Valid(NtlType())
+    val ntl = Bool() // Currently only DCache NTL is supported. So only 1 bit is needed.
     // from rename
     val psrc = Vec(numSrc, UInt(PhyRegIdxWidth.W))
     val psrcVl = UInt(VlPhyRegIdxWidth.W)
@@ -424,7 +424,7 @@ object Bundles {
     val wfflags  = Option.when(params.writeFflags)(Bool())
     val uopIdx   = Option.when(params.inVfSchd)(UopIdx())
     val lastUop  = Option.when(params.inVfSchd)(Bool())
-    val ntl      = Option.when(params.isMemBlockIQ)(Valid(NtlType()))
+    val ntl      = Option.when(params.isMemBlockIQ)(Bool())
     // from rename
     val robIdx    = new RobPtr
     val psrc      = Vec(numSrc, UInt(PhyRegIdxWidth.W))
@@ -468,7 +468,7 @@ object Bundles {
     val wfflags  = Option.when(params.writeFflags)(Bool())
     val uopIdx   = Option.when(params.inVfSchd)(UopIdx())
     val lastUop  = Option.when(params.inVfSchd)(Bool())
-    val ntl      = Option.when(params.isMemBlockIQ)(Valid(NtlType()))
+    val ntl      = Option.when(params.isMemBlockIQ)(Bool())
     // from rename
     val numLsElem = Option.when(params.isVecMemIQ)(NumLsElem())
     val rasAction = Option.when(params.needRasAction)(BranchAttribute.RasAction())
@@ -498,7 +498,7 @@ object Bundles {
     val wfflags  = Option.when(params.writeFflags)(Bool())
     val uopIdx   = Option.when(params.issueBlockParam.inVfSchd)(UopIdx())
     val lastUop  = Option.when(params.issueBlockParam.inVfSchd)(Bool())
-    val ntl      = Option.when(params.hasMemAddrFu)(Valid(NtlType()))
+    val ntl      = Option.when(params.hasMemAddrFu)(Bool())
     // from rename
     val numLsElem = Option.when(params.issueBlockParam.isVecMemIQ)(NumLsElem())
     val rasAction = Option.when(params.needRasAction)(BranchAttribute.RasAction())
@@ -593,7 +593,7 @@ object Bundles {
     val vlsInstr        = Bool()
     val wfflags         = Bool()
     val isMove          = Bool()
-    val ntl             = Valid(NtlType())
+    val ntl             = Bool() // Currently only DCache NTL is supported. So only 1 bit is needed.
     val isDropAmocasSta = Bool()
     val uopIdx          = UopIdx()
     val isVset          = Bool()
@@ -674,6 +674,8 @@ object Bundles {
     def connectRenameOutUop(source: RenameOutUop): Unit = {
       this := 0.U.asTypeOf(this)
       connectSamePort(this, source)
+      // Currently only DCache NTL is supported.
+      this.ntl := NtlType.toDcacheNtl(source.ntl, source.fuType, source.fuOpType)
       source.debug.foreach(x => {
         this.pc := x.pc
         this.debug_seqNum := x.debug_seqNum
@@ -1005,7 +1007,7 @@ object Bundles {
     val fpu      = Option.when(exuParams.writeFflags)(new FPUCtrlSignals)
     val vpu      = Option.when(iqParams.inVfSchd)(new VPUCtrlSignals)
     val wfflags  = Option.when(exuParams.writeFflags)(Bool())
-    val ntl        = Option.when(exuParams.hasMemAddrFu)(Valid(NtlType()))
+    val ntl        = Option.when(exuParams.hasMemAddrFu)(Bool())
     val numLsElem = Option.when(iqParams.isVecMemIQ)(NumLsElem())
     val rasAction = Option.when(exuParams.needRasAction)(BranchAttribute.RasAction())
     val storeSetHit    = Option.when(exuParams.hasLoadExu || exuParams.hasStoreAddrExu)(Bool())
@@ -1140,7 +1142,7 @@ object Bundles {
     val numLsElem      = OptionWrapper(params.hasVecLsFu, NumLsElem())
     val lqIdx = OptionWrapper(params.hasLoadFu || params.hasVecLsFu, new LqPtr)
     val sqIdx = OptionWrapper(params.hasLoadFu || params.hasStoreAddrFu || params.hasStdFu || params.hasVecLsFu, new SqPtr)
-    val ntl   = OptionWrapper(params.hasMemAddrFu, Valid(NtlType()))
+    val ntl   = OptionWrapper(params.hasMemAddrFu, Bool())
     val dataSources = Vec(params.numRegSrc, DataSource())
     val exuSources = OptionWrapper(params.isIQWakeUpSink, Vec(params.numRegSrc, ExuSource(params)))
     val loadDependency = OptionWrapper(params.needLoadDependency, Vec(LoadPipelineWidth, UInt(LoadDependencyWidth.W)))
@@ -1222,7 +1224,7 @@ object Bundles {
       uop.isRVC          := this.isRVC.getOrElse(false.B)
       uop.rasAction      := this.rasAction.getOrElse(0.U)
       uop.numLsElem      := this.numLsElem.getOrElse(0.U)
-      uop.ntl            := this.ntl.getOrElse(0.U.asTypeOf(Valid(NtlType())))
+      uop.ntl            := this.ntl.getOrElse(false.B)
       uop
     }
   }
@@ -1297,7 +1299,7 @@ object Bundles {
     val numLsElem      = Option.when(params.hasVecLsFu)(NumLsElem())
     val lqIdx          = Option.when(params.hasLoadExu || params.hasVecLsFu)(new LqPtr)
     val sqIdx          = Option.when(params.hasLoadExu || params.hasStoreAddrFu || params.hasStdFu || params.hasVecLsFu)(new SqPtr)
-    val ntl            = Option.when(params.hasMemAddrFu)(Valid(NtlType()))
+    val ntl            = Option.when(params.hasMemAddrFu)(Bool())
     val perfDebugInfo  = Option.when(backendParams.debugEn)(new PerfDebugInfo())
     val debug_seqNum   = Option.when(backendParams.debugEn)(InstSeqNum())
   }

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -172,6 +172,8 @@ object Bundles {
     val vlsInstr = Bool()
     val wfflags = Bool()
     val isMove = Bool()
+    val isNtlHint = Bool()
+    val ntl = Valid(NtlType())
     val uopIdx = UopIdx()
     val uopSplitType = UopSplitType()
     val isVset = Bool()
@@ -196,6 +198,8 @@ object Bundles {
     def isSoftPrefetch: Bool = {
       fuType === FuType.alu.U && fuOpType === ALUOpType.or && selImm === SelImm.IMM_I && ldest === 0.U
     }
+
+    def isMemAll: Bool = FuType.isMem(fuType) || FuType.isVls(fuType)
 
     def connectDecodeInUop(source: DecodeInUop): Unit = {
       (this: Data).waiveAll :<= (source: Data).waiveAll
@@ -261,6 +265,8 @@ object Bundles {
     val vlsInstr = Bool()
     val wfflags = Bool()
     val isMove = Bool()
+    val isNtlHint = Bool()
+    val ntl = Valid(NtlType())
     val uopIdx = UopIdx()
     val isVset = Bool()
     val firstUop = Bool()
@@ -356,6 +362,8 @@ object Bundles {
     val wfflags = Bool()
     val uopIdx = UopIdx()
     val lastUop = Bool()
+    val isNtlHint = Bool()
+    val ntl = Valid(NtlType())
     // from rename
     val psrc = Vec(numSrc, UInt(PhyRegIdxWidth.W))
     val psrcVl = UInt(VlPhyRegIdxWidth.W)
@@ -416,6 +424,7 @@ object Bundles {
     val wfflags  = Option.when(params.writeFflags)(Bool())
     val uopIdx   = Option.when(params.inVfSchd)(UopIdx())
     val lastUop  = Option.when(params.inVfSchd)(Bool())
+    val ntl      = Option.when(params.isMemBlockIQ)(Valid(NtlType()))
     // from rename
     val robIdx    = new RobPtr
     val psrc      = Vec(numSrc, UInt(PhyRegIdxWidth.W))
@@ -459,6 +468,7 @@ object Bundles {
     val wfflags  = Option.when(params.writeFflags)(Bool())
     val uopIdx   = Option.when(params.inVfSchd)(UopIdx())
     val lastUop  = Option.when(params.inVfSchd)(Bool())
+    val ntl      = Option.when(params.isMemBlockIQ)(Valid(NtlType()))
     // from rename
     val numLsElem = Option.when(params.isVecMemIQ)(NumLsElem())
     val rasAction = Option.when(params.needRasAction)(BranchAttribute.RasAction())
@@ -488,6 +498,7 @@ object Bundles {
     val wfflags  = Option.when(params.writeFflags)(Bool())
     val uopIdx   = Option.when(params.issueBlockParam.inVfSchd)(UopIdx())
     val lastUop  = Option.when(params.issueBlockParam.inVfSchd)(Bool())
+    val ntl      = Option.when(params.hasMemAddrFu)(Valid(NtlType()))
     // from rename
     val numLsElem = Option.when(params.issueBlockParam.isVecMemIQ)(NumLsElem())
     val rasAction = Option.when(params.needRasAction)(BranchAttribute.RasAction())
@@ -582,6 +593,7 @@ object Bundles {
     val vlsInstr        = Bool()
     val wfflags         = Bool()
     val isMove          = Bool()
+    val ntl             = Valid(NtlType())
     val isDropAmocasSta = Bool()
     val uopIdx          = UopIdx()
     val isVset          = Bool()
@@ -993,6 +1005,7 @@ object Bundles {
     val fpu      = Option.when(exuParams.writeFflags)(new FPUCtrlSignals)
     val vpu      = Option.when(iqParams.inVfSchd)(new VPUCtrlSignals)
     val wfflags  = Option.when(exuParams.writeFflags)(Bool())
+    val ntl        = Option.when(exuParams.hasMemAddrFu)(Valid(NtlType()))
     val numLsElem = Option.when(iqParams.isVecMemIQ)(NumLsElem())
     val rasAction = Option.when(exuParams.needRasAction)(BranchAttribute.RasAction())
     val storeSetHit    = Option.when(exuParams.hasLoadExu || exuParams.hasStoreAddrExu)(Bool())
@@ -1127,6 +1140,7 @@ object Bundles {
     val numLsElem      = OptionWrapper(params.hasVecLsFu, NumLsElem())
     val lqIdx = OptionWrapper(params.hasLoadFu || params.hasVecLsFu, new LqPtr)
     val sqIdx = OptionWrapper(params.hasLoadFu || params.hasStoreAddrFu || params.hasStdFu || params.hasVecLsFu, new SqPtr)
+    val ntl   = OptionWrapper(params.hasMemAddrFu, Valid(NtlType()))
     val dataSources = Vec(params.numRegSrc, DataSource())
     val exuSources = OptionWrapper(params.isIQWakeUpSink, Vec(params.numRegSrc, ExuSource(params)))
     val loadDependency = OptionWrapper(params.needLoadDependency, Vec(LoadPipelineWidth, UInt(LoadDependencyWidth.W)))
@@ -1174,6 +1188,7 @@ object Bundles {
       this.ssid          .foreach(_ := source.ssid.get)
       this.lqIdx         .foreach(_ := source.lqIdx.get)
       this.sqIdx         .foreach(_ := source.sqIdx.get)
+      this.ntl           .foreach(_ := source.ntl.get)
     }
 
     def toDynInst(): DynInst = {
@@ -1207,6 +1222,7 @@ object Bundles {
       uop.isRVC          := this.isRVC.getOrElse(false.B)
       uop.rasAction      := this.rasAction.getOrElse(0.U)
       uop.numLsElem      := this.numLsElem.getOrElse(0.U)
+      uop.ntl            := this.ntl.getOrElse(0.U.asTypeOf(Valid(NtlType())))
       uop
     }
   }
@@ -1281,6 +1297,7 @@ object Bundles {
     val numLsElem      = Option.when(params.hasVecLsFu)(NumLsElem())
     val lqIdx          = Option.when(params.hasLoadExu || params.hasVecLsFu)(new LqPtr)
     val sqIdx          = Option.when(params.hasLoadExu || params.hasStoreAddrFu || params.hasStdFu || params.hasVecLsFu)(new SqPtr)
+    val ntl            = Option.when(params.hasMemAddrFu)(Valid(NtlType()))
     val perfDebugInfo  = Option.when(backendParams.debugEn)(new PerfDebugInfo())
     val debug_seqNum   = Option.when(backendParams.debugEn)(InstSeqNum())
   }

--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -622,7 +622,7 @@ class CtrlBlockImp(
     decodePipeRename(i).ready := rename.io.in(i).ready
     rename.io.in(i).valid := decodePipeRename(i).valid && !fusionDecoder.io.clear(i)
     rename.io.in(i).bits := decodePipeRename(i).bits
-    dispatch.io.renameIn(i).valid := decodePipeRename(i).valid && !fusionDecoder.io.clear(i) && !decodePipeRename(i).bits.isMove
+    dispatch.io.renameIn(i).valid := decodePipeRename(i).valid && !fusionDecoder.io.clear(i) && !decodePipeRename(i).bits.isMove && !decodePipeRename(i).bits.isNtlHint
     dispatch.io.renameIn(i).bits := decodePipeRename(i).bits
     rename.io.validVec(i) := decodePipeRename(i).valid
     rename.io.isFusionVec(i) := false.B

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -138,6 +138,38 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   /** instructions decoded by simple decoders */
   val simpleDecodedInst = VecInit(decoders.map(_.io.deq.decodedInst))
 
+  /**
+   * NTL (Non-Temporal Locality) hint attach: bind hint at slot i to memory target at slot i+1 (or next cycle slot)
+   */
+  val ntlAddedSimpleDecodedInst = WireDefault(simpleDecodedInst)
+  val inFires = io.in.map(_.fire)
+  for (i <- 0 until DecodeWidth - 1) {
+    when (inFires(i) && simpleDecodedInst(i).isNtlHint && inFires(i + 1) && ntlAddedSimpleDecodedInst(i + 1).isMemAll) {
+      ntlAddedSimpleDecodedInst(i + 1).ntl.valid := true.B
+      ntlAddedSimpleDecodedInst(i + 1).ntl.bits  := NtlType(simpleDecodedInst(i).lsrc(1))
+    }
+  }
+  val pendingNtl = RegInit(0.U.asTypeOf(Valid(NtlType())))
+  when (pendingNtl.valid && inFires(0) && ntlAddedSimpleDecodedInst(0).isMemAll) {
+    ntlAddedSimpleDecodedInst(0).ntl.valid := true.B
+    ntlAddedSimpleDecodedInst(0).ntl.bits  := pendingNtl.bits
+  }
+  val lastFireSlotOH = (0 until DecodeWidth).map { i =>
+    if (i == DecodeWidth - 1) inFires(i) else inFires(i) && !inFires(i + 1)
+  }
+  val lastHintFire = lastFireSlotOH.zip(simpleDecodedInst.map(_.isNtlHint)).map {
+    case (oh, hint) => oh && hint
+  }.reduce(_ || _)
+
+  when (io.redirect.valid) {
+    pendingNtl.valid := false.B
+  }.elsewhen (lastHintFire) {
+    pendingNtl.valid := true.B
+    pendingNtl.bits  := Mux1H(lastFireSlotOH, simpleDecodedInst.map(inst => NtlType(inst.lsrc(1))))
+  }.elsewhen (pendingNtl.valid && inFires(0)) {
+    pendingNtl.valid := false.B
+  }
+
   /** whether instructions decoded by simple decoders are illegal */
   val isIllegalInstVec = VecInit((outValids lazyZip outReadys lazyZip io.out.map(_.bits)).map {
     case (valid, ready, decodedInst) =>
@@ -159,7 +191,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   /** existance of complex instructions among first few simple decoders' results, which needs decoding */
   val complexValid = VecInit((isComplexVec zip noMoreThanRenameReady).map(x => x._1 & x._2)).asUInt.orR
   /** selected complex instruction for complex decoder */
-  val complexInst = PriorityMuxDefault(isComplexVec.zip(decoders.map(_.io.deq.decodedInst)), 0.U.asTypeOf(new DecodeOutUop))
+  val complexInst = PriorityMuxDefault(isComplexVec.zip(ntlAddedSimpleDecodedInst), 0.U.asTypeOf(new DecodeOutUop))
   /** selected complex micro operation information for complex decoder */
   val complexUopInfo = PriorityMuxDefault(isComplexVec.zip(decoders.map(_.io.deq.uopInfo)), 0.U.asTypeOf(new UopInfo))
 
@@ -233,7 +265,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule
    * use simple decoded insts to fill the rest space in DecodeWidth.
    */
   for (i <- 0 until DecodeWidth) {
-    finalDecodedInst(i) := Mux(complexNum > i.U, complexDecodedInst(i), simpleDecodedInst(i.U - complexNum))
+    finalDecodedInst(i) := Mux(complexNum > i.U, complexDecodedInst(i), ntlAddedSimpleDecodedInst(i.U - complexNum))
     finalDecodedInstValid(i) := Mux(complexNum > i.U, complexDecodedInstValid(i), simplePrefixVec(i.U - complexNum))
   }
 

--- a/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeStage.scala
@@ -141,18 +141,17 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   /**
    * NTL (Non-Temporal Locality) hint attach: bind hint at slot i to memory target at slot i+1 (or next cycle slot)
    */
-  val ntlAddedSimpleDecodedInst = WireDefault(simpleDecodedInst)
   val inFires = io.in.map(_.fire)
   for (i <- 0 until DecodeWidth - 1) {
-    when (inFires(i) && simpleDecodedInst(i).isNtlHint && inFires(i + 1) && ntlAddedSimpleDecodedInst(i + 1).isMemAll) {
-      ntlAddedSimpleDecodedInst(i + 1).ntl.valid := true.B
-      ntlAddedSimpleDecodedInst(i + 1).ntl.bits  := NtlType(simpleDecodedInst(i).lsrc(1))
+    when (inFires(i) && simpleDecodedInst(i).isNtlHint && inFires(i + 1) && simpleDecodedInst(i + 1).isMemAll) {
+      simpleDecodedInst(i + 1).ntl.valid := true.B
+      simpleDecodedInst(i + 1).ntl.bits  := NtlType(simpleDecodedInst(i).lsrc(1))
     }
   }
   val pendingNtl = RegInit(0.U.asTypeOf(Valid(NtlType())))
-  when (pendingNtl.valid && inFires(0) && ntlAddedSimpleDecodedInst(0).isMemAll) {
-    ntlAddedSimpleDecodedInst(0).ntl.valid := true.B
-    ntlAddedSimpleDecodedInst(0).ntl.bits  := pendingNtl.bits
+  when (pendingNtl.valid && inFires(0) && simpleDecodedInst(0).isMemAll) {
+    simpleDecodedInst(0).ntl.valid := true.B
+    simpleDecodedInst(0).ntl.bits  := pendingNtl.bits
   }
   val lastFireSlotOH = (0 until DecodeWidth).map { i =>
     if (i == DecodeWidth - 1) inFires(i) else inFires(i) && !inFires(i + 1)
@@ -191,7 +190,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule
   /** existance of complex instructions among first few simple decoders' results, which needs decoding */
   val complexValid = VecInit((isComplexVec zip noMoreThanRenameReady).map(x => x._1 & x._2)).asUInt.orR
   /** selected complex instruction for complex decoder */
-  val complexInst = PriorityMuxDefault(isComplexVec.zip(ntlAddedSimpleDecodedInst), 0.U.asTypeOf(new DecodeOutUop))
+  val complexInst = PriorityMuxDefault(isComplexVec.zip(simpleDecodedInst), 0.U.asTypeOf(new DecodeOutUop))
   /** selected complex micro operation information for complex decoder */
   val complexUopInfo = PriorityMuxDefault(isComplexVec.zip(decoders.map(_.io.deq.uopInfo)), 0.U.asTypeOf(new UopInfo))
 
@@ -265,7 +264,7 @@ class DecodeStage(implicit p: Parameters) extends XSModule
    * use simple decoded insts to fill the rest space in DecodeWidth.
    */
   for (i <- 0 until DecodeWidth) {
-    finalDecodedInst(i) := Mux(complexNum > i.U, complexDecodedInst(i), ntlAddedSimpleDecodedInst(i.U - complexNum))
+    finalDecodedInst(i) := Mux(complexNum > i.U, complexDecodedInst(i), simpleDecodedInst(i.U - complexNum))
     finalDecodedInstValid(i) := Mux(complexNum > i.U, complexDecodedInstValid(i), simplePrefixVec(i.U - complexNum))
   }
 

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -859,6 +859,13 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
   // temp decode zimop as move
   decodedInst.isMove := (isMove || isZimop) && ctrl_flow.instr(RD_MSB, RD_LSB) =/= 0.U && !io.csrCtrl.singlestep
 
+  val isNtlAdd = BitPat("b0000000_00000_00000_000_?????_0110011") === ctrl_flow.instr &&
+                 inst.RD === 0.U && inst.RS1 === 0.U &&
+                 (inst.RS2 === 2.U || inst.RS2 === 3.U || inst.RS2 === 4.U || inst.RS2 === 5.U)
+  decodedInst.isNtlHint := isNtlAdd && !io.csrCtrl.singlestep
+  decodedInst.ntl.valid := false.B
+  decodedInst.ntl.bits  := 0.U
+
   // fmadd - b1000011
   // fmsub - b1000111
   // fnmsub- b1001011

--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -859,9 +859,9 @@ class DecodeUnit(implicit p: Parameters) extends XSModule with DecodeUnitConstan
   // temp decode zimop as move
   decodedInst.isMove := (isMove || isZimop) && ctrl_flow.instr(RD_MSB, RD_LSB) =/= 0.U && !io.csrCtrl.singlestep
 
-  val isNtlAdd = BitPat("b0000000_00000_00000_000_?????_0110011") === ctrl_flow.instr &&
-                 inst.RD === 0.U && inst.RS1 === 0.U &&
-                 (inst.RS2 === 2.U || inst.RS2 === 3.U || inst.RS2 === 4.U || inst.RS2 === 5.U)
+  // ZihintNTL: add x0, x0, x{2,3,4,5}; R-type layout funct7_rs2_rs1_funct3_rd_opcode
+  val isNtlAdd = BitPat("b0000000_00???_00000_000_00000_0110011") === ctrl_flow.instr &&
+                 (inst.RS2(2, 0) === 2.U || inst.RS2(2, 0) === 3.U || inst.RS2(2, 0) === 4.U || inst.RS2(2, 0) === 5.U)
   decodedInst.isNtlHint := isNtlAdd && !io.csrCtrl.singlestep
   decodedInst.ntl.valid := false.B
   decodedInst.ntl.bits  := 0.U

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -572,7 +572,7 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
   for (i <- 0 until RenameWidth){
     // update valid logic
     fromRenameUpdate(i).valid := fromRename(i).valid && allowDispatch(i) && !uopBlockByIQ(i) && thisCanActualOut(i) &&
-      !lsqRecoverStall && !fromRename(i).bits.isMove && !fromRename(i).bits.hasException && !fromRenameUpdate(i).bits.singleStep
+      !lsqRecoverStall && !fromRename(i).bits.isMove && !fromRename(i).bits.isNtlHint && !fromRename(i).bits.hasException && !fromRenameUpdate(i).bits.singleStep
     fromRename(i).ready := allowDispatch(i) && !uopBlockByIQ(i) && thisCanActualOut(i) && !lsqRecoverStall
     // update src type if eliminate old vd
     fromRenameUpdate(i).bits.srcType(numRegSrcVf - 1) := Mux(ignoreOldVdVec(i), SrcType.no, fromRename(i).bits.srcType(numRegSrcVf - 1))

--- a/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
+++ b/src/main/scala/xiangshan/backend/dispatch/Dispatch.scala
@@ -175,6 +175,9 @@ class Dispatch(implicit p: Parameters) extends XSModule with HasPerfEvents with 
     fromRenameUpdate(i).bits.srcState := 0.U.asTypeOf(fromRenameUpdate(i).bits.srcState)
     fromRenameUpdate(i).bits.srcStateVl := 0.U // dontCare this
     connectSamePort(fromRenameUpdate(i).bits, fromRename(i).bits)
+    // Currently only DCache NTL is supported. So only 1 bit is needed.
+    fromRenameUpdate(i).bits.ntl := NtlType.toDcacheNtl(
+      fromRename(i).bits.ntl, fromRename(i).bits.fuType, fromRename(i).bits.fuOpType)
     fromRenameUpdate(i).bits.debug.foreach(connectSamePort(_, fromRename(i).bits.debug.get))
     fromRenameUpdate(i).bits.ftqOffset := fromRename(i).bits.ftqLastOffset
     fromRenameUpdate(i).bits.ftqPtr := fromRename(i).bits.ftqPtr + fromRename(i).bits.crossFtq

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -426,6 +426,10 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
   isMove zip io.in.map(_.bits) foreach {
     case (move, in) => move := Mux(in.exceptionVec.orR, false.B, in.isMove)
   }
+  val isNtlHint = Wire(Vec(RenameWidth, Bool()))
+  isNtlHint zip io.in.map(_.bits) foreach {
+    case (hint, in) => hint := Mux(in.exceptionVec.orR, false.B, in.isNtlHint)
+  }
 
   val walkNeedIntDest = WireDefault(VecInit(Seq.fill(RenameWidth)(false.B)))
   val walkNeedFpDest = WireDefault(VecInit(Seq.fill(RenameWidth)(false.B)))
@@ -494,12 +498,12 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
     instrSize(i) := instrSizesVec(i) + io.fusionCross2FtqVec(i)
     uops(i).debug.foreach(_.fusionNum := PopCount(compressMasksVec(i) & Cat(io.isFusionVec.reverse)))
     val hasExceptionExceptFlushPipe = uops(i).exceptionVec.orR || TriggerAction.isDmode(uops(i).trigger)
-    when(isMove(i) || hasExceptionExceptFlushPipe) {
+    when(isMove(i) || isNtlHint(i) || hasExceptionExceptFlushPipe) {
       uops(i).numWB := 0.U
     }
     if (i > 0) {
       when(!needRobFlags(i - 1)) {
-        val numFusion = PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(fusionValidVec.reverse)))
+        val numFusion = PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(isNtlHint.reverse) | Cat(fusionValidVec.reverse)))
         val numuops = instrSizesVec(i) - numFusion
         dontTouch(numFusion)
         dontTouch(numuops)
@@ -509,12 +513,12 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
         // rob need first uop isrvc, as it may attach interrupt to first uop(calculate pc)
         // branch need last uop isrvc, it will change in dispatch
         uops(i).isRVC := uops(i - 1).isRVC
-        uops(i).numWB := instrSizesVec(i) - PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(fusionValidVec.reverse)))
+        uops(i).numWB := instrSizesVec(i) - PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(isNtlHint.reverse) | Cat(fusionValidVec.reverse)))
       }
     }
     when(!needRobFlags(i)) {
       uops(i).lastUop := false.B
-      uops(i).numWB := instrSizesVec(i) - PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(fusionValidVec.reverse)))
+      uops(i).numWB := instrSizesVec(i) - PopCount(compressMasksVec(i) & (Cat(isMove.reverse) | Cat(isNtlHint.reverse) | Cat(fusionValidVec.reverse)))
       if (i < RenameWidth - 1) {
         uops(i).crossFtqCommit := uops(i + 1).crossFtqCommit
         uops(i).crossFtq := uops(i + 1).crossFtq

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -1575,12 +1575,14 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   if (env.EnableDifftest || env.AlwaysBasicDiff) {
     // These are the structures used by difftest only and should be optimized after synthesis.
     val dt_eliminatedMove = Mem(RobSize, Bool())
+    val dt_eliminatedNtlHint = Mem(RobSize, Bool())
     val dt_isRVC = Mem(RobSize, Bool())
     val dt_pcTransType = Option.when(env.EnableDifftest)(Mem(RobSize, new AddrTransType))
     val dt_exuDebug = Reg(Vec(RobSize, new DebugBundle))
     for (i <- 0 until RenameWidth) {
       when(canEnqueue(i)) {
         dt_eliminatedMove(allocatePtrVec(i).value) := io.enq.req(i).bits.isMove
+        dt_eliminatedNtlHint(allocatePtrVec(i).value) := io.enq.req(i).bits.isNtlHint
         dt_isRVC(allocatePtrVec(i).value) := io.enq.req(i).bits.isRVC
         dt_pcTransType.foreach(_(allocatePtrVec(i).value) := io.debugInstrAddrTransType)
       }
@@ -1599,13 +1601,14 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
       val ptr = deqPtrVec(i).value
       val exuOut = dt_exuDebug(ptr)
       val eliminatedMove = dt_eliminatedMove(ptr)
+      val eliminatedNtlHint = dt_eliminatedNtlHint(ptr)
       val isRVC = dt_isRVC(ptr)
       val instr = uop.debug_instr.getOrElse(0.U).asTypeOf(new XSInstBitFields)
       val isVLoad = instr.isVecLoad
 
       val diffMaxPhyRegs = Seq(MaxPhyRegs, 2 * (V0PhyRegs + VfPhyRegs)).max // For width of wpdest and otherwpdest
       val difftest = DifftestModule(new DiffInstrCommit(diffMaxPhyRegs), delay = 3, dontCare = true)
-      val dt_skip = Mux(eliminatedMove, false.B, exuOut.isSkipDiff)
+      val dt_skip = Mux(eliminatedMove || eliminatedNtlHint, false.B, exuOut.isSkipDiff)
       difftest.coreid := io.hartId
       difftest.index := i.U
       difftest.valid := io.commits.commitValid(i) && io.commits.isCommit

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -452,7 +452,7 @@ class DCacheLineReq(implicit p: Parameters) extends DCacheBundle
   val data   = UInt((cfg.blockBytes * 8).W)
   val mask   = UInt(cfg.blockBytes.W)
   val id     = UInt(reqIdWidth.W)
-  val ntl    = Valid(NtlType())
+  val ntl    = Bool()
   def dump(cond: Bool) = {
     XSDebug(cond, "DCacheLineReq: cmd: %x addr: %x data: %x mask: %x id: %d\n",
       cmd, addr, data, mask, id)
@@ -469,7 +469,7 @@ class DCacheWordReqWithVaddrAndPfFlag(implicit p: Parameters) extends DCacheWord
   val prefetch = Bool()
   val vecValid = Bool()
   val sqNeedDeq = Bool()
-  val ntl = Valid(NtlType())
+  val ntl = Bool()
 
   def toDCacheWordReqWithVaddr() = {
     val res = Wire(new DCacheWordReqWithVaddr)
@@ -691,7 +691,7 @@ class DCacheLoadIO(implicit p: Parameters) extends DCacheWordIO
   // cycle 0: prefetch source bits
   val pf_source = Output(UInt(L1PfSourceBits.W))
   // cycle 0: ntl indicator
-  val ntl = Output(Valid(NtlType()))
+  val ntl = Output(Bool())
   // cycle0: load microop
  // val s0_uop = Output(new MicroOp)
   // cycle 0: virtual address: req.addr

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -452,6 +452,7 @@ class DCacheLineReq(implicit p: Parameters) extends DCacheBundle
   val data   = UInt((cfg.blockBytes * 8).W)
   val mask   = UInt(cfg.blockBytes.W)
   val id     = UInt(reqIdWidth.W)
+  val ntl    = Valid(NtlType())
   def dump(cond: Bool) = {
     XSDebug(cond, "DCacheLineReq: cmd: %x addr: %x data: %x mask: %x id: %d\n",
       cmd, addr, data, mask, id)
@@ -468,6 +469,7 @@ class DCacheWordReqWithVaddrAndPfFlag(implicit p: Parameters) extends DCacheWord
   val prefetch = Bool()
   val vecValid = Bool()
   val sqNeedDeq = Bool()
+  val ntl = Valid(NtlType())
 
   def toDCacheWordReqWithVaddr() = {
     val res = Wire(new DCacheWordReqWithVaddr)

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1720,8 +1720,9 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   //----------------------------------------
   // replacement algorithm
+  require(cacheParams.replacer.contains("setplru"),
+    s"zihintntl DCache NTL currently requires replacer=setplru, got ${cacheParams.replacer}")
   val replacer = new NtlSetAssocLRU(nSets, nWays) // PLRU that supports NTL (zihintntl) access
-  // val replacer = ReplacementPolicy.fromString(cacheParams.replacer, nWays, nSets)
   val replWayReqs = ldu.map(_.io.replace_way) ++ Seq(mainPipe.io.replace_way) ++ stu.map(_.io.replace_way)
 
   if (dwpuParam.enCfPred) {

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -399,6 +399,7 @@ abstract class DCacheBundle(implicit p: Parameters) extends L1CacheBundle
 class ReplacementAccessBundle(implicit p: Parameters) extends DCacheBundle {
   val set = UInt(log2Up(nSets).W)
   val way = UInt(log2Up(nWays).W)
+  val ntl = Bool() // true: mark hit way as PLRU victim; false: normal touch
 }
 
 class ReplacementWayReqIO(implicit p: Parameters) extends DCacheBundle {
@@ -1717,7 +1718,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   //----------------------------------------
   // replacement algorithm
-  val replacer = ReplacementPolicy.fromString(cacheParams.replacer, nWays, nSets)
+  val replacer = new NtlSetAssocLRU(nSets, nWays) // PLRU that supports NTL (zihintntl) access
+  // val replacer = ReplacementPolicy.fromString(cacheParams.replacer, nWays, nSets)
   val replWayReqs = ldu.map(_.io.replace_way) ++ Seq(mainPipe.io.replace_way) ++ stu.map(_.io.replace_way)
 
   if (dwpuParam.enCfPred) {
@@ -1753,7 +1755,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
       w.bits := req.bits.way
   }
   val touchSets = replAccessReqs.map(_.bits.set)
-  replacer.access(touchSets, touchWays)
+  val touchNtls = replAccessReqs.map(_.bits.ntl)
+  replacer.access(touchSets, touchWays, touchNtls)
 
   //----------------------------------------
   // assertions

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -687,6 +687,8 @@ class DCacheLoadIO(implicit p: Parameters) extends DCacheWordIO
   val is128Req = Bool()
   // cycle 0: prefetch source bits
   val pf_source = Output(UInt(L1PfSourceBits.W))
+  // cycle 0: ntl indicator
+  val ntl = Output(Valid(NtlType()))
   // cycle0: load microop
  // val s0_uop = Output(new MicroOp)
   // cycle 0: virtual address: req.addr

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -24,7 +24,7 @@ import utility._
 import xiangshan.cache.wpu._
 import xiangshan.mem.HasL1PrefetchSourceParameter
 import xiangshan.mem.prefetch._
-import xiangshan.{L1CacheErrorInfo, NtlType, XSCoreParamsKey}
+import xiangshan.{L1CacheErrorInfo, XSCoreParamsKey}
 
 class LoadPfDbBundle(implicit p: Parameters) extends DCacheBundle {
   val paddr = UInt(PAddrBits.W)
@@ -428,7 +428,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.miss_req.bits := DontCare
   io.miss_req.bits.source := s2_instrtype
   io.miss_req.bits.pf_source := RegNext(RegNext(io.lsu.pf_source))  // TODO: clock gate
-  io.miss_req.bits.isNtl := NtlType.isDcacheNtl(s2_ntl)
+  io.miss_req.bits.isNtl := s2_ntl
   io.miss_req.bits.cmd := s2_req.cmd
   io.miss_req.bits.addr := get_block_addr(s2_paddr)
   io.miss_req.bits.vaddr := s2_vaddr
@@ -549,7 +549,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s3_flag_error = s3_tl_error.asUInt.orR
   val s3_hit_prefetch = RegEnable(s2_hit_prefetch, s2_fire)
   val s3_ntl = RegEnable(s2_ntl, s2_fire)
-  val s3_is_dcache_ntl = NtlType.isDcacheNtl(s3_ntl)
+  val s3_is_dcache_ntl = s3_ntl
   val s3_error = s3_tag_error || s3_flag_error || s3_data_error
 
   // Register the S2 kill (includes load breakpoint trigger exception) so that

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -24,7 +24,7 @@ import utility._
 import xiangshan.cache.wpu._
 import xiangshan.mem.HasL1PrefetchSourceParameter
 import xiangshan.mem.prefetch._
-import xiangshan.{L1CacheErrorInfo, XSCoreParamsKey}
+import xiangshan.{L1CacheErrorInfo, NtlType, XSCoreParamsKey}
 
 class LoadPfDbBundle(implicit p: Parameters) extends DCacheBundle {
   val paddr = UInt(PAddrBits.W)
@@ -122,6 +122,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s0_valid = io.lsu.req.fire
   val s0_req = WireInit(io.lsu.req.bits)
   val s0_pf_source = io.lsu.pf_source
+  val s0_ntl = io.lsu.ntl
   s0_req.vaddr := Mux(io.load128Req, Cat(io.lsu.req.bits.vaddr(io.lsu.req.bits.vaddr.getWidth - 1, 4), 0.U(4.W)), io.lsu.req.bits.vaddr)
   val s0_fire = s0_valid && s1_ready
   val s0_vaddr = s0_req.vaddr
@@ -166,6 +167,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s1_valid = RegInit(false.B)
   val s1_req = RegEnable(s0_req, s0_fire)
   val s1_pf_source = RegEnable(s0_pf_source, s0_fire)
+  val s1_ntl = RegEnable(s0_ntl, s0_fire)
   // in stage 1, load unit gets the physical address
   val s1_paddr_dup_lsu = io.lsu.s1_paddr_dup_lsu
   val s1_paddr_dup_dcache = io.lsu.s1_paddr_dup_dcache
@@ -317,6 +319,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s2_valid_dup = RegInit(false.B)
   val s2_req = RegEnable(s1_req, s1_fire)
   val s2_pf_source = RegEnable(s1_pf_source, s1_fire)
+  val s2_ntl = RegEnable(s1_ntl, s1_fire)
   val s2_load128Req = RegEnable(s1_load128Req, s1_fire)
   val s2_paddr = RegEnable(s1_paddr_dup_dcache, s1_fire)
   val s2_vaddr = RegEnable(s1_vaddr, s1_fire)
@@ -425,6 +428,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.miss_req.bits := DontCare
   io.miss_req.bits.source := s2_instrtype
   io.miss_req.bits.pf_source := RegNext(RegNext(io.lsu.pf_source))  // TODO: clock gate
+  io.miss_req.bits.isNtl := NtlType.isDcacheNtl(s2_ntl)
   io.miss_req.bits.cmd := s2_req.cmd
   io.miss_req.bits.addr := get_block_addr(s2_paddr)
   io.miss_req.bits.vaddr := s2_vaddr
@@ -544,6 +548,8 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s3_tl_error = RegEnable(s2_tl_error, s2_fire)
   val s3_flag_error = s3_tl_error.asUInt.orR
   val s3_hit_prefetch = RegEnable(s2_hit_prefetch, s2_fire)
+  val s3_ntl = RegEnable(s2_ntl, s2_fire)
+  val s3_is_dcache_ntl = NtlType.isDcacheNtl(s3_ntl)
   val s3_error = s3_tag_error || s3_flag_error || s3_data_error
 
   // Register the S2 kill (includes load breakpoint trigger exception) so that
@@ -569,7 +575,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // report tag error / l2 corrupted to CACHE_ERROR csr
   io.error.valid := s3_error && s3_valid
 
-  io.replace_access.valid := s3_valid && s3_hit && !s3_kill
+  io.replace_access.valid := s3_valid && s3_hit && !s3_kill && !s3_is_dcache_ntl
   io.replace_access.bits.set := RegNext(RegNext(get_dcache_idx(s1_req.vaddr)))
   io.replace_access.bits.way := RegNext(RegNext(OHToUInt(s1_tag_match_way_dup_dc)))
 

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -575,9 +575,10 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   // report tag error / l2 corrupted to CACHE_ERROR csr
   io.error.valid := s3_error && s3_valid
 
-  io.replace_access.valid := s3_valid && s3_hit && !s3_kill && !s3_is_dcache_ntl
+  io.replace_access.valid := s3_valid && s3_hit && !s3_kill
   io.replace_access.bits.set := RegNext(RegNext(get_dcache_idx(s1_req.vaddr)))
   io.replace_access.bits.way := RegNext(RegNext(OHToUInt(s1_tag_match_way_dup_dc)))
+  io.replace_access.bits.ntl := s3_is_dcache_ntl
 
   // update access bit
   io.access_flag_write.valid := s3_valid && s3_hit && !s3_is_prefetch && !s3_kill

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -26,7 +26,7 @@ import org.chipsalliance.cde.config.Parameters
 import utility._
 import xiangshan.mem.HasL1PrefetchSourceParameter
 import xiangshan.mem.prefetch._
-import xiangshan.{L1CacheErrorInfo, NtlType, XSCoreParamsKey}
+import xiangshan.{L1CacheErrorInfo, XSCoreParamsKey}
 import xiangshan.mem.L1PrefetchReq
 
 class MainPipeReq(implicit p: Parameters) extends DCacheBundle {
@@ -100,7 +100,7 @@ class MainPipeReq(implicit p: Parameters) extends DCacheBundle {
     req.error := false.B
     req.id := store.id
     req.miss_fail_cause_evict_btot := false.B
-    req.isNtl := NtlType.isDcacheNtl(store.ntl)
+    req.isNtl := store.ntl
     req
   }
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -72,6 +72,7 @@ class MainPipeReq(implicit p: Parameters) extends DCacheBundle {
   // prefetch
   val pf_source = UInt(L1PfSourceBits.W)
   val access = Bool()
+  val isNtl = Bool()
 
   val id = UInt(reqIdWidth.W)
 
@@ -914,6 +915,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   miss_req := DontCare
   miss_req.source := s2_req.source
   miss_req.pf_source := s2_req.pf_source
+  miss_req.isNtl := false.B
   miss_req.cmd := s2_req.cmd
   miss_req.addr := s2_req.addr
   miss_req.vaddr := s2_req.vaddr
@@ -1111,7 +1113,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.wb.bits.miss_id := s3_req.miss_id
 
   // update plru in main pipe s3
-  io.replace_access.valid := GatedValidRegNext(s2_fire_to_s3) && !s3_req.probe && (s3_req.miss || ((s3_req.isAMO || s3_req.isStore) && s3_hit))
+  io.replace_access.valid := GatedValidRegNext(s2_fire_to_s3) && !s3_req.probe &&
+    (s3_req.miss || ((s3_req.isAMO || s3_req.isStore) && s3_hit)) && !(s3_req.miss && s3_req.isNtl)
   io.replace_access.bits.set := s3_idx
   io.replace_access.bits.way := OHToUInt(s3_way_en)
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -1117,6 +1117,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     (s3_req.miss || ((s3_req.isAMO || s3_req.isStore) && s3_hit)) && !(s3_req.miss && s3_req.isNtl)
   io.replace_access.bits.set := s3_idx
   io.replace_access.bits.way := OHToUInt(s3_way_en)
+  io.replace_access.bits.ntl := false.B
 
   io.replace_way.set.valid := GatedValidRegNext(s0_fire)
   io.replace_way.set.bits := s1_idx

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -26,7 +26,7 @@ import org.chipsalliance.cde.config.Parameters
 import utility._
 import xiangshan.mem.HasL1PrefetchSourceParameter
 import xiangshan.mem.prefetch._
-import xiangshan.{L1CacheErrorInfo, XSCoreParamsKey}
+import xiangshan.{L1CacheErrorInfo, NtlType, XSCoreParamsKey}
 import xiangshan.mem.L1PrefetchReq
 
 class MainPipeReq(implicit p: Parameters) extends DCacheBundle {
@@ -100,6 +100,7 @@ class MainPipeReq(implicit p: Parameters) extends DCacheBundle {
     req.error := false.B
     req.id := store.id
     req.miss_fail_cause_evict_btot := false.B
+    req.isNtl := NtlType.isDcacheNtl(store.ntl)
     req
   }
 
@@ -915,7 +916,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   miss_req := DontCare
   miss_req.source := s2_req.source
   miss_req.pf_source := s2_req.pf_source
-  miss_req.isNtl := false.B
+  miss_req.isNtl := s2_req.isNtl
   miss_req.cmd := s2_req.cmd
   miss_req.addr := s2_req.addr
   miss_req.vaddr := s2_req.vaddr
@@ -1117,7 +1118,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     (s3_req.miss || ((s3_req.isAMO || s3_req.isStore) && s3_hit)) && !(s3_req.miss && s3_req.isNtl)
   io.replace_access.bits.set := s3_idx
   io.replace_access.bits.way := OHToUInt(s3_way_en)
-  io.replace_access.bits.ntl := false.B
+  io.replace_access.bits.ntl := s3_req.isStore && s3_req.isNtl
 
   io.replace_way.set.valid := GatedValidRegNext(s0_fire)
   io.replace_way.set.bits := s1_idx

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -925,7 +925,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   // Each queryMQ request gets independent judgment
   for (i <- 0 until reqNum) {
     val _signals = computeMatchSignals(req, io.queryME(i).req.bits)
-    io.secondary_ready(i) := should_merge(_signals, io.queryME(i).req.bits) && !io.miss_req_pipe_reg.cancel
+    io.secondary_ready(i) := should_merge(_signals, io.queryME(i).req.bits) && !io.miss_req_pipe_reg.cancel && req_valid
     io.secondary_reject(i) := should_reject(_signals, io.queryME(i).req.bits)
   }
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -942,7 +942,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
                                     (!io.queryME(i).req.bits.isFromPrefetch || io.memSetPattenDetected)
     }
     val _signals = computeMatchSignals(req, io.queryME(i).req.bits)
-    io.queryME(i).secondary_ready  := should_merge(_signals, io.queryME(i).req.bits)
+    io.queryME(i).secondary_ready  := should_merge(_signals, io.queryME(i).req.bits) && req_valid
     io.queryME(i).secondary_reject := should_reject(_signals, io.queryME(i).req.bits)
     io.queryME(i).block_match := _signals.block_match && req_valid
   }

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -81,6 +81,7 @@ class MissReqWoStoreData(implicit p: Parameters) extends DCacheBundle {
   // - StorePipe: io.lsu.s2_kill
   // - MainPipe (miss): s2_grow_perm_fail
   val cancel = Bool()
+  val isNtl = Bool()
 
   // Req source decode
   // Note that req source is NOT cmd type
@@ -594,6 +595,10 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   val corrupt = RegInit(false.B)
   val prefetch = RegInit(false.B)
   val access = RegInit(false.B)
+  val isNtl = RegInit(false.B)
+
+  val ntlHoldCycles = Constantin.createRecord(s"ntlRefillHoldCycles${p(XSCoreParamsKey).HartId}_entry", initValue = 32)
+  val ntl_refill_hold = RegInit(0.U(7.W))
 
   val should_refill_data_reg =  Reg(Bool())
   val should_refill_data = WireInit(should_refill_data_reg)
@@ -666,6 +671,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
   when (release_entry && req_valid) {
     req_valid := false.B
+    isNtl := false.B
+    ntl_refill_hold := 0.U
   }
 
   when (io.miss_req_pipe_reg.alloc && !io.miss_req_pipe_reg.cancel) {
@@ -713,6 +720,8 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     corrupt := false.B
     prefetch := input_req_is_prefetch && !io.miss_req_pipe_reg.prefetch_late_en(signals_pipe_prefetch, io.queryME(0).req.bits, io.queryME(0).req.valid)
     access := false.B
+    isNtl := miss_req_pipe_reg_bits.isNtl
+    ntl_refill_hold := 0.U
     secondary_fired := false.B
 
     refill_start_time := GTimer()
@@ -758,6 +767,7 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
 
     should_refill_data := should_refill_data_reg || miss_req_pipe_reg_bits.isFromLoad
     should_refill_data_reg := should_refill_data
+    isNtl := miss_req_pipe_reg_bits.isNtl
     when (!input_req_is_prefetch) {
       access := true.B // when merge non-prefetch req, set access bit
     }
@@ -1020,7 +1030,16 @@ for(i <- 0 until reqNum) {
   io.mem_finish.bits := grantack
 
   // Send mainpipe_req when receive hint from L2 or receive data without hint
-  io.main_pipe_req.valid := !s_mainpipe_req && (w_l2hint || w_grantlast)
+  when (isNtl && w_grantlast) {
+    when (ntl_refill_hold < ntlHoldCycles) {
+      ntl_refill_hold := ntl_refill_hold + 1.U
+    }
+  }.elsewhen (!req_valid || !isNtl) {
+    ntl_refill_hold := 0.U
+  }
+
+  val ntl_mainpipe_ready = !isNtl || (w_grantlast && ntl_refill_hold >= ntlHoldCycles)
+  io.main_pipe_req.valid := !s_mainpipe_req && (w_l2hint || w_grantlast) && ntl_mainpipe_ready
   io.main_pipe_req.bits := DontCare
   io.main_pipe_req.bits.miss := true.B
   io.main_pipe_req.bits.miss_id := io.id
@@ -1036,6 +1055,7 @@ for(i <- 0 until reqNum) {
   io.main_pipe_req.bits.id := req.id
   io.main_pipe_req.bits.pf_source := req.pf_source
   io.main_pipe_req.bits.access := access
+  io.main_pipe_req.bits.isNtl := isNtl
   io.main_pipe_req.bits.occupy_way := req.occupy_way
   io.main_pipe_req.bits.miss_fail_cause_evict_btot := evict_BtoT_way
 

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -597,9 +597,6 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   val access = RegInit(false.B)
   val isNtl = RegInit(false.B)
 
-  val ntlHoldCycles = Constantin.createRecord(s"ntlRefillHoldCycles${p(XSCoreParamsKey).HartId}_entry", initValue = 32)
-  val ntl_refill_hold = RegInit(0.U(7.W))
-
   val should_refill_data_reg =  Reg(Bool())
   val should_refill_data = WireInit(should_refill_data_reg)
 
@@ -672,7 +669,6 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
   when (release_entry && req_valid) {
     req_valid := false.B
     isNtl := false.B
-    ntl_refill_hold := 0.U
   }
 
   when (io.miss_req_pipe_reg.alloc && !io.miss_req_pipe_reg.cancel) {
@@ -721,7 +717,6 @@ class MissEntry(edge: TLEdgeOut, reqNum: Int)(implicit p: Parameters) extends DC
     prefetch := input_req_is_prefetch && !io.miss_req_pipe_reg.prefetch_late_en(signals_pipe_prefetch, io.queryME(0).req.bits, io.queryME(0).req.valid)
     access := false.B
     isNtl := miss_req_pipe_reg_bits.isNtl
-    ntl_refill_hold := 0.U
     secondary_fired := false.B
 
     refill_start_time := GTimer()
@@ -1030,16 +1025,7 @@ for(i <- 0 until reqNum) {
   io.mem_finish.bits := grantack
 
   // Send mainpipe_req when receive hint from L2 or receive data without hint
-  when (isNtl && w_grantlast) {
-    when (ntl_refill_hold < ntlHoldCycles) {
-      ntl_refill_hold := ntl_refill_hold + 1.U
-    }
-  }.elsewhen (!req_valid || !isNtl) {
-    ntl_refill_hold := 0.U
-  }
-
-  val ntl_mainpipe_ready = !isNtl || (w_grantlast && ntl_refill_hold >= ntlHoldCycles)
-  io.main_pipe_req.valid := !s_mainpipe_req && (w_l2hint || w_grantlast) && ntl_mainpipe_ready
+  io.main_pipe_req.valid := !s_mainpipe_req && (w_l2hint || w_grantlast)
   io.main_pipe_req.bits := DontCare
   io.main_pipe_req.bits.miss := true.B
   io.main_pipe_req.bits.miss_id := io.id

--- a/src/main/scala/xiangshan/cache/dcache/meta/ReplacementNTL.scala
+++ b/src/main/scala/xiangshan/cache/dcache/meta/ReplacementNTL.scala
@@ -1,0 +1,112 @@
+/***************************************************************************************
+* Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2021 Peng Cheng Laboratory
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+// See LICENSE.Berkeley for license details.
+// See LICENSE.SiFive for license details.
+
+package xiangshan.cache
+
+import chisel3._
+import chisel3.util._
+import freechips.rocketchip.util._
+
+// Tree-PLRU helper for NTL: standard touch marks MRU; NTL touch marks the hit way as the replacement victim (oldest).
+class NtlPseudoLRU(n_ways: Int) extends PseudoLRU(n_ways) {
+  // Victim touch: update PLRU state so touch_way becomes the next replace candidate.
+  // Same tree walk as PseudoLRU.get_next_state, but with inverted root/leaf polarity.
+  def get_next_state_ntl(state: UInt, touch_way: UInt, tree_nways: Int): UInt = {
+    require(state.getWidth == (tree_nways-1),                   s"wrong state bits width ${state.getWidth} for $tree_nways ways")
+    require(touch_way.getWidth == (log2Ceil(tree_nways) max 1), s"wrong encoded way width ${touch_way.getWidth} for $tree_nways ways")
+
+    if (tree_nways > 2) {
+      // we are at a branching node in the tree, so recurse
+      val right_nways: Int = 1 << (log2Ceil(tree_nways) - 1)  // number of ways in the right sub-tree
+      val left_nways:  Int = tree_nways - right_nways         // number of ways in the left sub-tree
+      val set_left_older      = touch_way(log2Ceil(tree_nways)-1)  // NTL set the touch way as oldest
+      val left_subtree_state  = state.extract(tree_nways-3, right_nways-1)
+      val right_subtree_state = state(right_nways-2, 0)
+
+      if (left_nways > 1) {
+        // we are at a branching node in the tree with both left and right sub-trees, so recurse both sub-trees
+        Cat(set_left_older,
+            Mux(set_left_older,
+                get_next_state_ntl(left_subtree_state, touch_way.extract(log2Ceil(left_nways)-1,0), left_nways),
+                left_subtree_state),
+            Mux(set_left_older,
+                right_subtree_state,
+                get_next_state_ntl(right_subtree_state, touch_way(log2Ceil(right_nways)-1,0), right_nways)))
+      } else {
+        // we are at a branching node in the tree with only a right sub-tree, so recurse only right sub-tree
+        Cat(set_left_older,
+            Mux(set_left_older,
+                right_subtree_state,
+                get_next_state_ntl(right_subtree_state, touch_way(log2Ceil(right_nways)-1,0), right_nways)))
+      }
+    } else if (tree_nways == 2) {
+      // we are at a leaf node at the end of the tree
+      touch_way(0)
+    } else {  // tree_nways <= 1
+      // we are at an empty node in an empty tree for 1 way, so return single zero bit for Chisel (no zero-width wires)
+      0.U(1.W)
+    }
+  }
+
+  def get_next_state_ntl(state: UInt, touch_way: UInt): UInt = {
+    val touch_way_sized = if (touch_way.getWidth < log2Ceil(n_ways)) touch_way.padTo  (log2Ceil(n_ways))
+                                                                else touch_way.extract(log2Ceil(n_ways)-1,0)
+    get_next_state_ntl(state, touch_way_sized, n_ways)
+  }
+
+  // Select MRU touch or NTL victim touch for a single access.
+  def get_next_state_final(state: UInt, touch_way: UInt, ntl: Bool): UInt = {
+    Mux(ntl, get_next_state_ntl(state, touch_way), get_next_state(state, touch_way))
+  }
+
+  // Fold multiple port touches in order; each port picks MRU or victim via ntl(i).
+  def get_next_state_final(state: UInt, touch_ways: Seq[Valid[UInt]], ntl: Seq[Bool]): UInt = {
+    (touch_ways zip ntl).foldLeft(state) { case (prev, (touch_way, ntl)) =>
+      Mux(touch_way.valid,
+          get_next_state_final(prev, touch_way.bits, ntl),
+          prev)
+    }
+  }
+}
+
+class NtlSetAssocLRU(n_sets: Int, n_ways: Int) {
+  val logic = new NtlPseudoLRU(n_ways)
+  val state_vec =
+    if (logic.nBits == 0) Reg(Vec(n_sets, UInt(logic.nBits.W))) // Work around elaboration error on following line
+    else RegInit(VecInit(Seq.fill(n_sets)(0.U(logic.nBits.W))))
+
+  def access(set: UInt, touch_way: UInt, ntl: Bool = false.B) = {
+    state_vec(set) := logic.get_next_state_final(state_vec(set), touch_way, ntl)
+  }
+
+  def access(sets: Seq[UInt], touch_ways: Seq[Valid[UInt]], ntl: Seq[Bool]) = {
+    require(sets.size == touch_ways.size, "internal consistency check: should be same number of simultaneous updates for sets and touch_ways")
+    require(sets.size == ntl.size, "internal consistency check: should be same number of simultaneous updates for sets and ntls")
+    for (set <- 0 until n_sets) {
+      val set_touch_ways = (sets zip touch_ways).map { case (touch_set, touch_way) =>
+        Pipe(touch_way.valid && (touch_set === set.U), touch_way.bits, 0)}
+      when (set_touch_ways.map(_.valid).orR) {
+        state_vec(set) := logic.get_next_state_final(state_vec(set), set_touch_ways, ntl)
+      }
+    }
+  }
+
+  def way(set: UInt) = logic.get_replace_way(state_vec(set))
+
+}

--- a/src/main/scala/xiangshan/cache/dcache/storepipe/StorePipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/storepipe/StorePipe.scala
@@ -177,6 +177,7 @@ class StorePipe(id: Int)(implicit p: Parameters) extends DCacheModule{
   // only send out a prefetch write to Dcache
   io.miss_req.bits.source := DCACHE_PREFETCH_SOURCE.U
   io.miss_req.bits.pf_source := L1_HW_PREFETCH_STORE
+  io.miss_req.bits.isNtl := false.B
   io.miss_req.bits.cmd := MemoryOpConstants.M_PFW
   io.miss_req.bits.addr := get_block_addr(s2_paddr)
   io.miss_req.bits.vaddr := s2_req.vaddr

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -901,8 +901,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
 
       when (vSegmentFlag) {
         dcache.io.lsu.load(i).pf_source              := vSegmentUnit.io.rdcache.pf_source
-        dcache.io.lsu.load(i).ntl.valid              := false.B
-        dcache.io.lsu.load(i).ntl.bits               := DontCare
+        dcache.io.lsu.load(i).ntl                    := false.B
         dcache.io.lsu.load(i).s1_paddr_dup_lsu       := vSegmentUnit.io.rdcache.s1_paddr_dup_lsu
         dcache.io.lsu.load(i).s1_paddr_dup_dcache    := vSegmentUnit.io.rdcache.s1_paddr_dup_dcache
         dcache.io.lsu.load(i).s1_kill                := vSegmentUnit.io.rdcache.s1_kill

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -901,6 +901,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
 
       when (vSegmentFlag) {
         dcache.io.lsu.load(i).pf_source              := vSegmentUnit.io.rdcache.pf_source
+        dcache.io.lsu.load(i).ntl.valid              := false.B
+        dcache.io.lsu.load(i).ntl.bits               := DontCare
         dcache.io.lsu.load(i).s1_paddr_dup_lsu       := vSegmentUnit.io.rdcache.s1_paddr_dup_lsu
         dcache.io.lsu.load(i).s1_paddr_dup_dcache    := vSegmentUnit.io.rdcache.s1_paddr_dup_dcache
         dcache.io.lsu.load(i).s1_kill                := vSegmentUnit.io.rdcache.s1_kill
@@ -911,6 +913,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
         dcache.io.lsu.load(i).is128Req               := vSegmentUnit.io.rdcache.is128Req
       }.otherwise {
         dcache.io.lsu.load(i).pf_source              := newLoadUnits(i).io.dcache.pf_source
+        dcache.io.lsu.load(i).ntl                    := newLoadUnits(i).io.dcache.ntl
         dcache.io.lsu.load(i).s1_paddr_dup_lsu       := newLoadUnits(i).io.dcache.s1_paddr_dup_lsu
         dcache.io.lsu.load(i).s1_paddr_dup_dcache    := newLoadUnits(i).io.dcache.s1_paddr_dup_dcache
         dcache.io.lsu.load(i).s1_kill                := newLoadUnits(i).io.dcache.s1_kill

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQBundle.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQBundle.scala
@@ -55,7 +55,7 @@ class StoreQueueEnqIO(implicit p: Parameters) extends MemBlockBundle {
     val loadWaitStrict  = Bool()
     val ssid            = UInt(SSIDWidth.W)
     val storeSetHit     = Bool() // inst has been allocated an store set
-    val ntl             = Valid(NtlType())
+    val ntl             = Bool() // Currently only DCache NTL is supported. So only 1 bit is needed.
     // debug signal
     val pc              = Option.when(debugEn)(UInt(VAddrBits.W))
   }

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQBundle.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQBundle.scala
@@ -97,6 +97,9 @@ class StaUopInfo(implicit p: Parameters) extends MemBlockBundle {
   val isFirstIssue    = Bool()
   val isRVC           = Bool()
 
+  // Currently only DCache NTL is supported. So only 1 bit is needed.
+  val ntl             = Bool()
+
   // debug info
   val pc              = Option.when(debugEn)(UInt(VAddrBits.W))
   val debugInfo       = Option.when(debugEn)(new PerfDebugInfo)

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQBundle.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQBundle.scala
@@ -55,6 +55,7 @@ class StoreQueueEnqIO(implicit p: Parameters) extends MemBlockBundle {
     val loadWaitStrict  = Bool()
     val ssid            = UInt(SSIDWidth.W)
     val storeSetHit     = Bool() // inst has been allocated an store set
+    val ntl             = Valid(NtlType())
     // debug signal
     val pc              = Option.when(debugEn)(UInt(VAddrBits.W))
   }

--- a/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
@@ -125,6 +125,7 @@ class SQDataEntryBundle(implicit p: Parameters) extends MemBlockBundle {
   val cboType                  = CboType()
   val prefetch                 = Bool() //TODO: need it ?
   val isHyper                  = Bool()
+  val ntl                      = Valid(NtlType())
 
   // debug signal
   val debugPaddr               = Option.when(debugEn)(UInt((PAddrBits).W))
@@ -174,6 +175,7 @@ class WriteToSbufferReqEntry(implicit p: Parameters) extends MemBlockBundle {
   val vaddr        = UInt(VAddrBits.W)
   val data         = UInt(VLEN.W)
   val mask         = UInt((VLEN/8).W)
+  val ntl          = Valid(NtlType())
   val deqPtrMove   = Bool()
 }
 
@@ -704,6 +706,7 @@ abstract class PhysicalStoreQueueBase(implicit p: Parameters) extends LSQModule 
       sink.addr     := source.addr
       sink.vecValid := source.vecValid
       sink.prefetch := source.prefetch
+      sink.ntl      := source.ntl
       sink
     }
 
@@ -1240,6 +1243,7 @@ abstract class PhysicalStoreQueueBase(implicit p: Parameters) extends LSQModule 
 
       port.bits.wline    := ctrlEntry.isCbo && isCboZero(dataEntry.cboType)
       port.bits.prefetch := dataEntry.prefetch
+      port.bits.ntl      := dataEntry.ntl
       port.bits.vecValid := true.B
       if (i == 0) {
         // if cross16B, only port 1 deqPtr move, else both port 0 and port 1 deqPtr move.
@@ -1660,6 +1664,7 @@ class PhysicalStoreQueue(implicit p: Parameters) extends PhysicalStoreQueueBase 
 
     when(staSetValid) {
       connectSamePort(dataEntries(i).uop, selectBits.uop)
+      dataEntries(i).ntl := selectBits.uop.ntl
     }
 
     io.fromStoreUnit.storeAddrIn.zipWithIndex.map{case (port, j) =>

--- a/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
@@ -125,7 +125,7 @@ class SQDataEntryBundle(implicit p: Parameters) extends MemBlockBundle {
   val cboType                  = CboType()
   val prefetch                 = Bool() //TODO: need it ?
   val isHyper                  = Bool()
-  val ntl                      = Valid(NtlType())
+  val ntl                      = Bool()
 
   // debug signal
   val debugPaddr               = Option.when(debugEn)(UInt((PAddrBits).W))
@@ -175,7 +175,7 @@ class WriteToSbufferReqEntry(implicit p: Parameters) extends MemBlockBundle {
   val vaddr        = UInt(VAddrBits.W)
   val data         = UInt(VLEN.W)
   val mask         = UInt((VLEN/8).W)
-  val ntl          = Valid(NtlType())
+  val ntl          = Bool()
   val deqPtrMove   = Bool()
 }
 

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -458,7 +458,8 @@ class LoadUnitS0(param: ExeUnitParams)(
   io.replacementUpdated := DontCare
   io.pfSource := Mux(isHwPrefetch, io.prefetchReq.bits.pf_source.value, L1_HW_PREFETCH_NULL)
   val dcacheNtl = Wire(Valid(NtlType()))
-  dcacheNtl.valid := NtlType.isDcacheNtl(uop.ntl)
+  val ntlIgnored = NtlType.isNtlIgnored(uop.fuType, uop.fuOpType)
+  dcacheNtl.valid := NtlType.isDcacheNtl(uop.ntl) && !ntlIgnored
   dcacheNtl.bits := uop.ntl.bits
   io.ntlSource := dcacheNtl
 

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -67,6 +67,7 @@ class LoadUnitS0(param: ExeUnitParams)(
     val is128Req = Bool()
     val replacementUpdated = Bool()
     val pfSource = Output(UInt(L1PfSourceBits.W))
+    val ntlSource = Output(Valid(NtlType()))
 
     /**
       * Data forward request, including:
@@ -456,6 +457,10 @@ class LoadUnitS0(param: ExeUnitParams)(
   io.is128Req := readWholeBank
   io.replacementUpdated := DontCare
   io.pfSource := Mux(isHwPrefetch, io.prefetchReq.bits.pf_source.value, L1_HW_PREFETCH_NULL)
+  val dcacheNtl = Wire(Valid(NtlType()))
+  dcacheNtl.valid := NtlType.isDcacheNtl(uop.ntl)
+  dcacheNtl.bits := uop.ntl.bits
+  io.ntlSource := dcacheNtl
 
   io.sqSbForwardReq.valid := sink.valid
   io.sqSbForwardReq.bits := storeForwardReq
@@ -2019,6 +2024,7 @@ class NewLoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSMo
   io.dcache.is128Req := s0.io.is128Req
   io.dcache.replacementUpdated := s0.io.replacementUpdated
   io.dcache.pf_source := s0.io.pfSource
+  io.dcache.ntl := s0.io.ntlSource
   io.sqForward.s0Req := s0.io.sqSbForwardReq
   io.sbufferForward.s0Req := s0.io.sqSbForwardReq
   io.uncacheForward.s0Req := s0.io.uncacheForwardReq

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -67,7 +67,7 @@ class LoadUnitS0(param: ExeUnitParams)(
     val is128Req = Bool()
     val replacementUpdated = Bool()
     val pfSource = Output(UInt(L1PfSourceBits.W))
-    val ntlSource = Output(Valid(NtlType()))
+    val ntlSource = Output(Bool())
 
     /**
       * Data forward request, including:
@@ -457,11 +457,7 @@ class LoadUnitS0(param: ExeUnitParams)(
   io.is128Req := readWholeBank
   io.replacementUpdated := DontCare
   io.pfSource := Mux(isHwPrefetch, io.prefetchReq.bits.pf_source.value, L1_HW_PREFETCH_NULL)
-  val dcacheNtl = Wire(Valid(NtlType()))
-  val ntlIgnored = NtlType.isNtlIgnored(uop.fuType, uop.fuOpType)
-  dcacheNtl.valid := NtlType.isDcacheNtl(uop.ntl) && !ntlIgnored
-  dcacheNtl.bits := uop.ntl.bits
-  io.ntlSource := dcacheNtl
+  io.ntlSource := uop.ntl
 
   io.sqSbForwardReq.valid := sink.valid
   io.sqSbForwardReq.bits := storeForwardReq

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -216,7 +216,7 @@ class Sbuffer(implicit p: Parameters)
 
   val ptag = Reg(Vec(StoreBufferSize, UInt(PTagWidth.W)))
   val vtag = Reg(Vec(StoreBufferSize, UInt(VTagWidth.W)))
-  val ntl = Reg(Vec(StoreBufferSize, Valid(NtlType())))
+  val ntl = Reg(Vec(StoreBufferSize, Bool()))
   val debug_mask = Reg(Vec(StoreBufferSize, Vec(CacheLineWords, Vec(DataBytes, Bool()))))
   val waitInflightMask = Reg(Vec(StoreBufferSize, UInt(StoreBufferSize.W)))
   val data = dataModule.io.dataOut
@@ -426,7 +426,7 @@ class Sbuffer(implicit p: Parameters)
 
   def wordReqToBufLine( // allocate a new line in sbuffer
     req: DCacheWordReq,
-    reqNtl: Valid[UInt],
+    reqNtl: Bool,
     reqptag: UInt,
     reqvtag: UInt,
     insertIdx: UInt,
@@ -453,7 +453,7 @@ class Sbuffer(implicit p: Parameters)
 
   def mergeWordReq( // merge write req into an existing line
     req: DCacheWordReq,
-    reqNtl: Valid[UInt],
+    reqNtl: Bool,
     reqptag: UInt,
     reqvtag: UInt,
     mergeIdx: UInt,

--- a/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
+++ b/src/main/scala/xiangshan/mem/sbuffer/Sbuffer.scala
@@ -216,6 +216,7 @@ class Sbuffer(implicit p: Parameters)
 
   val ptag = Reg(Vec(StoreBufferSize, UInt(PTagWidth.W)))
   val vtag = Reg(Vec(StoreBufferSize, UInt(VTagWidth.W)))
+  val ntl = Reg(Vec(StoreBufferSize, Valid(NtlType())))
   val debug_mask = Reg(Vec(StoreBufferSize, Vec(CacheLineWords, Vec(DataBytes, Bool()))))
   val waitInflightMask = Reg(Vec(StoreBufferSize, UInt(StoreBufferSize.W)))
   val data = dataModule.io.dataOut
@@ -425,6 +426,7 @@ class Sbuffer(implicit p: Parameters)
 
   def wordReqToBufLine( // allocate a new line in sbuffer
     req: DCacheWordReq,
+    reqNtl: Valid[UInt],
     reqptag: UInt,
     reqvtag: UInt,
     insertIdx: UInt,
@@ -444,12 +446,14 @@ class Sbuffer(implicit p: Parameters)
         // missqReplayCount(insertIdx) := 0.U
         ptag(entryIdx) := reqptag
         vtag(entryIdx) := reqvtag // update vtag if a new sbuffer line is allocated
+        ntl(entryIdx) := reqNtl
       }
     })
   }
 
   def mergeWordReq( // merge write req into an existing line
     req: DCacheWordReq,
+    reqNtl: Valid[UInt],
     reqptag: UInt,
     reqvtag: UInt,
     mergeIdx: UInt,
@@ -460,6 +464,8 @@ class Sbuffer(implicit p: Parameters)
     (0 until StoreBufferSize).map(entryIdx => {
       when(mergeVec(entryIdx)) {
         cohCount(entryIdx) := 0.U
+        // merge updates ntl from the newly merged store (non-ntl clears the flag)
+        ntl(entryIdx) := reqNtl
         // missqReplayCount(entryIdx) := 0.U
         // check if vtag is the same, if not, trigger sbuffer flush
         when(reqvtag =/= vtag(entryIdx)) {
@@ -488,10 +494,10 @@ class Sbuffer(implicit p: Parameters)
     when(accessValid){
       when(canMerge(i)){
         writeReq(i).bits.wvec := mergeVec(i)
-        mergeWordReq(in.bits, inptags(i), invtags(i), mergeIdx(i), mergeVec(i), vwordOffset)
+        mergeWordReq(in.bits, in.bits.ntl, inptags(i), invtags(i), mergeIdx(i), mergeVec(i), vwordOffset)
       }.otherwise({
         writeReq(i).bits.wvec := insertVec
-        wordReqToBufLine(in.bits, inptags(i), invtags(i), insertIdx, insertVec, vwordOffset)
+        wordReqToBufLine(in.bits, in.bits.ntl, inptags(i), invtags(i), insertIdx, insertVec, vwordOffset)
         assert(debug_insertIdx === insertIdx)
       })
     }
@@ -701,6 +707,7 @@ class Sbuffer(implicit p: Parameters)
   io.dcache.req.bits.data  := data(sbuffer_out_s1_evictionIdx).asUInt
   io.dcache.req.bits.mask  := mask(sbuffer_out_s1_evictionIdx).asUInt
   io.dcache.req.bits.id := sbuffer_out_s1_evictionIdx
+  io.dcache.req.bits.ntl := ntl(sbuffer_out_s1_evictionIdx)
 
   XSDebug(sbuffer_out_s1_fire,
     p"send buf [$sbuffer_out_s1_evictionIdx] to Dcache, req fire\n"

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -722,6 +722,8 @@ class VSegmentUnit(val param: ExeUnitParams)(implicit p: Parameters) extends VLS
   }
   io.rdcache.replacementUpdated     := false.B
   io.rdcache.is128Req               := notCross16ByteReg
+  io.rdcache.ntl.valid              := false.B
+  io.rdcache.ntl.bits               := DontCare
 
 
   /**

--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -722,8 +722,7 @@ class VSegmentUnit(val param: ExeUnitParams)(implicit p: Parameters) extends VLS
   }
   io.rdcache.replacementUpdated     := false.B
   io.rdcache.is128Req               := notCross16ByteReg
-  io.rdcache.ntl.valid              := false.B
-  io.rdcache.ntl.bits               := DontCare
+  io.rdcache.ntl                    := false.B
 
 
   /**

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -728,12 +728,17 @@ package object xiangshan {
     def apply(rs2: UInt): UInt = Mux(rs2(2, 0) === 5.U, all,
                                  Mux(rs2(2, 0) === 4.U, s1,
                                  Mux(rs2(2, 0) === 3.U, pall, p1)))
+
     def isDcacheNtl(ntl: Valid[UInt]): Bool =
       ntl.valid && (ntl.bits === p1 || ntl.bits === pall || ntl.bits === all)
 
     // Currently, CMO and atomics ignore NTL for simplicity.
     def isNtlIgnored(fuType: UInt, fuOpType: UInt): Bool =
       FuType.isAMO(fuType) || LSUOpType.isCboAll(fuOpType)
+
+    // Compress to 1-bit DCache NTL; currently only DCache NTL is supported.
+    def toDcacheNtl(ntl: Valid[UInt], fuType: UInt, fuOpType: UInt): Bool =
+      isDcacheNtl(ntl) && !isNtlIgnored(fuType, fuOpType)
   }
 
   object LSUOpType {

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -19,7 +19,7 @@ import chisel3.experimental.SourceInfo
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import xiangshan.backend.BackendParams
-import xiangshan.backend.fu.FuConfig
+import xiangshan.backend.fu.{FuConfig, FuType}
 import xiangshan.backend.decode.{Imm, ImmUnion}
 
 package object xiangshan {
@@ -728,6 +728,12 @@ package object xiangshan {
     def apply(rs2: UInt): UInt = Mux(rs2(2, 0) === 5.U, all,
                                  Mux(rs2(2, 0) === 4.U, s1,
                                  Mux(rs2(2, 0) === 3.U, pall, p1)))
+    def isDcacheNtl(ntl: Valid[UInt]): Bool =
+      ntl.valid && (ntl.bits === p1 || ntl.bits === pall || ntl.bits === all)
+
+    // Currently, CMO and atomics ignore NTL for simplicity.
+    def isNtlIgnored(fuType: UInt, fuOpType: UInt): Bool =
+      FuType.isAMO(fuType) || LSUOpType.isCboAll(fuOpType)
   }
 
   object LSUOpType {

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -717,6 +717,19 @@ package object xiangshan {
     def isH(op: UInt) = op(0)
   }
 
+  // ZihintNTL: non-temporal locality hint variants (add x0,x0,x2~x5)
+  object NtlType {
+    def p1   = "b00".U
+    def pall = "b01".U
+    def s1   = "b10".U
+    def all  = "b11".U
+
+    def apply() = UInt(2.W)
+    def apply(rs2: UInt): UInt = Mux(rs2(2, 0) === 5.U, all,
+                                 Mux(rs2(2, 0) === 4.U, s1,
+                                 Mux(rs2(2, 0) === 3.U, pall, p1)))
+  }
+
   object LSUOpType {
     // The max length is 6 bits
     // load pipeline


### PR DESCRIPTION
This PR implements of RISC-V `zihintntl` (Non-Temporal Locality Hints) support in XiangShan:
- **Decode / rename / dispatch**: recognize `add x0, x0, x2~x5` hints, bind them to the following memory uop, and drop the hint uop before entering the backend (similar to `isMove`).
- **1-bit DCache NTL flag**: at dispatch exit, compress the full hint into a single `ntl` bit carried by memory uops (P1/PALL/ALL → 1; S1, atomics, CMO ignored), since only DCache NTL is implemented at this stage.
- **L1 DCache consumption**:
  - NTL load/store **hits** touch the hit way as the **PLRU victim** instead of MRU, so streaming data does not keep hot lines MRU.
  - NTL **miss refills** skip the replacer touch, so refill does not alter replacement state.
  - Store path propagates `ntl` through StoreQueue → sbuffer → MainPipe; load path through LoadPipe and MissQueue (`isNtl` on MSHR entries, merge updates from the newest request).

Scope: L1 DCache only; S1 hints are ignored; CMO and atomic operations ignore NTL.