### PR TITLE
fix(StoreUnit): only send paddr to UnalignQueue when both TLB  hit

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/NewStoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewStoreUnit.scala
@@ -415,16 +415,24 @@ class StoreUnitS1(param: ExeUnitParams)(
   val updateLFSTValid = fire && tlbHit && isScalar && !isUnalignTail && legalIssue
 
   /**
-    * Generate replay feedback for the RS.
-    * A miss here means the request must be replayed after translation ready.
+    * Generate replay feedback for scalar stores.
+    *
+    * A regular store reports its own TLB result. For a split unaligned store, the head does not
+    * report feedback; the tail combines the TLB results of both parts into one feedback.
+    *
+    * For a cross-page unaligned store, successful feedback also requires the UnalignQueue to accept
+    * the second physical address.
+    *
     * A illegalIssue means the request is out of range and must be replayed by RS.
     */
   val canFeedBack = isScalar && !isUnalignHead // unalign head should not feed back.
   val illegalScalarIssue = isScalar && illegalIssue
   val feedBackValid = fire && canFeedBack || illegalScalarIssue // if is illegalIssue, always feedback miss
-  val unalignTailHit = tlbHit && io.unalignHeadTlbHit && (!cross4KPage || io.toUnalignQueue.ready)
+  val unalignBothTlbHit = tlbHit && io.unalignHeadTlbHit
+  val unalignTailHit = unalignBothTlbHit && (!cross4KPage || io.toUnalignQueue.ready)
   val feedBackHit = Mux(isUnalignTail, unalignTailHit, tlbHit) && legalIssue
   val needRSReplay = feedBackValid && !feedBackHit
+  val toUnalignQueueValid = fire && isUnalignTail && cross4KPage && unalignBothTlbHit
 
   /**
     * Information sent to the StoreQueue:
@@ -527,7 +535,7 @@ class StoreUnitS1(param: ExeUnitParams)(
   io.toSqAddr.valid := toSqAddrValid
   io.toSqAddr.bits := toSqAddr
 
-  io.toUnalignQueue.valid := fire && isUnalignTail && cross4KPage
+  io.toUnalignQueue.valid := toUnalignQueueValid
   io.toUnalignQueue.bits.sqIdx := uop.sqIdx
   io.toUnalignQueue.bits.paddr := paddr
   io.toUnalignQueue.bits.robIdx := robIdx


### PR DESCRIPTION
## Background

  A cross-page unaligned store is split into head and tail requests. During the tail request, StoreUnit sends the physical
  address of the second page to the UnalignQueue.

  Previously, when the head TLB lookup hit but the tail TLB lookup missed, `io.toUnalignQueue.valid` could still be
  asserted. Because the tail address had not been translated yet, the UnalignQueue could capture an invalid physical
  The store could then commit with the incorrect tail address and cause a store difftest mismatch:

  - REF tail address: `0x0000000080064000`
  - DUT tail address: `0x0000000000000000`
  - Store mask: `0x007f`

  ## Root Cause

  The original `toUnalignQueue.valid` condition only checked that:

  - StoreUnit S1 fired;
  - the request was the tail of an unaligned store;
  - the store crossed a 4 KiB page boundary.

  It did not require both the head and tail TLB lookups to hit. As a result, an untranslated tail `paddr` could be written
  into the UnalignQueue.

  ## Changes

  - Add `unalignBothTlbHit` to indicate that both head and tail TLB lookups have completed successfully.
  - Only enqueue the tail physical address when `unalignBothTlbHit` is true.
  - Reuse the same condition when generating replay feedback for unaligned stores.
  - Extend the comments to clarify the feedback behavior for regular, unaligned, and cross-page stores.

  ## Behavior After This Change

  When either part of a cross-page unaligned store encounters a TLB miss:

  1. No physical address is written into the UnalignQueue.
  2. A miss feedback is returned to the reservation station.
  3. The store is replayed after address translation completes.
  4. The tail physical address is saved only after both TLB lookups hit.
  ## Verification

  This change passes the reproducer provided in Issue #6318.

  Before the fix, the reproducer triggered a store commit mismatch because the DUT committed the untranslated tail of a
  cross-page store with physical address `0x0`.

  After the fix:

  - The reproducer passes.
  - No store commit mismatch is reported.
  - The DUT no longer writes an untranslated tail physical address into the UnalignQueue.