### PR TITLE
Perf(DCache): hash tag array and corresponding data array

### DIFF
--- a/src/main/scala/xiangshan/cache/L1Cache.scala
+++ b/src/main/scala/xiangshan/cache/L1Cache.scala
@@ -78,7 +78,7 @@ trait HasL1CacheParameters extends HasXSParameter
   // the number of words in a block
   def blockWords = blockBytes / wordBytes
   def refillWords = refillBytes / wordBytes
-  def modeId = 1 //DCache index & alias mode: 1 for hash vaddr, 2 for direct extract vaddr[13:6]
+  def modeId = 2 //DCache index & alias mode: 1 for hash vaddr, 2 for direct extract vaddr[13:6]
   def hashBitPairs(addr: UInt, hi: Int = PAddrBits - 1, lo: Int = pgIdxBits, step: Int = 2): UInt = {
     require(hi >= lo)
     require(step > 0)

--- a/src/main/scala/xiangshan/cache/L1Cache.scala
+++ b/src/main/scala/xiangshan/cache/L1Cache.scala
@@ -78,7 +78,7 @@ trait HasL1CacheParameters extends HasXSParameter
   // the number of words in a block
   def blockWords = blockBytes / wordBytes
   def refillWords = refillBytes / wordBytes
-  def modeId = 2 //DCache index & alias mode: 1 for hash vaddr, 2 for direct extract vaddr[13:6]
+  def modeId = 1 //DCache index & alias mode: 1 for hash vaddr, 2 for direct extract vaddr[13:6]
   def hashBitPairs(addr: UInt, hi: Int = PAddrBits - 1, lo: Int = pgIdxBits, step: Int = 2): UInt = {
     require(hi >= lo)
     require(step > 0)

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1063,7 +1063,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   //----------------------------------------
   // core data structures
-  val bankedDataArray = if(dwpuParam.enWPU) Module(new SramedDataArray) else Module(new BankedDataArray)
+  // val bankedDataArray = if(dwpuParam.enWPU) Module(new SramedDataArray) else Module(new BankedDataArray)
+  val bankedDataArray = Module(new HTADataArray) //if(dwpuParam.enWPU) Module(new SramedDataArray) else Module(new BankedDataArray)
   val metaArray = Module(new L1CohMetaArray(readPorts = LoadPipelineWidth + 1, writePorts = 1))
   val errorArray = Module(new L1ErrorMetaArray(readPorts = LoadPipelineWidth + 1, writePorts = 1, enableBypass = true))
   val prefetchArray = Module(new L1PrefetchSourceArray(
@@ -1373,6 +1374,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   (0 until LoadPipelineWidth).map(i => {
     bankedDataArray.io.read(i) <> ldu(i).io.banked_data_read
     bankedDataArray.io.is128Req(i) <> ldu(i).io.is128Req
+    bankedDataArray.io.s2_tag_match_way(i) := ldu(i).io.s2_tag_match_way
     bankedDataArray.io.read_error_delayed(i) <> ldu(i).io.read_error_delayed
 
     ldu(i).io.banked_data_resp := bankedDataArray.io.read_resp(i)

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -242,7 +242,7 @@ trait HasDCacheParameters
   val errWritePort = tagWritePort + 1
   val wbPort = errWritePort + 1
   val HashTagBits = 4
-  val EnableHashTagPrefilter = true
+  val EnableDCacheHashTagArray = true
   val EnableHashTagMainPipe = false
 
   def set_to_dcache_div(set: UInt) = {
@@ -1076,7 +1076,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   val accessArray = Module(new L1FlagMetaArray(readPorts = AccessArrayReadPort, writePorts = LoadPipelineWidth + 1))
   val tagArray = Module(new DuplicatedTagArray(readPorts = TagReadPort))
   val hashTagReadPort = LoadPipelineWidth + (if (EnableHashTagMainPipe) 1 else 0)
-  val hashTagArray = Module(new HashTagArray(readPorts = hashTagReadPort, hashBits = HashTagBits))
+  val htagArray = Module(new HashTagArray(readPorts = hashTagReadPort, hashBits = HashTagBits))
   val prefetcherMonitor = Module(new PrefetcherMonitor)
   val bloomFilter =  Module(new BloomFilter(BLOOM_FILTER_ENTRY_NUM, true))
   val counterFilter = Module(new CounterFilter)
@@ -1312,16 +1312,16 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   }
 
   for (i <- 0 until LoadPipelineWidth) {
-    hashTagArray.io.read(i).valid := ldu(i).io.tag_read.valid
-    hashTagArray.io.read(i).bits := ldu(i).io.tag_read.bits
-    ldu(i).io.hash_tag_resp := hashTagArray.io.resp(i)
+    htagArray.io.read(i).valid := ldu(i).io.tag_read.fire
+    htagArray.io.read(i).bits := ldu(i).io.tag_read.bits
+    ldu(i).io.htag_resp := htagArray.io.resp(i)
   }
 
   tagArray.io.read.last <> mainPipe.io.tag_read
   mainPipe.io.tag_resp := tagArray.io.resp.last
   if (EnableHashTagMainPipe) {
-    hashTagArray.io.read.last.valid := mainPipe.io.tag_read.valid
-    hashTagArray.io.read.last.bits := mainPipe.io.tag_read.bits
+    htagArray.io.read.last.valid := mainPipe.io.tag_read.fire
+    htagArray.io.read.last.bits := mainPipe.io.tag_read.bits
   }
 
   val fake_tag_read_conflict_this_cycle = PopCount(ldu.map(ld=> ld.io.tag_read.valid))
@@ -1330,12 +1330,11 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   val tag_write_arb = Module(new Arbiter(new TagWriteReq, 1))
   tag_write_arb.io.in(0) <> mainPipe.io.tag_write
   tagArray.io.write <> tag_write_arb.io.out
-  hashTagArray.io.write.valid := tagArray.io.write.valid
-  hashTagArray.io.write.bits.idx := tagArray.io.write.bits.idx
-  hashTagArray.io.write.bits.way_en := tagArray.io.write.bits.way_en
-  hashTagArray.io.write.bits.vaddr := tagArray.io.write.bits.vaddr
-  hashTagArray.io.write.bits.tag := tagArray.io.write.bits.tag
-  hashTagArray.io.write.bits.ecc := tagArray.io.write.bits.ecc
+  htagArray.io.write.valid := tagArray.io.write.fire
+  htagArray.io.write.bits := DontCare
+  htagArray.io.write.bits.idx := tagArray.io.write.bits.idx
+  htagArray.io.write.bits.way_en := tagArray.io.write.bits.way_en
+  htagArray.io.write.bits.tag := tagArray.io.write.bits.tag
 
   ldu.map(m => {
     m.io.vtag_update.valid := tagArray.io.write.valid

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -1367,6 +1367,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   bankedDataArray.io.readline_stall := mainPipe.io.data_readline_stall
   bankedDataArray.io.readline_can_resp := mainPipe.io.data_readline_can_resp
   bankedDataArray.io.readline_intend := mainPipe.io.data_read_intend
+  bankedDataArray.io.repl_dirty := mainPipe.io.repl_dirty
+  bankedDataArray.io.repl_way_en := mainPipe.io.repl_way_en
   mainPipe.io.readline_error := bankedDataArray.io.readline_error
   mainPipe.io.readline_error_delayed := bankedDataArray.io.readline_error_delayed
   mainPipe.io.data_resp := bankedDataArray.io.readline_resp

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -243,7 +243,6 @@ trait HasDCacheParameters
   val wbPort = errWritePort + 1
   val HashTagBits = 4
   val EnableDCacheHashTagArray = true
-  val EnableHashTagMainPipe = false
 
   def set_to_dcache_div(set: UInt) = {
     require(set.getWidth >= DCacheSetBits)
@@ -1076,8 +1075,7 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   val accessArray = Module(new L1FlagMetaArray(readPorts = AccessArrayReadPort, writePorts = LoadPipelineWidth + 1))
   val tagArray = Module(new DuplicatedTagArray(readPorts = TagReadPort))
-  val hashTagReadPort = LoadPipelineWidth + (if (EnableHashTagMainPipe) 1 else 0)
-  val htagArray = Module(new HashTagArray(readPorts = hashTagReadPort, hashBits = HashTagBits))
+  val htagArray = Module(new HashTagArray(readPorts = TagReadPort, hashBits = HashTagBits))
   val prefetcherMonitor = Module(new PrefetcherMonitor)
   val bloomFilter =  Module(new BloomFilter(BLOOM_FILTER_ENTRY_NUM, true))
   val counterFilter = Module(new CounterFilter)
@@ -1320,10 +1318,9 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   tagArray.io.read.last <> mainPipe.io.tag_read
   mainPipe.io.tag_resp := tagArray.io.resp.last
-  if (EnableHashTagMainPipe) {
-    htagArray.io.read.last.valid := mainPipe.io.tag_read.fire
-    htagArray.io.read.last.bits := mainPipe.io.tag_read.bits
-  }
+  htagArray.io.read.last.valid := mainPipe.io.tag_read.fire
+  htagArray.io.read.last.bits := mainPipe.io.tag_read.bits
+  mainPipe.io.htag_resp := htagArray.io.resp.last
 
   val fake_tag_read_conflict_this_cycle = PopCount(ldu.map(ld=> ld.io.tag_read.valid))
   XSPerfAccumulate("fake_tag_read_conflict", fake_tag_read_conflict_this_cycle)
@@ -1367,8 +1364,6 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   bankedDataArray.io.readline_stall := mainPipe.io.data_readline_stall
   bankedDataArray.io.readline_can_resp := mainPipe.io.data_readline_can_resp
   bankedDataArray.io.readline_intend := mainPipe.io.data_read_intend
-  bankedDataArray.io.repl_dirty := mainPipe.io.repl_dirty
-  bankedDataArray.io.repl_way_en := mainPipe.io.repl_way_en
   mainPipe.io.readline_error := bankedDataArray.io.readline_error
   mainPipe.io.readline_error_delayed := bankedDataArray.io.readline_error_delayed
   mainPipe.io.data_resp := bankedDataArray.io.readline_resp

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -157,15 +157,18 @@ trait HasDCacheParameters
   require(!channelSelByAddr || isPow2(numMemChannels),
     s"channelSelByAddr requires numMemChannels to be a power of 2, got $numMemChannels")
 
-  // banked dcache support
+  // Use Hash Tag Array and corresponding DataArray
+  val UseHTADataArray = true
+  val HashTagBits = 4
+
   val DCacheSetDiv = 1
   val DCacheSets = cacheParams.nSets
   val DCacheWayDiv = 2
   val DCacheWays = cacheParams.nWays
-  val DCacheBanks = 32
+  val DCacheBanks = if (UseHTADataArray) 8 else 32
   val DCacheDupNum = 16
+  val DCacheSRAMRowBits = blockBits / DCacheBanks
   val DCacheSRAMRealRowBits = DCacheSRAMRowBits * DCacheWays // 1 real Bank = vitural_bank * way_nums
-  val DCacheSRAMRowBits = 16 
   val DCacheWordBits = 64 // hardcoded
   val DCacheWordBytes = DCacheWordBits / 8
   val MaxPrefetchEntry = cacheParams.nMaxPrefetchEntry
@@ -241,8 +244,6 @@ trait HasDCacheParameters
   val tagWritePort = metaWritePort + 1
   val errWritePort = tagWritePort + 1
   val wbPort = errWritePort + 1
-  val HashTagBits = 4
-  val EnableDCacheHashTagArray = true
 
   def set_to_dcache_div(set: UInt) = {
     require(set.getWidth >= DCacheSetBits)
@@ -1018,7 +1019,6 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   val edge = edges(0)
 
   require(pseudoErrorMaskBits >= tagBits, "pseudo-error masks must cover tagBits")
-  require(pseudoErrorMaskBits >= DCacheSRAMRowBits, "pseudo-error masks must cover data-bank row width")
   require(bus.d.bits.data.getWidth == l1BusDataWidth, "DCache: tilelink width does not match")
 
 
@@ -1062,8 +1062,10 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   //----------------------------------------
   // core data structures
-  // val bankedDataArray = if(dwpuParam.enWPU) Module(new SramedDataArray) else Module(new BankedDataArray)
-  val bankedDataArray = Module(new HTADataArray) //if(dwpuParam.enWPU) Module(new SramedDataArray) else Module(new BankedDataArray)
+  val bankedDataArray =
+    if (UseHTADataArray) Module(new HTADataArray)
+    else if (dwpuParam.enWPU) Module(new SramedDataArray)
+    else Module(new BankedDataArray)
   val metaArray = Module(new L1CohMetaArray(readPorts = LoadPipelineWidth + 1, writePorts = 1))
   val errorArray = Module(new L1ErrorMetaArray(readPorts = LoadPipelineWidth + 1, writePorts = 1, enableBypass = true))
   val prefetchArray = Module(new L1PrefetchSourceArray(
@@ -1371,7 +1373,6 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   (0 until LoadPipelineWidth).map(i => {
     bankedDataArray.io.read(i) <> ldu(i).io.banked_data_read
     bankedDataArray.io.is128Req(i) <> ldu(i).io.is128Req
-    bankedDataArray.io.s2_tag_match_way(i) := ldu(i).io.s2_tag_match_way
     bankedDataArray.io.read_error_delayed(i) <> ldu(i).io.read_error_delayed
 
     ldu(i).io.banked_data_resp := bankedDataArray.io.read_resp(i)
@@ -1379,6 +1380,11 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
     ldu(i).io.bank_conflict_slow := bankedDataArray.io.bank_conflict_slow(i)
     ldu(i).io.rr_bank_conflict_slow := bankedDataArray.io.rr_bank_conflict_slow(i)
   })
+
+  for (i <- 0 until LoadPipelineWidth) {
+    bankedDataArray.io.s2_tag_match_way(i) := ldu(i).io.s2_tag_match_way
+  }
+  bankedDataArray.io.readline_way_en_htag := mainPipe.io.readline_way_en_htag
 
   def processChannel(forward: DCacheForward, bus: TLBundle, i: Int): Unit = {
     val s0ReqValid = forward.s0Req.valid

--- a/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
+++ b/src/main/scala/xiangshan/cache/dcache/DCacheWrapper.scala
@@ -241,6 +241,9 @@ trait HasDCacheParameters
   val tagWritePort = metaWritePort + 1
   val errWritePort = tagWritePort + 1
   val wbPort = errWritePort + 1
+  val HashTagBits = 4
+  val EnableHashTagPrefilter = true
+  val EnableHashTagMainPipe = false
 
   def set_to_dcache_div(set: UInt) = {
     require(set.getWidth >= DCacheSetBits)
@@ -1072,6 +1075,8 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
 
   val accessArray = Module(new L1FlagMetaArray(readPorts = AccessArrayReadPort, writePorts = LoadPipelineWidth + 1))
   val tagArray = Module(new DuplicatedTagArray(readPorts = TagReadPort))
+  val hashTagReadPort = LoadPipelineWidth + (if (EnableHashTagMainPipe) 1 else 0)
+  val hashTagArray = Module(new HashTagArray(readPorts = hashTagReadPort, hashBits = HashTagBits))
   val prefetcherMonitor = Module(new PrefetcherMonitor)
   val bloomFilter =  Module(new BloomFilter(BLOOM_FILTER_ENTRY_NUM, true))
   val counterFilter = Module(new CounterFilter)
@@ -1305,8 +1310,19 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
         st.io.tag_resp := 0.U.asTypeOf(st.io.tag_resp)
     }
   }
+
+  for (i <- 0 until LoadPipelineWidth) {
+    hashTagArray.io.read(i).valid := ldu(i).io.tag_read.valid
+    hashTagArray.io.read(i).bits := ldu(i).io.tag_read.bits
+    ldu(i).io.hash_tag_resp := hashTagArray.io.resp(i)
+  }
+
   tagArray.io.read.last <> mainPipe.io.tag_read
   mainPipe.io.tag_resp := tagArray.io.resp.last
+  if (EnableHashTagMainPipe) {
+    hashTagArray.io.read.last.valid := mainPipe.io.tag_read.valid
+    hashTagArray.io.read.last.bits := mainPipe.io.tag_read.bits
+  }
 
   val fake_tag_read_conflict_this_cycle = PopCount(ldu.map(ld=> ld.io.tag_read.valid))
   XSPerfAccumulate("fake_tag_read_conflict", fake_tag_read_conflict_this_cycle)
@@ -1314,6 +1330,12 @@ class DCacheImp(outer: DCache) extends LazyModuleImp(outer) with HasDCacheParame
   val tag_write_arb = Module(new Arbiter(new TagWriteReq, 1))
   tag_write_arb.io.in(0) <> mainPipe.io.tag_write
   tagArray.io.write <> tag_write_arb.io.out
+  hashTagArray.io.write.valid := tagArray.io.write.valid
+  hashTagArray.io.write.bits.idx := tagArray.io.write.bits.idx
+  hashTagArray.io.write.bits.way_en := tagArray.io.write.bits.way_en
+  hashTagArray.io.write.bits.vaddr := tagArray.io.write.bits.vaddr
+  hashTagArray.io.write.bits.tag := tagArray.io.write.bits.tag
+  hashTagArray.io.write.bits.ecc := tagArray.io.write.bits.ecc
 
   ldu.map(m => {
     m.io.vtag_update.valid := tagArray.io.write.valid

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -121,8 +121,10 @@ class DataSRAM(bankIdx: Int, wayIdx: Int)(implicit p: Parameters) extends DCache
     shouldReset = false,
     holdRead = false,
     singlePort = true,
+    withClockGate = true,
     hasMbist = hasMbist,
-    hasSramCtl = hasSramCtl
+    hasSramCtl = hasSramCtl,
+    suffix = Some("dcsh_dat")
   ))
 
   data_sram.io.w.req.valid := io.w.en

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -54,6 +54,7 @@ class L1BankedDataReadReq(implicit p: Parameters) extends DCacheBundle
 class L1BankedDataReadReqWithMask(implicit p: Parameters) extends DCacheBundle
 {
   val way_en = Bits(DCacheWays.W)
+  val htag_miss = Bool()
   val addr = Bits(PAddrBits.W)
   val addr_dup = Bits(PAddrBits.W)
   val bankMask = Bits(DCacheBanks.W)
@@ -688,7 +689,7 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   data_banks.map(_.map(_.dump()))
 
   val way_en = Wire(Vec(LoadPipelineWidth, io.read(0).bits.way_en.cloneType))
-  val isMiss = way_en.map(w => !w.orR)
+  val htag_miss = io.read.map(_.bits.htag_miss)
   val set_addrs = Wire(Vec(LoadPipelineWidth, UInt()))
   val set_addrs_dup = Wire(Vec(LoadPipelineWidth, UInt()))
   val div_addrs = Wire(Vec(LoadPipelineWidth, UInt()))
@@ -746,7 +747,7 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
       div_addrs(x) === div_addrs(y) &&
       (io.read(x).bits.bankMask & io.read(y).bits.bankMask) =/= 0.U &&
       set_addrs(x) =/= set_addrs(y) &&
-      !isMiss(x) && !isMiss(y)
+      !htag_miss(x) && !htag_miss(y)
     }
   }
   ))
@@ -775,7 +776,7 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
       io.read(i).valid &&
       div_addrs(i) === line_div_addr &&
       set_addrs(i) =/= line_set_addr &&
-      !isMiss(i)
+      !htag_miss(i)
     }
     rrl_bank_conflict(i) := judge && io.readline.valid
     rrl_bank_conflict_intend(i) := judge && io.readline_intend
@@ -785,7 +786,7 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     write_valid_reg &&
     div_addrs(x) === write_div_addr_dup_reg.head &&
     (write_bank_mask_reg & io.read(x).bits.bankMask) =/= 0.U &&
-    !isMiss(x)
+    !htag_miss(x)
   )
   val wrl_bank_conflict = io.readline.valid && write_valid_reg &&
     line_div_addr === write_div_addr_dup_reg.head &&
@@ -859,11 +860,11 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
       //     +-----------------+
       val bank_addr_matchs = WireInit(VecInit(List.tabulate(LoadPipelineWidth)(i => {
         io.read(i).valid && div_addrs(i) === div_index.U &&
-          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i) && !isMiss(i)
+          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i) && !htag_miss(i)
       })))
       val bank_addr_matchs_dup = WireInit(VecInit(List.tabulate(LoadPipelineWidth)(i => {
         io.read(i).valid && div_addrs_dup(i) === div_index.U &&
-          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i) && !isMiss(i)
+          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i) && !htag_miss(i)
       })))
       val readline_match = Wire(Bool())
       if (ReduceReadlineConflict) {

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -254,6 +254,7 @@ abstract class AbstractBankedDataArray(implicit p: Parameters) extends DCacheMod
     // load pipeline read word req
     val read = Vec(LoadPipelineWidth, Flipped(DecoupledIO(new L1BankedDataReadReqWithMask)))
     val is128Req = Input(Vec(LoadPipelineWidth, Bool()))
+    val s2_tag_match_way = Input(Vec(LoadPipelineWidth, UInt(DCacheWays.W)))
     // main pipeline read / write line req
     val readline_intend = Input(Bool())
     val readline = Flipped(DecoupledIO(new L1BankedDataReadLineReq))

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -54,7 +54,6 @@ class L1BankedDataReadReq(implicit p: Parameters) extends DCacheBundle
 class L1BankedDataReadReqWithMask(implicit p: Parameters) extends DCacheBundle
 {
   val way_en = Bits(DCacheWays.W)
-  val htag_miss = Bool()
   val addr = Bits(PAddrBits.W)
   val addr_dup = Bits(PAddrBits.W)
   val bankMask = Bits(DCacheBanks.W)
@@ -65,7 +64,6 @@ class L1BankedDataReadLineReq(implicit p: Parameters) extends L1BankedDataReadRe
 {
   val rmask = Bits(DCacheBanks.W)
   val way = Bits(log2Up(DCacheWays).W) // UInt format of way_en for better timing
-  val way_en_htag = Bits(DCacheWays.W)
 }
 
 // Now, we can write a cache-block in a single cycle
@@ -257,7 +255,6 @@ abstract class AbstractBankedDataArray(implicit p: Parameters) extends DCacheMod
     // load pipeline read word req
     val read = Vec(LoadPipelineWidth, Flipped(DecoupledIO(new L1BankedDataReadReqWithMask)))
     val is128Req = Input(Vec(LoadPipelineWidth, Bool()))
-    val s2_tag_match_way = Input(Vec(LoadPipelineWidth, UInt(DCacheWays.W)))
     // main pipeline read / write line req
     val readline_intend = Input(Bool())
     val readline = Flipped(DecoupledIO(new L1BankedDataReadLineReq))
@@ -279,6 +276,8 @@ abstract class AbstractBankedDataArray(implicit p: Parameters) extends DCacheMod
     val rr_bank_conflict_slow = Output(Vec(LoadPipelineWidth, Bool()))
     val disable_ld_fast_wakeup = Output(Vec(LoadPipelineWidth, Bool()))
     val pseudo_error = Flipped(DecoupledIO(Vec(DCacheBanks, new CtrlUnitSignalingBundle)))
+    val readline_way_en_htag = Input(UInt(DCacheWays.W))
+    val s2_tag_match_way = Input(Vec(LoadPipelineWidth, UInt(DCacheWays.W)))
   })
 
   // Half of the data banks use the duplicate address path to reduce fanout.
@@ -693,7 +692,6 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   data_banks.map(_.map(_.dump()))
 
   val way_en = Wire(Vec(LoadPipelineWidth, io.read(0).bits.way_en.cloneType))
-  val htag_miss = io.read.map(_.bits.htag_miss)
   val set_addrs = Wire(Vec(LoadPipelineWidth, UInt()))
   val set_addrs_dup = Wire(Vec(LoadPipelineWidth, UInt()))
   val div_addrs = Wire(Vec(LoadPipelineWidth, UInt()))
@@ -750,8 +748,7 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
       io.read(x).valid && io.read(y).valid &&
       div_addrs(x) === div_addrs(y) &&
       (io.read(x).bits.bankMask & io.read(y).bits.bankMask) =/= 0.U &&
-      set_addrs(x) =/= set_addrs(y) &&
-      !htag_miss(x) && !htag_miss(y)
+      set_addrs(x) =/= set_addrs(y)
     }
   }
   ))
