### PR TITLE
perf(Ftq): set BpRunAheadDistance to icache wayLookupSize

### DIFF
--- a/src/main/scala/xiangshan/frontend/FrontendParameters.scala
+++ b/src/main/scala/xiangshan/frontend/FrontendParameters.scala
@@ -28,6 +28,7 @@ case class FrontendParameters(
     FetchBlockSize:           Int = 64, // bytes
     FetchPorts:               Int = 2,  // 2-fetch
     ResolveEntryBranchNumber: Int = 8,
+    PrefetchDepth:            Int = 32, // maximum icache prefetch / bpu runahead depth
     bpuParameters:            BpuParameters = BpuParameters(),
     ftqParameters:            FtqParameters = FtqParameters(),
     icacheParameters:         ICacheParameters = ICacheParameters(),
@@ -79,6 +80,8 @@ trait HasFrontendParameters extends HasXSParameter {
   def FetchBlockInstNum: Int = FetchBlockSize / instBytes
 //  def FetchBlockInstOffsetWidth = log2Ceil(FetchBlockInstNum) inherited from HasXSParameter
   def CfiPositionWidth: Int = log2Ceil(FetchBlockInstNum) // 2/4B(inst) aligned
+
+  def PrefetchDepth: Int = frontendParameters.PrefetchDepth
 
   // shared by Ifu and IBuffer
   // NOTE: we can enqueue FetchBlockInstNum instructions from Ifu,

--- a/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/Ftq.scala
@@ -179,7 +179,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
   // We limit the distance between BP and IF and stall counts of BP train so that branch update can be written back to
   // BPU
   io.fromBpu.prediction.ready := distanceBetween(bpuPtr(0), commitPtr(0)) < FtqSize.U &&
-    distanceBetween(bpuPtr(0), fetchPtr(0)) < BpRunAheadDistance.U &&
+    distanceBetween(bpuPtr(0), fetchPtr(0)) < PrefetchDepth.U &&
     bpTrainStallCnt < BpTrainStallLimit.U
   io.fromBpu.meta.ready := true.B
 
@@ -531,7 +531,7 @@ class Ftq(implicit p: Parameters) extends FtqModule
   when(!(distanceBetween(bpuPtr(0), commitPtr(0)) < FtqSize.U)) {
     topdownStage.reasons(TopDownCounters.FtqFullStall.id) := true.B
   }.elsewhen(
-    !(distanceBetween(bpuPtr(0), fetchPtr(0)) < BpRunAheadDistance.U && bpTrainStallCnt < BpTrainStallLimit.U)
+    !(distanceBetween(bpuPtr(0), fetchPtr(0)) < PrefetchDepth.U && bpTrainStallCnt < BpTrainStallLimit.U)
   ) {
     topdownStage.reasons(TopDownCounters.FtqUpdateBubble.id) := true.B
   }

--- a/src/main/scala/xiangshan/frontend/ftq/FtqParameters.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/FtqParameters.scala
@@ -20,11 +20,10 @@ import chisel3.util._
 import xiangshan.frontend.HasFrontendParameters
 
 case class FtqParameters(
-    FtqSize:            Int = 64,
-    ResolveQueueSize:   Int = 16,
-    BpRunAheadDistance: Int = 8,
-    BpTrainStallLimit:  Int = 8,
-    CommitQueueSize:    Int = 64
+    FtqSize:           Int = 64,
+    ResolveQueueSize:  Int = 16,
+    BpTrainStallLimit: Int = 8,
+    CommitQueueSize:   Int = 64
 ) {
   // sanity check
   require(isPow2(FtqSize))
@@ -34,7 +33,7 @@ trait HasFtqParameters extends HasFrontendParameters {
   def ftqParameters: FtqParameters = frontendParameters.ftqParameters
 
   def ResolveQueueSize:   Int = ftqParameters.ResolveQueueSize
-  def BpRunAheadDistance: Int = ftqParameters.BpRunAheadDistance
+  def BpRunAheadDistance: Int = frontendParameters.icacheParameters.WayLookupSize
   def BpTrainStallLimit:  Int = ftqParameters.BpTrainStallLimit
   def CommitQueueSize:    Int = ftqParameters.CommitQueueSize
 }

--- a/src/main/scala/xiangshan/frontend/ftq/FtqParameters.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/FtqParameters.scala
@@ -32,8 +32,7 @@ case class FtqParameters(
 trait HasFtqParameters extends HasFrontendParameters {
   def ftqParameters: FtqParameters = frontendParameters.ftqParameters
 
-  def ResolveQueueSize:   Int = ftqParameters.ResolveQueueSize
-  def BpRunAheadDistance: Int = frontendParameters.icacheParameters.WayLookupSize
-  def BpTrainStallLimit:  Int = ftqParameters.BpTrainStallLimit
-  def CommitQueueSize:    Int = ftqParameters.CommitQueueSize
+  def ResolveQueueSize:  Int = ftqParameters.ResolveQueueSize
+  def BpTrainStallLimit: Int = ftqParameters.BpTrainStallLimit
+  def CommitQueueSize:   Int = ftqParameters.CommitQueueSize
 }

--- a/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheImp.scala
@@ -71,7 +71,7 @@ class ICacheImp(outer: ICache) extends LazyModuleImp(outer) with HasICacheParame
   println(s"  Size(set * way * block): $nSets * $nWays * $blockBytes = ${nSets * nWays * blockBytes} bytes")
   println(s"  Replacer: $Replacer")
   println(s"  Mshr(fetch, prefetch): $NumFetchMshr, $NumPrefetchMshr entries")
-  println(s"  WayLookupSize: $WayLookupSize entries")
+  println(s"  WayLookup: $PrefetchDepth entries")
   println(s"  DataBanks: $DataBanks banks")
   println(s"  DataEccUnit: $DataEccUnit bits")
   println(s"  DataSramWidth(data + ecc + padding): $ICacheDataBits + $DataEccBits + $DataPaddingBits = $DataSramWidth")

--- a/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
+++ b/src/main/scala/xiangshan/frontend/icache/ICacheWayLookup.scala
@@ -47,7 +47,7 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
 
   val io: ICacheWayLookupIO = IO(new ICacheWayLookupIO)
 
-  class ICacheWayLookupPtr extends CircularQueuePtr[ICacheWayLookupPtr](WayLookupSize)
+  class ICacheWayLookupPtr extends CircularQueuePtr[ICacheWayLookupPtr](PrefetchDepth)
   private object ICacheWayLookupPtr {
     def apply(f: Bool, v: UInt): ICacheWayLookupPtr = {
       val ptr = Wire(new ICacheWayLookupPtr)
@@ -57,7 +57,7 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     }
   }
 
-  private val entries  = RegInit(VecInit(Seq.fill(WayLookupSize)(0.U.asTypeOf(new WayLookupEntry))))
+  private val entries  = RegInit(VecInit(Seq.fill(PrefetchDepth)(0.U.asTypeOf(new WayLookupEntry))))
   private val readPtr  = RegInit(ICacheWayLookupPtr(false.B, 0.U))
   private val writePtr = RegInit(ICacheWayLookupPtr(false.B, 0.U))
 
@@ -66,7 +66,7 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
   private val empty = readPtr === writePtr
 
   private val numValidEntries = distanceBetween(writePtr, readPtr)
-  private val numFreeEntries  = WayLookupSize.U - numValidEntries
+  private val numFreeEntries  = PrefetchDepth.U - numValidEntries
 
   // NOTE: May be unportable, we have bp3 == pf2 now, and WayLookup is written in pf1,
   // so up to one tail entry still in WayLookup might be flushed by bp3,
@@ -188,7 +188,7 @@ class ICacheWayLookup(implicit p: Parameters) extends ICacheModule
     distanceBetween(writePtr, readPtr),
     true.B,
     0,
-    WayLookupSize
+    PrefetchDepth
   )
   XSPerfAccumulate("write", io.write.head.fire)
   XSPerfAccumulate("empty_when_write", empty && io.write.head.fire)

--- a/src/main/scala/xiangshan/frontend/icache/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/icache/Parameters.scala
@@ -36,8 +36,6 @@ case class ICacheParameters(
     // missUnit
     NumFetchMshr:    Int = 4,
     NumPrefetchMshr: Int = 10,
-    // wayLookup
-    WayLookupSize: Int = 32,
     // ecc
     // NOTE: we call it "ecc" since it can be configured to use ecc like "secded", but by default it is parity
     // TODO: support disabling ecc completely (currently "none" will use "identity", we want to remove entire ecc logic)
@@ -117,9 +115,6 @@ trait HasICacheParameters extends HasFrontendParameters // scalastyle:ignore num
   def NumFetchMshr:    Int = icacheParameters.NumFetchMshr
   def NumPrefetchMshr: Int = icacheParameters.NumPrefetchMshr
   def NumAllMshr:      Int = NumFetchMshr + NumPrefetchMshr
-
-  // wayLookup
-  def WayLookupSize: Int = icacheParameters.WayLookupSize
 
   // metaArray w/ parity
   def MetaEcc:       String = icacheParameters.MetaEcc


### PR DESCRIPTION
to allow prefetchPipe filling-up wayLookup

<img width="3840" height="2115" alt="performance-comparison-score-nightly-kunminghu-v3-32747139204-12df8283-vs-clipboard-f19b53e4b" src="https://github.com/user-attachments/assets/061585eb-00b5-4814-b21e-ed18ed3c0f03" />
