### PR TITLE
build: add -Wunused to scalaOptions

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -154,7 +154,7 @@ object xiangshan extends ChiselModule {
     mvn"io.circe::circe-generic-extras:0.14.4"
   )
 
-  def scalacOptions: T[Seq[String]] = super.scalacOptions() ++ Agg("-deprecation", "-feature")
+  def scalacOptions: T[Seq[String]] = super.scalacOptions() ++ Agg("-deprecation", "-feature", "-Wunused")
 
   private def publishLocale: Locale = new Locale.Builder().setLanguage("en").build()
   private def publishVersion: T[String] = VcsVersion.vcsState().format(


### PR DESCRIPTION
To allow the Metals plugin to show unused variables or imports.
<img width="1188" height="282" alt="image" src="https://github.com/user-attachments/assets/1a5661d6-62b9-4491-9736-3676bd055db3" />
