### PR TITLE
feat(Bpu): add s2_override

### DIFF
--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -53,6 +53,7 @@ import xiangshan.frontend.instruncache.InstrUncacheResp
 class BpuToFtqIO(implicit p: Parameters) extends FrontendBundle {
   val prediction: DecoupledIO[BpuPrediction] = Decoupled(new BpuPrediction)
   val meta:       DecoupledIO[BpuMeta]       = Decoupled(new BpuMeta)
+  val s2FtqPtr:   FtqPtr                     = Output(new FtqPtr)
   val s3FtqPtr:   FtqPtr                     = Output(new FtqPtr)
 
   // perfMeta uses the same valid signal as meta

--- a/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Abstracts.scala
@@ -46,6 +46,14 @@ abstract class BasePredictorIO(implicit p: Parameters) extends BpuBundle {
   val sramResetDone: Bool = Output(Bool())
 }
 
+trait HasAheadPredictorIO extends BasePredictorIO {
+  val redirect:        Bool      = Input(Bool())
+  val bpuS2Override:   Bool      = Input(Bool())
+  val bpuS3Override:   Bool      = Input(Bool())
+  val newStartPc:      GuardedPc = Input(GuardedPc())
+  val overrideStartPc: GuardedPc = Input(GuardedPc())
+}
+
 trait HasFastTrainIO extends BasePredictorIO {
   override val fastTrain: Option[Valid[FastTrain]] = Option(Input(Valid(new FastTrain)))
 }

--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -133,9 +133,11 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val s2_valid = RegInit(false.B)
   private val s3_valid = RegInit(false.B)
 
+  private val s2_override = WireDefault(false.B)
   private val s3_override = WireDefault(false.B)
 
   private val s1_prediction = Wire(new Prediction)
+  private val s2_prediction = Wire(new Prediction)
   private val s3_prediction = Wire(new Prediction)
 
   private val debug_bpId = RegInit(0.U(XLEN.W))
@@ -191,37 +193,40 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     // fastTrain is an Option[Valid[BpuFastTrain]], we need .foreach
     p.io.fastTrain.foreach(_ := fastTrain)
   }
+
+  Seq(abtb.io, utage.io).foreach { io =>
+    io.redirect        := redirect.valid
+    io.bpuS2Override   := s2_override
+    io.bpuS3Override   := s3_override
+    io.newStartPc      := s1_prediction.target
+    io.overrideStartPc := Mux(s3_override, s3_prediction.target, s2_prediction.target)
+  }
+
   io.fromFtq.train.ready := predictors.map(_.io.trainReady).reduce(_ && _)
 
   /* *** predictor specific inputs *** */
-  abtb.io.redirectValid  := redirect.valid
-  abtb.io.overrideValid  := s3_override
   abtb.io.normalPathHist := phr.io.oldFoldedPhr
+  abtb.io.debug_bpuS2StartPc.foreach(_ := s2_startPc.get)
+  abtb.io.debug_bpuS3StartPc.foreach(_ := s3_startPc.get)
 
-  // utage.io.foldedPathHist         := phr.io.oldFoldedPhr
-  // utage.io.foldedPathHistForTrain := phr.io.trainFoldedPhr
-  utage.io.abtbPrediction := abtb.io.abtbResult
-  utage.io.abtbPosVec     := abtb.io.abtbPos
-  utage.io.overrideValid  := s3_override
-  utage.io.redirectValid  := redirect.valid
-
+  utage.io.fromAheadBtb     := abtb.io.toMicroTage
   utage.io.normalPathHist   := phr.io.oldFoldedPhr
   utage.io.s1PathHist       := phr.io.s1_foldedPhr
-  utage.io.overridePathHist := phr.io.s3_foldedPhr
+  utage.io.overridePathHist := Mux(s3_override, phr.io.s3_foldedPhr, phr.io.s2_foldedPhr)
 
-  utage.io.s1StartPc       := s1_prediction.target.unGuard
-  utage.io.overrideStartPc := s3_prediction.target.unGuard
-
-  // uras
-  uras.io.specIn.startPc                := s1_startPc.get
-  uras.io.specIn.cfiPosition            := s1_prediction.cfiPosition
-  uras.io.specIn.attribute              := s1_prediction.attribute
-  uras.io.hasRedirect                   := redirect.valid
-  uras.io.overrideData.valid            := s3_override
-  uras.io.overrideData.bits.startPc     := s3_startPc.get.toUInt
-  uras.io.overrideData.bits.attribute   := s3_prediction.attribute
-  uras.io.overrideData.bits.cfiPosition := s3_prediction.cfiPosition
-  uras.io.fullRetAddr                   := ras.io.topRetAddr
+  uras.io.specIn.startPc                  := s1_startPc.get
+  uras.io.specIn.cfiPosition              := s1_prediction.cfiPosition
+  uras.io.specIn.attribute                := s1_prediction.attribute
+  uras.io.hasRedirect                     := redirect.valid
+  uras.io.s2OverrideData.valid            := s2_override
+  uras.io.s2OverrideData.bits.startPc     := s2_startPc.get
+  uras.io.s2OverrideData.bits.attribute   := s2_prediction.attribute
+  uras.io.s2OverrideData.bits.cfiPosition := s2_prediction.cfiPosition
+  uras.io.s3OverrideData.valid            := s3_override
+  uras.io.s3OverrideData.bits.startPc     := s3_startPc.get.toUInt
+  uras.io.s3OverrideData.bits.attribute   := s3_prediction.attribute
+  uras.io.s3OverrideData.bits.cfiPosition := s3_prediction.cfiPosition
+  uras.io.fullRetAddr                     := ras.io.topRetAddr
 
   ras.io.redirect                := redirect
   ras.io.commit                  := commit
@@ -249,7 +254,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   s3_flush := redirect.valid
   s2_flush := s3_flush || s3_override
-  s1_flush := s2_flush
+  s1_flush := s2_flush || s2_override
 
   s1_ready := s1_fire || !s1_valid || s1_flush
   s2_ready := s2_fire || !s2_valid
@@ -277,7 +282,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     .elsewhen(s3_fire)(s3_valid := false.B)
 
   // s0_stall should be exclusive with any other PC source
-  s0_stall := !(s1_valid || s3_override || redirect.valid)
+  s0_stall := !(s1_valid || s2_override || s3_override || redirect.valid)
 
   private val s1_ubtbPrediction = Wire(new Prediction)
   private val s1_abtbPrediction = Wire(Vec(NumAheadBtbPredictionEntries, new Prediction))
@@ -288,30 +293,33 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     ubtb.io.prediction.bits.target
   )
   for (i <- 0 until NumAheadBtbPredictionEntries) {
-    s1_abtbPrediction(i) := abtb.io.prediction(i).bits
+    s1_abtbPrediction(i) := abtb.io.result.entries(i).bits
   }
 
