### PR TITLE
build(elaboration): add a parameter cache to speed up the elaboration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,9 @@ ifeq ($(DISABLE_XMR),1)
 COMMON_EXTRA_ARGS += --disable-xmr
 endif
 
-ifeq ($(CACHED_PARAM),1)
-COMMON_EXTRA_ARGS += --cached-parameters
-endif 
+ifeq ($(CACHED_PARAM_DISABLE),1)
+COMMON_EXTRA_ARGS += --disable-cached-parameters
+endif
 
 # configuration from yaml file
 ifneq ($(YAML_CONFIG),)

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,10 @@ ifeq ($(DISABLE_XMR),1)
 COMMON_EXTRA_ARGS += --disable-xmr
 endif
 
+ifeq ($(CACHED_PARAM),1)
+COMMON_EXTRA_ARGS += --cached-parameters
+endif 
+
 # configuration from yaml file
 ifneq ($(YAML_CONFIG),)
 COMMON_EXTRA_ARGS += --yaml-config $(YAML_CONFIG)

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -232,6 +232,11 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(DumpCSR = true)
           }), tail)
+        case "--cached-parameters"::tail => {
+          nextOption(config.alter((site, here, up) => {
+            case CachedParameterKey => true
+          }), tail)
+        }
         case option :: tail =>
           // unknown option, maybe a firrtl option, skip
           firrtlOpts :+= option

