### PR TITLE
fix(SelImmField,ImmIsUnsign5b): VMSGTU.VI etc should use sign-extended

### DIFF
--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeFields/SimpleDecodeChannel/SelImmField.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeFields/SimpleDecodeChannel/SelImmField.scala
@@ -88,8 +88,5 @@ object SelImmField extends DecodeField[InstPattern, ValidIO[UInt]] {
   }
 
   val unsignedImmVecInst = getVariableNameSeq(
-    VMSLEU_VI,
-    VMSGTU_VI,
-    VSADDU_VI,
   )
 }

--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeFields/VecDecodeChannel/ImmIsUnsign5b.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeFields/VecDecodeChannel/ImmIsUnsign5b.scala
@@ -24,9 +24,6 @@ object ImmIsUnsign5b extends BoolDecodeField[VecInstPattern] {
   }
 
   val uimmInst: Set[String] = getVariableNameSeq(
-    VMSGTU_VI,
-    VMSLEU_VI,
-    VSADDU_VI,
     VNCLIP_WI,
   ).toSet
 }


### PR DESCRIPTION
* The immediate of VMSGTU.VI, VMSLEU.VI, and VSADDU.VI should be sign-extended instead of zero-extended.