### PR TITLE
fix(difftest): record the dedicated VL RAT destination

### DIFF
--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -206,6 +206,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
       update.valid := renameOut.fire && !io.redirect.valid
       update.bits.ldest := renameOut.bits.ldest
       update.bits.pdest := renameOut.bits.pdest
+      update.bits.pdestVl := renameOut.bits.pdestVl
       update.bits.rfWen := renameOut.bits.rfWen
       update.bits.fpWen := renameOut.bits.fpWen
       update.bits.vecWen := renameOut.bits.vecWen

--- a/src/main/scala/xiangshan/backend/rob/DiffRatStateBuffer.scala
+++ b/src/main/scala/xiangshan/backend/rob/DiffRatStateBuffer.scala
@@ -49,6 +49,7 @@ class DiffRatState(val params: DiffRatStateParams)(implicit p: Parameters) exten
 class DiffRatRenameUpdate(implicit p: Parameters) extends XSBundle {
   val ldest = UInt(LogicRegsWidth.W)
   val pdest = UInt(PhyRegIdxWidth.W)
+  val pdestVl = UInt(VlPhyRegIdxWidth.W)
   val rfWen = Bool()
   val fpWen = Bool()
   val vecWen = Bool()
@@ -106,8 +107,9 @@ class DiffRatStateBuffer(implicit p: Parameters) extends XSModule {
       next.vecRat(reg) := Mux(hit, req.bits.pdest, prev.vecRat(reg))
     }
     for (reg <- 0 until params.vlEntries) {
-      val hit = req.valid && req.bits.vlWen && req.bits.ldest === reg.U
-      next.vlRat(reg) := Mux(hit, req.bits.pdest, prev.vlRat(reg))
+      // VL has a single logical register indexed 0, so it does not use the generic ldest.
+      val hit = req.valid && req.bits.vlWen
+      next.vlRat(reg) := Mux(hit, req.bits.pdestVl, prev.vlRat(reg))
     }
   }
 


### PR DESCRIPTION
VL-writing uops allocate their destination from the dedicated VL free list and carry it in pdestVl. The generic pdest belongs to the normal integer/floating-point/vector destination path and can be unrelated or zero for a vlWen uop, so using it to update the Difftest VL RAT records an incorrect mapping.

Propagate pdestVl through the Difftest rename update payload and use it exclusively when updating vlRat. The VL RAT has one fixed logical entry, vl0, so its update is selected by vlWen rather than the generic ldest.