--- a/src/main/scala/top/ArgParser.scala
+++ b/src/main/scala/top/ArgParser.scala
@@ -232,9 +232,9 @@ object ArgParser {
           nextOption(config.alter((site, here, up) => {
             case DebugOptionsKey => up(DebugOptionsKey).copy(DumpCSR = true)
           }), tail)
-        case "--cached-parameters"::tail => {
+        case "--disable-cached-parameters"::tail => {
           nextOption(config.alter((site, here, up) => {
-            case CachedParameterKey => true
+            case CachedParameterKey => false
           }), tail)
         }
         case option :: tail =>

--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -96,10 +96,10 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
   println(s"FPGASoC cores: $NumCores banks: $L3NBanks block size: $L3BlockSize bus size: $L3OuterBusWidth")
 
   val core_with_l2 = tiles.map(coreParams =>
-    LazyModule(new XSTile()(p.alter((site, here, up) => {
+    LazyModule(new XSTile()(XSCachedParametersOptional(p(CachedParameterKey), p.alter((site, here, up) => {
       case XSCoreParamsKey => coreParams
       case PerfCounterOptionsKey => up(PerfCounterOptionsKey).copy(perfDBHartID = coreParams.HartId)
-    })))
+    }))))
   )
   val chi_llcBridge_opt = Option.when(enableCHI)(
     LazyModule(new OpenNCB()(p.alter((site, here, up) => {

--- a/src/main/scala/top/XSCachedParameters.scala
+++ b/src/main/scala/top/XSCachedParameters.scala
@@ -55,4 +55,4 @@ private[top] object XSCachedParametersOptional {
   } 
 }
 
-private[top] case object CachedParameterKey extends Field[Boolean](false)
+private[top] case object CachedParameterKey extends Field[Boolean](true)

--- a/src/main/scala/top/XSCachedParameters.scala
+++ b/src/main/scala/top/XSCachedParameters.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Beijing Institute of Open Source Chip (BOSC)
+//
+// XiangShan is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//          https://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+
+package top
+
+import org.chipsalliance.cde.config.{View, Field, Parameters}
+
+import scala.collection.mutable
+
+
+private[top] object XSCachedParameters {
+  def cached(underlying: Parameters): Parameters = new CachedParameters(underlying)
+  def apply(underlying: Parameters): Parameters = cached(underlying)
+
+  private class CachedParameters(underlying: Parameters) extends Parameters {
+    private val cache = mutable.HashMap.empty[Field[_], Option[Any]]
+
+    override def find[T](key: Field[T]): Option[T] =
+      cache.get(key) match {
+        case Some(value) =>
+          value.asInstanceOf[Option[T]]
+
+        case None =>
+          val value = underlying.lift(key)
+          cache(key) = value
+          value
+      }
+
+    override def chain[T](
+      site:  View,
+      here:  View,
+      up:    View,
+      pname: Field[T]
+    ): Option[T] = { 
+      throw new Exception("The XSCachedParameters is frozen thus cannot participate in alter/orElse")
+    }
+  }
+}
+
+private[top] object XSCachedParametersOptional {
+  def apply(enable:Boolean, p: Parameters) : Parameters = if (enable) XSCachedParameters(p) else p
+  def apply(enable: Option[Boolean], p: Parameters) : Parameters  = enable match {
+    case Some(b) => apply(b,p)
+    case None => p
+  } 
+}
+
+private[top] case object CachedParameterKey extends Field[Boolean](false)

--- a/src/main/scala/top/XSNoCTop.scala
+++ b/src/main/scala/top/XSNoCTop.scala
@@ -193,10 +193,10 @@ trait HasCoreLowPowerImp[+L <: HasXSTile] { this: BaseXSSocImp with HasXSTileCHI
 trait HasXSTile { this: BaseXSSoc =>
 
   // xstile
-  val core_with_l2 = LazyModule(new XSTileWrap()(p.alter((site, here, up) => {
+  val core_with_l2 = LazyModule(new XSTileWrap()(XSCachedParametersOptional(p(CachedParameterKey), p.alter((site, here, up) => {
     case XSCoreParamsKey => tiles.head
     case PerfCounterOptionsKey => up(PerfCounterOptionsKey).copy(perfDBHartID = tiles.head.HartId)
-  })))
+  }))))
   // interrupts
   val clintIntNode = Option.when(!UsePrivateClint)(IntSourceNode(IntSourcePortSimple(1, 1, 2)))
   val debugIntNode = IntSourceNode(IntSourcePortSimple(1, 1, 1))


### PR DESCRIPTION
Parameter querying currently accounts for a significant portion of XiangShan elaboration time.

Using 1 ms profiler samples and de-duplicating nested `org.chipsalliance.cde.config.View.apply` calls, I observed the following:

| Scope                      | CPU time  | Wall time |
| -------------------------- | --------- | --------- |
| XiangShan elaboration main | 469.294 s | 862.908 s |
| CDE parameter queries      | 346.884 s | 303.392 s |
| Query share of elaboration | 73.92%    | 35.16%    |
| DCache elaboration         | 171.336 s | 175.174 s |
| Queries inside DCache      | 164.333 s | 168.036 s |
| Query share of DCache      | 95.91%    | 95.92%    |

CDE parameter queries account for about **73.92% of the CPU time** during XiangShan elaboration.

The problem is particularly visible in DCache elaboration, where parameter queries account for about **96% of both CPU and wall time**. Profiling shows a large number of repeated queries for parameters such as `PAddrBits`, making parameter lookup a major source of elaboration overhead.

--- 

This PR introduces an optional parameter cache, `XSCachedParameters`, at the `XSTile` level.

Caching parameters is generally at odds with the context-dependent design of CDE, where a parameter may resolve to different values depending on the context. In this design, **we cache a parameter view, rather than assuming that CDE parameters are globally cacheable.**

Before constructing an `XSTile`, XiangShan first applies its tile-specific parameter overrides and then wraps the resulting parameter view with `XSCachedParameters`. The cache therefore operates on an already composed, tile-specific parameter view.

On a cache miss, `XSCachedParameters` delegates the query to the underlying CDE parameter view and caches the resolved result. Repeated queries to the same parameter can then avoid traversing the CDE parameter lookup chain again.

`XSCachedParameters` is not intended to be further composed with other CDE parameter views. Its `chain` implementation reports an error if a query through such a composition reaches the cached view, avoiding reuse of cached results under a different parameter environment.

---

In a preliminary experiment, enabling the parameter cache reduced elaboration time from **766 s** to **511 s**, a reduction of about **33%**. A significant portion of the remaining time is spent in the firtool transformation.

For now, this optimization is disabled by default. It can be enabled explicitly through either the Makefile option or the corresponding command-line flag.