### PR TITLE
fix(Vector): support unit-stride store partial replay

### DIFF
--- a/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
+++ b/src/main/scala/xiangshan/mem/vector/VMergeBuffer.scala
@@ -322,8 +322,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
       entries(latchWbIndex).flowNum := entries(latchWbIndex).flowNum - latchFlowNum
 
       if (isVStore) {
-        val isUnitStride = LSUOpType.isAllUS(entries(wbIndex).uop.fuOpType)
-        when(!io.fromPipeline(i).bits.hit && !isUnitStride) {
+        when(!io.fromPipeline(i).bits.hit) {
           val replayFlowNumOffset = PopCount(mergePortMatrixMiss(i))
           val replayFlowMask = (0 until pipeWidth).map{case i => (0 until pipeWidth).map{case j =>
             UIntToOH(io.fromPipeline(j).bits.splitIndex, VLENB) & Fill(VLENB, mergePortMatrixMiss(i)(j))
@@ -366,6 +365,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     val selAllocated = allocated(entryIdx)
     val selNeedRSReplay = needRSReplay(entryIdx)
     val selIsUnitStride = LSUOpType.isAllUS(selEntry.uop.fuOpType)
+    val selDoPartialReplay = selNeedRSReplay && (isVStore.B || !selIsUnitStride)
     val selFire  = selValid && canGo
     val canDeq = selFire && !selNeedRSReplay
     when(selFire) {
@@ -374,7 +374,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
       selEntry.replayFlowMask := 0.U
       uopFinish(entryIdx)   := false.B
 
-      when (!selNeedRSReplay || selIsUnitStride) {
+      when (!selDoPartialReplay) {
         freeMaskVec(entryIdx) := selAllocated
         allocated(entryIdx)   := false.B
       } .otherwise {
@@ -398,7 +398,7 @@ abstract class BaseVMergeBuffer(isVStore: Boolean=false)(implicit p: Parameters)
     feedbackOut.dataInvalidSqIdx         := DontCare
     feedbackOut.sqIdx                    := selEntry.uop.sqIdx
     feedbackOut.lqIdx                    := selEntry.uop.lqIdx
-    feedbackOut.isVecPartReplay.foreach(_:= selNeedRSReplay && !selIsUnitStride)
+    feedbackOut.isVecPartReplay.foreach(_:= selDoPartialReplay)
     feedbackOut.vecReplayMask.foreach(_  := selEntry.replayFlowMask)
     feedbackOut.vecReplayMbIdx.foreach(_ := entryIdx)
 

--- a/src/main/scala/xiangshan/mem/vector/VSplit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSplit.scala
@@ -110,7 +110,6 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
   val flowsPrevThisUop = (uopIdxInField << flowsLog2).asUInt // # of flows before this uop in a field
   val flowsPrevThisVd = (vdIdxInField << numFlowsSameVdLog2).asUInt // # of flows before this vd in a field
   val flowsIncludeThisUop = ((uopIdxInField +& 1.U) << flowsLog2).asUInt // # of flows before this uop besides this uop
-//  val flowNum = Mux(io.in.bits.isVecPartReplay.get, PopCount(io.in.bits.vecReplayMask.get), io.in.bits.flowNum.get)
   val flowNum = io.in.bits.flowNum.get
   // max index in vd, only use in index instructions for calculate index
   val maxIdxInVdIndex = GenVLMAX(Mux(s0_emul.asSInt > 0.S, 0.U, s0_emul), s0_eew)
@@ -132,10 +131,8 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
   val srcMask = GenFlowMask(Mux(s0_vm, Fill(VLEN, 1.U(1.W)), io.in.bits.src_mask), vvstart, evl, true)
   val srcMaskShiftBits = Mux(isSpecialIndexed, flowsPrevThisUop, flowsPrevThisVd)
 
-  val flowMask = Mux(io.in.bits.isVecPartReplay.get,
-    io.in.bits.vecReplayMask.get,
-    ((srcMask & UIntToMask(flowsIncludeThisUop.asUInt, VLEN + 1) &
-    (~UIntToMask(flowsPrevThisUop.asUInt, VLEN)).asUInt) >> srcMaskShiftBits)(VLENB - 1, 0))
+  val flowMask = ((srcMask & UIntToMask(flowsIncludeThisUop.asUInt, VLEN + 1) &
+    (~UIntToMask(flowsPrevThisUop.asUInt, VLEN)).asUInt) >> srcMaskShiftBits)(VLENB - 1, 0)
   val indexedSrcMask = (srcMask >> flowsPrevThisVd).asUInt //only for index instructions
 
   // Used to calculate the element index.
@@ -179,6 +176,7 @@ class VSplitPipeline(isVStore: Boolean = false)(implicit p: Parameters) extends 
     x.indexVlMaxInVd := indexVlMaxInVd
     x.isVecPartReplay := io.in.bits.isVecPartReplay.get
     x.vecReplayMbIdx := io.in.bits.vecReplayMbIdx.get
+    x.vecReplayFlowMask := io.in.bits.vecReplayMask.get
   }
   s0_valid := io.in.valid && !s0_kill
   /**-------------------------------------
@@ -377,7 +375,9 @@ abstract class VSplitBuffer(isVStore: Boolean = false)(implicit p: Parameters) e
   val regOffset        = getCheckAddrLowBits(issueUsLowBitsAddr, maxMemByteNum) // offset in 256-bits vd
   XSError((splitIdx > 1.U && usNoSplit) || (splitIdx > 1.U && !issuePreIsSplit) , "Unit-Stride addr split error!\n")
 
-  val vecActive = Mux(!issuePreIsSplit, usSplitMask.orR, (flowMask & UIntToOH(splitIdx)).orR)
+  val normalFlowActive = Mux(!issuePreIsSplit, usSplitMask.orR, (flowMask & UIntToOH(splitIdx)).orR)
+  val replayFlowActive = (issueEntry.vecReplayFlowMask & UIntToOH(splitIdx, maxFlowNum)).orR
+  val vecActive = Mux(issueEntry.isVecPartReplay, replayFlowActive, normalFlowActive)
   // no-unit-stride can trigger misalign
   val addrAligned = LookupTree(Mux(isIndexed(issueInstType), issueSew, issueEew), List(
     "b00".U   -> true.B,                //b
@@ -633,4 +633,3 @@ class VSSplitImp(implicit p: Parameters) extends VLSUModule{
 
   io.vstdMisalign.get <> splitBuffer.io.vstdMisalign.get
 }
-


### PR DESCRIPTION
Extend the existing vector store partial replay mechanism to unit-stride stores.

`VMergeBuffer` now records missed unit-stride flows by their original `splitIndex`, retains the merge-buffer entry during replay, and feeds the replay mask back to the issue queue.

`VSplit` keeps the replay mask separate from the original access mask. The original `flowMask` still determines the byte mask and store data, while `vecReplayFlowMask` only selects which split should be reissued. 

This prevents completed unit-stride flows from being reissued and avoids cross-page flows repeatedly competing for the same TLB/GPA resource. 