### PR TITLE
fix(MemEncrypt) : mode=0 close request never updates KeyTable (#6369) and add assert single-outstanding AXI id in TweakTable (#6371)

### DIFF
--- a/src/main/scala/device/MemEncrypt.scala
+++ b/src/main/scala/device/MemEncrypt.scala
@@ -941,7 +941,8 @@ class KeyExtender(implicit p: Parameters) extends MemEncryptModule{
     reg_tweak_round_keys(reg_count_round) := data_after_round(31, 0)
     keyTable.io.write_req.keyid_valid := false.B
   }.otherwise {
-    keyTable.io.write_req.keyid_valid := current
+    keyTable.io.write_req.keyid_valid := (current === keyExpansion) ||
+                                         io.keyextend_req.fire && !io.keyextend_req.bits.enc_mode
   }
   io.tweak_round_keys := reg_tweak_round_keys
 }

--- a/src/main/scala/device/MemEncryptUtil.scala
+++ b/src/main/scala/device/MemEncryptUtil.scala
@@ -596,6 +596,7 @@ class TweakTable(implicit p: Parameters) extends MemEncryptModule {
 
   // write tweak table entry logic
   when(io.write.valid) {
+      assert(!tweak_table(io.write.bits.id).v_flag, "[MemEncrypt] TweakTable overwrite detected: duplicate AXI ID")
       val write_entry = tweak_table(io.write.bits.id)
       write_entry.tweak_encrpty    := io.write.bits.tweak_encrpty
       write_entry.keyid            := io.write.bits.addr(PAddrBits-1, PAddrBits-KeyIDBits)


### PR DESCRIPTION
`MemEncryptCSR` receives a `key_init_req` with `mode = 0` and issues it with `enc_mode = false`. However, the `KeyExtender` module only transitions from the `idle` state to the `keyExpansion` state when `enc_mode` is true. In `KeyTable`, the write enable for `encdec_mode` is controlled by `keyTable.io.write_req.keyid_valid`, which is assigned the current state encoding (current). Since the request has `enc_mode = false`, the state machine cannot enter `keyExpansion`, so `keyTable.io.write_req.keyid_valid` is never asserted, consequently preventing any update to `KeyTable` from taking effect.

`TweakTable` holds a single slot per AXI id, so a repeated request with the same id would overwrite a slot that has not been consumed yet. This is not reachable under the current platform configuration, so only an assertion is added to make the assumption explicit.

## Changes
(#6369 )Kept the closing semantics of mode = 0 and added the missing write enable in KeyExtender: keyid_valid now also asserts when keyextend_req.fire && !keyextend_req.bits.enc_mode, updating encdec_mode.
(#6371 )Added an assertion in `TweakTable` rejecting a context write to an id whose entry is still valid