### PR TITLE
fix(lsu): nuke Load S1 from cross-16B store head

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -957,6 +957,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     newLoadUnits(i).io.pmp <> pmp_check(i).resp
     // st-ld violation query
     newLoadUnits(i).io.staNukeQueryReq <> storeUnits.map(_.io.staNukeQueryReq)
+    newLoadUnits(i).io.staS2HeadNukeQueryReq <> storeUnits.map(_.io.staS2HeadNukeQueryReq)
 
     // load replay
     newLoadUnits(i).io.replay <> lsq.io.replay(i)

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -556,6 +556,7 @@ class LoadUnitS1(param: ExeUnitParams)(
 
     // Nuke check with StoreUnit
     val staNukeQueryReq = Flipped(Vec(StorePipelineWidth, ValidIO(new StoreNukeQueryReq)))
+    val staS2HeadNukeQueryReq = Flipped(Vec(StorePipelineWidth, ValidIO(new StoreNukeQueryReq)))
 
     // prefetch train hint
     val prefetchTrainHint = Output(Bool())
@@ -687,8 +688,9 @@ class LoadUnitS1(param: ExeUnitParams)(
   /**
     * Nuke check with StoreUnit
     */
-  val nukeQueryValids = io.staNukeQueryReq.map(_.valid)
-  val nukeQueryReqs = io.staNukeQueryReq.map(_.bits)
+  val allNukeReqs = io.staNukeQueryReq ++ io.staS2HeadNukeQueryReq
+  val nukeQueryValids = allNukeReqs.map(_.valid)
+  val nukeQueryReqs = allNukeReqs.map(_.bits)
   val nukePAddrMatches = nukeQueryReqs.map(req => nukePAddrMatch(req.paddr, req.matchType, paddr))
   val nukeStoreOlders = nukeQueryReqs.map(req => isAfter(robIdx, req.robIdx))
   val nukeMaskMatches = nukeQueryReqs.map(req => (req.mask & in.mask).orR)
@@ -1958,6 +1960,7 @@ class LoadUnitIO(val param: ExeUnitParams)(implicit p: Parameters) extends XSBun
   val uncacheBypass = new UncacheBypass
   // Nuke check with StoreUnit
   val staNukeQueryReq = Flipped(Vec(StorePipelineWidth, ValidIO(new StoreNukeQueryReq)))
+  val staS2HeadNukeQueryReq = Flipped(Vec(StorePipelineWidth, ValidIO(new StoreNukeQueryReq)))
   // Nuke check with RAR / RAW
   val rarNukeQuery = new LoadRARNukeQuery
   val rawNukeQuery = new LoadRAWNukeQuery
@@ -2051,6 +2054,7 @@ class NewLoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSMo
   }
   s1.io.uncacheBypassResp := io.uncacheBypass.s1Resp
   s1.io.staNukeQueryReq := io.staNukeQueryReq
+  s1.io.staS2HeadNukeQueryReq := io.staS2HeadNukeQueryReq
   io.prefetchTrainHintS1 := s1.io.prefetchTrainHint
   io.swInstrPrefetch := s1.io.swInstrPrefetch
   s1.io.csrTrigger := io.csrTrigger

--- a/src/main/scala/xiangshan/mem/pipeline/NewStoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewStoreUnit.scala
@@ -586,6 +586,8 @@ class StoreUnitS2(param: ExeUnitParams)(
     // Exception info and memory type to to Store Queue
     val toSqAddrRe = Output(new StoreAddrIO)
 
+    val staS2HeadNukeQueryReq = ValidIO(new StoreNukeQueryReq)
+
     // unalign head sent tlb info to unalign tail
     val unalignHeadTlbHit = Output(Bool())
 
@@ -688,6 +690,13 @@ class StoreUnitS2(param: ExeUnitParams)(
   io.dcacheKill := killDCache
   io.dcachePC := uop.pc
   io.dcacheResp.ready := true.B
+
+  val s2HeadNukeValid = pipeIn.valid && !kill && tlbHit && isUnalignHead && !isHwPrefetch
+  io.staS2HeadNukeQueryReq.valid := s2HeadNukeValid
+  io.staS2HeadNukeQueryReq.bits.robIdx := robIdx
+  io.staS2HeadNukeQueryReq.bits.paddr := in.paddr.get
+  io.staS2HeadNukeQueryReq.bits.mask := in.mask
+  io.staS2HeadNukeQueryReq.bits.matchType := StLdNukeMatchType.Normal
 
   io.toSqAddrRe.memBackTypeMM := memBackTypeMM
   io.toSqAddrRe.mmio := isMMIO
@@ -920,6 +929,7 @@ class StoreUnitIO(val param: ExeUnitParams)(implicit p: Parameters) extends XSBu
   val toUnalignQueue = DecoupledIO(new UnalignQueueIO)
   // Nuke check req to LoadUnit
   val staNukeQueryReq = ValidIO(new StoreNukeQueryReq)
+  val staS2HeadNukeQueryReq = ValidIO(new StoreNukeQueryReq)
   // Prefetch Train
   val prefetchTrainHintS1 = Output(Bool())
   val prefetchTrainHintS2 = Output(Bool())
@@ -973,6 +983,7 @@ class NewStoreUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSM
   io.dcache.s1_kill := s1.io.dcacheKill
   io.updateLFST := s1.io.updateLFST
   io.staNukeQueryReq := s1.io.staNukeQueryReq
+  io.staS2HeadNukeQueryReq := s2.io.staS2HeadNukeQueryReq
   io.toSqAddr := s1.io.toSqAddr
   io.debugInfo := s1.io.debugInfo
   io.prefetchTrainHintS1 := s1.io.prefetchTrainHint


### PR DESCRIPTION
## Problem

For a cross-16B split store, the tail does not set `addrValid` until it reaches Store S1.

Consider the following situation:

- The store head is in Store S1 while a one-cycle-younger load is in Load S0.
- The load overlaps the head store address, but cannot receive data forwarding from the head, since `addrValid` is not set.
- Store S1 does not nuke Load S0.
- On the following cycle, the head has moved to Store S2 and the tail enters Store S1, while the load reaches Load S1, the load can therefore proceed with stale data.

## Fix

Emit a dedicated nuke request from the cross-16B store head in Store S2 to nuke the affected Load S1.
