### PR TITLE
fix(ittage): remove invalid read requests to mitigate read-write conflicts

### DIFF
--- a/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/Bpu.scala
@@ -239,6 +239,7 @@ class Bpu(implicit p: Parameters) extends BpuModule with HalfAlignHelper {
 
   ittage.io.s1_foldedPhr   := phr.io.s1_foldedPhr
   ittage.io.trainFoldedPhr := phr.io.trainFoldedPhr
+  ittage.io.s2_flush       := s2_flush
 
   sc.io.mbtbResult          := mbtb.io.result
   sc.io.providerTakenCtrs   := tage.io.toSc.providerTakenCtrVec

--- a/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
+++ b/src/main/scala/xiangshan/frontend/bpu/ittage/Ittage.scala
@@ -46,6 +46,7 @@ class Ittage(implicit p: Parameters) extends BasePredictor with HasIttageParamet
     // prediction bundles
     val s1_foldedPhr:   PhrAllFoldedHistories = Input(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
     val trainFoldedPhr: PhrAllFoldedHistories = Input(new PhrAllFoldedHistories(AllFoldedHistoryInfo))
+    val s2_flush:       Bool                  = Input(Bool())
 
     val prediction: IttagePrediction = Output(new IttagePrediction)
     val meta:       IttageMeta       = Output(new IttageMeta)
@@ -188,7 +189,7 @@ class Ittage(implicit p: Parameters) extends BasePredictor with HasIttageParamet
 
   // Predict
   tables.foreach { t =>
-    t.io.req.valid           := s1_fire && s1_isIndirect // TODO: s1_isIndirect for low power
+    t.io.req.valid           := !io.s2_flush && s1_fire && s1_isIndirect // TODO: s1_isIndirect for low power
     t.io.req.bits.startPc    := s1_startPc.unGuard
     t.io.req.bits.foldedHist := io.s1_foldedPhr
   }


### PR DESCRIPTION
Flushing the read request of the current-cycle ittage is invalid; removing it can reduce read requests while alleviating read-write conflicts.