### PR TITLE
fix(StoreQueue): fix unexpected uncacheMove due to vector inactive element

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/NewStoreQueue.scala
@@ -1284,7 +1284,7 @@ abstract class PhysicalStoreQueueBase(implicit p: Parameters) extends LSQModule 
       else v && (deqPtrVectorInactiveValid(i - 1) || deqPtrMoveFromSbuffer(i - 1).asBool)
     })
 
-    private val uncacheMove = VecInit(deqCtrlEntries.map(x => x.handleFinish && x.committed)).asUInt
+    private val uncacheMove = VecInit(deqCtrlEntries.map(x => x.handleFinish && x.committed && !x.vecInactive)).asUInt
 
     // The credit vector needs one more cycle because storeQueue forwarding observes the entry for one additional cycle.
     val deqCount = Cat(deqPtrMoveFromSbuffer.asUInt, deqPtrVectorInactiveMove, uncacheMove) // timing is ok ?


### PR DESCRIPTION
When there is a vector inactive entry, STA won't write to the entry, and `handleFinish` won't be cleared, which leads to unexpected `uncacheMove`.