### PR TITLE
fix(Bpu): fix s3_override

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -415,8 +415,8 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   s3_override := {
     val takenDiff       = s3_taken =/= s3_s1Prediction.taken
-    val cfiPositionDiff = Mux1H(s3_firstTakenBranchOH, s3_mbtbCfiPositionDiffVec)
-    val attributeDiff   = Mux1H(s3_firstTakenBranchOH, s3_mbtbAttributeDiffVec)
+    val cfiPositionDiff = s3_taken && Mux1H(s3_firstTakenBranchOH, s3_mbtbCfiPositionDiffVec)
+    val attributeDiff   = s3_taken && Mux1H(s3_firstTakenBranchOH, s3_mbtbAttributeDiffVec)
     val targetDiff =
       MuxCase(
         false.B, // fall-through


### PR DESCRIPTION
When the results of both `s1` and `s3` are `not taken`, `takenDiff` is `false`. In this case, `s3_firstTakenBranchOH` is an all-zero `Vec`. As noted in the comment for `Mux1H`, a non-one-hot input may produce undefined values, so `cfiPositionDiff` or `attributeDiff` could be incorrectly asserted, which could in turn trigger an unnecessary `s3_override`.

Why hasn’t this caused problems so far? Because in the current Chisel implementation, when the input is an all-zero `Vec`, it returns `0`, so it happens not to cause a functional issue. However, to eliminate this potential risk, we fixed the condition for `s3_override`.