@@ -779,8 +776,7 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     } else {
       io.read(i).valid &&
       div_addrs(i) === line_div_addr &&
-      set_addrs(i) =/= line_set_addr &&
-      !htag_miss(i)
+      set_addrs(i) =/= line_set_addr
     }
     rrl_bank_conflict(i) := judge && io.readline.valid
     rrl_bank_conflict_intend(i) := judge && io.readline_intend
@@ -789,8 +785,7 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     io.read(x).valid &&
     write_valid_reg &&
     div_addrs(x) === write_div_addr_dup_reg.head &&
-    (write_bank_mask_reg & io.read(x).bits.bankMask) =/= 0.U &&
-    !htag_miss(x)
+    (write_bank_mask_reg & io.read(x).bits.bankMask) =/= 0.U
   )
   val wrl_bank_conflict = io.readline.valid && write_valid_reg &&
     line_div_addr === write_div_addr_dup_reg.head &&
@@ -864,11 +859,11 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
       //     +-----------------+
       val bank_addr_matchs = WireInit(VecInit(List.tabulate(LoadPipelineWidth)(i => {
         io.read(i).valid && div_addrs(i) === div_index.U &&
-          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i) && !htag_miss(i)
+          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i)
       })))
       val bank_addr_matchs_dup = WireInit(VecInit(List.tabulate(LoadPipelineWidth)(i => {
         io.read(i).valid && div_addrs_dup(i) === div_index.U &&
-          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i) && !htag_miss(i)
+          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i)
       })))
       val readline_match = Wire(Bool())
       if (ReduceReadlineConflict) {

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -261,6 +261,8 @@ abstract class AbstractBankedDataArray(implicit p: Parameters) extends DCacheMod
     val readline_can_go = Input(Bool())
     val readline_stall = Input(Bool())
     val readline_can_resp = Input(Bool())
+    val repl_dirty = Input(Bool())
+    val repl_way_en = Input(UInt(DCacheWays.W))
     val write = Flipped(DecoupledIO(new L1BankedDataWriteReq))
     val write_dup = Vec(DCacheBanks, Flipped(Decoupled(new L1BankedDataWriteReqCtrl)))
     // data for readline and loadpipe

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -688,6 +688,7 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   data_banks.map(_.map(_.dump()))
 
   val way_en = Wire(Vec(LoadPipelineWidth, io.read(0).bits.way_en.cloneType))
+  val isMiss = way_en.map(w => !w.orR)
   val set_addrs = Wire(Vec(LoadPipelineWidth, UInt()))
   val set_addrs_dup = Wire(Vec(LoadPipelineWidth, UInt()))
   val div_addrs = Wire(Vec(LoadPipelineWidth, UInt()))
@@ -744,7 +745,8 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
       io.read(x).valid && io.read(y).valid &&
       div_addrs(x) === div_addrs(y) &&
       (io.read(x).bits.bankMask & io.read(y).bits.bankMask) =/= 0.U &&
-      set_addrs(x) =/= set_addrs(y)
+      set_addrs(x) =/= set_addrs(y) &&
+      !isMiss(x) && !isMiss(y)
     }
   }
   ))
@@ -772,7 +774,8 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     } else {
       io.read(i).valid &&
       div_addrs(i) === line_div_addr &&
-      set_addrs(i) =/= line_set_addr
+      set_addrs(i) =/= line_set_addr &&
+      !isMiss(i)
     }
     rrl_bank_conflict(i) := judge && io.readline.valid
     rrl_bank_conflict_intend(i) := judge && io.readline_intend
@@ -781,7 +784,8 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     io.read(x).valid &&
     write_valid_reg &&
     div_addrs(x) === write_div_addr_dup_reg.head &&
-    (write_bank_mask_reg & io.read(x).bits.bankMask) =/= 0.U
+    (write_bank_mask_reg & io.read(x).bits.bankMask) =/= 0.U &&
+    !isMiss(x)
   )
   val wrl_bank_conflict = io.readline.valid && write_valid_reg &&
     line_div_addr === write_div_addr_dup_reg.head &&
@@ -855,11 +859,11 @@ class BankedDataArray(implicit p: Parameters) extends AbstractBankedDataArray {
       //     +-----------------+
       val bank_addr_matchs = WireInit(VecInit(List.tabulate(LoadPipelineWidth)(i => {
         io.read(i).valid && div_addrs(i) === div_index.U &&
-          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i)
+          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i) && !isMiss(i)
       })))
       val bank_addr_matchs_dup = WireInit(VecInit(List.tabulate(LoadPipelineWidth)(i => {
         io.read(i).valid && div_addrs_dup(i) === div_index.U &&
-          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i)
+          io.read(i).bits.bankMask(bank_index) && !rr_bank_conflict_oldest(i) && !isMiss(i)
       })))
       val readline_match = Wire(Bool())
       if (ReduceReadlineConflict) {

--- a/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/BankedDataArray.scala
@@ -65,6 +65,7 @@ class L1BankedDataReadLineReq(implicit p: Parameters) extends L1BankedDataReadRe
 {
   val rmask = Bits(DCacheBanks.W)
   val way = Bits(log2Up(DCacheWays).W) // UInt format of way_en for better timing
+  val way_en_htag = Bits(DCacheWays.W)
 }
 
 // Now, we can write a cache-block in a single cycle
@@ -261,8 +262,6 @@ abstract class AbstractBankedDataArray(implicit p: Parameters) extends DCacheMod
     val readline_can_go = Input(Bool())
     val readline_stall = Input(Bool())
     val readline_can_resp = Input(Bool())
-    val repl_dirty = Input(Bool())
-    val repl_way_en = Input(UInt(DCacheWays.W))
     val write = Flipped(DecoupledIO(new L1BankedDataWriteReq))
     val write_dup = Vec(DCacheBanks, Flipped(Decoupled(new L1BankedDataWriteReqCtrl)))
     // data for readline and loadpipe

--- a/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
@@ -57,6 +57,7 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   val line_set_addr = addr_to_dcache_div_set(io.readline.bits.addr)
   val line_div_addr = addr_to_dcache_div(io.readline.bits.addr)
   val line_way_en = io.readline.bits.way_en
+  val line_way_en_htag = io.readline.bits.way_en_htag
 
   val write_bank_mask_reg = RegEnable(io.write.bits.wmask, 0.U(DCacheBanks.W), io.write.valid)
   val write_data_reg = RegEnable(io.write.bits.data, io.write.valid)
@@ -116,7 +117,7 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     // val judge = if (ReduceReadlineConflict) io.read(i).valid && (io.readline.bits.rmask & io.read(i).bits.bankMask) =/= 0.U && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i)
     //             else io.read(i).valid && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i)
     val judge = io.read(i).valid && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i) &&