-  private val s1_abtbPosition       = abtb.io.abtbResultPos
-  private val s1_utageHitMask       = utage.io.prediction.hitVec
-  private val s1_utageTakenMask     = utage.io.prediction.takenVec
-  private val s1_jumpValidVec       = abtb.io.predCtrl.jumpValidVec
-  private val s1_conditonalValidVec = abtb.io.predCtrl.conditionValidVec
-  private val s1_abtbTakenMask = VecInit(abtb.io.prediction.zipWithIndex.map { case (pred, i) =>
+  private val s1_abtbPosition   = VecInit(s1_abtbPrediction.map(_.cfiPosition))
+  private val s1_utageHitMask   = utage.io.prediction.hitVec
+  private val s1_utageTakenMask = utage.io.prediction.takenVec
+
+  private val s1_abtbTakenMask = VecInit(abtb.io.result.entries.zipWithIndex.map { case (pred, i) =>
+    val isJump = pred.bits.attribute.isDirect || pred.bits.attribute.isIndirect
+    val isCond = pred.bits.attribute.isConditional
     XSPerfAccumulate(
       s"abtb_attribute_mismatch_takenCtr${i}",
-      pred.valid && (pred.bits.attribute.isDirect || pred.bits.attribute.isIndirect) && !pred.bits.taken
+      pred.valid && isJump && !pred.bits.taken
     )
     XSPerfAccumulate(
       s"microTage_false_hit_way${i}",
-      pred.valid && !pred.bits.attribute.isConditional && s1_utageHitMask(i)
+      pred.valid && !isCond && s1_utageHitMask(i)
     )
-    s1_jumpValidVec(i) || (s1_conditonalValidVec(i) && Mux(s1_utageHitMask(i), s1_utageTakenMask(i), pred.bits.taken))
+    pred.valid && (
+      isJump || (isCond && Mux(s1_utageHitMask(i), s1_utageTakenMask(i), pred.bits.taken))
+    )
   })
 
   private val s1_compareMatrix      = CompareMatrix(s1_abtbPosition)
   private val s1_abtbFirstTakenBrOH = s1_compareMatrix.getLeastElementOH(s1_abtbTakenMask)
   private val s1_abtbFirstTakenBr   = Mux1H(s1_abtbFirstTakenBrOH, s1_abtbPrediction)
-  private val s1_abtbValid          = abtb.io.prediction.map(_.valid).reduce(_ || _)
+  private val s1_abtbValid          = abtb.io.result.entries.map(_.valid).reduce(_ || _)
 
   private val s1_abtbResult = Wire(new Prediction)
   s1_abtbResult       := s1_abtbFirstTakenBr
@@ -344,13 +352,40 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
       s2_utageMeta.abtbResult(idx).valid && (s2_utageMeta.abtbResult(idx).cfiPosition <= s2_s1Prediction.cfiPosition)
   }
 
-  private val s2_compareMatrix = CompareMatrix(VecInit(mbtb.io.result.map(_.bits.cfiPosition)))
-  private val s2_jumpTakenVec = VecInit(mbtb.io.result.map {
+  private val s2_compareMatrix = RegEnable(CompareMatrix(mbtb.io.s1_positions), s1_fire)
+
+  private val s2_isJumpVec = VecInit(mbtb.io.result.map {
     entry => entry.valid && (entry.bits.attribute.isDirect || entry.bits.attribute.isIndirect)
   })
-  private val s2_isBrVec = VecInit(mbtb.io.result.map {
+  private val s2_isCondVec = VecInit(mbtb.io.result.map {
     entry => entry.valid && entry.bits.attribute.isConditional
   })
+
+  private val s2_takenMask = VecInit(mbtb.io.result.zipWithIndex.map { case (entry, i) =>
+    val tagePredValid = tage.io.prediction.fastTakenVec(i).valid
+    val tagePred      = tage.io.prediction.fastTakenVec(i).bits
+    s2_isJumpVec(i) || (s2_isCondVec(i) && Mux(tagePredValid, tagePred, entry.bits.taken))
+  })
+  private val s2_taken              = s2_takenMask.reduce(_ || _)
+  private val s2_firstTakenBranchOH = s2_compareMatrix.getLeastElementOH(s2_takenMask)
+  private val s2_firstTakenBranch   = Mux1H(s2_firstTakenBranchOH, mbtb.io.result)
+
+  private val s2_fallThroughPrediction = RegEnable(fallThrough.io.prediction, s1_fire)
+
+  s2_prediction       := Mux(s2_taken, s2_firstTakenBranch.bits, s2_fallThroughPrediction)
+  s2_prediction.taken := s2_taken
+
+  private val s2_mbtbCfiPositionDiffVec =
+    VecInit(mbtb.io.result.map(_.bits.cfiPosition =/= s2_s1Prediction.cfiPosition))
+  private val s2_mbtbAttributeDiffVec = VecInit(mbtb.io.result.map(_.bits.attribute =/= s2_s1Prediction.attribute))
+
+  s2_override := {
+    val takenDiff       = s2_taken =/= s2_s1Prediction.taken
+    val cfiPositionDiff = s2_taken && Mux1H(s2_firstTakenBranchOH, s2_mbtbCfiPositionDiffVec)
+    val attributeDiff   = s2_taken && Mux1H(s2_firstTakenBranchOH, s2_mbtbAttributeDiffVec)
+
+    s2_valid && (takenDiff || cfiPositionDiff || attributeDiff)
+  }
 
   /* *** s3 prediction selection *** */
   private val s3_mbtbResult     = RegEnable(mbtb.io.result, s2_fire)
@@ -359,17 +394,33 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val s3_scTakenMask    = RegEnable(sc.io.scTakenMask, s2_fire)
   private val s3_compareMatrix  = RegEnable(s2_compareMatrix, s2_fire)
   private val s3_s1Prediction   = RegEnable(s2_s1Prediction, s2_fire)
-  private val s3_jumpTakenVec   = RegEnable(s2_jumpTakenVec, s2_fire)
-  private val s3_isBrVec        = RegEnable(s2_isBrVec, s2_fire)
+  private val s3_s2Override     = RegEnable(s2_override, s2_fire)
+  private val s3_s2Prediction   = RegEnable(s2_prediction, s2_fire)
+  private val s3_isJumpVec      = RegEnable(s2_isJumpVec, s2_fire)
+  private val s3_isCondVec      = RegEnable(s2_isCondVec, s2_fire)
 
-  // timing optimization: The comparison of predictions and the generation of the s3_taken are performed in parallel.
-  private val s3_mbtbCfiPositionDiffVec = VecInit(s3_mbtbResult.map(_.bits.cfiPosition =/= s3_s1Prediction.cfiPosition))
-  private val s3_mbtbAttributeDiffVec   = VecInit(s3_mbtbResult.map(_.bits.attribute =/= s3_s1Prediction.attribute))
-  // timing optimization: btb's target is Cat(getUpper(startPc), entry.lower), so we can compare only lower bits
-  private val s3_mbtbTargetDiffVec = VecInit(s3_mbtbResult.map(_.bits.targetLower =/= s3_s1Prediction.targetLower))
-  // but we still need to compare full target for ittage/ras
-  private val s3_ittageTargetDiff = ittage.io.prediction.target =/= s3_s1Prediction.target
-  private val s3_rasTargetDiff    = ras.io.topRetAddr =/= s3_s1Prediction.target
+  private val s3_s2FirstTakenBranchOH = RegEnable(s2_firstTakenBranchOH, s2_fire)
+
+  // S2 does not compare targets. An S2 override already uses the selected MBTB target, so a later MBTB target
+  // comparison is redundant; a changed MBTB branch is caught by firstTakenBranchDiff. Only RAS/ITTAGE need target
+  // comparison after an S2 override.
+  private val s3_mbtbTargetDiffVec = VecInit(s3_mbtbResult.map { entry =>
+    Mux(
+      s3_s2Override,
+      false.B,
+      entry.bits.targetLower =/= s3_s1Prediction.targetLower
+    )
+  })
+  private val s3_ittageTargetDiff = Mux(
+    s3_s2Override,
+    ittage.io.prediction.target =/= s3_s2Prediction.target,
+    ittage.io.prediction.target =/= s3_s1Prediction.target
+  )
+  private val s3_rasTargetDiff = Mux(
+    s3_s2Override,
+    ras.io.topRetAddr =/= s3_s2Prediction.target,
+    ras.io.topRetAddr =/= s3_s1Prediction.target
+  )
 
   private val s3_takenMask = VecInit(s3_mbtbResult.zipWithIndex.map { case (entry, i) =>
     val useTage   = s3_tagePrediction.takenVec(i).valid
@@ -377,8 +428,8 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     val useSc     = s3_scUsed(i)
     val scTaken   = s3_scTakenMask(i)
 
-    s3_jumpTakenVec(i) ||
-    (s3_isBrVec(i) &&
+    s3_isJumpVec(i) ||
+    (s3_isCondVec(i) &&
       MuxCase(
         entry.bits.taken, // default: base table
         Seq(
@@ -394,14 +445,10 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val s3_useRas             = s3_firstTakenBranch.bits.attribute.isReturn
   private val s3_useIttage          = s3_firstTakenBranch.bits.attribute.needIttage && ittage.io.prediction.hit
 
-  private val s2_fallThroughPrediction = RegEnable(fallThrough.io.prediction, s1_fire)
   private val s3_fallThroughPrediction = RegEnable(s2_fallThroughPrediction, s2_fire)
 
   // used for mainBTB replacer
   mbtb.io.s3_takenMask := s3_takenMask
-
-  // used for ghr
-  private val s3_condHitMask = VecInit(s3_mbtbResult.map(e => e.valid && e.bits.attribute.isConditional))
 
   s3_prediction       := Mux(s3_taken, s3_firstTakenBranch.bits, s3_fallThroughPrediction)
   s3_prediction.taken := s3_taken
@@ -415,21 +462,21 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
       )
     )
 
-  s3_override := {
-    val takenDiff       = s3_taken =/= s3_s1Prediction.taken
-    val cfiPositionDiff = s3_taken && Mux1H(s3_firstTakenBranchOH, s3_mbtbCfiPositionDiffVec)
-    val attributeDiff   = s3_taken && Mux1H(s3_firstTakenBranchOH, s3_mbtbAttributeDiffVec)
-    val targetDiff =
-      MuxCase(
-        false.B, // fall-through
-        Seq(
-          (s3_taken && s3_useRas)    -> s3_rasTargetDiff,
-          (s3_taken && s3_useIttage) -> s3_ittageTargetDiff,
-          s3_taken                   -> Mux1H(s3_firstTakenBranchOH, s3_mbtbTargetDiffVec)
-        )
+  private val s3_targetDiff =
+    MuxCase(
+      false.B,
+      Seq(
+        (s3_taken && s3_useRas)    -> s3_rasTargetDiff,
+        (s3_taken && s3_useIttage) -> s3_ittageTargetDiff,
+        s3_taken                   -> Mux1H(s3_firstTakenBranchOH, s3_mbtbTargetDiffVec)
       )
+    )
 
-    s3_valid && (takenDiff || cfiPositionDiff || attributeDiff || targetDiff)
+  s3_override := {
+    val takenDiff            = s3_taken =/= s3_s2Prediction.taken
+    val firstTakenBranchDiff = !(s3_firstTakenBranchOH === s3_s2FirstTakenBranchOH)
+
+    s3_valid && (takenDiff || firstTakenBranchDiff || s3_targetDiff)
   }
 
   private val s2_phrMeta = RegEnable(phr.io.phrMeta, s1_fire)
@@ -466,17 +513,21 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   println(s"bpu commit meta width: ${s3_commitMeta.getWidth}")
 
   /* *** bpu to ftq io *** */
-  io.toFtq.prediction.valid := s1_valid && s2_ready || s3_override
+  io.toFtq.prediction.valid := s1_valid && s2_ready || s2_override || s3_override
   when(s3_override) {
     io.toFtq.prediction.bits.fromStage(s3_startPc.get, s3_prediction)
+  }.elsewhen(s2_override) {
+    io.toFtq.prediction.bits.fromStage(s2_startPc.get, s2_prediction)
   }.otherwise {
     io.toFtq.prediction.bits.fromStage(s1_startPc.get, s1_prediction)
   }
+  io.toFtq.prediction.bits.s2Override := s2_override
   io.toFtq.prediction.bits.s3Override := s3_override
 
-  // used for meta enqueue and s3 override
+  // used for meta enqueue and override
   private val s2_ftqPtr = RegEnable(io.fromFtq.bpuPtr, s1_fire)
   private val s3_ftqPtr = RegEnable(s2_ftqPtr, s2_fire)
+  io.toFtq.s2FtqPtr := s2_ftqPtr
   io.toFtq.s3FtqPtr := s3_ftqPtr
 
   io.toFtq.meta.valid             := s3_valid
@@ -490,6 +541,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     Seq(
       redirect.valid -> redirect.bits.target,
       s3_override    -> s3_prediction.target,
+      s2_override    -> s2_prediction.target,
       s1_valid       -> s1_prediction.target
     )
   )
@@ -506,23 +558,27 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     s1_ubtbPredWithURas.bits.target := uras.io.specOut.retTarget
   }
 
-  private val s1_abtbPredWithURas = WireInit(abtb.io.prediction)
+  private val s1_abtbPredWithURas = WireInit(abtb.io.result.entries)
   s1_abtbPredWithURas.foreach {
     case p => when(p.valid && p.bits.attribute.isReturn && uras.io.specOut.isCanUse) {
         p.bits.target := uras.io.specOut.retTarget
       }
   }
 
-  phr.io.train.s0_stall      := s0_stall
-  phr.io.train.stageCtrl     := stageCtrl
-  phr.io.train.redirect      := redirect
-  phr.io.train.s3_override   := s3_override
-  phr.io.train.s3_phrMeta    := s3_phrMeta
-  phr.io.train.s3_prediction := s3_prediction
-  phr.io.train.s3_startPc    := s3_startPc.get.unGuard
-  phr.io.s1Train.valid       := s1_fire
-  phr.io.s1Train.startPc     := s1_startPc.get.unGuard
-  phr.io.s1Train.prediction  := s1_prediction
+  phr.io.train.s0_stall         := s0_stall
+  phr.io.train.stageCtrl        := stageCtrl
+  phr.io.train.redirect         := redirect
+  phr.io.train.s2.overrideValid := s2_override
+  phr.io.train.s2.phrMeta       := s2_phrMeta
+  phr.io.train.s2.prediction    := s2_prediction
+  phr.io.train.s2.startPc       := s2_startPc.get.unGuard
+  phr.io.train.s3.overrideValid := s3_override
+  phr.io.train.s3.phrMeta       := s3_phrMeta
+  phr.io.train.s3.prediction    := s3_prediction
+  phr.io.train.s3.startPc       := s3_startPc.get.unGuard
+  phr.io.s1Train.valid          := s1_fire
+  phr.io.s1Train.startPc        := s1_startPc.get.unGuard
+  phr.io.s1Train.prediction     := s1_prediction
 
   phr.io.commit.valid := io.fromFtq.train.fire
   phr.io.commit.bits.fromBpuTrain(train)
@@ -542,29 +598,25 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     s1_prediction.taken && s1_prediction.attribute.isConditional &&
       (s1_cfiPc.addr(CompareAddrLowWidth - 1, 0) > s1_prediction.target.addr(CompareAddrLowWidth - 1, 0))
 
-  commonHR.io.stageCtrl                 := stageCtrl
-  commonHR.io.s0_startPc.get            := s0_startPc.get.unGuard
-  commonHR.io.s1_imliTaken              := s1_imliTaken
-  commonHR.io.s2StartPc                 := s2_startPc.get.unGuard
-  commonHR.io.s2CondHitMask             := VecInit(mbtb.io.result.map(e => e.valid && e.bits.attribute.isConditional))
-  commonHR.io.s2CfiPositions            := VecInit(mbtb.io.result.map(_.bits.cfiPosition))
-  commonHR.io.s2CfiTargets              := VecInit(mbtb.io.result.map(_.bits.target.unGuard))
-  commonHR.io.update.startPc            := s3_startPc.get.unGuard
-  commonHR.io.update.target             := s3_prediction.target.unGuard
-  commonHR.io.update.taken              := s3_taken
-  commonHR.io.update.s3Override         := s3_override
-  commonHR.io.update.attributes         := VecInit(s3_mbtbResult.map(_.bits.attribute))
-  commonHR.io.update.targets            := VecInit(s3_mbtbResult.map(_.bits.target.unGuard))
-  commonHR.io.update.firstTakenBranchOH := s3_firstTakenBranchOH
-  commonHR.io.update.firstTakenBranch   := s3_firstTakenBranch
-  commonHR.io.update.position           := VecInit(s3_mbtbResult.map(_.bits.cfiPosition))
-  commonHR.io.update.condHitMask        := s3_condHitMask
-  commonHR.io.redirect.valid            := redirect.valid
-  commonHR.io.redirect.cfiPc            := redirect.bits.cfiPc
-  commonHR.io.redirect.target           := redirect.bits.target.unGuard
-  commonHR.io.redirect.taken            := redirect.bits.taken
-  commonHR.io.redirect.attribute        := redirect.bits.attribute
-  commonHR.io.redirect.meta             := redirect.bits.meta.commonHRMeta
+  commonHR.io.stageCtrl                   := stageCtrl
+  commonHR.io.s0_startPc.get              := s0_startPc.get.unGuard
+  commonHR.io.s1_imliTaken                := s1_imliTaken
+  commonHR.io.s2Update.isOverride         := s2_override
+  commonHR.io.s2Update.startPc            := s2_startPc.get.unGuard
+  commonHR.io.s2Update.prediction         := s2_prediction
+  commonHR.io.s2Update.condHitMask        := s2_isCondVec
+  commonHR.io.s2Update.positions          := VecInit(mbtb.io.result.map(_.bits.cfiPosition))
+  commonHR.io.s2Update.targets            := VecInit(mbtb.io.result.map(_.bits.target.unGuard))
+  commonHR.io.s3Update.isOverride         := s3_override
+  commonHR.io.s3Update.startPc            := s3_startPc.get.unGuard
+  commonHR.io.s3Update.prediction         := s3_prediction
+  commonHR.io.s3Update.firstTakenBranchOH := s3_firstTakenBranchOH
+  commonHR.io.redirect.valid              := redirect.valid
+  commonHR.io.redirect.cfiPc              := redirect.bits.cfiPc
+  commonHR.io.redirect.target             := redirect.bits.target.unGuard
+  commonHR.io.redirect.taken              := redirect.bits.taken
+  commonHR.io.redirect.attribute          := redirect.bits.attribute
+  commonHR.io.redirect.meta               := redirect.bits.meta.commonHRMeta
 
   // Power-on reset
   private val powerOnResetState = RegInit(true.B)
@@ -578,8 +630,10 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   )
 
   /* *** check abtb output *** */
-  when(io.toFtq.prediction.fire && abtb.io.prediction.map(_.valid).reduce(_ || _)) {
-    assert(abtb.io.debug_startPc === s1_startPc.head.unGuard)
+  abtb.io.result.debug_startPc.foreach { debug_startPc =>
+    when(io.toFtq.prediction.fire && !s1_flush && abtb.io.result.entries.map(_.valid).reduce(_ || _)) {
+      assert(debug_startPc === s1_startPc.head)
+    }
   }
 
   /* *** Debug Meta *** */
@@ -612,9 +666,11 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   s3_perfMeta.startPc             := s3_startPc.head.unGuard
   s3_perfMeta.bpId                := debug_bpId
   s3_perfMeta.s1Prediction        := s3_s1Prediction
+  s3_perfMeta.s2Prediction        := s3_s2Prediction
   s3_perfMeta.s3Prediction        := s3_prediction
   s3_perfMeta.bpSource.s1Source   := s3_s1PredictionSource
   s3_perfMeta.bpSource.s3Source   := s3_predictionSource
+  s3_perfMeta.bpSource.s2Override := s3_s2Override
   s3_perfMeta.bpSource.s3Override := s3_override
   s3_perfMeta.mbtbMeta            := RegEnable(mbtb.io.meta, s2_fire)
   s3_perfMeta.scUsed              := s3_scUsed.asUInt
@@ -664,6 +720,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   /* *** perf pred *** */
 
   XSPerfAccumulate("toFtqFire", io.toFtq.prediction.fire)
+  XSPerfAccumulate("s2Override", io.toFtq.prediction.fire && io.toFtq.prediction.bits.s2Override)
   XSPerfAccumulate("s3Override", io.toFtq.prediction.fire && io.toFtq.prediction.bits.s3Override)
   XSPerfHistogram(
     "fetchBlockSize",
@@ -678,7 +735,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   )
   XSPerfSeqAccumulate(
     "s1_use",
-    io.toFtq.prediction.fire,
+    io.toFtq.prediction.fire && !s2_override && !s3_override,
     Seq(
       ("ubtb", debug_s1UseUbtb),
       ("abtb", debug_s1UseAbtb),
@@ -693,7 +750,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   XSPerfSeqAccumulate(
     "finalPred_s1",
-    s3_fire && !s3_override,
+    s3_fire && !s3_s2Override && !s3_override,
     BpuPredictionSource.Stage1.getValidSeq(s3_perfMeta.bpSource.s1Source)
   )
 
@@ -733,8 +790,8 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   XSPerfSeqAccumulate(
     s"s3Override_positionMismatch",
     io.toFtq.prediction.fire && s3_override &&
-      s3_prediction.taken && s3_s1Prediction.taken &&
-      s3_prediction.cfiPosition =/= s3_s1Prediction.cfiPosition,
+      s3_prediction.taken && s3_s2Prediction.taken &&
+      s3_prediction.cfiPosition =/= s3_s2Prediction.cfiPosition,
     perf_s1TakenSourceVec
   )
 
@@ -742,9 +799,9 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   XSPerfSeqAccumulate(
     s"s3Override_attributeMismatch",
     io.toFtq.prediction.fire && s3_override &&
-      s3_prediction.taken && s3_s1Prediction.taken &&
-//      s3_prediction.cfiPosition === s3_s1Prediction.cfiPosition &&
-      !(s3_prediction.attribute === s3_s1Prediction.attribute),
+      s3_prediction.taken && s3_s2Prediction.taken &&
+//      s3_prediction.cfiPosition === s3_s2Prediction.cfiPosition &&
+      !(s3_prediction.attribute === s3_s2Prediction.attribute),
     perf_s1TakenSourceVec
   )
 
@@ -760,9 +817,9 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   XSPerfSeqAccumulate(
     s"s3Override_targetMismatch",
     io.toFtq.prediction.fire && s3_override &&
-      s3_prediction.taken && s3_s1Prediction.taken &&
-      s3_prediction.cfiPosition === s3_s1Prediction.cfiPosition &&
-      !(s3_prediction.target === s3_s1Prediction.target),
+      s3_prediction.taken && s3_s2Prediction.taken &&
+      s3_prediction.cfiPosition === s3_s2Prediction.cfiPosition &&
+      s3_targetDiff,
     perf_fullTakenSourceVec
   )
 

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -149,6 +149,7 @@ object BranchAttribute {
 class BpuPredictionSource extends Bundle {
   val s1Source:   UInt = BpuPredictionSource.Stage1()
   val s3Source:   UInt = BpuPredictionSource.Stage3()
+  val s2Override: Bool = Bool()
   val s3Override: Bool = Bool()
 
   def s1Ubtb:        Bool = s1Source === BpuPredictionSource.Stage1.Ubtb
@@ -202,6 +203,7 @@ class BpuPrediction(implicit p: Parameters) extends BpuBundle {
   val taken:       Bool      = Bool()
   val endPosition: UInt      = UInt(CfiPositionWidth.W)
   // override valid
+  val s2Override: Bool = Bool()
   val s3Override: Bool = Bool()
 
   def fromStage(startPc: GuardedPc, prediction: Prediction): Unit = {
@@ -336,11 +338,18 @@ class BpuPerfMeta(implicit p: Parameters) extends BpuBundle {
   val scUsed:       UInt                = UInt(NumBtbResultEntries.W)
   val startPc:      Pc                  = new Pc
   val s1Prediction: Prediction          = new Prediction
+  val s2Prediction: Prediction          = new Prediction
   val s3Prediction: Prediction          = new Prediction
   val mbtbMeta:     MainBtbMeta         = new MainBtbMeta
   val bpSource:     BpuPredictionSource = new BpuPredictionSource
 
-  def bpPred: Prediction = Mux(bpSource.s3Override, s3Prediction, s1Prediction)
+  def bpPred: Prediction = MuxCase(
+    s1Prediction,
+    Seq(
+      bpSource.s3Override -> s3Prediction,
+      bpSource.s2Override -> s2Prediction
+    )
+  )
 }
 
 class BpuMeta(implicit p: Parameters) extends BpuBundle {

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
@@ -19,28 +19,27 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.XSPerfAccumulate
-import xiangshan.frontend.Pc
+import xiangshan.frontend.GuardedPc
 import xiangshan.frontend.bpu.BasePredictor
 import xiangshan.frontend.bpu.BasePredictorIO
+import xiangshan.frontend.bpu.HasAheadPredictorIO
 import xiangshan.frontend.bpu.HasFastTrainIO
-import xiangshan.frontend.bpu.Prediction
 import xiangshan.frontend.bpu.history.phr.PhrAllFoldedHistories
 
 /**
  * This module is the implementation of the ahead BTB (Branch Target Buffer).
  */
 class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
-  class AheadBtbIO(implicit p: Parameters) extends BasePredictorIO with HasFastTrainIO {
-    val redirectValid: Bool                       = Input(Bool())
-    val overrideValid: Bool                       = Input(Bool())
-    val prediction:    Vec[Valid[Prediction]]     = Output(Vec(NumAheadBtbPredictionEntries, Valid(new Prediction)))
-    val predCtrl:      AbtbBranchCtrl             = Output(new AbtbBranchCtrl)
-    val abtbResult:    Vec[Valid[AheadBtbResult]] = Output(Vec(NumAheadBtbPredictionEntries, Valid(new AheadBtbResult)))
-    val abtbResultPos: Vec[UInt]                  = Output(Vec(NumAheadBtbPredictionEntries, UInt(CfiPositionWidth.W)))
-    val abtbPos:       Vec[UInt]                  = Output(Vec(NumAheadBtbPredictionEntries, UInt(CfiPositionWidth.W)))
-    val meta:          AheadBtbMeta               = Output(new AheadBtbMeta)
-    val debug_startPc: Pc                         = Output(Pc())
+  class AheadBtbIO(implicit p: Parameters) extends BasePredictorIO with HasAheadPredictorIO with HasFastTrainIO {
     val normalPathHist: PhrAllFoldedHistories = Input(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
+
+    val result: AheadBtbResult = Output(new AheadBtbResult)
+    val meta:   AheadBtbMeta   = Output(new AheadBtbMeta)
+
+    val toMicroTage: AheadBtbToMicroTageIO = Output(new AheadBtbToMicroTageIO)
+
+    val debug_bpuS2StartPc: Option[GuardedPc] = Option.when(!env.FPGAPlatform)(Input(GuardedPc()))
+    val debug_bpuS3StartPc: Option[GuardedPc] = Option.when(!env.FPGAPlatform)(Input(GuardedPc()))
   }
   val io: AheadBtbIO = IO(new AheadBtbIO)
 
@@ -64,41 +63,26 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
     )
   )
 
+  /* --------------------------------------------------------------------------------------------------------------
+     predict pipeline control
+     -------------------------------------------------------------------------------------------------------------- */
+
   private val s0_fire = Wire(Bool())
   private val s1_fire = Wire(Bool())
   private val s2_fire = Wire(Bool())
 
-  private val s1_ready = Wire(Bool())
   private val s2_ready = Wire(Bool())
-
-  private val s1_flush = Wire(Bool())
-  private val s2_flush = Wire(Bool())
 
   private val s1_valid = RegInit(false.B)
   private val s2_valid = RegInit(false.B)
 
-  private val predictReqValid = io.stageCtrl.s0_fire
-  private val predictionSent  = io.stageCtrl.s1_fire
-  private val redirectValid   = io.redirectValid
-  private val overrideValid   = io.overrideValid
+  private val s2_state = RegInit(0.U.asTypeOf(new PipelineState))
 
-  s0_fire := io.enable && predictReqValid
-  s1_fire := io.enable && s1_valid && s2_ready && predictReqValid
-  s2_fire := io.enable && s2_valid && predictionSent
+  private val bpuS3ReplayState = RegInit(0.U.asTypeOf(Valid(new PipelineState)))
 
-  s1_ready := s1_fire || !s1_valid
-  s2_ready := s2_fire || !s2_valid || overrideValid || redirectValid
-
-  s2_flush := redirectValid
-  s1_flush := s2_flush
-
-  when(s0_fire)(s1_valid := true.B)
-    .elsewhen(s1_flush)(s1_valid := false.B)
-    .elsewhen(s1_fire)(s1_valid := false.B)
-
-  when(s1_fire)(s2_valid := true.B)
-    .elsewhen(s2_flush)(s2_valid := false.B)
-    .elsewhen(s2_fire)(s2_valid := false.B)
+  private val bpuS0Fire = io.stageCtrl.s0_fire
+  private val bpuS1Fire = io.stageCtrl.s1_fire
+  private val bpuS2Fire = io.stageCtrl.s2_fire
 
   /* --------------------------------------------------------------------------------------------------------------
      predict pipeline stage 0
@@ -106,136 +90,137 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
      - send read request to selected bank
      -------------------------------------------------------------------------------------------------------------- */
 
-  private val s0_previousStartPc = io.startPc
+  s0_fire := io.enable && bpuS0Fire
 
   private val s0_simpleHash = io.normalPathHist.getHistWithInfo(AbtbHashFhInfo).foldedHist(AheadBtbHashBitWidth - 1, 0)
-  private val s0_hashIndex  = s0_previousStartPc(log2Ceil(NumEntries / NumWays) - 1, 0) ^ s0_simpleHash
+  private val s0_hashIndex  = io.startPc(log2Ceil(NumEntries / NumWays) - 1, 0) ^ s0_simpleHash
   private val s0_setIdx     = s0_hashIndex(log2Ceil(NumEntries / NumWays) - 1, log2Ceil(NumBanks))
   private val s0_bankIdx    = s0_hashIndex(log2Ceil(NumBanks) - 1, 0)
   private val s0_bankMask   = UIntToOH(s0_bankIdx)
 
   banks.zipWithIndex.foreach { case (b, i) =>
-    b.io.readReq.valid       := predictReqValid && s0_bankMask(i)
+    b.io.readReq.valid       := s0_fire && s0_bankMask(i)
     b.io.readReq.bits.setIdx := s0_setIdx
   }
 
   /* --------------------------------------------------------------------------------------------------------------
      predict pipeline stage 1
-     - get the latest start pc for compare tag in s2
-     - get entries from bank
+     - receive the SRAM entries
+     - use the normal-path start PC to match the SRAM entries
+     - use the override target to rematch old S2 data or the BPU S3 replay state
+     - select the normal or override result and prepare the complete S2 state
      -------------------------------------------------------------------------------------------------------------- */
 
-  private val s1_startPc = io.startPc
+  s1_fire := io.enable && s1_valid && s2_ready && bpuS0Fire
 
-  private val s1_setIdx   = RegEnable(s0_setIdx, s0_fire)
-  private val s1_bankIdx  = RegEnable(s0_bankIdx, s0_fire)
-  private val s1_bankMask = RegEnable(s0_bankMask, s0_fire)
+  when(!io.enable) {
+    s1_valid := false.B
+  }.elsewhen(s0_fire) {
+    s1_valid := true.B
+  }.elsewhen(io.redirect || s1_fire) {
+    s1_valid := false.B
+  }
 
-  private val s1_entries    = Mux1H(s1_bankMask, banks.map(_.io.readResp.entries))
-  private val s1_ctrVec     = takenCounter(s1_bankIdx)(s1_setIdx)
-  private val s1_ctrResult  = VecInit(s1_ctrVec.map(_.isPositive))
-  private val s1_strongBias = VecInit(s1_ctrVec.map(_.isSaturate))
+  private val s1_setIdx       = RegEnable(s0_setIdx, s0_fire)
+  private val s1_bankIdx      = RegEnable(s0_bankIdx, s0_fire)
+  private val s1_bankMask     = RegEnable(s0_bankMask, s0_fire)
+  private val s1_debugIndexPc = Option.when(!env.FPGAPlatform)(RegEnable(io.startPc, s0_fire))
+
+  private val s1_entries = Mux1H(s1_bankMask, banks.map(_.io.readResp.entries))
+  private val s1_ctrVec  = takenCounter(s1_bankIdx)(s1_setIdx)
+
+  private val s1_normalState = WireInit(0.U.asTypeOf(new PipelineState))
+  s1_normalState.startPc  := io.newStartPc
+  s1_normalState.setIdx   := s1_setIdx
+  s1_normalState.bankIdx  := s1_bankIdx
+  s1_normalState.bankMask := s1_bankMask
+  s1_normalState.entries  := s1_entries
+  s1_normalState.ctrVec   := s1_ctrVec
+  s1_normalState.hitMask  := s1_normalState.getHitMask
+  s1_normalState.debug_indexPc.zip(s1_debugIndexPc).foreach { case (a, b) => a := b }
+
+  // compute hit mask for the override state, which is used to rematch the old S2 state or the BPU S3 replay state
+  private val s1_overrideState = WireInit(Mux(io.bpuS3Override, bpuS3ReplayState.bits, s2_state))
+  s1_overrideState.startPc := io.overrideStartPc
+  s1_overrideState.hitMask := s1_overrideState.getHitMask
+
+  private val s1_state = Mux(io.bpuS3Override || io.bpuS2Override, s1_overrideState, s1_normalState)
+
+  s2_state.debug_indexPc.zip(io.debug_bpuS2StartPc).foreach { case (indexPc, bpuStartPc) =>
+    when(io.enable && !io.redirect && io.bpuS2Override && !io.bpuS3Override && s2_valid) {
+      assert(indexPc === bpuStartPc, "AheadBtb S2 override reuses entries indexed by the wrong PC")
+    }
+  }
+  bpuS3ReplayState.bits.debug_indexPc.zip(io.debug_bpuS3StartPc).foreach { case (indexPc, bpuStartPc) =>
+    when(io.enable && !io.redirect && io.bpuS3Override && bpuS3ReplayState.valid) {
+      assert(indexPc === bpuStartPc, "AheadBtb S3 override reuses entries indexed by the wrong PC")
+    }
+  }
+
+  io.toMicroTage.fastPositions := s1_state.entries.map(_.position)
+
   /* --------------------------------------------------------------------------------------------------------------
-     predict pipeline stage 2 / 3
-     - get taken counter result
-     - compare tag and get taken mask
-     - compare positions and find first taken entry
-     - get target from found entry
-     - output prediction
-     - stage 3 is only for fast prediction when override is valid
+     predict pipeline stage 2
+     - latch the normal or replay state prepared in S1
+     - output the prediction
      -------------------------------------------------------------------------------------------------------------- */
 
-  private val s3_setIdx     = RegInit(0.U.asTypeOf(s1_setIdx))
-  private val s3_bankIdx    = RegInit(0.U.asTypeOf(s1_bankIdx))
-  private val s3_bankMask   = RegInit(0.U.asTypeOf(s1_bankMask))
-  private val s3_entries    = RegInit(0.U.asTypeOf(s1_entries))
-  private val s3_startPc    = RegInit(0.U.asTypeOf(s1_startPc))
-  private val s3_ctrResult  = RegInit(VecInit.fill(NumWays)(false.B))
-  private val s3_strongBias = RegInit(VecInit.fill(NumWays)(false.B))
+  s2_ready := s2_fire || !s2_valid || io.bpuS2Override || io.bpuS3Override || io.redirect
 
-  private val s1_realEntries = Mux(overrideValid, s3_entries, s1_entries)
-  private val s1_tag         = getTag(s1_startPc)
-  private val s1_realHitMask = VecInit(s1_realEntries.map(entry => entry.valid && entry.tag === s1_tag))
-  private val s2_setIdx      = RegEnable(Mux(overrideValid, s3_setIdx, s1_setIdx), s1_fire)
-  private val s2_bankIdx     = RegEnable(Mux(overrideValid, s3_bankIdx, s1_bankIdx), s1_fire)
-  private val s2_bankMask    = RegEnable(Mux(overrideValid, s3_bankMask, s1_bankMask), s1_fire)
-  private val s2_ctrResult   = RegEnable(Mux(overrideValid, s3_ctrResult, s1_ctrResult), s1_fire)
-  private val s2_strongBias  = RegEnable(Mux(overrideValid, s3_strongBias, s1_strongBias), s1_fire)
-  private val s2_entries     = RegEnable(s1_realEntries, s1_fire)
-  private val s2_startPc     = RegEnable(s1_startPc, s1_fire)
-  private val s2_hitMask     = RegEnable(s1_realHitMask, s1_fire)
-
-  when(s2_fire) {
-    s3_setIdx     := s2_setIdx
-    s3_bankIdx    := s2_bankIdx
-    s3_bankMask   := s2_bankMask
-    s3_entries    := s2_entries
-    s3_startPc    := s2_startPc
-    s3_ctrResult  := s2_ctrResult
-    s3_strongBias := s2_strongBias
+  when(s1_fire || io.bpuS2Override || io.bpuS3Override) {
+    s2_state := s1_state
   }
 
-  // private val s2_tag = getTag(s2_startPc)
-  // dontTouch(s2_tag)
-  // private val s2_hitMask = s2_entries.map(entry => entry.valid && entry.tag === s2_tag)
-  // private val s2_hit     = s2_hitMask.reduce(_ || _)
-  private val s2_hit = s2_hitMask.reduce(_ || _)
-
-  // When detect multi-hit, we need to invalidate one entry.
-  private val (s2_multiHit, s2_multiHitWayIdx) = detectMultiHit(s2_hitMask, s2_entries.map(_.position))
-
-  private val s2_jumpValidVec      = RegInit(VecInit.fill(NumAheadBtbPredictionEntries)(false.B))
-  private val s2_conditionValidVec = RegInit(VecInit.fill(NumAheadBtbPredictionEntries)(false.B))
-  when(s1_fire) {
-    s2_jumpValidVec := VecInit.tabulate(NumAheadBtbPredictionEntries) {
-      i => (s1_realEntries(i).attribute.isDirect || s1_realEntries(i).attribute.isIndirect) && s1_realHitMask(i)
-    }
-    s2_conditionValidVec := VecInit.tabulate(NumAheadBtbPredictionEntries) {
-      i => s1_realEntries(i).attribute.isConditional && s1_realHitMask(i)
-    }
-  }.elsewhen(s2_flush || s2_fire) {
-    s2_jumpValidVec      := VecInit.fill(NumAheadBtbPredictionEntries)(false.B)
-    s2_conditionValidVec := VecInit.fill(NumAheadBtbPredictionEntries)(false.B)
+  when(!io.enable || io.redirect) {
+    s2_valid := false.B
+  }.elsewhen(io.bpuS3Override) {
+    s2_valid := bpuS3ReplayState.valid
+  }.elsewhen(s1_fire && !io.bpuS2Override) {
+    s2_valid := true.B
+  }.elsewhen(s2_fire) {
+    s2_valid := false.B
   }
 
-  io.prediction.zipWithIndex.foreach { case (pred, i) =>
-    pred.valid            := s2_valid && s2_hitMask(i)
-    pred.bits.taken       := s2_ctrResult(i)
-    pred.bits.cfiPosition := s2_entries(i).position
-    pred.bits.attribute   := s2_entries(i).attribute
-    pred.bits.target      := getFullTarget(s2_startPc, s2_entries(i).targetLowerBits, s2_entries(i).targetCarry)
-  }
-  // Advance the calculation of critical control signals.
-  io.predCtrl.jumpValidVec      := s2_jumpValidVec
-  io.predCtrl.conditionValidVec := s2_conditionValidVec
-  io.abtbResult.zipWithIndex.foreach { case (pred, i) =>
-    pred.valid             := s2_valid && s2_hitMask(i)
-    pred.bits.taken        := s2_ctrResult(i)
-    pred.bits.cfiPosition  := s2_entries(i).position
-    pred.bits.attribute    := s2_entries(i).attribute
-    pred.bits.isStrongBias := s2_strongBias(i)
-  }
-  io.abtbResultPos.zipWithIndex.map { case (pos, i) =>
-    // Aggregates scattered position bits from wide entries for matrix comparison.
-    pos := RegEnable(s1_realEntries(i).position, s1_fire)
-  }
-  io.abtbPos.zipWithIndex.map { case (pos, i) =>
-    // Direct routing to MicroTage for pipelined comparison; potentially timing beneficial.
-    pos := s1_realEntries(i).position
-  }
+  s2_fire := s2_valid && bpuS1Fire && !io.bpuS3Override && !io.bpuS2Override && !io.redirect
 
+  io.result.entries.zipWithIndex.foreach { case (pred, i) =>
+    pred.valid            := s2_valid && s2_state.hitMask(i)
+    pred.bits.taken       := s2_state.ctrVec(i).isPositive
+    pred.bits.cfiPosition := s2_state.entries(i).position
+    pred.bits.attribute   := s2_state.entries(i).attribute
+    pred.bits.target :=
+      getFullTarget(s2_state.startPc, s2_state.entries(i).targetLowerBits, s2_state.entries(i).targetCarry)
+  }
+  io.toMicroTage.result.zipWithIndex.foreach { case (pred, i) =>
+    pred.valid             := s2_valid && s2_state.hitMask(i)
+    pred.bits.taken        := s2_state.ctrVec(i).isPositive
+    pred.bits.cfiPosition  := s2_state.entries(i).position
+    pred.bits.attribute    := s2_state.entries(i).attribute
+    pred.bits.isStrongBias := s2_state.ctrVec(i).isSaturate
+  }
   io.meta.valid    := s2_valid
-  io.meta.setIdx   := s2_setIdx
-  io.meta.bankMask := s2_bankMask
+  io.meta.setIdx   := s2_state.setIdx
+  io.meta.bankMask := s2_state.bankMask
   io.meta.entries.zipWithIndex.foreach { case (e, i) =>
-    e.hit             := s2_hitMask(i)
-    e.attribute       := s2_entries(i).attribute
-    e.position        := s2_entries(i).position
-    e.targetLowerBits := s2_entries(i).targetLowerBits
+    e.hit             := s2_state.hitMask(i)
+    e.attribute       := s2_state.entries(i).attribute
+    e.position        := s2_state.entries(i).position
+    e.targetLowerBits := s2_state.entries(i).targetLowerBits
   }
 
   // used for check abtb output
-  io.debug_startPc := s2_startPc.unGuard
+  io.result.debug_startPc.foreach(_ := s2_state.startPc)
+
+  /* --------------------------------------------------------------------------------------------------------------
+     old state for bpu s3 override
+     -------------------------------------------------------------------------------------------------------------- */
+
+  when(!io.enable || io.redirect || io.bpuS3Override) {
+    bpuS3ReplayState.valid := false.B
+  }.elsewhen(bpuS2Fire) {
+    bpuS3ReplayState.valid := s2_valid
+    bpuS3ReplayState.bits  := s2_state
+  }
 
   /* --------------------------------------------------------------------------------------------------------------
      train pipeline stage 0
@@ -334,6 +319,24 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
   private val t2_hitMask           = RegNext(VecInit(t1_hitMask))
   private val t2_trainTaken        = RegNext(t1_trainTaken)
 
+  // When detect multi-hit, we need to invalidate one entry.
+  private val (s2_multiHit, s2_multiHitWayIdx) =
+    detectMultiHit(s2_state.hitMask, s2_state.entries.map(_.position))
+  private val s2_needCleanMultiHit = s2_fire && s2_multiHit
+
+  private val multiHitSetIdx   = RegEnable(s2_state.setIdx, s2_needCleanMultiHit)
+  private val multiHitBankMask = RegEnable(s2_state.bankMask, s2_needCleanMultiHit)
+  private val multiHitWayIdx   = RegEnable(s2_multiHitWayIdx, s2_needCleanMultiHit)
+
+  private val cleanMultiHitValid   = RegInit(false.B)
+  private val cleanMultiHitApplied = WireInit(VecInit.fill(NumBanks)(false.B))
+
+  when(s2_needCleanMultiHit) {
+    cleanMultiHitValid := true.B
+  }.elsewhen(cleanMultiHitApplied.asUInt.orR) {
+    cleanMultiHitValid := false.B
+  }
+
   banks.zipWithIndex.foreach { case (b, i) =>
     when(t2_fire && t2_needWriteNewEntry && t2_bankMask(i)) {
       b.io.writeReq.valid             := true.B
@@ -347,11 +350,12 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
       b.io.writeReq.bits.setIdx       := t2_setIdx
       b.io.writeReq.bits.wayIdx       := OHToUInt(t2_hitMaskOH)
       b.io.writeReq.bits.entry        := t2_writeEntry
-    }.elsewhen(s2_valid && s2_multiHit && s2_bankMask(i)) {
+    }.elsewhen(cleanMultiHitValid && multiHitBankMask(i)) {
+      cleanMultiHitApplied(i)         := true.B
       b.io.writeReq.valid             := true.B
       b.io.writeReq.bits.needResetCtr := true.B
-      b.io.writeReq.bits.setIdx       := s2_setIdx
-      b.io.writeReq.bits.wayIdx       := s2_multiHitWayIdx
+      b.io.writeReq.bits.setIdx       := multiHitSetIdx
+      b.io.writeReq.bits.wayIdx       := multiHitWayIdx
       b.io.writeReq.bits.entry        := 0.U.asTypeOf(new AheadBtbEntry)
     }.otherwise {
       b.io.writeReq.valid := false.B
@@ -376,11 +380,11 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
      performance counter
      -------------------------------------------------------------------------------------------------------------- */
 
-  XSPerfAccumulate("predict_req_num", predictReqValid)
+  XSPerfAccumulate("predict_req_num", s0_fire)
   XSPerfAccumulate("predict_num", s2_fire)
-  XSPerfAccumulate("predict_hit", s2_fire && s2_hit)
-  XSPerfAccumulate("predict_miss", s2_fire && !s2_hit)
-  XSPerfAccumulate("predict_hit_entry_num", Mux(s2_fire, PopCount(s2_hitMask), 0.U))
+  XSPerfAccumulate("predict_hit", s2_fire && s2_state.hitMask.reduce(_ || _))
+  XSPerfAccumulate("predict_miss", s2_fire && !s2_state.hitMask.reduce(_ || _))
+  XSPerfAccumulate("predict_hit_entry_num", Mux(s2_fire, PopCount(s2_state.hitMask), 0.U))
   XSPerfAccumulate("predict_multi_hit", s2_fire && s2_multiHit)
 
   XSPerfAccumulate("train_req_num", io.fastTrain.get.valid)
@@ -388,11 +392,14 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
   XSPerfAccumulate("train_actual_taken", t1_fire && t1_trainTaken)
   XSPerfAccumulate("train_actual_not_taken", t1_fire && !t1_trainTaken)
 
-  XSPerfAccumulate("total_write", t1_fire && (t1_needWriteNewEntry || t1_needCorrectTarget) || s2_valid && s2_multiHit)
+  XSPerfAccumulate(
+    "total_write",
+    t1_fire && (t1_needWriteNewEntry || t1_needCorrectTarget) || s2_fire && s2_multiHit
+  )
   XSPerfAccumulate("train_write_new_entry", t1_fire && t1_needWriteNewEntry)
   XSPerfAccumulate("train_correct_target", t1_fire && t1_needCorrectTarget)
   XSPerfAccumulate(
     "train_write_conflict",
-    t1_fire && (t1_needWriteNewEntry || t1_needCorrectTarget) && s2_valid && s2_multiHit
+    t1_fire && (t1_needWriteNewEntry || t1_needCorrectTarget) && s2_fire && s2_multiHit
   )
 }

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/Bundles.scala
@@ -19,8 +19,10 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import xiangshan.XSCoreParamsKey
-import xiangshan.frontend.PrunedAddr
+import xiangshan.frontend.GuardedPc
 import xiangshan.frontend.bpu.BranchAttribute
+import xiangshan.frontend.bpu.Prediction
+import xiangshan.frontend.bpu.SaturateCounter
 import xiangshan.frontend.bpu.SaturateCounterFactory
 import xiangshan.frontend.bpu.TargetCarry
 import xiangshan.frontend.bpu.WriteReqBundle
@@ -90,14 +92,35 @@ class AheadBtbEntry(implicit p: Parameters) extends AheadBtbBundle {
   val targetCarry: Option[TargetCarry] = if (EnableTargetFix) Option(new TargetCarry) else None
 }
 
+class PipelineState(implicit p: Parameters) extends AheadBtbBundle with Helpers {
+  val startPc:  GuardedPc            = GuardedPc()
+  val setIdx:   UInt                 = UInt(SetIdxWidth.W)
+  val bankIdx:  UInt                 = UInt(BankIdxWidth.W)
+  val bankMask: UInt                 = UInt(NumBanks.W)
+  val entries:  Vec[AheadBtbEntry]   = Vec(NumWays, new AheadBtbEntry)
+  val ctrVec:   Vec[SaturateCounter] = Vec(NumWays, TakenCounter())
+  val hitMask:  Vec[Bool]            = Vec(NumWays, Bool())
+
+  val debug_indexPc: Option[GuardedPc] = Option.when(!env.FPGAPlatform)(GuardedPc())
+
+  def getHitMask: Vec[Bool] =
+    VecInit(entries.map(e => e.valid && e.tag === getTag(startPc)))
+}
+
 class AheadBtbResult(implicit p: Parameters) extends AheadBtbBundle {
+  val entries:       Vec[Valid[Prediction]] = Vec(NumAheadBtbPredictionEntries, Valid(new Prediction))
+  val debug_startPc: Option[GuardedPc]      = Option.when(!env.FPGAPlatform)(GuardedPc())
+}
+
+class AheadBtbToMicroTageResult(implicit p: Parameters) extends AheadBtbBundle {
   val taken:        Bool            = Bool()
   val cfiPosition:  UInt            = UInt(CfiPositionWidth.W)
   val attribute:    BranchAttribute = new BranchAttribute
   val isStrongBias: Bool            = Bool()
 }
 
-class AbtbBranchCtrl(implicit p: Parameters) extends AheadBtbBundle {
-  val jumpValidVec:      Vec[Bool] = Vec(NumAheadBtbPredictionEntries, Bool())
-  val conditionValidVec: Vec[Bool] = Vec(NumAheadBtbPredictionEntries, Bool())
+class AheadBtbToMicroTageIO(implicit p: Parameters) extends AheadBtbBundle {
+  val result: Vec[Valid[AheadBtbToMicroTageResult]] =
+    Vec(NumAheadBtbPredictionEntries, Valid(new AheadBtbToMicroTageResult))
+  val fastPositions: Vec[UInt] = Vec(NumAheadBtbPredictionEntries, UInt(CfiPositionWidth.W))
 }

--- a/src/main/scala/xiangshan/frontend/bpu/history/commonhr/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/commonhr/Bundles.scala
@@ -31,17 +31,21 @@ class CommonHREntry(implicit p: Parameters) extends CommonHRBundle {
 
   val predStartPc: Option[Pc] = Some(Pc()) // for debug
 }
-class CommonHRUpdate(implicit p: Parameters) extends CommonHRBundle {
-  val taken:              Bool                 = Bool()
-  val s3Override:         Bool                 = Bool()
-  val condHitMask:        Vec[Bool]            = Vec(NumBtbResultEntries, Bool())
-  val position:           Vec[UInt]            = Vec(NumBtbResultEntries, UInt(CfiPositionWidth.W))
-  val attributes:         Vec[BranchAttribute] = Vec(NumBtbResultEntries, new BranchAttribute)
-  val targets:            Vec[Pc]              = Vec(NumBtbResultEntries, Pc())
-  val firstTakenBranchOH: Vec[Bool]            = Vec(NumBtbResultEntries, Bool())
-  val firstTakenBranch:   Valid[Prediction]    = Valid(new Prediction)
-  val startPc:            Pc                   = Pc()
-  val target:             Pc                   = Pc()
+
+class Update(implicit p: Parameters) extends CommonHRBundle {
+  val isOverride: Bool       = Bool()
+  val startPc:    Pc         = Pc()
+  val prediction: Prediction = new Prediction()
+}
+
+class S2Update(implicit p: Parameters) extends Update {
+  val condHitMask: Vec[Bool] = Vec(NumBtbResultEntries, Bool())
+  val positions:   Vec[UInt] = Vec(NumBtbResultEntries, UInt(CfiPositionWidth.W))
+  val targets:     Vec[Pc]   = Vec(NumBtbResultEntries, Pc())
+}
+
+class S3Update(implicit p: Parameters) extends Update {
+  val firstTakenBranchOH: Vec[Bool] = Vec(NumBtbResultEntries, Bool())
 }
 
 class CommonHRResolveMeta(implicit p: Parameters) extends CommonHRBundle {

--- a/src/main/scala/xiangshan/frontend/bpu/history/commonhr/CommonHR.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/commonhr/CommonHR.scala
@@ -28,11 +28,8 @@ class CommonHR(implicit p: Parameters) extends CommonHRModule with Helpers with 
   class CommonHRIO extends CommonHRBundle {
     val stageCtrl:      StageCtrl           = Input(new StageCtrl)
     val s1_imliTaken:   Bool                = Input(Bool())
-    val s2StartPc:      Pc                  = Input(Pc())
-    val s2CondHitMask:  Vec[Bool]           = Input(Vec(NumBtbResultEntries, Bool()))
-    val s2CfiPositions: Vec[UInt]           = Input(Vec(NumBtbResultEntries, UInt(CfiPositionWidth.W)))
-    val s2CfiTargets:   Vec[Pc]             = Input(Vec(NumBtbResultEntries, Pc()))
-    val update:         CommonHRUpdate      = Input(new CommonHRUpdate)
+    val s2Update:       S2Update            = Input(new S2Update)
+    val s3Update:       S3Update            = Input(new S3Update)
     val redirect:       CommonHRRedirect    = Input(new CommonHRRedirect)
     val s0_imli:        UInt                = Output(UInt(ImliHistoryLength.W))
     val s0_commonHR:    CommonHREntry       = Output(new CommonHREntry)
@@ -49,7 +46,8 @@ class CommonHR(implicit p: Parameters) extends CommonHRModule with Helpers with 
   private val s2_fire = io.stageCtrl.s2_fire
   private val s3_fire = io.stageCtrl.s3_fire
 
-  private val s3_override = io.update.s3Override
+  private val s2_override = io.s2Update.isOverride
+  private val s3_override = io.s3Update.isOverride
 
   // common history register
   private val s0_imli                = WireInit(0.U(ImliHistoryLength.W))
@@ -90,18 +88,20 @@ class CommonHR(implicit p: Parameters) extends CommonHRModule with Helpers with 
    * Precompute per-CFI candidate information in s2 for the s3 CommonHR update.
    */
   // Deduplicate conditional hits by position before counting older conditional branches.
-  private val s2_hitMask          = dedupHitPositions(io.s2CondHitMask, io.s2CfiPositions)
+  private val s2_update           = io.s2Update
+  private val s2_prediction       = s2_update.prediction
+  private val s2_hitMask          = dedupHitPositions(s2_update.condHitMask, s2_update.positions)
   private val s2_numHit           = PopCount(s2_hitMask)
   private val s2_bwTakenCandidate = Wire(Vec(NumBtbResultEntries, Bool()))
   private val s2_numLessCandidate = Wire(Vec(NumBtbResultEntries, UInt(log2Ceil(NumBtbResultEntries + 1).W)))
 
   for (i <- 0 until NumBtbResultEntries) {
-    val pos    = io.s2CfiPositions(i)
-    val target = io.s2CfiTargets(i)
-    val lessThanCurrent = VecInit(io.s2CfiPositions.zip(s2_hitMask).map { case (otherPos, hit) =>
+    val pos    = s2_update.positions(i)
+    val target = s2_update.targets(i)
+    val lessThanCurrent = VecInit(s2_update.positions.zip(s2_hitMask).map { case (otherPos, hit) =>
       hit && (otherPos < pos)
     })
-    val currentCfiPc = getCfiPcFromPosition(io.s2StartPc, pos)
+    val currentCfiPc = getCfiPcFromPosition(s2_update.startPc, pos)
 
     s2_numLessCandidate(i) := PopCount(lessThanCurrent)
     s2_bwTakenCandidate(i) := isBackwardBranch(currentCfiPc, target)
@@ -110,14 +110,15 @@ class CommonHR(implicit p: Parameters) extends CommonHRModule with Helpers with 
   /*
    * Use the latched s2 candidate information to update CommonHR when s3 fires.
    */
-  private val s3_update           = io.update // bp pipeline s3 level update
+  private val s3_update           = io.s3Update // bp pipeline s3 level update
+  private val s3_prediction       = s3_update.prediction
   private val s3_hitMask          = RegEnable(s2_hitMask, s2_fire)
-  private val s3_taken            = s3_update.taken
-  private val s3_firstTakenPos    = s3_update.firstTakenBranch.bits.cfiPosition
-  private val s3_firstTakenIsCond = s3_update.firstTakenBranch.bits.attribute.isConditional
+  private val s3_taken            = s3_prediction.taken
+  private val s3_firstTakenPos    = s3_prediction.cfiPosition
+  private val s3_firstTakenIsCond = s3_prediction.attribute.isConditional
   private val s3_cfiPc            = getCfiPcFromPosition(s3_update.startPc, s3_firstTakenPos)
   private val s3_bwTakenDiff      = WireInit(false.B)
-  private val s3_bwTaken          = isBackwardBranch(s3_cfiPc, s3_update.target)
+  private val s3_bwTaken          = isBackwardBranch(s3_cfiPc, s3_prediction.target.unGuard)
 
   // NOTE: Usually, the maximum value of GhrShamt is NumBtbResultEntries, but in reality, the maximum value is NumBtbResultEntries+ 1
   private val s3_numLessCandidate = RegEnable(s2_numLessCandidate, s2_fire)
@@ -138,7 +139,7 @@ class CommonHR(implicit p: Parameters) extends CommonHRModule with Helpers with 
   s3_takenCommonHR.foreach(_ := 0.U.asTypeOf(new CommonHREntry))
   for (i <- 0 until NumBtbResultEntries) {
     val candidate      = s3_takenCommonHR(i)
-    val isCond         = s3_update.attributes(i).isConditional
+    val isCond         = s3_firstTakenIsCond
     val numLessCurrent = s3_numLessCandidate(i)
     val currentBwTaken = s3_bwTakenCandidate(i)
     candidate.valid           := s3_fire
@@ -159,7 +160,10 @@ class CommonHR(implicit p: Parameters) extends CommonHRModule with Helpers with 
   s3_defaultCommonHR.ghr             := (commonHR.ghr << s3_numHit)(GhrHistoryLength - 1, 0)
   s3_defaultCommonHR.bw              := (commonHR.bw << s3_numHit)(BWHistoryLength - 1, 0)
 
-  XSError(s3_fire && s3_taken && !s3_update.firstTakenBranchOH.reduce(_ || _), "taken but no firstTakenBranchOH")
+  XSError(
+    s3_fire && s3_taken && !s3_update.firstTakenBranchOH.reduce(_ || _),
+    "taken but no firstTakenBranchOH"
+  )
   s3_newCommonHR := Mux(s3_taken, s3_selectedTakenCommonHR, s3_defaultCommonHR)
 
   /*
@@ -267,6 +271,11 @@ class CommonHR(implicit p: Parameters) extends CommonHRModule with Helpers with 
   }
 
   // imli update
+  private val s2_overrideCfiPc   = getCfiPcFromPosition(s2_update.startPc, s2_prediction.cfiPosition)
+  private val s2_overrideBwTaken = isBackwardBranch(s2_overrideCfiPc, s2_prediction.target.unGuard)
+  private val s2_overrideImliTaken =
+    s2_prediction.taken && s2_overrideBwTaken && s2_prediction.attribute.isConditional
+
   when(r0_valid) {
     val r0_newImli = Mux(
       r0_taken && r0_bwTaken && r0_isCond,
@@ -279,6 +288,14 @@ class CommonHR(implicit p: Parameters) extends CommonHRModule with Helpers with 
     val s3_newImli = Mux(s3_taken && s3_bwTaken && s3_firstTakenIsCond, Mux(s3_imli.andR, s3_imli, s3_imli + 1.U), 0.U)
     imli    := s3_newImli
     s0_imli := s3_newImli
+  }.elsewhen(s2_override) {
+    val s2_newImli = Mux(
+      s2_overrideImliTaken,
+      Mux(s2_imli.andR, s2_imli, s2_imli + 1.U),
+      0.U
+    )
+    imli    := s2_newImli
+    s0_imli := s2_newImli
   }.elsewhen(s1_fire) {
     val s1_newImli = Mux(io.s1_imliTaken, Mux(s1_imli.andR, s1_imli, s1_imli + 1.U), 0.U)
     imli    := s1_newImli
@@ -318,6 +335,26 @@ class CommonHR(implicit p: Parameters) extends CommonHRModule with Helpers with 
     predPtr                           := realRecoverPtr
     writePtr                          := writePtr + 1.U
     recoverPtr                        := realRecoverPtr
+  }.elsewhen(s2_override) {
+    // S2 keeps the corrected block, flushes the younger S1 block, and starts a
+    // new S0 block. Compact the queue so the next write still corresponds to
+    // the block that will reach S3 next.
+    val writePtrPlus1 = writePtr + 1.U
+    val writePtrPlus2 = writePtr + 2.U
+    val writePtrPlus3 = writePtr + 3.U
+    val nextWritePtr  = Mux(s3_fire, writePtrPlus1, writePtr)
+    val newS0Ptr      = Mux(s3_fire, writePtrPlus2, writePtrPlus1)
+    val nextEnqPtr    = Mux(s3_fire, writePtrPlus3, writePtrPlus2)
+
+    when(s3_fire) {
+      histQueue(writePtr.value) := s3_newCommonHR
+    }
+    histQueue(newS0Ptr.value) := initCommonHR
+
+    enqPtr     := nextEnqPtr
+    predPtr    := Mux(predEnable, predPtr + 1.U, predPtr)
+    writePtr   := nextWritePtr
+    recoverPtr := Mux(recoverInc, recoverPtr + 1.U, recoverPtr)
   }.otherwise {
     when(enqEnable) {
       histQueue(enqPtr.value) := initCommonHR

--- a/src/main/scala/xiangshan/frontend/bpu/history/phr/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/phr/Bundles.scala
@@ -24,6 +24,7 @@ import xiangshan.XSCoreParamsKey
 import xiangshan.frontend.Pc
 import xiangshan.frontend.bpu.BpuRedirect
 import xiangshan.frontend.bpu.FoldedHistoryInfo
+import xiangshan.frontend.bpu.HalfAlignHelper
 import xiangshan.frontend.bpu.Prediction
 import xiangshan.frontend.bpu.StageCtrl
 
@@ -48,17 +49,34 @@ class S1Train(implicit p: Parameters) extends PhrBundle {
   val prediction: Prediction = new Prediction
 }
 
-class PhrUpdateData(implicit p: Parameters) extends PhrBundle with HasPhrParameters {
+class PhrUpdateData(implicit p: Parameters) extends PhrBundle with HasPhrParameters with HalfAlignHelper {
   val valid:   Bool    = Bool()
   val taken:   Bool    = Bool()
   val cfiPc:   Pc      = Pc()
   val target:  Pc      = Pc()
   val phrMeta: PhrMeta = new PhrMeta()
+
+  def fromUpdateStage(stage: PhrUpdate.Stage): Unit = {
+    valid   := stage.overrideValid
+    taken   := stage.prediction.taken
+    cfiPc   := getCfiPcFromPosition(stage.startPc, stage.prediction.cfiPosition)
+    target  := stage.prediction.target.unGuard
+    phrMeta := stage.phrMeta
+  }
 }
 
 class PhrUpdateResult(implicit p: Parameters) extends PhrBundle with HasPhrParameters {
   val phrPtr:     PhrPtr = new PhrPtr
   val phrLowBits: UInt   = UInt(PathHashHighWidth.W)
+}
+
+object PhrUpdate {
+  class Stage(implicit p: Parameters) extends PhrBundle {
+    val overrideValid: Bool       = Bool()
+    val phrMeta:       PhrMeta    = new PhrMeta()
+    val prediction:    Prediction = new Prediction()
+    val startPc:       Pc         = Pc()
+  }
 }
 
 class PhrUpdate(implicit p: Parameters) extends PhrBundle {
@@ -68,10 +86,8 @@ class PhrUpdate(implicit p: Parameters) extends PhrBundle {
 
   val redirect: Valid[BpuRedirect] = Valid(new BpuRedirect)
 
-  val s3_override:   Bool       = Bool()
-  val s3_phrMeta:    PhrMeta    = new PhrMeta()
-  val s3_prediction: Prediction = new Prediction()
-  val s3_startPc:    Pc         = Pc()
+  val s2: PhrUpdate.Stage = new PhrUpdate.Stage
+  val s3: PhrUpdate.Stage = new PhrUpdate.Stage
 }
 
 class PhrMeta(implicit p: Parameters) extends PhrBundle {

--- a/src/main/scala/xiangshan/frontend/bpu/history/phr/Phr.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/history/phr/Phr.scala
@@ -44,8 +44,9 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
   private val phr    = RegInit(0.U.asTypeOf(Vec(PhrHistoryLength, Bool())))
   private val phrPtr = RegInit(0.U.asTypeOf(new PhrPtr))
 
-  // s1Train and s3 override commit to the physical PHR one cycle later.
-  // A redirect cancels any pending write; s3 override also cancels pending writes from s1.
+  // s1Train, s2 override and s3 override commit to the physical PHR one
+  // cycle later. A redirect cancels any pending write; either override also
+  // cancels pending writes from s1.
   private val pendingValid     = RegInit(false.B)
   private val pendingTaken     = RegInit(false.B)
   private val pendingLowBits   = RegInit(0.U(PathHashHighWidth.W))
@@ -108,13 +109,21 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
 
   private val s1UpdateData    = WireInit(0.U.asTypeOf(new PhrUpdateData))
   private val redirectData    = WireInit(0.U.asTypeOf(new PhrUpdateData))
-  private val s3_override     = WireInit(false.B)
-  private val s3_overrideData = WireInit(0.U.asTypeOf(new PhrUpdateData))
+  private val s2_overrideData = Wire(new PhrUpdateData)
+  private val s3_overrideData = Wire(new PhrUpdateData)
+  s2_overrideData.fromUpdateStage(io.train.s2)
+  s3_overrideData.fromUpdateStage(io.train.s3)
+  private val s2_override = s2_overrideData.valid
+  private val s3_override = s3_overrideData.valid
 
   private val redirectS0PhrPtr     = WireInit(0.U.asTypeOf(new PhrPtr))
   private val redirectS0PhrLowBits = WireInit(0.U(PathHashHighWidth.W))
   private val redirectS0FoldedPhr  = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)))
   private val redirectUpdate       = WireInit(0.U.asTypeOf(new PhrUpdateResult))
+  private val s2S0PhrPtr           = WireInit(0.U.asTypeOf(new PhrPtr))
+  private val s2S0PhrLowBits       = WireInit(0.U(PathHashHighWidth.W))
+  private val s2S0FoldedPhr        = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)))
+  private val s2Update             = WireInit(0.U.asTypeOf(new PhrUpdateResult))
   private val s3S0PhrPtr           = WireInit(0.U.asTypeOf(new PhrPtr))
   private val s3S0PhrLowBits       = WireInit(0.U(PathHashHighWidth.W))
   private val s3S0FoldedPhr        = WireInit(0.U.asTypeOf(new PhrAllFoldedHistories(AllFoldedHistoryInfo)))
@@ -133,13 +142,6 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
   redirectData.target  := io.train.redirect.bits.target.unGuard
   redirectData.phrMeta := io.train.redirect.bits.meta.phr
 
-  s3_override             := io.train.s3_override
-  s3_overrideData.valid   := s3_override
-  s3_overrideData.taken   := io.train.s3_prediction.taken
-  s3_overrideData.cfiPc   := getCfiPcFromPosition(io.train.s3_startPc, io.train.s3_prediction.cfiPosition)
-  s3_overrideData.target  := io.train.s3_prediction.target.unGuard
-  s3_overrideData.phrMeta := io.train.s3_phrMeta
-
   s1UpdateData.valid              := s1_valid
   s1UpdateData.taken              := io.s1Train.prediction.taken
   s1UpdateData.cfiPc              := getCfiPcFromPosition(io.s1Train.startPc, io.s1Train.prediction.cfiPosition)
@@ -149,22 +151,28 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
 
   // Compute all ShiftBits values and the high bits of the hash
   private val redirectHashComponents = getPathHashComponents(redirectData.cfiPc, redirectData.target)
+  private val s2HashComponents       = getPathHashComponents(s2_overrideData.cfiPc, s2_overrideData.target)
   private val s3HashComponents       = getPathHashComponents(s3_overrideData.cfiPc, s3_overrideData.target)
   private val s1HashComponents       = getPathHashComponents(s1UpdateData.cfiPc, s1UpdateData.target)
 
   private val redirectShiftBits = redirectHashComponents._1
   private val redirectHashHigh  = redirectHashComponents._2
+  private val s2ShiftBits       = s2HashComponents._1
+  private val s2HashHigh        = s2HashComponents._2
   private val s3ShiftBits       = s3HashComponents._1
   private val s3HashHigh        = s3HashComponents._2
 
   // Compute all phrPtr and phrLowBits for updates
   redirectUpdate := getUpdatePtrs(redirectData, redirectHashHigh)
+  s2Update       := getUpdatePtrs(s2_overrideData, s2HashHigh)
   s3Update       := getUpdatePtrs(s3_overrideData, s3HashHigh)
   s1Update       := getUpdatePtrs(s1UpdateData, s1HashComponents._2)
   private val s1ShiftBits = s1HashComponents._1
 
   redirectS0PhrPtr     := redirectUpdate.phrPtr
   redirectS0PhrLowBits := redirectUpdate.phrLowBits
+  s2S0PhrPtr           := s2Update.phrPtr
+  s2S0PhrLowBits       := s2Update.phrLowBits
   s3S0PhrPtr           := s3Update.phrPtr
   s3S0PhrLowBits       := s3Update.phrLowBits
   s1S0PhrPtr           := Mux(io.s1Train.prediction.taken, s1Update.phrPtr, s1_phrPtr)
@@ -175,6 +183,7 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
     Seq(
       redirectData.valid -> redirectS0PhrPtr,
       s3_override        -> s3S0PhrPtr,
+      s2_override        -> s2S0PhrPtr,
       s1_valid           -> s1S0PhrPtr
     )
   )
@@ -183,6 +192,7 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
     Seq(
       redirectData.valid -> redirectS0PhrPtr,
       s3_override        -> s3S0PhrPtr,
+      s2_override        -> s2S0PhrPtr,
       s1_valid           -> s1S0PhrPtr
     )
   )
@@ -203,8 +213,20 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
     RegEnable(s2_oldestBits, 0.U.asTypeOf(new PhrAllFoldedHistoryOldestBits(AllFoldedHistoryInfo)), s2_fire)
 
   XSError(
-    s3_fire && s3_override && s3_phrMeta.asUInt =/= io.train.s3_phrMeta.asUInt,
+    s2_fire && s2_override && s2_phrMeta.asUInt =/= io.train.s2.phrMeta.asUInt,
+    "s2_phrMeta mismatch!\n"
+  )
+  XSError(
+    s3_fire && s3_override && s3_phrMeta.asUInt =/= io.train.s3.phrMeta.asUInt,
     "s3_phrMeta mismatch!\n"
+  )
+
+  s2S0FoldedPhr := getNextFoldedPhr(
+    s2_overrideData,
+    s2_oldestBits,
+    s2_foldedPhrReg,
+    s2HashHigh,
+    s2ShiftBits
   )
 
   s3S0FoldedPhr := getNextFoldedPhr(
@@ -239,13 +261,19 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
 
   private val redirectBits = Cat(redirectS0PhrLowBits, redirectShiftBits)
 
-  private val s1UpdateWins = s1_valid && io.s1Train.prediction.taken && !redirectData.valid && !s3_override
+  private val s1UpdateWins =
+    s1_valid && io.s1Train.prediction.taken && !redirectData.valid && !s3_override && !s2_override
+  private val s2UpdateWins = s2_override && !redirectData.valid && !s3_override
   private val s3UpdateWins = s3_override && !redirectData.valid
-  pendingValid := s3UpdateWins || s1UpdateWins
+  pendingValid := s3UpdateWins || s2UpdateWins || s1UpdateWins
   when(s3UpdateWins) {
     pendingTaken     := s3_overrideData.taken
     pendingLowBits   := s3S0PhrLowBits
     pendingShiftBits := s3ShiftBits
+  }.elsewhen(s2UpdateWins) {
+    pendingTaken     := s2_overrideData.taken
+    pendingLowBits   := s2S0PhrLowBits
+    pendingShiftBits := s2ShiftBits
   }.elsewhen(s1UpdateWins) {
     pendingTaken     := true.B
     pendingLowBits   := s1S0PhrLowBits
@@ -277,6 +305,7 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
     Seq(
       redirectData.valid                        -> redirectS0FoldedPhr,
       s3_override                               -> s3S0FoldedPhr,
+      s2_override                               -> s2S0FoldedPhr,
       (s1_valid && io.s1Train.prediction.taken) -> s1S0FoldedPhr
     )
   )
@@ -302,6 +331,7 @@ class Phr(implicit p: Parameters) extends PhrModule with HasPhrParameters with H
     Seq(
       redirectData.valid -> computeAllFoldedPhr(redirectPhr),
       s3_override        -> s3_foldedPhrReg,
+      s2_override        -> s2_foldedPhrReg,
       s1_valid           -> s1_foldedPhrReg
     )
   )

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
@@ -120,6 +120,8 @@ class MainBtbAlignBank(
   /* *** s1 ***
    * receive read resp from internal banks
    * select 1 internal bank's resp
+   * check entries hit
+   * filter-out unneeded entries
    */
   private val s1_fire             = io.stageCtrl.s1_fire
   private val s1_startPc          = RegEnable(s0_startPc, s0_fire)
@@ -136,47 +138,54 @@ class MainBtbAlignBank(
     internalBanks.map(_.io.read.resp.counters)
   )
 
-  io.read.s1_positions := VecInit(s1_rawEntries.map(e => Cat(s1_posHigherBits, e.position)))
+  private val s1_tag = getTag(s1_startPc)
 
-  /* *** s2 ***
-   * check entries hit
-   * filter-out unneeded entries
-   * send resp to top
-   */
-  private val s2_fire             = io.stageCtrl.s2_fire
-  private val s2_startPc          = RegEnable(s1_startPc, s1_fire)
-  private val s2_posHigherBits    = RegEnable(s1_posHigherBits, s1_fire)
-  private val s2_crossPage        = RegEnable(s1_crossPage, s1_fire)
-  private val s2_internalBankMask = RegEnable(s1_internalBankMask, s1_fire)
-  private val s2_rawEntries       = RegEnable(s1_rawEntries, s1_fire)
-  private val s2_rawCounters      = RegEnable(s1_rawCounters, s1_fire)
-
-  private val s2_setIdx = getSetIndex(s2_startPc)
-  private val s2_tag    = getTag(s2_startPc)
+  // send rawHit for training
+  private val s1_rawHitMask = VecInit(s1_rawEntries.map(e => e.valid && e.tag === s1_tag))
 
   // NOTE: when we calculate startPc in MainBtb top, we have selected whether lower bits should be masked
   //       (see s0_startPcVec)
-  //       so here, if this alignBank is not the first alignBank of the fetch block, we'll get s2_alignedInstOffset = 0
+  //       so here, if this alignBank is not the first alignBank of the fetch block, we'll get s1_alignedInstOffset = 0
   //       and, we'll do a (e.position >= 0) check later, which is always true
-  private val s2_alignedInstOffset = getAlignedInstOffset(s2_startPc)
+  private val s1_alignedInstOffset = getAlignedInstOffset(s1_startPc)
+
+  private val s1_predictions = VecInit((s1_rawEntries zip s1_rawCounters zip s1_rawHitMask).map {
+    case ((e, c), rawHit) =>
+      val pred = Wire(Valid(new Prediction))
+      // filter out branches before alignedInstOffset
+      // also filter out all entries if crossPage to satisfy Ifu/ICache's requirement
+      val hit = rawHit && e.position >= s1_alignedInstOffset && !s1_crossPage
+      pred.valid            := hit
+      pred.bits.cfiPosition := Cat(s1_posHigherBits, e.position)
+      pred.bits.target      := getFullTarget(s1_startPc, e.targetLowerBits, e.targetCarry)
+      pred.bits.attribute   := e.attribute
+      pred.bits.taken       := c.isPositive
+      pred
+  })
+
+  io.read.s1_positions := s1_predictions.map(_.bits.cfiPosition)
+
+  /* *** s2 ***
+   * send resp to top
+   * generate metadata for training
+   */
+  private val s2_fire             = io.stageCtrl.s2_fire
+  private val s2_startPc          = RegEnable(s1_startPc, s1_fire)
+  private val s2_internalBankMask = RegEnable(s1_internalBankMask, s1_fire)
+  private val s2_rawCounters      = RegEnable(s1_rawCounters, s1_fire)
+  private val s2_rawHitMask       = RegEnable(s1_rawHitMask, s1_fire)
+  private val s2_predictions      = RegEnable(s1_predictions, s1_fire)
+
+  private val s2_setIdx = getSetIndex(s2_startPc)
 
   // send resp
-  (r.resp.predictions zip r.resp.metas zip s2_rawEntries zip s2_rawCounters).foreach { case (((pred, meta), e), c) =>
-    // send rawHit for training
-    val rawHit = e.valid && e.tag === s2_tag
-    // filter out branches before alignedInstOffset
-    // also filter out all entries if crossPage to satisfy Ifu/ICache's requirement
-    val hit = rawHit && e.position >= s2_alignedInstOffset && !s2_crossPage
-    pred.valid            := hit
-    pred.bits.cfiPosition := Cat(s2_posHigherBits, e.position)
-    pred.bits.target      := getFullTarget(s2_startPc, e.targetLowerBits, e.targetCarry)
-    pred.bits.attribute   := e.attribute
-    pred.bits.taken       := c.isPositive
+  r.resp.predictions := s2_predictions
 
-    meta.rawHit    := rawHit
-    meta.attribute := e.attribute
-    meta.position  := Cat(s2_posHigherBits, e.position)
-    meta.counter   := c
+  r.resp.metas.zipWithIndex.foreach { case (meta, i) =>
+    meta.rawHit    := s2_rawHitMask(i)
+    meta.attribute := s2_predictions(i).bits.attribute
+    meta.position  := s2_predictions(i).bits.cfiPosition
+    meta.counter   := s2_rawCounters(i)
   }
 
   // add an alias for hitMask for later use & debug purpose
@@ -291,7 +300,7 @@ class MainBtbAlignBank(
   }
 
   /* *** multi-hit detection & flush *** */
-  private val s2_multiHitMask = detectMultiHit(s2_hitMask, VecInit(s2_rawEntries.map(_.position)))
+  private val s2_multiHitMask = detectMultiHit(s2_hitMask, s2_predictions.map(_.bits.cfiPosition))
 
   internalBanks.zipWithIndex.foreach { case (b, i) =>
     b.io.flush.req.valid        := s2_fire && s2_multiHitMask.orR && s2_internalBankMask(i)

--- a/src/main/scala/xiangshan/frontend/bpu/ras/MicroRas.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/MicroRas.scala
@@ -53,11 +53,12 @@ class MicroRas(implicit p: Parameters) extends BasePredictor with HasRasParamete
       val retTarget: GuardedPc = GuardedPc() // Predicted return address
       val isCanUse:  Bool      = Bool()      // Whether the prediction is valid
     }
-    val specIn:      MicroRasSpecIn  = Input(new MicroRasSpecIn)
-    val specOut:     MicroRasSpecOut = Output(new MicroRasSpecOut)
-    val hasRedirect: Bool            = Input(Bool()) // Global redirect signal (e.g., misprediction)
-    val overrideData: Valid[MicroRasSpecIn] = Input(Valid(new MicroRasSpecIn)) // S3-level override (flushes S1–S2)
-    val fullRetAddr:  GuardedPc             = Input(GuardedPc())               // Current top of the main RAS
+    val specIn:         MicroRasSpecIn        = Input(new MicroRasSpecIn)
+    val specOut:        MicroRasSpecOut       = Output(new MicroRasSpecOut)
+    val hasRedirect:    Bool                  = Input(Bool())      // Global redirect signal (e.g., misprediction)
+    val s2OverrideData: Valid[MicroRasSpecIn] = Input(Valid(new MicroRasSpecIn))
+    val s3OverrideData: Valid[MicroRasSpecIn] = Input(Valid(new MicroRasSpecIn))
+    val fullRetAddr:    GuardedPc             = Input(GuardedPc()) // Current top of the main RAS
   }
   val io = IO(new MicroRasIO)
   io.sramResetDone := true.B
@@ -85,18 +86,28 @@ class MicroRas(implicit p: Parameters) extends BasePredictor with HasRasParamete
 
   // One-cycle delayed version of redirect; used to detect RAS recovery state
   private val redirectDelay1 = RegNext(io.hasRedirect, init = false.B)
-  private val hasOverride    = io.overrideData.valid
-  private val s3_realPush    = io.overrideData.bits.attribute.isCall
-  private val s3_realPop     = io.overrideData.bits.attribute.isReturn
+
+  private val s2_override = io.s2OverrideData.valid
+  private val s2_realPush = io.s2OverrideData.bits.attribute.isCall
+  private val s2_realPop  = io.s2OverrideData.bits.attribute.isReturn
+  private val s2_realPushAddr =
+    getCfiPcFromPosition(io.s2OverrideData.bits.startPc, io.s2OverrideData.bits.cfiPosition) + 2.U
+
+  private val s3_override = io.s3OverrideData.valid
+  private val s3_realPush = io.s3OverrideData.bits.attribute.isCall
+  private val s3_realPop  = io.s3OverrideData.bits.attribute.isReturn
   private val s3_realPushAddr =
-    getCfiPcFromPosition(io.overrideData.bits.startPc, io.overrideData.bits.cfiPosition) + 2.U
+    getCfiPcFromPosition(io.s3OverrideData.bits.startPc, io.s3OverrideData.bits.cfiPosition) + 2.U
 
   // -------------------------------
   // Pipeline control for S2 stage
   // -------------------------------
-  when(hasOverride || io.hasRedirect) {
+  when(s3_override || io.hasRedirect) {
     s2_hasPush := false.B
     s2_hasPop  := false.B
+  }.elsewhen(s2_override) {
+    s2_hasPush := Mux(io.stageCtrl.s2_fire, false.B, s2_realPush)
+    s2_hasPop  := Mux(io.stageCtrl.s2_fire, false.B, s2_realPop)
   }.elsewhen(io.stageCtrl.s1_fire) {
     s2_hasPush := specPush
     s2_hasPop  := specPop
@@ -108,14 +119,14 @@ class MicroRas(implicit p: Parameters) extends BasePredictor with HasRasParamete
   // -------------------------------
   // Pipeline control for S3 stage
   // -------------------------------
-  when(hasOverride || io.hasRedirect) {
+  when(s3_override || io.hasRedirect) {
     // Redirect flushes entire pipeline, including S3
     s3_hasPush := false.B
     s3_hasPop  := false.B
   }.elsewhen(io.stageCtrl.s2_fire) {
     // Move S2 ops into S3
-    s3_hasPush := s2_hasPush
-    s3_hasPop  := s2_hasPop
+    s3_hasPush := Mux(s2_override, s2_realPush, s2_hasPush)
+    s3_hasPop  := Mux(s2_override, s2_realPop, s2_hasPop)
   }.elsewhen(io.stageCtrl.s3_fire) {
     // Clear S3 after it completes
     s3_hasPush := false.B
@@ -123,13 +134,16 @@ class MicroRas(implicit p: Parameters) extends BasePredictor with HasRasParamete
   }
 
   // Capture return address for speculative CALL in S1 → store in S2
-  when(io.stageCtrl.s1_fire && specPush) {
+  when(io.stageCtrl.s1_fire && !s2_override && specPush) {
     s2_retAddr := specPushAddr
   }
 
   // Pass return address from S2 to S3
   when(io.stageCtrl.s2_fire) {
-    s3_retAddr := s2_retAddr
+    s3_retAddr := Mux(s2_override, s2_realPushAddr, s2_retAddr)
+  }
+  when(s2_override && !io.stageCtrl.s2_fire && s2_realPush) {
+    s2_retAddr := s2_realPushAddr
   }
 
   // ------------------------------------------------------------
@@ -140,7 +154,7 @@ class MicroRas(implicit p: Parameters) extends BasePredictor with HasRasParamete
     // On redirect, the main RAS state is being restored,
     // and the S1–S3 pipeline is flushed → no valid prediction.
     isCanUse := false.B
-  }.elsewhen(hasOverride) {
+  }.elsewhen(s3_override) {
     // On S3 override (e.g., late redirect), S1–S2 are flushed.
     // Only S3’s operation affects the RAS state seen by the next S1:
     // - If S3 pops, the main RAS top changes → prediction invalid.
@@ -153,11 +167,29 @@ class MicroRas(implicit p: Parameters) extends BasePredictor with HasRasParamete
         0.U.asTypeOf(GuardedPc()),
         Mux(s3_realPush, s3_realPushAddr, io.fullRetAddr)
       )
-  }.elsewhen(io.stageCtrl.s1_fire && specPush) {
+  }.elsewhen(s2_override) {
+    // The corrected S2 operation is now the youngest speculative operation.
+    // Older S3 operations still precede it in stack order.
+    when(s2_realPush) {
+      isCanUse   := true.B
+      topRetAddr := s2_realPushAddr
+    }.elsewhen(s2_realPop) {
+      isCanUse   := s3_hasPush
+      topRetAddr := Mux(s3_hasPush, io.fullRetAddr, 0.U.asTypeOf(GuardedPc()))
+    }.elsewhen(s3_hasPush) {
+      isCanUse   := true.B
+      topRetAddr := s3_retAddr
+    }.elsewhen(s3_hasPop) {
+      isCanUse := false.B
+    }.otherwise {
+      isCanUse   := Mux(redirectDelay1, false.B, true.B)
+      topRetAddr := Mux(redirectDelay1, 0.U.asTypeOf(GuardedPc()), io.fullRetAddr)
+    }
+  }.elsewhen(io.stageCtrl.s1_fire && !s2_override && specPush) {
     // S1 sees a CALL → next cycle’s RAS top will be the return address of this CALL.
     isCanUse   := true.B
     topRetAddr := specPushAddr
-  }.elsewhen(io.stageCtrl.s1_fire && specPop) {
+  }.elsewhen(io.stageCtrl.s1_fire && !s2_override && specPop) {
     // S1 sees a RET → we must predict what the RAS top will be after resolving
     // in-flight pushes/pops in S2 and S3.
     when(s2_hasPush) {
@@ -184,7 +216,7 @@ class MicroRas(implicit p: Parameters) extends BasePredictor with HasRasParamete
       // No pairing possible; main RAS will be popped → unknown new top.
       isCanUse := false.B
     }
-  }.elsewhen(io.stageCtrl.s1_fire) {
+  }.elsewhen(io.stageCtrl.s1_fire && !s2_override) {
     // S1 processes a non-CFI (or non-call/ret) instruction.
     // We still need to predict the RAS top for potential future RETs.
     when(s2_hasPush) {
@@ -213,7 +245,7 @@ class MicroRas(implicit p: Parameters) extends BasePredictor with HasRasParamete
   io.specOut.isCanUse  := isCanUse
   io.specOut.retTarget := topRetAddr
 
-  private val s3_overrideHasRasAction     = hasOverride && (s3_realPush || s3_realPop)
+  private val s3_overrideHasRasAction     = s3_override && (s3_realPush || s3_realPop)
   private val s3_overrideHasRasActionNext = RegNext(s3_overrideHasRasAction, false.B)
   XSPerfAccumulate("s3_override_has_rasAction", s3_overrideHasRasAction)
   XSPerfAccumulate(

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Bundles.scala
@@ -59,6 +59,8 @@ class TageEntry(implicit p: Parameters) extends TageBundle {
 
 class TagePrediction(implicit p: Parameters) extends TageBundle {
   val takenVec: Vec[Valid[Bool]] = Vec(NumBtbResultEntries, Valid(Bool()))
+  // Fast s2 path: raw provider result, without alt/base selection.
+  val fastTakenVec: Vec[Valid[Bool]] = Vec(NumBtbResultEntries, Valid(Bool()))
 }
 
 class PhrToTageIO(implicit p: Parameters) extends TageBundle {

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
@@ -21,6 +21,8 @@ import freechips.rocketchip.util.SeqToAugmentedSeq
 import org.chipsalliance.cde.config.Parameters
 import utility.ChiselDB
 import utility.DataHoldBypass
+import utility.ParallelORR
+import utility.ParallelPriorityMux
 import utility.XSPerfAccumulate
 import utility.XSPerfHistogram
 import xiangshan.frontend.bpu.BasePredictor
@@ -82,63 +84,84 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
   /* --------------------------------------------------------------------------------------------------------------
      predict pipeline stage 1
      - get read resp from tables
-     - compute tag
+     - compute tags
      -------------------------------------------------------------------------------------------------------------- */
 
   private val s1_fire       = io.stageCtrl.s1_fire
   private val s1_startPc    = RegEnable(s0_startPc, s0_fire)
   private val s1_foldedHist = RegEnable(s0_foldedHist, s0_fire)
 
-  // Vec[NumBtbResultEntries][NumTables]
-  private val s1_tag = VecInit(io.fromMainBtb.s1_positions.map { position =>
-    VecInit((tables zip s1_foldedHist).map { case (table, hist) =>
+  private val s1_readResp = DataHoldBypass(VecInit(tables.map(_.io.readResp(0))), RegNext(s0_fire))
+
+  private val s1_tags = VecInit(io.fromMainBtb.s1_positions.map { position =>
+    VecInit(tables.zip(s1_foldedHist).map { case (table, hist) =>
       table.getTag(s1_startPc, hist.forTag, position)
     })
   })
 
-  private val s1_readResp = DataHoldBypass(VecInit(tables.map(_.io.readResp(0))), RegNext(s0_fire))
+  private val s1_hits = VecInit(s1_tags.map { branchTags =>
+    VecInit(s1_readResp.zip(branchTags).map { case (tableReadResp, tag) =>
+      tableReadResp.entries.map(entry => entry.valid && entry.tag === tag).asUInt
+    })
+  })
 
   /* --------------------------------------------------------------------------------------------------------------
      predict pipeline stage 2
      - get results from mbtb
-     - get prediction for each branch
+     - generate the fast provider candidate for each table way
+     - select the hit way and provider
+     - select the alternate and complete the prediction for each branch
      -------------------------------------------------------------------------------------------------------------- */
 
   private val s2_fire     = io.stageCtrl.s2_fire
-  private val s2_startPc  = RegEnable(s1_startPc, s1_fire)
-  private val s2_tag      = RegEnable(s1_tag, s1_fire)
   private val s2_readResp = RegEnable(s1_readResp, s1_fire)
-
+  private val s2_hits     = RegEnable(s1_hits, s1_fire)
   private val s2_branches = io.fromMainBtb.result
 
-  s2_branches.zipWithIndex.foreach { case (branch, i) =>
-    val position = branch.bits.cfiPosition
+  s2_branches.indices.foreach { branchIdx =>
+    val candidates = TableInfos.indices.reverse.flatMap { tableIdx =>
+      (0 until TableInfos(tableIdx).NumWays).map { wayIdx =>
+        val hit   = s2_hits(branchIdx)(tableIdx)(wayIdx)
+        val taken = s2_readResp(tableIdx).entries(wayIdx).takenCtr.isPositive
+        hit -> taken
+      }
+    }
+    io.prediction.fastTakenVec(branchIdx).valid := ParallelORR(candidates.map(_._1))
+    io.prediction.fastTakenVec(branchIdx).bits  := ParallelPriorityMux(candidates)
+  }
 
-    // compare tags of each branch with all tables
+  s2_branches.zipWithIndex.foreach { case (branch, i) =>
     val allTableTagMatchResults = s2_readResp.zipWithIndex.map { case (tableReadResp, tableIdx) =>
-      val tag          = s2_tag(i)(tableIdx)
-      val hitWayMask   = tableReadResp.entries.map(entry => entry.valid && entry.tag === tag)
+      val hitWayMask   = s2_hits(i)(tableIdx)
       val hitWayMaskOH = PriorityEncoderOH(hitWayMask)
 
-      val result = Wire(new PredictTagMatchResult).suggestName(s"s2_branch_${i}_table_${tableIdx}_result")
-      result.hit          := hitWayMask.reduce(_ || _)
+      val result = Wire(new PredictTagMatchResult)
+      result.hit          := hitWayMask.orR
       result.hitWayMaskOH := hitWayMaskOH.asUInt
       result.takenCtr     := Mux1H(hitWayMaskOH, tableReadResp.entries.map(_.takenCtr))
       result.usefulCtr    := Mux1H(hitWayMaskOH, tableReadResp.usefulCtrs)
       result.hitWayMask   := hitWayMask.asUInt
       result
     }
+
     // find the provider, the table with the longest history among the hit tables
-    val hitTableMask    = allTableTagMatchResults.map(_.hit)
-    val hasProvider     = hitTableMask.reduce(_ || _)
-    val providerTableOH = getLongestHistTableOH(hitTableMask)
-    val provider        = Mux1H(providerTableOH, allTableTagMatchResults)
+    val hitTableMask = VecInit(allTableTagMatchResults.map(_.hit)).asUInt
+    val hasProvider  = ParallelORR(hitTableMask)
+    val providerTableOH = ParallelPriorityMux(
+      allTableTagMatchResults.zipWithIndex.reverse.map { case (result, tableIdx) =>
+        result.hit -> UIntToOH(tableIdx.U, NumTables)
+      }
+    )
+    val provider = ParallelPriorityMux(
+      allTableTagMatchResults.reverse.map(result => result.hit -> result)
+    )
 
     // find the alt, the table with the second longest history among the hit tables
-    val hitTableMaskNoProvider = hitTableMask.zip(providerTableOH).map { case (a, b) => a && !b }
-    val hasAlt                 = hasProvider && hitTableMaskNoProvider.reduce(_ || _)
-    val altTableOH             = getLongestHistTableOH(hitTableMaskNoProvider)
-    val alt                    = Mux1H(altTableOH, allTableTagMatchResults)
+    val hitTableMaskNoProvider = hitTableMask & (~providerTableOH)
+    val hasAlt                 = hasProvider && ParallelORR(hitTableMaskNoProvider)
+    val alt = ParallelPriorityMux(
+      hitTableMaskNoProvider.asBools.zip(allTableTagMatchResults).reverse
+    )
 
     val altConf          = Mux(hasAlt, !alt.takenCtr.isWeak, io.fromMainBtb.baseConf(i))
     val providerTableIdx = OHToUInt(providerTableOH)
@@ -696,6 +719,16 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     "predict_cond_num", {
       val condMask = s2_branches.map(branch => branch.valid && branch.bits.attribute.isConditional)
       Mux(io.stageCtrl.s2_fire, PopCount(condMask), 0.U)
+    }
+  )
+  XSPerfAccumulate(
+    "fast_final_prediction_mismatch", {
+      val mismatchMask = s2_branches.zipWithIndex.map { case (branch, i) =>
+        val fastTaken  = Mux(io.prediction.fastTakenVec(i).valid, io.prediction.fastTakenVec(i).bits, branch.bits.taken)
+        val finalTaken = Mux(io.prediction.takenVec(i).valid, io.prediction.takenVec(i).bits, branch.bits.taken)
+        branch.valid && branch.bits.attribute.isConditional && fastTaken =/= finalTaken
+      }
+      Mux(s2_fire, PopCount(mismatchMask), 0.U)
     }
   )
   XSPerfAccumulate("total_train", io.stageCtrl.t0_fire)

--- a/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
@@ -16,45 +16,32 @@ package xiangshan.frontend.bpu.utage
 
 import chisel3._
 import chisel3.util._
-import freechips.rocketchip.util.SeqToAugmentedSeq
 import org.chipsalliance.cde.config.Parameters
-import scala.math.min
 import utility.ChiselDB
 import utility.ParallelPriorityMux
 import utility.XSPerfAccumulate
 import utility.XSPerfSeqAccumulate
-import xiangshan.frontend.Pc
 import xiangshan.frontend.bpu.BasePredictor
 import xiangshan.frontend.bpu.BasePredictorIO
 import xiangshan.frontend.bpu.CompareMatrix
 import xiangshan.frontend.bpu.FastTrain
-import xiangshan.frontend.bpu.FoldedHistoryInfo
+import xiangshan.frontend.bpu.HasAheadPredictorIO
 import xiangshan.frontend.bpu.HasFastTrainIO
-import xiangshan.frontend.bpu.Prediction
-import xiangshan.frontend.bpu.SaturateCounter
-import xiangshan.frontend.bpu.abtb.AheadBtbResult
+import xiangshan.frontend.bpu.abtb.AheadBtbToMicroTageIO
 import xiangshan.frontend.bpu.history.phr.PhrAllFoldedHistories
 
 /**
  * This module is the implementation of the TAGE (TAgged GEometric history length predictor).
  */
 class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageParameters with Helpers {
-  class MicroTageIO(implicit p: Parameters) extends BasePredictorIO with HasFastTrainIO {
-    val prediction: MicroTagePrediction  = Output(new MicroTagePrediction)
-    val meta:       Valid[MicroTageMeta] = Output(Valid(new MicroTageMeta))
-    // Send ABTB position early, pipeline registers inside the module.
-    // Consideration: improve routing and enhance driving capablility.
-    val abtbPosVec:     Vec[UInt]                  = Input(Vec(NumAheadBtbPredictionEntries, UInt(CfiPositionWidth.W)))
-    val abtbPrediction: Vec[Valid[AheadBtbResult]] = Input(Vec(NumAheadBtbPredictionEntries, Valid(new AheadBtbResult)))
-    val overrideValid:  Bool                       = Input(Bool())
-    val redirectValid:  Bool                       = Input(Bool())
+  class MicroTageIO(implicit p: Parameters) extends BasePredictorIO with HasAheadPredictorIO with HasFastTrainIO {
+    val prediction:   MicroTagePrediction   = Output(new MicroTagePrediction)
+    val meta:         Valid[MicroTageMeta]  = Output(Valid(new MicroTageMeta))
+    val fromAheadBtb: AheadBtbToMicroTageIO = Input(new AheadBtbToMicroTageIO)
 
     val normalPathHist:   PhrAllFoldedHistories = Input(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
     val s1PathHist:       PhrAllFoldedHistories = Input(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
     val overridePathHist: PhrAllFoldedHistories = Input(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
-
-    val s1StartPc:       Pc = Input(new Pc)
-    val overrideStartPc: Pc = Input(new Pc)
   }
   val io: MicroTageIO = IO(new MicroTageIO)
   io.trainReady := true.B
@@ -64,9 +51,8 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
   // Problem scenario: the same entry accessed by different branches in different cycles.
   private val a0_fire                = io.enable && io.stageCtrl.s0_fire
   private val a1_fire                = a0_fire
-  private val a2_fire                = io.stageCtrl.s1_fire
-  private val overrideValid          = io.overrideValid
-  private val redirectValid          = io.redirectValid
+  private val bpuS2Fire              = io.stageCtrl.s2_fire
+  private val redirectValid          = io.redirect
   private val a0_indexPc             = io.startPc.unGuard
   private val a0_indexFoldedPathHist = io.normalPathHist
 
@@ -104,7 +90,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
   private val a1_readIndex   = RegEnable(a0_readIndex, a0_fire)
   private val a1_predRead    = Wire(Vec(NumTables, new MicroTageTablePred))
   for (i <- 0 until NumTables) {
-    val predTag = computeHashTag(io.s1StartPc, io.s1PathHist, TableInfos, i)
+    val predTag = computeHashTag(io.newStartPc, io.s1PathHist, TableInfos, i)
     a1_predRead(i).taken := a1_predEntries(i).takenCtr.isPositive
     a1_predRead(i).valid := a1_predEntries(i).valid
     a1_predRead(i).tag   := a1_predEntries(i).tag
@@ -120,7 +106,8 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
   private val a1_posHitVec = Wire(Vec(NumAheadBtbPredictionEntries, Vec(NumTables, Bool())))
   for (i <- 0 until NumAheadBtbPredictionEntries) {
     for (j <- 0 until NumTables) {
-      a1_posHitVec(i)(j) := a1_predEntries(j).valid && (a1_predEntries(j).cfiPosition === io.abtbPosVec(i))
+      a1_posHitVec(i)(j) :=
+        a1_predEntries(j).valid && (a1_predEntries(j).cfiPosition === io.fromAheadBtb.fastPositions(i))
     }
   }
   // Get finally selected Table ID for each branch instruction of abtb.
@@ -143,58 +130,77 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
     a1_abtbTableIDVec(i) := ParallelPriorityMux(tmpTableHitVec.reverse, tabeIDVec.reverse)
   }
 
+  private val a2_readIndex = RegInit(0.U.asTypeOf(a1_readIndex))
+  private val a2_predRead  = RegInit(0.U.asTypeOf(a1_predRead))
+  private val a2_posHitVec = RegInit(0.U.asTypeOf(a1_posHitVec))
+
   private val a3_readIndex = RegInit(0.U.asTypeOf(a1_readIndex))
   private val a3_predRead  = RegInit(0.U.asTypeOf(a1_predRead))
   private val a3_posHitVec = RegInit(0.U.asTypeOf(a1_posHitVec))
 
-  // ------------------------------  ----------------------------------------- //
-  private val overridePredRead = Wire(Vec(NumTables, new MicroTageTablePred))
+  // BPU S2 override reuses the current A2 entries, while BPU S3 override reuses the older A3 snapshot.
+  private val overrideSourcePredRead = Mux(io.bpuS3Override, a3_predRead, a2_predRead)
+  private val overridePosHitVec      = Mux(io.bpuS3Override, a3_posHitVec, a2_posHitVec)
+  private val overridePredRead       = Wire(Vec(NumTables, new MicroTageTablePred))
   for (i <- 0 until NumTables) {
-    val predTag = computeHashTag(io.overrideStartPc, io.overridePathHist, TableInfos, i)
-    overridePredRead(i).taken       := a3_predRead(i).taken
-    overridePredRead(i).valid       := a3_predRead(i).valid
-    overridePredRead(i).tag         := a3_predRead(i).tag
-    overridePredRead(i).tagHit      := a3_predRead(i).tag === predTag
-    overridePredRead(i).cfiPosition := a3_predRead(i).cfiPosition
+    val predTag = computeHashTag(io.overrideStartPc.unGuard, io.overridePathHist, TableInfos, i)
+    overridePredRead(i).taken       := overrideSourcePredRead(i).taken
+    overridePredRead(i).valid       := overrideSourcePredRead(i).valid
+    overridePredRead(i).tag         := overrideSourcePredRead(i).tag
+    overridePredRead(i).tagHit      := overrideSourcePredRead(i).tag === predTag
+    overridePredRead(i).cfiPosition := overrideSourcePredRead(i).cfiPosition
     overridePredRead(i).posHit      := false.B
-    overridePredRead(i).takenCtr    := a3_predRead(i).takenCtr
+    overridePredRead(i).takenCtr    := overrideSourcePredRead(i).takenCtr
   }
 
-  private val a3_abtbTableIDVec = Wire(Vec(NumAheadBtbPredictionEntries, UInt(log2Ceil(NumTables).W)))
-  private val a3_abtbTakenVec   = Wire(Vec(NumAheadBtbPredictionEntries, Bool()))
-  private val a3_abtbHitVec     = Wire(Vec(NumAheadBtbPredictionEntries, Bool()))
+  private val overrideAbtbTableIDVec = Wire(Vec(NumAheadBtbPredictionEntries, UInt(log2Ceil(NumTables).W)))
+  private val overrideAbtbTakenVec   = Wire(Vec(NumAheadBtbPredictionEntries, Bool()))
+  private val overrideAbtbHitVec     = Wire(Vec(NumAheadBtbPredictionEntries, Bool()))
   for (i <- 0 until NumAheadBtbPredictionEntries) {
     // tmp prefix highlights the temporary scope within the loop.
     val tmpTableHitVec   = Wire(Vec(NumTables, Bool()))
     val tmpTableTakenVec = Wire(Vec(NumTables, Bool()))
     for (j <- 0 until NumTables) {
-      tmpTableHitVec(j)   := overridePredRead(j).tagHit && a3_posHitVec(i)(j)
+      tmpTableHitVec(j)   := overridePredRead(j).tagHit && overridePosHitVec(i)(j)
       tmpTableTakenVec(j) := overridePredRead(j).taken
     }
-    a3_abtbHitVec(i)     := tmpTableHitVec.reduce(_ || _)
-    a3_abtbTakenVec(i)   := ParallelPriorityMux(tmpTableHitVec.reverse, tmpTableTakenVec.reverse)
-    a3_abtbTableIDVec(i) := ParallelPriorityMux(tmpTableHitVec.reverse, tabeIDVec.reverse)
+    overrideAbtbHitVec(i)     := tmpTableHitVec.reduce(_ || _)
+    overrideAbtbTakenVec(i)   := ParallelPriorityMux(tmpTableHitVec.reverse, tmpTableTakenVec.reverse)
+    overrideAbtbTableIDVec(i) := ParallelPriorityMux(tmpTableHitVec.reverse, tabeIDVec.reverse)
   }
 
-  private val a2_readIndex = RegEnable(Mux(overrideValid, a3_readIndex, a1_readIndex), a1_fire)
-  private val a2_predRead =
-    RegEnable(Mux(overrideValid, overridePredRead, a1_predRead), 0.U.asTypeOf(a1_predRead), a1_fire)
-  private val a2_posHitVec =
-    RegEnable(Mux(overrideValid, a3_posHitVec, a1_posHitVec), 0.U.asTypeOf(a1_posHitVec), a1_fire)
+  when(a1_fire) {
+    when(io.bpuS3Override) {
+      a2_readIndex := a3_readIndex
+      a2_posHitVec := a3_posHitVec
+    }.elsewhen(!io.bpuS2Override) {
+      a2_readIndex := a1_readIndex
+      a2_posHitVec := a1_posHitVec
+    }
+    a2_predRead := Mux(io.bpuS3Override || io.bpuS2Override, overridePredRead, a1_predRead)
+  }
   private val a2_foldedPathHist =
-    RegEnable(Mux(overrideValid, io.overridePathHist, io.s1PathHist), a1_fire)
-  private val a2_fromAbtbPos = RegEnable(io.abtbPosVec, a1_fire)
+    RegEnable(Mux(io.bpuS3Override || io.bpuS2Override, io.overridePathHist, io.s1PathHist), a1_fire)
+  private val a2_fromAbtbPos = RegEnable(io.fromAheadBtb.fastPositions, a1_fire)
   private val a2_abtbUseTableIDVec =
-    RegEnable(Mux(overrideValid, a3_abtbTableIDVec, a1_abtbTableIDVec), 0.U.asTypeOf(a1_abtbTableIDVec), a1_fire)
+    RegEnable(
+      Mux(io.bpuS3Override || io.bpuS2Override, overrideAbtbTableIDVec, a1_abtbTableIDVec),
+      0.U.asTypeOf(a1_abtbTableIDVec),
+      a1_fire
+    )
   private val a2_abtbTakenVec =
-    RegEnable(Mux(overrideValid, a3_abtbTakenVec, a1_abtbTakenVec), 0.U.asTypeOf(a1_abtbTakenVec), a1_fire)
+    RegEnable(
+      Mux(io.bpuS3Override || io.bpuS2Override, overrideAbtbTakenVec, a1_abtbTakenVec),
+      0.U.asTypeOf(a1_abtbTakenVec),
+      a1_fire
+    )
   private val a2_abtbTakenCtrVec = Wire(Vec(NumAheadBtbPredictionEntries, TakenCounter()))
 
   private val a2_abtbHitVec = RegInit(VecInit.fill(NumAheadBtbPredictionEntries)(false.B))
   when(redirectValid) {
     a2_abtbHitVec := 0.U.asTypeOf(Vec(NumAheadBtbPredictionEntries, Bool()))
-  }.elsewhen(overrideValid) {
-    a2_abtbHitVec := a3_abtbHitVec
+  }.elsewhen(io.bpuS3Override || io.bpuS2Override) {
+    a2_abtbHitVec := overrideAbtbHitVec
   }.elsewhen(a1_fire) {
     a2_abtbHitVec := a1_abtbHitVec
   }
@@ -219,13 +225,15 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
     // On the cycle following a redirect, MicroTage provides no prediction;
     // therefore, this cycle is excluded from training.
     s1_predMeta.bits.abtbResult(i).valid :=
-      io.abtbPrediction(i).valid && io.abtbPrediction(i).bits.attribute.isConditional && RegNext(!redirectValid)
-    s1_predMeta.bits.abtbResult(i).baseTaken        := io.abtbPrediction(i).bits.taken
-    s1_predMeta.bits.abtbResult(i).hit              := a2_abtbHitVec(i) && io.abtbPrediction(i).valid
+      io.fromAheadBtb.result(i).valid && io.fromAheadBtb.result(i).bits.attribute.isConditional && RegNext(
+        !redirectValid
+      )
+    s1_predMeta.bits.abtbResult(i).baseTaken        := io.fromAheadBtb.result(i).bits.taken
+    s1_predMeta.bits.abtbResult(i).hit              := a2_abtbHitVec(i) && io.fromAheadBtb.result(i).valid
     s1_predMeta.bits.abtbResult(i).predTaken        := a2_abtbTakenVec(i)
     s1_predMeta.bits.abtbResult(i).tableId          := a2_abtbUseTableIDVec(i)
-    s1_predMeta.bits.abtbResult(i).cfiPosition      := a2_fromAbtbPos(i) // io.abtbPrediction(i).bits.cfiPosition
-    s1_predMeta.bits.abtbResult(i).baseIsStrongBias := io.abtbPrediction(i).bits.isStrongBias
+    s1_predMeta.bits.abtbResult(i).cfiPosition      := a2_fromAbtbPos(i)
+    s1_predMeta.bits.abtbResult(i).baseIsStrongBias := io.fromAheadBtb.result(i).bits.isStrongBias
     s1_predMeta.bits.abtbResult(i).takenCtr         := a2_abtbTakenCtrVec(i)
   }
 
@@ -235,7 +243,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
   io.prediction.hitVec := a2_abtbHitVec
   io.meta              := s1_predMeta
 
-  when(a2_fire) {
+  when(bpuS2Fire) {
     a3_predRead  := a2_predRead
     a3_readIndex := a2_readIndex
     a3_posHitVec := a2_posHitVec

--- a/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Bundles.scala
@@ -72,11 +72,13 @@ class FtqRead[T <: Data](private val gen: T)(implicit p: Parameters) extends Ftq
 }
 
 class BpuFlushInfo(implicit p: Parameters) extends FtqBundle with HasCircularQueuePtrHelper {
+  val s2 = Valid(new FtqPtr)
   val s3 = Valid(new FtqPtr)
 
   def stage(idx: Int): Valid[FtqPtr] = {
-    require(idx >= 3 && idx <= 3)
+    require(idx >= 2 && idx <= 3)
     idx match {
+      case 2 => s2
       case 3 => s3
     }
   }
@@ -84,6 +86,7 @@ class BpuFlushInfo(implicit p: Parameters) extends FtqBundle with HasCircularQue
   private def shouldFlushBy(src: Valid[FtqPtr], idxToFlush: FtqPtr, valid: Bool): Bool =
     valid && src.valid && !isAfter(src.bits, idxToFlush)
 
+  def shouldFlushByStage2(idx: FtqPtr, valid: Bool): Bool = shouldFlushBy(s2, idx, valid)
   def shouldFlushByStage3(idx: FtqPtr, valid: Bool): Bool = shouldFlushBy(s3, idx, valid)
 }
 

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -185,6 +185,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
 
   private val prediction = io.fromBpu.prediction
 
+  private val bpuS2Redirect = prediction.valid && prediction.bits.s2Override
   private val bpuS3Redirect = prediction.valid && prediction.bits.s3Override
 
   io.toBpu.bpuPtr := bpuPtr(0)
@@ -193,17 +194,20 @@ class Ftq(implicit p: Parameters) extends FtqModule
   private val predictionPtr = MuxCase(
     bpuPtr(0),
     Seq(
-      prediction.bits.s3Override -> io.fromBpu.s3FtqPtr
+      prediction.bits.s3Override -> io.fromBpu.s3FtqPtr,
+      prediction.bits.s2Override -> io.fromBpu.s2FtqPtr
     )
   )
 
   when(prediction.bits.s3Override) {
     bpuPtr := io.fromBpu.s3FtqPtr + 1.U
+  }.elsewhen(prediction.bits.s2Override) {
+    bpuPtr := io.fromBpu.s2FtqPtr + 1.U
   }.elsewhen(bpuEnqueue) {
     bpuPtr := bpuPtr + 1.U
   }
 
-  when((prediction.fire || bpuS3Redirect) && !redirect.valid) {
+  when((prediction.fire || bpuS2Redirect || bpuS3Redirect) && !redirect.valid) {
     entryQueue(predictionPtr.value).startPc     := prediction.bits.startPc
     entryQueue(predictionPtr.value).taken       := prediction.bits.taken
     entryQueue(predictionPtr.value).endPosition := prediction.bits.endPosition
@@ -251,10 +255,9 @@ class Ftq(implicit p: Parameters) extends FtqModule
     fetchPtr := Mux(io.fromICache.fromMainPipe.realTwoFetchValid, fetchPtr + 2.U, fetchPtr + 1.U)
   }
 
-  // TODO: wait for Ifu/ICache to remove bpu s2 flush
-  for (stage <- 3 to 3) {
-    val redirect = if (stage == 3) prediction.bits.s3Override else false.B
-    val ftqIdx   = if (stage == 3) io.fromBpu.s3FtqPtr else 0.U.asTypeOf(new FtqPtr)
+  for (stage <- 2 to 3) {
+    val redirect = if (stage == 2) prediction.bits.s2Override else prediction.bits.s3Override
+    val ftqIdx   = if (stage == 2) io.fromBpu.s2FtqPtr else io.fromBpu.s3FtqPtr
 
     io.toICache.flushFromBpu.stage(stage).valid := redirect
     io.toICache.flushFromBpu.stage(stage).bits  := ftqIdx
@@ -352,7 +355,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // Interaction with backend
   // --------------------------------------------------------------------------------
 
-  io.toBackend.wen     := (prediction.fire || bpuS3Redirect) && !redirect.valid
+  io.toBackend.wen     := (prediction.fire || bpuS2Redirect || bpuS3Redirect) && !redirect.valid
   io.toBackend.ftqIdx  := predictionPtr.value
   io.toBackend.startPc := prediction.bits.startPc
 
@@ -580,7 +583,8 @@ class Ftq(implicit p: Parameters) extends FtqModule
 
   XSPerfSeqAccumulate(
     "resolve_branch_mispredicts_s1_source",
-    backendRedirect.valid && backendRedirect.bits.isMisPred && !redirectPerfMeta.bpSource.s3Override,
+    backendRedirect.valid && backendRedirect.bits.isMisPred &&
+      !redirectPerfMeta.bpSource.s2Override && !redirectPerfMeta.bpSource.s3Override,
     perf_mispredS1SourceVec
   )
 
@@ -632,7 +636,8 @@ class Ftq(implicit p: Parameters) extends FtqModule
 
   XSPerfSeqAccumulate(
     "commit_branch_mispredicts_s1_mispred_s1_source",
-    perf_commitHasMispredict && !commitPerfMeta.bpuPerf.bpSource.s3Override,
+    perf_commitHasMispredict &&
+      !commitPerfMeta.bpuPerf.bpSource.s2Override && !commitPerfMeta.bpuPerf.bpSource.s3Override,
     BpuPredictionSource.Stage1.getValidSeq(commitPerfMeta.bpuPerf.bpSource.s1Source)
   )
   XSPerfSeqAccumulate(

--- a/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheMainPipe.scala
@@ -158,7 +158,8 @@ class ICacheMainPipe(implicit p: Parameters) extends ICacheModule
 
   s0_req(1).valid := s0_realTwoFetchValid
 
-  s0_flush := io.flush || io.flushFromBpu.shouldFlushByStage3(s0_ftqIdx, s0_valid)
+  s0_flush := io.flush || io.flushFromBpu.shouldFlushByStage2(s0_ftqIdx, s0_valid) ||
+    io.flushFromBpu.shouldFlushByStage3(s0_ftqIdx, s0_valid)
 
   private val s0_canAccept = toData.ready && s1_ready
   io.fromFtq.ready       := s0_canAccept && io.fromWayLookup.valid && !s0_flush

--- a/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICachePrefetchPipe.scala
@@ -93,8 +93,10 @@ class ICachePrefetchPipe(implicit p: Parameters) extends ICacheModule
   private val s0_readMetaSetIdx = s0_twoPrefetchCase.selectMetaSetIdx(s0_req)
   private val s0_readDoubleLine = s0_twoPrefetchCase.selectIsCrossLine(s0_req)
 
-  fromBpuS0Flush := !s0_isSoftPrefetch && io.flushFromBpu.shouldFlushByStage3(s0_ftqIdx, s0_valid)
-  s0_flush       := io.flush || fromBpuS0Flush || s1_flush
+  fromBpuS0Flush := !s0_isSoftPrefetch &&
+    (io.flushFromBpu.shouldFlushByStage2(s0_ftqIdx, s0_valid) ||
+      io.flushFromBpu.shouldFlushByStage3(s0_ftqIdx, s0_valid))
+  s0_flush := io.flush || fromBpuS0Flush || s1_flush
 
   io.fromFtq.ready := s1_ready && toItlb.ready && toMeta.ready && !s0_flush
 


### PR DESCRIPTION
This PR: 
uses the fast prediction results from MainBTB and TAGE (based only on the provider’s results) as the BPU S2 prediction, which overrides the S1 prediction. 
In addition, AheadBTB was refactored to support the S2 override.