### PR TITLE
fix(Bpu): enable & debug-related fix & cleanup

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -97,15 +97,15 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
       csrCtrl
 
   fallThrough.io.enable := true.B // fallThrough is always enabled
-  utage.io.enable       := true.B
-  uras.io.enable        := true.B
+  utage.io.enable       := ctrl.abtbEnable
+  uras.io.enable        := ctrl.rasEnable && ctrl.mbtbEnable
   ubtb.io.enable        := ctrl.ubtbEnable
   abtb.io.enable        := ctrl.abtbEnable
   mbtb.io.enable        := ctrl.mbtbEnable
-  tage.io.enable        := ctrl.tageEnable
-  sc.io.enable          := ctrl.scEnable
-  ittage.io.enable      := ctrl.ittageEnable
-  ras.io.enable         := ctrl.rasEnable
+  tage.io.enable        := ctrl.tageEnable && ctrl.mbtbEnable
+  sc.io.enable          := ctrl.scEnable && ctrl.mbtbEnable
+  ittage.io.enable      := ctrl.ittageEnable && ctrl.mbtbEnable
+  ras.io.enable         := ctrl.rasEnable && ctrl.mbtbEnable
   // For some reason s0 stalled, usually FTQ Full
   private val s0_stall = Wire(Bool())
 

--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -338,7 +338,6 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val s1_taken             = s1_prediction.taken
   private val useAbtb              = s1_abtbValid && s1_abtbResult.taken
   private val debug_s1UseUbtb      = s1_taken && !useAbtb
-  private val debug_s1UseUbtbUtage = s1_taken && !useAbtb
   private val debug_s1UseAbtb      = s1_taken && useAbtb && !s1_utageHitMask.reduce(_ || _)
   private val debug_s1UseAbtbUtage = s1_taken && useAbtb && s1_utageHitMask.reduce(_ || _)
 
@@ -645,7 +644,6 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
       BpuPredictionSource.Stage1.Fallthrough,
       Seq(
         debug_s1UseUbtb      -> BpuPredictionSource.Stage1.Ubtb,
-        debug_s1UseUbtbUtage -> BpuPredictionSource.Stage1.UbtbUtage,
         debug_s1UseAbtb      -> BpuPredictionSource.Stage1.Abtb,
         debug_s1UseAbtbUtage -> BpuPredictionSource.Stage1.AbtbUtage
       )
@@ -739,7 +737,6 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
     Seq(
       ("ubtb", debug_s1UseUbtb),
       ("abtb", debug_s1UseAbtb),
-      ("ubtb_microTage", debug_s1UseUbtbUtage),
       ("abtb_microTage", debug_s1UseAbtbUtage),
       ("fallThrough", !s1_taken)
     )

--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -88,31 +88,24 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
   private val redirect = io.fromFtq.redirect
 
   /* *** CSR ctrl sub-predictor enable *** */
-  private val ctrl      = DelayN(io.ctrl, 2) // delay 2 cycle for timing
-  private val constCtrl = Constantin.createRecord("constCtrl")
+  private val csrCtrl   = DelayN(io.ctrl, 2) // delay 2 cycle for timing
+  private val constCtrl = Constantin.createRecord("BpuCtrl").asTypeOf(new BpuConstCtrl)
+  private val ctrl =
+    if (env.EnableConstantin && !env.FPGAPlatform)
+      Mux(constCtrl.use, constCtrl.ctrl, csrCtrl)
+    else
+      csrCtrl
 
   fallThrough.io.enable := true.B // fallThrough is always enabled
   utage.io.enable       := true.B
   uras.io.enable        := true.B
