### PR TITLE
fix(VSetFuncUnit): Add vill op check

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/VTypeGen.scala
+++ b/src/main/scala/xiangshan/backend/decode/VTypeGen.scala
@@ -58,6 +58,7 @@ class VTypeGen(implicit p: Parameters) extends XSModule {
     vsetModule.in.vlFromImm.bits := instFieldVec(i).UIMM_VSETIVLI
     vsetModule.in.vlFromVl.valid := false.B
     vsetModule.in.vlFromVl.bits := DontCare
+    vsetModule.in.vill := false.B
   }
 
   private val vtypeNewVec = vsetModuleVec.map(_.out.vtype)

--- a/src/main/scala/xiangshan/backend/fu/wrapper/VSet.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VSet.scala
@@ -150,6 +150,7 @@ class VSetUnit(cfg: FuConfig)(implicit p: Parameters) extends PipedFuncUnit(cfg)
   vsetFu.in.vlFromVl.bits := in.data.vl.get // vl
   vsetFu.in.vlFromImm.valid := VSetOpcodes.vlIsImm(op)
   vsetFu.in.vlFromImm.bits := Imm_VSETIVLI().getAvl(imm)
+  vsetFu.in.vill := VSetOpcodes.isIll(op)
 
   private val vl = vsetFu.out.vl
   private val vlmax = vsetFu.out.vlmax

--- a/src/main/scala/xiangshan/backend/vector/Decoder/VSetFuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/VSetFuncUnit.scala
@@ -58,9 +58,9 @@ class VSetFuncUnit(
   private val villFromVTypeImm = newVTypeDecodeBundle(villField)
 
   // vlmax is OH, use |(a&b) will be cheaper than =/=
-  private val vlmaxChange = (vlmax & oldVlmax).orR && oldVType.valid
+  private val vlmaxChange = !((vlmax & oldVlmax).orR) && oldVType.valid
 
-  private val vill = vtype.illegal || villFromVTypeImm || in.rdIsZero && in.rs1IsZero && vlmaxChange
+  private val vill = in.vill || vtype.illegal || villFromVTypeImm || in.rdIsZero && in.rs1IsZero && vlmaxChange
 
   private val vl =
     Mux(
@@ -103,6 +103,7 @@ object VSetFuncUnit {
     val vlFromImm = ValidIO(UInt(5.W))
     // vl from vl regfile
     val vlFromVl = ValidIO(Vl(vlen))
+    val vill = Bool()
   }
 
   class Out(vlen: Int) extends Bundle {


### PR DESCRIPTION
When execute 0x400072d7 (vsetvli with vtype[10] set), vl is 1 instead of 0.

This bug is because when VsetDecoder detect a illegal vtype, it generate uop uvset_ill. But uvset_ill is regarded as vsetivli, and it interpret the input imm as {uimm[4:0], vtypei[9:0]}. However, as a vsetvli inst, it generate imm as {vtypei[10:0]}, so the bit 1 in vtypei[10] became the 1 in uimm and is passed as vl.

This commit add a input for uvset_ill and therefore fix this issue.