### PR TITLE
feat(MMU): improve performance counters

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -1020,15 +1020,20 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   for (i <- 0 until PtwWidth) {
     XSPerfAccumulate(s"req_count${i}", io.tlb(i).req(0).fire)
     XSPerfAccumulate(s"req_blocked_count_${i}", io.tlb(i).req(0).valid && !io.tlb(i).req(0).ready)
+    XSPerfAccumulate(s"resp_count${i}", io.tlb(i).resp.fire)
+    XSPerfAccumulate(s"cache_resp_count${i}", mergeArb(i).in(outArbCachePort).fire)
+    XSPerfAccumulate(s"ptw_resp_count${i}", mergeArb(i).in(outArbFsmPort).fire)
+    XSPerfAccumulate(s"llptw_resp_count${i}", mergeArb(i).in(outArbMqPort).fire)
+    XSPerfAccumulate(s"resp_fault_count${i}", io.tlb(i).resp.fire && (io.tlb(i).resp.bits.s1.pf || io.tlb(i).resp.bits.s1.af || io.tlb(i).resp.bits.s2.gpf || io.tlb(i).resp.bits.s2.gaf))
   }
   XSPerfAccumulate(s"req_blocked_by_mq", arb1.io.out.valid && missQueue.io.out.valid)
-  for (i <- 0 until (MemReqWidth + 1)) {
-    XSPerfAccumulate(s"mem_req_util${i}", PopCount(waiting_resp) === i.U)
-  }
+  XSPerfAccumulate("req_outstanding_cycle", tlbCounter)
+  XSPerfAccumulate("req_full_cycle", tlbCounter === MissQueueSize.U)
   XSPerfAccumulate("mem_cycle", PopCount(waiting_resp) =/= 0.U)
+  XSPerfAccumulate("mem_outstanding_cycle", PopCount(waiting_resp))
   XSPerfAccumulate("mem_count", mem.a.fire)
   for (i <- 0 until PtwWidth) {
-    XSPerfAccumulate(s"llptw_ppn_af${i}", mergeArb(i).in(outArbMqPort).valid && mergeArb(i).in(outArbMqPort).bits.s1.entry(OHToUInt(mergeArb(i).in(outArbMqPort).bits.s1.pteidx)).af && !llptw_out.bits.af)
+    XSPerfAccumulate(s"llptw_ppn_af${i}", mergeArb(i).in(outArbMqPort).fire && mergeArb(i).in(outArbMqPort).bits.s1.entry(OHToUInt(mergeArb(i).in(outArbMqPort).bits.s1.pteidx)).af && !llptw_out.bits.af)
     XSPerfAccumulate(s"access_fault${i}", io.tlb(i).resp.fire && io.tlb(i).resp.bits.s1.af)
   }
 

--- a/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableCache.scala
@@ -342,20 +342,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   val spvmids = sp.map(_.vmid)
   val sph = Reg(Vec(l2tlbParams.spSize, UInt(2.W)))
 
-  // Access Perf
-  val l3AccessPerf = if(EnableSv48) Some(Wire(Vec(l2tlbParams.l3Size, Bool()))) else None
-  val l2AccessPerf = Wire(Vec(l2tlbParams.l2Size, Bool()))
-  val l1AccessPerf = Wire(Vec(l2tlbParams.l1nWays, Bool()))
-  val l0AccessPerf = Wire(Vec(l2tlbParams.l0nWays, Bool()))
-  val spAccessPerf = Wire(Vec(l2tlbParams.spSize, Bool()))
-  if (EnableSv48) l3AccessPerf.map(_.map(_ := false.B))
-  l2AccessPerf.map(_ := false.B)
-  l1AccessPerf.map(_ := false.B)
-  l0AccessPerf.map(_ := false.B)
-  spAccessPerf.map(_ := false.B)
-
-
-
   def vpn_match(vpn1: UInt, vpn2: UInt, level: Int) = {
     (vpn1(vpnLen-1, vpnnLen*level+3) === vpn2(vpnLen-1, vpnnLen*level+3))
   }
@@ -403,7 +389,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
 
     when (hit && stageDelay_valid_1cycle) { ptwl3replace.get.access(OHToUInt(hitVec)) }
 
-    l3AccessPerf.get.zip(hitVec).map{ case (l, h) => l := h && stageDelay_valid_1cycle}
     for (i <- 0 until l2tlbParams.l3Size) {
       XSDebug(stageReq.fire, p"[l3] l3(${i.U}) ${l3.get(i)} hit:${l3.get(i).hit(vpn_search, io.csr_dup(2).satp.asid, io.csr_dup(2).vsatp.asid, io.csr_dup(2).hgatp.vmid, ignoreID = l3g.get(i), s2xlate = h_search)}\n")
     }
