### PR TITLE
fix(VSegmentUnit): align trigger results with latched address

### DIFF
--- a/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
+++ b/src/main/scala/xiangshan/mem/vector/VSegmentUnit.scala
@@ -477,8 +477,9 @@ class VSegmentUnit (implicit p: Parameters) extends VLSUModule
   segmentTrigger.io.fromLoadStore.mask                  := 0.U
 
   val triggerAction = segmentTrigger.io.toLoadStore.triggerAction
-  val triggerDebugMode = RegEnable(TriggerAction.isDmode(triggerAction), false.B, state === s_tlb_req)
-  val triggerBreakpoint = RegEnable(TriggerAction.isExp(triggerAction), false.B, state === s_tlb_req)
+  // s_wait_tlb_resp gives the updated latchVaddr a cycle to reach the trigger registers.
+  val triggerDebugMode = RegNext(TriggerAction.isDmode(triggerAction), false.B)
+  val triggerBreakpoint = RegNext(TriggerAction.isExp(triggerAction), false.B)
 
   // tlb resp
   when(io.dtlb.resp.fire && state === s_wait_tlb_resp){


### PR DESCRIPTION
latchVaddr is updated in s_tlb_req, but the trigger registers were enabled in the same cycle and captured results for the previous address. This could miss a trigger or report a stale match.

Update both debug-mode and breakpoint results every cycle with RegNext. The s_wait_tlb_resp state lets results for the updated address reach the registers before s_pm consumes them.