### PR TITLE
refactor(regfile): banked regfile use index's lower bit at bankIndex

### DIFF
--- a/src/main/scala/xiangshan/backend/datapath/RFReadArbiter.scala
+++ b/src/main/scala/xiangshan/backend/datapath/RFReadArbiter.scala
@@ -206,7 +206,9 @@ abstract class RFBankReadArbiterBase(val params: RFRdArbParams)(implicit p: Para
       arbiters.get.zipWithIndex.map{ case (arbiter, i) => {
           arbiter.io.in.zip(inGroup(portIdx)).zipWithIndex.foreach { case ((arbiterIn, ioIn), idx) =>
             arbiterIn.valid := (if(params.pregParams.numBank == 1) ioIn.valid else ioIn.bits.bankValidVec.get(i))
-            arbiterIn.bits := ioIn.bits
+            arbiterIn.bits.addr := pregParams.bankAddr(ioIn.bits.addr)
+            arbiterIn.bits.robIdx := ioIn.bits.robIdx
+            arbiterIn.bits.issueValid := ioIn.bits.issueValid
             ioIn.ready := arbiters.get.map(x => x.io.in(idx).ready).reduce(_ && _)
           }
         }

--- a/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
+++ b/src/main/scala/xiangshan/backend/issue/EntryBundles.scala
@@ -116,7 +116,7 @@ object EntryBundles extends HasCircularQueuePtrHelper {
       this.rfBankRen.foreach{x => x.zipWithIndex.map{case(xx, idx) => xx.zipWithIndex.map{case(xxx, bank) => xxx :=
         SrcType.isXp(entry.payload.srcType(idx)) &&
         entry.status.srcStatus(idx).dataSources.readReg &&
-        entry.status.srcStatus(idx).psrc.head(log2Ceil(coreParams.intPreg.numBank)) === bank.U
+        coreParams.intPreg.bankIndex(entry.status.srcStatus(idx).psrc) === bank.U
       }}}
       this.fpRen.foreach(x => x.zipWithIndex.foreach{case (xx, idx) => xx := SrcType.isFp(entry.payload.srcType(idx)) && entry.status.srcStatus(idx).dataSources.readReg})
       this.vecRen.foreach(x => x.zipWithIndex.foreach{case (xx, idx) => xx := SrcType.isVp(entry.payload.srcType(idx)) && entry.status.srcStatus(idx).dataSources.readReg})

--- a/src/main/scala/xiangshan/backend/regfile/PregParams.scala
+++ b/src/main/scala/xiangshan/backend/regfile/PregParams.scala
@@ -1,5 +1,6 @@
 package xiangshan.backend.regfile
 
+import chisel3._
 import chisel3.util._
 import xiangshan.backend.datapath.DataConfig._
 
@@ -16,6 +17,16 @@ abstract class PregParams {
   def bankRaddrWidth = log2Ceil(numBank)
   // addr for read each bank
   def arbiterAddrWidth = addrWidth - bankRaddrWidth
+
+  def bankIndex(addr: UInt): UInt = {
+    require(numBank > 0 && isPow2(numBank), s"numBank must be a positive power of two, but got $numBank")
+    if (numBank == 1) 0.U else addr(bankRaddrWidth - 1, 0)
+  }
+
+  def bankAddr(addr: UInt): UInt = {
+    require(numBank > 0 && isPow2(numBank), s"numBank must be a positive power of two, but got $numBank")
+    addr(addrWidth - 1, bankRaddrWidth)
+  }
 }
 
 case class IntPregParams(

--- a/src/main/scala/xiangshan/backend/regfile/Regfile.scala
+++ b/src/main/scala/xiangshan/backend/regfile/Regfile.scala
@@ -162,8 +162,9 @@ class RegfileBank
   })
   override def desiredName = name
   println(name + ": size: " + numPregs + " read: " + numReadPorts + " write: " + numWritePorts + " numBank: " + numBank)
-  val bankRaddrWidth = log2Ceil(numBank)
-  val bankEntryNum = 1 << (width - bankRaddrWidth)
+  require(isPow2(numBank), s"numBank must be a power of two, but got $numBank")
+  require(numPregs >= numBank, s"numPregs ($numPregs) must be no less than numBank ($numBank)")
+  require(width == log2Up(numPregs), s"address width ($width) does not match numPregs ($numPregs)")
 
   val mem_0 = if (isVlRegfile) RegInit(0.U(len.W)) else Reg(UInt(len.W))
   val mem = Reg(Vec(numPregs, UInt(len.W)))
@@ -172,11 +173,12 @@ class RegfileBank
     if (i == 0) m := mem_0
     else m := mem(i)
   }
+  val banks = (0 until numBank).map { bank =>
+    memForRead.zipWithIndex.filter { case (_, index) => index % numBank == bank }.map(_._1)
+  }
   for (r <- io.readPorts) {
-    for (i <- 0 until numBank){
-      val startIdx = bankEntryNum * i
-      val endIdx = math.min(bankEntryNum * (i + 1), numPregs)
-      val thisBank = VecInit(memForRead.slice(startIdx, endIdx))
+    for (i <- 0 until numBank) {
+      val thisBank = VecInit(banks(i))
       r.data(i) := thisBank(RegNext(r.addr(i)))
     }
   }


### PR DESCRIPTION
Old design:
1. use `upper` bits of Index as bank-index
2. each bank is required to has 1 << (ptagWidth - BankIdxWidth) Problem:
1. Unbalanced bank.
2. When last bank has zero entry, compile error.

Current design: use `lower` bits of Index ad bank-index Resolve the problem of unbalanced and compile error.

Next: explicitly divide BankIndex and Index inside bank:  PTAG = IndexInBank ## BankIndex