@@ -437,7 +422,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
 
     when (hit && stageDelay_valid_1cycle) { ptwl2replace.access(OHToUInt(hitVec)) }
 
-    l2AccessPerf.zip(hitVec).map{ case (l, h) => l := h && stageDelay_valid_1cycle}
     for (i <- 0 until l2tlbParams.l2Size) {
       XSDebug(stageReq.fire, p"[l2] l2(${i.U}) ${l2(i)} hit:${l2(i).hit(vpn_search, io.csr_dup(2).satp.asid, io.csr_dup(2).vsatp.asid, io.csr_dup(2).hgatp.vmid, ignoreID = l2g(i), s2xlate = h_search)}\n")
     }
@@ -503,7 +487,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
 
     when (hit && stageCheck_valid_1cycle) { ptwl1replace.access(genPtwL1SetIdx(check_vpn), hitWay) }
 
-    l1AccessPerf.zip(hitVec).map{ case (l, h) => l := h && stageCheck_valid_1cycle }
     XSDebug(stageDelay_valid_1cycle, p"[l1] ridx:0x${Hexadecimal(ridx)}\n")
     for (i <- 0 until l2tlbParams.l1nWays) {
       XSDebug(stageCheck_valid_1cycle, p"[l1] ramDatas(${i.U}) ${ramDatas(i)}  l1v:${vVec(i)}  hit:${hit}\n")
@@ -581,7 +564,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
 
     when (hit && stageCheck_valid_1cycle) { ptwl0replace.access(genPtwL0SetIdx(check_vpn), hitWay) }
 
-    l0AccessPerf.zip(hitVec).map{ case (l, h) => l := h && stageCheck_valid_1cycle }
     XSDebug(stageReq.fire, p"[l0] ridx:0x${Hexadecimal(ridx)}\n")
     for (i <- 0 until l2tlbParams.l0nWays) {
       XSDebug(stageCheck_valid_1cycle, p"[l0] ramDatas(${i.U}) ${ramDatas(i)}  l0v:${vVec(i)}  hit:${hitVec(i)}\n")
@@ -664,7 +646,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
 
     when (hit && stageDelay_valid_1cycle) { spreplace.access(OHToUInt(hitVec)) }
 
-    spAccessPerf.zip(hitVec).map{ case (s, h) => s := h && stageDelay_valid_1cycle }
     for (i <- 0 until l2tlbParams.spSize) {
       XSDebug(stageReq.fire, p"[sp] sp(${i.U}) ${sp(i)} hit:${sp(i).hit(vpn_search, io.csr_dup(0).satp.asid, io.csr_dup(0).vsatp.asid, io.csr_dup(0).hgatp.vmid, allType = true, s2xlate = h_search)} spv:${spv(i)}\n")
     }
@@ -1323,7 +1304,7 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   if (EnableSv48) {
     XSPerfAccumulate("l3_hit_pre", base_valid_access_0 && resp_l3_pre.get && io.resp.bits.toFsm.l3Hit.get && !io.resp.bits.toFsm.l2Hit && !io.resp.bits.toFsm.l1Hit && !io.resp.bits.hit)
   }
-  XSPerfAccumulate("l2_hit_pre", base_valid_access_0 && resp_l2_pre && !io.resp.bits.toFsm.l2Hit && !io.resp.bits.toFsm.l1Hit && !io.resp.bits.hit)
+  XSPerfAccumulate("l2_hit_pre", base_valid_access_0 && resp_l2_pre && io.resp.bits.toFsm.l2Hit && !io.resp.bits.toFsm.l1Hit && !io.resp.bits.hit)
   XSPerfAccumulate("l1_hit_pre", base_valid_access_0 && resp_l1_pre && io.resp.bits.toFsm.l1Hit && !io.resp.bits.hit)
   XSPerfAccumulate("l0_hit_pre", base_valid_access_0 && resp_l0_pre && resp_l0)
   XSPerfAccumulate("sp_hit_pre", base_valid_access_0 && resp_sp_pre && resp_sp)
@@ -1392,21 +1373,6 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   XSPerfAccumulate("rwHarzad", io.req.valid && !io.req.ready)
   XSPerfAccumulate("out_blocked", io.resp.valid && !io.resp.ready)
   if (EnableSv48) {
-    l3AccessPerf.get.zipWithIndex.map{ case (l, i) => XSPerfAccumulate(s"l3AccessIndex${i}", l) }
-  }
-  l2AccessPerf.zipWithIndex.map{ case (l, i) => XSPerfAccumulate(s"l2AccessIndex${i}", l) }
-  l1AccessPerf.zipWithIndex.map{ case (l, i) => XSPerfAccumulate(s"l1AccessIndex${i}", l) }
-  l0AccessPerf.zipWithIndex.map{ case (l, i) => XSPerfAccumulate(s"l0AccessIndex${i}", l) }
-  spAccessPerf.zipWithIndex.map{ case (l, i) => XSPerfAccumulate(s"SPAccessIndex${i}", l) }
-  if (EnableSv48) {
-    l3RefillPerf.get.zipWithIndex.map{ case (l, i) => XSPerfAccumulate(s"l3RefillIndex${i}", l) }
-  }
-  l2RefillPerf.zipWithIndex.map{ case (l, i) => XSPerfAccumulate(s"l2RefillIndex${i}", l) }
-  l1RefillPerf.zipWithIndex.map{ case (l, i) => XSPerfAccumulate(s"l1RefillIndex${i}", l) }
-  l0RefillPerf.zipWithIndex.map{ case (l, i) => XSPerfAccumulate(s"l0RefillIndex${i}", l) }
-  spRefillPerf.zipWithIndex.map{ case (l, i) => XSPerfAccumulate(s"SPRefillIndex${i}", l) }
-
-  if (EnableSv48) {
     XSPerfAccumulate("l3Refill", Cat(l3RefillPerf.get).orR)
   }
   XSPerfAccumulate("l2Refill", Cat(l2RefillPerf).orR)
@@ -1442,14 +1408,14 @@ class PtwCache()(implicit p: Parameters) extends XSModule with HasPtwConst with 
   XSDebug(RegNext(sfence_dup(0).valid), p"[sfence] spv:${Binary(spv)}\n")
 
   val perfEvents = Seq(
-    ("access           ", base_valid_access_0             ),
-    ("l2_hit           ", l2Hit                           ),
-    ("l1_hit           ", l1Hit                           ),
-    ("l0_hit           ", l0Hit                           ),
-    ("sp_hit           ", spHit                           ),
-    ("pte_hit          ", l0Hit || spHit                  ),
-    ("rwHarzad         ", io.req.valid && !io.req.ready   ),
-    ("out_blocked      ", io.resp.valid && !io.resp.ready ),
+    ("access           ", base_valid_access_0),
+    ("l2_hit           ", base_valid_access_0 && io.resp.bits.toFsm.l2Hit && !io.resp.bits.toFsm.l1Hit && !io.resp.bits.hit),
+    ("l1_hit           ", base_valid_access_0 && io.resp.bits.toFsm.l1Hit && !io.resp.bits.hit),
+    ("l0_hit           ", base_valid_access_0 && resp_l0),
+    ("sp_hit           ", base_valid_access_0 && resp_sp),
+    ("pte_hit          ", base_valid_access_0 && io.resp.bits.hit),
+    ("rwHarzad         ", io.req.valid && !io.req.ready),
+    ("out_blocked      ", io.resp.valid && !io.resp.ready),
   )
   generatePerfEvent()
 }

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -679,17 +679,22 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   XSDebug(p"[ptw] level:${level} notFound:${pageFault}\n")
 
   // perf
-  XSPerfAccumulate("fsm_count", io.req.fire)
-  for (i <- 0 until PtwWidth) {
-    XSPerfAccumulate(s"fsm_count_source${i}", io.req.fire && io.req.bits.req_info.source === i.U)
+  XSPerfAccumulate("ptw_fsm_req_count", io.req.fire)
+  for (i <- 0 until sourceWidth) {
+    XSPerfAccumulate(s"ptw_fsm_req_count_source${i}", io.req.fire && io.req.bits.req_info.source === i.U)
   }
-  XSPerfAccumulate("fsm_busy", !idle)
-  XSPerfAccumulate("fsm_idle", idle)
-  XSPerfAccumulate("resp_blocked", io.resp.valid && !io.resp.ready)
-  XSPerfAccumulate("ptw_ppn_af", io.resp.fire && ppn_af)
-  XSPerfAccumulate("mem_count", mem.req.fire)
-  XSPerfAccumulate("mem_cycle", BoolStopWatch(mem.req.fire, mem.resp.fire, true))
-  XSPerfAccumulate("mem_blocked", mem.req.valid && !mem.req.ready)
+  XSPerfAccumulate("ptw_fsm_busy_cycle", !idle)
+  XSPerfAccumulate("ptw_fsm_idle_cycle", idle)
+  XSPerfAccumulate("ptw_fsm_resp_blocked_cycle", io.resp.valid && !io.resp.ready)
+  XSPerfAccumulate("ptw_ppn_af_count", io.resp.fire && ppn_af)
+  XSPerfAccumulate("ptw_resp_count", io.resp.fire)
+  XSPerfAccumulate("ptw_hptw_req_count", io.hptw.req.fire)
+  XSPerfAccumulate("ptw_mem_req_count", mem.req.fire)
+  for (i <- 0 until sourceWidth) {
+    XSPerfAccumulate(s"ptw_mem_req_count_source${i}", mem.req.fire && source === i.U)
+  }
+  XSPerfAccumulate("ptw_mem_wait_cycle", BoolStopWatch(mem.req.fire, mem.resp.fire, true))
+  XSPerfAccumulate("ptw_mem_req_blocked_cycle", mem.req.valid && !mem.req.ready)
 
   val perfEvents = Seq(
     ("fsm_count         ", io.req.fire                                     ),
@@ -1299,18 +1304,18 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   }
 
   XSPerfAccumulate("llptw_in_count", io.in.fire)
-  XSPerfAccumulate("llptw_in_block", io.in.valid && !io.in.ready)
-  for (i <- 0 until 7) {
-    XSPerfAccumulate(s"enq_state${i}", io.in.fire && enq_state === i.U)
+  XSPerfAccumulate("llptw_in_blocked_cycle", io.in.valid && !io.in.ready)
+  XSPerfAccumulate("llptw_mem_req_count", io.mem.req.fire)
+  XSPerfAccumulate("llptw_mem_busy_cycle", PopCount(is_waiting) =/= 0.U)
+  XSPerfAccumulate("llptw_entry_occupancy_cycle", PopCount(is_emptys.map(!_)))
+  XSPerfAccumulate("llptw_mem_wait_entry_cycle", PopCount(is_waiting))
+  for (i <- 0 until sourceWidth) {
+    XSPerfAccumulate(s"llptw_in_count_source${i}", io.in.fire && io.in.bits.req_info.source === i.U)
+    XSPerfAccumulate(s"llptw_mem_req_count_source${i}", io.mem.req.fire && mem_arb.io.out.bits.req_info.source === i.U)
   }
-  for (i <- 0 until (l2tlbParams.llptwsize + 1)) {
-    XSPerfAccumulate(s"util${i}", PopCount(is_emptys.map(!_)) === i.U)
-    XSPerfAccumulate(s"mem_util${i}", PopCount(is_mems) === i.U)
-    XSPerfAccumulate(s"waiting_util${i}", PopCount(is_waiting) === i.U)
-  }
-  XSPerfAccumulate("mem_count", io.mem.req.fire)
-  XSPerfAccumulate("mem_cycle", PopCount(is_waiting) =/= 0.U)
-  XSPerfAccumulate("blocked_in", io.in.valid && !io.in.ready)
+  XSPerfAccumulate("llptw_out_count", io.out.fire)
+  XSPerfAccumulate("llptw_cache_retry_count", io.cache.fire)
+  XSPerfAccumulate("llptw_hptw_req_count", io.hptw.req.fire)
 
   val perfEvents = Seq(
     ("tlbllptw_incount           ", io.in.fire               ),
@@ -1705,4 +1710,12 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
       bitmap_checkfailed := false.B
     }
   }
+
+  XSPerfAccumulate("hptw_req_count", io.req.fire)
+  XSPerfAccumulate("hptw_req_blocked_cycle", io.req.valid && !io.req.ready)
+  XSPerfAccumulate("hptw_busy_cycle", !idle)
+  XSPerfAccumulate("hptw_resp_count", io.resp.fire)
+  XSPerfAccumulate("hptw_mem_req_count", io.mem.req.fire)
+  XSPerfAccumulate("hptw_mem_req_blocked_cycle", io.mem.req.valid && !io.mem.req.ready)
+
 }

--- a/src/main/scala/xiangshan/cache/mmu/Repeater.scala
+++ b/src/main/scala/xiangshan/cache/mmu/Repeater.scala
@@ -294,32 +294,22 @@ class PTWFilterEntry(Width: Int, Size: Int, hasHint: Boolean = false)(implicit p
 
   // Perf Counter
   val counter = PopCount(v)
-  val inflight_counter = RegInit(0.U(log2Up(Size).W))
-  val inflight_full = inflight_counter === Size.U
-  when (io.ptw.req(0).fire =/= io.ptw.resp.fire) {
-    inflight_counter := Mux(io.ptw.req(0).fire, inflight_counter + 1.U, inflight_counter - 1.U)
-  }
-
-  assert(inflight_counter <= Size.U, "inflight should be no more than Size")
+  val fullReqVec = io.tlb.req.indices.map(i =>
+    io.tlb.req(i).valid && !ptwResp_ReqMatchVec(i) && !entryIsMatchVec(i) && !canenq(i)
+  )
+  val sentEntryCount = PopCount(v.zip(sent).map { case (valid, issued) => valid && issued })
   when (counter === 0.U) {
     assert(!io.ptw.req(0).fire, "when counter is 0, should not req")
   }
 
-  when (io.flush) {
-    inflight_counter := 0.U
-  }
-
   XSPerfAccumulate("tlb_req_count", PopCount(Cat(io.tlb.req.map(_.valid))))
   XSPerfAccumulate("tlb_req_count_filtered", PopCount(enqvalid))
+  XSPerfAccumulate("tlb_req_full_count", PopCount(fullReqVec))
+  XSPerfAccumulate("entry_cycle", counter)
+  XSPerfAccumulate("sent_entry_cycle", sentEntryCount)
   XSPerfAccumulate("ptw_req_count", io.ptw.req(0).fire)
-  XSPerfAccumulate("ptw_req_cycle", inflight_counter)
-  XSPerfAccumulate("tlb_resp_count", io.tlb.resp.fire)
-  XSPerfAccumulate("ptw_resp_count", io.ptw.resp.fire)
-  XSPerfAccumulate("inflight_cycle", Cat(sent).orR)
-
-  for (i <- 0 until Size + 1) {
-    XSPerfAccumulate(s"counter${i}", counter === i.U)
-  }
+  XSPerfAccumulate("ptw_req_blocked", io.ptw.req(0).valid && !io.ptw.req(0).ready)
+  XSPerfAccumulate("ptw_resp_match_count", io.refill)
 
 }
 
@@ -637,15 +627,16 @@ class PTWFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameters) 
 
   // perf
   XSPerfAccumulate("tlb_req_count", PopCount(Cat(io.tlb.req.map(_.valid))))
