### PR TITLE
fix(Top): match ZhuJiang AXI memory outstanding configuration

### DIFF
--- a/src/main/scala/top/Top.scala
+++ b/src/main/scala/top/Top.scala
@@ -183,11 +183,17 @@ class XSTop()(implicit p: Parameters) extends BaseXSSoc()
   private val zhujiangCfgNodes = zhujiangNocConfig
     .map(_.island.filter(_.nodeType == xijiang.NodeType.HI))
     .getOrElse(Seq.empty)
+  private val zhujiangMemNodes = zhujiangNocConfig
+    .map(_.island.filter(_.nodeType == xijiang.NodeType.S))
+    .getOrElse(Seq.empty)
+  private val zhujiangMemOutstanding = zhujiangMemNodes.headOption
+    .map(_.outstanding)
+    .getOrElse(8)
 
   val zhujiangMemMaster = Option.when(isZhuJiang)(AXI4MasterNode(Seq(AXI4MasterPortParameters(
     masters = Seq(AXI4MasterParameters(
       name = "zhujiang-mem",
-      id = IdRange(0, 8),
+      id = IdRange(0, zhujiangMemOutstanding),
       aligned = true,
       maxFlight = Some(1)
     ))

--- a/src/main/scala/top/ZhuJiangNoCTopology.scala
+++ b/src/main/scala/top/ZhuJiangNoCTopology.scala
@@ -5,6 +5,8 @@ import zhujiang.ZJParameters
 import zhujiang.device.AxiDeviceParams
 
 object ZhuJiangNoCTopology {
+  private val MemoryOutstanding = 64
+
   def apply(numCores: Int, base: ZJParameters = ZJParameters()): ZJParameters = {
     apply(numCores, base, base.cfgAxiDataBits)
   }
@@ -27,7 +29,10 @@ object ZhuJiangNoCTopology {
     NodeParam(nodeType = NodeType.RI, axiDevParams = Some(AxiDeviceParams(wrapper = "east", attr = "main"))),
     NodeParam(nodeType = NodeType.HI, axiDevParams = Some(AxiDeviceParams(wrapper = "east", attr = "main")), defaultHni = true),
     NodeParam(nodeType = NodeType.HF, bankId = 1, hfpId = 1),
-    NodeParam(nodeType = NodeType.S, axiDevParams = Some(AxiDeviceParams(wrapper = "south", attr = "mem_0"))),
+    NodeParam(
+      nodeType = NodeType.S,
+      axiDevParams = Some(AxiDeviceParams(outstanding = MemoryOutstanding, wrapper = "south", attr = "mem_0"))
+    ),
     NodeParam(nodeType = NodeType.HF, bankId = 0, hfpId = 1),
     NodeParam(nodeType = NodeType.M, axiDevParams = Some(AxiDeviceParams(wrapper = "misc", attr = "hwa"))),
     NodeParam(nodeType = NodeType.P)
@@ -41,7 +46,10 @@ object ZhuJiangNoCTopology {
     NodeParam(nodeType = NodeType.RI, axiDevParams = Some(AxiDeviceParams(wrapper = "east", attr = "main"))),
     NodeParam(nodeType = NodeType.HI, axiDevParams = Some(AxiDeviceParams(wrapper = "east", attr = "main")), defaultHni = true),
     NodeParam(nodeType = NodeType.HF, bankId = 1, hfpId = 1),
-    NodeParam(nodeType = NodeType.S, axiDevParams = Some(AxiDeviceParams(wrapper = "south", attr = "mem_0"))),
+    NodeParam(
+      nodeType = NodeType.S,
+      axiDevParams = Some(AxiDeviceParams(outstanding = MemoryOutstanding, wrapper = "south", attr = "mem_0"))
+    ),
     NodeParam(nodeType = NodeType.HF, bankId = 0, hfpId = 1),
     NodeParam(nodeType = NodeType.M, axiDevParams = Some(AxiDeviceParams(wrapper = "misc", attr = "hwa"))),
     NodeParam(nodeType = NodeType.P)


### PR DESCRIPTION
Set the ZhuJiang memory endpoint outstanding capacity to 64 and derive
the top-level `zhujiang-mem` AXI ID range from the generated topology.

Keep `maxFlight` at one per ID, so total capacity matches the 64-ID
memory endpoint. Update XSCache with the matching ZhuJiang SF
performance changes.