### PR TITLE
ci(emu): determine emu-mc threads with verilator version

### DIFF
--- a/.github/workflows/emu.yml
+++ b/.github/workflows/emu.yml
@@ -35,7 +35,7 @@ jobs:
   ### Misc Tests
   # NOTE: These tests may be built and ran both on 'builder' machines, this might be confusing.
   #       The reason is that we dont want a complex builder-runner workflow like EMU Performance Test,
-  #       and these tests may consume ~16 threads verlator, while 'runner' label is designed to be used with single-thread gsim,
+  #       and these tests uses 8-16 threads verlator, while 'runner' label is designed to be used with single-thread gsim,
   #       so we just run them on 'builder' to ensure enough resource.
 
   # GSIM functional test
@@ -184,10 +184,20 @@ jobs:
           mkdir -p ${WAVE_HOME} ${PERF_HOME}
           make init-force
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py --clean
+          # determine emulation threads, verilator 5.050+ has refactored multi-threading,
+          # with which 8-thread can achieve better performance then 16-thread in verilator 5.048
+          VERILATOR_VERSION=$(verilator --version | grep -oP 'Verilator \K\d+\.\d+')
+          if [ $(echo $VERILATOR_VERSION | sed 's/\.//') -ge 5050 ]; then
+            EMU_THREADS=8
+          else
+            EMU_THREADS=16
+          fi
+          echo "Using $EMU_THREADS threads for verilator $VERILATOR_VERSION"
+          echo "EMU_THREADS=$EMU_THREADS" >> $GITHUB_ENV
       - name: Build MC EMU
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py --build \
-            --emulator verilator --threads 16 \
+            --emulator verilator --threads ${EMU_THREADS} \
              --num-cores 2 --emu-optimize "" \
              --with-dramsim3 --dramsim3 /nfs/home/share/ci-workloads/DRAMsim3 \
              --pgo /nfs/home/share/ci-workloads/linux-hello-smp-new/bbl.bin --llvm-profdata llvm-profdata \
@@ -196,14 +206,14 @@ jobs:
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
             --wave-dump ${WAVE_HOME} \
-            --numa --threads 16 \
+            --numa --threads ${EMU_THREADS} \
             --diff ./ready-to-run/riscv64-nemu-interpreter-dual-so \
             --ci mc-tests 2> /dev/zero
       - name: MC Test - SMP Linux
         run: |
           python3 ${GITHUB_WORKSPACE}/scripts/xiangshan.py \
             --wave-dump ${WAVE_HOME} \
-            --numa --threads 16 \
+            --numa --threads ${EMU_THREADS} \
             --diff ./ready-to-run/riscv64-nemu-interpreter-dual-so \
             --ci linux-hello-smp-new 2> /dev/null
 


### PR DESCRIPTION
Verilator 5.048 -> 5.052 have changed the multi-threaded MTask scheduler (e.g. verilator/verilator#8120 refactors the MTask graph and greedy merge algorithm, and verilator/verilator#8133 adds missing read/write dependencies), which reduces available parallelism for large designs and makes `--threads 16` hit the default MTask limit. The build now fails with:

```
%Warning-UNOPTTHREADS: Thread scheduler is unable to provide requested parallelism; suggest asking for fewer threads.
                       ... For warning description see https://verilator.org/warn/UNOPTTHREADS?v=5.052
                       ... Use "/* verilator lint_off UNOPTTHREADS */" and lint_on around source to disable this message.
```

Test results (2 trial avg) on 9684x:

| verilator | threads | compile (w/ pgo) | run (linux-smp-hello) |
| --- | --- | --- | --- |
| 5.048 | 8 | 107m | 137m |
| 5.048 | 16 | 95m | 80m |
| 5.052 | 8 | 59m | 76m |
| 5.052 | 16 (-Wno-UNOPTTHREADS) | 102m | 114m |

* the test command is the same as CI, using commit 421ad2da1836ad966a98e2f727dc1c319d098f40

This PR determines emu-mc EMU_THREADS with `verilator --version` in init step:
- 8 for verilator 5.050 or newer
- 16 for verilator 5.048 or older

for better overall resource utilization and prepare for verilator version bump.