### PR TITLE
fix(GPAMem): correct GPA offset for non-RVC instructions

### DIFF
--- a/src/main/scala/xiangshan/backend/CtrlBlock.scala
+++ b/src/main/scala/xiangshan/backend/CtrlBlock.scala
@@ -452,6 +452,7 @@ class CtrlBlockImp(
     gpaMem.io.exceptionReadAddr.valid := rob.io.readGPAMemAddr.valid
     gpaMem.io.exceptionReadAddr.bits.ftqPtr := rob.io.readGPAMemAddr.bits.ftqPtr
     gpaMem.io.exceptionReadAddr.bits.ftqOffset := rob.io.readGPAMemAddr.bits.ftqOffset
+    gpaMem.io.exceptionReadAddr.bits.isRVC := rob.io.readGPAMemAddr.bits.isRVC
   }
 
   // vtype commit

--- a/src/main/scala/xiangshan/backend/GPAMem.scala
+++ b/src/main/scala/xiangshan/backend/GPAMem.scala
@@ -4,6 +4,7 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import org.chipsalliance.cde.config.Parameters
+import utility._
 import utility.SyncDataModuleTemplate
 import xiangshan.HasXSParameter
 import xiangshan.frontend.{IfuToBackendIO}
@@ -28,9 +29,14 @@ class GPAMemImp(override val wrapper: GPAMem)(implicit p: Parameters) extends La
   mem.io.raddr.head := io.exceptionReadAddr.bits.ftqPtr.value
 
   private val ftqOffset = RegEnable(io.exceptionReadAddr.bits.ftqOffset, io.exceptionReadAddr.valid)
+  private val isRVC     = RegEnable(io.exceptionReadAddr.bits.isRVC, io.exceptionReadAddr.valid)
+
+  private val gpaFtqOffset = (ftqOffset << instOffsetBits).asUInt
+  private val gpaRvcOffset = Mux(isRVC, 0.U, 2.U)
+  private val gpaOffset    = SignExt(gpaFtqOffset -& gpaRvcOffset, PAddrBitsMax)
 
   private val gpabase = mem.io.rdata.head.gpaddr
-  private val gpa = gpabase + Cat(ftqOffset, 0.U(instOffsetBits.W))
+  private val gpa = gpabase + gpaOffset
 
   io.exceptionReadData.gpaddr := gpa
   io.exceptionReadData.isForVSnonLeafPTE := mem.io.rdata.head.isForVSnonLeafPTE
@@ -52,6 +58,7 @@ class GPAMemIO(implicit val p: Parameters) extends Bundle with HasXSParameter {
   val exceptionReadAddr = Input(ValidIO(new Bundle {
     val ftqPtr = new FtqPtr()
     val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
+    val isRVC = Bool()
   }))
   val exceptionReadData = Output(new GPAMemEntry)
 }

--- a/src/main/scala/xiangshan/backend/rob/Rob.scala
+++ b/src/main/scala/xiangshan/backend/rob/Rob.scala
@@ -113,6 +113,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     val readGPAMemAddr = ValidIO(new Bundle {
       val ftqPtr = new FtqPtr()
       val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
+      val isRVC = Bool()
     })
     val readGPAMemData = Input(new GPAMemEntry)
     val vstartIsZero = Input(Bool())
@@ -717,6 +718,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
   io.readGPAMemAddr.valid := exceptionHappen
   io.readGPAMemAddr.bits.ftqPtr := exceptionDataRead.bits.ftqPtr
   io.readGPAMemAddr.bits.ftqOffset := exceptionDataRead.bits.ftqOffset
+  io.readGPAMemAddr.bits.isRVC := exceptionDataRead.bits.isRVC
 
   XSDebug(io.flushOut.valid,
     p"generate redirect: pc 0x${Hexadecimal(io.exception.bits.pc)} intr $intrEnable " +
@@ -1204,6 +1206,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     exceptionGen.io.enq(i).bits.robIdx := io.enq.req(i).bits.robIdx
     exceptionGen.io.enq(i).bits.ftqPtr := io.enq.req(i).bits.ftqPtr
     exceptionGen.io.enq(i).bits.ftqOffset := io.enq.req(i).bits.ftqOffset
+    exceptionGen.io.enq(i).bits.isRVC := io.enq.req(i).bits.isRVC
     exceptionGen.io.enq(i).bits.exceptionVec := io.enq.req(i).bits.exceptionVec
     exceptionGen.io.enq(i).bits.satpFlushFirstFetchFault := io.enq.req(i).bits.satpFlushFirstFetchFault
     exceptionGen.io.enq(i).bits.hasException := io.enq.req(i).bits.hasException
@@ -1242,6 +1245,7 @@ class RobImp(override val wrapper: Rob)(implicit p: Parameters, params: BackendP
     // only enq inst use ftqPtr to read gpa
     exc_wb.bits.ftqPtr          := 0.U.asTypeOf(exc_wb.bits.ftqPtr)
     exc_wb.bits.ftqOffset       := 0.U.asTypeOf(exc_wb.bits.ftqOffset)
+    exc_wb.bits.isRVC           := false.B
     exc_wb.bits.exceptionVec    := wb.bits.exceptionVec
     exc_wb.bits.satpFlushFirstFetchFault := false.B
     exc_wb.bits.hasException    := wb.bits.exceptionVec.orR // Todo: use io.writebackNeedFlush(i) instead

--- a/src/main/scala/xiangshan/backend/rob/RobBundles.scala
+++ b/src/main/scala/xiangshan/backend/rob/RobBundles.scala
@@ -326,6 +326,7 @@ class RobExceptionInfo(exceptList: Seq[Int]=ExceptionNO.all)(implicit p: Paramet
   val robIdx = new RobPtr
   val ftqPtr = new FtqPtr
   val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
+  val isRVC = Bool()
   // set 1 if there is 1 exists in exceptionVec
   val hasException = Bool()
   // This signal is valid iff currentValid is true


### PR DESCRIPTION
Propagate isRVC through ExceptionGen and the GPA read path. Subtract the extra halfword encoded in ftqOffset when reconstructing the faulting instruction GPA.