### PR TITLE
config(FpgaDiff): disable L2 tp as default

### DIFF
--- a/src/main/scala/top/Configs.scala
+++ b/src/main/scala/top/Configs.scala
@@ -593,7 +593,7 @@ class FpgaDefaultConfig(n: Int = 1) extends Config(
 
 class FpgaDiffDefaultConfig(n: Int = 1) extends Config(
   (OpenLLCConfig("3MB", banks = 1, ways = 6)
-    ++ L2CacheConfig("1MB", inclusive = true, banks = 4)
+    ++ L2CacheConfig("1MB", inclusive = true, banks = 4, tp = false)
     ++ WithNKBL1D(64, ways = 4)
     ++ new BaseConfig(n)).alter((site, here, up) => {
     case DebugOptionsKey => up(DebugOptionsKey).copy(


### PR DESCRIPTION
## Summary

Disable the L2 temporal prefetcher in FpgaDiffDefaultConfig.

FpgaDiffMinimalConfig remains inherited from MinimalConfig, which already configures its L2 with tp=false.

## Why

FpgaDiff uses XSTileDiffTop without an L3 TP metadata sink. Leaving TP enabled creates an unconnected BundleBridge sink during elaboration.

## Verification

- Rebased onto kunminghu-v3.
- mill -i xiangshan.compile