### PR TITLE
timing(Bpu): Pre-compute t0_firstMispredictMask  before trainCache

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -168,20 +168,8 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   stageCtrl.s3_fire := s3_fire
   stageCtrl.t0_fire := io.fromFtq.train.fire
 
-  private val t0_compareMatrix = CompareMatrix(VecInit(io.fromFtq.train.bits.branches.map(_.bits.cfiPosition)))
-  // mark all branches after the first mispredict as invalid
-  // i.e. we have (valid, position, mispredict) for each branch:
-  // (1, 2, 0), (1, 5, 1), (1, 8, 0)
-  // then the first mispredict branch is @5, so mask should be (1, 1, 0)
-  private val t0_firstMispredictMask = t0_compareMatrix.getLowerElementMask(
-    VecInit(io.fromFtq.train.bits.branches.map(b => b.valid && b.bits.mispredict))
-  )
-
   private val train = Wire(new BpuTrain)
   train := io.fromFtq.train.bits
-  train.branches.zipWithIndex.foreach { case (b, i) =>
-    b.valid := io.fromFtq.train.bits.branches(i).valid && t0_firstMispredictMask(i)
-  }
 
   private val fastTrain = Wire(Valid(new FastTrain))
   fastTrain.valid                := s3_valid

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -259,9 +259,8 @@ class BpuTrain(implicit p: Parameters) extends BpuBundle with HalfAlignHelper {
 
   def startPc: PrunedAddr = startPcVec.get.head // get one duplicate and use its head (startPc for first alignBank)
 
-  // we masked out all branches after the first mispredict branch in Bpu top (refer to Bpu.scala t0_firstMispredictMask)
-  // so, we can assert that branches.map(b => b.valid && b.bits.mispredict) is at-most-one-hot
-  // NOTE: do not use this on Bpu.io.fromFtq.train, it does not ensure the above assertion
+  // FTQ masks out all branches after the first mispredicted branch before sending training to BPU,
+  // so branches.map(b => b.valid && b.bits.mispredict) is at-most-one-hot.
   def mispredictBranch: Valid[BranchInfo] =
     Mux1H(branches.map(b => (b.valid && b.bits.mispredict, b)))
 }

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -56,6 +56,7 @@ import xiangshan.frontend.bpu.BpuResolveMeta
 import xiangshan.frontend.bpu.BpuTrain
 import xiangshan.frontend.bpu.BranchAttribute
 import xiangshan.frontend.bpu.BranchInfo
+import xiangshan.frontend.bpu.CompareMatrix
 import xiangshan.frontend.bpu.HalfAlignHelper
 import xiangshan.frontend.icache.ICacheDataHelper
 import xiangshan.frontend.icache.ICacheToFtqIO
@@ -379,6 +380,13 @@ class Ftq(implicit p: Parameters) extends FtqModule
   private val flushTrainCache =
     backendRedirect.valid && trainCache.valid && trainIndexCache > backendRedirect.bits.ftqIdx
 
+  private val trainBranches      = resolveQueue.io.bpuTrain.bits.branches
+  private val trainCompareMatrix = CompareMatrix(VecInit(trainBranches.map(_.bits.cfiPosition)))
+  // All branches after the first mispredicted branch must not update the predictors.
+  private val trainFirstMispredictMask = trainCompareMatrix.getLowerElementMask(
+    VecInit(trainBranches.map(b => b.valid && b.bits.mispredict))
+  )
+
   when(flushTrainCache) {
     trainCache.valid := false.B
   }.elsewhen(resolveQueue.io.bpuTrain.fire) {
@@ -399,7 +407,11 @@ class Ftq(implicit p: Parameters) extends FtqModule
           startPc := getAlignedPc(resolveQueue.io.bpuTrain.bits.startPc + (i << FetchBlockAlignWidth).U)
       }
     }
-    trainCache.bits.branches     := resolveQueue.io.bpuTrain.bits.branches
+    trainCache.bits.branches.zip(trainBranches).zip(trainFirstMispredictMask).foreach {
+      case ((cachedBranch, branch), mask) =>
+        cachedBranch.bits  := branch.bits
+        cachedBranch.valid := branch.valid && mask
+    }
     trainCache.bits.perfMeta     := perfQueue(resolveQueue.io.bpuTrain.bits.ftqIdx.value).bpuPerf
     trainCache.bits.debug_source := resolveQueue.io.bpuTrain.bits.debug_source
     trainIndexCache              := resolveQueue.io.bpuTrain.bits.ftqIdx


### PR DESCRIPTION
Pre-compute t0_firstMispredictMask before the trainCache write to optimize the ftq->bpTrain path timing