### PR TITLE
fix(build/xspdb): add required filelist arg for new picker

### DIFF
--- a/scripts/Makefile.pdb
+++ b/scripts/Makefile.pdb
@@ -55,6 +55,7 @@ $(PDB_HOME)/libUTSimTop.so: $(PDB_HOME)/picker.f
 		--lang python \
 		--tdir $(PDB_HOME)/pyxscore \
 		--fs $(PDB_HOME)/picker.f \
+		-S "-I$(NOOP_HOME)/build/generated-src" \
 		-V "--output-split;20000;--no-timing;--threads;8;+define+DIFFTEST;-I$(NOOP_HOME)/build/generated-src" \
 		-C "-fPIC -lz -I$(PICKER_INCLUDE) -L$(PDB_HOME)/pydifftest -ldifftest -Wl,-rpath='$$ORIGIN../pydifftest' -lpython$(PYTHON_VERSION) $(SIM_LDFLAGS)" 
 


### PR DESCRIPTION
With new picker, xspdb build fails with:

```
Fatal: Failed to parse RTL sources with slang:
difftest/src/test/vsrc/common/DifftestClockGate.v:17:10: error: 'DifftestMacros.svh': No such file or directory
`include "DifftestMacros.svh"
         ^~~~~~~~~~~~~~~~~~~~
```

due to the refactored filelist parsing and handling.

This PR adds the required arg and prepare for picker/verilator version bump.

Link: https://github.com/XS-MLVP/picker/pull/103