### PR TITLE
fix(LoadUnit): preserve head TLB metadata for unaligned replay

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -1494,7 +1494,12 @@ class LoadUnitS3(param: ExeUnitParams)(
   // Writeback to LQ
   val lqWriteValid = pipeIn.valid && !doFastReplay && endPipe
   val lqWriteReady = io.lqWrite.ready
-  val lqWriteCause = Mux(s4HeadValid && s4HeadShouldReplay, s4HeadReplayCause, cause)
+  
+  val useS4HeadReplay = s4HeadValid && s4HeadShouldReplay
+  val lqWriteCause = Mux(useS4HeadReplay, s4HeadReplayCause, cause)
+  val lqWriteTlbId = Mux(useS4HeadReplay, s4Head.tlbId.get, in.tlbId.get)
+  val lqWriteTlbFull = Mux(useS4HeadReplay, s4Head.tlbFull.get, in.tlbFull.get)
+  
   val lqWriteNeedReplay = lqWriteCause.asUInt.orR
   val lqWriteCauseOH = PriorityEncoderOH(lqWriteCause)
   val lqWrite = Wire(new LqWriteBundle)
@@ -1540,8 +1545,8 @@ class LoadUnitS3(param: ExeUnitParams)(
   lqWrite.rep_info.need_rep := lqWriteNeedReplay
   lqWrite.rep_info.cause := lqWriteCauseOH
   lqWrite.rep_info.debug := uop.perfDebugInfo
-  lqWrite.rep_info.tlb_id := in.tlbId.get
-  lqWrite.rep_info.tlb_full := in.tlbFull.get
+  lqWrite.rep_info.tlb_id := lqWriteTlbId
+  lqWrite.rep_info.tlb_full := lqWriteTlbFull
 
   val perfIsReplayExec = LoadEntrance.isReplay(entrance) || s4HeadIsReplay && s4HeadValid
   val perfMdpAddrValid = Mux(s4HeadValid, s4Head.perfMdpAddrValid.get, in.perfMdpAddrValid.get)


### PR DESCRIPTION
When an unaligned load head replays, lqWriteCause selects the S4 head cause while tlb_id and tlb_full still come from the current S3 tail.

Use the same head replay selector for TLB metadata so LRQ receives a consistent replay record and does not wait for an unrelated TLB hint.