### PR TITLE
chore(xiangshan.py): better get_free_cores

### DIFF
--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -29,6 +29,7 @@ import shlex
 import psutil
 import re
 import pathlib
+from typing import List, Tuple, Set
 
 def find_files_with_suffix(root_dir, suffixes):
     matching_files = []
@@ -713,29 +714,29 @@ class XiangShan(object):
                 return ret
         return 0
 
-def get_free_cores(n: int, max_retry: int = 60) -> tuple[int, int, int]:
+def get_free_cores(n: int, max_retry: int = 60) -> Tuple[int, int, int]:
     '''get contiguous free N cores that numactl can bind to, return (numa_node, start_core, end_core)'''
     def get_numa_count() -> int:
         '''get numa node count'''
         node_dir = pathlib.Path("/sys/devices/system/node/")
         return len(list(node_dir.glob("node*")))
 
-    def get_cpu_usage() -> list[float]:
+    def get_cpu_usage() -> List[float]:
         '''get cpu usage of all cores'''
         return psutil.cpu_percent(interval=0.5, percpu=True)
 
-    def get_physical_cores() -> set[int]:
+    def get_physical_cores() -> Set[int]:
         '''get all physical cores'''
         count = psutil.cpu_count(logical=False)
         if count is None:
             raise RuntimeError("Failed to get physical core count")
         return set(range(count))
 
-    def get_usable_cores() -> set[int]:
+    def get_usable_cores() -> Set[int]:
         '''get all cores current process can bind to'''
         return os.sched_getaffinity(0)
 
-    def get_bound_cores() -> set[int]:
+    def get_bound_cores() -> Set[int]:
         '''get all cores that are already bound by other processes'''
         valid_list = ["running", "disk-sleep", "waking", "waiting"]
         cores = set()
@@ -750,7 +751,7 @@ def get_free_cores(n: int, max_retry: int = 60) -> tuple[int, int, int]:
 
         return cores
 
-    def detect(n: int):
+    def detect(n: int) -> Tuple[bool, int, int, int]:
         numa_count = get_numa_count()
         phy_cores = get_physical_cores() # invariant, get once
         num_core = len(phy_cores)

--- a/scripts/xiangshan.py
+++ b/scripts/xiangshan.py
@@ -28,6 +28,7 @@ import time
 import shlex
 import psutil
 import re
+import pathlib
 
 def find_files_with_suffix(root_dir, suffixes):
     matching_files = []
@@ -92,6 +93,7 @@ class XSArgs(object):
         self.ram_size = args.ram_size
         self.seed = args.seed if args.seed is not None else random.randint(0, 9999)
         self.numa = args.numa
+        self.numa_max_retry = args.numa_max_retry
         self.diff = args.diff
         if args.spike and "nemu" in args.diff:
             self.diff = self.diff.replace("nemu-interpreter", "spike")
@@ -289,7 +291,7 @@ class XiangShan(object):
         numa_args = ""
         if self.args.numa:
             if self.numa_info is None:
-                self.numa_info = get_free_cores(self.args.threads)
+                self.numa_info = get_free_cores(self.args.threads, self.args.numa_max_retry)
             numa_args = f"numactl -m {self.numa_info[0]} -C {self.numa_info[1]}-{self.numa_info[2]}"
         fork_args = "--enable-fork" if self.args.fork else ""
         diff_args = "--no-diff" if self.args.disable_diff else ""
@@ -711,88 +713,99 @@ class XiangShan(object):
                 return ret
         return 0
 
-def get_free_cores(n):
-    def numa_count():
-        node_dir = "/sys/devices/system/node/"
-        nodes = [node for node in os.listdir(node_dir) if node.startswith("node")]
-        return len(nodes)
+def get_free_cores(n: int, max_retry: int = 60) -> tuple[int, int, int]:
+    '''get contiguous free N cores that numactl can bind to, return (numa_node, start_core, end_core)'''
+    def get_numa_count() -> int:
+        '''get numa node count'''
+        node_dir = pathlib.Path("/sys/devices/system/node/")
+        return len(list(node_dir.glob("node*")))
 
-    def get_unset_cores(cpu_count=None, core_usage=None) -> list[int]:
-        # FIXME: SMT is not considered temporaryly
-        if cpu_count is None:
-            cpu_count = psutil.cpu_count(logical=False)
-        if core_usage is None:
-            core_usage = psutil.cpu_percent(interval=0.5, percpu=True)
+    def get_cpu_usage() -> list[float]:
+        '''get cpu usage of all cores'''
+        return psutil.cpu_percent(interval=0.5, percpu=True)
 
-        cpu_affinity_count = {i: 0 for i in range(cpu_count)}
+    def get_physical_cores() -> set[int]:
+        '''get all physical cores'''
+        count = psutil.cpu_count(logical=False)
+        if count is None:
+            raise RuntimeError("Failed to get physical core count")
+        return set(range(count))
+
+    def get_usable_cores() -> set[int]:
+        '''get all cores current process can bind to'''
+        return os.sched_getaffinity(0)
+
+    def get_bound_cores() -> set[int]:
+        '''get all cores that are already bound by other processes'''
         valid_list = ["running", "disk-sleep", "waking", "waiting"]