-  if (env.EnableConstantin && !env.FPGAPlatform) {
-    ubtb.io.enable   := Mux(constCtrl(0), constCtrl(1), ctrl.ubtbEnable)
-    abtb.io.enable   := Mux(constCtrl(0), constCtrl(2), ctrl.abtbEnable)
-    mbtb.io.enable   := Mux(constCtrl(0), constCtrl(3), ctrl.mbtbEnable)
-    tage.io.enable   := Mux(constCtrl(0), constCtrl(4), ctrl.tageEnable)
-    sc.io.enable     := Mux(constCtrl(0), constCtrl(5), ctrl.scEnable)
-    ittage.io.enable := Mux(constCtrl(0), constCtrl(6), ctrl.ittageEnable)
-    ras.io.enable    := Mux(constCtrl(0), constCtrl(7), ctrl.rasEnable)
-    // utage.io.enable  := Mux(constCtrl(0), constCtrl(8), ctrl.utageEnable)
-  } else {
-    ubtb.io.enable   := ctrl.ubtbEnable
-    abtb.io.enable   := ctrl.abtbEnable
-    mbtb.io.enable   := ctrl.mbtbEnable
-    tage.io.enable   := ctrl.tageEnable
-    sc.io.enable     := ctrl.scEnable
-    ittage.io.enable := ctrl.ittageEnable
-    ras.io.enable    := ctrl.rasEnable
-    // utage.io.enable  := ctrl.utageEnable
-  }
+  ubtb.io.enable        := ctrl.ubtbEnable
+  abtb.io.enable        := ctrl.abtbEnable
+  mbtb.io.enable        := ctrl.mbtbEnable
+  tage.io.enable        := ctrl.tageEnable
+  sc.io.enable          := ctrl.scEnable
+  ittage.io.enable      := ctrl.ittageEnable
+  ras.io.enable         := ctrl.rasEnable
   // For some reason s0 stalled, usually FTQ Full
   private val s0_stall = Wire(Bool())
 
@@ -441,8 +434,10 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   private val s3_firstTakenBranchOH = s3_compareMatrix.getLeastElementOH(s3_takenMask)
   private val s3_firstTakenBranch   = Mux1H(s3_firstTakenBranchOH, s3_mbtbResult)
