### PR TITLE
fix(dramsim3): sample DPI calls at stable phases

### DIFF
--- a/src/main/scala/device/AXI4Memory.scala
+++ b/src/main/scala/device/AXI4Memory.scala
@@ -69,11 +69,18 @@ class MemoryRequestHelper(requestType: Int)
     "  input             io_req_valid,",
     "  input      [63:0] io_req_bits_addr,",
     "  input      [31:0] io_req_bits_id,",
-    "  output            io_response",
+    "  output reg        io_response",
     ");",
     "",
-    "assign io_response = reset ? 1'b0 :",
-    "  (io_req_valid ? memory_request(io_req_bits_addr, io_req_bits_id, REQUEST_TYPE) : 1'b0);",
+    "always @(negedge clock or posedge reset) begin",
+    "  if (reset) begin",
+    "    io_response <= 1'b0;",
+    "  end else if (io_req_valid) begin",
+    "    io_response <= memory_request(io_req_bits_addr, io_req_bits_id, REQUEST_TYPE);",
+    "  end else begin",
+    "    io_response <= 1'b0;",
+    "  end",
+    "end",
     "endmodule"
   )
   setInline(s"$desiredName.v", verilogLines.mkString("\n"))
@@ -114,11 +121,18 @@ class MemoryResponseHelper(requestType: Int)
     "  input             clock,",
     "  input             reset,",
     "  input             enable,",
-    "  output [63:0]     response",
+    "  output reg [63:0] response",
     ");",
     "",
-    "assign response = reset ? 64'b0 :",
-    "  (enable ? memory_response(REQUEST_TYPE) : 64'b0);",
+    "always @(negedge clock or posedge reset) begin",
+    "  if (reset) begin",
+    "    response <= 64'b0;",
+    "  end else if (enable) begin",
+    "    response <= memory_response(REQUEST_TYPE);",
+    "  end else begin",
+    "    response <= 64'b0;",
+    "  end",
+    "end",
     "endmodule"
   )
   setInline(s"$desiredName.v", verilogLines.mkString("\n"))


### PR DESCRIPTION
memory_request() and memory_response() mutate DRAMSim3 state.
Calling them from continuous assignments lets a simulator evaluate them
repeatedly while settling combinational logic. Caching the first call in
an RTL cycle is unsafe because that evaluation can observe transient
inputs.

Move the Verilator DPI helpers to the falling clock edge, after their
inputs have settled. Preserve V2's existing GSIM ExtModule execution
once per simulation step and its registered helper-result boundary.
This gives each backend one stable transaction phase per cycle and
keeps request and response ordering deterministic.