### PR TITLE
fix(transforms): resolve module names before CHIRRTL serialization

### DIFF
--- a/src/main/scala/xiangshan/transforms/PrintModuleName.scala
+++ b/src/main/scala/xiangshan/transforms/PrintModuleName.scala
@@ -19,7 +19,7 @@ package chisel3.stage.phases.xiangshan
 
 import chisel3._
 import chisel3.stage.ChiselCircuitAnnotation
-import chisel3.stage.phases.Elaborate
+import chisel3.stage.phases.{AddSerializationAnnotations, Elaborate}
 import firrtl.AnnotationSeq
 import firrtl.options.{Dependency, Phase}
 
@@ -30,6 +30,10 @@ class PrintModuleName extends Phase {
   import chisel3.internal.firrtl.ir._
 
   override def prerequisites = Seq(Dependency[Elaborate])
+  // The circuit serialized as CHIRRTL is captured by AddSerializationAnnotations, so module
+  // names must be resolved before that phase takes its snapshot. Without this ordering, the
+  // emitted FIRRTL keeps the raw module object names in log and assertion messages.
+  override def optionalPrerequisiteOf = Seq(Dependency[AddSerializationAnnotations])
   override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {


### PR DESCRIPTION
## Problem

  `XSLog` embeds `module.toString` into log and assertion messages during
  elaboration, and the `PrintModuleName` phase later rewrites those into instance
  paths. It does this by *replacing* the `ChiselCircuitAnnotation` with a new one.

  `AddSerializationAnnotations` captures the circuit for file emission, and there
  is no ordering constraint between the two phases — so whichever the
  `PhaseManager` happens to schedule first decides what the emitted CHIRRTL
  contains. With the snapshot taken first, the `.fir` keeps raw object names:
```
  [ERROR][time=%d] xiangshan.frontend.bpu.WriteBuffer@1c5c6fee: WriteBuffer_abtbBank3 port0_hitMask should be no more than 1
```
  instead of the instance that reported it:
```
  [ERROR][time=%d] SimTop.cpu.l_soc.core_with_l2.core.frontend.inner.bpu.abtb.banks_3.writeBuffer: WriteBuffer_abtbBank3 port0_hitMask should be no more than 1
```
  The Verilog flow serializes the rewritten circuit directly, so it was never
  affected. Every consumer of the CHIRRTL output was:

  - `make sim-verilog CHISEL_TARGET=chirrtl` — the "Generate chirrtl only" job in
    `emu.yml`
  - DiffTest's nightly `libdifftest.so` build, which elaborates the same way
  - any GSIM emulator built from the `.fir`

  ## Fix

  Declare the ordering explicitly with `optionalPrerequisiteOf`, which is the
  mechanism `PhaseManager` provides for this. `PrintModuleName` now always runs
  before the circuit is captured for serialization.

  `AddSerializationAnnotations` is the only phase in `XiangShanStage` that
  snapshots the circuit for emission — the others read the circuit name or produce
  annotations — so no other phase needs the same constraint.
