### PR TITLE
fix(prefetchbuffer): update may_be_replace logic to ensure valid state check

### DIFF
--- a/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/L1PrefetchComponent.scala
@@ -300,7 +300,7 @@ class MLPReqFilterBundle(implicit p: Parameters) extends XSBundle with HasL1Pref
 
   def may_be_replace(valid: Bool): Bool = {
     // either invalid or has sent out all reqs out
-    !valid || RegNext(PopCount(sent_vec) === BIT_VEC_WITDH.U)
+    !valid || RegNext(valid) && RegNext(PopCount(sent_vec) === BIT_VEC_WITDH.U)
   }
 
   def get_pf_addr(): UInt = {


### PR DESCRIPTION
## Description

  This PR fixes an X-propagation issue in the replacement selection logic of `MutiLevelPrefetchFilter`.

  `l1_array` and `l2_array` are implemented using uninitialized `Reg(Vec(...))`, while `l1_valids` and `l2_valids` are reset to all false. Each entry is fully written on its first allocation, so uninitialized entry data should remain masked while the entry is invalid.

  However, `may_be_replace` used the current-cycle `valid` together with a previous-cycle `sent_vec` result:

  ```scala
  !valid || RegNext(PopCount(sent_vec) === BIT_VEC_WITDH.U)
  ```
  When an entry transitions from invalid to valid, valid is already asserted, while the delayed sent_vec result still comes from the previously uninitialized entry. This can make the replacement vector X and propagate X through the L1 prefetch request path.

  ## Changes

  Gate the delayed sent_vec result with the correspondingly delayed entry validity:

  ```scala
  !valid || (RegNext(valid) && RegNext(PopCount(sent_vec) === BIT_VEC_WITDH.U))
  ```
  During an invalid-to-valid transition, RegNext(valid) is false and masks the uninitialized previous-cycle sent_vec result.