-                Mux(io.repl_dirty, (io.repl_way_en & way_en_htag(i)) =/= 0.U, true.B)
+                (line_way_en_htag & way_en_htag(i)) =/= 0.U
     rrl_bank_conflict(i) := judge && io.readline.valid
     rrl_bank_conflict_intend(i) := judge && io.readline_intend
   }
@@ -128,7 +129,7 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     (way_en_htag(i) & write_wayen_dup_reg.head) =/= 0.U
   )
   val wrl_bank_conflict = io.readline.valid && write_valid_reg && line_div_addr === write_div_addr_dup_reg.head &&
-                          Mux(io.repl_dirty, (io.repl_way_en & write_wayen_dup_reg.head) =/= 0.U, true.B)
+                          (line_way_en_htag & write_wayen_dup_reg.head) =/= 0.U
   // ready
   io.readline.ready := !(wrl_bank_conflict)
   io.read.zipWithIndex.map { case (x, i) => x.ready := !(wr_bank_conflict(i) || rrhazard) }
@@ -235,7 +236,7 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
           !rr_conflict_evict(i) &&
           way_en_htag(i)(way_index)
         }))
-        val readline_en = io.readline.valid && div_index.U === line_div_addr && Mux(io.repl_dirty, io.repl_way_en(way_index), true.B)
+        val readline_en = io.readline.valid && div_index.U === line_div_addr && line_way_en_htag(way_index)
         // if (ReduceReadlineConflict) {
         //   readline_en := io.readline.valid && io.readline.bits.rmask(bank_index) && line_way_en(way_index) && div_index.U === line_div_addr
         // } else {
@@ -303,8 +304,6 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   // readline port: latch read data at readline_can_go (one cycle after readline.fire) and
   // expose at readline_can_resp, matching SramedDataArray / MainPipe timing.
   val readline_error_delayed = Wire(Vec(DCacheBanks, Bool()))
-  val readline_r_way_en = RegEnable(io.readline.bits.way_en, io.readline.fire)
-  assert(PopCount(readline_r_way_en) <= 1.U, "HTADataArray: more than one readline_r_way_en is true")
   val readline_r_way_addr = RegEnable(OHToUInt(io.readline.bits.way_en), io.readline.fire)
   val readline_rr_way_addr = RegEnable(readline_r_way_addr, RegNext(io.readline.fire))
   val readline_r_div_addr = RegEnable(line_div_addr, io.readline.fire)
@@ -313,8 +312,7 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   (0 until DCacheBanks).map(i => {
     readline_resp_hold(i) := Mux(
       io.readline_can_go,
-    //   read_result(readline_r_div_addr)(i)(readline_r_way_addr),
-      Mux1H(readline_r_way_en, read_result(readline_r_div_addr)(i)),
+      read_result(readline_r_div_addr)(i)(readline_r_way_addr),
       RegEnable(readline_resp_hold(i), io.readline_stall)
     )
     readline_error_delayed(i) := read_result(readline_rr_div_addr)(i)(readline_rr_way_addr).error_delayed

--- a/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
@@ -1,0 +1,368 @@
+/***************************************************************************************
+* Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2021 Peng Cheng Laboratory
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+*
+*
+* Acknowledgement
+*
+* This implementation is inspired by several key papers:
+* [1] Gurindar S. Sohi, and Manoj Franklin. "[High-bandwidth data memory systems for superscalar processors.]
+* (https://doi.org/10.1145/106972.106980)" 4th International Conference on Architectural Support for Programming
+* Languages and Operating Systems (ASPLOS). 1991.
+***************************************************************************************/
+
+package xiangshan.cache
+
+import org.chipsalliance.cde.config.Parameters
+import chisel3._
+import utils._
+import utility._
+import utility.sram.SRAMTemplate
+import chisel3.util._
+import utility.mbist.MbistPipeline
+import xiangshan.mem.LqPtr
+import xiangshan.{L1CacheErrorInfo, XSCoreParamsKey}
+
+// For Dcache with Hash Tag Array
+class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
+  println("  DCache Data Array Type: HTADataArray")
+  require(LoadPipelineWidth == 3, "So far, HTADataArray only supports LoadPipelineWidth = 3")
+
+  io.write.ready := true.B
+  io.write_dup.foreach(_.ready := true.B)
+
+  val data_banks = List.tabulate(DCacheSetDiv)( k => {
+    val banks = List.tabulate(DCacheBanks)(i => List.tabulate(DCacheWays)(j => Module(new DataSRAM(i,j))))
+    val mbistPl = MbistPipeline.PlaceMbistPipeline(1, s"MbistPipeDataSet$k", hasMbist)
+    banks
+  })
+  data_banks.map(_.map(_.map(_.dump())))
+
+  val way_en_htag = Wire(Vec(LoadPipelineWidth, io.read(0).bits.way_en.cloneType))
+  val set_addrs = Wire(Vec(LoadPipelineWidth, UInt()))
+  val div_addrs = Wire(Vec(LoadPipelineWidth, UInt()))
+  val bank_addrs = Wire(Vec(LoadPipelineWidth, Vec(VLEN/DCacheSRAMRowBits, UInt())))
+
+  val line_set_addr = addr_to_dcache_div_set(io.readline.bits.addr)
+  val line_div_addr = addr_to_dcache_div(io.readline.bits.addr)
+  val line_way_en = io.readline.bits.way_en
+
+  val write_bank_mask_reg = RegEnable(io.write.bits.wmask, 0.U(DCacheBanks.W), io.write.valid)
+  val write_data_reg = RegEnable(io.write.bits.data, io.write.valid)
+  val write_valid_reg = RegNext(io.write.valid)
+  val write_valid_dup_reg = io.write_dup.map(x => RegNext(x.valid))
+  val write_wayen_dup_reg = io.write_dup.map(x => RegEnable(x.bits.way_en, 0.U(DCacheWays.W), x.valid))
+  val write_set_addr_dup_reg = io.write_dup.map(x => RegEnable(addr_to_dcache_div_set(x.bits.addr), x.valid))
+  val write_div_addr_dup_reg = io.write_dup.map(x => RegEnable(addr_to_dcache_div(x.bits.addr), x.valid))
+
+  // read data_banks and ecc_banks
+  // for single port SRAM, do not allow read and write in the same cycle
+  val rrhazard = false.B // io.readline.valid
+  (0 until LoadPipelineWidth).map(rport_index => {
+    div_addrs(rport_index) := addr_to_dcache_div(io.read(rport_index).bits.addr)
+    set_addrs(rport_index) := addr_to_dcache_div_set(io.read(rport_index).bits.addr)
+    bank_addrs(rport_index)(0) := addr_to_dcache_bank(io.read(rport_index).bits.addr)
+    bank_addrs(rport_index)(1) := Mux(io.is128Req(rport_index), bank_addrs(rport_index)(0) + 1.U, bank_addrs(rport_index)(0))
+
+    // use way_en to select a way after data read out
+    // assert(!(RegNext(io.read(rport_index).fire && PopCount(io.read(rport_index).bits.way_en) > 1.U)))
+    way_en_htag(rport_index) := io.read(rport_index).bits.way_en
+  })
+
+//   // read conflict
+//   val rr_bank_conflict = Seq.tabulate(LoadPipelineWidth)(x => Seq.tabulate(LoadPipelineWidth)(y => {
+//     if (x == y) {
+//       false.B
+//     } else {
+//       io.read(x).valid && io.read(y).valid &&
+//         div_addrs(x) === div_addrs(y) &&
+//         (io.read(x).bits.bankMask & io.read(y).bits.bankMask) =/= 0.U &&
+//         io.read(x).bits.way_en === io.read(y).bits.way_en &&
+//         set_addrs(x) =/= set_addrs(y)
+//     }
+//   }))
+//   val load_req_with_bank_conflict = rr_bank_conflict.map(_.reduce(_ || _))
+  val load_req_valid = io.read.map(_.valid)
+  val load_req_lqIdx = io.read.map(_.bits.lqIdx)
+//   val load_req_index = (0 until LoadPipelineWidth).map(_.asUInt)
+
+
+//   val load_req_bank_conflict_selcet = selcetOldestPort(load_req_with_bank_conflict, load_req_lqIdx, load_req_index)
+//   val load_req_bank_select_port  = UIntToOH(load_req_bank_conflict_selcet._2).asBools
+
+//   val rr_bank_conflict_oldest = (0 until LoadPipelineWidth).map(i =>
+//     !load_req_bank_select_port(i) && load_req_with_bank_conflict(i)
+//   )
+
+  val rrl_bank_conflict = Wire(Vec(LoadPipelineWidth, Bool()))
+  val rrl_bank_conflict_intend = Wire(Vec(LoadPipelineWidth, Bool()))
+  (0 until LoadPipelineWidth).foreach { i =>
+    // val judge = if (ReduceReadlineConflict) io.read(i).valid && (io.readline.bits.rmask & io.read(i).bits.bankMask) =/= 0.U && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i)
+    //             else io.read(i).valid && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i)
+    val judge = io.read(i).valid && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i)
+    rrl_bank_conflict(i) := judge && io.readline.valid
+    rrl_bank_conflict_intend(i) := judge && io.readline_intend
+  }
+  val wr_bank_conflict = Seq.tabulate(LoadPipelineWidth)(x =>
+    io.read(x).valid && write_valid_reg &&
+    div_addrs(x) === write_div_addr_dup_reg.head &&
+    // way_en(x) === write_wayen_dup_reg.head &&
+    (write_bank_mask_reg(bank_addrs(x)(0)) || write_bank_mask_reg(bank_addrs(x)(1)) && io.is128Req(x))
+  )
+  val wrl_bank_conflict = io.readline.valid && write_valid_reg && line_div_addr === write_div_addr_dup_reg.head
+  // ready
+  io.readline.ready := !(wrl_bank_conflict)
+  io.read.zipWithIndex.map { case (x, i) => x.ready := !(wr_bank_conflict(i) || rrhazard) }
+
+  val rr_bank_overlap = Seq.tabulate(LoadPipelineWidth)(x => Seq.tabulate(LoadPipelineWidth)(y => {
+    if (x == y) {
+      false.B
+    } else {
+      io.read(x).valid && io.read(y).valid &&
+        div_addrs(x) === div_addrs(y) &&
+        (io.read(x).bits.bankMask & io.read(y).bits.bankMask) =/= 0.U &&
+        set_addrs(x) =/= set_addrs(y)
+    }
+  }))
+  val rr_way_overlap = Seq.tabulate(LoadPipelineWidth)(x => Seq.tabulate(LoadPipelineWidth)(y => {
+    if (x == y) {
+      false.B
+    } else {
+      (way_en_htag(x).asUInt & way_en_htag(y).asUInt) =/= 0.U
+    }
+  }))
+  val rr_conflict_evict = (0 until LoadPipelineWidth).map(i => {
+    if (i == 0) {
+      false.B
+    } else {
+      (0 until i).map(j => rr_bank_overlap(j)(i) && rr_way_overlap(j)(i)).reduce(_ || _)
+    }
+  })
+  // rr_bank_conflict_oldest --> rr_conflict_evict
+  val rr_bank_conflict = rr_bank_overlap
+
+  val perf_multi_read = PopCount(io.read.map(_.valid)) >= 2.U
+//   val bank_conflict_fast = Wire(Vec(LoadPipelineWidth, Bool()))
+  (0 until LoadPipelineWidth).foreach(i => {
+    // bank_conflict_fast(i) := wr_bank_conflict(i) || rrl_bank_conflict(i) ||
+    // rr_bank_conflict_oldest(i)
+    // io.bank_conflict_slow(i) := RegNext(bank_conflict_fast(i))
+    io.bank_conflict_slow(i) := RegNext(wr_bank_conflict(i)) || RegNext(rrl_bank_conflict(i)) ||
+                                RegNext(rr_conflict_evict(i))
+    io.disable_ld_fast_wakeup(i) := wr_bank_conflict(i) || rrl_bank_conflict_intend(i) ||
+      (if (i == 0) 0.B else (0 until i).map(rr_bank_conflict(_)(i)).reduce(_ || _))
+  })
+  XSPerfAccumulate("data_array_multi_read", perf_multi_read)
+  (1 until LoadPipelineWidth).foreach(y => (0 until y).foreach(x =>
+    XSPerfAccumulate(s"data_array_rr_bank_conflict_${x}_${y}", rr_bank_conflict(x)(y))
+  ))
+  (0 until LoadPipelineWidth).foreach(i => {
+    XSPerfAccumulate(s"data_array_rrl_bank_conflict_${i}", rrl_bank_conflict(i))
+    XSPerfAccumulate(s"data_array_rw_bank_conflict_${i}", wr_bank_conflict(i))
+    XSPerfAccumulate(s"data_array_read_${i}", io.read(i).valid)
+  })
+  XSPerfAccumulate("data_array_access_total", PopCount(io.read.map(_.valid)))
+  XSPerfAccumulate("data_array_read_line", io.readline.valid)
+  XSPerfAccumulate("data_array_write", io.write.valid)
+
+  val read_result = Wire(Vec(DCacheSetDiv, Vec(DCacheBanks, Vec(DCacheWays,new L1BankedDataReadResult()))))
+  val read_result_delayed = Wire(Vec(DCacheSetDiv, Vec(DCacheBanks, Vec(DCacheWays,new L1BankedDataReadResult()))))
+  val read_error_delayed_result = Wire(Vec(DCacheSetDiv, Vec(DCacheBanks, Vec(DCacheWays, Bool()))))
+  dontTouch(read_result)
+  dontTouch(read_error_delayed_result)
+
+  val pseudo_data_toggle_mask = io.pseudo_error.bits.map {
+    case bank =>
+      Mux(io.pseudo_error.valid && bank.valid, bank.mask, 0.U)
+  }
+  val readline_hit = io.readline.fire &&
+                     (io.readline.bits.rmask & VecInit(io.pseudo_error.bits.map(_.valid)).asUInt).orR
+  val readbank_hit = io.read.zip(bank_addrs.zip(io.is128Req)).zipWithIndex.map {
+                          case ((read, (bank_addr, is128Req)), i) =>
+                            val error_bank0 = io.pseudo_error.bits(bank_addr(0))
+                            val error_bank1 = io.pseudo_error.bits(bank_addr(1))
+                            read.fire && (error_bank0.valid || error_bank1.valid && is128Req) && !io.bank_conflict_slow(i)
+                      }.reduce(_|_)
+  io.pseudo_error.ready := RegNext(readline_hit || readbank_hit)
+
+  for (div_index <- 0 until DCacheSetDiv){
+    for (bank_index <- 0 until DCacheBanks) {
+      for (way_index <- 0 until DCacheWays) {
+        //     Set Addr & Read Way Mask
+        //
+        //    Pipe 0   ....  Pipe (n-1)
+        //      +      ....     +
+        //      |      ....     |
+        // +----+---------------+-----+
+        //  X                        X
+        //   X                      +------+ Bank Addr Match
+        //    +---------+----------+
+        //              |
+        //     +--------+--------+
+        //     |    Data Bank    |
+        //     +-----------------+
+        val loadpipe_en = WireInit(VecInit(List.tabulate(LoadPipelineWidth)(i => {
+          io.read(i).valid && div_addrs(i) === div_index.U && (bank_addrs(i)(0) === bank_index.U || bank_addrs(i)(1) === bank_index.U && io.is128Req(i)) &&
+        //   way_en(i)(way_index) &&
+        //   !rr_bank_conflict_oldest(i)
+          !rr_conflict_evict(i) &&
+          way_en_htag(i)(way_index)
+        })))
+        val readline_en = Wire(Bool())
+        // if (ReduceReadlineConflict) {
+        //   readline_en := io.readline.valid && io.readline.bits.rmask(bank_index) && line_way_en(way_index) && div_index.U === line_div_addr
+        // } else {
+          readline_en := io.readline.valid && line_way_en(way_index) && div_index.U === line_div_addr
+        // }
+        val sram_set_addr = Mux(readline_en,
+          addr_to_dcache_div_set(io.readline.bits.addr),
+          PriorityMux(Seq.tabulate(LoadPipelineWidth)(i => loadpipe_en(i) -> set_addrs(i)))
+        )
+        val read_en = loadpipe_en.asUInt.orR || readline_en
+        // read raw data
+        val data_bank = data_banks(div_index)(bank_index)(way_index)
+        data_bank.io.r.en := read_en
+        data_bank.io.r.addr := sram_set_addr
+
+        read_result(div_index)(bank_index)(way_index).ecc := getECCFromEncWord(data_bank.io.r.data)
+        read_result(div_index)(bank_index)(way_index).raw_data := getDataFromEncWord(data_bank.io.r.data) ^ pseudo_data_toggle_mask(bank_index)
+
+        if (EnableDataEcc) {
+          val ecc_data = read_result(div_index)(bank_index)(way_index).asECCData()
+          val ecc_data_delayed = RegEnable(ecc_data, RegNext(read_en))
+          read_result(div_index)(bank_index)(way_index).error_delayed := dcacheParameters.dataCode.decode(ecc_data_delayed).error
+          read_error_delayed_result(div_index)(bank_index)(way_index) := read_result(div_index)(bank_index)(way_index).error_delayed
+        } else {
+          read_result(div_index)(bank_index)(way_index).error_delayed := false.B
+          read_error_delayed_result(div_index)(bank_index)(way_index) := false.B
+        }
+
+        read_result_delayed(div_index)(bank_index)(way_index) := RegEnable(read_result(div_index)(bank_index)(way_index), RegNext(read_en))
+      }
+    }
+  }
+
+  val data_read_oh = WireInit(VecInit(Seq.fill(DCacheSetDiv * DCacheBanks * DCacheWays)(0.U(1.W))))
+  for(div_index <- 0 until DCacheSetDiv){
+    for (bank_index <- 0 until DCacheBanks) {
+      for (way_index <- 0 until DCacheWays) {
+        data_read_oh(div_index *  DCacheBanks * DCacheWays + bank_index * DCacheWays + way_index) := data_banks(div_index)(bank_index)(way_index).io.r.en
+      }
+    }
+  }
+  XSPerfAccumulate("data_read_counter", PopCount(Cat(data_read_oh)))
+
+  // read result: expose banked read result
+  // TODO: clock gate
+  (0 until LoadPipelineWidth).map(i => {
+    // io.read_resp(i) := read_result(RegNext(bank_addrs(i)))(RegNext(OHToUInt(way_en(i))))
+    val r_read_fire = RegNext(io.read(i).fire)
+    val r_div_addr  = RegEnable(div_addrs(i), io.read(i).fire)
+    val r_bank_addr = RegEnable(bank_addrs(i), io.read(i).fire)
+    val r_way_addr = OHToUInt(io.s2_tag_match_way(i))
+    val rr_read_fire = RegNext(RegNext(io.read(i).fire))
+    val rr_div_addr = RegEnable(RegEnable(div_addrs(i), io.read(i).fire), r_read_fire)
+    val rr_bank_addr = RegEnable(RegEnable(bank_addrs(i), io.read(i).fire), r_read_fire)
+    val rr_way_addr = RegEnable(r_way_addr, r_read_fire)
+    (0 until VLEN/DCacheSRAMRowBits).map( j =>{
+    //   io.read_resp(i)(j) := read_result(r_div_addr)(r_bank_addr(j))(r_way_addr)
+      io.read_resp(i)(j) := Mux1H(io.s2_tag_match_way(i), read_result(r_div_addr)(r_bank_addr(j)))
+      // error detection
+      // normal read ports
+      io.read_error_delayed(i)(j) := rr_read_fire && read_error_delayed_result(rr_div_addr)(rr_bank_addr(j))(rr_way_addr) && !RegNext(io.bank_conflict_slow(i))
+    })
+  })
+
+  // readline port: latch read data at readline_can_go (one cycle after readline.fire) and
+  // expose at readline_can_resp, matching SramedDataArray / MainPipe timing.
+  val readline_error_delayed = Wire(Vec(DCacheBanks, Bool()))
+  val readline_r_way_addr = RegEnable(OHToUInt(io.readline.bits.way_en), io.readline.fire)
+  val readline_rr_way_addr = RegEnable(readline_r_way_addr, RegNext(io.readline.fire))
+  val readline_r_div_addr = RegEnable(line_div_addr, io.readline.fire)
+  val readline_rr_div_addr = RegEnable(readline_r_div_addr, RegNext(io.readline.fire))
+  val readline_resp_hold = Wire(io.readline_resp.cloneType)
+  (0 until DCacheBanks).map(i => {
+    readline_resp_hold(i) := Mux(
+      io.readline_can_go,
+      read_result(readline_r_div_addr)(i)(readline_r_way_addr),
+      RegEnable(readline_resp_hold(i), io.readline_stall)
+    )
+    readline_error_delayed(i) := read_result(readline_rr_div_addr)(i)(readline_rr_way_addr).error_delayed
+  })
+  io.readline_resp := RegEnable(readline_resp_hold, io.readline_can_resp)
+  io.readline_error := RegNext(RegNext(io.readline.fire)) && readline_error_delayed.asUInt.orR
+  io.readline_error_delayed := RegNext(RegNext(io.readline.fire)) && readline_error_delayed.asUInt.orR
+
+  // write data_banks & ecc_banks
+  for (div_index <- 0 until DCacheSetDiv) {
+    for (bank_index <- 0 until DCacheBanks) {
+      for (way_index <- 0 until DCacheWays) {
+        // data write
+        val wen_reg = write_bank_mask_reg(bank_index) &&
+          write_valid_dup_reg(bank_index) &&
+          write_div_addr_dup_reg(bank_index) === div_index.U &&
+          write_wayen_dup_reg(bank_index)(way_index)
+        val write_ecc_reg = RegEnable(getECCFromEncWord(cacheParams.dataCode.encode(io.write.bits.data(bank_index))), io.write.valid)
+        val data_bank = data_banks(div_index)(bank_index)(way_index)
+        data_bank.io.w.en := wen_reg
+        data_bank.io.w.addr := write_set_addr_dup_reg(bank_index)
+        data_bank.io.w.data := asECCData(write_ecc_reg, write_data_reg(bank_index))
+      }
+    }
+  }
+
+  val tableName =  "BankConflict" + p(XSCoreParamsKey).HartId.toString
+  val siteName = "BankedDataArray" + p(XSCoreParamsKey).HartId.toString
+  val bankConflictTable = ChiselDB.createTable(tableName, new BankConflictDB)
+  val bankConflictData = Wire(new BankConflictDB)
+  for (i <- 0 until LoadPipelineWidth) {
+    bankConflictData.set_index(i) := set_addrs(i)
+    bankConflictData.addr(i) := io.read(i).bits.addr
+  }
+
+  // FIXME: rr_bank_conflict(0)(1) no generalization
+  when(rr_bank_conflict(0)(1)) {
+    (0 until (VLEN/DCacheSRAMRowBits)).map(i => {
+      bankConflictData.bank_index(i) := bank_addrs(0)(i)
+    })
+    bankConflictData.way_index  := OHToUInt(way_en_htag(0))
+    bankConflictData.fake_rr_bank_conflict := set_addrs(0) === set_addrs(1) && div_addrs(0) === div_addrs(1)
+  }.otherwise {
+    (0 until (VLEN/DCacheSRAMRowBits)).map(i => {
+      bankConflictData.bank_index(i) := 0.U
+    })
+    bankConflictData.way_index := 0.U
+    bankConflictData.fake_rr_bank_conflict := false.B
+  }
+
+  val isWriteBankConflictTable = Constantin.createRecord(s"isWriteBankConflictTable${p(XSCoreParamsKey).HartId}")
+  bankConflictTable.log(
+    data = bankConflictData,
+    en = isWriteBankConflictTable.orR && rr_bank_conflict(0)(1),
+    site = siteName,
+    clock = clock,
+    reset = reset
+  )
+
+  (1 until LoadPipelineWidth).foreach(y => (0 until y).foreach(x =>
+    XSPerfAccumulate(s"data_array_fake_rr_bank_conflict_${x}_${y}", rr_bank_conflict(x)(y) && set_addrs(x)===set_addrs(y) && div_addrs(x) === div_addrs(y))
+  ))
+
+  if (backendParams.debugEn){
+    // rr_conflict_evict.map(dontTouch(_))
+    dontTouch(read_result)
+    dontTouch(read_error_delayed_result)
+  }
+}