+        cores = set()
         for proc in psutil.process_iter(["pid", "name", "cpu_affinity", "status"]):
             try:
-                affinity = proc.info["cpu_affinity"]
-                valid = proc.info["status"] in valid_list
-                if affinity and max(affinity) < cpu_count and len(affinity) > 1 and valid:
-                    for cpu in affinity:
-                        cpu_affinity_count[cpu] += 1
+                # our script usually bind <= 16 cores for verilator, only consider these processes, so skip if len > 16
+                if not proc.info["status"] in valid_list or len(proc.info["cpu_affinity"]) > 16:
+                    continue
+                cores |= set(proc.info["cpu_affinity"])
             except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
                 pass
 
-        unset_cores = [cpu for cpu, count in cpu_affinity_count.items() if count == 0]
-        return unset_cores
+        return cores
 
-    def detect(n):
-        percpu_use_thres = 30
+    def detect(n: int):
+        numa_count = get_numa_count()
+        phy_cores = get_physical_cores() # invariant, get once
+        num_core = len(phy_cores)
+        num_window = num_core // n
 
-        # SMT is not allowed
-        num_core = psutil.cpu_count(logical=False)
-        num_window = max(num_core // n - 1, 0)
-        numa_node = numa_count()  # default 2
+        def check(i) -> bool:
+            window = range(i * n, i * n + n)
+            # may change during execution (other processes may taskset this process), get in loop
+            candidates = phy_cores & get_usable_cores()
+            if not set(window).issubset(candidates): # fail-fast
+                return False
 
-        def check(i):
-            core_usage = psutil.cpu_percent(interval=0.5, percpu=True)
-            unset_cores = get_unset_cores(num_core, core_usage)
+            # then get unused cores in phy_cores & usable_cores
+            candidates -= get_bound_cores()
+            if not set(window).issubset(candidates): # fail-fast
+                return False
 
-            window_cores = range(i * n, i * n + n)
+            core_usage = get_cpu_usage()
             window_usage = core_usage[i * n : i * n + n]
 
-            # average usage of window_cores less than percpu_use_thres
-            cond1 = sum(window_usage) < percpu_use_thres * n
-            # less than 1 core has high usage in window_cores
-            cond2 = (
+            return (
+                # average usage of window_cores less than percpu_use_thres
+                sum(window_usage) < 30 * n and
+                # less than 1 core has high usage in window_cores
                 sum(map(lambda x: x > 80, window_usage)) < 1
             )
-            # window_cores is unset
-            cond3 = set(window_cores).issubset(unset_cores)
-            return cond1 and cond2 and cond3
 
         for i in random.sample(range(num_window), num_window):
             if not check(i):
                 continue
 
             # sleep random time to avoid contention, then re-check
-            time.sleep(random.uniform(1, 30))
+            time.sleep(random.uniform(0, 10))
             if not check(i):
                 continue
 
             # return (Success?, memory node, start_core, end_core)
             return (
                 True,
-                (int)(((i * n) % num_core) // (num_core // numa_node)),
+                (int)(((i * n) % num_core) // (num_core // numa_count)),
                 (int)(i * n),
                 (int)(i * n + n - 1),
-                num_core,
             )
 
-        return (False, 0, 0, 0, num_core)
-    
-    while True:
-        success, node, start_core, end_core, num_core = detect(n)
+        return (False, 0, 0, 0)
+
+    for _ in range(max_retry):
+        success, node, start_core, end_core = detect(n)
         if success:
             print(f"Found free cores: {start_core}-{end_core} on NUMA node {node}")
             return (node, start_core, end_core)
-        else:
-            print("No free cores found, retrying...")
-            time.sleep(60)
+        print("No free cores found, retry after 60 seconds...")
+        time.sleep(60)
 
+    raise RuntimeError(f"Failed to find {n} free cores after {max_retry} retries")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Python wrapper for XiangShan')
@@ -834,6 +847,7 @@ if __name__ == "__main__":
     parser.add_argument('--simfrontend', action='store_true', help='enable the simfrontend')
     # emu arguments
     parser.add_argument('--numa', action='store_true', help='use numactl')
+    parser.add_argument('--numa-max-retry', type=int, default=60, help='max retry to find free numa cores')
     parser.add_argument('--diff', nargs='?', default="./ready-to-run/riscv64-nemu-interpreter-so", type=str, help='nemu so')
     parser.add_argument('--max-instr', nargs='?', type=int, help='max instr')
     parser.add_argument('--disable-fork', action='store_true', help='disable lightSSS')


### PR DESCRIPTION
1. check os.sched_getaffinity(0) to make sure numactl can bind to it
2. simplify unset core enumeration using set op
3. add max-retry to prevent loop forever, raise Exception instead, to let user/cirunner scheduler to use another machine
4. reduce random backoff time from (1,30) to (0,10) to speedup, should be enough as `get_bound_cores()` scan is strict enough