### PR TITLE
ci(perf): add KunminghuV2Config trigger option

### DIFF
--- a/.github/workflows/perf-trigger.yml
+++ b/.github/workflows/perf-trigger.yml
@@ -30,6 +30,7 @@ on:
         options:
           - DefaultConfig
           - BackendV2Config
+          - KunminghuV2Config
         default: DefaultConfig
       benchmark_type:
         description: Benchmark type


### PR DESCRIPTION
Allow the v3 performance trigger to select the v2 configuration when testing a kunminghu-v2 based branch.