### PR TITLE
timing(Bpu): compare only lower bits for btb target

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -365,9 +365,11 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   // timing optimization: The comparison of predictions and the generation of the s3_taken are performed in parallel.
   private val s3_mbtbCfiPositionDiffVec = VecInit(s3_mbtbResult.map(_.bits.cfiPosition =/= s3_s1Prediction.cfiPosition))
   private val s3_mbtbAttributeDiffVec   = VecInit(s3_mbtbResult.map(_.bits.attribute =/= s3_s1Prediction.attribute))
-  private val s3_mbtbTargetDiffVec      = VecInit(s3_mbtbResult.map(_.bits.target =/= s3_s1Prediction.target))
-  private val s3_ittageTargetDiff       = ittage.io.prediction.target =/= s3_s1Prediction.target
-  private val s3_rasTargetDiff          = ras.io.topRetAddr =/= s3_s1Prediction.target
+  // timing optimization: btb's target is Cat(getUpper(startPc), entry.lower), so we can compare only lower bits
+  private val s3_mbtbTargetDiffVec = VecInit(s3_mbtbResult.map(_.bits.targetLower =/= s3_s1Prediction.targetLower))
+  // but we still need to compare full target for ittage/ras
+  private val s3_ittageTargetDiff = ittage.io.prediction.target =/= s3_s1Prediction.target
+  private val s3_rasTargetDiff    = ras.io.topRetAddr =/= s3_s1Prediction.target
 
   private val s3_takenMask = VecInit(s3_mbtbResult.zipWithIndex.map { case (entry, i) =>
     val useTage   = s3_tagePrediction.takenVec(i).valid

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -398,4 +398,6 @@ class Prediction(implicit p: Parameters) extends BpuBundle {
   val target:      GuardedPc       = GuardedPc()
   val attribute:   BranchAttribute = new BranchAttribute
   val taken:       Bool            = Bool()
+
+  def targetLower: UInt = target(MaxBtbTargetWidth + instOffsetBits - 1, instOffsetBits)
 }

--- a/src/main/scala/xiangshan/frontend/bpu/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Parameters.scala
@@ -80,6 +80,12 @@ trait HasBpuParameters extends HasFrontendParameters {
 
   def CompareAddrLowWidth: Int = bpuParameters.mbtbParameters.TargetWidth
 
+  def MaxBtbTargetWidth: Int = Seq(
+    bpuParameters.mbtbParameters.TargetWidth + (if (bpuParameters.mbtbParameters.EnableTargetFix) 1 else 0),
+    bpuParameters.ubtbParameters.TargetWidth + (if (bpuParameters.ubtbParameters.EnableTargetFix) 1 else 0),
+    bpuParameters.abtbParameters.TargetWidth + (if (bpuParameters.abtbParameters.EnableTargetFix) 1 else 0)
+  ).max
+
   // phr history
   def AllFoldedHistoryInfo: Set[FoldedHistoryInfo] =
     bpuParameters.tageParameters.TableInfos.map {

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/Bundles.scala
@@ -70,7 +70,7 @@ class AheadBtbMetaEntry(implicit p: Parameters) extends AheadBtbBundle {
   val hit:             Bool            = Bool()
   val attribute:       BranchAttribute = new BranchAttribute
   val position:        UInt            = UInt(CfiPositionWidth.W)
-  val targetLowerBits: UInt            = UInt(TargetLowerBitsWidth.W)
+  val targetLowerBits: UInt            = UInt(TargetWidth.W)
 }
 
 class AheadBtbMeta(implicit p: Parameters) extends AheadBtbBundle {
@@ -85,7 +85,7 @@ class AheadBtbEntry(implicit p: Parameters) extends AheadBtbBundle {
   val tag:             UInt            = UInt(TagWidth.W)
   val position:        UInt            = UInt(CfiPositionWidth.W)
   val attribute:       BranchAttribute = new BranchAttribute
-  val targetLowerBits: UInt            = UInt(TargetLowerBitsWidth.W)
+  val targetLowerBits: UInt            = UInt(TargetWidth.W)
   // target fix, see comment in Parameters.scala
   val targetCarry: Option[TargetCarry] = if (EnableTargetFix) Option(new TargetCarry) else None
 }

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/Helpers.scala
@@ -30,7 +30,7 @@ trait Helpers extends HasAheadBtbParameters with TargetFixHelper {
     maxWidth = Option(VAddrBits),
     extraFields = Seq(
       ("tag", instOffsetBits, TagWidth),
-      ("targetLower", instOffsetBits, TargetLowerBitsWidth)
+      ("targetLower", instOffsetBits, TargetWidth)
     )
   )
 

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/Parameters.scala
@@ -21,13 +21,13 @@ import xiangshan.frontend.bpu.FoldedHistoryInfo
 import xiangshan.frontend.bpu.HasBpuParameters
 
 case class AheadBtbParameters(
-    NumEntries:           Int = 1024,
-    NumBanks:             Int = 4,
-    NumWays:              Int = 4,
-    TagWidth:             Int = 24,
-    TargetLowerBitsWidth: Int = 22,
-    WriteBufferSize:      Int = 4,
-    TakenCounterWidth:    Int = 2,
+    NumEntries:        Int = 1024,
+    NumBanks:          Int = 4,
+    NumWays:           Int = 4,
+    TagWidth:          Int = 24,
+    TargetWidth:       Int = 22,
+    WriteBufferSize:   Int = 4,
+    TakenCounterWidth: Int = 2,
     // enable carry and borrow fix for target, so jumps around 2^(TargetWidth+1) boundary will not cause misprediction
     // mainBtb should handle this case, so performance affect should be slight, and, bad for timing
     EnableTargetFix: Boolean = false
@@ -36,17 +36,17 @@ case class AheadBtbParameters(
 trait HasAheadBtbParameters extends HasBpuParameters {
   def abtbParameters: AheadBtbParameters = bpuParameters.abtbParameters
 
-  def NumEntries:           Int = abtbParameters.NumEntries
-  def NumBanks:             Int = abtbParameters.NumBanks
-  def NumWays:              Int = abtbParameters.NumWays
-  def NumSets:              Int = NumEntries / NumWays / NumBanks
-  def TagWidth:             Int = abtbParameters.TagWidth
-  def TargetLowerBitsWidth: Int = abtbParameters.TargetLowerBitsWidth
-  def SetIdxWidth:          Int = log2Ceil(NumSets)
-  def WayIdxWidth:          Int = log2Ceil(NumWays)
-  def BankIdxWidth:         Int = log2Ceil(NumBanks)
-  def WriteBufferSize:      Int = abtbParameters.WriteBufferSize
-  def TakenCounterWidth:    Int = abtbParameters.TakenCounterWidth
+  def NumEntries:        Int = abtbParameters.NumEntries
+  def NumBanks:          Int = abtbParameters.NumBanks
+  def NumWays:           Int = abtbParameters.NumWays
+  def NumSets:           Int = NumEntries / NumWays / NumBanks
+  def TagWidth:          Int = abtbParameters.TagWidth
+  def TargetWidth:       Int = abtbParameters.TargetWidth
+  def SetIdxWidth:       Int = log2Ceil(NumSets)
+  def WayIdxWidth:       Int = log2Ceil(NumWays)
+  def BankIdxWidth:      Int = log2Ceil(NumBanks)
+  def WriteBufferSize:   Int = abtbParameters.WriteBufferSize
+  def TakenCounterWidth: Int = abtbParameters.TakenCounterWidth
 
   def EnableTargetFix: Boolean = abtbParameters.EnableTargetFix
 


### PR DESCRIPTION
these target are Cat(getUpper(startPc), entry.targetLower), so comparing upper bits is meaningless

this computes max(btb target bits) and compare these bits only, might not on critical path so might not good for timing but good for area anyway.

also rename abtb `TargetLowerBitsWidth` to `TargetWidth` to sync wich u/mbtb.

idea from @TheKiteRunner24 