-  private val s3_useRas             = s3_firstTakenBranch.bits.attribute.isReturn
-  private val s3_useIttage          = s3_firstTakenBranch.bits.attribute.needIttage && ittage.io.prediction.hit
+  // tage, ittage, etc.'s `hit` is gated by `enable` so no extra `&& .enable` is required,
+  // but ras does not have a `hit` or `valid` output, so gate directly using `.enable`
+  private val s3_useRas    = s3_firstTakenBranch.bits.attribute.isReturn && ras.io.enable
+  private val s3_useIttage = s3_firstTakenBranch.bits.attribute.needIttage && ittage.io.prediction.hit
 
   private val s3_fallThroughPrediction = RegEnable(s2_fallThroughPrediction, s2_fire)
 

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -167,7 +167,7 @@ object BpuPredictionSource {
   object Stage1 extends EnumUInt(5) {
     def Ubtb:        UInt = 0.U(width.W)
     def Abtb:        UInt = 1.U(width.W)
-    def UbtbUtage:   UInt = 2.U(width.W)
+    def UbtbUtage:   UInt = 2.U(width.W) // now utage must work with abtb, so this is unused and reserved
     def AbtbUtage:   UInt = 3.U(width.W)
     def Fallthrough: UInt = 4.U(width.W)
   }

--- a/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bundles.scala
@@ -195,6 +195,11 @@ class BpuCtrl extends Bundle {
   val ittageEnable: Bool = Bool()
   val rasEnable:    Bool = Bool()
 }
+// for constantin
+class BpuConstCtrl extends Bundle {
+  val use:  Bool    = Bool()
+  val ctrl: BpuCtrl = new BpuCtrl
+}
 
 // Bpu -> Ftq
 class BpuPrediction(implicit p: Parameters) extends BpuBundle {

--- a/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/abtb/AheadBtb.scala
@@ -184,7 +184,7 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
   s2_fire := s2_valid && bpuS1Fire && !io.bpuS3Override && !io.bpuS2Override && !io.redirect
 
   io.result.entries.zipWithIndex.foreach { case (pred, i) =>
-    pred.valid            := s2_valid && s2_state.hitMask(i)
+    pred.valid            := s2_valid && s2_state.hitMask(i) && io.enable
     pred.bits.taken       := s2_state.ctrVec(i).isPositive
     pred.bits.cfiPosition := s2_state.entries(i).position
     pred.bits.attribute   := s2_state.entries(i).attribute
@@ -192,13 +192,13 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
       getFullTarget(s2_state.startPc, s2_state.entries(i).targetLowerBits, s2_state.entries(i).targetCarry)
   }
   io.toMicroTage.result.zipWithIndex.foreach { case (pred, i) =>
-    pred.valid             := s2_valid && s2_state.hitMask(i)
+    pred.valid             := s2_valid && s2_state.hitMask(i) && io.enable
     pred.bits.taken        := s2_state.ctrVec(i).isPositive
     pred.bits.cfiPosition  := s2_state.entries(i).position
     pred.bits.attribute    := s2_state.entries(i).attribute
     pred.bits.isStrongBias := s2_state.ctrVec(i).isSaturate
   }
-  io.meta.valid    := s2_valid
+  io.meta.valid    := s2_valid && io.enable
   io.meta.setIdx   := s2_state.setIdx
   io.meta.bankMask := s2_state.bankMask
   io.meta.entries.zipWithIndex.foreach { case (e, i) =>
@@ -229,7 +229,7 @@ class AheadBtb(implicit p: Parameters) extends BasePredictor with Helpers {
 
   private val t0_train = io.fastTrain.get.bits
 
-  private val t0_fire = io.enable && io.fastTrain.get.valid && t0_train.abtbMeta.valid
+  private val t0_fire = io.fastTrain.get.valid && t0_train.abtbMeta.valid && io.enable
 
   /* --------------------------------------------------------------------------------------------------------------
      train pipeline stage 1

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtb.scala
@@ -54,20 +54,16 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
 
   io.trainReady := true.B
 
-  private val s0_fire, s1_fire, s2_fire, s3_fire, t0_fire = Wire(Bool())
   alignBanks.foreach { b =>
-    b.io.stageCtrl.s0_fire := s0_fire
-    b.io.stageCtrl.s1_fire := s1_fire
-    b.io.stageCtrl.s2_fire := s2_fire
-    b.io.stageCtrl.s3_fire := s3_fire
-    b.io.stageCtrl.t0_fire := t0_fire
+    b.io.stageCtrl := io.stageCtrl
+    b.io.enable    := io.enable
   }
 
   /* *** s0 ***
    * calculate per-bank startPc and posHigherBits
    * send read request to alignBanks
    */
-  s0_fire := io.stageCtrl.s0_fire && io.enable
+  // predict pipeline is in the alignBank, so no top-level s0_fire etc..
   private val s0_startPc = io.startPc
   // rotate read addresses according to the first align bank index
   // e.g. if NumAlignBanks = 4, startPc locates in alignBank 1,
@@ -95,15 +91,7 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   /* *** s1 ***
    * just wait alignBanks
    */
-  s1_fire := io.stageCtrl.s1_fire && io.enable
-
   io.s1_positions := VecInit(alignBanks.flatMap(_.io.read.s1_positions))
-
-  /* *** s2 ***
-   * receive read response from alignBanks
-   * send out prediction result and meta info
-   */
-  s2_fire := io.stageCtrl.s2_fire && io.enable
 
   // we don't care about the order of alignBanks' responses,
   // (as s0_posHigherBitsVec is already computed and concatenated to each entry's posLowerBits)
@@ -113,20 +101,11 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   // we don't need to flatten meta entries, keep the alignBank structure, anyway we just use them per alignBank
   io.meta.entries := VecInit(alignBanks.map(_.io.read.resp.metas))
 
-  /* *** s3 ***
-   * touch replacer using final takenMask (mbtb + tage + sc)
-   */
-  s3_fire := io.enable && io.stageCtrl.s3_fire
-  // io.result is flattened, so is s3_takenMask from Bpu top, here we need to slice it back to alignBank structure
-  alignBanks.zipWithIndex.foreach { case (b, i) =>
-    b.io.s3_takenMask := io.s3_takenMask.slice(i * NumWay, (i + 1) * NumWay)
-  }
-
   /* *** t0 ***
    * receive training data
    * send startPc to alignBank for replacer state reading
    */
-  t0_fire := io.stageCtrl.t0_fire && io.enable
+  private val t0_fire  = io.stageCtrl.t0_fire && io.enable
   private val t0_train = io.train
 
   private val t0_startPc    = t0_train.startPc
@@ -140,7 +119,7 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   /* *** t1 ***
    * calculate write data and write to alignBanks
    */
-  private val t1_fire  = RegNext(t0_fire, init = false.B) && io.enable
+  private val t1_fire  = RegNext(t0_fire, init = false.B)
   private val t1_train = RegEnable(t0_train, t0_fire)
 
   private val t1_rotator    = RegEnable(t0_rotator, t0_fire)
@@ -186,6 +165,7 @@ class MainBtb(implicit p: Parameters) extends BasePredictor with HasMainBtbParam
   )
 
   /* *** statistics *** */
+  private val s2_fire                    = io.stageCtrl.s2_fire && io.enable
   private val perf_s2HitMask             = VecInit(alignBanks.flatMap(_.io.read.resp.predictions.map(_.valid)))
   private val perf_t1HitMispredictBranch = t1_meta.entries.flatten.map(_.hit(t1_mispredictInfo.bits)).reduce(_ || _)
 

--- a/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/mbtb/MainBtbAlignBank.scala
@@ -68,15 +68,13 @@ class MainBtbAlignBank(
       val req: Valid[Req] = Flipped(Valid(new Req))
     }
 
+    val enable:        Bool      = Input(Bool())
     val sramResetDone: Bool      = Output(Bool())
     val stageCtrl:     StageCtrl = Input(new StageCtrl)
 
     val read:  Read                  = new Read
     val write: Write                 = new Write
     val trace: MainBtbAlignBankTrace = Output(new MainBtbAlignBankTrace)
-
-    // final s3_takenMask (mbtb + tage + sc), used to touch replacer accurately
-    val s3_takenMask: Vec[Bool] = Input(Vec(NumWay, Bool()))
 
     // fast path of train pc, used to read replacer in advance for better timing
     val t0_startPc: Pc = Input(new Pc)
@@ -99,7 +97,7 @@ class MainBtbAlignBank(
   /* *** s0 ***
    * send read req to internal banks (srams)
    */
-  private val s0_fire             = io.stageCtrl.s0_fire
+  private val s0_fire             = io.stageCtrl.s0_fire && io.enable
   private val s0_startPc          = r.req.startPc
   private val s0_posHigherBits    = r.req.posHigherBits
   private val s0_crossPage        = r.req.crossPage
@@ -123,7 +121,7 @@ class MainBtbAlignBank(
    * check entries hit
    * filter-out unneeded entries
    */
-  private val s1_fire             = io.stageCtrl.s1_fire
+  private val s1_fire             = io.stageCtrl.s1_fire && io.enable
   private val s1_startPc          = RegEnable(s0_startPc, s0_fire)
   private val s1_posHigherBits    = RegEnable(s0_posHigherBits, s0_fire)
   private val s1_crossPage        = RegEnable(s0_crossPage, s0_fire)
@@ -155,7 +153,7 @@ class MainBtbAlignBank(
       // filter out branches before alignedInstOffset
       // also filter out all entries if crossPage to satisfy Ifu/ICache's requirement
       val hit = rawHit && e.position >= s1_alignedInstOffset && !s1_crossPage
-      pred.valid            := hit
+      pred.valid            := hit && io.enable
       pred.bits.cfiPosition := Cat(s1_posHigherBits, e.position)
       pred.bits.target      := getFullTarget(s1_startPc, e.targetLowerBits, e.targetCarry)
       pred.bits.attribute   := e.attribute
@@ -182,7 +180,7 @@ class MainBtbAlignBank(
   r.resp.predictions := s2_predictions
 
   r.resp.metas.zipWithIndex.foreach { case (meta, i) =>
-    meta.rawHit    := s2_rawHitMask(i)
+    meta.rawHit    := s2_rawHitMask(i) && io.enable
     meta.attribute := s2_predictions(i).bits.attribute
     meta.position  := s2_predictions(i).bits.cfiPosition
     meta.counter   := s2_rawCounters(i)
@@ -192,17 +190,10 @@ class MainBtbAlignBank(
   private val s2_hitMask = VecInit(r.resp.predictions.map(_.valid))
   dontTouch(s2_hitMask)
 
-  /* *** s3 ***
-   * touch replacer using final takenMask (mbtb + tage + sc)
-   */
-  private val s3_fire           = io.stageCtrl.s3_fire
-  private val s3_replacerSetIdx = RegEnable(getReplacerSetIndex(s2_startPc), s2_fire)
-  private val s3_takenMask      = io.s3_takenMask
-
   /* *** t0 ***
    * read replacer in advance for better timing
    */
-  private val t0_fire    = io.stageCtrl.t0_fire
+  private val t0_fire    = io.stageCtrl.t0_fire && io.enable
   private val t0_startPc = io.t0_startPc
 
   replacer.io.train.t0_setIdx := getReplacerSetIndex(t0_startPc)

--- a/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ras/Ras.scala
@@ -71,7 +71,7 @@ class Ras(implicit p: Parameters) extends BasePredictor with HasRasParameters wi
   stack.spec.pushValid := specPush && !stackNearOverflow
   stack.spec.popValid  := specPop && !stackNearOverflow
   stack.spec.pushAddr  := GuardedPcInit(specAlignPc + (specIn.cfiPosition << 1.U).asUInt + 2.U)
-  stack.spec.fire      := io.specIn.valid
+  stack.spec.fire      := io.specIn.valid && io.enable
 
   private val redirectMeta = Wire(new RasRedirectMeta)
   redirectMeta.ssp        := stack.meta.ssp
@@ -95,15 +95,15 @@ class Ras(implicit p: Parameters) extends BasePredictor with HasRasParameters wi
   private val stackTOSW    = stack.meta.tosw
   private val redirectTOSW = redirect.bits.meta.ras.tosw
 
-  stack.redirect.valid  := redirect.valid && (isBefore(redirectTOSW, stackTOSW) || !stackNearOverflow)
+  stack.redirect.valid  := redirect.valid && (isBefore(redirectTOSW, stackTOSW) || !stackNearOverflow) && io.enable
   stack.redirect.isCall := redirect.bits.attribute.isCall
   stack.redirect.isRet  := redirect.bits.attribute.isReturn
   stack.redirect.meta   := redirect.bits.meta.ras
   // Redirected branch PC points to end of instruction.
   stack.redirect.callAddr := redirect.bits.cfiPc.signGuard + 2.U
 
-  private val commitValid    = RegNext(io.commit.valid, init = false.B)
-  private val commitInfo     = RegEnable(io.commit.bits, io.commit.valid)
+  private val commitValid    = RegNext(io.commit.valid && io.enable, init = false.B)
+  private val commitInfo     = RegEnable(io.commit.bits, io.commit.valid && io.enable)
   private val commitPushAddr = DontCare
   stack.commit.valid     := commitValid
   stack.commit.pushValid := commitValid && commitInfo.attribute.isCall

--- a/src/main/scala/xiangshan/frontend/bpu/sc/Sc.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/sc/Sc.scala
@@ -310,7 +310,7 @@ class Sc(implicit p: Parameters) extends BasePredictor with HasScParameters with
         (predValid && tageConfLow)  -> s2_sumAboveThresholdShift3(i)
       )
     )
-    s2_useScPred(i)     := conf
+    s2_useScPred(i)     := conf && io.enable
     s2_sumAboveThres(i) := Mux(predValid, conf, true.B)
     dontTouch(tageConfHigh)
     dontTouch(tageConfMid)

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
@@ -87,7 +87,7 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
      - compute tags
      -------------------------------------------------------------------------------------------------------------- */
 
-  private val s1_fire       = io.stageCtrl.s1_fire
+  private val s1_fire       = io.stageCtrl.s1_fire && io.enable
   private val s1_startPc    = RegEnable(s0_startPc, s0_fire)
   private val s1_foldedHist = RegEnable(s0_foldedHist, s0_fire)
 
@@ -113,7 +113,7 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
      - select the alternate and complete the prediction for each branch
      -------------------------------------------------------------------------------------------------------------- */
 
-  private val s2_fire     = io.stageCtrl.s2_fire
+  private val s2_fire     = io.stageCtrl.s2_fire && io.enable
   private val s2_readResp = RegEnable(s1_readResp, s1_fire)
   private val s2_hits     = RegEnable(s1_hits, s1_fire)
   private val s2_branches = io.fromMainBtb.result
@@ -172,10 +172,10 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     // use the alternate prediction.
     val useProvider = hasProvider && !(useAltOnNa && provider.takenCtr.isWeak)
 
-    io.prediction.takenVec(i).valid := useProvider || hasAlt
+    io.prediction.takenVec(i).valid := (useProvider || hasAlt) && io.enable
     io.prediction.takenVec(i).bits  := Mux(useProvider, provider.takenCtr.isPositive, alt.takenCtr.isPositive)
 
-    io.toSc.providerTakenCtrVec(i).valid := hasProvider && branch.valid
+    io.toSc.providerTakenCtrVec(i).valid := (hasProvider && branch.valid) && io.enable
     io.toSc.providerTakenCtrVec(i).bits  := provider.takenCtr
 
     io.meta.entries(i).useProvider       := useProvider

--- a/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ubtb/MicroBtb.scala
@@ -90,7 +90,7 @@ class MicroBtb(implicit p: Parameters) extends BasePredictor with HasMicroBtbPar
   private val s1_hitEntry = Mux1H(s1_hitOH, entries)
 
   // we do always-taken prediction in ubtb
-  io.prediction.valid            := s1_hit
+  io.prediction.valid            := s1_hit && io.enable
   io.prediction.bits.taken       := s1_hit
   io.prediction.bits.cfiPosition := s1_hitEntry.slot1.position
   io.prediction.bits.target      := getFullTarget(s1_startPc, s1_hitEntry.slot1.target, s1_hitEntry.slot1.targetCarry)

--- a/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/utage/MicroTage.scala
@@ -51,7 +51,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
   // Problem scenario: the same entry accessed by different branches in different cycles.
   private val a0_fire                = io.enable && io.stageCtrl.s0_fire
   private val a1_fire                = a0_fire
-  private val bpuS2Fire              = io.stageCtrl.s2_fire
+  private val bpuS2Fire              = io.enable && io.stageCtrl.s2_fire
   private val redirectValid          = io.redirect
   private val a0_indexPc             = io.startPc.unGuard
   private val a0_indexFoldedPathHist = io.normalPathHist
@@ -251,7 +251,7 @@ class MicroTage(implicit p: Parameters) extends BasePredictor with HasMicroTageP
 
   // ------------ MicroTage is only concerned with conditional branches ---------- //
   private val t0_train                  = RegNext(io.fastTrain.get.bits, 0.U.asTypeOf(new FastTrain))
-  private val t0_fire                   = RegNext(io.fastTrain.get.valid, false.B)
+  private val t0_fire                   = io.enable && RegNext(io.fastTrain.get.valid, false.B)
   private val t0_trainMeta              = t0_train.utageMeta
   private val t0_abtbResult             = t0_trainMeta.abtbResult
   private val t0_trainRead              = VecInit(tables.map(_.train.t0_read))


### PR DESCRIPTION
1. Remove unused and confusing useUbtbUtage.
    - Fixes #6048
3. Fix io.enable gate for each sub-predictor:
    - add gate to utage t0
    - add gate to ras redirect/commit train
    - add gate to tage s1/2
    - add gate to all sub-predictor's prediction valid/hit.
        - Fixes #6135
        - Fixes #6137
        - Fixes #6149
4. Consider interconnection
    - utage works only with abtb, so it should be also gated with abtbEnable.
        - Fixes #6155
        - Fixes #6159
    - uras is add-on to main ras, so it uses the same gate with ras
    - tage/sc/ittage/ras works only with mbtb, so they should be also gated with mbtbEnable

This is still not perfect, stale data can be used short after io.enable changes from 0 to 1. But as disabling sub-predictors are rarely used and cause only some performance loss, I guess the current implementation is good enough.

Also: remove unused mbtb s3 stage
