### PR TITLE
feat(fpu): execute scalar Zfa FLI through I2F

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
+++ b/src/main/scala/xiangshan/backend/decode/DecodeUnit.scala
@@ -478,6 +478,16 @@ case class Imm_OPIVIU() extends Imm(5, SelImm.IMM_OPIVIU){
   }
 }
 
+case class Imm_FI() extends Imm(5, SelImm.IMM_FI){
+  override def do_toImm32(minBits: UInt): UInt = ZeroExt(minBits, 32)
+
+  override def extract(width: Int)(imm: UInt): UInt = ZeroExt(imm.take(5), width)
+
+  override def minBitsFromInstr(instr: UInt): UInt = {
+    instr(19, 15)
+  }
+}
+
 case class Imm_VSETVLI() extends Imm(11, SelImm.IMM_VSETVLI){
   override def do_toImm32(minBits: UInt): UInt = SignExt(minBits, 32)
 
@@ -554,13 +564,14 @@ object ImmUnion {
   val Z = Imm_Z()
   val OPIVIS = Imm_OPIVIS()
   val OPIVIU = Imm_OPIVIU()
+  val FI = Imm_FI()
   val VSETVLI = Imm_VSETVLI()
   val VSETIVLI = Imm_VSETIVLI()
   val LUI32 = Imm_LUI32()
   val VRORVI = Imm_VRORVI()
 
   // do not add special type lui32 to this, keep ImmUnion max len being 20.
-  val imms = Seq(I, S, B, U, J, Z, OPIVIS, OPIVIU, VSETVLI, VSETIVLI, VRORVI)
+  val imms = Seq(I, S, B, U, J, Z, OPIVIS, OPIVIU, FI, VSETVLI, VSETIVLI, VRORVI)
   val maxLen = imms.maxBy(_.len).len
   val immSelMap = Seq(
     SelImm.IMM_I,
@@ -571,6 +582,7 @@ object ImmUnion {
     SelImm.IMM_Z,
     SelImm.IMM_OPIVIS,
     SelImm.IMM_OPIVIU,
+    SelImm.IMM_FI,
     SelImm.IMM_VSETVLI,
     SelImm.IMM_VSETIVLI,
     SelImm.IMM_VRORVI,

--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -253,6 +253,7 @@ object FuConfig {
     writeFflags = true,
     latency = CertainLatency(2, extraValue = 1),
     needSrcFrm = true,
+    immType = Set(Imm_FI()),
   )
 
   val FcmpCfg: FuConfig = FuConfig(

--- a/src/main/scala/xiangshan/backend/fu/wrapper/I2F.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/I2F.scala
@@ -6,7 +6,7 @@ import chisel3.util._
 import chisel3.util.experimental.decode._
 import utility.XSError
 import xiangshan.backend.fu.FuConfig
-import xiangshan.backend.fu.fpu.FpPipedFuncUnit
+import xiangshan.backend.fu.fpu.{FliDTable, FliHTable, FliSTable, FpPipedFuncUnit}
 import utility._
 import yunsuan.scalar.FPCVT
 import yunsuan.encoding.Opcode.Opcodes.FCvtOpcode
@@ -53,22 +53,44 @@ class I2F(cfg: FuConfig)(implicit p: Parameters) extends FpPipedFuncUnit(cfg) {
   }
 
   val outIsMvInst = FCvtOpcode.getCvtSign(fuOpType).andR
+  val isFli = FCvtOpcode.isFli(fuOpType)
+
+  val fliHTable = Module(new FliHTable)
+  val fliSTable = Module(new FliSTable)
+  val fliDTable = Module(new FliDTable)
+  val fliIndex = inData.imm(4, 0)
+  fliHTable.src := fliIndex
+  fliSTable.src := fliIndex
+  fliDTable.src := fliIndex
+
+  val fliData = Mux1H(Seq(
+    FCvtOpcode.outIs16(fuOpType) -> Cat(Fill(48, true.B), fliHTable.out),
+    FCvtOpcode.outIs32(fuOpType) -> Cat(Fill(32, true.B), fliSTable.out, 0.U(16.W)),
+    FCvtOpcode.outIs64(fuOpType) -> Cat(fliDTable.out, 0.U(48.W)),
+  ))
 
   // modules
   val fcvt = Module(new FPCVT(XLEN, isI2F = true))
-  fcvt.io.fire          := fire
+  fcvt.io.fire          := fire && !isFli
   fcvt.io.src           := src1
   fcvt.io.opType        := fuOpType
   fcvt.io.rm            := fpRm
   fcvt.io.inSew1H       := inSew1H
   fcvt.io.outSew1H      := outSew1H
 
-  io.out.bits.res.fflags.get := Mux(outIsMvInst, 0.U, fcvt.io.fflags)
+  val outIsFli = RegEnable(RegEnable(isFli, fire), fireReg)
+  val outFliData = RegEnable(RegEnable(fliData, fire), fireReg)
+
+  io.out.bits.res.fflags.get := Mux(outIsFli || outIsMvInst, 0.U, fcvt.io.fflags)
 
   val result = Mux(
-    RegEnable(RegEnable(outIsMvInst, fire), fireReg),
-    RegEnable(RegEnable(src1, fire), fireReg),
-    fcvt.io.result
+    outIsFli,
+    outFliData,
+    Mux(
+      RegEnable(RegEnable(outIsMvInst, fire), fireReg),
+      RegEnable(RegEnable(src1, fire), fireReg),
+      fcvt.io.result
+    )
   )
   // box
   val res1H = RegEnable(RegEnable(outSew1H(3, 1), fire), fireReg)

--- a/src/main/scala/xiangshan/backend/rename/Rename.scala
+++ b/src/main/scala/xiangshan/backend/rename/Rename.scala
@@ -206,6 +206,7 @@ class Rename(implicit p: Parameters) extends XSModule with HasCircularQueuePtrHe
       update.valid := renameOut.fire && !io.redirect.valid
       update.bits.ldest := renameOut.bits.ldest
       update.bits.pdest := renameOut.bits.pdest
+      update.bits.pdestVl := renameOut.bits.pdestVl
       update.bits.rfWen := renameOut.bits.rfWen
       update.bits.fpWen := renameOut.bits.fpWen
       update.bits.vecWen := renameOut.bits.vecWen

--- a/src/main/scala/xiangshan/backend/rob/DiffRatStateBuffer.scala
+++ b/src/main/scala/xiangshan/backend/rob/DiffRatStateBuffer.scala
@@ -49,6 +49,7 @@ class DiffRatState(val params: DiffRatStateParams)(implicit p: Parameters) exten
 class DiffRatRenameUpdate(implicit p: Parameters) extends XSBundle {
   val ldest = UInt(LogicRegsWidth.W)
   val pdest = UInt(PhyRegIdxWidth.W)
+  val pdestVl = UInt(VlPhyRegIdxWidth.W)
   val rfWen = Bool()
   val fpWen = Bool()
   val vecWen = Bool()
@@ -106,8 +107,9 @@ class DiffRatStateBuffer(implicit p: Parameters) extends XSModule {
       next.vecRat(reg) := Mux(hit, req.bits.pdest, prev.vecRat(reg))
     }
     for (reg <- 0 until params.vlEntries) {
-      val hit = req.valid && req.bits.vlWen && req.bits.ldest === reg.U
-      next.vlRat(reg) := Mux(hit, req.bits.pdest, prev.vlRat(reg))
+      // VL has a single logical register indexed 0, so it does not use the generic ldest.
+      val hit = req.valid && req.bits.vlWen
+      next.vlRat(reg) := Mux(hit, req.bits.pdestVl, prev.vlRat(reg))
     }
   }
 

--- a/src/main/scala/xiangshan/backend/vector/Decoder/Uop/ScalaUopTable.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/Uop/ScalaUopTable.scala
@@ -452,7 +452,7 @@ object ScalaUopTable {
 
     F_ZFAType.mapUopcode(
       _.FLEQ_S     -> fleq_fp32,
-      _.FLI_S      -> fleq_fp32, // todo
+      _.FLI_S      -> I2fOpcodes.fli_fp32,
       _.FLTQ_S     -> fltq_fp32,
       _.FMAXM_S    -> FAluOpcodes.fmaxm_fp32,
       _.FMINM_S    -> FAluOpcodes.fminm_fp32,
@@ -466,7 +466,7 @@ object ScalaUopTable {
 
     D_ZFAType.mapUopcode(
       _.FLEQ_D      -> fleq_fp64,
-      _.FLI_D       -> fleq_fp64,
+      _.FLI_D       -> I2fOpcodes.fli_fp64,
       _.FLTQ_D      -> fltq_fp64,
       _.FMAXM_D     -> FAluOpcodes.fmaxm_fp64,
       _.FMINM_D     -> FAluOpcodes.fminm_fp64,
@@ -481,7 +481,7 @@ object ScalaUopTable {
 
     ZFH_ZFAType.mapUopcode(
       _.FLEQ_H      -> fleq_fp16,
-      _.FLI_H       -> fleq_fp16, // todo
+      _.FLI_H       -> I2fOpcodes.fli_fp16,
       _.FLTQ_H      -> fltq_fp16,
       _.FMAXM_H     -> FAluOpcodes.fmaxm_fp16,
       _.FMINM_H     -> FAluOpcodes.fminm_fp16,

--- a/src/main/scala/xiangshan/package.scala
+++ b/src/main/scala/xiangshan/package.scala
@@ -589,6 +589,7 @@ package object xiangshan {
     def IMM_VSETIVLI  = "b1011".U
     def IMM_VRORVI    = "b1100".U
     def IMM_LUI32     = "b1110".U
+    def IMM_FI        = "b1111".U
 
     def X      = BitPat("b0000")
 
@@ -608,6 +609,7 @@ package object xiangshan {
         IMM_VSETIVLI.litValue  -> "VSETIVLI",
         IMM_LUI32.litValue     -> "LUI32",
         IMM_VRORVI.litValue    -> "VRORVI",
+        IMM_FI.litValue        -> "FI",
       )
       strMap(immType.litValue)
     }
@@ -626,6 +628,7 @@ package object xiangshan {
         IMM_VSETIVLI.litValue  -> ImmUnion.VSETIVLI,
         IMM_LUI32.litValue     -> ImmUnion.LUI32,
         IMM_VRORVI.litValue    -> ImmUnion.VRORVI,
+        IMM_FI.litValue        -> ImmUnion.FI,
       )
       iuMap(immType.litValue)
     }


### PR DESCRIPTION
1. Route fli.h, fli.s, and fli.d to the existing I2F resource instead of FP compare uops.
2. Carry instr(19,15) as the FI table index through the legacy immediate path, with no GPR source dependency.
3. Select H/S/D lookup-table results in I2F with scalar NaN boxing and retained conversion latency.
4. Bypass FPCVT for FLI and return zero fflags.