### PR TITLE
fix(vector,exu): src should not always use bypass data

### DIFF
--- a/src/main/scala/xiangshan/backend/vector/Exu.scala
+++ b/src/main/scala/xiangshan/backend/vector/Exu.scala
@@ -52,13 +52,13 @@ class Exu(val param: ExuParam)(implicit val p: Parameters) extends Module with H
   inEx.valid := in.uop.valid
   inEx.bits :<#= in.uop.bits
   inEx.bits.fuSel := VecInit(param.fuConfigs.map(_.fuSel2(in.uop.bits)))
+  inEx.bits.data.src := bypass.out.src
 
   ex zip (inEx +: ex) foreach {
     case (sink: ValidIO[Exu.ExStage], source: ValidIO[Exu.ExStage]) =>
       sink.valid := source.valid && !source.bits.ctrl.robIdx.needFlush(in.flush)
       when(source.valid) {
         sink.bits := source.bits
-        sink.bits.data.src := bypass.out.src
       }
   }
 


### PR DESCRIPTION
This commit fix the error that all stages use bypass data as source data. Only sources of stage 0 should use bypass data.