### PR TITLE
build: generate CHIRRTL only for gsim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ TEST_FILE = $(shell find ./src/test/scala -name '*.scala')
 CONFIG ?= DefaultConfig
 NUM_CORES ?= 1
 ISSUE ?= E.b
-CHISEL_TARGET ?= systemverilog
 
 SUPPORT_CHI_ISSUE = B C E.b
 ifeq ($(findstring $(ISSUE), $(SUPPORT_CHI_ISSUE)),)
@@ -65,6 +64,21 @@ ifeq ($(MAKECMDGOALS),)
 GOALS = verilog
 else
 GOALS = $(MAKECMDGOALS)
+endif
+
+# GSIM reads CHIRRTL directly, so Verilog is not needed for these goals.
+# An explicit CHISEL_TARGET on the command line still takes precedence.
+ifneq ($(filter sim-chirrtl gsim,$(GOALS)),)
+CHISEL_TARGET ?= chirrtl
+endif
+CHISEL_TARGET ?= systemverilog
+
+# The RTL emitted by the simulation top depends on the chisel target:
+# CHIRRTL stops right after elaboration, the other targets run firtool and convert to SV
+ifeq ($(CHISEL_TARGET),chirrtl)
+SIM_TOP_OUT = $(RTL_DIR)/$(SIM_TOP).fir
+else
+SIM_TOP_OUT = $(SIM_TOP_V)
 endif
 
 # JVM memory configurations
@@ -286,9 +300,9 @@ endif
 
 verilog: $(call docker-deps,$(TOP_V))
 
-$(SIM_TOP_V): $(SCALA_FILE) $(TEST_FILE)
+$(SIM_TOP_OUT): $(SCALA_FILE) $(TEST_FILE)
 	mkdir -p $(@D)
-	@echo -e "\n[mill] Generating Verilog files..." > $(TIMELOG)
+	@echo -e "\n[mill] Generating $(CHISEL_TARGET) files..." > $(TIMELOG)
 	@date -R | tee -a $(TIMELOG)
 	$(TIME_CMD) mill -i $(MILL_BUILD_ARGS) xiangshan.test.runMain $(SIMTOP) \
 		--target-dir $(@D) --config $(CONFIG) --issue $(ISSUE) \
@@ -309,7 +323,10 @@ endif
 	sed -i -e "s/\$$error(/\$$fwrite(32\'h80000002, /g" $(RTL_DIR)/*.$(RTL_SUFFIX)
 endif
 
-sim-verilog: $(call docker-deps,$(SIM_TOP_V))
+sim-verilog: $(call docker-deps,$(SIM_TOP_OUT))
+
+# elaboration only, stopping at CHIRRTL without generating Verilog
+sim-chirrtl: $(call docker-deps,$(SIM_TOP_OUT))
 
 clean:
 	$(MAKE) -C ./difftest clean
@@ -354,7 +371,7 @@ emu-mk: sim-verilog
 emu: $(call docker-deps,emu-mk)
 	$(MAKE) -C ./difftest emu NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX) OBJCACHE=$(OBJCACHE)
 
-gsim: sim-verilog
+gsim: sim-chirrtl
 	$(MAKE) -C ./difftest emu GSIM=1 SIM_TOP=SimTop DESIGN_DIR=$(NOOP_HOME) NUM_CORES=$(NUM_CORES) RTL_SUFFIX=$(RTL_SUFFIX)
 
 # vcs simulation
@@ -385,4 +402,4 @@ include Makefile.test
 
 include src/main/scala/device/standalone/standalone_device.mk
 
-.PHONY: FORCE verilog sim-verilog gsim emu clean help init init-force bump bsp $(REF_SO)
+.PHONY: FORCE verilog sim-verilog sim-chirrtl gsim emu clean help init init-force bump bsp $(REF_SO)


### PR DESCRIPTION
  ## Problem

  `make gsim` runs the full `sim-verilog` flow, but GSIM consumes exactly one
  artifact: `build/rtl/SimTop.fir`. That file is written by chisel's `--dump-fir`
  *before* firtool is invoked, so every one of the 2053 `.sv`/`.v` files firtool
  produces for this flow is discarded.

  Measured on MinimalConfig:

  | phase | wall |
  |---|---|
  | elaboration + `.fir` write | ~1m20 |
  | firtool + split-verilog | ~3m00 |
  | total `sim-verilog` | 4m23 |

  So roughly 70% of the generation step, plus ~400MB of SystemVerilog, is thrown
  away on every GSIM build.

  ## Change

  Chisel's CIRCT phase returns before invoking firtool when the target is
  `chirrtl`, and the `.fir` is still written to the target dir under the same
  name. So the flow only needs to select a different chisel target.

  - The chisel target now selects the artifact the simulation top produces
    (`.fir` for `chirrtl`, `.sv`/`.v` otherwise), so one rule covers both. The
    `.sv` post-processing and the firtool-only arguments were already fenced
    behind the systemverilog condition.
  - New `sim-chirrtl` goal exposes the elaboration-only flow.
  - `gsim` defaults to it. An explicit `CHISEL_TARGET=` on the command line still
    wins, for anyone who wants the Verilog alongside.
  - As a side effect, `make sim-verilog CHISEL_TARGET=chirrtl` — already used by
    `emu.yml` and DiffTest's nightly build — now has a target file that actually
    exists, so it stops re-elaborating on every invocation.

  Nothing changes for `verilog`, `emu`, `simv`, `xsim` or `pldm-build`; they all
  still resolve to `systemverilog`.