### PR TITLE
feat(Tage): refactor meta

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/tage/Bundles.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Bundles.scala
@@ -110,15 +110,14 @@ class TableWriteReq(implicit p: Parameters, info: TageTableInfo) extends TageBun
 }
 
 class TageMetaEntry(implicit p: Parameters) extends TageBundle {
-  val useProvider:       Bool            = Bool()
-  val hasProvider:       Bool            = Bool()
-  val hasAlt:            Bool            = Bool()
-  val providerTableIdx:  UInt            = UInt(TableIdxWidth.W)
-  val providerWayIdx:    UInt            = UInt(MaxNumWays.W)
+  val providerLocation:  UInt            = UInt(ProviderLocationWidth.W)
   val providerTakenCtr:  SaturateCounter = TakenCounter()
   val providerUsefulCtr: SaturateCounter = UsefulCounter()
-  val altOrBasePred:     Bool            = Bool()
-  val altConf:           Bool            = Bool()
+
+  val altLocation: UInt            = UInt(AltLocationWidth.W)
+  val altTakenCtr: SaturateCounter = TakenCounter()
+
+  val useAltOnNa: Bool = Bool()
 }
 
 class TageMeta(implicit p: Parameters) extends TageBundle {

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Helpers.scala
@@ -37,6 +37,59 @@ trait TopHelper extends HasTageParameters {
 
   def getLongestHistTableOH(hitTableMask: Seq[Bool]): Seq[Bool] =
     PriorityEncoderOH(hitTableMask.reverse).reverse
+
+  private def encodeLocation(
+      valid:        Bool,
+      tableOH:      Seq[Bool],
+      wayOH:        UInt,
+      numTables:    Int,
+      encodedWidth: Int
+  ): UInt = {
+    val encoded      = Wire(UInt(encodedWidth.W))
+    val numLocations = TableInfos.take(numTables).map(_.NumWays).sum
+    if (numTables == 0) {
+      encoded := numLocations.U
+    } else {
+      val wayIdx = OHToUInt(wayOH)
+      val flatLocation = Mux1H(
+        tableOH.take(numTables),
+        TableWayOffsets.take(numTables).map(offset => offset.U(encodedWidth.W) + wayIdx)
+      )
+      encoded := Mux(valid, flatLocation, numLocations.U)
+    }
+    encoded
+  }
+
+  private def decodeLocation(encoded: UInt, numTables: Int): (Bool, UInt, UInt) = {
+    val numLocations = TableInfos.take(numTables).map(_.NumWays).sum
+    val valid        = encoded < numLocations.U
+    val flatLocation = encoded
+    val tableOH = VecInit(TableInfos.zipWithIndex.map { case (info, tableIdx) =>
+      if (tableIdx < numTables) {
+        val offset = TableWayOffsets(tableIdx)
+        valid && flatLocation >= offset.U && flatLocation < (offset + info.NumWays).U
+      } else {
+        false.B
+      }
+    })
+    val wayOH = Mux1H(TableInfos.zipWithIndex.map { case (info, tableIdx) =>
+      val localWayIdx = flatLocation - TableWayOffsets(tableIdx).U
+      tableOH(tableIdx) -> UIntToOH(localWayIdx, info.NumWays).pad(MaxNumWays)
+    })
+    (valid, tableOH.asUInt, wayOH)
+  }
+
+  def encodeProviderLocation(valid: Bool, tableOH: Seq[Bool], wayOH: UInt): UInt =
+    encodeLocation(valid, tableOH, wayOH, NumTables, ProviderLocationWidth)
+
+  def encodeAltLocation(valid: Bool, tableOH: Seq[Bool], wayOH: UInt): UInt =
+    encodeLocation(valid, tableOH, wayOH, NumTables - 1, AltLocationWidth)
+
+  def decodeProviderLocation(encoded: UInt): (Bool, UInt, UInt) =
+    decodeLocation(encoded, NumTables)
+
+  def decodeAltLocation(encoded: UInt): (Bool, UInt, UInt) =
+    decodeLocation(encoded, NumTables - 1)
 }
 
 trait TableHelper extends TopHelper { // extends TopHelper for getBankIndex

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Helpers.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Helpers.scala
@@ -99,7 +99,6 @@ trait TableHelper extends TopHelper { // extends TopHelper for getBankIndex
   val addrFields = AddrField(
     Seq(
       ("instOffset", instOffsetBits),
-      ("bankIdx", BankIdxWidth),
       ("setIdx", SetIdxWidth),
       ("tag", TagWidth)
     ),
@@ -107,7 +106,7 @@ trait TableHelper extends TopHelper { // extends TopHelper for getBankIndex
   )
 
   def getBankIndex(pc: PrunedAddr): UInt =
-    addrFields.extract("bankIdx", pc)
+    pc(2, 1) ^ pc(7, 6) ^ pc(13, 12) ^ pc(20, 19)
 
   def getSetIndex(pc: PrunedAddr, hist: UInt): UInt =
     addrFields.extract("setIdx", pc) ^ hist

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Parameters.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Parameters.scala
@@ -15,7 +15,6 @@
 
 package xiangshan.frontend.bpu.tage
 
-import chisel3._
 import chisel3.util._
 import xiangshan.frontend.bpu.HasBpuParameters
 import xiangshan.frontend.bpu.TageTableInfo
@@ -70,13 +69,20 @@ trait HasTageParameters extends HasBpuParameters {
   def MaxSetIdxWidth: Int = log2Ceil(MaxNumSets)
 
   def MaxNumWays:     Int = TableInfos.map(_.NumWays).max
-  def MaxWayIdxWidth: Int = log2Ceil(MaxNumWays)
+  def MaxWayIdxWidth: Int = log2Ceil(MaxNumWays).max(1)
+
+  // Encode table and way as a dense location. The value after the last location means that no entry exists.
+  def TableWayOffsets:       Seq[Int] = TableInfos.scanLeft(0)((offset, info) => offset + info.NumWays).dropRight(1)
+  def NumProviderLocations:  Int      = TableInfos.map(_.NumWays).sum
+  def NumAltLocations:       Int      = TableInfos.dropRight(1).map(_.NumWays).sum
+  def ProviderLocationWidth: Int      = log2Ceil(NumProviderLocations + 1).max(1)
+  def AltLocationWidth:      Int      = log2Ceil(NumAltLocations + 1).max(1)
 
   // per table parameters
   def NumSets(implicit info:     TageTableInfo): Int = info.getNumSets(NumBanks)
   def SetIdxWidth(implicit info: TageTableInfo): Int = log2Ceil(NumSets)
   def NumWays(implicit info:     TageTableInfo): Int = info.NumWays
-  def WayIdxWidth(implicit info: TageTableInfo): Int = log2Ceil(NumWays)
+  def WayIdxWidth(implicit info: TageTableInfo): Int = log2Ceil(NumWays).max(1)
 
   def NumUsefulCtrSramFolds: Int = tageParameters.NumUsefulCtrSramFolds
 

--- a/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/tage/Tage.scala
@@ -96,7 +96,7 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     })
   })
 
-  private val s1_readResp = DataHoldBypass(VecInit(tables.map(_.io.readResp(0))), RegNext(s0_fire))
+  private val s1_readResp = tables.map(table => DataHoldBypass(table.io.readResp(0), RegNext(s0_fire)))
 
   /* --------------------------------------------------------------------------------------------------------------
      predict pipeline stage 2
@@ -107,7 +107,7 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
   private val s2_fire     = io.stageCtrl.s2_fire
   private val s2_startPc  = RegEnable(s1_startPc, s1_fire)
   private val s2_tag      = RegEnable(s1_tag, s1_fire)
-  private val s2_readResp = RegEnable(s1_readResp, s1_fire)
+  private val s2_readResp = s1_readResp.map(resp => RegEnable(resp, s1_fire))
 
   private val s2_branches = io.fromMainBtb.result
 
@@ -155,15 +155,12 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     io.toSc.providerTakenCtrVec(i).valid := hasProvider && branch.valid
     io.toSc.providerTakenCtrVec(i).bits  := provider.takenCtr
 
-    io.meta.entries(i).useProvider       := useProvider
-    io.meta.entries(i).hasProvider       := hasProvider
-    io.meta.entries(i).hasAlt            := hasAlt
-    io.meta.entries(i).providerTableIdx  := providerTableIdx
-    io.meta.entries(i).providerWayIdx    := OHToUInt(provider.hitWayMaskOH)
+    io.meta.entries(i).useAltOnNa        := useAltOnNa
+    io.meta.entries(i).providerLocation  := encodeProviderLocation(hasProvider, providerTableOH, provider.hitWayMaskOH)
     io.meta.entries(i).providerTakenCtr  := provider.takenCtr
     io.meta.entries(i).providerUsefulCtr := provider.usefulCtr
-    io.meta.entries(i).altOrBasePred     := Mux(hasAlt, alt.takenCtr.isPositive, branch.bits.taken)
-    io.meta.entries(i).altConf           := altConf
+    io.meta.entries(i).altLocation       := encodeAltLocation(hasAlt, altTableOH, alt.hitWayMaskOH)
+    io.meta.entries(i).altTakenCtr       := alt.takenCtr
 
     XSPerfAccumulate(
       s"s2_branch_${i}_multihit_on_same_table",
@@ -200,15 +197,12 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     (mbtbHit, baseCtr, meta)
   }.unzip3
 
-  // Meta stores enough state for provider-only training. Re-read SRAM when an alternate
-  // table entry is needed, or when the prediction was wrong and allocation state is needed.
+  // Re-read SRAM when has mispredict
   private val t0_needRead = t0_branches.zipWithIndex.map { case (branch, i) =>
     val mbtbHit      = t0_mbtbHitMask(i)
     val isCond       = t0_condMask(i)
-    val useProvider  = t0_meta(i).useProvider
-    val hasAlt       = t0_meta(i).hasAlt
     val mispredicted = branch.bits.mispredict
-    mbtbHit && isCond && (mispredicted || (!useProvider && hasAlt))
+    mbtbHit && isCond && mispredicted
   }.reduce(_ || _)
   private val t0_useMeta = !t0_needRead
 
@@ -287,7 +281,7 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     table.getRawTag(t1_startPc, hist.forTag)
   })
 
-  private val t1_readResp = VecInit(tables.map(_.io.readResp(1)))
+  private val t1_readResp = tables.map(_.io.readResp(1))
 
   /* --------------------------------------------------------------------------------------------------------------
     train pipeline stage 2
@@ -302,7 +296,7 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
   private val t2_setIdx   = RegEnable(t1_setIdx, t1_fire)
   private val t2_bankMask = RegEnable(t1_bankMask, t1_fire)
   private val t2_rawTag   = RegEnable(t1_rawTag, t1_fire)
-  private val t2_readResp = RegEnable(t1_readResp, t1_fire)
+  private val t2_readResp = t1_readResp.map(resp => RegEnable(resp, t1_fire))
 
   private val t2_useMeta     = RegEnable(t1_useMeta, t1_fire)
   private val t2_meta        = RegEnable(t1_meta, t1_fire)
@@ -341,25 +335,30 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     val altTableOH = Wire(UInt(NumTables.W))
     val alt        = Wire(new TrainTagMatchResult)
 
-    val useProvider   = Wire(Bool())
-    val useAlt        = Wire(Bool())
-    val altOrBasePred = Wire(Bool())
+    val useProvider = Wire(Bool())
+    val useAlt      = Wire(Bool())
+
+    val (metaHasProvider, metaProviderTableOH, metaProviderWayOH) = decodeProviderLocation(meta.providerLocation)
+    val (metaHasAlt, metaAltTableOH, metaAltWayOH)                = decodeAltLocation(meta.altLocation)
 
     when(t2_useMeta) {
-      hasProvider     := meta.hasProvider
-      providerTableOH := Mux(meta.hasProvider, UIntToOH(meta.providerTableIdx, NumTables), 0.U)
+      hasProvider     := metaHasProvider
+      providerTableOH := metaProviderTableOH
 
-      provider.hit          := meta.hasProvider
-      provider.hitWayMaskOH := Mux(meta.hasProvider, UIntToOH(meta.providerWayIdx, MaxNumWays), 0.U)
-      provider.tag          := t2_rawTag(meta.providerTableIdx) ^ position
+      provider.hit          := metaHasProvider
+      provider.hitWayMaskOH := metaProviderWayOH
+      provider.tag          := t2_rawTag(OHToUInt(metaProviderTableOH)) ^ position
       provider.takenCtr     := meta.providerTakenCtr
       provider.usefulCtr    := meta.providerUsefulCtr
 
-      hasAlt     := false.B
-      altTableOH := 0.U
-      alt        := 0.U.asTypeOf(new TrainTagMatchResult)
+      hasAlt     := metaHasAlt
+      altTableOH := metaAltTableOH
 
-      altOrBasePred := meta.altOrBasePred
+      alt.hit          := metaHasAlt
+      alt.hitWayMaskOH := metaAltWayOH
+      alt.tag          := t2_rawTag(OHToUInt(metaAltTableOH)) ^ position
+      alt.takenCtr     := meta.altTakenCtr
+      alt.usefulCtr    := UsefulCounter.Zero
     }.otherwise { // use result from sram read resp
       hasProvider     := hitTableMask.reduce(_ || _)
       providerTableOH := getLongestHistTableOH(hitTableMask).asUInt
@@ -369,15 +368,15 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
       hasAlt     := hasProvider && hitTableMaskNoProvider.reduce(_ || _)
       altTableOH := getLongestHistTableOH(hitTableMaskNoProvider).asUInt
       alt        := Mux1H(altTableOH, allTableTagMatchResults)
-
-      altOrBasePred := Mux(hasAlt, alt.takenCtr.isPositive, t2_baseCtr(i).isPositive)
     }
 
-    val altConf       = Mux(t2_useMeta, meta.altConf, Mux(hasAlt, !alt.takenCtr.isWeak, t2_baseCtr(i).isSaturate))
-    val useAltOnNaIdx = Cat(OHToUInt(providerTableOH), altConf)
-    val useAltOnNa    = useAltOnNaVec(useAltOnNaIdx).isPositive
-    useProvider := Mux(t2_useMeta, meta.useProvider, hasProvider && !(useAltOnNa && provider.takenCtr.isWeak))
-    useAlt      := !t2_useMeta && !useProvider && hasAlt
+    val altOrBasePred     = Mux(hasAlt, alt.takenCtr.isPositive, t2_baseCtr(i).isPositive)
+    val altConf           = Mux(hasAlt, !alt.takenCtr.isWeak, t2_baseCtr(i).isSaturate)
+    val useAltOnNaIdx     = Cat(OHToUInt(providerTableOH), altConf)
+    val currentUseAltOnNa = useAltOnNaVec(useAltOnNaIdx).isPositive
+    val useAltOnNa        = Mux(t2_useMeta, meta.useAltOnNa, currentUseAltOnNa)
+    useProvider := hasProvider && !(useAltOnNa && provider.takenCtr.isWeak)
+    useAlt      := !useProvider && hasAlt
 
     val providerPred = provider.takenCtr.isPositive
     val finalPred    = Mux(useProvider, providerPred, altOrBasePred)
@@ -458,7 +457,7 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
   private val t3_setIdx       = RegEnable(t2_setIdx, t2_fire)
   private val t3_bankMask     = RegEnable(t2_bankMask, t2_fire)
   private val t3_rawTag       = RegEnable(t2_rawTag, t2_fire)
-  private val t3_readResp     = RegEnable(t2_readResp, t2_fire)
+  private val t3_readResp     = t2_readResp.map(resp => RegEnable(resp, t2_fire))
   private val t3_useMeta      = RegEnable(t2_useMeta, t2_fire)
   private val t3_mbtbHitMask  = RegEnable(t2_mbtbHitMask, t2_fire)
   private val t3_trainInfoVec = RegEnable(t2_trainInfoVec, t2_fire)
@@ -515,7 +514,12 @@ class Tage(implicit p: Parameters) extends BasePredictor with HasTageParameters 
     t3_canAllocateTableMask
   )
   private val t3_allocateTableOH = PriorityEncoderOH(t3_preferredAllocateTableMask)
-  private val t3_allocateWayMask = Mux1H(t3_allocateTableOH, t3_allTableCanAllocateWayMask)
+  private val t3_allTableCanAllocateWayMaskPadded = t3_allTableCanAllocateWayMask.map { mask =>
+    val padded = Wire(UInt(MaxNumWays.W))
+    padded := mask
+    padded
+  }
+  private val t3_allocateWayMask = Mux1H(t3_allocateTableOH, t3_allTableCanAllocateWayMaskPadded)
   private val t3_allocateWayOH   = PriorityEncoderOH(t3_allocateWayMask)
   dontTouch(t3_allocateTableOH)
   dontTouch(t3_allocateWayOH)


### PR DESCRIPTION
Previously, each branch used 14 bits of meta information. Part of this information was associated with alt, but the full alt information was not preserved. The new design encodes the location of both provider and alt, and also stores their corresponding information explicitly. Compared to the previous layout, this requires only 4 additional bit of storage.

Under the current configuration(8 table, each table 2 way)
old: 1+1+1+3+1+3+2+1+1=14 bits
new: 5+3+2+4+3+1=18 bits

Under a future configuration (for example, 8 tables, 4 tables - 2 way, 2 tables - 4 way, 2 tables - 6 way)
old: 1+1+1+3+3+3+2+1+1= 16bits
new: 5+3+2+5+3+1=19 bits