--- a/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
@@ -38,7 +38,6 @@ import xiangshan.{L1CacheErrorInfo, XSCoreParamsKey}
 // For Dcache with Hash Tag Array
 class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   println("  DCache Data Array Type: HTADataArray")
-  require(LoadPipelineWidth == 3, "So far, HTADataArray only supports LoadPipelineWidth = 3")
 
   io.write.ready := true.B
   io.write_dup.foreach(_.ready := true.B)
@@ -98,6 +97,15 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   val load_req_lqIdx = io.read.map(_.bits.lqIdx)
 //   val load_req_index = (0 until LoadPipelineWidth).map(_.asUInt)
 
+  
+  // Age matrix of lqIdx: if i < j and matrix(i, j) == true, then i is older than j
+  val lqIdx_age_matrix = Seq.tabulate(LoadPipelineWidth)(i => Seq.tabulate(LoadPipelineWidth)(j => {
+    if (i >= j) {
+      false.B
+    } else {
+      io.read(i).bits.lqIdx < io.read(j).bits.lqIdx
+    }
+  }))
 
 //   val load_req_bank_conflict_selcet = selcetOldestPort(load_req_with_bank_conflict, load_req_lqIdx, load_req_index)
 //   val load_req_bank_select_port  = UIntToOH(load_req_bank_conflict_selcet._2).asBools
@@ -147,12 +155,17 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     }
   }))
   val rr_conflict_evict = (0 until LoadPipelineWidth).map(i => {
-    if (i == 0) {
-      false.B
-    } else {
-      (0 until i).map(j => rr_bank_overlap(j)(i) && rr_way_overlap(j)(i)).reduce(_ || _)
-    }
+    (0 until LoadPipelineWidth).map(j => {
+      if (i > j) {
+        lqIdx_age_matrix(j)(i) && rr_bank_overlap(j)(i) && rr_way_overlap(j)(i)
+      } else if (i < j) {
+        !lqIdx_age_matrix(i)(j) && rr_bank_overlap(i)(j) && rr_way_overlap(i)(j)
+      } else {
+        false.B
+      }
+    }).reduce(_ || _)
   })
+  
   // rr_bank_conflict_oldest --> rr_conflict_evict
   val rr_bank_conflict = rr_bank_overlap
 

--- a/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
@@ -111,7 +111,8 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   (0 until LoadPipelineWidth).foreach { i =>
     // val judge = if (ReduceReadlineConflict) io.read(i).valid && (io.readline.bits.rmask & io.read(i).bits.bankMask) =/= 0.U && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i)
     //             else io.read(i).valid && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i)
-    val judge = io.read(i).valid && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i)
+    val judge = io.read(i).valid && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i) &&
+                Mux(io.repl_dirty, (io.repl_way_en & way_en_htag(i)) =/= 0.U, true.B)
     rrl_bank_conflict(i) := judge && io.readline.valid
     rrl_bank_conflict_intend(i) := judge && io.readline_intend
   }
@@ -119,9 +120,11 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     io.read(x).valid && write_valid_reg &&
     div_addrs(x) === write_div_addr_dup_reg.head &&
     // way_en(x) === write_wayen_dup_reg.head &&
-    (write_bank_mask_reg(bank_addrs(x)(0)) || write_bank_mask_reg(bank_addrs(x)(1)) && io.is128Req(x))
+    (write_bank_mask_reg(bank_addrs(x)(0)) || write_bank_mask_reg(bank_addrs(x)(1)) && io.is128Req(x)) &&
+    (way_en_htag(x) & write_wayen_dup_reg.head) =/= 0.U
   )
-  val wrl_bank_conflict = io.readline.valid && write_valid_reg && line_div_addr === write_div_addr_dup_reg.head
+  val wrl_bank_conflict = io.readline.valid && write_valid_reg && line_div_addr === write_div_addr_dup_reg.head &&
+                          Mux(io.repl_dirty, (io.repl_way_en & write_wayen_dup_reg.head) =/= 0.U, true.B)
   // ready
   io.readline.ready := !(wrl_bank_conflict)
   io.read.zipWithIndex.map { case (x, i) => x.ready := !(wr_bank_conflict(i) || rrhazard) }
@@ -224,7 +227,8 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
         // if (ReduceReadlineConflict) {
         //   readline_en := io.readline.valid && io.readline.bits.rmask(bank_index) && line_way_en(way_index) && div_index.U === line_div_addr
         // } else {
-          readline_en := io.readline.valid && line_way_en(way_index) && div_index.U === line_div_addr
+        //   readline_en := io.readline.valid && line_way_en(way_index) && div_index.U === line_div_addr
+          readline_en := io.readline.valid && div_index.U === line_div_addr && Mux(io.repl_dirty, io.repl_way_en(way_index), true.B)
         // }
         val sram_set_addr = Mux(readline_en,
           addr_to_dcache_div_set(io.readline.bits.addr),

--- a/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
@@ -100,11 +100,7 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   
   // Age matrix of lqIdx: if i < j and matrix(i, j) == true, then i is older than j
   val lqIdx_age_matrix = Seq.tabulate(LoadPipelineWidth)(i => Seq.tabulate(LoadPipelineWidth)(j => {
-    if (i >= j) {
-      false.B
-    } else {
-      io.read(i).bits.lqIdx < io.read(j).bits.lqIdx
-    }
+    if (i >= j) false.B else (io.read(i).bits.lqIdx < io.read(j).bits.lqIdx)
   }))
 
 //   val load_req_bank_conflict_selcet = selcetOldestPort(load_req_with_bank_conflict, load_req_lqIdx, load_req_index)
@@ -124,12 +120,12 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     rrl_bank_conflict(i) := judge && io.readline.valid
     rrl_bank_conflict_intend(i) := judge && io.readline_intend
   }
