### PR TITLE
ci(emu-performance): dedup & eta filter & disable xscc

### DIFF
--- a/.github/workflows/ckpt_select.py
+++ b/.github/workflows/ckpt_select.py
@@ -72,10 +72,16 @@ class CkptJson:
         return self.path.parent.parent / "checkpoint"
 
 
+def __format_name(group: str, benchmark: str) -> str:
+    """Format the name of the checkpoint"""
+    return f"{group}_{benchmark}" if benchmark else group
+
+
 def __select_ckpts(
     j: CkptJson,
     prefix: str,
     select_func: Callable[[dict[tuple[str, str], float]], tuple[str, str]],
+    exclude: set[tuple[str, str]] = set(),
 ) -> list[SelectedCkpt]:
     """Select checkpoints based on the provided selection function"""
     selected = []
@@ -85,9 +91,10 @@ def __select_ckpts(
             (benchmark, point): weight
             for benchmark, data in benchmarks.items()
             for point, weight in data.points.items()
+            if (__format_name(group, benchmark), point) not in exclude
         }
         benchmark, point = select_func(flattened)
-        name = f"{group}_{benchmark}" if benchmark else group
+        name = __format_name(group, benchmark)
         ckpt_path = next((j.ckpt_path / name / point).glob("*.zstd"), None)
         if ckpt_path is None:
             print(
@@ -113,11 +120,15 @@ def select_most_weighted(j: CkptJson, prefix: str) -> list[SelectedCkpt]:
         j, prefix, lambda points: max(points, key=lambda p: points[p])
     )
 
-
-def select_random(j: CkptJson, prefix: str, n: int) -> list[SelectedCkpt]:
+def select_random(
+    j: CkptJson, prefix: str, n: int, already_selected: list[SelectedCkpt]
+) -> list[SelectedCkpt]:
     """Select n random benchmarks, and 1 checkpoint for each benchmark"""
     selected = __select_ckpts(
-        j, prefix, lambda points: random.choice(list(points.keys()))
+        j,
+        prefix,
+        lambda points: random.choice(list(points.keys())),
+        exclude={(c.name, c.point) for c in already_selected},
     )
     return random.sample(selected, min(n, len(selected))) if selected else []
 
@@ -133,16 +144,18 @@ def main() -> None:
         legacy_ckpt_json = CkptJson.from_json(Path(CKPT_JSON_LEGACY))
         selected.extend(select_most_weighted(legacy_ckpt_json, "legacy-"))
 
-    # run random 5 checkpoints from xscc
-    # use fuzz- prefix to skip performance report
-    xscc_ckpt_json = CkptJson.from_json(Path(CKPT_JSON_XSCC))
-    selected.extend(select_random(xscc_ckpt_json, "fuzz-", 5))
-
     # run the most weighted checkpoints from the main ckpt json
     ckpt_json = CkptJson.from_json(Path(CKPT_JSON))
     selected.extend(select_most_weighted(ckpt_json, ""))
-    # also run random 5 checkpoints from the main ckpt json, use fuzz- prefix too
-    selected.extend(select_random(ckpt_json, "fuzz-", 5))
+
+    # run random 5 checkpoints from the main ckpt json
+    # use fuzz- prefix to skip performance report
+    selected.extend(select_random(ckpt_json, "fuzz-", 5, already_selected=selected))
+
+    # also run random 5 checkpoints from xscc, use fuzz- prefix too
+    if CKPT_JSON_XSCC != "":
+        xscc_ckpt_json = CkptJson.from_json(Path(CKPT_JSON_XSCC))
+        selected.extend(select_random(xscc_ckpt_json, "fuzz-", 5, already_selected=selected))
 
     print(json.dumps([asdict(c) for c in selected]))
 

--- a/.github/workflows/ckpt_select.py
+++ b/.github/workflows/ckpt_select.py
@@ -11,8 +11,12 @@ from typing import Callable
 CKPT_JSON_LEGACY = os.environ.get("CKPT_JSON_LEGACY", "")
 CKPT_JSON_XSCC = os.environ.get("CKPT_JSON_XSCC", "")
 CKPT_JSON = os.environ.get("CKPT_JSON", "")
+PROFILE_PATH = os.environ.get("PROFILE_PATH", "")
 
-RANDOM_SEED = os.environ.get("GITHUB_RUN_NUMBER", "0")  # for reproducibility
+# for filtering out slow benchmarks, in seconds
+ETA_THRESHOLD = float(os.environ.get("ETA_THRESHOLD", "30000"))
+# for reproducibility
+RANDOM_SEED = os.environ.get("GITHUB_RUN_NUMBER", "0")
 
 
 @dataclass
@@ -22,6 +26,7 @@ class SelectedCkpt:
     name: str
     point: str
     weight: float
+    eta: float
     path: str
     prefix: str
 
@@ -36,6 +41,16 @@ class CkptJson:
 
         insts: int
         points: dict[str, float]
+        etas: dict[str, float]
+
+        @property
+        def filtered_points(self) -> dict[str, float]:
+            """Get the filtered points based on ETA_THRESHOLD"""
+            return {
+                point: weight
+                for point, weight in self.points.items()
+                if self.etas.get(point, 0.0) < ETA_THRESHOLD
+            }
 
     path: Path
     # the original is group_benchmark -> {point -> weight}