-  XSPerfAccumulate("tlb_req_count_filtered", Mux(do_enq, accumEnqNum(Width - 1), 0.U))
+  XSPerfAccumulate("tlb_req_fire_count", PopCount(io.tlb.req.map(_.fire)))
+  XSPerfAccumulate("tlb_req_blocked_count", PopCount(io.tlb.req.map(req => req.valid && !req.ready)))
+  XSPerfAccumulate("tlb_req_count_filtered", Mux(do_enq, enqNum, 0.U))
+  XSPerfAccumulate("itlb_filter_allocated_cycle", counter)
   XSPerfAccumulate("ptw_req_count", io.ptw.req(0).fire)
+  XSPerfAccumulate("ptw_req_blocked", io.ptw.req(0).valid && !io.ptw.req(0).ready)
   XSPerfAccumulate("ptw_req_cycle", inflight_counter)
   XSPerfAccumulate("tlb_resp_count", io.tlb.resp.fire)
   XSPerfAccumulate("ptw_resp_count", io.ptw.resp.fire)
   XSPerfAccumulate("inflight_cycle", !isEmptyDeq)
-  for (i <- 0 until Size + 1) {
-    XSPerfAccumulate(s"counter${i}", counter === i.U)
-  }
 }
 
 object PTWRepeater {

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -739,9 +739,12 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       XSPerfAccumulate("first_miss" + Integer.toString(i, 10), result_ok(i) && portTranslateEnable(i) && missVec(i) && RegEnable(req(i).bits.debug.isFirstIssue, req(i).valid))
       XSPerfAccumulate("miss" + Integer.toString(i, 10), result_ok(i) && portTranslateEnable(i) && missVec(i))
     }
+    XSPerfAccumulate(s"ptw_req${i}", ptw.req(i).fire)
+    XSPerfAccumulate(s"tlb_replay${i}", io.tlbreplay(i))
   }
   XSPerfAccumulate("ptw_resp_count", ptw.resp.fire)
   XSPerfAccumulate("ptw_resp_pf_count", ptw.resp.fire && ptw.resp.bits.s1.pf)
+  XSPerfAccumulate("refill_count", refill)
 
   // Log
   for(i <- 0 until Width) {


### PR DESCRIPTION
Add focused XSPerf counters for TLBs, request filters, page-table walkers, and L2TLB completion paths.

Remove low-value histograms, give walker counters distinct names, and correct counters whose conditions do not match completed requests.

Keep the existing HPM event names, order, and selector indices unchanged while correcting the PageCache hit conditions.