-  val wr_bank_conflict = Seq.tabulate(LoadPipelineWidth)(x =>
-    io.read(x).valid && write_valid_reg &&
-    div_addrs(x) === write_div_addr_dup_reg.head &&
+  val wr_bank_conflict = Seq.tabulate(LoadPipelineWidth)(i =>
+    io.read(i).valid && write_valid_reg &&
+    div_addrs(i) === write_div_addr_dup_reg.head &&
     // way_en(x) === write_wayen_dup_reg.head &&
-    (write_bank_mask_reg(bank_addrs(x)(0)) || write_bank_mask_reg(bank_addrs(x)(1)) && io.is128Req(x)) &&
-    (way_en_htag(x) & write_wayen_dup_reg.head) =/= 0.U
+    (write_bank_mask_reg(bank_addrs(i)(0)) || write_bank_mask_reg(bank_addrs(i)(1)) && io.is128Req(i)) &&
+    (way_en_htag(i) & write_wayen_dup_reg.head) =/= 0.U
   )
   val wrl_bank_conflict = io.readline.valid && write_valid_reg && line_div_addr === write_div_addr_dup_reg.head &&
                           Mux(io.repl_dirty, (io.repl_way_en & write_wayen_dup_reg.head) =/= 0.U, true.B)
@@ -137,23 +133,26 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   io.readline.ready := !(wrl_bank_conflict)
   io.read.zipWithIndex.map { case (x, i) => x.ready := !(wr_bank_conflict(i) || rrhazard) }
 
-  val rr_bank_overlap = Seq.tabulate(LoadPipelineWidth)(x => Seq.tabulate(LoadPipelineWidth)(y => {
-    if (x == y) {
+  val rr_bank_overlap = Seq.tabulate(LoadPipelineWidth)(i => Seq.tabulate(LoadPipelineWidth)(j => {
+    if (i == j) {
       false.B
     } else {
-      io.read(x).valid && io.read(y).valid &&
-        div_addrs(x) === div_addrs(y) &&
-        (io.read(x).bits.bankMask & io.read(y).bits.bankMask) =/= 0.U &&
-        set_addrs(x) =/= set_addrs(y)
+      io.read(i).valid && io.read(j).valid &&
+      div_addrs(i) === div_addrs(j) &&
+      (io.read(i).bits.bankMask & io.read(j).bits.bankMask) =/= 0.U &&
+      set_addrs(i) =/= set_addrs(j)
     }
   }))
-  val rr_way_overlap = Seq.tabulate(LoadPipelineWidth)(x => Seq.tabulate(LoadPipelineWidth)(y => {
-    if (x == y) {
-      false.B
-    } else {
-      (way_en_htag(x).asUInt & way_en_htag(y).asUInt) =/= 0.U
-    }
+  val rr_way_overlap = Seq.tabulate(LoadPipelineWidth)(i => Seq.tabulate(LoadPipelineWidth)(j => {
+    if (i == j) false.B else (way_en_htag(i) & way_en_htag(j)) =/= 0.U
   }))
+//   val rr_conflict_evict = (0 until LoadPipelineWidth).map(i => {
+//     if (i == 0) {
+//       false.B
+//     } else {
+//       (0 until i).map(j => rr_bank_overlap(j)(i) && rr_way_overlap(j)(i)).reduce(_ || _)
+//     }
+//   })
   val rr_conflict_evict = (0 until LoadPipelineWidth).map(i => {
     (0 until LoadPipelineWidth).map(j => {
       if (i > j) {
@@ -165,7 +164,7 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
       }
     }).reduce(_ || _)
   })
-  
+
   // rr_bank_conflict_oldest --> rr_conflict_evict
   val rr_bank_conflict = rr_bank_overlap
 
@@ -229,19 +228,18 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
         //     +--------+--------+
         //     |    Data Bank    |
         //     +-----------------+
-        val loadpipe_en = WireInit(VecInit(List.tabulate(LoadPipelineWidth)(i => {
+        val loadpipe_en = VecInit(Seq.tabulate(LoadPipelineWidth)(i => {
           io.read(i).valid && div_addrs(i) === div_index.U && (bank_addrs(i)(0) === bank_index.U || bank_addrs(i)(1) === bank_index.U && io.is128Req(i)) &&
         //   way_en(i)(way_index) &&
         //   !rr_bank_conflict_oldest(i)
           !rr_conflict_evict(i) &&
           way_en_htag(i)(way_index)
-        })))
-        val readline_en = Wire(Bool())
+        }))
+        val readline_en = io.readline.valid && div_index.U === line_div_addr && Mux(io.repl_dirty, io.repl_way_en(way_index), true.B)
         // if (ReduceReadlineConflict) {
         //   readline_en := io.readline.valid && io.readline.bits.rmask(bank_index) && line_way_en(way_index) && div_index.U === line_div_addr
         // } else {
         //   readline_en := io.readline.valid && line_way_en(way_index) && div_index.U === line_div_addr
-          readline_en := io.readline.valid && div_index.U === line_div_addr && Mux(io.repl_dirty, io.repl_way_en(way_index), true.B)
         // }
         val sram_set_addr = Mux(readline_en,
           addr_to_dcache_div_set(io.readline.bits.addr),
@@ -289,9 +287,9 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     val r_div_addr  = RegEnable(div_addrs(i), io.read(i).fire)
     val r_bank_addr = RegEnable(bank_addrs(i), io.read(i).fire)
     val r_way_addr = OHToUInt(io.s2_tag_match_way(i))
-    val rr_read_fire = RegNext(RegNext(io.read(i).fire))
-    val rr_div_addr = RegEnable(RegEnable(div_addrs(i), io.read(i).fire), r_read_fire)
-    val rr_bank_addr = RegEnable(RegEnable(bank_addrs(i), io.read(i).fire), r_read_fire)
+    val rr_read_fire = RegNext(r_read_fire)
+    val rr_div_addr = RegEnable(r_div_addr, r_read_fire)
+    val rr_bank_addr = RegEnable(r_bank_addr, r_read_fire)
     val rr_way_addr = RegEnable(r_way_addr, r_read_fire)
     (0 until VLEN/DCacheSRAMRowBits).map( j =>{
     //   io.read_resp(i)(j) := read_result(r_div_addr)(r_bank_addr(j))(r_way_addr)
@@ -305,6 +303,8 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   // readline port: latch read data at readline_can_go (one cycle after readline.fire) and
   // expose at readline_can_resp, matching SramedDataArray / MainPipe timing.
   val readline_error_delayed = Wire(Vec(DCacheBanks, Bool()))
+  val readline_r_way_en = RegEnable(io.readline.bits.way_en, io.readline.fire)
+  assert(PopCount(readline_r_way_en) <= 1.U, "HTADataArray: more than one readline_r_way_en is true")
   val readline_r_way_addr = RegEnable(OHToUInt(io.readline.bits.way_en), io.readline.fire)
   val readline_rr_way_addr = RegEnable(readline_r_way_addr, RegNext(io.readline.fire))
   val readline_r_div_addr = RegEnable(line_div_addr, io.readline.fire)
@@ -313,7 +313,8 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   (0 until DCacheBanks).map(i => {
     readline_resp_hold(i) := Mux(
       io.readline_can_go,
-      read_result(readline_r_div_addr)(i)(readline_r_way_addr),
+    //   read_result(readline_r_div_addr)(i)(readline_r_way_addr),
+      Mux1H(readline_r_way_en, read_result(readline_r_div_addr)(i)),
       RegEnable(readline_resp_hold(i), io.readline_stall)
     )
     readline_error_delayed(i) := read_result(readline_rr_div_addr)(i)(readline_rr_way_addr).error_delayed
@@ -328,9 +329,9 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
       for (way_index <- 0 until DCacheWays) {
         // data write
         val wen_reg = write_bank_mask_reg(bank_index) &&
-          write_valid_dup_reg(bank_index) &&
-          write_div_addr_dup_reg(bank_index) === div_index.U &&
-          write_wayen_dup_reg(bank_index)(way_index)
+                      write_valid_dup_reg(bank_index) &&
+                      write_div_addr_dup_reg(bank_index) === div_index.U &&
+                      write_wayen_dup_reg(bank_index)(way_index)
         val write_ecc_reg = RegEnable(getECCFromEncWord(cacheParams.dataCode.encode(io.write.bits.data(bank_index))), io.write.valid)
         val data_bank = data_banks(div_index)(bank_index)(way_index)
         data_bank.io.w.en := wen_reg

--- a/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
@@ -56,8 +56,7 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
 
   val line_set_addr = addr_to_dcache_div_set(io.readline.bits.addr)
   val line_div_addr = addr_to_dcache_div(io.readline.bits.addr)
-  val line_way_en = io.readline.bits.way_en
-  val line_way_en_htag = io.readline.bits.way_en_htag
+  val line_way_en_htag = io.readline_way_en_htag
 
   val write_bank_mask_reg = RegEnable(io.write.bits.wmask, 0.U(DCacheBanks.W), io.write.valid)
   val write_data_reg = RegEnable(io.write.bits.data, io.write.valid)

--- a/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
@@ -137,6 +137,7 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   (0 until LoadPipelineWidth).foreach(i => {
     io.bank_conflict_slow(i) := RegNext(wr_bank_conflict(i)) || RegNext(rrl_bank_conflict(i)) ||
                                 RegNext(rr_conflict_evict(i))
+    io.rr_bank_conflict_slow(i) := RegNext(rr_conflict_evict(i))
     io.disable_ld_fast_wakeup(i) := wr_bank_conflict(i) || rrl_bank_conflict_intend(i) ||
       (if (i == 0) 0.B else (0 until i).map(rr_bank_conflict(_)(i)).reduce(_ || _))
   })

--- a/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
@@ -80,22 +80,8 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     way_en_htag(rport_index) := io.read(rport_index).bits.way_en
   })
 
-//   // read conflict
-//   val rr_bank_conflict = Seq.tabulate(LoadPipelineWidth)(x => Seq.tabulate(LoadPipelineWidth)(y => {
-//     if (x == y) {
-//       false.B
-//     } else {
-//       io.read(x).valid && io.read(y).valid &&
-//         div_addrs(x) === div_addrs(y) &&
-//         (io.read(x).bits.bankMask & io.read(y).bits.bankMask) =/= 0.U &&
-//         io.read(x).bits.way_en === io.read(y).bits.way_en &&
-//         set_addrs(x) =/= set_addrs(y)
-//     }
-//   }))
-//   val load_req_with_bank_conflict = rr_bank_conflict.map(_.reduce(_ || _))
   val load_req_valid = io.read.map(_.valid)
   val load_req_lqIdx = io.read.map(_.bits.lqIdx)
-//   val load_req_index = (0 until LoadPipelineWidth).map(_.asUInt)
 
   
   // Age matrix of lqIdx: if i < j and matrix(i, j) == true, then i is older than j
@@ -103,18 +89,9 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     if (i >= j) false.B else (io.read(i).bits.lqIdx < io.read(j).bits.lqIdx)
   }))
 
-//   val load_req_bank_conflict_selcet = selcetOldestPort(load_req_with_bank_conflict, load_req_lqIdx, load_req_index)
-//   val load_req_bank_select_port  = UIntToOH(load_req_bank_conflict_selcet._2).asBools
-
-//   val rr_bank_conflict_oldest = (0 until LoadPipelineWidth).map(i =>
-//     !load_req_bank_select_port(i) && load_req_with_bank_conflict(i)
-//   )
-
   val rrl_bank_conflict = Wire(Vec(LoadPipelineWidth, Bool()))
   val rrl_bank_conflict_intend = Wire(Vec(LoadPipelineWidth, Bool()))
   (0 until LoadPipelineWidth).foreach { i =>
-    // val judge = if (ReduceReadlineConflict) io.read(i).valid && (io.readline.bits.rmask & io.read(i).bits.bankMask) =/= 0.U && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i)
-    //             else io.read(i).valid && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i)
     val judge = io.read(i).valid && line_div_addr === div_addrs(i) && line_set_addr =/= set_addrs(i) &&
                 (line_way_en_htag & way_en_htag(i)) =/= 0.U
     rrl_bank_conflict(i) := judge && io.readline.valid
@@ -123,7 +100,6 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   val wr_bank_conflict = Seq.tabulate(LoadPipelineWidth)(i =>
     io.read(i).valid && write_valid_reg &&
     div_addrs(i) === write_div_addr_dup_reg.head &&
-    // way_en(x) === write_wayen_dup_reg.head &&
     (write_bank_mask_reg(bank_addrs(i)(0)) || write_bank_mask_reg(bank_addrs(i)(1)) && io.is128Req(i)) &&
     (way_en_htag(i) & write_wayen_dup_reg.head) =/= 0.U
   )
@@ -146,13 +122,6 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   val rr_way_overlap = Seq.tabulate(LoadPipelineWidth)(i => Seq.tabulate(LoadPipelineWidth)(j => {
     if (i == j) false.B else (way_en_htag(i) & way_en_htag(j)) =/= 0.U
   }))
-//   val rr_conflict_evict = (0 until LoadPipelineWidth).map(i => {
-//     if (i == 0) {
-//       false.B
-//     } else {
-//       (0 until i).map(j => rr_bank_overlap(j)(i) && rr_way_overlap(j)(i)).reduce(_ || _)
-//     }
-//   })
   val rr_conflict_evict = (0 until LoadPipelineWidth).map(i => {
     (0 until LoadPipelineWidth).map(j => {
       if (i > j) {
@@ -169,11 +138,7 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
   val rr_bank_conflict = rr_bank_overlap
 
   val perf_multi_read = PopCount(io.read.map(_.valid)) >= 2.U
-//   val bank_conflict_fast = Wire(Vec(LoadPipelineWidth, Bool()))
   (0 until LoadPipelineWidth).foreach(i => {
-    // bank_conflict_fast(i) := wr_bank_conflict(i) || rrl_bank_conflict(i) ||
-    // rr_bank_conflict_oldest(i)
-    // io.bank_conflict_slow(i) := RegNext(bank_conflict_fast(i))
     io.bank_conflict_slow(i) := RegNext(wr_bank_conflict(i)) || RegNext(rrl_bank_conflict(i)) ||
                                 RegNext(rr_conflict_evict(i))
     io.disable_ld_fast_wakeup(i) := wr_bank_conflict(i) || rrl_bank_conflict_intend(i) ||
@@ -236,11 +201,6 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
           way_en_htag(i)(way_index)
         }))
         val readline_en = io.readline.valid && div_index.U === line_div_addr && line_way_en_htag(way_index)
-        // if (ReduceReadlineConflict) {
-        //   readline_en := io.readline.valid && io.readline.bits.rmask(bank_index) && line_way_en(way_index) && div_index.U === line_div_addr
-        // } else {
-        //   readline_en := io.readline.valid && line_way_en(way_index) && div_index.U === line_div_addr
-        // }
         val sram_set_addr = Mux(readline_en,
           addr_to_dcache_div_set(io.readline.bits.addr),
           PriorityMux(Seq.tabulate(LoadPipelineWidth)(i => loadpipe_en(i) -> set_addrs(i)))

--- a/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/data/HTADataArray.scala
@@ -79,10 +79,6 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
     // assert(!(RegNext(io.read(rport_index).fire && PopCount(io.read(rport_index).bits.way_en) > 1.U)))
     way_en_htag(rport_index) := io.read(rport_index).bits.way_en
   })
-
-  val load_req_valid = io.read.map(_.valid)
-  val load_req_lqIdx = io.read.map(_.bits.lqIdx)
-
   
   // Age matrix of lqIdx: if i < j and matrix(i, j) == true, then i is older than j
   val lqIdx_age_matrix = Seq.tabulate(LoadPipelineWidth)(i => Seq.tabulate(LoadPipelineWidth)(j => {
@@ -193,19 +189,24 @@ class HTADataArray(implicit p: Parameters) extends AbstractBankedDataArray {
         //     +--------+--------+
         //     |    Data Bank    |
         //     +-----------------+
-        val loadpipe_en = VecInit(Seq.tabulate(LoadPipelineWidth)(i => {
-          io.read(i).valid && div_addrs(i) === div_index.U && (bank_addrs(i)(0) === bank_index.U || bank_addrs(i)(1) === bank_index.U && io.is128Req(i)) &&
-        //   way_en(i)(way_index) &&
-        //   !rr_bank_conflict_oldest(i)
-          !rr_conflict_evict(i) &&
-          way_en_htag(i)(way_index)
+        val loadpipe_en_fast = VecInit(Seq.tabulate(LoadPipelineWidth)(i => {
+          io.read(i).valid && div_addrs(i) === div_index.U && (bank_addrs(i)(0) === bank_index.U || bank_addrs(i)(1) === bank_index.U && io.is128Req(i))
         }))
+        val loadpipe_en_origin = Seq.tabulate(LoadPipelineWidth)(i => loadpipe_en_fast(i) && way_en_htag(i)(way_index))
+        // Use age check to evict way-conflict younger one
+        val loadpipe_en = (0 until LoadPipelineWidth).map(i => {
+          val evicted_by_older = (0 until LoadPipelineWidth).filter(_ != i).map(j => {
+            val j_older_than_i = if (j < i) lqIdx_age_matrix(j)(i) else !lqIdx_age_matrix(i)(j)
+            loadpipe_en_origin(j) && j_older_than_i
+          }).reduce(_ || _)
+          loadpipe_en_origin(i) && !evicted_by_older
+        })
         val readline_en = io.readline.valid && div_index.U === line_div_addr && line_way_en_htag(way_index)
         val sram_set_addr = Mux(readline_en,
           addr_to_dcache_div_set(io.readline.bits.addr),
           PriorityMux(Seq.tabulate(LoadPipelineWidth)(i => loadpipe_en(i) -> set_addrs(i)))
         )
-        val read_en = loadpipe_en.asUInt.orR || readline_en
+        val read_en = loadpipe_en.reduce(_ || _) || readline_en
         // read raw data
         val data_bank = data_banks(div_index)(bank_index)(way_index)
         data_bank.io.r.en := read_en

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -129,10 +129,9 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s0_vaddr = s0_req.vaddr
   val s0_replayCarry = s0_req.replayCarry
   val s0_load128Req = io.load128Req
-  val s0_base_bank = addr_to_dcache_bank(s0_vaddr)
-  val s0_bank_mask_128b = bankMaskFromBase(s0_base_bank, DCacheVWordBankCount)
-  val s0_bank_mask_normal = byteMaskToBankMask(s0_vaddr, s0_req.mask)
-  val s0_bank_oh = Mux(s0_load128Req, s0_bank_mask_128b, s0_bank_mask_normal)
+  val s0_bank_oh_64 = UIntToOH(addr_to_dcache_bank(s0_vaddr))
+  val s0_bank_oh_128 = (s0_bank_oh_64 << 1.U).asUInt | s0_bank_oh_64.asUInt
+  val s0_bank_oh = Mux(s0_load128Req, s0_bank_oh_128, s0_bank_oh_64)
   assert(RegNext(!(s0_valid && (s0_req.cmd =/= MemoryOpConstants.M_XRD && s0_req.cmd =/= MemoryOpConstants.M_PFR && s0_req.cmd =/= MemoryOpConstants.M_PFW))), "LoadPipe only accepts load req / softprefetch read or write!")
   dump_pipeline_reqs("LoadPipe s0", s0_valid, s0_req)
 
@@ -413,7 +412,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
   val s2_hit = s2_tag_match && s2_has_permission && s2_hit_coh === s2_new_hit_coh && !s2_wpu_pred_fail
 
-  val s2_data128bit = Cat((0 until DCacheVWordBankCount).reverse.map(i => io.banked_data_resp(i).raw_data))
+  val s2_data128bit = Cat(io.banked_data_resp(1).raw_data, io.banked_data_resp(0).raw_data)
   val s2_resp_data  = s2_data128bit
 
   val s2_is_prefetch = s2_req.instrtype === DCACHE_PREFETCH_SOURCE.U
@@ -535,7 +534,6 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
   val s3_valid = RegNext(s2_valid)
   val s3_load128Req = RegEnable(s2_load128Req, s2_fire)
-  val s3_read_error_lane_mask = RegEnable(bankMaskToReadErrorLaneMask(s2_bank_oh, addrToVWordBankBase(s2_vaddr)), s2_fire)
   val s3_vaddr = RegEnable(s2_vaddr, s2_fire)
   val s3_paddr = RegEnable(s2_paddr, s2_fire)
   val s3_hit = RegEnable(s2_hit, s2_fire)
@@ -544,11 +542,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s3_is_prefetch = s3_req_instrtype === DCACHE_PREFETCH_SOURCE.U
 
   val s3_banked_data_resp_word = RegEnable(s2_resp_data, s2_fire)
-  val s3_data_error = Mux(
-    s3_load128Req,
-    io.read_error_delayed.asUInt.orR,
-    (io.read_error_delayed.asUInt & s3_read_error_lane_mask).orR
-  ) && s3_hit
+  val s3_data_error = Mux(s3_load128Req, io.read_error_delayed.asUInt.orR, io.read_error_delayed(0)) && s3_hit
   val s3_tag_error = RegEnable(s2_tag_error, s2_fire)
   val s3_tl_error = RegEnable(s2_tl_error, s2_fire)
   val s3_flag_error = s3_tl_error.asUInt.orR

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -51,6 +51,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
     val banked_data_read = DecoupledIO(new L1BankedDataReadReqWithMask)
     val is128Req = Output(Bool())
+    val s2_tag_match_way = Output(UInt(nWays.W))
     val banked_data_resp = Input(Vec(VLEN/DCacheSRAMRowBits, new L1BankedDataReadResult()))
     val read_error_delayed = Input(Vec(VLEN/DCacheSRAMRowBits, Bool()))
 
@@ -214,8 +215,8 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s1_tag_match_way_dup_dc = wayMap((w: Int) => s1_tag_resp(w) === get_tag(s1_paddr_dup_dcache) && meta_resp(w).coh.isValid()).asUInt
   val s1_tag_match_way_dup_lsu = wayMap((w: Int) => s1_tag_resp(w) === get_tag(s1_paddr_dup_lsu) && meta_resp(w).coh.isValid()).asUInt
   val s1_hash_tag = XORFoldTA(get_tag(s1_paddr_dup_dcache), HashTagBits)
-  val s1_hash_match_way = wayMap((w: Int) => io.htag_resp(w) === s1_hash_tag && meta_resp(w).coh.isValid()).asUInt
-  val s1_htag_miss = if (EnableDCacheHashTagArray) !s1_hash_match_way.orR else false.B
+  val s1_htag_match_way = wayMap((w: Int) => io.htag_resp(w) === s1_hash_tag && meta_resp(w).coh.isValid()).asUInt
+  val s1_htag_miss = if (EnableDCacheHashTagArray) !s1_htag_match_way.orR else false.B
   val s1_wpu_pred_valid = RegEnable(io.dwpu.resp(0).valid, s0_fire)
   val s1_wpu_pred_way_en = RegEnable(io.dwpu.resp(0).bits.s0_pred_way_en, s0_fire)
 
@@ -306,7 +307,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.banked_data_read.valid := s1_fire && !s1_nack && !s1_is_prefetch
   io.banked_data_read.bits.addr := s1_vaddr
   io.banked_data_read.bits.addr_dup := s1_vaddr_dup
-  io.banked_data_read.bits.way_en := s1_pred_tag_match_way_dup_dc
+  io.banked_data_read.bits.way_en := { if (EnableDCacheHashTagArray) s1_htag_match_way else s1_pred_tag_match_way_dup_dc }
   io.banked_data_read.bits.htag_miss := s1_htag_miss
   io.banked_data_read.bits.bankMask := s1_bank_oh
   io.banked_data_read.bits.lqIdx := s1_req.lqIdx
@@ -360,6 +361,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s2_tag_errors = RegEnable(s1_tag_errors, s1_fire)
   val s2_tag_match_way = RegEnable(s1_tag_match_way_dup_dc, s1_fire)
   val s2_tag_match = RegEnable(s1_tag_match_dup_dc, s1_fire)
+  io.s2_tag_match_way := s2_tag_match_way
 
   // lsu side tag match
   val s2_hit_dup_lsu = RegNext(s1_tag_match_dup_lsu)

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -216,7 +216,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s1_tag_match_way_dup_lsu = wayMap((w: Int) => s1_tag_resp(w) === get_tag(s1_paddr_dup_lsu) && meta_resp(w).coh.isValid()).asUInt
   val s1_hash_tag = XORFoldTA(get_tag(s1_paddr_dup_dcache), HashTagBits)
   val s1_htag_match_way = wayMap((w: Int) => io.htag_resp(w) === s1_hash_tag && meta_resp(w).coh.isValid()).asUInt
-  val s1_htag_miss = if (EnableDCacheHashTagArray) !s1_htag_match_way.orR else false.B
+  val s1_htag_miss = if (UseHTADataArray) !s1_htag_match_way.orR else false.B
   val s1_wpu_pred_valid = RegEnable(io.dwpu.resp(0).valid, s0_fire)
   val s1_wpu_pred_way_en = RegEnable(io.dwpu.resp(0).bits.s0_pred_way_en, s0_fire)
 
@@ -267,7 +267,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
   val s1_tag_match_dup_dc = ParallelORR(s1_tag_match_way_dup_dc)
   val s1_tag_match_dup_lsu = ParallelORR(s1_tag_match_way_dup_lsu)
-  if (EnableDCacheHashTagArray) {
+  if (UseHTADataArray) {
     XSError(s1_valid && !io.pseudo_error.valid && s1_tag_match_way_dup_dc.orR && s1_htag_miss, "hash-tag-array indicates miss but there is tag match")
   }
   assert(RegNext(!s1_valid || PopCount(s1_tag_match_way_dup_dc) <= 1.U), "tag should not match with more than 1 way")
@@ -307,8 +307,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.banked_data_read.valid := s1_fire && !s1_nack && !s1_is_prefetch
   io.banked_data_read.bits.addr := s1_vaddr
   io.banked_data_read.bits.addr_dup := s1_vaddr_dup
-  io.banked_data_read.bits.way_en := { if (EnableDCacheHashTagArray) s1_htag_match_way else s1_pred_tag_match_way_dup_dc }
-  io.banked_data_read.bits.htag_miss := s1_htag_miss
+  io.banked_data_read.bits.way_en := { if (UseHTADataArray) s1_htag_match_way else s1_pred_tag_match_way_dup_dc }
   io.banked_data_read.bits.bankMask := s1_bank_oh
   io.banked_data_read.bits.lqIdx := s1_req.lqIdx
   io.is128Req := s1_load128Req

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -46,7 +46,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
     val tag_read = DecoupledIO(new TagReadReq)
     val tag_resp = Input(Vec(nWays, UInt(encTagBits.W)))
-    val hash_tag_resp = Input(Vec(nWays, UInt(HashTagBits.W)))
+    val htag_resp = Input(Vec(nWays, UInt(HashTagBits.W)))
     val vtag_update = Flipped(DecoupledIO(new TagWriteReq))
 
     val banked_data_read = DecoupledIO(new L1BankedDataReadReqWithMask)
@@ -189,12 +189,6 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
   // tag check
   def wayMap[T <: Data](f: Int => T) = VecInit((0 until nWays).map(f))
-  def foldXorHash(tag: UInt): UInt = {
-    val chunks = (tagBits + HashTagBits - 1) / HashTagBits
-    val paddedBits = chunks * HashTagBits
-    val paddedTag = if (paddedBits == tagBits) tag else Cat(0.U((paddedBits - tagBits).W), tag)
-    (0 until chunks).map(i => paddedTag((i + 1) * HashTagBits - 1, i * HashTagBits)).reduce(_ ^ _)
-  }
   val meta_resp = io.meta_resp
   // pseudo enc ecc tag
   val pseudo_tag_toggle_mask = Mux(
@@ -219,9 +213,9 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s1_tag_errors = wayMap((w: Int) => meta_resp(w).coh.isValid() && dcacheParameters.tagCode.decode(s1_enctag_resp(w)).error).asUInt
   val s1_tag_match_way_dup_dc = wayMap((w: Int) => s1_tag_resp(w) === get_tag(s1_paddr_dup_dcache) && meta_resp(w).coh.isValid()).asUInt
   val s1_tag_match_way_dup_lsu = wayMap((w: Int) => s1_tag_resp(w) === get_tag(s1_paddr_dup_lsu) && meta_resp(w).coh.isValid()).asUInt
-  val s1_hash_tag = foldXorHash(get_tag(s1_paddr_dup_dcache))
-  val s1_hash_match_way = wayMap((w: Int) => io.hash_tag_resp(w) === s1_hash_tag && meta_resp(w).coh.isValid()).asUInt
-  val s1_hash_miss = if (EnableHashTagPrefilter) !s1_hash_match_way.orR else false.B
+  val s1_hash_tag = XORFoldTA(get_tag(s1_paddr_dup_dcache), HashTagBits)
+  val s1_hash_match_way = wayMap((w: Int) => io.htag_resp(w) === s1_hash_tag && meta_resp(w).coh.isValid()).asUInt
+  val s1_htag_miss = if (EnableDCacheHashTagArray) !s1_hash_match_way.orR else false.B
   val s1_wpu_pred_valid = RegEnable(io.dwpu.resp(0).valid, s0_fire)
   val s1_wpu_pred_way_en = RegEnable(io.dwpu.resp(0).bits.s0_pred_way_en, s0_fire)
 
@@ -272,9 +266,8 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
   val s1_tag_match_dup_dc = ParallelORR(s1_tag_match_way_dup_dc)
   val s1_tag_match_dup_lsu = ParallelORR(s1_tag_match_way_dup_lsu)
-  if (EnableHashTagPrefilter) {
-    XSError(s1_valid && !io.pseudo_error.valid && s1_tag_match_way_dup_dc.orR && s1_hash_miss,
-      "hash prefilter false negative in LoadPipe\n")
+  if (EnableDCacheHashTagArray) {
+    XSError(s1_valid && !io.pseudo_error.valid && s1_tag_match_way_dup_dc.orR && s1_htag_miss, "hash-tag-array indicates miss but there is tag match")
   }
   assert(RegNext(!s1_valid || PopCount(s1_tag_match_way_dup_dc) <= 1.U), "tag should not match with more than 1 way")
   io.pseudo_tag_error_inj_done := s1_fire && wayMap((w: Int) => meta_resp(w).coh.isValid()).asUInt.orR
@@ -314,7 +307,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.banked_data_read.bits.addr := s1_vaddr
   io.banked_data_read.bits.addr_dup := s1_vaddr_dup
   io.banked_data_read.bits.way_en := s1_pred_tag_match_way_dup_dc
-  io.banked_data_read.bits.htag_miss := s1_hash_miss
+  io.banked_data_read.bits.htag_miss := s1_htag_miss
   io.banked_data_read.bits.bankMask := s1_bank_oh
   io.banked_data_read.bits.lqIdx := s1_req.lqIdx
   io.is128Req := s1_load128Req

--- a/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/loadpipe/LoadPipe.scala
@@ -46,6 +46,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
     val tag_read = DecoupledIO(new TagReadReq)
     val tag_resp = Input(Vec(nWays, UInt(encTagBits.W)))
+    val hash_tag_resp = Input(Vec(nWays, UInt(HashTagBits.W)))
     val vtag_update = Flipped(DecoupledIO(new TagWriteReq))
 
     val banked_data_read = DecoupledIO(new L1BankedDataReadReqWithMask)
@@ -188,6 +189,12 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
   // tag check
   def wayMap[T <: Data](f: Int => T) = VecInit((0 until nWays).map(f))
+  def foldXorHash(tag: UInt): UInt = {
+    val chunks = (tagBits + HashTagBits - 1) / HashTagBits
+    val paddedBits = chunks * HashTagBits
+    val paddedTag = if (paddedBits == tagBits) tag else Cat(0.U((paddedBits - tagBits).W), tag)
+    (0 until chunks).map(i => paddedTag((i + 1) * HashTagBits - 1, i * HashTagBits)).reduce(_ ^ _)
+  }
   val meta_resp = io.meta_resp
   // pseudo enc ecc tag
   val pseudo_tag_toggle_mask = Mux(
@@ -212,6 +219,9 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   val s1_tag_errors = wayMap((w: Int) => meta_resp(w).coh.isValid() && dcacheParameters.tagCode.decode(s1_enctag_resp(w)).error).asUInt
   val s1_tag_match_way_dup_dc = wayMap((w: Int) => s1_tag_resp(w) === get_tag(s1_paddr_dup_dcache) && meta_resp(w).coh.isValid()).asUInt
   val s1_tag_match_way_dup_lsu = wayMap((w: Int) => s1_tag_resp(w) === get_tag(s1_paddr_dup_lsu) && meta_resp(w).coh.isValid()).asUInt
+  val s1_hash_tag = foldXorHash(get_tag(s1_paddr_dup_dcache))
+  val s1_hash_match_way = wayMap((w: Int) => io.hash_tag_resp(w) === s1_hash_tag && meta_resp(w).coh.isValid()).asUInt
+  val s1_hash_miss = if (EnableHashTagPrefilter) !s1_hash_match_way.orR else false.B
   val s1_wpu_pred_valid = RegEnable(io.dwpu.resp(0).valid, s0_fire)
   val s1_wpu_pred_way_en = RegEnable(io.dwpu.resp(0).bits.s0_pred_way_en, s0_fire)
 
@@ -262,6 +272,10 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
 
   val s1_tag_match_dup_dc = ParallelORR(s1_tag_match_way_dup_dc)
   val s1_tag_match_dup_lsu = ParallelORR(s1_tag_match_way_dup_lsu)
+  if (EnableHashTagPrefilter) {
+    XSError(s1_valid && !io.pseudo_error.valid && s1_tag_match_way_dup_dc.orR && s1_hash_miss,
+      "hash prefilter false negative in LoadPipe\n")
+  }
   assert(RegNext(!s1_valid || PopCount(s1_tag_match_way_dup_dc) <= 1.U), "tag should not match with more than 1 way")
   io.pseudo_tag_error_inj_done := s1_fire && wayMap((w: Int) => meta_resp(w).coh.isValid()).asUInt.orR
 
@@ -300,6 +314,7 @@ class LoadPipe(id: Int)(implicit p: Parameters) extends DCacheModule with HasPer
   io.banked_data_read.bits.addr := s1_vaddr
   io.banked_data_read.bits.addr_dup := s1_vaddr_dup
   io.banked_data_read.bits.way_en := s1_pred_tag_match_way_dup_dc
+  io.banked_data_read.bits.htag_miss := s1_hash_miss
   io.banked_data_read.bits.bankMask := s1_bank_oh
   io.banked_data_read.bits.lqIdx := s1_req.lqIdx
   io.is128Req := s1_load128Req

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -363,15 +363,14 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s1_htag_match_way = Wire(UInt(nWays.W))
   val s1_miss_need_data = s1_repl_coh.state === ClientStates.Dirty &&
     (!s1_req.isBtoT || s1_req.miss_fail_cause_evict_btot)
-  // val s1_probe_might_need_data = meta_resp.map(m => (m.asTypeOf(new ClientMetadata) === ClientStates.Dirty)).reduce(_ || _)
   val s1_way_dirty = wayMap(w => Meta(meta_resp(w)).coh.state === ClientStates.Dirty).asUInt
   val s1_probe_might_need_data = (s1_htag_match_way & s1_way_dirty).orR
   val s1_need_data = if (dcacheParameters.alwaysReleaseData) {
     RegEnable(banked_need_data, s0_fire)
   } else {
     Mux(s1_req.miss, s1_miss_need_data,
-    Mux(s1_req.probe, s1_probe_might_need_data,
-        RegEnable(banked_need_data, s0_fire)))
+    // Mux(s1_req.probe, s1_probe_might_need_data,
+        RegEnable(banked_need_data, s0_fire))
   }
 
   val s1_banked_rmask = RegEnable(s0_banked_rmask, s0_fire)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -36,6 +36,7 @@ class MainPipeReq(implicit p: Parameters) extends DCacheBundle {
   val miss_dirty = Bool()
   val occupy_way = UInt(nWays.W)
   val miss_fail_cause_evict_btot = Bool()
+  val isBtoT = Bool()
 
   val probe = Bool()
   val probe_param = UInt(TLPermissions.bdWidth.W)
@@ -99,6 +100,7 @@ class MainPipeReq(implicit p: Parameters) extends DCacheBundle {
     req.error := false.B
     req.id := store.id
     req.miss_fail_cause_evict_btot := false.B
+    req.isBtoT := false.B
     req
   }
 
@@ -358,10 +360,12 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val meta_resp = Wire(Vec(nWays, (new Meta).asUInt))
   val s1_repl_way_en = WireInit(0.U(nWays.W))
   val s1_repl_coh = ParallelMux(s1_repl_way_en.asBools, (0 until nWays).map(w => meta_resp(w))).asTypeOf(new ClientMetadata)
+  val s1_miss_need_data = s1_repl_coh.state === ClientStates.Dirty &&
+    (!s1_req.isBtoT || s1_req.miss_fail_cause_evict_btot)
   val s1_need_data = if (dcacheParameters.alwaysReleaseData) {
     RegEnable(banked_need_data, s0_fire)
   } else {
-    Mux(!s1_req.miss, RegEnable(banked_need_data, s0_fire), s1_repl_coh.state === ClientStates.Dirty)
+    Mux(!s1_req.miss, RegEnable(banked_need_data, s0_fire), s1_miss_need_data)
   }
 
   val s1_banked_rmask = RegEnable(s0_banked_rmask, s0_fire)
@@ -418,7 +422,6 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val htag_resp = Wire(io.htag_resp.cloneType)
   htag_resp := Mux(GatedValidRegNext(s0_fire), io.htag_resp, RegEnable(htag_resp, s1_valid))
   val s1_htag_match_way = wayMap((w: Int) => htag_resp(w) === s1_hash_tag && s1_meta_valids(w)).asUInt
-  // TODO: add BtoT field in miss-req, which indicates no need to readline (improve performance)
   val s1_way_en_htag = Mux(s1_req.miss, s1_repl_way_en, s1_htag_match_way)
 
   val s1_hit_tag = get_tag(s1_req.addr)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -175,6 +175,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     val data_read = Vec(LoadPipelineWidth, Input(Bool()))
     val data_read_intend = Output(Bool())
     val data_readline = DecoupledIO(new L1BankedDataReadLineReq)
+    val readline_way_en_htag = Output(UInt(nWays.W))
     val data_readline_can_go = Output(Bool())
     val data_readline_stall = Output(Bool())
     val data_readline_can_resp = Output(Bool())
@@ -921,7 +922,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.data_read_intend := s1_valid && s1_need_data
   io.data_readline.valid := s1_valid && s1_need_data
   io.data_readline.bits.rmask := s1_banked_rmask
-  io.data_readline.bits.way_en_htag := s1_way_en_htag
+  io.readline_way_en_htag := s1_way_en_htag
   io.data_readline.bits.way_en := s1_way_en
   io.data_readline.bits.way := s1_way
   io.data_readline.bits.addr := s1_req.vaddr

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -176,8 +176,6 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     val data_readline_can_go = Output(Bool())
     val data_readline_stall = Output(Bool())
     val data_readline_can_resp = Output(Bool())
-    val repl_dirty = Output(Bool())
-    val repl_way_en = Output(UInt(DCacheWays.W))
     val data_resp = Input(Vec(DCacheBanks, new L1BankedDataReadResult()))
     val readline_error = Input(Bool())
     val readline_error_delayed = Input(Bool())
@@ -198,6 +196,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     // tag sram
     val tag_read = DecoupledIO(new TagReadReq)
     val tag_resp = Input(Vec(nWays, UInt(encTagBits.W)))
+    val htag_resp = Input(Vec(nWays, UInt(HashTagBits.W)))
     val tag_write = DecoupledIO(new TagWriteReq)
     val tag_write_ready_dup = Vec(nDupTagWriteReady, Input(Bool()))
     val tag_write_intend = Output(new Bool())
@@ -414,6 +413,13 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s1_has_real_tag_eq_way = ParallelORR(s1_real_tag_eq_way)
   val s1_real_tag_match_way_en = PriorityEncoderOH(s1_real_tag_eq_way)
   val s1_real_tag_match_way = PriorityEncoder(s1_real_tag_eq_way)
+
+  val s1_hash_tag = XORFoldTA(get_tag(s1_req.addr), HashTagBits)
+  val htag_resp = Wire(io.htag_resp.cloneType)
+  htag_resp := Mux(GatedValidRegNext(s0_fire), io.htag_resp, RegEnable(htag_resp, s1_valid))
+  val s1_htag_match_way = wayMap((w: Int) => htag_resp(w) === s1_hash_tag && s1_meta_valids(w)).asUInt
+  // TODO: add BtoT field in miss-req, which indicates no need to readline (improve performance)
+  val s1_way_en_htag = Mux(s1_req.miss, s1_repl_way_en, s1_htag_match_way)
 
   val s1_hit_tag = get_tag(s1_req.addr)
   val s1_hit_coh = ClientMetadata(ParallelMux(s1_tag_ecc_match_way.asBools, (0 until nWays).map(w => meta_resp(w))))
@@ -907,11 +913,10 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.data_read_intend := s1_valid && s1_need_data
   io.data_readline.valid := s1_valid && s1_need_data
   io.data_readline.bits.rmask := s1_banked_rmask
+  io.data_readline.bits.way_en_htag := s1_way_en_htag
   io.data_readline.bits.way_en := s1_way_en
   io.data_readline.bits.way := s1_way
   io.data_readline.bits.addr := s1_req.vaddr
-  io.repl_dirty := s1_valid && s1_need_replacement && (s1_repl_coh.state === ClientStates.Dirty)
-  io.repl_way_en := s1_repl_way_en
 
   io.miss_req.valid := s2_valid && s2_can_go_to_mq
   val miss_req = io.miss_req.bits

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -324,30 +324,17 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
 
   val store_need_data = !s0_req.probe && s0_req.isStore && banked_store_rmask.orR
   val probe_need_data = s0_req.probe
-  val amo_need_data = !s0_req.probe && s0_req.isAMO && !s0_req.miss
+  val amo_need_data = !s0_req.probe && s0_req.isAMO
   val miss_need_data = s0_req.miss
   val replace_need_data = s0_req.replace
 
   val banked_need_data = store_need_data || probe_need_data || amo_need_data || miss_need_data || replace_need_data
-  val banked_amo_rmask = Mux(
-    isAMOCASQ(s0_req.cmd),
-    bankMaskFromBase(quadWordBankBase(s0_req.quad_word_idx), DCacheQuadWordBankCount),
-    bankMaskFromBase(wordBankBase(s0_req.word_idx), DCacheWordBankCount)
-  )
 
-  val s0_banked_rmask = Mux(
-    store_need_data,
-    banked_store_rmask,
-    Mux(
-      amo_need_data,
-      banked_amo_rmask,
-      Mux(
-        probe_need_data || miss_need_data || replace_need_data,
-        banked_full_rmask,
-        banked_none_rmask
-      )
-    )
-  )
+  val s0_banked_rmask = Mux(store_need_data, banked_store_rmask,
+    Mux(probe_need_data || amo_need_data || miss_need_data || replace_need_data,
+      banked_full_rmask,
+      banked_none_rmask
+    ))
 
   // generate wmask here and use it in stage 2
   val banked_store_wmask = bank_write
@@ -632,25 +619,11 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     s3_store_data_merged(i) := mergePutData(s3_store_data_merged_without_cache(i), s3_data(i), s3_merge_mask(i))
   }
 
-  val s3_word_bank_base = wordBankBase(s3_req.word_idx)
-  val s3_quad_word_bank_base = quadWordBankBase(s3_req.quad_word_idx)
-  val s3_data_words = VecInit((0 until blockWords).map(i => {
-    assembleBankData(
-      s3_store_data_merged,
-      wordBankBase(i.U(log2Up(blockWords).W)),
-      DCacheWordBankCount
-    )
-  }))
-  val s3_data_word = s3_data_words(s3_req.word_idx)
-  val s3_data_quad_word = VecInit((0 until blockWords).map(i => {
-    if (i == blockWords - 1) {
-      Cat(0.U(DCacheWordBits.W), s3_data_words(i))
-    } else {
-      Cat(s3_data_words(i + 1), s3_data_words(i))
-    }
+  val s3_data_word = s3_store_data_merged(s3_req.word_idx)
+  val s3_data_quad_word = VecInit((0 until DCacheBanks).map(i => {
+    if (i == (DCacheBanks - 1)) s3_store_data_merged(i)
+    else Cat(s3_store_data_merged(i + 1), s3_store_data_merged(i))
   }))(s3_req.word_idx)
-  val s3_amo_resp_data = s3_data_quad_word
-  val s3_data_line = Cat((0 until DCacheBanks).reverse.map(i => s3_data(i)))
 
   val s3_refill_latency = RegEnable(s2_refill_latency, s2_fire_to_s3)
   val s3_sc_fail  = Wire(Bool()) // miss or lr mismatch
@@ -717,7 +690,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val debug_s3_sc_fail_addr_match = s3_sc && lrsc_addr === get_block_addr(s3_req.addr) && !lrsc_valid
 
   s3_sc_fail  := s3_sc && (!s3_lrsc_addr_match || !s3_hit)
-  val s3_cas_fail = s3_cas && (FillInterleaved(8, s3_req.amo_mask) & (s3_req.amo_cmp ^ s3_amo_resp_data)) =/= 0.U
+  val s3_cas_fail = s3_cas && (FillInterleaved(8, s3_req.amo_mask) & (s3_req.amo_cmp ^ s3_data_quad_word)) =/= 0.U
 
   val s3_can_do_amo = (s3_req.miss && !s3_req.probe && s3_req.isAMO) || s3_amo_hit
   val s3_can_do_amo_write = s3_can_do_amo && isWrite(s3_req.cmd) && !s3_sc_fail && !s3_cas_fail
@@ -779,6 +752,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   XSError(debug_sc_addr_match_fail_cnt > 100.U, "L1DCache failed too many SCs in a row, resv set addr always match")
 
 
+  val banked_amo_wmask = UIntToOH(s3_req.word_idx)
   val update_data = s3_req.miss || s3_store_hit || s3_can_do_amo_write
 
   // generate write data
@@ -796,37 +770,28 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s3_cas_data_merged = Wire(Vec(DCacheBanks, UInt(DCacheSRAMRowBits.W)))
   for (i <- 0 until DCacheBanks) {
     val old_data = s3_store_data_merged(i)
-    val wordPieceSel = (0 until DCacheWordBankCount).map { offset =>
-      i.U === s3_word_bank_base + offset.U
-    }
-    val quadPieceSel = (0 until DCacheQuadWordBankCount).map { offset =>
-      i.U === s3_quad_word_bank_base + offset.U
-    }
-    s3_amo_data_merged(i) := mergePutData(
-      old_data,
-      selectDataPiece(amoalu.io.out, wordPieceSel, DCacheWordBankCount),
-      selectFullMask(wordPieceSel)
+    val new_data = amoalu.io.out
+    val wmask = Mux(
+      s3_req.word_idx === i.U,
+      ~0.U(wordBytes.W),
+      0.U(wordBytes.W)
     )
-    s3_sc_data_merged(i) := mergePutData(
-      old_data,
-      selectDataPiece(s3_req.amo_data, wordPieceSel, DCacheWordBankCount),
-      selectMaskPiece(s3_req.amo_mask, wordPieceSel, DCacheWordBankCount)
-    )
+    s3_amo_data_merged(i) := mergePutData(old_data, new_data, wmask)
+    s3_sc_data_merged(i) := mergePutData(old_data, s3_req.amo_data, s3_req.amo_mask)
+    val l_select = !s3_cas_fail && s3_req.word_idx === i.U
+    val h_select = !s3_cas_fail && s3_req.cmd === M_XA_CASQ &&
+      (if (i % 2 == 1) s3_req.word_idx === (i - 1).U else false.B)
     s3_cas_data_merged(i) := mergePutData(
       old_data = old_data,
-      new_data = Mux(
-        isAMOCASQ(s3_req.cmd),
-        selectDataPiece(s3_req.amo_data, quadPieceSel, DCacheQuadWordBankCount),
-        selectDataPiece(s3_req.amo_data, wordPieceSel, DCacheWordBankCount)
-      ),
+      new_data = Mux(h_select, s3_req.amo_data >> DataBits, s3_req.amo_data.take(DataBits)),
       wmask = Mux(
-        !s3_cas_fail,
+        h_select,
+        s3_req.amo_mask >> wordBytes,
         Mux(
-          isAMOCASQ(s3_req.cmd),
-          selectMaskPiece(s3_req.amo_mask, quadPieceSel, DCacheQuadWordBankCount),
-          selectMaskPiece(s3_req.amo_mask, wordPieceSel, DCacheWordBankCount)
-        ),
-        0.U(DCacheSRAMRowBytes.W)
+          l_select,
+          s3_req.amo_mask.take(wordBytes),
+          0.U(wordBytes.W)
+        )
       )
     )
   }
@@ -891,8 +856,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
         s3_can_do_amo_write,
         Mux(
           isAMOCASQ(s3_req.cmd),
-          bankMaskFromBase(quadWordBankBase(s3_req.quad_word_idx), DCacheQuadWordBankCount),
-          bankMaskFromBase(wordBankBase(s3_req.word_idx), DCacheWordBankCount)
+          FillInterleaved(2, UIntToOH(s3_req.quad_word_idx)),
+          UIntToOH(s3_req.word_idx)
         ),
         banked_none_wmask
       )
@@ -978,7 +943,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
 
   val atomic_hit_resp = Wire(new MainPipeResp)
   atomic_hit_resp.source := s3_req.source
-  atomic_hit_resp.data := Mux(s3_sc, s3_sc_fail.asUInt, s3_amo_resp_data)
+  atomic_hit_resp.data := Mux(s3_sc, s3_sc_fail.asUInt, s3_data_quad_word)
   atomic_hit_resp.miss := false.B
   atomic_hit_resp.miss_id := s3_req.miss_id
   atomic_hit_resp.error := s3_error_wb
@@ -1123,7 +1088,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.wb.bits.voluntary := s3_req.miss || s3_req.replace
   io.wb.bits.hasData := writeback_data && !s3_tag_error_wb
   io.wb.bits.dirty := s3_coh === ClientStates.Dirty
-  io.wb.bits.data := s3_data_line
+  io.wb.bits.data := s3_data.asUInt
   io.wb.bits.corrupt := s3_tag_error_wb || s3_data_error_wb
   io.wb.bits.delay_release := s3_req.replace
   io.wb.bits.miss_id := s3_req.miss_id

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -360,12 +360,18 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val meta_resp = Wire(Vec(nWays, (new Meta).asUInt))
   val s1_repl_way_en = WireInit(0.U(nWays.W))
   val s1_repl_coh = ParallelMux(s1_repl_way_en.asBools, (0 until nWays).map(w => meta_resp(w))).asTypeOf(new ClientMetadata)
+  val s1_htag_match_way = Wire(UInt(nWays.W))
   val s1_miss_need_data = s1_repl_coh.state === ClientStates.Dirty &&
     (!s1_req.isBtoT || s1_req.miss_fail_cause_evict_btot)
+  // val s1_probe_might_need_data = meta_resp.map(m => (m.asTypeOf(new ClientMetadata) === ClientStates.Dirty)).reduce(_ || _)
+  val s1_way_dirty = wayMap(w => Meta(meta_resp(w)).coh.state === ClientStates.Dirty).asUInt
+  val s1_probe_might_need_data = (s1_htag_match_way & s1_way_dirty).orR
   val s1_need_data = if (dcacheParameters.alwaysReleaseData) {
     RegEnable(banked_need_data, s0_fire)
   } else {
-    Mux(!s1_req.miss, RegEnable(banked_need_data, s0_fire), s1_miss_need_data)
+    Mux(s1_req.miss, s1_miss_need_data,
+    Mux(s1_req.probe, s1_probe_might_need_data,
+        RegEnable(banked_need_data, s0_fire)))
   }
 
   val s1_banked_rmask = RegEnable(s0_banked_rmask, s0_fire)
@@ -421,7 +427,7 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   val s1_hash_tag = XORFoldTA(get_tag(s1_req.addr), HashTagBits)
   val htag_resp = Wire(io.htag_resp.cloneType)
   htag_resp := Mux(GatedValidRegNext(s0_fire), io.htag_resp, RegEnable(htag_resp, s1_valid))
-  val s1_htag_match_way = wayMap((w: Int) => htag_resp(w) === s1_hash_tag && s1_meta_valids(w)).asUInt
+  s1_htag_match_way := wayMap((w: Int) => htag_resp(w) === s1_hash_tag && s1_meta_valids(w)).asUInt
   val s1_way_en_htag = Mux(s1_req.miss, s1_repl_way_en, s1_htag_match_way)
 
   val s1_hit_tag = get_tag(s1_req.addr)

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -176,6 +176,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
     val data_readline_can_go = Output(Bool())
     val data_readline_stall = Output(Bool())
     val data_readline_can_resp = Output(Bool())
+    val repl_dirty = Output(Bool())
+    val repl_way_en = Output(UInt(DCacheWays.W))
     val data_resp = Input(Vec(DCacheBanks, new L1BankedDataReadResult()))
     val readline_error = Input(Bool())
     val readline_error_delayed = Input(Bool())
@@ -908,6 +910,8 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   io.data_readline.bits.way_en := s1_way_en
   io.data_readline.bits.way := s1_way
   io.data_readline.bits.addr := s1_req.vaddr
+  io.repl_dirty := s1_valid && s1_need_replacement && (s1_repl_coh.state === ClientStates.Dirty)
+  io.repl_way_en := s1_repl_way_en
 
   io.miss_req.valid := s2_valid && s2_can_go_to_mq
   val miss_req = io.miss_req.bits

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MissQueue.scala
@@ -1037,6 +1037,7 @@ for(i <- 0 until reqNum) {
   io.main_pipe_req.bits.pf_source := req.pf_source
   io.main_pipe_req.bits.access := access
   io.main_pipe_req.bits.occupy_way := req.occupy_way
+  io.main_pipe_req.bits.isBtoT := req.isBtoT
   io.main_pipe_req.bits.miss_fail_cause_evict_btot := evict_BtoT_way
 
   io.probe.block := req_valid && w_grantlast &&

--- a/src/main/scala/xiangshan/cache/dcache/meta/HashTagArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/meta/HashTagArray.scala
@@ -4,32 +4,30 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 
-class HashTagArray(readPorts: Int, hashBits: Int = 4)(implicit p: Parameters) extends DCacheModule {
-  val io = IO(new Bundle {
-    val read = Vec(readPorts, Flipped(DecoupledIO(new TagReadReq)))
-    val resp = Output(Vec(readPorts, Vec(nWays, UInt(hashBits.W))))
-    val write = Flipped(DecoupledIO(new TagWriteReq))
-  })
-
-  val table = Reg(Vec(nSets, Vec(nWays, UInt(hashBits.W))))
-
-  private def foldXorHash(tag: UInt): UInt = {
-    val nChunks = (tagBits + hashBits - 1) / hashBits
-    val paddedBits = nChunks * hashBits
-    val paddedTag = if (paddedBits == tagBits) tag else Cat(0.U((paddedBits - tagBits).W), tag)
+object XORFoldTA { // for Hash Tag Array of DCache
+  def apply(input: UInt, resWidth: Int): UInt = {
+    val nChunks = 4
+    require(input.getWidth >= nChunks * resWidth)
     (0 until nChunks).map { i =>
-      paddedTag((i + 1) * hashBits - 1, i * hashBits)
+      input((i + 1) * resWidth - 1, i * resWidth)
     }.reduce(_ ^ _)
   }
+}
+class HashTagArray(readPorts: Int, hashBits: Int = 4)(implicit p: Parameters) extends DCacheModule {
+  val io = IO(new Bundle {
+    val read = Vec(readPorts, Flipped(ValidIO(new TagReadReq)))
+    val resp = Output(Vec(readPorts, Vec(nWays, UInt(hashBits.W))))
+    val write = Flipped(ValidIO(new TagWriteReq))
+  })
+
+  val table = Reg(Vec(nSets, Vec(nWays, UInt(hashBits.W)))) 
 
   for (i <- 0 until readPorts) {
-    io.read(i).ready := true.B
-    io.resp(i) := RegEnable(table(io.read(i).bits.idx), io.read(i).fire)
+    io.resp(i) := RegEnable(table(io.read(i).bits.idx), io.read(i).valid)
   }
 
-  io.write.ready := true.B
-  when (io.write.fire) {
-    val hashedTag = foldXorHash(io.write.bits.tag)
+  when (io.write.valid) {
+    val hashedTag = XORFoldTA(io.write.bits.tag, hashBits)
     for (w <- 0 until nWays) {
       when (io.write.bits.way_en(w)) {
         table(io.write.bits.idx)(w) := hashedTag

--- a/src/main/scala/xiangshan/cache/dcache/meta/HashTagArray.scala
+++ b/src/main/scala/xiangshan/cache/dcache/meta/HashTagArray.scala
@@ -1,0 +1,39 @@
+package xiangshan.cache
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+
+class HashTagArray(readPorts: Int, hashBits: Int = 4)(implicit p: Parameters) extends DCacheModule {
+  val io = IO(new Bundle {
+    val read = Vec(readPorts, Flipped(DecoupledIO(new TagReadReq)))
+    val resp = Output(Vec(readPorts, Vec(nWays, UInt(hashBits.W))))
+    val write = Flipped(DecoupledIO(new TagWriteReq))
+  })
+
+  val table = Reg(Vec(nSets, Vec(nWays, UInt(hashBits.W))))
+
+  private def foldXorHash(tag: UInt): UInt = {
+    val nChunks = (tagBits + hashBits - 1) / hashBits
+    val paddedBits = nChunks * hashBits
+    val paddedTag = if (paddedBits == tagBits) tag else Cat(0.U((paddedBits - tagBits).W), tag)
+    (0 until nChunks).map { i =>
+      paddedTag((i + 1) * hashBits - 1, i * hashBits)
+    }.reduce(_ ^ _)
+  }
+
+  for (i <- 0 until readPorts) {
+    io.read(i).ready := true.B
+    io.resp(i) := RegEnable(table(io.read(i).bits.idx), io.read(i).fire)
+  }
+
+  io.write.ready := true.B
+  when (io.write.fire) {
+    val hashedTag = foldXorHash(io.write.bits.tag)
+    for (w <- 0 until nWays) {
+      when (io.write.bits.way_en(w)) {
+        table(io.write.bits.idx)(w) := hashedTag
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Problem to Solve
The DCache dataArray is currently accessed by 3 LoadPipes and 1 MainPipe. When a bank conflict occurs, the hash tag array can further check whether a way conflict is possible. If there is no way conflict, accesses to the same bank can proceed in parallel.

# Basic Idea
The hash tag array has the same number of entries as the tag array, but each entry stores a hash of the physical address (e.g., a 4-bit fold-XOR of the paddr).

In DCache stage S1, the hashed values read from the hash tag array are compared with the hash of the true paddr. A match means that way may hit; a mismatch means that way must miss.

For example (assuming a 4-way DCache):

If the comparison against the four hash-tag ways yields [0, 0, 0, 0], the request is definitely a miss.
If it yields [0, 1, 0, 0], way 1 may hit or miss.
If it yields [0, 1, 0, 1], way 1 may hit, or way 3 may hit, or both may miss.
Thus, if two LoadPipes produce [0, 1, 0, 0] and [0, 0, 0, 1], they do not conflict: even on the same bank, they can access different ways.

If two LoadPipes produce [0, 1, 0, 1] and [0, 0, 0, 1] and access the same bank, they are treated as conflicting, because both assert way 3.

# Performance
Comparing to 32 x 2B banks data-array design, hash-tag-array got about 0.9% improvement on SPEC06 1.0c. (This means about 1.5% improvement upon original 8 x 8B banks desgin)
