### PR TITLE
fix(MMU): align CSR-change TLB flush latency

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -568,7 +568,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
 
   // ptw
   val sfence = RegNext(RegNext(io.ooo_to_mem.sfence))
-  val tlbcsr = RegNext(RegNext(io.ooo_to_mem.tlbCsr))
+  val tlbcsr = RegNext(io.ooo_to_mem.tlbCsr)
   private val ptw = outer.ptw.module
   private val ptw_to_l2_buffer = outer.ptw_to_l2_buffer.module
   private val l1d_to_l2_buffer = outer.l1d_to_l2_buffer.map(_.module)


### PR DESCRIPTION
The frontend and MemBlock currently observe CSR changes with different latencies. The frontend flushes its TLB after three cycles, while MemBlock flushes after four cycles because its tlbCsr path contains one extra RegNext.

This one-cycle mismatch allows an old-epoch PTW request to cross the TLB flush boundary. In virtualized checkpoint workloads, the PTW filter can then overflow its in-flight counter and trigger the "inflight should be no more than Size" assertion.

Remove one RegNext from the MemBlock CSR path so both TLB flush paths have the same latency. Keep the sfence path unchanged because its latency is already aligned.