### PR TITLE
perf(LoadQueueReplay): optimized latency of `LoadQueueReplay`

### DIFF
--- a/src/main/scala/xiangshan/backend/Region.scala
+++ b/src/main/scala/xiangshan/backend/Region.scala
@@ -535,8 +535,8 @@ class Region(val params: SchdBlockParams)(implicit p: Parameters) extends XSModu
         toMem(i)(j).valid := RegNext(toMemValidAfterCancel)
         toMem(i)(j).bits := RegNext(toMemExuInput.bits)
         if (toMem(i)(j).bits.params.hasLoadFu){
-          toMemExuInput.ready := toMem(i)(j).ready
           val toMemValidReg = RegInit(Bool(), false.B)
+          toMemExuInput.ready := toMem(i)(j).ready || !toMemValidReg
           toMemValidReg := toMemValidAfterCancel && (!toMemValidReg || toMem(i)(j).fire) ||
                            toMemValidReg && !toMem(i)(j).fire && !toMem(i)(j).bits.robIdx.needFlush(flushCopyRegVec.last)
           toMem(i)(j).valid := toMemValidReg

--- a/src/main/scala/xiangshan/cache/dcache/Uncache.scala
+++ b/src/main/scala/xiangshan/cache/dcache/Uncache.scala
@@ -212,7 +212,7 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
 
   val (bus, edge) = outer.clientNode.out.head
 
-  val req  = io.lsq.req
+  val req  = Wire(Decoupled(new UncacheWordReq))
   val resp = io.lsq.resp
   val mem_acquire = bus.a
   val mem_grant   = bus.d
@@ -225,10 +225,9 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
   bus.d.ready := false.B
   bus.e.valid := false.B
   bus.e.bits  := DontCare
-  io.lsq.req.ready := req_ready
+  req.ready := req_ready
   io.lsq.resp.valid := false.B
   io.lsq.resp.bits := DontCare
-
 
   /******************************************************************
    * Data Structure
@@ -241,6 +240,7 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
   val noPending = RegInit(VecInit(Seq.fill(UncacheBufferSize)(true.B)))
 
   // drain buffer
+  val entriesEmpty = Wire(Bool())
   val empty = Wire(Bool())
   val f1_needDrain = Wire(Bool())
   val do_uarch_drain = RegInit(false.B)
@@ -251,6 +251,16 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
   }.otherwise{
     do_uarch_drain := false.B
   }
+
+  // Flush and uarch drain stop new requests at the skid input. Requests already
+  // accepted by the skid must still reach e0 so that the uncache buffer drains.
+  val skidOccupied = skidBuffer(
+    io.lsq.req,
+    req,
+    false.B,
+    "UncacheSkidBuffer",
+    !(io.flush.valid || do_uarch_drain)
+  )
 
   val q0_entry = Wire(new UncacheEntry)
   val q0_canSentIdx = Wire(UInt(INDEX_WIDTH.W))
@@ -355,7 +365,10 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
   val (e0_allocIdx, e0_canAlloc) = PriorityEncoderWithFlag(e0_invalidVec)
   val e0_allocWaitSame = e0_allocWaitSameVec.reduce(_ || _)
   val e0_sid = Mux(e0_canMerge, e0_mergeIdx, e0_allocIdx)
-  val e0_reject = do_uarch_drain || (!e0_canMerge && !e0_invalidVec.asUInt.orR) || e0_rejectVec.reduce(_ || _)
+  // During a drain, only the request already captured by the skid buffer may
+  // enter e0. New LSQ requests are stopped at the skid input.
+  val e0_reject = (do_uarch_drain && !skidOccupied) ||
+    (!e0_canMerge && !e0_invalidVec.asUInt.orR) || e0_rejectVec.reduce(_ || _)
 
   // e0_fire is used to guarantee that it will not be rejected
   when(e0_canMerge && e0_req_valid){
@@ -490,7 +503,8 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
    * Buffer Flush
    * 1. when io.flush.valid is true: drain store queue and ubuffer
    ******************************************************************/
-  empty := !VecInit(states.map(_.isValid())).asUInt.orR
+  entriesEmpty := !VecInit(states.map(_.isValid())).asUInt.orR
+  empty := entriesEmpty && !skidOccupied
   io.flush.empty := empty
 
 
@@ -600,20 +614,21 @@ class UncacheImp(outer: Uncache)extends LazyModuleImp(outer)
   XSPerfAccumulate("q0_acquire", q0_canSent)
   XSPerfAccumulate("q0_acquire_store", q0_canSent && q0_isStore)
   XSPerfAccumulate("q0_acquire_load", q0_canSent && !q0_isStore)
-  XSPerfAccumulate("uncache_memBackTypeMM", io.lsq.req.fire && io.lsq.req.bits.memBackTypeMM)
-  XSPerfAccumulate("uncache_mmio_store", io.lsq.req.fire && isStore(io.lsq.req.bits.cmd) && !io.lsq.req.bits.nc)
-  XSPerfAccumulate("uncache_mmio_load", io.lsq.req.fire && !isStore(io.lsq.req.bits.cmd) && !io.lsq.req.bits.nc)
-  XSPerfAccumulate("uncache_nc_store", io.lsq.req.fire && isStore(io.lsq.req.bits.cmd) && io.lsq.req.bits.nc)
-  XSPerfAccumulate("uncache_nc_load", io.lsq.req.fire && !isStore(io.lsq.req.bits.cmd) && io.lsq.req.bits.nc)
+  XSPerfAccumulate("skid_enqueue", io.lsq.req.fire)
+  XSPerfAccumulate("uncache_memBackTypeMM", e0_fire && e0_req.memBackTypeMM)
+  XSPerfAccumulate("uncache_mmio_store", e0_fire && isStore(e0_req.cmd) && !e0_req.nc)
+  XSPerfAccumulate("uncache_mmio_load", e0_fire && !isStore(e0_req.cmd) && !e0_req.nc)
+  XSPerfAccumulate("uncache_nc_store", e0_fire && isStore(e0_req.cmd) && e0_req.nc)
+  XSPerfAccumulate("uncache_nc_load", e0_fire && !isStore(e0_req.cmd) && e0_req.nc)
   XSPerfAccumulate("uncache_outstanding", uState =/= s_idle && mem_acquire.fire)
   XSPerfAccumulate("forward_count", PopCount(io.forward.map(_.s2Resp.bits.forwardMask.asUInt.orR)))
   XSPerfAccumulate("forward_vaddr_match_failed", PopCount(f1_tagMismatchVec))
 
   val perfEvents = Seq(
-    ("uncache_mmio_store", io.lsq.req.fire && isStore(io.lsq.req.bits.cmd) && !io.lsq.req.bits.nc),
-    ("uncache_mmio_load", io.lsq.req.fire && !isStore(io.lsq.req.bits.cmd) && !io.lsq.req.bits.nc),
-    ("uncache_nc_store", io.lsq.req.fire && isStore(io.lsq.req.bits.cmd) && io.lsq.req.bits.nc),
-    ("uncache_nc_load", io.lsq.req.fire && !isStore(io.lsq.req.bits.cmd) && io.lsq.req.bits.nc),
+    ("uncache_mmio_store", e0_fire && isStore(e0_req.cmd) && !e0_req.nc),
+    ("uncache_mmio_load", e0_fire && !isStore(e0_req.cmd) && !e0_req.nc),
+    ("uncache_nc_store", e0_fire && isStore(e0_req.cmd) && e0_req.nc),
+    ("uncache_nc_load", e0_fire && !isStore(e0_req.cmd) && e0_req.nc),
     ("uncache_outstanding", uState =/= s_idle && mem_acquire.fire),
     ("forward_count", PopCount(io.forward.map(_.s2Resp.bits.forwardMask.asUInt.orR))),
     ("forward_vaddr_match_failed", PopCount(f1_tagMismatchVec))

--- a/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
+++ b/src/main/scala/xiangshan/cache/dcache/mainpipe/MainPipe.scala
@@ -27,7 +27,7 @@ import utility._
 import xiangshan.mem.HasL1PrefetchSourceParameter
 import xiangshan.mem.prefetch._
 import xiangshan.{L1CacheErrorInfo, XSCoreParamsKey}
-import xiangshan.mem.L1PrefetchReq
+import xiangshan.mem.{L1PrefetchReq, skidBuffer}
 
 class MainPipeReq(implicit p: Parameters) extends DCacheBundle {
   val miss = Bool() // only amo miss will refill in main pipe
@@ -248,10 +248,6 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
 
   val s1_s0_set_conflict, s2_s0_set_conflict, s3_s0_set_conflict = Wire(Bool())
   val set_conflict = s1_s0_set_conflict || s2_s0_set_conflict || s3_s0_set_conflict
-  // check sbuffer store req set_conflict in parallel with req arbiter
-  // it will speed up the generation of store_req.ready, which is in crit. path
-  val s1_s0_set_conflict_store, s2_s0_set_conflict_store, s3_s0_set_conflict_store = Wire(Bool())
-  val store_set_conflict = s1_s0_set_conflict_store || s2_s0_set_conflict_store || s3_s0_set_conflict_store
   val s1_ready, s2_ready, s3_ready = Wire(Bool())
 
   // convert store req to main pipe req, and select a req from store and probe
@@ -282,26 +278,27 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
 
   // s0: read meta and tag
   val req = Wire(DecoupledIO(new MainPipeReq))
+  val arbiter_out = Wire(DecoupledIO(new MainPipeReq))
   arbiter(
     in = Seq(
       io.probe_req,
       io.refill_req,
       prefetch_req, // Todo: what's the best priority
-      store_req, // Note: store_req.ready is now manually assigned for better timing
+      store_req,
       io.atomic_req,
     ),
-    out = req,
+    out = arbiter_out,
     name = Some("main_pipe_req")
   )
-
-  val store_idx = get_dcache_idx(io.store_req.bits.vaddr)
-  // manually assign store_req.ready for better timing
-  // now store_req set conflict check is done in parallel with req arbiter
-  store_req.ready := io.meta_read.ready && io.tag_read.ready && s1_ready && !store_set_conflict &&
-    !io.probe_req.valid && !io.refill_req.valid && !prefetch_req.valid
-  // Prefetch request has lower priority, so it needs to check higher priority requests
-  prefetch_req.ready := io.meta_read.ready && io.tag_read.ready && s1_ready && !set_conflict &&
-    !io.probe_req.valid && !io.refill_req.valid
+  // skidBuffer to cut timing path of ready
+  skidBuffer(
+    arbiter_out,
+    req,
+    false.B,
+    "MainPipeSkidBuffer"
+  )
+  // Keep requestor ready driven by the arbiter so it observes the same
+  // handshake as the skid buffer input.
   val s0_req = req.bits
   val s0_idx = get_dcache_idx(s0_req.vaddr)
   val s0_need_tag = io.tag_read.valid
@@ -379,7 +376,6 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   }
   s1_ready := !s1_valid || s1_can_go
   s1_s0_set_conflict := s1_valid && s0_idx === s1_idx && !s1_isPrefetch
-  s1_s0_set_conflict_store := s1_valid && store_idx === s1_idx && !s1_isPrefetch
 
   def wayMap[T <: Data](f: Int => T) = VecInit((0 until nWays).map(f))
   meta_resp := Mux(GatedValidRegNext(s0_fire), VecInit(io.meta_resp.map(_.asUInt)), RegEnable(meta_resp, s1_valid))
@@ -526,7 +522,6 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
   }
 
   s2_s0_set_conflict := s2_valid && s0_idx === s2_idx && !s2_isPrefetch
-  s2_s0_set_conflict_store := s2_valid && store_idx === s2_idx && !s2_isPrefetch
 
   // BtoT grow blocked: too many in-flight BtoT occupies in this set; replay store
   val s2_has_more_then_3_ways_BtoT = PopCount(io.btot_ways_for_set) > (nWays-2).U
@@ -891,7 +886,6 @@ class MainPipe(implicit p: Parameters) extends DCacheModule with HasPerfEvents w
 
   s3_ready := !s3_valid || s3_can_go
   s3_s0_set_conflict := s3_valid && s3_idx === s0_idx && !s3_isPrefetch
-  s3_s0_set_conflict_store := s3_valid && s3_idx === store_idx && !s3_isPrefetch
   //assert(RegNext(!s3_valid || !(s3_req.source === STORE_SOURCE.U && !s3_req.probe) || s3_hit)) // miss store should never come to s3 ,fixed(reserve)
 
   io.meta_read.valid := req.valid

--- a/src/main/scala/xiangshan/cache/mmu/Repeater.scala
+++ b/src/main/scala/xiangshan/cache/mmu/Repeater.scala
@@ -314,7 +314,7 @@ class PTWFilterEntry(Width: Int, Size: Int, hasHint: Boolean = false)(implicit p
     })
 
     // Multiple matching entries are handled by the original replay_all hint.
-    fastHint.valid := fastRespValidReg && PopCount(fastMatchReg) === 1.U && !io.flush
+    fastHint.valid := fastRespValidReg && fastMatchReg.orR && !io.flush
     fastHint.bits.id := fastHintId
     fastHint.bits.replay_all := false.B
   }

--- a/src/main/scala/xiangshan/cache/mmu/Repeater.scala
+++ b/src/main/scala/xiangshan/cache/mmu/Repeater.scala
@@ -153,11 +153,17 @@ class PTWFilterIO(Width: Int, hasHint: Boolean = false)(implicit p: Parameters) 
 
 }
 
