### PR TITLE
feat(CDP): add CDP prefetcher in L2

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -302,6 +302,7 @@ case class L2CacheConfig
   banks: Int = 1,
   tp: Boolean = true,
   nl: Boolean = false,
+  cdp: Boolean = true,
   enablePC: Boolean = false, // Enable PC field for L1Param
   enableFlush: Boolean = false
 ) extends Config((site, here, up) => {
@@ -338,6 +339,7 @@ case class L2CacheConfig
         prefetch = Seq(BOPParameters()) ++
           (if (tp) Seq(TPParameters()) else Nil) ++
           (if (nl) Seq(NLParameters()) else Nil) ++
+          (if (cdp) Seq(CDPParameters()) else Nil) ++
           (if (p.prefetcher.nonEmpty) Seq(PrefetchReceiverParams()) else Nil),
         enableL2Flush = enableFlush,
         enablePerf = !site(DebugOptionsKey).FPGAPlatform && site(DebugOptionsKey).EnablePerfDebug,

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/CSRCustom.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/CSRCustom.scala
@@ -78,6 +78,7 @@ class SbpctlBundle extends CSRBundle {
 }
 
 class SpfctlBundle extends CSRBundle {
+  val L2_PF_CDP_ENABLE        = RW(    33).withReset(true.B).withDescription("Enable CDP-based L2 training and L2 prefetching.")
   val BERTI_ENABLE            = RW(    32).withReset(true.B).withDescription("Enable the Berti prefetcher.")
   val L2_PF_DELAY_LATENCY     = SpfctlL2PfDelayLatency(31, 22).withReset(SpfctlL2PfDelayLatency.initValue).withDescription("Delay latency used when training the L2 prefetcher.")
   val L2_PF_TP_ENABLE         = RW(    21).withReset(true.B).withDescription("Enable TP-based L2 training and L2 prefetching.")

--- a/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/NewCSR/NewCSR.scala
@@ -1428,6 +1428,7 @@ class NewCSR(implicit val p: Parameters) extends Module
   io.status.custom.pf_ctrl.l2_pf_tp_enable         := spfctl.regOut.L2_PF_TP_ENABLE.asBool
   io.status.custom.pf_ctrl.l2_pf_delay_latency     := spfctl.regOut.L2_PF_DELAY_LATENCY.asUInt
   io.status.custom.pf_ctrl.berti_enable            := spfctl.regOut.BERTI_ENABLE.asBool
+  io.status.custom.pf_ctrl.l2_pf_cdp_enable        := spfctl.regOut.L2_PF_CDP_ENABLE.asBool
 
   io.status.custom.lvpred_disable          := slvpredctl.regOut.LVPRED_DISABLE.asBool
   io.status.custom.no_spec_load            := slvpredctl.regOut.NO_SPEC_LOAD.asBool

--- a/src/main/scala/xiangshan/mem/prefetch/BasePrefecher.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/BasePrefecher.scala
@@ -52,6 +52,7 @@ class PrefetchCtrl(implicit p: Parameters) extends XSBundle {
   val l2_pf_pbop_enable = Bool()
   val l2_pf_vbop_enable = Bool()
   val l2_pf_tp_enable = Bool()
+  val l2_pf_cdp_enable = Bool()
   val l2_pf_delay_latency = UInt(10.W)
   val berti_enable = Bool()
 
@@ -62,6 +63,7 @@ class PrefetchCtrl(implicit p: Parameters) extends XSBundle {
     res.l2_pbop_en := l2_pf_pbop_enable
     res.l2_vbop_en := l2_pf_vbop_enable
     res.l2_tp_en := l2_pf_tp_enable
+    res.l2_cdp_en := l2_pf_cdp_enable
     res.l2_pf_delay_latency := l2_pf_delay_latency
     res
   }


### PR DESCRIPTION
## Bump XSCache with CDP Prefetcher Support

Update the XSCache submodule to the version integrated with the CDP prefetcher.

CDP PR: https://github.com/OpenXiangShan/XSCache/pull/15

### Main Changes

* Add CSR control logic for the CDP prefetcher in the core.
* Add a compile-time configuration option for CDP in `Config.scala`.
* Bump the XSCache submodule to the CDP-integrated version.
