### PR TITLE
feat(VsetDecoder): raise illegal instruction exception when VS is off

### DIFF
--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeChannel/VsetDecoder.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeChannel/VsetDecoder.scala
@@ -114,6 +114,7 @@ class VsetDecoder extends Module {
   out.bits.renameInfo.valid := legalInst
   out.bits.renameInfo.bits := uop
   out.bits.renameInfo.bits.gpWen := uop.gpWen && instFields.RD =/= 0.U
+  out.bits.illegal := legalInst && in.vsIsOff
   out.bits.src.src1 := instFields.RS1
   out.bits.src.src2 := instFields.RS2
   out.bits.src.dest := instFields.RD
@@ -412,6 +413,7 @@ object VsetDecoder {
 
   class In extends Bundle {
     val rawInst = UInt(32.W)
+    val vsIsOff = Bool()
   }
 
   class Out extends Bundle {
@@ -423,6 +425,7 @@ object VsetDecoder {
     val imm = UInt(32.W)
     val flushPipe = Bool()
     val isVSETVL = Bool()
+    val illegal = Bool()
   }
 }
 

--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeChannels.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeChannels.scala
@@ -196,6 +196,7 @@ class DecodeChannels(
   val vsetDecodeChannelsIn: Seq[VsetDecoder.In] = vsetDecodeChannels.map(_.in)
   vsetDecodeChannelsIn.zipWithIndex.foreach { case (modIn, i) =>
     modIn.rawInst := in.mops(i).bits.info.rawInst
+    modIn.vsIsOff := in.mops(i).bits.info.fromCSR.illegalInst.vsIsOff
   }
 
   val simDecodeChannelsIn: Seq[DecodeChannelInput] = simpleDecodeChannels.map(_.in)
@@ -491,7 +492,7 @@ object DecodeChannelOutput {
     uop.src12Rev := false.B
 
     uop.isMove := false.B
-    uop.exceptionII := false.B
+    uop.exceptionII := vuop.illegal
     uop.exceptionVI := false.B
 
     uop


### PR DESCRIPTION
When decoding vset instructions (vsetvli/vsetivli/vsetvl) while vector extension (VS) is turned off in mstatus, mark the decoded uop with exceptionII so that an illegal instruction exception is raised at commit, instead of silently executing the instruction.