### PR TITLE
fix(LoadQueueReplay): handle delayed wakeups for unaligned head replays

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -338,6 +338,10 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   // Fast hint selects C_TM replays directly. The delayed original hint remains the fallback.
   val fastTlbHintResp = io.fast_tlb_hint
   val tlbHintResp = delayWakeup(io.tlb_hint.resp)
+  // An unaligned head enters the replay queue one cycle later than an ordinary load.
+  // Retain the previous TLB hint and let only S4-delayed head records consume it.
+  val tlbHintPrevCycleValid = RegNext(tlbHintResp.valid, false.B)
+  val tlbHintPrevCycleBits = RegEnable(tlbHintResp.bits, tlbHintResp.valid)
   // Arrive-cycle hint unblocks first-beat C_DM. Last-beat uses the same match,
   // registered for one cycle, so s0 never rematches a delayed hint.
   val l2Hint = io.l2_hint
@@ -902,8 +906,13 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
 
       // special case: tlb miss
       when (replayInfo.cause(LoadReplayCauses.C_TM)) {
+        val tlbHintHitThisCycle = tlbHintResp.valid &&
+          (tlbHintResp.bits.id === replayInfo.tlb_id || tlbHintResp.bits.replay_all)
+        val tlbHintHitPrevCycle = replayInfo.rep_from_unalign_head &&
+          tlbHintPrevCycleValid &&
+          (tlbHintPrevCycleBits.id === replayInfo.tlb_id || tlbHintPrevCycleBits.replay_all)
         blocking(enqIndex) := !replayInfo.tlb_full &&
-          !(tlbHintResp.valid && (tlbHintResp.bits.id === replayInfo.tlb_id || tlbHintResp.bits.replay_all))
+          !(tlbHintHitThisCycle || tlbHintHitPrevCycle)
         when (fastTlbHintResp.valid && fastTlbHintResp.bits.id === replayInfo.tlb_id) {
           blocking(enqIndex) := false.B
         }

--- a/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LoadQueueReplay.scala
@@ -335,6 +335,7 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
   val storeDataWakeupCancel = VecInit(io.storeDataWakeupCancel.map(cancel => RegNext(cancel, 0.U.asTypeOf(cancel))))
   val loadWakeup = VecInit(io.loadWakeup.map(delayWakeup(_)))
   val loadWakeupPrev = VecInit(loadWakeup.map(delayWakeup(_)))
+  val loadWakeupPrevPrev = VecInit(loadWakeupPrev.map(delayWakeup(_)))
   // Fast hint selects C_TM replays directly. The delayed original hint remains the fallback.
   val fastTlbHintResp = io.fast_tlb_hint
   val tlbHintResp = delayWakeup(io.tlb_hint.resp)
@@ -433,6 +434,10 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
 
   private def tlDChannelHitPrev(mshrId: UInt): Bool = {
     VecInit(loadWakeupPrev.map(ch => ch.valid && ch.bits.mshrId === mshrId)).asUInt.orR
+  }
+
+  private def tlDChannelHitPrevPrev(mshrId: UInt): Bool = {
+    VecInit(loadWakeupPrevPrev.map(ch => ch.valid && ch.bits.mshrId === mshrId)).asUInt.orR
   }
 
   private def l2HintMatchVec(mshrId: UInt): Seq[Bool] = {
@@ -923,9 +928,11 @@ class LoadQueueReplay(implicit p: Parameters) extends XSModule
       when (replayInfo.cause(LoadReplayCauses.C_DM) && enq.bits.handledByMSHR) {
         val tlDHitThisCycle = tlDChannelHit(replayInfo.mshr_id)
         val tlDHitPrevCycle = tlDChannelHitPrev(replayInfo.mshr_id)
+        val tlDHitPrevPrevCycle = tlDChannelHitPrevPrev(replayInfo.mshr_id)
         blocking(enqIndex) := !replayInfo.full_fwd && //  dcache miss
                               !tlDHitThisCycle && // no refill in this cycle
-                              !tlDHitPrevCycle // not refill in last cycle
+                              !tlDHitPrevCycle && // not refill in last cycle
+                              !(replayInfo.rep_from_unalign_head && tlDHitPrevPrevCycle)
       }
 
       when (isFF) {

--- a/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/LoadUnit.scala
@@ -65,6 +65,7 @@ class LoadToLsqReplayIO(implicit p: Parameters) extends XSBundle
   // tlb hint
   val tlb_id          = UInt(log2Up(loadfiltersize).W)
   val tlb_full        = Bool()
+  val rep_from_unalign_head = Bool()
 
   // alias
   def mem_amb       = cause(LoadReplayCauses.C_MA)

--- a/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/NewLoadUnit.scala
@@ -1601,6 +1601,7 @@ class LoadUnitS3(param: ExeUnitParams)(
   lqWrite.rep_info.debug := uop.perfDebugInfo
   lqWrite.rep_info.tlb_id := lqWriteTlbId
   lqWrite.rep_info.tlb_full := lqWriteTlbFull
+  lqWrite.rep_info.rep_from_unalign_head := useS4HeadReplay
 
   val perfIsReplayExec = LoadEntrance.isReplay(entrance) || s4HeadIsReplay && s4HeadValid
   val perfMdpAddrValid = Mux(s4HeadValid, s4Head.perfMdpAddrValid.get, in.perfMdpAddrValid.get)


### PR DESCRIPTION
When an unaligned load head replays through S4, its replay record
reaches LoadQueueReplay later than an ordinary load. The corresponding
TLB hint or DCache refill wakeup can therefore arrive before the record
is enqueued, leaving it blocked after completion.

Retain the previous TLB hint and an additional cycle of DCache wakeup
history. Mark S4-delayed unaligned-head records in LoadUnit and allow
only those records to consume the retained responses, preventing
ordinary loads from matching stale TLB or MSHR IDs.