### PR TITLE
fix(StoreUnit/StoreQueue): prevent replay writeback and duplicate rdataPtr advances

### DIFF
--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -319,13 +319,16 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   val sqReadCnt = WireInit(0.U(log2Ceil(EnsbufferWidth + 1).W))
   val readyReadGoVec = Wire(Vec(EnsbufferWidth, Bool()))
   for (i <- 0 until EnsbufferWidth) {
+    // A split store uses both enqueue ports but retires only the SQ entry selected by sqPtr.
+    val dataBufferReadGo = dataBuffer.io.enq.map(enq =>
+      enq.fire && enq.bits.sqNeedDeq && (enq.bits.sqPtr === rdataPtrExt(i))
+    ).reduce(_ || _)
+    val ncReadGo = allocated(rdataPtrExt(i).value) && completed(rdataPtrExt(i).value) && nc(rdataPtrExt(i).value)
     if (i == 0) {
-      readyReadGoVec(i) := dataBuffer.io.enq(i).fire && dataBuffer.io.enq(i).bits.sqNeedDeq ||
-        allocated(rdataPtrExt(i).value) && completed(rdataPtrExt(i).value) && nc(rdataPtrExt(i).value) ||
+      readyReadGoVec(i) := dataBufferReadGo || ncReadGo ||
         io.mmioStout.fire || io.vecmmioStout.fire
     } else {
-      readyReadGoVec(i) := dataBuffer.io.enq(i).fire && dataBuffer.io.enq(i).bits.sqNeedDeq ||
-        allocated(rdataPtrExt(i).value) && completed(rdataPtrExt(i).value) && nc(rdataPtrExt(i).value) && readyReadGoVec(i - 1)
+      readyReadGoVec(i) := (dataBufferReadGo || ncReadGo) && readyReadGoVec(i - 1)
     }
   }
   sqReadCnt := PopCount(readyReadGoVec)  

--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -530,7 +530,11 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   s2_misalign_stout.bits.need_rep := RegEnable(s1_tlb_miss, s1_fire)
   io.misalign_stout := s2_misalign_stout
 
-  val s2_misalign_cango = !s2_mis_align || s2_in.isvec && (s2_misalignNeedReplay || s2_exception) || !s2_in.isvec && !s2_misalignNeedReplay && s2_exception
+  val s2_misalign_cango = Mux(
+    s2_in.isvec,
+    !s2_mis_align || s2_misalignNeedReplay || s2_exception,
+    !s2_misalignNeedReplay && (!s2_mis_align || s2_exception)
+  )
 
   // mmio and exception
   io.lsq_replenish := s2_out
@@ -539,8 +543,8 @@ class StoreUnit(implicit p: Parameters) extends XSModule
 
   // prefetch related
   io.lsq_replenish.miss := io.dcache.resp.fire && io.dcache.resp.bits.miss // miss info
-  io.lsq_replenish.updateAddrValid := !s2_mis_align && (!s2_frm_mabuf || s2_out.isFinalSplit) ||
-    !s2_in.isvec && s2_exception && !s2_misalignNeedReplay || s2_in.isvec && s2_exception
+  val s2_updateAddrValid = !s2_mis_align && (!s2_frm_mabuf || s2_out.isFinalSplit) || s2_exception
+  io.lsq_replenish.updateAddrValid := s2_updateAddrValid && (s2_in.isvec || !s2_misalignNeedReplay)
   io.lsq_replenish.isvec := s2_out.isvec || s2_frm_mab_vec
 
   io.lsq_replenish.hasException := (ExceptionNO.selectByFu(s2_out.uop.exceptionVec, StaCfg).asUInt.orR ||


### PR DESCRIPTION
Previously:

A scalar cross-16B store with `s2_misalignNeedReplay` could still satisfy `s2_misalign_cango`, because NC/MMIO stores do not set `s2_mis_align`. The same issued request was rejected by `feedback_slow` for replay, while also entering `s3` and later writing back through `io.stout`.

The request could also assert `io.lsq_replenish.updateAddrValid` while `s2_misalignNeedReplay` was set. StoreQueue then updated `hasException` and cleared `waitStoreS2` before the replay completed.

An unaligned NC store with a store page fault could leave `nc`, `hasException`, `completed`, `unaligned`, and `cross16Byte` set in the same SQ entry. When its split high beat asserted `sqNeedDeq`, `readyReadGoVec` counted both the completed-NC path and the DataBuffer path, even though both events referred to the same `sqPtr`. This advanced `rdataPtr` by two and skipped the following SQ entry.

Currently:

For scalar stores, `s2_misalignNeedReplay` blocks both `s2_misalign_cango` and `io.lsq_replenish.updateAddrValid`. A replayed request can update ROB and StoreQueue only after it reaches the SQ commit head and is issued successfully.

StoreQueue maps each fired `sqNeedDeq` event to the matching `rdataPtrExt` entry using the full `sqPtr` before constructing `readyReadGoVec`. The NC completion and split DataBuffer completion of the same SQ entry are therefore counted once.

A normal split store still advances `rdataPtr` by one. Two independent stores with different `sqPtr` values can still advance it by two. Vector store replay behavior is unchanged.