+class PTWNewFilterIO(Width: Int)(implicit p: Parameters) extends PTWFilterIO(Width, hasHint = true) {
+  val fastHint = ValidIO(new TLBHintResp)
+}
+
 class PTWFilterEntryIO(Width: Int, hasHint: Boolean = false)(implicit p: Parameters) extends PTWFilterIO(Width, hasHint){
   val flush = Input(Bool())
   val refill = Output(Bool())
   val getGpa = Output(Bool())
   val memidx = Output(new MemBlockidxBundle)
+  val fastResp = if (hasHint) Some(Flipped(ValidIO(new PtwRespS2))) else None
+  val fastHint = if (hasHint) Some(ValidIO(new TLBHintResp)) else None
 }
 
 class PTWFilterEntry(Width: Int, Size: Int, hasHint: Boolean = false)(implicit p: Parameters) extends XSModule with HasPtwConst {
@@ -278,6 +284,8 @@ class PTWFilterEntry(Width: Int, Size: Int, hasHint: Boolean = false)(implicit p
 
   if (hasHint) {
     val hintIO = io.hint.getOrElse(new TlbHintIO)
+    val fastResp = io.fastResp.getOrElse(Flipped(ValidIO(new PtwRespS2)))
+    val fastHint = io.fastHint.getOrElse(ValidIO(new TLBHintResp))
     for (i <- 0 until LdExuCnt) {
       hintIO.req(i).id := enqidx(i)
       hintIO.req(i).full := !canenq(i) || ptwResp_ReqMatchVec(i)
@@ -285,6 +293,30 @@ class PTWFilterEntry(Width: Int, Size: Int, hasHint: Boolean = false)(implicit p
     hintIO.resp.valid := io.refill
     hintIO.resp.bits.id := ptwResp_EntryMatchFirst
     hintIO.resp.bits.replay_all := PopCount(ptwResp_EntryMatchVec) > 1.U
+
+    // Keep the L2 response path short: match only the originating vpn/s2xlate,
+    // register the one-hot result, and encode the id from the registered bits.
+    val fastRespVpn = Mux(
+      fastResp.bits.s2xlate === onlyStage2,
+      fastResp.bits.s2.entry.tag(vpnLen - 1, 0),
+      Cat(fastResp.bits.s1.entry.tag, fastResp.bits.s1.addr_low)
+    )
+    val fastMatchVec = VecInit(vpn.zip(v).zip(s2xlate).map { case ((entryVpn, entryValid), entryS2xlate) =>
+      entryValid && entryS2xlate === fastResp.bits.s2xlate && entryVpn === fastRespVpn
+    }).asUInt
+    val fastMatchReg = RegEnable(fastMatchVec, 0.U(Size.W), fastResp.valid)
+    val fastRespValidReg = RegNext(fastResp.valid && !io.flush, init = false.B)
+    val fastHintId = Cat((0 until log2Up(Size)).reverse.map { bit =>
+      val idMask = (0 until Size).foldLeft(BigInt(0)) { case (mask, index) =>
+        if (((index >> bit) & 1) == 1) mask.setBit(index) else mask
+      }
+      (fastMatchReg & idMask.U(Size.W)).orR
+    })
+
+    // Multiple matching entries are handled by the original replay_all hint.
+    fastHint.valid := fastRespValidReg && PopCount(fastMatchReg) === 1.U && !io.flush
+    fastHint.bits.id := fastHintId
+    fastHint.bits.replay_all := false.B
   }
 
   io.rob_head_miss_in_tlb := VecInit(v.zip(vpn).map{case (vi, vpni) => {
@@ -324,7 +356,7 @@ class PTWNewFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameter
   // all store address execute units, including sta and hyu
   private val StaExuCnt = backendParams.StaExuCnt
 
-  val io = IO(new PTWFilterIO(Width, hasHint = true))
+  val io = IO(new PTWNewFilterIO(Width))
 
   val load_filter = VecInit(Seq.fill(1) {
     val load_entry = Module(new PTWFilterEntry(Width = LdExuCnt + PfNumInDtlbLD, Size = loadfiltersize, hasHint = true))
@@ -384,6 +416,11 @@ class PTWNewFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameter
 
   val hintIO = io.hint.getOrElse(new TlbHintIO)
   val load_hintIO = load_filter(0).hint.getOrElse(new TlbHintIO)
+  val load_fastResp = load_filter(0).fastResp.getOrElse(Flipped(ValidIO(new PtwRespS2)))
+  val load_fastHint = load_filter(0).fastHint.getOrElse(ValidIO(new TLBHintResp))
+  load_fastResp.valid := io.ptw.resp.fire
+  load_fastResp.bits := io.ptw.resp.bits
+  io.fastHint := load_fastHint
   for (i <- 0 until LdExuCnt) {
     hintIO.req(i) := RegNext(load_hintIO.req(i))
   }

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -964,6 +964,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
     newLoadUnits(i).io.csrTrigger.debugMode := debugMode
   }
 
+  lsq.io.fast_tlb_hint <> dtlbRepeater.io.fastHint
+
   lsq.io.cmoOpReq <> dcache.io.cmoOpReq
   lsq.io.cmoOpResp <> dcache.io.cmoOpResp
 

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -519,6 +519,23 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   val storeUnits = Seq.tabulate(StaCnt)(i => Module(new NewStoreUnit(staParams(i))))
   val stdExeUnits = Seq.tabulate(StdCnt)(i => Module(new StdExeUnit(stdParams(i))))
 
+  val stdDataWriteNow = stdExeUnits.map(_.io.sqData)
+  val stdDataWritePrev = stdDataWriteNow.map { now =>
+    val prev = Wire(Valid(new SqPtr))
+    prev.valid := RegNext(now.valid, false.B)
+    prev.bits := RegEnable(now.bits.sqIdx, now.valid)
+    prev
+  }
+  newLoadUnits.foreach { ldu =>
+    ldu.io.stdDataWrite.current.zip(stdDataWriteNow).foreach { case (sink, source) =>
+      sink.valid := source.valid
+      sink.bits := source.bits.sqIdx
+    }
+    ldu.io.stdDataWrite.previous.zip(stdDataWritePrev).foreach { case (sink, source) =>
+      sink := source
+    }
+  }
+
   wakeupToLRQCancel.take(StaCnt).zip(storeUnits).zip(io.ooo_to_mem.wakeupToLRQCancel.take(StaCnt)).foreach {
     case ((sink, stu), source) =>
       sink.og0Cancel := source.og0Cancel

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -895,7 +895,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
 
   val rrBankConflictFastReplay = newLoadUnits.map(_.io.rrBankConflictFastReplay)
   val rrBankConflictFastReplayCandidates = rrBankConflictFastReplay.map(_.candidate)
-  val rrBankConflictFastReplayArb = Module(new RRArbiterInit(Bool(), LduCnt))
+  val rrBankConflictFastReplayArb = Module(new TwoLevelRRArbiter(Bool(), LduCnt))
   rrBankConflictFastReplayArb.suggestName("rr_bank_conflict_fast_replay_arb")
   rrBankConflictFastReplayArb.io.out.ready := true.B
   rrBankConflictFastReplayArb.io.in.zip(rrBankConflictFastReplayCandidates).foreach { case (in, candidate) =>

--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -558,6 +558,16 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   newLoadUnits.zipWithIndex.map(x => x._1.suggestName("LoadUnit_"+x._2))
   storeUnits.zipWithIndex.map(x => x._1.suggestName("StoreUnit_"+x._2))
 
+  storeUnits.foreach(_.io.perfRobHeadPtr := io.ooo_to_mem.lsqio.pendingPtr)
+  stdExeUnits.foreach(_.io.perfRobHeadPtr := io.ooo_to_mem.lsqio.pendingPtr)
+  XSPerfAccumulate("store_addr_writeback_rob_head", PopCount(storeUnits.map(_.io.writebackAtRobHead)))
+  XSPerfAccumulate("store_data_writeback_rob_head", PopCount(stdExeUnits.map(_.io.writebackAtRobHead)))
+
+  for (i <- 0 until LoadEntrance.num) {
+    val sourceName = LoadEntrance.findNameById(i)
+    val eventCount = PopCount(newLoadUnits.map(_.io.sourceExecuteFailRobHead(i)))
+    XSPerfAccumulate(s"${sourceName}_execute_fail_rob_head", eventCount)
+  }
 
   writebackLda.zipWithIndex.foreach { case (wb, i) =>
     if (i == AtomicWBPort) {

--- a/src/main/scala/xiangshan/mem/MemCommon.scala
+++ b/src/main/scala/xiangshan/mem/MemCommon.scala
@@ -232,3 +232,71 @@ class SelectOldest[T <: Data](gen: T, numIn: Int, f: (T, T) => Bool) extends Mod
   io.out.bits := oldest._2.head
 
 }
+
+class skidBufferConnect[T <: Data](gen: T) extends Module {
+  val io = IO(new Bundle() {
+    val in = Flipped(DecoupledIO(gen.cloneType))
+    val flush = Input(Bool())
+    val enqEnable = Input(Bool())
+    val out = DecoupledIO(gen.cloneType)
+    val occupied = Output(Bool())
+  })
+
+  val (_, occupied) = skidBuffer.connect(io.in, io.out, io.flush, io.enqEnable)
+  io.occupied := occupied
+}
+
+object skidBuffer {
+  /*
+   * Skid Buffer used to break timing path of ready
+   */
+  def connect[T <: Data](
+    in: DecoupledIO[T],
+    out: DecoupledIO[T],
+    flush: Bool,
+    enqEnable: Bool = true.B
+  ): (T, Bool) = {
+    val empty :: skid :: Nil = Enum(2)
+    val state = RegInit(empty)
+    val stateNext = WireInit(empty)
+    val dataBuffer = RegEnable(in.bits, !out.ready && in.fire)
+
+    when(state === empty) {
+      stateNext := Mux(!out.ready && in.fire && !flush, skid, empty)
+    }.elsewhen(state === skid) {
+      stateNext := Mux(out.ready || flush, empty, skid)
+    }
+    state := stateNext
+
+    in.ready := state === empty && enqEnable
+    out.bits := Mux(state === skid, dataBuffer, in.bits)
+    out.valid := state === skid || (state === empty && enqEnable && in.valid)
+
+    (dataBuffer, state === skid)
+  }
+
+  def apply[T <: Data](
+    in: DecoupledIO[T],
+    out: DecoupledIO[T],
+    flush: Bool,
+    moduleName: String
+  ): Unit = {
+    apply(in, out, flush, moduleName, true.B)
+  }
+
+  def apply[T <: Data](
+    in: DecoupledIO[T],
+    out: DecoupledIO[T],
+    flush: Bool,
+    moduleName: String,
+    enqEnable: Bool
+  ): Bool = {
+    val buffer = Module(new skidBufferConnect(in.bits))
+    buffer.suggestName(moduleName)
+    buffer.io.in <> in
+    buffer.io.flush := flush
+    buffer.io.enqEnable := enqEnable
+    out <> buffer.io.out
+    buffer.io.occupied
+  }
+}

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -31,7 +31,7 @@ import xiangshan.mem.Bundles._
 import xiangshan.cache._
 import xiangshan.cache.{DCacheLineIO, DCacheWordIO, MemoryOpConstants}
 import xiangshan.cache.{CMOReq, CMOResp}
-import xiangshan.cache.mmu.{TlbHintIO, TlbRequestIO}
+import xiangshan.cache.mmu.{TLBHintResp, TlbHintIO, TlbRequestIO}
 
 class ExceptionAddrIO(implicit p: Parameters) extends XSBundle {
   val isStore = Input(Bool())
@@ -134,6 +134,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule
     val issuePtrExt = Output(new SqPtr)
     val l2_hint = Input(Vec(cfg.numMemChannels, Valid(new L2ToL1Hint())))
     val tlb_hint = Flipped(new TlbHintIO)
+    val fast_tlb_hint = Flipped(ValidIO(new TLBHintResp))
     val wakeupToLRQ = Vec(StaCnt + StdCnt, Flipped(ValidIO(new IssueQueueLRQWakeUpBundle)))
     val wakeupToLRQCancel = Input(Vec(StaCnt + StdCnt, new LRQWakeUpCancelBundle))
     val cmoOpReq  = DecoupledIO(new CMOReq)
@@ -254,6 +255,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule
   loadQueue.io.bypass              <> io.bypass
   loadQueue.io.l2_hint             <> io.l2_hint
   loadQueue.io.tlb_hint            <> io.tlb_hint
+  loadQueue.io.fast_tlb_hint       <> io.fast_tlb_hint
   loadQueue.io.wakeupToLRQ         <> io.wakeupToLRQ
   loadQueue.io.wakeupToLRQCancel   := io.wakeupToLRQCancel
   loadQueue.io.lqEmpty             <> io.lqEmpty

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -209,6 +209,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
     val tlbReplayDelayCycleCtrl = Vec(4, Input(UInt(ReSelectLen.W)))
     val l2_hint = Input(Vec(cfg.numMemChannels, Valid(new L2ToL1Hint())))
     val tlb_hint = Flipped(new TlbHintIO)
+    val fast_tlb_hint = Flipped(ValidIO(new TLBHintResp))
     val wakeupToLRQ = Vec(StaCnt + StdCnt, Flipped(ValidIO(new IssueQueueLRQWakeUpBundle)))
     val wakeupToLRQCancel = Input(Vec(StaCnt + StdCnt, new LRQWakeUpCancelBundle))
     val lqEmpty = Output(Bool())
@@ -303,6 +304,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   loadQueueReplay.io.rawFull          <> loadQueueRAW.io.lqFull
   loadQueueReplay.io.l2_hint          <> io.l2_hint
   loadQueueReplay.io.tlb_hint         <> io.tlb_hint
+  loadQueueReplay.io.fast_tlb_hint    <> io.fast_tlb_hint
   loadQueueReplay.io.tlbReplayDelayCycleCtrl <> io.tlbReplayDelayCycleCtrl
   loadQueueReplay.io.storeAddrWakeup.zip(io.wakeupToLRQ.take(StaCnt)).foreach { case (sink, source) => sink := source }
   loadQueueReplay.io.storeDataWakeup.zip(io.wakeupToLRQ.drop(StaCnt).take(StdCnt)).foreach { case (sink, source) => sink := source }

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -308,6 +308,10 @@ class LoadQueue(implicit p: Parameters) extends XSModule
   loadQueueReplay.io.storeDataWakeup.zip(io.wakeupToLRQ.drop(StaCnt).take(StdCnt)).foreach { case (sink, source) => sink := source }
   loadQueueReplay.io.storeAddrWakeupCancel.zip(io.wakeupToLRQCancel.take(StaCnt)).foreach { case (sink, source) => sink := source }
   loadQueueReplay.io.storeDataWakeupCancel.zip(io.wakeupToLRQCancel.drop(StaCnt).take(StdCnt)).foreach { case (sink, source) => sink := source }
+  loadQueueReplay.io.storeDataWrite.zip(io.std.storeDataIn).foreach { case (sink, source) =>
+    sink.valid := source.valid
+    sink.bits := source.bits.sqIdx
+  }
   loadQueueReplay.io.physicalUpperSqIdx <> io.sq.physicalUpperSqIdx
 
   loadQueueReplay.io.mmioWakeup := uncacheBuffer.io.mmioWakeup

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala
@@ -289,6 +289,7 @@ class LoadQueue(implicit p: Parameters) extends XSModule
    * LoadQueueReplay
    */
   loadQueueReplay.io.redirect         <> io.redirect
+  loadQueueReplay.io.robHeadPtr       := io.rob.pendingPtrNext
   loadQueueReplay.io.enq              <> io.ldu.ldin // from load_s3
   loadQueueReplay.io.replay           <> io.replay
   loadQueueReplay.io.loadWakeup       <> io.loadWakeup

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -281,16 +281,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val uop = Reg(Vec(LoadQueueReplaySize, new DynInst))
   val isNC = RegInit(VecInit(List.fill(LoadQueueReplaySize)(false.B)))
   val vecReplay = Reg(Vec(LoadQueueReplaySize, new VecReplayInfo))
-  val vaddrModule = Module(new LqVAddrModule(
-    gen = UInt(VAddrBits.W),
-    numEntries = LoadQueueReplaySize,
-    numRead = LoadPipelineWidth,
-    numWrite = LoadPipelineWidth,
-    numWBank = LoadQueueNWriteBanks,
-    numWDelay = 1,
-    numCamPort = 0))
-  vaddrModule.io := DontCare
-  val debug_vaddr = RegInit(VecInit(List.fill(LoadQueueReplaySize)(0.U(VAddrBits.W))))
+  val vaddr = Reg(Vec(LoadQueueReplaySize, UInt(VAddrBits.W)))
   val cause = RegInit(VecInit(List.fill(LoadQueueReplaySize)(0.U(LoadReplayCauses.allCauses.W))))
   val blocking = RegInit(VecInit(List.fill(LoadQueueReplaySize)(false.B)))
   val strict = RegInit(VecInit(List.fill(LoadQueueReplaySize)(false.B)))
@@ -347,7 +338,9 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   // Fast hint selects C_TM replays directly. The delayed original hint remains the fallback.
   val fastTlbHintResp = io.fast_tlb_hint
   val tlbHintResp = delayWakeup(io.tlb_hint.resp)
-  val l2Hint = VecInit(io.l2_hint.map(delayWakeup(_)))
+  // Arrive-cycle hint unblocks first-beat C_DM. Last-beat uses the same match,
+  // registered for one cycle, so s0 never rematches a delayed hint.
+  val l2Hint = io.l2_hint
   val mmioWakeup = delayWakeup(io.mmioWakeup)
   val ncWakeup = delayWakeup(io.ncWakeup)
 
@@ -452,6 +445,10 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     Mux(VecInit(matchVec).asUInt.orR, Mux1H(matchVec.zip(l2Hint.map(_.bits.isKeyword))), false.B)
   }
 
+  private def l2HintSelectThisBeat(mshrId: UInt, dataInLastBeat: Bool): Bool = {
+    Mux(l2HintIsKeyword(mshrId), dataInLastBeat, !dataInLastBeat)
+  }
+
   val storeAddrWakeupCancelVec = VecInit((0 until LoadQueueReplaySize).map(i =>
     allocated(i) && cause(i)(LoadReplayCauses.C_MA) &&
       StoreWakeupShouldCancel(storeIssueScoreBoard(i), storeAddrWakeupCancel, isStd = false)
@@ -482,6 +479,15 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     // case C_DM
     when (cause(i)(LoadReplayCauses.C_DM)) {
       blocking(i) := Mux(tlDChannelHit(missMSHRId(i)), false.B, blocking(i))
+    }
+    // Arrive-cycle match once. First-beat unblocks now; last-beat is the
+    // registered leftover of that same match, not a second delayed-hint CAM.
+    val l2HintMatchThisCycle = allocated(i) && cause(i)(LoadReplayCauses.C_DM) && l2HintHit(missMSHRId(i))
+    val l2HintFirstBeat = l2HintMatchThisCycle && l2HintSelectThisBeat(missMSHRId(i), dataInLastBeatReg(i))
+    val l2HintLastBeat = l2HintMatchThisCycle && !l2HintSelectThisBeat(missMSHRId(i), dataInLastBeatReg(i))
+    val l2HintLastBeatUnblock = RegNext(l2HintLastBeat, false.B)
+    when (l2HintFirstBeat || l2HintLastBeatUnblock) {
+      blocking(i) := false.B
     }
     // case C_RAR
     when (cause(i)(LoadReplayCauses.C_RAR)) {
@@ -544,10 +550,10 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     (0 until LoadQueueReplaySize / LoadPipelineWidth).map(i => { input(LoadPipelineWidth * i + rem) })
   }
 
-  // stage 0: select entries and start reading their vaddr
+  // stage 0: select entries
   val s0_oldestSel = Wire(Vec(LoadPipelineWidth, Valid(UInt(LoadQueueReplaySize.W))))
   val s1_can_go = Wire(Vec(LoadPipelineWidth, Bool()))
-  val s1_oldestSel = Wire(Vec(LoadPipelineWidth, Valid(UInt(log2Up(LoadQueueReplaySize + 1).W))))
+  val s1_oldestSel = Wire(Vec(LoadPipelineWidth, Valid(UInt(LoadQueueReplaySize.W))))
 
   // generate mask
   val needCancel = Wire(Vec(LoadQueueReplaySize, Bool()))
@@ -561,33 +567,13 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val s0_loadFreeSelMask = GatedRegNext(freeMaskVec.asUInt)
   val s0_remFreeSelVec = VecInit(Seq.tabulate(LoadPipelineWidth)(rem => getRemBits(s0_loadFreeSelMask)(rem)))
 
-  // l2 hint wakes up cache missed load
-  // l2 will send GrantData in next 2/3 cycle, wake up the missed load early and sent them to load pipe, so them will hit the data in D channel or mshr in load S1
-  val s0_loadHintWakeMask = VecInit((0 until LoadQueueReplaySize).map(i => {
-    allocated(i) && !scheduled(i) && cause(i)(LoadReplayCauses.C_DM) && blocking(i) && l2HintHit(missMSHRId(i))
-  })).asUInt
   val s0_tlbHintWakeMask = VecInit((0 until LoadQueueReplaySize).map(i => {
     allocated(i) && !scheduled(i) && cause(i)(LoadReplayCauses.C_TM) && blocking(i) &&
       fastTlbHintResp.valid && fastTlbHintResp.bits.id === tlbHintId(i)
   })).asUInt
-  // l2 will send 2 beats data in 2 cycles, so if data needed by this load is in first beat, select it this cycle, otherwise next cycle
-  // when isKeyword = 1, s0_loadHintSelMask need overturn
-    val s0_loadHintSelMask = VecInit((0 until LoadQueueReplaySize).map(i => {
-      s0_loadHintWakeMask(i) && Mux(
-        l2HintIsKeyword(missMSHRId(i)),
-        dataInLastBeatReg(i),
-        !dataInLastBeatReg(i)
-      )
-    })).asUInt
-  val s0_remLoadHintSelMask = VecInit((0 until LoadPipelineWidth).map(rem => getRemBits(s0_loadHintSelMask)(rem)))
-  val s0_remHintSelValidVec = VecInit((0 until LoadPipelineWidth).map(rem => ParallelORR(s0_remLoadHintSelMask(rem))))
-  val s0_hintSelValid = ParallelORR(s0_loadHintSelMask)
 
-  // wake up cache missed load
+  // wake up tlb-missed load. L2 hint already unblocked matching C_DM last cycle.
   (0 until LoadQueueReplaySize).foreach(i => {
-    when(s0_loadHintWakeMask(i)) {
-      blocking(i) := false.B
-    }
     when(s0_tlbHintWakeMask(i)) {
       blocking(i) := false.B
     }
@@ -595,23 +581,21 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
 
   // generate replay mask
   // replay select priority is given as follow
-  // 1. hint wake up load
-  // 2. higher priority load
-  // 3. lower priority load
+  // 1. higher priority load (C_DM / C_FF / C_UNCACHE, including C_DM unblocked by last-cycle L2 hint)
+  // 2. lower priority load
   val s0_loadHigherPriorityReplaySelMask = VecInit((0 until LoadQueueReplaySize).map(i => {
     val hasHigherPriority = cause(i)(LoadReplayCauses.C_DM) || cause(i)(LoadReplayCauses.C_FF) || cause(i)(LoadReplayCauses.C_UNCACHE)
     allocated(i) && !scheduled(i) && !blocking(i) && hasHigherPriority
   })).asUInt // use uint instead vec to reduce verilog lines
   val s0_remLoadHigherPriorityReplaySelMask = VecInit((0 until LoadPipelineWidth).map(rem => getRemBits(s0_loadHigherPriorityReplaySelMask)(rem)))
   val s0_loadLowerPriorityReplaySelMask = VecInit((0 until LoadQueueReplaySize).map(i => {
-    val hasLowerPriority = !cause(i)(LoadReplayCauses.C_DM) && !cause(i)(LoadReplayCauses.C_FF)
-    allocated(i) && !scheduled(i) && (!blocking(i) || s0_tlbHintWakeMask(i)) && hasLowerPriority
-  })).asUInt // use uint instead vec to reduce verilog lines
+    val hasLowerPriority = !cause(i)(LoadReplayCauses.C_DM) && !cause(i)(LoadReplayCauses.C_FF) && !cause(i)(LoadReplayCauses.C_UNCACHE)
+    allocated(i) && !scheduled(i) && !blocking(i) && hasLowerPriority
+  })).asUInt | s0_tlbHintWakeMask // use uint instead vec to reduce verilog lines
   val s0_remLoadLowerPriorityReplaySelMask = VecInit((0 until LoadPipelineWidth).map(rem => getRemBits(s0_loadLowerPriorityReplaySelMask)(rem)))
-  val s0_loadNormalReplaySelMask = s0_loadLowerPriorityReplaySelMask | s0_loadHigherPriorityReplaySelMask | s0_loadHintSelMask
+  val s0_loadNormalReplaySelMask = s0_loadLowerPriorityReplaySelMask | s0_loadHigherPriorityReplaySelMask
   val s0_remPriorityReplaySelVec = VecInit((0 until LoadPipelineWidth).map(rem => {
-        Mux(s0_remHintSelValidVec(rem), s0_remLoadHintSelMask(rem),
-          Mux(ParallelORR(s0_remLoadHigherPriorityReplaySelMask(rem)), s0_remLoadHigherPriorityReplaySelMask(rem), s0_remLoadLowerPriorityReplaySelMask(rem)))
+        Mux(ParallelORR(s0_remLoadHigherPriorityReplaySelMask(rem)), s0_remLoadHigherPriorityReplaySelMask(rem), s0_remLoadLowerPriorityReplaySelMask(rem))
       }))
   /******************************************************************************************************
    * WARNING: Make sure that OldestSelectStride must less than or equal stages of load pipeline.        *
@@ -625,28 +609,9 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val s0_remOldestMatchMask = (0 until LoadPipelineWidth).map(rem => VecInit(s0_remOldestMatchMaskVec(rem).map(_.head)).asUInt)
   val s0_remOlderMatchMask = (0 until LoadPipelineWidth).map(rem => VecInit(s0_remOlderMatchMaskVec(rem).map(VecInit(_).asUInt.orR)).asUInt)
   val s0_remOldestMatch = s0_remOldestMatchMask.map(ParallelORR(_))
-  val s0_remOlderMatch = s0_remOlderMatchMask.map(ParallelORR(_))
   val s0_remOldestSelVec = (0 until LoadPipelineWidth).map(rem =>
     Mux(s0_remOldestMatch(rem), s0_remOldestMatchMask(rem), s0_remOlderMatchMask(rem))
   )
-  val s0_remOldestHintSelVec_ = s0_remOldestMatchMask.zip(s0_remLoadHintSelMask).map { case (oldestVec, hintVec) =>
-    oldestVec & hintVec
-  }
-  val s0_remOlderHintSelVec_ = s0_remOlderMatchMask.zip(s0_remLoadHintSelMask).map { case (olderVec, hintVec) =>
-    olderVec & hintVec
-  }
-  val s0_remOldestHintSel = (0 until LoadPipelineWidth).map(rem =>
-    Mux(s0_remOldestMatch(rem), ParallelORR(s0_remOldestHintSelVec_(rem)), ParallelORR(s0_remOlderHintSelVec_(rem)))
-  )
-  val s0_remOldestHintSelOH = (0 until LoadPipelineWidth).map(rem =>
-    Mux(s0_remOldestMatch(rem), PriorityEncoderOH(s0_remOldestHintSelVec_(rem)), PriorityEncoderOH(s0_remOlderHintSelVec_(rem)))
-  )
-  val s0_remOldestSelOH = (0 until LoadPipelineWidth).map(rem =>
-    Mux(s0_remOldestMatch(rem), PriorityEncoderOH(s0_remOldestMatchMask(rem)), PriorityEncoderOH(s0_remOlderMatchMask(rem)))
-  )
-  val s0_remOldestHintSelVec = s0_remOldestSelVec.zip(s0_remLoadHintSelMask).map {
-    case(oldestVec, hintVec) => oldestVec & hintVec
-  }
 
   // select oldest logic
   s0_oldestSel := VecInit((0 until LoadPipelineWidth).map(rport => {
@@ -657,9 +622,8 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val ageOldestIndexOH = ageOldest.bits
 
     // select program order oldest
-    val l2HintFirst = ParallelORR(s0_remOldestHintSelVec(rport))
-    val issOldestValid = l2HintFirst || ParallelORR(s0_remOldestSelVec(rport))
-    val issOldestIndexOH = Mux(l2HintFirst, PriorityEncoderOH(s0_remOldestHintSelVec(rport)), PriorityEncoderOH(s0_remOldestSelVec(rport)))
+    val issOldestValid = ParallelORR(s0_remOldestSelVec(rport))
+    val issOldestIndexOH =  PriorityEncoderOH(s0_remOldestSelVec(rport))
 
     val oldest = Wire(Valid(UInt()))
     val oldestSel = Mux(issOldestValid, issOldestIndexOH, ageOldestIndexOH)
@@ -689,23 +653,35 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
 
   val replay_req = io.replay
   val s1_cancelReplay = Wire(Vec(LoadPipelineWidth, Bool()))
+  val s1_replayIdxOH = Wire(Vec(LoadPipelineWidth, UInt((LoadQueueReplaySize / LoadPipelineWidth).W)))
+  val s1_replayIdx = Wire(Vec(LoadPipelineWidth, UInt(log2Up(LoadQueueReplaySize + 1).W)))
+  val s1_replayUop = Wire(Vec(LoadPipelineWidth, new DynInst))
+  for (i <- 0 until LoadPipelineWidth) {
+    s1_replayIdxOH(i) := getRemBits(s1_oldestSel(i).bits)(i)
+    // TODO: should use bank idx in pipeline
+    s1_replayIdx(i) := OHToUInt(s1_oldestSel(i).bits)
+  }
 
   for (i <- 0 until LoadPipelineWidth) {
-    val s0_can_go = s1_can_go(i) ||
-                    s1_cancelReplay(i) ||
-                    uop(s1_oldestSel(i).bits).robIdx.needFlush(io.redirect) ||
-                    uop(s1_oldestSel(i).bits).robIdx.needFlush(RegNext(io.redirect))
+    // s1_can_go already includes s1_cancelReplay (flushed last cycle, or this-cycle redirect).
+    val s0_can_go = s1_can_go(i)
     val s0_oldestSelIndexOH = s0_oldestSel(i).bits // one-hot
     val s0_oldestSelV = s0_oldestSel(i).valid
+    // Read uop in s0 with the bank-local one-hot. s1 only uses the registered snapshot
+    // for needFlush / replay payload so the 40-to-1 Mux is off the s1 valid path.
+    val s0_replayIdxOH = getRemBits(s0_oldestSel(i).bits)(i)
+    val s0_replayUop = Mux1H(
+      s0_replayIdxOH,
+      (0 until LoadQueueReplaySize / LoadPipelineWidth).map(j => uop(j * LoadPipelineWidth + i))
+    )
     // A fired request must leave s1 even when cooldown prevents accepting another selection.
     s1_oldestSel(i).valid := RegEnable(
       Mux(s0_can_go, s0_oldestSelV, false.B),
       false.B,
       s0_can_go || replay_req(i).fire
     )
-    s1_oldestSel(i).bits := RegEnable(OHToUInt(s0_oldestSel(i).bits), s0_can_go)
-    vaddrModule.io.ren(i) := s0_can_go && s0_oldestSelV
-    vaddrModule.io.raddr(i) := OHToUInt(s0_oldestSel(i).bits)
+    s1_oldestSel(i).bits := RegEnable(s0_oldestSel(i).bits, s0_can_go)
+    s1_replayUop(i) := RegEnable(s0_replayUop, s0_can_go)
 
     for (j <- 0 until LoadQueueReplaySize) {
       when (s0_can_go && s0_oldestSelV && s0_oldestSelIndexOH(j)) {
@@ -714,21 +690,56 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     }
   }
   for (i <- 0 until LoadPipelineWidth) {
-    val s1_replayIdx = s1_oldestSel(i).bits
-    val s1_redirectCancel = uop(s1_replayIdx).robIdx.needFlush(io.redirect) ||
-      uop(s1_replayIdx).robIdx.needFlush(RegNext(io.redirect))
-    s1_cancelReplay(i) := s1_redirectCancel
-    s1_can_go(i) := replayCanFire(i) && (!s1_oldestSel(i).valid || replay_req(i).fire) || s1_cancelReplay(i)
+    /*
+     * s1_redirectCancel:
+     *   - s1_flushed: this entry was deallocated last cycle (s0)
+     *   - s1_needCancel: this-cycle redirect hits the s0-selected robIdx
+     * Current-cycle flush of a still-valid entry is also killed in ldu s1.
+     */
+    val s1_flushed = Mux1H(
+      s1_replayIdxOH(i),
+      (0 until LoadQueueReplaySize / LoadPipelineWidth).map(j => !allocated(j * LoadPipelineWidth + i))
+    )
 
-    val s1_replayUop = uop(s1_replayIdx)
-    val s1_nc = isNC(s1_replayIdx)
-    val s1_vecReplay = vecReplay(s1_replayIdx)
-    val s1_replayMSHRId = missMSHRId(s1_replayIdx)
-    val s1_missDbUpdated = missDbUpdated(s1_replayIdx)
-    val s1_replayCauses = cause(s1_replayIdx)
-    val replay_req_vaddr = vaddrModule.io.rdata(i)
-    val replay_req_size = LSUOpType.size(s1_replayUop.fuOpType)
-    replay_req(i).valid := s1_oldestSel(i).valid && !s1_cancelReplay(i)
+    val s1_nc = Mux1H(
+      s1_replayIdxOH(i),
+      (0 until LoadQueueReplaySize / LoadPipelineWidth).map(j => isNC(j * LoadPipelineWidth + i))
+    )
+    val s1_vecReplay = Mux1H(
+      s1_replayIdxOH(i),
+      (0 until LoadQueueReplaySize / LoadPipelineWidth).map(j => vecReplay(j * LoadPipelineWidth + i))
+    )
+    val s1_replayMSHRId = Mux1H(
+      s1_replayIdxOH(i),
+      (0 until LoadQueueReplaySize / LoadPipelineWidth).map(j => missMSHRId(j * LoadPipelineWidth + i))
+    )
+    val s1_missDbUpdated = Mux1H(
+      s1_replayIdxOH(i),
+      (0 until LoadQueueReplaySize / LoadPipelineWidth).map(j => missDbUpdated(j * LoadPipelineWidth + i))
+    )
+    val s1_replayCauses = Mux1H(
+      s1_replayIdxOH(i),
+      (0 until LoadQueueReplaySize / LoadPipelineWidth).map(j => cause(j * LoadPipelineWidth + i))
+    )
+
+    // This-cycle redirect: one needFlush on the already bank-selected robIdx.
+    // Last-cycle deallocate: s1_flushed. allocated is a Reg, so a same-cycle s0
+    // select of a just-redirected entry shows up as flushed only in the next cycle.
+    // Form valid as a parallel AND so redirect does not wait for the flushed Mux1H:
+    //   valid = s1_valid && !flushed && !needFlush
+    val s1_needFlush = s1_replayUop(i).robIdx.needFlush(io.redirect)
+    val s1_needCancel = s1_oldestSel(i).valid && s1_needFlush
+    val replay_req_vaddr = Mux1H(
+      s1_replayIdxOH(i),
+      (0 until LoadQueueReplaySize / LoadPipelineWidth).map(j => vaddr(LoadPipelineWidth * j + i))
+    )
+
+    val s1_redirectCancel = s1_flushed || s1_needCancel
+    s1_cancelReplay(i) := s1_redirectCancel
+    s1_can_go(i) := replayCanFire(i) && (!s1_oldestSel(i).valid || replay_req(i).fire) || s1_redirectCancel
+
+    val replay_req_size = LSUOpType.size(s1_replayUop(i).fuOpType)
+    replay_req(i).valid := s1_oldestSel(i).valid && !s1_flushed && !s1_needFlush
     replay_req(i).bits.entrance := Mux(
       s1_replayCauses(LoadReplayCauses.C_DM) || s1_replayCauses(LoadReplayCauses.C_UNCACHE),
       LoadEntrance.replayHiPrio.U,
@@ -737,7 +748,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     replay_req(i).bits.accessType.instrType := Mux(s1_vecReplay.isvec, InstrType.vector.U, InstrType.scalar.U)
     replay_req(i).bits.accessType.pftType := DontCare
     replay_req(i).bits.accessType.pftCoh := DontCare
-    replay_req(i).bits.uop := s1_replayUop
+    replay_req(i).bits.uop := s1_replayUop(i)
     replay_req(i).bits.uop.exceptionVec(loadAddrMisaligned) := false.B
     replay_req(i).bits.vaddr := replay_req_vaddr
     replay_req(i).bits.fullva := replay_req_vaddr
@@ -749,7 +760,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     )
     replay_req(i).bits.occupySource := DontCare
     replay_req(i).bits.mshrId.get := s1_replayMSHRId
-    replay_req(i).bits.replayQueueIdx.get := s1_replayIdx
+    replay_req(i).bits.replayQueueIdx.get := s1_replayIdx(i)
     replay_req(i).bits.cause.get := s1_replayCauses.asTypeOf(replay_req(i).bits.cause.get)
     replay_req(i).bits.forwardDChannel.get := s1_replayCauses(LoadReplayCauses.C_DM)
     replay_req(i).bits.uncacheReplay.get := s1_replayCauses(LoadReplayCauses.C_UNCACHE)
@@ -764,7 +775,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     replay_req(i).bits.hasROBEntry := true.B
     replay_req(i).bits.missDbUpdated := s1_missDbUpdated
 
-    XSError(replay_req(i).fire && !allocated(s1_replayIdx), p"LoadQueueReplay: why replay an invalid entry ${s1_replayIdx} ?")
+    XSError(replay_req(i).fire && !allocated(s1_replayIdx(i)), p"LoadQueueReplay: why replay an invalid entry ${s1_replayIdx(i)} ?")
   }
 
   // update cold counter
@@ -795,7 +806,6 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
 
   val ffEnqNonblocking = Wire(Vec(LoadPipelineWidth, Bool()))
   for ((enq, w) <- io.enq.zipWithIndex) {
-    vaddrModule.io.wen(w) := false.B
     freeList.io.doAllocate(w) := false.B
 
     freeList.io.allocateReq(w) := true.B
@@ -866,10 +876,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       vecReplay(enqIndex).is_first_ele := enq.bits.is_first_ele
       vecReplay(enqIndex).mask         := enq.bits.mask
 
-      vaddrModule.io.wen(w)   := true.B
-      vaddrModule.io.waddr(w) := enqIndex
-      vaddrModule.io.wdata(w) := enq.bits.vaddr
-      debug_vaddr(enqIndex)   := enq.bits.vaddr
+      vaddr(enqIndex) := enq.bits.vaddr
 
       /**
        * used for feedback and replay
@@ -939,7 +946,6 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       }
     }
   }
-
   // misprediction recovery / exception redirect
   for (i <- 0 until LoadQueueReplaySize) {
     needCancel(i) := uop(i).robIdx.needFlush(io.redirect) && allocated(i)
@@ -962,7 +968,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       u.uop := uop(i)
     }
   }
-  val lq_match_vec = (debug_vaddr.zip(allocated)).map{case(va, alloc) => alloc && (va === robHeadVaddr.bits)}
+  val lq_match_vec = (vaddr.zip(allocated)).map{case(va, alloc) => alloc && (va === robHeadVaddr.bits)}
   val rob_head_lq_match = ParallelOperation(lq_match_vec.zip(uop_wrapper), (a: Tuple2[Bool, XSBundleWithMicroOp], b: Tuple2[Bool, XSBundleWithMicroOp]) => {
     val (a_v, a_uop) = (a._1, a._2)
     val (b_v, b_uop) = (b._1, b._2)
@@ -1165,7 +1171,11 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("replay_forward_fail", replayForwardFailCount)
   XSPerfAccumulate("replay_forward_fail_enq_nonblocking", replayForwardFailEnqNonblockingCount)
   XSPerfAccumulate("replay_dcache_miss", replayDCacheMissCount)
-  XSPerfAccumulate("replay_hint_wakeup", s0_hintSelValid)
+  val l2HintUnblockCount = PopCount(VecInit((0 until LoadQueueReplaySize).map(i =>
+    allocated(i) && cause(i)(LoadReplayCauses.C_DM) && l2HintHit(missMSHRId(i)) &&
+      l2HintSelectThisBeat(missMSHRId(i), dataInLastBeatReg(i))
+  )))
+  XSPerfAccumulate("replay_hint_wakeup", l2HintUnblockCount)
   XSPerfAccumulate("replay_hint_priority_beat1", PopCount(VecInit(l2Hint.map(hint => hint.valid && hint.bits.isKeyword))))
   XSPerfAccumulate("replay_storeQueue_multi_match", replayMultiMatchCount)
   XSPerfAccumulate("replay_store_addr_wakeup", storeAddrWakeupCount)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -209,6 +209,9 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val storeDataWakeup = Vec(StorePipelineWidth, Flipped(ValidIO(new IssueQueueLRQWakeUpBundle)))
     val storeDataWakeupCancel = Vec(StorePipelineWidth, Input(new LRQWakeUpCancelBundle))
 
+    // actual store data writes accepted by StoreQueue
+    val storeDataWrite = Vec(StorePipelineWidth, Flipped(ValidIO(new SqPtr)))
+
     // queue-based replay
     val replay = Vec(LoadPipelineWidth, Decoupled(new LoadReplayIO))
 
@@ -260,7 +263,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     numRead = LoadPipelineWidth,
     numWrite = LoadPipelineWidth,
     numWBank = LoadQueueNWriteBanks,
-    numWDelay = 2,
+    numWDelay = 1,
     numCamPort = 0))
   vaddrModule.io := DontCare
   val debug_vaddr = RegInit(VecInit(List.fill(LoadQueueReplaySize)(0.U(VAddrBits.W))))
@@ -297,6 +300,26 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val freeMaskVec = Wire(Vec(LoadQueueReplaySize, Bool()))
   // LoadQueueReplaySize * StorePipelineWidth
   val storeIssueScoreBoard = RegInit(VecInit(List.fill(LoadQueueReplaySize)(VecInit(List.fill(StorePipelineWidth)(0.U(LoadDependenceScoreBoardWidth.W))))))
+
+  // Replay now reaches the load pipeline one cycle earlier. Delay pulse wakeups locally so
+  // their producer data keeps the same alignment with the replayed load.
+  def delayWakeup[T <: Data](source: ValidIO[T]): ValidIO[T] = {
+    val delayed = Wire(Valid(chiselTypeOf(source.bits)))
+    delayed.valid := RegNext(source.valid, false.B)
+    delayed.bits := RegEnable(source.bits, source.valid)
+    delayed
+  }
+
+  val storeAddrWakeup = VecInit(io.storeAddrWakeup.map(delayWakeup(_)))
+  val storeDataWakeup = VecInit(io.storeDataWakeup.map(delayWakeup(_)))
+  val storeAddrWakeupCancel = VecInit(io.storeAddrWakeupCancel.map(cancel => RegNext(cancel, 0.U.asTypeOf(cancel))))
+  val storeDataWakeupCancel = VecInit(io.storeDataWakeupCancel.map(cancel => RegNext(cancel, 0.U.asTypeOf(cancel))))
+  val loadWakeup = VecInit(io.loadWakeup.map(delayWakeup(_)))
+  val loadWakeupPrev = VecInit(loadWakeup.map(delayWakeup(_)))
+  val tlbHintResp = delayWakeup(io.tlb_hint.resp)
+  val l2Hint = VecInit(io.l2_hint.map(delayWakeup(_)))
+  val mmioWakeup = delayWakeup(io.mmioWakeup)
+  val ncWakeup = delayWakeup(io.ncWakeup)
 
   /**
    * Enqueue
@@ -342,16 +365,16 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     !strict(i) && stAddrReadyVec(blockSqIdx(i).value) && blockSqIdx(i) < io.physicalUpperSqIdx || io.sqEmpty // for better timing
     // store address execute
     (0 until StorePipelineWidth).map(w => {
-      storeAddrWakeupVec(i)(w) := io.storeAddrWakeup(w).valid &&
-        io.storeAddrWakeup(w).bits.sqIdx.withInPhysicalQueue(io.sqDeqPtr) &&
-        blockSqIdx(i) === io.storeAddrWakeup(w).bits.sqIdx
+      storeAddrWakeupVec(i)(w) := storeAddrWakeup(w).valid &&
+        storeAddrWakeup(w).bits.sqIdx.withInPhysicalQueue(io.sqDeqPtr) &&
+        blockSqIdx(i) === storeAddrWakeup(w).bits.sqIdx
     })
     storeAddrInSameCycleVec(i) := storeAddrWakeupVec(i).asUInt.orR // for better timing
 
     // store data execute
     (0 until StorePipelineWidth).map(w => {
-      storeDataWakeupVec(i)(w) := io.storeDataWakeup(w).valid &&
-        blockSqIdx(i) === io.storeDataWakeup(w).bits.sqIdx
+      storeDataWakeupVec(i)(w) := storeDataWakeup(w).valid &&
+        blockSqIdx(i) === storeDataWakeup(w).bits.sqIdx
     })
     storeDataInSameCycleVec(i) := storeDataWakeupVec(i).asUInt.orR // for better timing
 
@@ -371,31 +394,22 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
 
   // mmio/nc issue check
   val lqIdxMatchMmio = VecInit((0 until LoadQueueReplaySize).map { i =>
-    io.mmioWakeup.valid && io.mmioWakeup.bits === uop(i).lqIdx
+    mmioWakeup.valid && mmioWakeup.bits === uop(i).lqIdx
   })
 
   val lqIdxMatchNc = VecInit((0 until LoadQueueReplaySize).map { i =>
-    io.ncWakeup.valid && io.ncWakeup.bits === uop(i).lqIdx
+    ncWakeup.valid && ncWakeup.bits === uop(i).lqIdx
   })
   private def tlDChannelHit(mshrId: UInt): Bool = {
-    VecInit(io.loadWakeup.map(ch => ch.valid && ch.bits.mshrId === mshrId)).asUInt.orR
+    VecInit(loadWakeup.map(ch => ch.valid && ch.bits.mshrId === mshrId)).asUInt.orR
   }
 
-  private val tlDChannelLastCycleValid = RegNext(
-    VecInit(io.loadWakeup.map(_.valid)),
-    0.U.asTypeOf(Vec(cfg.numMemChannels, Bool()))
-  )
-  private val tlDChannelLastCycleMshrId = RegNext(
-    VecInit(io.loadWakeup.map(_.bits.mshrId)),
-    0.U.asTypeOf(Vec(cfg.numMemChannels, UInt(log2Up(cfg.nMissEntries).W)))
-  )
-
-  private def tlDChannelHitLastCycle(mshrId: UInt): Bool = {
-    VecInit((0 until cfg.numMemChannels).map(i => tlDChannelLastCycleValid(i) && tlDChannelLastCycleMshrId(i) === mshrId)).asUInt.orR
+  private def tlDChannelHitPrev(mshrId: UInt): Bool = {
+    VecInit(loadWakeupPrev.map(ch => ch.valid && ch.bits.mshrId === mshrId)).asUInt.orR
   }
 
   private def l2HintMatchVec(mshrId: UInt): Seq[Bool] = {
-    io.l2_hint.map(hint => hint.valid && hint.bits.sourceId === mshrId)
+    l2Hint.map(hint => hint.valid && hint.bits.sourceId === mshrId)
   }
 
   private def l2HintHit(mshrId: UInt): Bool = {
@@ -405,16 +419,16 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   private def l2HintIsKeyword(mshrId: UInt): Bool = {
     val matchVec = l2HintMatchVec(mshrId)
     assert(PopCount(VecInit(matchVec)) <= 1.U, "multiple l2_hint hits for one replay entry")
-    Mux(VecInit(matchVec).asUInt.orR, Mux1H(matchVec.zip(io.l2_hint.map(_.bits.isKeyword))), false.B)
+    Mux(VecInit(matchVec).asUInt.orR, Mux1H(matchVec.zip(l2Hint.map(_.bits.isKeyword))), false.B)
   }
 
   val storeAddrWakeupCancelVec = VecInit((0 until LoadQueueReplaySize).map(i =>
     allocated(i) && cause(i)(LoadReplayCauses.C_MA) &&
-      StoreWakeupShouldCancel(storeIssueScoreBoard(i), io.storeAddrWakeupCancel, isStd = false)
+      StoreWakeupShouldCancel(storeIssueScoreBoard(i), storeAddrWakeupCancel, isStd = false)
   ))
   val storeDataWakeupCancelVec = VecInit((0 until LoadQueueReplaySize).map(i =>
     allocated(i) && cause(i)(LoadReplayCauses.C_FF) &&
-      StoreWakeupShouldCancel(storeIssueScoreBoard(i), io.storeDataWakeupCancel, isStd = true)
+      StoreWakeupShouldCancel(storeIssueScoreBoard(i), storeDataWakeupCancel, isStd = true)
   ))
   val storeAddrWakeupCount = PopCount((0 until LoadQueueReplaySize).map(i => storeAddrWakeupVec(i).asUInt.orR && allocated(i)))
   val storeDataWakeupCount = PopCount((0 until LoadQueueReplaySize).map(i => storeDataWakeupVec(i).asUInt.orR && allocated(i)))
@@ -427,9 +441,9 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     }
     // case C_TM
     when (cause(i)(LoadReplayCauses.C_TM)) {
-      blocking(i) := Mux(io.tlb_hint.resp.valid &&
-                     (io.tlb_hint.resp.bits.replay_all ||
-                     io.tlb_hint.resp.bits.id === tlbHintId(i)), false.B, blocking(i))
+      blocking(i) := Mux(tlbHintResp.valid &&
+                     (tlbHintResp.bits.replay_all ||
+                     tlbHintResp.bits.id === tlbHintId(i)), false.B, blocking(i))
     }
     // case C_FF
     when (cause(i)(LoadReplayCauses.C_FF)) {
@@ -490,7 +504,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       XSError(allocated(i) && cause(i)(LoadReplayCauses.C_FF) && PopCount(storeDataWakeupVec(i)) > 1.U, s"storeDataWakeup source exceed 1! ${i}\n")
   }
 
-  //  Replay is splitted into 3 stages
+  // Replay is split into selection and request stages.
   require((LoadQueueReplaySize % LoadPipelineWidth) == 0)
   def getRemBits(input: UInt)(rem: Int): UInt = {
     VecInit((0 until LoadQueueReplaySize / LoadPipelineWidth).map(i => { input(LoadPipelineWidth * i + rem) })).asUInt
@@ -500,12 +514,10 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     (0 until LoadQueueReplaySize / LoadPipelineWidth).map(i => { input(LoadPipelineWidth * i + rem) })
   }
 
-  // stage1: select 2 entries and read their vaddr
+  // stage 0: select entries and start reading their vaddr
   val s0_oldestSel = Wire(Vec(LoadPipelineWidth, Valid(UInt(LoadQueueReplaySize.W))))
   val s1_can_go = Wire(Vec(LoadPipelineWidth, Bool()))
   val s1_oldestSel = Wire(Vec(LoadPipelineWidth, Valid(UInt(log2Up(LoadQueueReplaySize + 1).W))))
-  val s2_can_go = Wire(Vec(LoadPipelineWidth, Bool()))
-  val s2_oldestSel = Wire(Vec(LoadPipelineWidth, Valid(UInt(log2Up(LoadQueueReplaySize + 1).W))))
 
   // generate mask
   val needCancel = Wire(Vec(LoadQueueReplaySize, Bool()))
@@ -627,7 +639,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     oldest
   }))
 
-  // stage2: send replay request to load unit
+  // stage 1: hold and send the replay request to the load unit
   // replay cold down
   val ColdDownCycles = 16
   val coldCounter = RegInit(VecInit(List.fill(LoadPipelineWidth)(0.U(log2Up(ColdDownCycles).W))))
@@ -640,7 +652,6 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
 
   val replay_req = io.replay
   val s1_cancelReplay = Wire(Vec(LoadPipelineWidth, Bool()))
-  val s2_cancelReplay = Wire(Vec(LoadPipelineWidth, Bool()))
 
   for (i <- 0 until LoadPipelineWidth) {
     val s0_can_go = s1_can_go(i) ||
@@ -651,6 +662,8 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val s0_oldestSelV = s0_oldestSel(i).valid
     s1_oldestSel(i).valid := RegEnable(s0_oldestSelV, false.B, s0_can_go)
     s1_oldestSel(i).bits := RegEnable(OHToUInt(s0_oldestSel(i).bits), s0_can_go)
+    vaddrModule.io.ren(i) := s0_can_go && s0_oldestSelV
+    vaddrModule.io.raddr(i) := OHToUInt(s0_oldestSel(i).bits)
 
     for (j <- 0 until LoadQueueReplaySize) {
       when (s0_can_go && s0_oldestSelV && s0_oldestSelIndexOH(j)) {
@@ -663,65 +676,53 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val s1_redirectCancel = uop(s1_replayIdx).robIdx.needFlush(io.redirect) ||
       uop(s1_replayIdx).robIdx.needFlush(RegNext(io.redirect))
     s1_cancelReplay(i) := s1_redirectCancel
-    val s1_oldestSelV = s1_oldestSel(i).valid && !s1_cancelReplay(i)
-    s1_can_go(i)          := replayCanFire(i) && (!s2_oldestSel(i).valid || replay_req(i).fire) || s2_cancelReplay(i)
-    s2_oldestSel(i).valid := RegEnable(Mux(s1_can_go(i), s1_oldestSelV, false.B), false.B, (s1_can_go(i) || replay_req(i).fire))
-    s2_oldestSel(i).bits  := RegEnable(s1_oldestSel(i).bits, s1_can_go(i))
+    s1_can_go(i) := replayCanFire(i) && (!s1_oldestSel(i).valid || replay_req(i).fire) || s1_cancelReplay(i)
 
-    vaddrModule.io.ren(i) := s1_oldestSelV && s1_can_go(i)
-    vaddrModule.io.raddr(i) := s1_replayIdx
-  }
-
-  for (i <- 0 until LoadPipelineWidth) {
-    val s1_replayIdx = s1_oldestSel(i).bits
-    val s2_replayUop = RegEnable(uop(s1_replayIdx), s1_can_go(i))
-    val s2_nc      = RegEnable(isNC(s1_replayIdx), s1_can_go(i))
-    val s2_vecReplay = RegEnable(vecReplay(s1_replayIdx), s1_can_go(i))
-    val s2_replayMSHRId = RegEnable(missMSHRId(s1_replayIdx), s1_can_go(i))
-    val s2_missDbUpdated = RegEnable(missDbUpdated(s1_replayIdx), s1_can_go(i))
-    val s2_replayCauses = RegEnable(cause(s1_replayIdx), s1_can_go(i))
-    s2_cancelReplay(i) := s2_replayUop.robIdx.needFlush(io.redirect)
-
-    s2_can_go(i) := DontCare
+    val s1_replayUop = uop(s1_replayIdx)
+    val s1_nc = isNC(s1_replayIdx)
+    val s1_vecReplay = vecReplay(s1_replayIdx)
+    val s1_replayMSHRId = missMSHRId(s1_replayIdx)
+    val s1_missDbUpdated = missDbUpdated(s1_replayIdx)
+    val s1_replayCauses = cause(s1_replayIdx)
     val replay_req_vaddr = vaddrModule.io.rdata(i)
-    val replay_req_size = LSUOpType.size(s2_replayUop.fuOpType)
-    replay_req(i).valid := s2_oldestSel(i).valid && !s2_cancelReplay(i)
+    val replay_req_size = LSUOpType.size(s1_replayUop.fuOpType)
+    replay_req(i).valid := s1_oldestSel(i).valid && !s1_cancelReplay(i)
     replay_req(i).bits.entrance := Mux(
-      s2_replayCauses(LoadReplayCauses.C_DM) || s2_replayCauses(LoadReplayCauses.C_UNCACHE),
+      s1_replayCauses(LoadReplayCauses.C_DM) || s1_replayCauses(LoadReplayCauses.C_UNCACHE),
       LoadEntrance.replayHiPrio.U,
       LoadEntrance.replayLoPrio.U
     )
-    replay_req(i).bits.accessType.instrType := Mux(s2_vecReplay.isvec, InstrType.vector.U, InstrType.scalar.U)
+    replay_req(i).bits.accessType.instrType := Mux(s1_vecReplay.isvec, InstrType.vector.U, InstrType.scalar.U)
     replay_req(i).bits.accessType.pftType := DontCare
     replay_req(i).bits.accessType.pftCoh := DontCare
-    replay_req(i).bits.uop := s2_replayUop
+    replay_req(i).bits.uop := s1_replayUop
     replay_req(i).bits.uop.exceptionVec(loadAddrMisaligned) := false.B
     replay_req(i).bits.vaddr := replay_req_vaddr
     replay_req(i).bits.fullva := replay_req_vaddr
-    replay_req(i).bits.size := Mux(s2_vecReplay.isvec, s2_vecReplay.alignedType, replay_req_size)
+    replay_req(i).bits.size := Mux(s1_vecReplay.isvec, s1_vecReplay.alignedType, replay_req_size)
     replay_req(i).bits.mask := Mux(
-      s2_vecReplay.isvec,
-      s2_vecReplay.mask,
+      s1_vecReplay.isvec,
+      s1_vecReplay.mask,
       genVWmask(replay_req_vaddr, replay_req_size)
     )
     replay_req(i).bits.occupySource := DontCare
-    replay_req(i).bits.mshrId.get := s2_replayMSHRId
-    replay_req(i).bits.replayQueueIdx.get := s2_oldestSel(i).bits
-    replay_req(i).bits.cause.get := s2_replayCauses.asTypeOf(replay_req(i).bits.cause.get)
-    replay_req(i).bits.forwardDChannel.get := s2_replayCauses(LoadReplayCauses.C_DM)
-    replay_req(i).bits.uncacheReplay.get := s2_replayCauses(LoadReplayCauses.C_UNCACHE)
-    replay_req(i).bits.ncReplay.get := s2_replayCauses(LoadReplayCauses.C_UNCACHE) && s2_nc
-    replay_req(i).bits.elemIdx.get := s2_vecReplay.elemIdx
-    replay_req(i).bits.mbIndex.get := s2_vecReplay.mbIndex
-    replay_req(i).bits.regOffset.get := s2_vecReplay.reg_offset
-    replay_req(i).bits.elemIdxInsideVd.get := s2_vecReplay.elemIdxInsideVd
+    replay_req(i).bits.mshrId.get := s1_replayMSHRId
+    replay_req(i).bits.replayQueueIdx.get := s1_replayIdx
+    replay_req(i).bits.cause.get := s1_replayCauses.asTypeOf(replay_req(i).bits.cause.get)
+    replay_req(i).bits.forwardDChannel.get := s1_replayCauses(LoadReplayCauses.C_DM)
+    replay_req(i).bits.uncacheReplay.get := s1_replayCauses(LoadReplayCauses.C_UNCACHE)
+    replay_req(i).bits.ncReplay.get := s1_replayCauses(LoadReplayCauses.C_UNCACHE) && s1_nc
+    replay_req(i).bits.elemIdx.get := s1_vecReplay.elemIdx
+    replay_req(i).bits.mbIndex.get := s1_vecReplay.mbIndex
+    replay_req(i).bits.regOffset.get := s1_vecReplay.reg_offset
+    replay_req(i).bits.elemIdxInsideVd.get := s1_vecReplay.elemIdxInsideVd
     replay_req(i).bits.vecBaseVaddr.get := DontCare
     replay_req(i).bits.vecVaddrOffset.get := DontCare
     replay_req(i).bits.vecTriggerMask.get := DontCare
     replay_req(i).bits.hasROBEntry := true.B
-    replay_req(i).bits.missDbUpdated := s2_missDbUpdated
+    replay_req(i).bits.missDbUpdated := s1_missDbUpdated
 
-    XSError(replay_req(i).fire && !allocated(s2_oldestSel(i).bits), p"LoadQueueReplay: why replay an invalid entry ${s2_oldestSel(i).bits} ?")
+    XSError(replay_req(i).fire && !allocated(s1_replayIdx), p"LoadQueueReplay: why replay an invalid entry ${s1_replayIdx} ?")
   }
 
   // update cold counter
@@ -750,6 +751,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       newEnq := needEnq && !enq.bits.isLoadReplay
   }
 
+  val ffEnqNonblocking = Wire(Vec(LoadPipelineWidth, Bool()))
   for ((enq, w) <- io.enq.zipWithIndex) {
     vaddrModule.io.wen(w) := false.B
     freeList.io.doAllocate(w) := false.B
@@ -774,6 +776,16 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val isFF = replayInfo.cause(LoadReplayCauses.C_FF)
     val isRAW = replayInfo.cause(LoadReplayCauses.C_RAW)
     val isSMF = replayInfo.cause(LoadReplayCauses.C_SMF)
+    val ffWaitSqIdx = replayInfo.data_inv_sq_idx
+    val ffWakeupMatch = VecInit(storeDataWakeup.map { wakeup =>
+      wakeup.valid && wakeup.bits.sqIdx === ffWaitSqIdx
+    }).asUInt.orR
+    val ffStoreWriteMatch = VecInit(io.storeDataWrite.map { write =>
+      write.valid && write.bits === ffWaitSqIdx
+    }).asUInt.orR
+    val ffProducerReadyNow = ffWakeupMatch || ffStoreWriteMatch
+    val ffEnqAccepted = enqFireBase && replayInfo.need_rep && isFF
+    ffEnqNonblocking(w) := ffEnqAccepted && ffProducerReadyNow
     val nextBlockSqIdx = Mux(isMA, replayInfo.addr_inv_sq_idx,
     Mux(isFF, replayInfo.data_inv_sq_idx, enq.bits.uop.sqIdx))
 
@@ -842,18 +854,21 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       // special case: tlb miss
       when (replayInfo.cause(LoadReplayCauses.C_TM)) {
         blocking(enqIndex) := !replayInfo.tlb_full &&
-          !(io.tlb_hint.resp.valid && (io.tlb_hint.resp.bits.id === replayInfo.tlb_id || io.tlb_hint.resp.bits.replay_all))
+          !(tlbHintResp.valid && (tlbHintResp.bits.id === replayInfo.tlb_id || tlbHintResp.bits.replay_all))
         tlbHintId(enqIndex) := replayInfo.tlb_id
       }
 
       // special case: dcache miss
       when (replayInfo.cause(LoadReplayCauses.C_DM) && enq.bits.handledByMSHR) {
         val tlDHitThisCycle = tlDChannelHit(replayInfo.mshr_id)
-        val tlDHitLastCycle = tlDChannelHitLastCycle(replayInfo.mshr_id)
+        val tlDHitPrevCycle = tlDChannelHitPrev(replayInfo.mshr_id)
         blocking(enqIndex) := !replayInfo.full_fwd && //  dcache miss
                               !tlDHitThisCycle && // no refill in this cycle
-                              !tlDHitLastCycle // not refill in last cycle
+                              !tlDHitPrevCycle // not refill in last cycle
+      }
 
+      when (isFF) {
+        blocking(enqIndex) := !ffProducerReadyNow
       }
 
       // extra info
@@ -954,6 +969,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val replayForwardFailCount  = PopCount(io.enq.map(enq => enq.fire && !enq.bits.isLoadReplay && enq.bits.rep_info.cause(LoadReplayCauses.C_FF)))
   val replayDCacheMissCount   = PopCount(io.enq.map(enq => enq.fire && !enq.bits.isLoadReplay && enq.bits.rep_info.cause(LoadReplayCauses.C_DM)))
   val replayMultiMatchCount   = PopCount(io.enq.map(enq => enq.fire && !enq.bits.isLoadReplay && enq.bits.rep_info.cause(LoadReplayCauses.C_SMF)))
+  val replayForwardFailEnqNonblockingCount = PopCount(ffEnqNonblocking)
   val replayStoreAddrWakeupCancelCount = PopCount(storeAddrWakeupCancelVec)
   val replayStoreDataWakeupCancelCount = PopCount(storeDataWakeupCancelVec)
   def storeIssueScoreBoardDelay3(idx: UInt): Bool = {
@@ -981,9 +997,10 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   XSPerfAccumulate("replay_bank_conflict", replayBankConflictCount)
   XSPerfAccumulate("replay_dcache_replay", replayDCacheReplayCount)
   XSPerfAccumulate("replay_forward_fail", replayForwardFailCount)
+  XSPerfAccumulate("replay_forward_fail_enq_nonblocking", replayForwardFailEnqNonblockingCount)
   XSPerfAccumulate("replay_dcache_miss", replayDCacheMissCount)
   XSPerfAccumulate("replay_hint_wakeup", s0_hintSelValid)
-  XSPerfAccumulate("replay_hint_priority_beat1", PopCount(VecInit(io.l2_hint.map(hint => hint.valid && hint.bits.isKeyword))))
+  XSPerfAccumulate("replay_hint_priority_beat1", PopCount(VecInit(l2Hint.map(hint => hint.valid && hint.bits.isKeyword))))
   XSPerfAccumulate("replay_storeQueue_multi_match", replayMultiMatchCount)
   XSPerfAccumulate("replay_store_addr_wakeup", storeAddrWakeupCount)
   XSPerfAccumulate("replay_store_data_wakeup", storeDataWakeupCount)

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -236,6 +236,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     val rawFull = Input(Bool())
     val l2_hint  = Input(Vec(cfg.numMemChannels, Valid(new L2ToL1Hint())))
     val tlb_hint = Flipped(new TlbHintIO)
+    val fast_tlb_hint = Flipped(ValidIO(new TLBHintResp))
     val tlbReplayDelayCycleCtrl = Vec(4, Input(UInt(ReSelectLen.W)))
 
     val debugTopDown = new LoadQueueTopDownIO
@@ -316,6 +317,8 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val storeDataWakeupCancel = VecInit(io.storeDataWakeupCancel.map(cancel => RegNext(cancel, 0.U.asTypeOf(cancel))))
   val loadWakeup = VecInit(io.loadWakeup.map(delayWakeup(_)))
   val loadWakeupPrev = VecInit(loadWakeup.map(delayWakeup(_)))
+  // Fast hint selects C_TM replays directly. The delayed original hint remains the fallback.
+  val fastTlbHintResp = io.fast_tlb_hint
   val tlbHintResp = delayWakeup(io.tlb_hint.resp)
   val l2Hint = VecInit(io.l2_hint.map(delayWakeup(_)))
   val mmioWakeup = delayWakeup(io.mmioWakeup)
@@ -536,6 +539,10 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val s0_loadHintWakeMask = VecInit((0 until LoadQueueReplaySize).map(i => {
     allocated(i) && !scheduled(i) && cause(i)(LoadReplayCauses.C_DM) && blocking(i) && l2HintHit(missMSHRId(i))
   })).asUInt
+  val s0_tlbHintWakeMask = VecInit((0 until LoadQueueReplaySize).map(i => {
+    allocated(i) && !scheduled(i) && cause(i)(LoadReplayCauses.C_TM) && blocking(i) &&
+      fastTlbHintResp.valid && fastTlbHintResp.bits.id === tlbHintId(i)
+  })).asUInt
   // l2 will send 2 beats data in 2 cycles, so if data needed by this load is in first beat, select it this cycle, otherwise next cycle
   // when isKeyword = 1, s0_loadHintSelMask need overturn
     val s0_loadHintSelMask = VecInit((0 until LoadQueueReplaySize).map(i => {
@@ -554,6 +561,9 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
     when(s0_loadHintWakeMask(i)) {
       blocking(i) := false.B
     }
+    when(s0_tlbHintWakeMask(i)) {
+      blocking(i) := false.B
+    }
   })
 
   // generate replay mask
@@ -568,7 +578,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val s0_remLoadHigherPriorityReplaySelMask = VecInit((0 until LoadPipelineWidth).map(rem => getRemBits(s0_loadHigherPriorityReplaySelMask)(rem)))
   val s0_loadLowerPriorityReplaySelMask = VecInit((0 until LoadQueueReplaySize).map(i => {
     val hasLowerPriority = !cause(i)(LoadReplayCauses.C_DM) && !cause(i)(LoadReplayCauses.C_FF)
-    allocated(i) && !scheduled(i) && !blocking(i) && hasLowerPriority
+    allocated(i) && !scheduled(i) && (!blocking(i) || s0_tlbHintWakeMask(i)) && hasLowerPriority
   })).asUInt // use uint instead vec to reduce verilog lines
   val s0_remLoadLowerPriorityReplaySelMask = VecInit((0 until LoadPipelineWidth).map(rem => getRemBits(s0_loadLowerPriorityReplaySelMask)(rem)))
   val s0_loadNormalReplaySelMask = s0_loadLowerPriorityReplaySelMask | s0_loadHigherPriorityReplaySelMask | s0_loadHintSelMask
@@ -855,6 +865,9 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       when (replayInfo.cause(LoadReplayCauses.C_TM)) {
         blocking(enqIndex) := !replayInfo.tlb_full &&
           !(tlbHintResp.valid && (tlbHintResp.bits.id === replayInfo.tlb_id || tlbHintResp.bits.replay_all))
+        when (fastTlbHintResp.valid && fastTlbHintResp.bits.id === replayInfo.tlb_id) {
+          blocking(enqIndex) := false.B
+        }
         tlbHintId(enqIndex) := replayInfo.tlb_id
       }
 

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -22,6 +22,7 @@ import utility._
 import xiangshan._
 import xiangshan.ExceptionNO._
 import xiangshan.backend.Bundles.{DynInst, ExuOutput, MemExuOutput, IssueQueueLRQWakeUpBundle}
+import xiangshan.backend.rob.RobPtr
 import xiangshan.mem.Bundles._
 import xiangshan.cache._
 import xiangshan.cache.wpu.ReplayCarry
@@ -70,6 +71,27 @@ object LoadReplayCauses {
   val C_MF  = 12
   // total causes
   val allCauses = 13
+
+  private val perfCauseNameMap = Seq(
+    C_UNCACHE -> "uncache",
+    C_SMF -> "storeQueue_multi_match",
+    C_MA -> "mem_amb",
+    C_TM -> "tlb_miss",
+    C_FF -> "forward_fail",
+    C_DR -> "dcache_replay",
+    C_DM -> "dcache_miss",
+    C_WF -> "wpu_fail",
+    C_BC -> "bank_conflict",
+    C_RAR -> "rar_nack",
+    C_RAW -> "raw_nack",
+    C_NK -> "nuke",
+    C_MF -> "misalign_buffer_full"
+  )
+  require(perfCauseNameMap.map(_._1).distinct.size == allCauses)
+  require(perfCauseNameMap.map(_._1).sorted == (0 until allCauses))
+  require(perfCauseNameMap.map(_._2).distinct.size == allCauses)
+
+  val perfCauseNames: Seq[String] = perfCauseNameMap.sortBy(_._1).map(_._2)
 }
 
 class VecReplayInfo(implicit p: Parameters) extends XSBundle with HasVLSUParameters {
@@ -197,6 +219,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val io = IO(new Bundle() {
     // control
     val redirect = Flipped(ValidIO(new Redirect))
+    val robHeadPtr = Input(new RobPtr)
 
     // from load unit s3
     val enq = Vec(LoadPipelineWidth, Flipped(Decoupled(new LqWriteBundle)))
@@ -271,6 +294,10 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val cause = RegInit(VecInit(List.fill(LoadQueueReplaySize)(0.U(LoadReplayCauses.allCauses.W))))
   val blocking = RegInit(VecInit(List.fill(LoadQueueReplaySize)(false.B)))
   val strict = RegInit(VecInit(List.fill(LoadQueueReplaySize)(false.B)))
+  // Saturating residence timer for each LRQ entry. It covers the whole lifetime from the
+  // first allocation to normal release; re-replay and cause updates do not restart it.
+  private val replayResidenceWidth = 16
+  val replayResidenceCycles = RegInit(VecInit(List.fill(LoadQueueReplaySize)(0.U(replayResidenceWidth.W))))
 
   // freeliset: store valid entries index.
   // +---+---+--------------+-----+-----+
@@ -670,7 +697,12 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
                     uop(s1_oldestSel(i).bits).robIdx.needFlush(RegNext(io.redirect))
     val s0_oldestSelIndexOH = s0_oldestSel(i).bits // one-hot
     val s0_oldestSelV = s0_oldestSel(i).valid
-    s1_oldestSel(i).valid := RegEnable(s0_oldestSelV, false.B, s0_can_go)
+    // A fired request must leave s1 even when cooldown prevents accepting another selection.
+    s1_oldestSel(i).valid := RegEnable(
+      Mux(s0_can_go, s0_oldestSelV, false.B),
+      false.B,
+      s0_can_go || replay_req(i).fire
+    )
     s1_oldestSel(i).bits := RegEnable(OHToUInt(s0_oldestSel(i).bits), s0_can_go)
     vaddrModule.io.ren(i) := s0_can_go && s0_oldestSelV
     vaddrModule.io.raddr(i) := OHToUInt(s0_oldestSel(i).bits)
@@ -952,7 +984,6 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val rob_head_confilct_replay = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_BC)
   val rob_head_forward_fail    = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_FF)
   val rob_head_mshrfull_replay = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_DR)
-  val rob_head_dcache_miss     = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_DM)
   val rob_head_rar_nack        = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_RAR)
   val rob_head_raw_nack        = lq_match && cause(lq_match_idx)(LoadReplayCauses.C_RAW)
   val rob_head_other_replay    = lq_match && (rob_head_rar_nack || rob_head_raw_nack || rob_head_forward_fail)
@@ -969,6 +1000,128 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val perfValidCount = RegNext(PopCount(allocated))
 
   //  perf cnt
+  val normalRelease = VecInit(io.enq.zipWithIndex.map { case (enq, w) =>
+    val schedIndex = enq.bits.schedIndex
+    enq.fire && !cancelEnq(w) && enq.bits.isLoadReplay && !needReplay(w) && allocated(schedIndex)
+  })
+  // Entry-level release mask. Besides aggregating releases across load pipelines, it keeps
+  // the release cycle out of both the residence timer and the ROB-head occupancy count.
+  val normalReleaseOH = VecInit((0 until LoadQueueReplaySize).map { entryIdx =>
+    VecInit(io.enq.zip(normalRelease).map { case (enq, release) =>
+      release && enq.bits.schedIndex === entryIdx.U
+    }).asUInt.orR
+  })
+  val newAllocate = VecInit(newEnqueue.zip(io.enq).map { case (newEnq, enq) =>
+    newEnq && enq.fire
+  })
+  val newAllocateOH = VecInit((0 until LoadQueueReplaySize).map { entryIdx =>
+    VecInit(newAllocate.zip(enqIndexOH).map { case (allocate, indexOH) =>
+      allocate && indexOH(entryIdx)
+    }).asUInt.orR
+  })
+
+  val replayResidenceMax = ((1 << replayResidenceWidth) - 1).U(replayResidenceWidth.W)
+  // Reset only for a newly allocated entry. Redirect/cancel stops the timer without creating
+  // a latency sample, while a live entry saturates at replayResidenceMax instead of wrapping.
+  replayResidenceCycles.zipWithIndex.foreach { case (timer, entryIdx) =>
+    when (newAllocateOH(entryIdx)) {
+      timer := 0.U
+    }.elsewhen (allocated(entryIdx) && !normalReleaseOH(entryIdx) && !needCancel(entryIdx)) {
+      when (timer =/= replayResidenceMax) {
+        timer := timer + 1.U
+      }
+    }
+  }
+
+  val releaseTimers = VecInit(io.enq.map(enq => replayResidenceCycles(enq.bits.schedIndex)))
+  // The timer contains completed cycles before the current cycle, so add the normal-release
+  // cycle to obtain T_release - T_enq. If the timer already reached the maximum, the exact
+  // latency is larger than the representable value and this release sample is an overflow.
+  val releaseLatencies = VecInit(releaseTimers.map { timer =>
+    Mux(timer === replayResidenceMax, replayResidenceMax, timer + 1.U)
+  })
+  // Attribute each normal release to the entry's final one-hot cause. The per-cause reductions
+  // preserve multiple releases in the same cycle by summing across all load pipelines.
+  val releaseCauseEvents = (0 until LoadReplayCauses.allCauses).map { causeIdx =>
+    VecInit(io.enq.zipWithIndex.map { case (enq, w) =>
+      normalRelease(w) && cause(enq.bits.schedIndex)(causeIdx)
+    })
+  }
+  val releaseCauseCounts = releaseCauseEvents.map(PopCount(_))
+  val releaseCauseLatencies = releaseCauseEvents.map { events =>
+    events.zip(releaseLatencies).map { case (event, latency) =>
+      Mux(event, latency, 0.U(replayResidenceWidth.W))
+    }.reduce(_ +& _)
+  }
+  // Count released samples whose exact latency exceeded replayResidenceMax. This is a sample
+  // count, not the number of cycles beyond the representable range.
+  val releaseCauseOverflowCounts = releaseCauseEvents.map { events =>
+    PopCount(events.zip(releaseTimers).map { case (event, timer) =>
+      event && timer === replayResidenceMax
+    })
+  }
+
+  val scalarRobHeadRelease = VecInit(io.enq.zipWithIndex.map { case (enq, w) =>
+    val schedIndex = enq.bits.schedIndex
+    normalRelease(w) && !vecReplay(schedIndex).isvec && uop(schedIndex).robIdx === io.robHeadPtr
+  })
+  val robHeadReleaseCauseEvents = (0 until LoadReplayCauses.allCauses).map { causeIdx =>
+    VecInit(io.enq.zipWithIndex.map { case (enq, w) =>
+      val schedIndex = enq.bits.schedIndex
+      scalarRobHeadRelease(w) && cause(schedIndex)(causeIdx)
+    })
+  }
+  val robHeadReleaseCauseCounts = robHeadReleaseCauseEvents.map(PopCount(_))
+  // Count unreleased scalar ROB-head occupancy using the current cause. Cancel and normal-release
+  // cycles are excluded. The OR reduction limits each cause to at most one increment per cycle.
+  val scalarUnreleasedRobHeadEntries = VecInit((0 until LoadQueueReplaySize).map { entryIdx =>
+    allocated(entryIdx) &&
+      !vecReplay(entryIdx).isvec &&
+      uop(entryIdx).robIdx === io.robHeadPtr &&
+      !needCancel(entryIdx) &&
+      !normalReleaseOH(entryIdx)
+  })
+  val scalarUnreleasedRobHeadByCause = (0 until LoadReplayCauses.allCauses).map { causeIdx =>
+    VecInit((0 until LoadQueueReplaySize).map { entryIdx =>
+      scalarUnreleasedRobHeadEntries(entryIdx) && cause(entryIdx)(causeIdx)
+    }).asUInt.orR
+  }
+
+  io.enq.zipWithIndex.foreach { case (enq, w) =>
+    val schedIndex = enq.bits.schedIndex
+    when (normalRelease(w)) {
+      assert(PopCount(cause(schedIndex)) === 1.U, "released replay entry cause must be one-hot")
+    }
+  }
+  for (i <- 0 until LoadPipelineWidth; j <- i + 1 until LoadPipelineWidth) {
+    assert(!(normalRelease(i) && normalRelease(j) &&
+      io.enq(i).bits.schedIndex === io.enq(j).bits.schedIndex),
+      "a replay entry must not be released by multiple ports")
+  }
+  assert(robHeadReleaseCauseCounts.reduce(_ +& _) === PopCount(scalarRobHeadRelease),
+    "replay cause increments must equal scalar ROB-head releases")
+  XSError(releaseCauseCounts.reduce(_ +& _) =/= PopCount(normalRelease),
+    "release cause increments must equal normal replay releases\n")
+  XSError(PopCount(normalReleaseOH) =/= PopCount(normalRelease),
+    "normal release entry mask must preserve the release count\n")
+  XSError(releaseCauseOverflowCounts.reduce(_ +& _) > PopCount(normalRelease),
+    "overflow release samples must not exceed normal replay releases\n")
+
+  // event counters
+  LoadReplayCauses.perfCauseNames.zip(robHeadReleaseCauseCounts).foreach { case (causeName, count) =>
+    XSPerfAccumulate(s"replay_${causeName}_scalar_release_rob_head", count)
+  }
+
+  // slot counters
+  // Offline average residence latency is release_latency_cycles / release_count. Overflow count
+  // reports how many released samples exceeded the representable latency.
+  LoadReplayCauses.perfCauseNames.zipWithIndex.foreach { case (causeName, causeIdx) =>
+    XSPerfAccumulate(s"replay_${causeName}_release_latency_cycles", releaseCauseLatencies(causeIdx))
+    XSPerfAccumulate(s"replay_${causeName}_release_count", releaseCauseCounts(causeIdx))
+    XSPerfAccumulate(s"replay_${causeName}_release_latency_overflow_count", releaseCauseOverflowCounts(causeIdx))
+    XSPerfAccumulate(s"replay_${causeName}_scalar_rob_head_blocked_cycles", scalarUnreleasedRobHeadByCause(causeIdx))
+  }
+
   val enqNumber               = PopCount(io.enq.map(enq => enq.fire && !enq.bits.isLoadReplay))
   val deqNumber               = PopCount(io.replay.map(_.fire))
   val deqBlockCount           = PopCount(io.replay.map(r => r.valid && !r.ready))

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueUncache.scala
@@ -233,10 +233,10 @@ class UncacheEntry(entryIndex: Int)(implicit p: Parameters) extends XSModule
   io.mmioWakeup.valid := uncacheState === s_wakeup && req.mmio && !needFlush && !needFlushReg
   io.mmioWakeup.bits := req.uop.lqIdx
 
-  io.exception.valid := writeback
-  io.exception.bits := req
-  io.exception.bits.uop.exceptionVec(loadAccessFault) := nderr
-  io.exception.bits.uop.exceptionVec(hardwareError) := derr
+  io.exception.valid := RegNext(writeback)
+  io.exception.bits := RegEnable(req, writeback)
+  io.exception.bits.uop.exceptionVec(loadAccessFault) := RegEnable(nderr, writeback)
+  io.exception.bits.uop.exceptionVec(hardwareError) := RegEnable(derr, writeback)
 
   /* debug log */
   XSDebug(io.uncache.req.fire,

--- a/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
@@ -831,7 +831,7 @@ abstract class PhysicalStoreQueueBase(implicit p: Parameters) extends LSQModule 
       val sqDeqCnt        = Output(UInt(log2Ceil(EnsbufferWidth + 1).W))
       val rdataPtrExt     = Input(Vec(EnsbufferWidth, new SqPtr))
       val deqPtrExt       = Input(Vec(EnsbufferWidth, new SqPtr))
-      val validCnt        = Input(UInt(log2Ceil(StoreQueuePhysicalSize + 1).W))
+      val validCnt        = Input(UInt(log2Ceil(StoreQueueSize + 1).W))
       val fromVirtualStoreQueue = Flipped(new VirtualStoreQueueToPhysicalQueueIO(PhysicalQueuePtr))
       val fromUnalignQueue = Flipped(DecoupledIO(new Bundle {
         val paddr         = UInt(PAddrBits.W)
@@ -1568,7 +1568,7 @@ abstract class PhysicalStoreQueueBase(implicit p: Parameters) extends LSQModule 
   deqModule.io.fromUnalignQueue <> unalignQueue.io.toDeqModule
   deqModule.io.deqPtrExt        := deqPtrExt
   deqModule.io.rdataPtrExt      := rdataPtrExt
-  deqModule.io.validCnt         := validCount
+  deqModule.io.validCnt         := virtualValidCount
   io.exceptionInfo              := deqModule.io.exceptionInfo
 
   // unalignQueue connection

--- a/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/VirtualLoadQueue.scala
@@ -137,7 +137,7 @@ class VirtualLoadQueue(implicit p: Parameters) extends XSModule
   // make chisel happy
   val deqCountMask = Wire(UInt(DeqPtrMoveStride.W))
   deqCountMask := deqLookup.asUInt & (~deqInSameRedirectCycle.asUInt).asUInt
-  val commitCount = PopCount(PriorityEncoderOH(~deqCountMask) - 1.U)
+  val commitCount = PriorityEncoder(true.B ## ~deqCountMask)
   val lastCommitCount = GatedRegNext(commitCount)
 
   // update deqPtr

--- a/src/main/scala/xiangshan/mem/pipeline/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/Bundles.scala
@@ -233,6 +233,11 @@ class VectorLoadIn(implicit p: Parameters)
 class LoadStageIO(implicit p: Parameters, implicit val s: LoadStage)
   extends LoadPipeBundle(LoadStageIOParam())
 
+class StdDataWriteWindow(numStdPorts: Int)(implicit p: Parameters) extends XSBundle {
+  val current = Vec(numStdPorts, Valid(new SqPtr))
+  val previous = Vec(numStdPorts, Valid(new SqPtr))
+}
+
 sealed trait HasStorePipeBundleParam {
   def hasVector: Boolean = false
   def hasStoreSet: Boolean = false

--- a/src/main/scala/xiangshan/mem/pipeline/Bundles.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/Bundles.scala
@@ -87,6 +87,7 @@ class LoadPipeBundle(
   val align = Option.when(param.hasUnalignHandling)(Bool())
   val unalignHead = Option.when(param.hasUnalignHandling)(Bool())
   val readWholeBank = Option.when(param.hasUnalignHandling)(Bool()) // TODO: remove this
+  val lrqAmbReplay = Option.when(param.hasUnalignHandling)(Bool())
 
   // MMU & exception handling
   val tlbAccessResult = Option.when(param.hasAddrTrans)(TlbAccessResult())
@@ -143,6 +144,8 @@ class LoadPipeBundle(
   val matchInvalid = Option.when(param.hasS3PreProcess)(Bool())
   val shouldWakeup = Option.when(param.hasS3PreProcess)(Bool())
   val shouldWriteback = Option.when(param.hasS3PreProcess)(Bool())
+  val sqSbufferForwarded = Option.when(param.hasS3PreProcess)(Bool())
+  val sqSbufferFullForwarded = Option.when(param.hasS3PreProcess)(Bool())
   // S3 -> S4
   val hasException = Option.when(param.hasS4PreProcess)(Bool())
   val headAlwaysWriteback = Option.when(param.hasS4PreProcess)(Bool())
@@ -172,6 +175,7 @@ class LoadPipeBundle(
     forwardDChannel.get := false.B
     uncacheReplay.get := false.B
     ncReplay.get := false.B
+    lrqAmbReplay.foreach(_ := false.B)
   }
   def DontCareVectorFields(): Unit = {
     elemIdx.get := 0.U

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -129,6 +129,7 @@ class LoadUnitS0(param: ExeUnitParams)(
   replay.noQuery.get := io.replay.bits.uncacheReplay.get
   replay.DontCarePAddr()
   replay.DontCareUnalign() // assign later in sink
+  replay.lrqAmbReplay.get := io.replay.bits.cause.get(C_MA)
   val replayIsHiPrio = io.replay.bits.isReplayHiPrioEntrance()
   replayHiPrio.valid := io.replay.valid && replayIsHiPrio
   replayHiPrio.bits := replay
@@ -141,6 +142,7 @@ class LoadUnitS0(param: ExeUnitParams)(
   fastReplay.bits.noQuery.get := true.B
   fastReplay.bits.entrance := io.fastReplay.bits.entrance | LoadEntrance.fastReplay.U
   fastReplay.bits.DontCareUnalign() // assign later in sink
+  fastReplay.bits.lrqAmbReplay.get := false.B
   fastReplay.bits.occupySource := VecInit(sources.map(_.valid)).asUInt // for perf
 
   // 3. low-priority replay from LRQ
@@ -471,6 +473,8 @@ class LoadUnitS0(param: ExeUnitParams)(
   XSPerfAccumulate("vector_addr_vlen_align", false.B)
   XSPerfAccumulate("vector_addr_vlen_unalign", false.B)
   XSPerfAccumulate("forward_tld_channel", io.replay.fire && io.replay.bits.forwardDChannel.get)
+  val loadFromLrqAmbReplay = io.replay.fire && io.replay.bits.cause.get(C_MA)
+  XSPerfAccumulate("load_from_lrq_amb_replay", loadFromLrqAmbReplay)
   XSPerfAccumulate("hardware_prefetch_fire", io.prefetchReq.fire)
   XSPerfAccumulate("software_prefetch_fire", io.ldin.fire && LSUOpType.isPrefetch(io.ldin.bits.fuOpType))
   XSPerfAccumulate("hardware_prefetch_block", io.prefetchReq.valid && !io.prefetchReq.ready)
@@ -959,6 +963,27 @@ class LoadUnitS2(param: ExeUnitParams)(
 
   val forwardInvalid = io.sqForwardResp.valid && io.sqForwardResp.bits.forwardInvalid
 
+  val requestedMask = in.mask
+  val sqForwardMask = Mux(
+    io.sqForwardResp.valid,
+    io.sqForwardResp.bits.forwardMask.asUInt,
+    0.U((VLEN / 8).W)
+  )
+  val sbufferForwardMask = Mux(
+    io.sbufferForwardResp.valid,
+    io.sbufferForwardResp.bits.forwardMask.asUInt,
+    0.U((VLEN / 8).W)
+  )
+  val sqSbufferMatchInvalid = io.sqForwardResp.valid && io.sqForwardResp.bits.matchInvalid ||
+    io.sbufferForwardResp.valid && io.sbufferForwardResp.bits.matchInvalid
+  val sqSbufferForwardValid = !sqDataInvalid && !forwardInvalid && !sqSbufferMatchInvalid
+  val sqRequestedForwardedMask = requestedMask & sqForwardMask
+  val sbufferRequestedForwardedMask = requestedMask & sbufferForwardMask
+  val sqSbufferForwardedMask = sqRequestedForwardedMask | sbufferRequestedForwardedMask
+  val sqForwarded = sqRequestedForwardedMask.orR
+  val sqSbufferForwarded = sqSbufferForwardValid && sqForwarded
+  val sqSbufferFullForwarded = sqSbufferForwarded && sqSbufferForwardedMask === requestedMask
+
   // MSHR / TileLink-D channel
   val mshrForwardDenied = io.mshrForwardResp.valid && io.mshrForwardResp.bits.denied
   val tldForwardDenied = io.tldForwardResp.valid && io.tldForwardResp.bits.denied
@@ -1159,6 +1184,8 @@ class LoadUnitS2(param: ExeUnitParams)(
   stageInfo.matchInvalid.get := matchInvalid && troubleMaker
   stageInfo.shouldWakeup.get := shouldWakeup
   stageInfo.shouldWriteback.get := shouldWriteback
+  stageInfo.sqSbufferForwarded.get := sqSbufferForwarded
+  stageInfo.sqSbufferFullForwarded.get := sqSbufferFullForwarded
 
   when (pipeIn.fire) { pipeOutBits := stageInfo }
 
@@ -1255,7 +1282,6 @@ class LoadUnitS3(param: ExeUnitParams)(
     val redirect = Flipped(ValidIO(new Redirect))
     val kill = Input(Bool())
     val unalignTailValid = Input(Bool())
-    val perfRobHeadPtr = Input(new RobPtr)
 
     // DCache response
     val dcacheError = Input(Bool())
@@ -1699,6 +1725,7 @@ class LoadUnitS3(param: ExeUnitParams)(
   io.rollback.bits := DontCare
   io.rollback.bits.isRVC := uop.isRVC
   io.rollback.bits.robIdx := robIdx
+  io.rollback.bits.satpFlush := false.B
   io.rollback.bits.ftqIdx := uop.ftqPtr
   io.rollback.bits.ftqOffset := uop.ftqOffset
   io.rollback.bits.level := rollbackLevel
@@ -1722,6 +1749,30 @@ class LoadUnitS3(param: ExeUnitParams)(
   /**
     * Perf counters
     */
+  val demandLoad = isScalar || isVector
+  val transactionReplay = shouldReplay || s4HeadValid && s4HeadShouldReplay
+  val loadFromSqSbufferBase = pipeIn.fire && !kill && demandLoad &&
+    !transactionReplay && !exception && !rarViolation && !matchInvalid && in.sqSbufferForwarded.get
+  val loadFromSqSbufferFullData = loadFromSqSbufferBase && in.sqSbufferFullForwarded.get
+  val loadFromSqSbufferPartialData = loadFromSqSbufferBase && !in.sqSbufferFullForwarded.get
+  val loadFromSqSbufferSuccess = loadFromSqSbufferPartialData || loadFromSqSbufferFullData
+  val loadSuccessfulWriteback = (io.ldout.toRob.fire || io.vldout.toRob.valid) && !kill && demandLoad &&
+    !transactionReplay && !exception && !rollbackValid
+  val lrqAmbReplay = Mux(s4HeadValid, s4Head.lrqAmbReplay.get, in.lrqAmbReplay.get)
+  val lrqAmbSqSbufferForwarded = Mux(
+    s4HeadValid,
+    s4Head.sqSbufferForwarded.get || in.sqSbufferForwarded.get,
+    in.sqSbufferForwarded.get
+  )
+  val loadFromLrqAmbForwardSuccess = pipeIn.fire && endPipe && !kill && demandLoad && lrqAmbReplay &&
+    lrqAmbSqSbufferForwarded && !transactionReplay && !exception && !rarViolation && !matchInvalid
+
+  XSPerfAccumulate("load_from_sq_sbuffer_success", loadFromSqSbufferSuccess)
+  XSPerfAccumulate("load_from_sq_sbuffer_partial_data", loadFromSqSbufferPartialData)
+  XSPerfAccumulate("load_from_sq_sbuffer_full_data", loadFromSqSbufferFullData)
+  XSPerfAccumulate("load_successful_writeback", loadSuccessfulWriteback)
+  XSPerfAccumulate("load_from_lrq_amb_forward_success", loadFromLrqAmbForwardSuccess)
+
   XSPerfAccumulate("rollback_total", rollbackValid)
   XSPerfAccumulate("rollback_rar_violation", rollbackValid && rarViolation)
   XSPerfAccumulate("rollback_match_invalid", rollbackValid && matchInvalid)
@@ -1923,7 +1974,6 @@ class LoadUnitDataPath(val param: ExeUnitParams)(implicit p: Parameters) extends
 class LoadUnitIO(val param: ExeUnitParams)(implicit p: Parameters) extends XSBundle {
   private val numMemChannels = p(XSCoreParamsKey).dcacheParametersOpt.get.numMemChannels
   val redirect = Flipped(ValidIO(new Redirect))
-  val perfRobHeadPtr = Input(new RobPtr)
   // Request sources
   val ldin = Flipped(DecoupledIO(new ExuInput(param)))
   val replay = Flipped(DecoupledIO(new LoadReplayIO))
@@ -2085,7 +2135,6 @@ class NewLoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSMo
 
   // S3
   s3.io.redirect := io.redirect
-  s3.io.perfRobHeadPtr := io.perfRobHeadPtr
   s3.io.dcacheError := io.dcache.resp.bits.error_delayed
   io.ldout <> s3.io.ldout
   io.vldout := s3.io.vldout

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -1068,9 +1068,10 @@ class LoadUnitS2(param: ExeUnitParams)(
   // if store pipeline is waiting for store, send this load to fast replay
   val fastReplayNuke = cause(C_NK) &&  // TODO: use C_RAR or C_NK?
     !hasHigherPriorityCauses(VecInit(cause.patch(C_MA, Seq(cause(C_MA) && !fastReplayNukeFirst), 1)), C_RAR)
-  val fastReplay = !LoadEntrance.isFastReplay(entrance) && // 1.3.1
-    (fastReplayMSHRNack || fastReplayBankConflict || fastReplayNuke || fastReplayForwardFail) && // 1.3.2
-    !isUnalign && !tlbMiss // 1.3.3, if tlb miss, should not to fast replay
+  val fastReplayEligible = !LoadEntrance.isFastReplay(entrance) &&
+    !isUnalign && !tlbMiss
+  val fastReplay = fastReplayEligible && // 1.3.1, 1.3.3
+    (fastReplayMSHRNack || fastReplayBankConflict || fastReplayNuke || fastReplayForwardFail) // 1.3.2
 
   /**
     * Nuke query to LQRAR / LQRAW
@@ -1078,7 +1079,8 @@ class LoadUnitS2(param: ExeUnitParams)(
     * For timing considerations, violation check requests issued in s2 do not need to be accurate. But MUST ensure that
     * accurate `revoke` signals are given in s3 to withdraw requests that do not require violation check.
     */
-  val nukeQueryReqValid = troubleMaker && !prevStageNuke
+  val canNukeQuery = !isMMIOReplay && !isPrefetch
+  val nukeQueryReqValid = canNukeQuery && !prevStageNuke
   val nukeQueryReq = Wire(new LoadNukeQueryReq)
   nukeQueryReq.robIdx := robIdx
   nukeQueryReq.paddr := paddr
@@ -1169,8 +1171,11 @@ class LoadUnitS2(param: ExeUnitParams)(
   stageInfo.perfWaitStoreRetired.get := io.sqForwardResp.valid && io.sqForwardResp.bits.perfWaitStoreRetired
   stageInfo.perfIsCmaReplay.get := perfIsCmaReplay
   // Pre-process for s3
+  // A RR candidate is a bank-conflict fast replay only. Keep it off the
+  // general fast-replay cause OR so the S2 candidate-to-arbiter path is
+  // independent of MSHR-nack, nuke, and forward-fail logic.
   val rrBankConflictFastReplay =
-    !kill && fastReplay && fastReplayBankConflict && io.dcacheRRBankConflict && !exception
+    !kill && fastReplayEligible && fastReplayBankConflict && io.dcacheRRBankConflict
   val rrBankConflictFastReplayCandidate = pipeIn.fire && rrBankConflictFastReplay
   io.rrBankConflictFastReplayCandidate := rrBankConflictFastReplayCandidate
   XSError(
@@ -1198,7 +1203,7 @@ class LoadUnitS2(param: ExeUnitParams)(
 
   io.unalignTailValid := pipeIn.valid && isUnalignTail
 
-  io.dcacheKill := kill || exception || isUncache || isUncacheReplay || !needDCacheAccess
+  io.dcacheKill := kill || exception || isUncache || isUncacheReplay
   io.dcacheResp.ready := true.B
 
   io.rarNukeQueryReq.valid := nukeQueryReqValid && pipeIn.valid

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -832,6 +832,8 @@ class LoadUnitS2(param: ExeUnitParams)(
 
     val uncacheBypassResp = Flipped(ValidIO(new UncacheBypassRespS2))
 
+    val stdDataWrite = Input(new StdDataWriteWindow(StdCnt))
+
     // Nuke query from StoreUnit
     val staNukeQueryReq = Flipped(Vec(StorePipelineWidth, ValidIO(new StoreNukeQueryReq)))
     // Nuke query to LQRAR / LQRAW
@@ -1027,13 +1029,22 @@ class LoadUnitS2(param: ExeUnitParams)(
   val troubleMaker = !isPrefetch && !alwaysWriteback
   // 1.3 fast replay
   val cause = Wire(in.cause.get.cloneType)
+  val stdDataWriteCurrentMatch = VecInit(io.stdDataWrite.current.map { write =>
+    write.valid && write.bits === sqDataInvalidSqIdx
+  }).asUInt.orR
+  val stdDataWritePreviousMatch = VecInit(io.stdDataWrite.previous.map { write =>
+    write.valid && write.bits === sqDataInvalidSqIdx
+  }).asUInt.orR
+  val ffStdDataWriteMatch = stdDataWriteCurrentMatch || stdDataWritePreviousMatch
+  val fastReplayForwardFail = cause(C_FF) &&
+    !hasHigherPriorityCauses(cause, C_FF) && ffStdDataWriteMatch
   val fastReplayMSHRNack = cause(C_DR) && !hasHigherPriorityCauses(cause, C_DR)
   val fastReplayBankConflict = cause(C_BC) && !hasHigherPriorityCauses(cause, C_BC)
   // if store pipeline is waiting for store, send this load to fast replay
   val fastReplayNuke = cause(C_NK) &&  // TODO: use C_RAR or C_NK?
     !hasHigherPriorityCauses(VecInit(cause.patch(C_MA, Seq(cause(C_MA) && !fastReplayNukeFirst), 1)), C_RAR)
   val fastReplay = !LoadEntrance.isFastReplay(entrance) && // 1.3.1
-    (fastReplayMSHRNack || fastReplayBankConflict || fastReplayNuke) && // 1.3.2
+    (fastReplayMSHRNack || fastReplayBankConflict || fastReplayNuke || fastReplayForwardFail) && // 1.3.2
     !isUnalign && !tlbMiss // 1.3.3, if tlb miss, should not to fast replay
 
   /**
@@ -1160,7 +1171,7 @@ class LoadUnitS2(param: ExeUnitParams)(
 
   io.unalignTailValid := pipeIn.valid && isUnalignTail
 
-  io.dcacheKill := kill || exception || isUncache || isUncacheReplay
+  io.dcacheKill := kill || exception || isUncache || isUncacheReplay || !needDCacheAccess
   io.dcacheResp.ready := true.B
 
   io.rarNukeQueryReq.valid := nukeQueryReqValid && pipeIn.valid
@@ -1198,8 +1209,11 @@ class LoadUnitS2(param: ExeUnitParams)(
    *  Perf counters
    */
   val fire = pipeIn.fire && !kill
+  val ffFastReplayInitiate = fire && fastReplayForwardFail &&
+    !LoadEntrance.isFastReplay(entrance) && !isUnalign && !tlbMiss && !exception
   XSPerfAccumulate("valid", pipeIn.valid)
   XSPerfAccumulate("fire", fire)
+  XSPerfAccumulate("forward_fail_fast_replay_initiate", ffFastReplayInitiate)
   XSPerfAccumulate("fire_first_issue", fire && in.isFirstIssue())
   XSPerfAccumulate("dcache_miss", fire && io.dcacheResp.bits.miss)
   XSPerfAccumulate("dcache_miss_first_issue", fire && io.dcacheResp.bits.miss && in.isFirstIssue())
@@ -1241,6 +1255,7 @@ class LoadUnitS3(param: ExeUnitParams)(
     val redirect = Flipped(ValidIO(new Redirect))
     val kill = Input(Bool())
     val unalignTailValid = Input(Bool())
+    val perfRobHeadPtr = Input(new RobPtr)
 
     // DCache response
     val dcacheError = Input(Bool())
@@ -1285,6 +1300,8 @@ class LoadUnitS3(param: ExeUnitParams)(
     val perfLqHeadPtr = Input(new LqPtr)
     val perfLqFull = Input(Bool())
     val perfMdpAddr = Output(new PerfMdpAddr)
+    // ROB-head source execute-fail events
+    val sourceExecuteFailRobHead = Output(LoadEntrance())
 
     // CSR control signals
     val csrCtrl = Flipped(new CustomCSRCtrlIO)
@@ -1354,6 +1371,12 @@ class LoadUnitS3(param: ExeUnitParams)(
   val s4HeadCacheMiss = s4Head.cause.get(C_DM)
   val s4HeadMshrId    = s4Head.mshrId.get
   val s4HeadHandledByMSHR = s4Head.handledByMSHR.get
+
+  val perfOutcomeUop = Mux(s4HeadValid, s4Head.uop, uop)
+  val perfOutcomeHasROBEntry = Mux(s4HeadValid, s4Head.hasROBEntry, in.hasROBEntry)
+  val perfOutcomeKill = io.kill || perfOutcomeUop.robIdx.needFlush(redirect)
+  val perfAtRobHead = pipeIn.valid && !perfOutcomeKill && perfOutcomeHasROBEntry &&
+    perfOutcomeUop.robIdx === io.perfRobHeadPtr
 
   val vaddr = Mux(s4HeadValid, s4HeadVAddr, in.vaddr)
   val paddr = Mux(s4HeadValid, s4HeadPAddr, in.paddr.get)
@@ -1676,7 +1699,6 @@ class LoadUnitS3(param: ExeUnitParams)(
   io.rollback.bits := DontCare
   io.rollback.bits.isRVC := uop.isRVC
   io.rollback.bits.robIdx := robIdx
-  io.rollback.bits.satpFlush := false.B
   io.rollback.bits.ftqIdx := uop.ftqPtr
   io.rollback.bits.ftqOffset := uop.ftqOffset
   io.rollback.bits.level := rollbackLevel
@@ -1711,6 +1733,15 @@ class LoadUnitS3(param: ExeUnitParams)(
   val executeFail = lqWriteValid && lqWriteCause.asUInt.orR || pipeIn.valid && shouldFastReplay
   // fastReplay's entrance maybe not one-hot.
   val perfEntrance = Mux((pipeIn.bits.entrance & LoadEntrance.fastReplay.U).orR, LoadEntrance.fastReplay.U, pipeIn.bits.entrance)
+
+  val sourceExecuteFailRobHead = Mux(perfAtRobHead && executeFail, perfEntrance, 0.U)
+  io.sourceExecuteFailRobHead := sourceExecuteFailRobHead
+
+  for (i <- 0 until LoadEntrance.num) {
+    val sourceName = LoadEntrance.findNameById(i)
+    XSPerfAccumulate(s"${sourceName}_execute_fail_rob_head", sourceExecuteFailRobHead(i))
+  }
+
   for (i <- 0 until LoadEntrance.num) {
     val highPrioNume = LoadEntrance.findNameById(i)
     for (j <- i + 1 until LoadEntrance.num) {
@@ -1892,6 +1923,7 @@ class LoadUnitDataPath(val param: ExeUnitParams)(implicit p: Parameters) extends
 class LoadUnitIO(val param: ExeUnitParams)(implicit p: Parameters) extends XSBundle {
   private val numMemChannels = p(XSCoreParamsKey).dcacheParametersOpt.get.numMemChannels
   val redirect = Flipped(ValidIO(new Redirect))
+  val perfRobHeadPtr = Input(new RobPtr)
   // Request sources
   val ldin = Flipped(DecoupledIO(new ExuInput(param)))
   val replay = Flipped(DecoupledIO(new LoadReplayIO))
@@ -1944,6 +1976,9 @@ class LoadUnitIO(val param: ExeUnitParams)(implicit p: Parameters) extends XSBun
   // Debug info and top-down info
   val debugInfo = Output(new DebugLsInfoBundle)
   val topDownInfo = Output(new LsTopdownInfo)
+  // ROB-head source execute-fail events for MemBlock aggregation
+  val sourceExecuteFailRobHead = Output(LoadEntrance())
+  val stdDataWrite = Input(new StdDataWriteWindow(backendParams.StdCnt))
 }
 
 class NewLoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModule with HasPerfEvents {
@@ -2046,9 +2081,11 @@ class NewLoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSMo
   io.prefetchTrain.valid := GatedValidRegNext(s2.io.prefetchTrain.valid)
   io.prefetchTrain.bits := RegEnable(s2.io.prefetchTrain.bits, s2.io.prefetchTrain.valid)
   s2.io.csrCtrl := io.csrCtrl
+  s2.io.stdDataWrite := io.stdDataWrite
 
   // S3
   s3.io.redirect := io.redirect
+  s3.io.perfRobHeadPtr := io.perfRobHeadPtr
   s3.io.dcacheError := io.dcache.resp.bits.error_delayed
   io.ldout <> s3.io.ldout
   io.vldout := s3.io.vldout
@@ -2065,6 +2102,7 @@ class NewLoadUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSMo
   s3.io.perfLqFull := io.perfLqFull
   io.perfMdpAddr := s3.io.perfMdpAddr
   io.exceptionInfo := s3.io.exceptionInfo
+  io.sourceExecuteFailRobHead := s3.io.sourceExecuteFailRobHead
   s3.io.csrCtrl := io.csrCtrl
   io.vldS3WakeUp := s3.io.vldS3WakeUp
 
@@ -2217,6 +2255,8 @@ class NewLoadUnitTop(implicit val p: Parameters) extends Module
   with HasMemBlockParameters {
   val param = ldaParams.head
   param.bindBackendParam(backendParams)
+  val issueBlockParam = intSchdParams.issueBlockParams.find(_.allExuParams.contains(param)).get
+  param.bindIssueBlockParam(issueBlockParam)
   val io = IO(new LoadUnitIO(param))
   val ldu = Module(new NewLoadUnit(param))
   io <> ldu.io

--- a/src/main/scala/xiangshan/mem/pipeline/NewStoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewStoreUnit.scala
@@ -27,6 +27,7 @@ import xiangshan.backend.exu.ExeUnitParams
 import xiangshan.backend.fu.FuConfig._
 import xiangshan.backend.fu.PMPRespBundle
 import xiangshan.backend.fu.NewCSR._
+import xiangshan.backend.rob.RobPtr
 import xiangshan.cache._
 import xiangshan.cache.mmu._
 import xiangshan.ExceptionNO._
@@ -873,6 +874,8 @@ class StoreUnitIO(val param: ExeUnitParams)(implicit p: Parameters) extends XSBu
   // Writeback
   val stout = new MemWriteBack(param)
   val exceptionInfo = ValidIO(new MemExceptionInfo)
+  val perfRobHeadPtr = Input(new RobPtr)
+  val writebackAtRobHead = Output(Bool())
 
   val debugInfo = Output(new DebugLsInfoBundle)
 }
@@ -932,6 +935,7 @@ class NewStoreUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSM
   // s3
   s3.io.redirect := io.redirect
   io.stout := s3.io.stout
+  io.writebackAtRobHead := io.stout.toRob.valid && io.stout.toRob.bits.robIdx === io.perfRobHeadPtr
   io.exceptionInfo := s3.io.exceptionInfo
 }
 

--- a/src/main/scala/xiangshan/mem/pipeline/StdExeUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StdExeUnit.scala
@@ -25,6 +25,7 @@ import xiangshan.backend._
 import xiangshan.backend.Bundles._
 import xiangshan.backend.exu.ExeUnitParams
 import xiangshan.backend.fu.FuType
+import xiangshan.backend.rob.RobPtr
 
 class StdExeUnitIO(val param: ExeUnitParams)(implicit p: Parameters) extends XSBundle {
   val flush = Flipped(ValidIO(new Redirect()))
@@ -36,6 +37,8 @@ class StdExeUnitIO(val param: ExeUnitParams)(implicit p: Parameters) extends XSB
   val feedBack = ValidIO(new RSFeedback)
   // store queue deqPtr
   val sqDeqPtr = Input(new SqPtr)
+  val perfRobHeadPtr = Input(new RobPtr)
+  val writebackAtRobHead = Output(Bool())
 }
 
 class StdExeUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSModule {
@@ -68,6 +71,7 @@ class StdExeUnit(val param: ExeUnitParams)(implicit p: Parameters) extends XSMod
   io.out.toRob.bits.debugInfo := DontCare
   io.out.toRob.bits.debugInfo.perfDebugInfo.foreach(_ := io.in.bits.perfDebugInfo.get)
   io.out.toRob.bits.debugInfo.debug_seqNum.foreach(_ := io.in.bits.debug_seqNum.get)
+  io.writebackAtRobHead := io.out.toRob.valid && io.out.toRob.bits.robIdx === io.perfRobHeadPtr
 
   io.atomicData.valid := io.in.fire && FuType.storeIsAMO(io.in.bits.fuType)
   io.atomicData.bits := io.in.bits

--- a/src/main/scala/xiangshan/mem/prefetch/PrefetcherMonitor.scala
+++ b/src/main/scala/xiangshan/mem/prefetch/PrefetcherMonitor.scala
@@ -82,9 +82,9 @@ class PrefetcherMonitor()(implicit p: Parameters) extends XSModule with HasStrea
   val StrideMonitor = Module(new L1PrefetchMonitor(PrefetcherMonitorParam.fromString("stride")))
   val BertiMonitor = Module(new L1PrefetchMonitor(PrefetcherMonitorParam.fromString("berti")))
 
-  StreamMonitor.io.prefetch_info:= prefetch_info
-  StrideMonitor.io.prefetch_info := prefetch_info
-  BertiMonitor.io.prefetch_info := prefetch_info
+  StreamMonitor.io.prefetch_info:= RegNext(prefetch_info)
+  StrideMonitor.io.prefetch_info := RegNext(prefetch_info)
+  BertiMonitor.io.prefetch_info := RegNext(prefetch_info)
   
   // stream 0, stride 1
   io.pf_ctrl(0) := StreamMonitor.io.pf_ctrl


### PR DESCRIPTION
## Summary

This PR improves load replay performance and shortens several critical paths in the `MemBlock`. It reduces `LoadQueueReplay` latency, accelerates forward-fail and TLB-miss scheduling, re-times L2 hint handling, optimizes `DCache` and `Uncache` request timing paths, and adds detailed performance counters for replay and ROB-head analysis.

  ## Key Changes

  ### Load Replay Optimization

  - Reduce the `LRQ` replay pipeline from three stages to two.
  - Use bank-local one-hot selection and registered `uop` snapshots to shorten replay selection and metadata read paths.
  - Preserve redirect and flush cancellation behavior in the shortened pipeline.
  - Delay wakeup signals locally to keep store, refill, MMIO, and NC data aligned with the earlier replay request.
  - Allow forward-fail entries to become non-blocking when the corresponding store-data wakeup or `StoreQueue` write is already visible.
  - Add forward-fail fast replay using the current and previous store-data write windows.

  ### L2 and TLB Hint Handling

  - Re-timing L2 hint handling so the hint first unblocks the matching `DCache-miss` entry and normal `LRQ` selection occurs in the following cycle.
  - Preserve the original GrantData alignment:
      - Original: hint selects in cycle N, replay reaches the Load Pipeline in N+2.
      - New: hint unblocks in cycle N, selection occurs in N+1, and replay still reaches the Load Pipeline in N+2.

  - Add a fast `TLB` hint generated directly from the stage-2 `PTW` response.
  - Use the fast hint to wake and select matching TLB-miss replays while retaining the original TLB hint as a fallback.

  ### Timing Optimization

  - Replace the load bank-conflict replay arbiter with a two-level round-robin arbiter.
  - Isolate bank-conflict fast-replay arbitration from unrelated replay causes.
  - Simplify the load nuke-query request path while retaining precise cancellation in the following stage.
  - Add skid buffers to the `DCache MainPipe` and `Uncache` request paths to break long ready paths.
  - Preserve `Uncache` flush and drain semantics for requests already accepted by the skid buffer.
  - Move the reusable skid-buffer implementation into the common memory utilities and add enqueue gating and occupancy tracking.
  - Register `Uncache` exception outputs and `PrefetcherMonitor` inputs.
  - Simplify `VirtualLoadQueue` commit-count generation using a priority encoder.

  ### StoreQueue Optimization

  - Use the `Virtual StoreQueue` valid-entry count for force-write decisions so the threshold reflects the queue state visible to the virtual queue.

  ### Performance Counters

  - Add per-cause `LRQ` release count, residence latency, overflow, ROB-head release, and ROB-head blocked-cycle counters.
  - Cover all replay causes, including `TLB` miss, `DCache` miss/replay, bank conflict, forward fail, memory ambiguity, RAR/RAW rejection, nuke, uncache.
  - Add counters for successful `SQ/SBuffer` forwarding, partial/full forwarding, successful load writeback, and `LRQ` memory-ambiguity replay outcomes.
  - Add ROB-head load execute-fail counters grouped by load entrance.
  - Add ROB-head store-address and store-data writeback counters.
  - Add counters for forward-fail entries that are immediately unblocked or sent through fast replay.


## performance 

<img width="489" height="813" alt="image" src="https://github.com/user-attachments/assets/f647c366-f7eb-44dc-9246-6f00dd80d987" />

base: https://github.com/OpenXiangShan/XiangShan/actions/runs/32923421199

new: https://github.com/OpenXiangShan/XiangShan/actions/runs/32923457139