### PR TITLE
fix(ifu, ftq): add direct jump branch training on misprediction to handle misprediction caused by self-modifying code

### DIFF
--- a/src/main/scala/xiangshan/Bundle.scala
+++ b/src/main/scala/xiangshan/Bundle.scala
@@ -94,7 +94,6 @@ class CtrlFlow(implicit p: Parameters) extends XSBundle {
   val backendException = Bool()
   val trigger = TriggerAction()
   val isRvc = Bool()
-  val fixedTaken = Bool()
   val predTaken  = Bool()
   val crossPageIPFFix = Bool()
   val storeSetHit = Bool() // inst has been allocated an store set

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -109,7 +109,6 @@ object Bundles {
     val isFetchMalAddr = Bool()
     val trigger = TriggerAction()
     val isRVC = Bool()
-    val fixedTaken = Bool()
     val predTaken  = Bool()
     val crossPageIPFFix = Bool()
     val ftqPtr = new FtqPtr
@@ -143,7 +142,6 @@ object Bundles {
     val isFetchMalAddr = Bool()
     val trigger = TriggerAction()
     val isRVC = Bool()
-    val fixedTaken = Bool()
     val predTaken  = Bool()
     val crossPageIPFFix = Bool()
     val ftqPtr = new FtqPtr
@@ -235,7 +233,6 @@ object Bundles {
     val isFetchMalAddr = Bool()
     val trigger = TriggerAction()
     val isRVC = Bool()
-    val fixedTaken = Bool()
     val predTaken = Bool()
     val crossPageIPFFix = Bool()
     val ftqPtr = new FtqPtr
@@ -373,7 +370,6 @@ object Bundles {
     def numSrc = backendParams.numSrc
     // from frontend
     val isRVC = Bool()
-    val fixedTaken = Bool()
     val predTaken = Bool()
     val ftqPtr = new FtqPtr
     val ftqOffset = UInt(FetchBlockInstOffsetWidth.W)
@@ -440,7 +436,6 @@ object Bundles {
     def numSrc = params.numSrc
     // from frontend
     val isRVC      = Option.when(params.needIsRVC)(Bool())
-    val fixedTaken = Option.when(params.needTaken)(Bool())
     val predTaken  = Option.when(params.needTaken)(Bool())
     val ftqPtr     = Option.when(params.needFtqPtr)(new FtqPtr)
     val ftqOffset  = Option.when(params.needFtqPtr)(UInt(FetchBlockInstOffsetWidth.W))
@@ -498,7 +493,6 @@ object Bundles {
 
     // from frontend
     val isRVC      = Option.when(params.needIsRVC)(Bool())
-    val fixedTaken = Option.when(params.needTaken)(Bool())
     val predTaken  = Option.when(params.needTaken)(Bool())
     // from decode
     val fuOpType = Opcode()
@@ -528,7 +522,6 @@ object Bundles {
     def numSrc = params.numSrc
     // from frontend
     val isRVC      = Option.when(params.needIsRVC)(Bool())
-    val fixedTaken = Option.when(params.needTaken)(Bool())
     val predTaken  = Option.when(params.needTaken)(Bool())
     // from decode
     val fuOpType = FuOpType()
@@ -606,7 +599,6 @@ object Bundles {
     val hasException    = Bool()
     val trigger         = TriggerAction()
     val isRVC           = Bool()
-    val fixedTaken      = Bool()
     val predTaken       = Bool()
     val crossPageIPFFix = Bool()
     val ftqPtr          = new FtqPtr
@@ -944,7 +936,6 @@ object Bundles {
     val exuSources     = Option.when(exuParams.isIQWakeUpSink)(Vec(exuParams.numRegSrc, ExuSource(exuParams)))
     val loadDependency = OptionWrapper(exuParams.needLoadDependency, Vec(LoadPipelineWidth, UInt(LoadDependencyWidth.W)))
     val isRVC          = Option.when(exuParams.needIsRVC)(Bool())
-    val fixedTaken     = Option.when(exuParams.needTaken)(Bool())
     val predTaken      = Option.when(exuParams.needTaken)(Bool())
     val fuOpType       = FuOpType()
     val selImm         = Option.when(exuParams.needImm)(SelImm())
@@ -1011,7 +1002,6 @@ object Bundles {
       // fields not carried in Og0InUop are explicitly cleared here
       this.rfRen.foreach(_.foreach(_ := false.B))
       this.isRVC.foreach(_ := false.B)
-      this.fixedTaken.foreach(_ := false.B)
       this.predTaken.foreach(_ := false.B)
       this.fuOpType := 0.U
       this.selImm.foreach(_ := 0.U)
@@ -1038,7 +1028,6 @@ object Bundles {
 
     def fromIssueDeqOg1PayloadBundle(source: IssueQueueDeqOg1Payload): Unit = {
       this.isRVC.foreach(_ := source.isRVC.get)
-      this.fixedTaken.foreach(_ := source.fixedTaken.get)
       this.predTaken.foreach(_ := source.predTaken.get)
 
       this.fuOpType := source.fuOpType
@@ -1209,7 +1198,6 @@ object Bundles {
 
     def fromIssueOg1PayloadBundle(source: EntryOg1Payload): Unit = {
       this.isRVC         .foreach(_ := source.isRVC.get)
-      this.predictInfo.foreach(_.fixedTaken := source.fixedTaken.get)
       this.predictInfo.foreach(_.predTaken  := source.predTaken.get)
       this.fuOpType                 := source.fuOpType
       this.imm                      := source.imm.getOrElse(0.U) // sta need this, other use immInfo assign in bypassNetwork
@@ -1269,7 +1257,6 @@ object Bundles {
 
   class PredictInfo(implicit p: Parameters) extends XSBundle {
     val target = UInt(VAddrData().dataWidth.W)
-    val fixedTaken = Bool()
     val predTaken = Bool()
   }
 

--- a/src/main/scala/xiangshan/backend/datapath/BypassNetwork.scala
+++ b/src/main/scala/xiangshan/backend/datapath/BypassNetwork.scala
@@ -153,7 +153,6 @@ class BypassNetwork()(implicit p: Parameters, params: BackendParams) extends XSM
     sink.bits.is0Lat.foreach(_ := 0.U)
     sink.bits.predictInfo.foreach{ case x =>
       x.target := source.bits.predTarget.get
-      x.fixedTaken := source.bits.fixedTaken.get
       x.predTaken := source.bits.predTaken.get
     }
     sink.bits.frm.foreach(_ := source.bits.frm.get)

--- a/src/main/scala/xiangshan/backend/fu/Branch.scala
+++ b/src/main/scala/xiangshan/backend/fu/Branch.scala
@@ -26,7 +26,7 @@ class BranchModule(implicit p: Parameters) extends XSModule {
   val io = IO(new Bundle() {
     val src = Vec(2, Input(UInt(XLEN.W)))
     val func = Input(FuOpType())
-    val fixedTaken = Input(Bool())
+    val predTaken = Input(Bool())
     val taken, mispredict = Output(Bool())
   })
   val (src1, src2, func) = (io.src(0), io.src(1), io.func)
@@ -47,5 +47,5 @@ class BranchModule(implicit p: Parameters) extends XSModule {
   val taken = LookupTree(BRUOpType.getBranchType(func), branchOpTable) ^ BRUOpType.isBranchInvert(func)
 
   io.taken := taken
-  io.mispredict := io.fixedTaken ^ taken
+  io.mispredict := io.predTaken ^ taken
 }

--- a/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuncUnit.scala
@@ -63,7 +63,6 @@ class FuncUnitCtrlInput(cfg: FuConfig)(implicit p: Parameters) extends XSBundle 
   val ftqOffset   = OptionWrapper(cfg.needPc || cfg.replayInst || cfg.isSta || cfg.isCsr, UInt(FetchBlockInstOffsetWidth.W))
   val predictInfo = OptionWrapper(cfg.needPdInfo, new Bundle {
     val target     = UInt(VAddrData().dataWidth.W)
-    val fixedTaken = Bool()
     val predTaken  = Bool()
   })
   val frm         = Option.when(cfg.needInstFrm)(Frm())

--- a/src/main/scala/xiangshan/backend/fu/wrapper/BranchUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/BranchUnit.scala
@@ -35,7 +35,7 @@ class BranchUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
   dataModule.io.src(0) := io.in.bits.data.src(0) // rs1
   dataModule.io.src(1) := io.in.bits.data.src(1) // rs2
   dataModule.io.func := io.in.bits.ctrl.fuOpType
-  dataModule.io.fixedTaken := io.in.bits.ctrl.predictInfo.get.fixedTaken
+  dataModule.io.predTaken := io.in.bits.ctrl.predictInfo.get.predTaken
 
   val pcExtend = io.instrAddrTransType.get.extend(io.in.bits.data.pc.get, VAddrBits + 2)
   addModule.io.pcExtend := pcExtend
@@ -49,7 +49,7 @@ class BranchUnit(cfg: FuConfig)(implicit p: Parameters) extends FuncUnit(cfg) {
 
   val brhPredictTarget = io.in.bits.ctrl.predictInfo.get.target
   val brhRealTarget = addModule.io.target(VAddrData().dataWidth - 1, 0)
-  val targetWrong = dataModule.io.fixedTaken && dataModule.io.taken && (brhRealTarget =/= brhPredictTarget)
+  val targetWrong = dataModule.io.predTaken && dataModule.io.taken && (brhRealTarget =/= brhPredictTarget)
   val isMisPred = dataModule.io.mispredict || targetWrong
   io.out.bits.res.data := 0.U
   io.out.bits.res.redirect.get match {

--- a/src/main/scala/xiangshan/backend/fu/wrapper/JumpUnit.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/JumpUnit.scala
@@ -22,13 +22,12 @@ class JumpUnit(cfg: FuConfig)(implicit p: Parameters) extends PipedFuncUnit(cfg)
   private val isJr = JumpOpType.jumpUopisjr(func)
   private val jumpTarget = Mux(isJr, src, pc) + SignExt(imm, XLEN)
 
-  private val fixedTaken = io.in.bits.ctrl.predictInfo.get.fixedTaken
   private val predTaken = io.in.bits.ctrl.predictInfo.get.predTaken
   private val jmpPredictTarget = io.in.bits.ctrl.predictInfo.get.target
   private val jumpRealTarget = jumpTarget(VAddrData().dataWidth - 1, 0)
 
   private val targetWrong = jumpRealTarget =/= jmpPredictTarget
-  private val needRedirect = !fixedTaken || targetWrong
+  private val needRedirect = !predTaken || targetWrong
   private val needTrain = !predTaken || targetWrong
 
   val redirect: Redirect = io.out.bits.res.redirect.get.bits

--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeChannels.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeChannels.scala
@@ -657,7 +657,6 @@ class MopCtrlBundle(implicit p: Parameters) extends XSBundle {
   val isFetchMalAddr   = Bool()
   val trigger          = TriggerAction()
   val isRVC            = Bool()
-  val fixedTaken       = Bool()
   val predTaken        = Bool()
   val crossPageIPFFix  = Bool()
   val ftqPtr           = new FtqPtr

--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeStage.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeStage.scala
@@ -100,7 +100,6 @@ class DecodeStageImp(
         ctrl.isFetchMalAddr   := inMopBits.isFetchMalAddr
         ctrl.trigger          := inMopBits.trigger
         ctrl.isRVC            := inMopBits.isRVC
-        ctrl.fixedTaken       := inMopBits.fixedTaken
         ctrl.predTaken        := inMopBits.predTaken
         ctrl.crossPageIPFFix  := inMopBits.crossPageIPFFix
         ctrl.ftqPtr           := inMopBits.ftqPtr
@@ -135,7 +134,6 @@ class DecodeStageImp(
         bits.isFetchMalAddr := mopInfo.isFetchMalAddr
         bits.trigger := mopInfo.trigger
         bits.isRVC := mopInfo.isRVC
-        bits.fixedTaken := mopInfo.fixedTaken
         bits.predTaken := mopInfo.predTaken
         bits.crossPageIPFFix := mopInfo.crossPageIPFFix
         bits.ftqPtr := mopInfo.ftqPtr

--- a/src/main/scala/xiangshan/frontend/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/Bundles.scala
@@ -299,9 +299,8 @@ class FtqPcOffset(implicit p: Parameters) extends FrontendBundle {
 }
 
 class InstrEndOffset(implicit p: Parameters) extends FrontendBundle {
-  val predTaken:  Bool = Bool()
-  val fixedTaken: Bool = Bool()
-  val offset:     UInt = UInt(FetchBlockInstOffsetWidth.W)
+  val predTaken: Bool = Bool()
+  val offset:    UInt = UInt(FetchBlockInstOffsetWidth.W)
 }
 
 class FetchToIBuffer(implicit p: Parameters) extends FrontendBundle {

--- a/src/main/scala/xiangshan/frontend/ftq/ResolveQueue.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/ResolveQueue.scala
@@ -86,7 +86,7 @@ class ResolveQueue(implicit p: Parameters) extends FtqModule with HalfAlignHelpe
   private val backendFilteredResolve = io.backendResolve.map { backendResolve =>
     val filteredResolve = Wire(Valid(new ResolveWithSource))
     filteredResolve.valid := backendResolve.valid &&
-      !(backendResolve.bits.attribute.isDirect || backendResolve.bits.attribute.isReturn)
+      !((backendResolve.bits.attribute.isDirect || backendResolve.bits.attribute.isReturn) && !backendResolve.bits.mispredict)
     filteredResolve.bits.fromResolve(ResolveSource.Backend, backendResolve.bits)
     filteredResolve
   }

--- a/src/main/scala/xiangshan/frontend/ftq/ResolveQueue.scala
+++ b/src/main/scala/xiangshan/frontend/ftq/ResolveQueue.scala
@@ -85,8 +85,10 @@ class ResolveQueue(implicit p: Parameters) extends FtqModule with HalfAlignHelpe
 
   private val backendFilteredResolve = io.backendResolve.map { backendResolve =>
     val filteredResolve = Wire(Valid(new ResolveWithSource))
-    filteredResolve.valid := backendResolve.valid &&
-      !((backendResolve.bits.attribute.isDirect || backendResolve.bits.attribute.isReturn) && !backendResolve.bits.mispredict)
+    filteredResolve.valid := backendResolve.valid && !(
+      (backendResolve.bits.attribute.isDirect && !backendResolve.bits.mispredict) ||
+        backendResolve.bits.attribute.isReturn
+    )
     filteredResolve.bits.fromResolve(ResolveSource.Backend, backendResolve.bits)
     filteredResolve
   }

--- a/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/ibuffer/Bundles.scala
@@ -53,7 +53,6 @@ class IBufEntry(implicit p: Parameters) extends IBufferBundle {
   val foldpc:           UInt   = UInt(MemPredPCWidth.W)
   val isRvc:            Bool   = Bool()
   val predTaken:        Bool   = Bool()
-  val fixedTaken:       Bool   = Bool()
   val ftqPtr:           FtqPtr = new FtqPtr
   val instrEndOffset:   UInt   = UInt(FetchBlockInstOffsetWidth.W)
   val triggered:        UInt   = TriggerAction()
@@ -67,7 +66,6 @@ class IBufEntry(implicit p: Parameters) extends IBufferBundle {
     foldpc           := fetch.foldpc(i)
     isRvc            := fetch.isRvc(i)
     predTaken        := fetch.instrEndOffset(i).predTaken
-    fixedTaken       := fetch.instrEndOffset(i).fixedTaken
     ftqPtr           := fetch.ftqPtr(i)
     instrEndOffset   := fetch.instrEndOffset(i).offset
     triggered        := fetch.triggered(i)
@@ -85,7 +83,6 @@ class IBufEntry(implicit p: Parameters) extends IBufferBundle {
     result.foldpc             := foldpc
     result.isRvc              := isRvc
     result.predTaken          := predTaken
-    result.fixedTaken         := fixedTaken
     result.ftqPtr             := ftqPtr
     result.exceptionType      := exception.exceptionType
     result.exceptionCrossPage := exception.exceptionCrossPage
@@ -125,7 +122,6 @@ class IBufOutEntry(implicit p: Parameters) extends IBufferBundle {
   val foldpc:             UInt          = UInt(MemPredPCWidth.W)
   val isRvc:              Bool          = Bool()
   val predTaken:          Bool          = Bool()
-  val fixedTaken:         Bool          = Bool()
   val ftqPtr:             FtqPtr        = new FtqPtr
   val exceptionType:      ExceptionType = new ExceptionType
   val exceptionCrossPage: Bool          = Bool()
@@ -154,7 +150,6 @@ class IBufOutEntry(implicit p: Parameters) extends IBufferBundle {
     cf.satpFlushFirstFetchFault                      := hasSatpFlush && exceptionType.hasException
     cf.trigger                                       := triggered
     cf.isRvc                                         := isRvc
-    cf.fixedTaken                                    := fixedTaken
     cf.predTaken                                     := predTaken
     cf.crossPageIPFFix                               := exceptionCrossPage
     cf.storeSetHit                                   := DontCare

--- a/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
+++ b/src/main/scala/xiangshan/frontend/ifu/Ifu.scala
@@ -557,9 +557,8 @@ class Ifu(implicit p: Parameters) extends IfuModule
     else enq(i) ^ ((select(i) === select(i + 1)) & enq(i + 1))
   }
   io.toIBuffer.bits.instrEndOffset.zipWithIndex.foreach { case (a, i) =>
-    a.predTaken  := s2_expandedInstrVec(i).isPredTaken && !s2_reqIsUncache
-    a.fixedTaken := checkerOutStage1.fixedTaken(i) && !s2_reqIsUncache
-    a.offset     := s2_endOffsetVec(i)
+    a.predTaken := checkerOutStage1.fixedTaken(i) && !s2_reqIsUncache
+    a.offset    := s2_endOffsetVec(i)
   }
   io.toIBuffer.bits.foldpc := s2_alignedFoldPc
   // mark the exception only on first instruction

--- a/src/main/scala/xiangshan/frontend/simfrontend/SimFrontend.scala
+++ b/src/main/scala/xiangshan/frontend/simfrontend/SimFrontend.scala
@@ -245,8 +245,7 @@ class SimFrontendInlinedImp(outer: FrontendInlined) extends FrontendInlinedImpBa
 
     cfVec.bits.isRvc := fetchOut.preDecode(1)
 
-    cfVec.bits.fixedTaken := fetchOut.preDecode(6)
-    cfVec.bits.predTaken  := fetchOut.preDecode(6)
+    cfVec.bits.predTaken := fetchOut.preDecode(6)
 
     cfVec.bits.ftqPtr.value := fetchOut.preDecode(12, 7)
     cfVec.bits.ftqPtr.flag  := fetchOut.preDecode(13)


### PR DESCRIPTION
The fixedTaken signal doesn't seem to be needed anymore — I'll give it a shot and remove it.