@@ -49,6 +64,20 @@ class CkptJson:
         """Parse the JSON file into a CkptJson object"""
         with path.open("r", encoding="utf-8") as f:
             content = json.load(f)
+
+        # load profile (group_benchmark -> {point -> eta}) if PROFILE_PATH is set
+        profile_content = {}
+        if PROFILE_PATH:
+            profile_path = Path(PROFILE_PATH) / f"{path.parent.parent.name}.json"
+            if profile_path.exists():
+                print(f"Loading profile from {profile_path}", file=sys.stderr)
+                with profile_path.open("r", encoding="utf-8") as f:
+                    profile_content = json.load(f)
+            else:
+                print(f"{profile_path} does not exist, skipping", file=sys.stderr)
+        else:
+            print("PROFILE_PATH is not set, skipping profile loading", file=sys.stderr)
+
         benchmarks = {}
         for group_benchmark, data in content.items():
             if "_" in group_benchmark:
@@ -57,8 +86,11 @@ class CkptJson:
                 group, benchmark = group_benchmark, ""
             if group not in benchmarks:
                 benchmarks[group] = {}
+
             benchmarks[group][benchmark] = CkptJson.Benchmark(
-                insts=data["insts"], points=data["points"]
+                insts=data["insts"],
+                points=data["points"],
+                etas=profile_content.get(group_benchmark, {}),
             )
         return CkptJson(path=path, benchmarks=benchmarks)
 
@@ -90,7 +122,7 @@ def __select_ckpts(
         flattened = {
             (benchmark, point): weight
             for benchmark, data in benchmarks.items()
-            for point, weight in data.points.items()
+            for point, weight in data.filtered_points.items()
             if (__format_name(group, benchmark), point) not in exclude
         }
         benchmark, point = select_func(flattened)
@@ -107,6 +139,7 @@ def __select_ckpts(
                 name=name,
                 point=point,
                 weight=benchmarks[benchmark].points[point],
+                eta=benchmarks[benchmark].etas.get(point, 0.0),
                 path=str(ckpt_path),
                 prefix=prefix,
             )
@@ -119,6 +152,7 @@ def select_most_weighted(j: CkptJson, prefix: str) -> list[SelectedCkpt]:
     return __select_ckpts(
         j, prefix, lambda points: max(points, key=lambda p: points[p])
     )
+
 
 def select_random(
     j: CkptJson, prefix: str, n: int, already_selected: list[SelectedCkpt]
@@ -150,12 +184,15 @@ def main() -> None:
 
     # run random 5 checkpoints from the main ckpt json
     # use fuzz- prefix to skip performance report
-    selected.extend(select_random(ckpt_json, "fuzz-", 5, already_selected=selected))
+    selected.extend(select_random(ckpt_json, "fuzz-", 5, selected))
 
     # also run random 5 checkpoints from xscc, use fuzz- prefix too
     if CKPT_JSON_XSCC != "":
         xscc_ckpt_json = CkptJson.from_json(Path(CKPT_JSON_XSCC))
-        selected.extend(select_random(xscc_ckpt_json, "fuzz-", 5, already_selected=selected))
+        selected.extend(select_random(xscc_ckpt_json, "fuzz-", 5, selected))
+
+    # sort by eta for better scheduling, descending order
+    selected.sort(key=lambda c: -c.eta)
 
     print(json.dumps([asdict(c) for c in selected]))
 

--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -16,6 +16,7 @@ env:
   CKPT_JSON_LEGACY: /nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260604/json/checkpoints_all.json
   CKPT_JSON: /nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/json/checkpoints_all.json
   CKPT_JSON_XSCC: /nfs/share/checkpoints_profiles/spec06_xscc_v1_rv64gcb_base_260122/checkpoint-0-0-0/cluster-0-0.json
+  PROFILE_PATH: /nfs/share/ci-workloads/env-scripts/perf_trigger/profile
 
 jobs:
   changes:

--- a/.github/workflows/emu-performance.yml
+++ b/.github/workflows/emu-performance.yml
@@ -15,7 +15,7 @@ env:
   PERF_HOME: /nfs/home/ci-runner/emu-performance/${{ github.run_number }}
   CKPT_JSON_LEGACY: /nfs/home/share/checkpoints_profiles/spec06_gcc15_rv64gcb_base_260604/json/checkpoints_all.json
   CKPT_JSON: /nfs/home/share/checkpoints_profiles/spec06_gcc16_rva23_novec_260820/json/checkpoints_all.json
-  CKPT_JSON_XSCC: /nfs/share/checkpoints_profiles/spec06_xscc_v1_rv64gcb_base_260122/checkpoint-0-0-0/cluster-0-0.json
+#  CKPT_JSON_XSCC: /nfs/share/checkpoints_profiles/spec06_xscc_v1_rv64gcb_base_260122/checkpoint-0-0-0/cluster-0-0.json
   PROFILE_PATH: /nfs/share/ci-workloads/env-scripts/perf_trigger/profile
 
 jobs:


### PR DESCRIPTION
1. exclude already-selected ckpt from random selection to dedup
2. filter-out slow checkpoints and sort using [profiled eta from perf-trigger](https://github.com/OpenXiangShan/env-scripts/tree/main/perf_trigger/profile)
3. disable XSCC fuzz for the moment, we have known issue with some vectorized mem/str function now