### PR TITLE
fix(mmu): clamp PTWFilter inflight_counter to avoid underflow

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/Repeater.scala
+++ b/src/main/scala/xiangshan/cache/mmu/Repeater.scala
@@ -465,7 +465,9 @@ class PTWFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameters) 
   }
 
   when (io.ptw.req(0).fire =/= io.ptw.resp.fire) {
-    inflight_counter := Mux(io.ptw.req(0).fire, inflight_counter + 1.U, inflight_counter - 1.U)
+    // a response of a request flushed away still fires, so the decrement needs a floor
+    inflight_counter := Mux(io.ptw.req(0).fire, inflight_counter + 1.U,
+                            Mux(inflight_counter === 0.U, 0.U, inflight_counter - 1.U))
   }
 
   val canEnqueue = Wire(Bool()) // NOTE: actually enqueue


### PR DESCRIPTION
### Bug Description

The page table walk filter keeps a count of the requests that it has sent to the second-level TLB and that have not been answered yet. Any flush clears the count to zero. Requests that were already sent are not cancelled by a flush, and the responses to some of them still arrive afterwards. The filter accepts a response whenever one arrives, so a late response decrements a count that already reads zero. With a filter of size 8 the counter holds four bits, and the subtraction wraps it to 15, which trips the assertion that the number of outstanding requests never exceeds the filter size. 

### Environment
```
XiangShan     00eb9ee7c544caddef192eef81f9490533ffbad3
              "fix(Rename): fix vl free-list leak that permanently stalls rename (#6246)"
              Wed Aug 5 11:03:38 2026 +0200
              Clean tree, no local modifications.

Config        CONFIG=MinimalConfig
Build         make emu CONFIG=MinimalConfig EMU_THREADS=4 -j32
Verilator     5.024 2024-04-05 rev v5.024
Toolchain     riscv64-unknown-elf-gcc 16.1.0
```
### Reproduce

The attached image [poc.elf.zip](https://github.com/user-attachments/files/31037258/poc.elf.zip) is a program that trips the assertion:

```
    li    t4, 0xe03000        # offset of the leaf table
    add   t4, t4, x31         # x31 holds the window base
    sd    ...                 # 12 leaf entries of the region being walked
    csrw  hstatus, ...        # 12 environment CSRs, vsatp and hgatp last
    csrw  scause, 13          # the landing block checks the previous cause
    fence
    ld    x1 .. x30, table    # values recorded at that boundary
    li    t0, 0x2788
    add   t0, t0, x31
    jr    t0### Bug
```
Error log:
```
$ ./build/emu -i poc.elf --ram-size=4GB -I 100000000 --no-diff
Assertion failed at /home/xxxx/XiangShan/build/rtl/PTWFilter.sv:1105.
Core 0: ABORT at pc = 0x80002ea0
Core-0 instrCnt = 30,737, cycleCnt = 35,329, IPC = 0.870022
Assertion failed: inflight should be no more than Size
