### PR TITLE
fix(VTypeGen): exclude vsetivli from keep-VL detection

### DIFF
--- a/src/main/scala/xiangshan/backend/decode/VTypeGen.scala
+++ b/src/main/scala/xiangshan/backend/decode/VTypeGen.scala
@@ -87,9 +87,9 @@ class VTypeGen(implicit p: Parameters) extends XSModule {
   // prevVlmax(i) = vlmax BEFORE instruction i (i.e., after all vsets before i)
   private val prevVlmax = specVlmax +: cumVlmax.take(DecodeWidth - 1)
 
-  // Detect keepVl vsets: rd == 0 && rs1 == 0
+  // Only vsetvli can keep VL here; vsetivli's RS1 field encodes an AVL immediate.
   private val keepVlMask = VecInit((0 until DecodeWidth).map { i =>
-    isVsetiVec(i) && instFieldVec(i).RD === 0.U && instFieldVec(i).RS1 === 0.U
+    isVsetvli(i) && instFieldVec(i).RD === 0.U && instFieldVec(i).RS1 === 0.U
   })
 
   // For keepVl vsets, compute the correct vlmaxChange against the true prevVlmax

--- a/src/test/resources/vsetivli-zero-avl.c
+++ b/src/test/resources/vsetivli-zero-avl.c
@@ -1,0 +1,31 @@
+#include "trap.h"
+
+int main(const char *args) {
+  unsigned long vtype, vl, rd;
+  __asm__ volatile("csrs mstatus, %0" : : "r"(1UL << 9) : "memory");
+
+  __asm__ volatile(
+      "vsetivli t0, 1, e8, m1, tu, mu\n"
+      "vsetivli t1, 0, e16, m1, tu, mu\n"
+      "csrr %0, vtype\n"
+      "csrr %1, vl\n"
+      "mv %2, t1\n"
+      : "=r"(vtype), "=r"(vl), "=r"(rd)
+      :
+      : "t0", "t1", "memory");
+  nemu_assert(vtype == 0x08 && vl == 0 && rd == 0);
+  printf("Nonzero-rd control passed\n");
+  if (args[0] == 'c') return 0;
+
+  __asm__ volatile(
+      "vsetivli t0, 1, e8, m1, tu, mu\n"
+      "vsetivli zero, 0, e16, m1, tu, mu\n"
+      "csrr %0, vtype\n"
+      "csrr %1, vl\n"
+      : "=r"(vtype), "=r"(vl)
+      :
+      : "t0", "memory");
+  nemu_assert(vtype == 0x08 && vl == 0);
+  printf("Zero-rd zero-AVL regression passed\n");
+  return 0;
+}

--- a/src/test/scala/xiangshan/backend/fu/VTypeGenSpec.scala
+++ b/src/test/scala/xiangshan/backend/fu/VTypeGenSpec.scala
@@ -1,0 +1,141 @@
+package xiangshan.backend.fu
+
+import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import org.scalatest.flatspec.AnyFlatSpec
+import top.DefaultConfig
+import xiangshan.{XSCoreParameters, XSCoreParamsKey}
+import xiangshan.backend.decode.VTypeGen
+import xiangshan.backend.fu.vector.Bundles.VType
+
+class VTypeGenSpec extends AnyFlatSpec with ChiselSim {
+  private val config = (new DefaultConfig).alterPartial {
+    case XSCoreParamsKey => XSCoreParameters()
+  }
+
+  private def vsetivli(rd: Int, avl: Int, vtype: Int): BigInt =
+    BigInt("c0007057", 16) | (BigInt(vtype) << 20) | (BigInt(avl) << 15) | (BigInt(rd) << 7)
+
+  private def vsetvli(rd: Int, rs1: Int, vtype: Int): BigInt =
+    BigInt("00007057", 16) | (BigInt(vtype) << 20) | (BigInt(rs1) << 15) | (BigInt(rd) << 7)
+
+  behavior of "VTypeGen"
+
+  it should "distinguish immediate AVL from keep-VL across lanes and packets" in {
+    simulate(new VTypeGen()(config)) { dut =>
+      val width = dut.in.insts.length
+
+      def pokeType(target: VType, value: Int, illegal: Boolean = false): Unit = {
+        target.illegal.poke(illegal.B)
+        target.vma.poke(((value & 0x80) != 0).B)
+        target.vta.poke(((value & 0x40) != 0).B)
+        target.vsew.poke(((value >> 3) & 7).U)
+        target.vlmul.poke((value & 7).U)
+      }
+
+      def expectType(target: VType, value: Int, illegal: Boolean = false): Unit = {
+        target.illegal.expect(illegal.B)
+        target.vma.expect(((value & 0x80) != 0).B)
+        target.vta.expect(((value & 0x40) != 0).B)
+        target.vsew.expect(((value >> 3) & 7).U)
+        target.vlmul.expect((value & 7).U)
+      }
+
+      def packet(insts: (Int, BigInt)*): Unit = {
+        for (lane <- 0 until width) {
+          dut.in.insts(lane).valid.poke(false.B)
+          dut.in.insts(lane).bits.poke(0x13.U)
+        }
+        for ((lane, inst) <- insts) {
+          dut.in.insts(lane).valid.poke(true.B)
+          dut.in.insts(lane).bits.poke(inst.U(32.W))
+        }
+      }
+
+      def seed(vtype: Int): Unit = {
+        dut.in.canUpdateVType.poke(true.B)
+        packet(0 -> vsetivli(5, 1, vtype))
+        expectType(dut.out.vtype(width - 1), vtype)
+        dut.clock.step()
+        packet()
+      }
+
+      dut.in.walkToArchVType.poke(false.B)
+      dut.in.walkVType.valid.poke(false.B)
+      pokeType(dut.in.walkVType.bits, 0)
+      pokeType(dut.in.vsetvlVType, 0)
+      dut.in.commitVType.hasVsetvl.poke(false.B)
+      dut.in.commitVType.vtype.valid.poke(false.B)
+      pokeType(dut.in.commitVType.vtype.bits, 0)
+      dut.in.canUpdateVType.poke(true.B)
+      packet()
+
+      val legalTypes = Seq(0x00, 0x08, 0x10, 0x18, 0x09, 0x05, 0xc8)
+      for {
+        oldType <- legalTypes
+        newType <- legalTypes
+        rd <- Seq(0, 5)
+        avl <- Seq(0, 1, 31)
+        lane <- 0 until width
+      } {
+        withClue(s"old=$oldType new=$newType rd=$rd avl=$avl lane=$lane: ") {
+          seed(oldType)
+          packet(lane -> vsetivli(rd, avl, newType))
+          for (i <- 0 until width) {
+            expectType(dut.out.specvtype(i), if (i <= lane) oldType else newType)
+            expectType(dut.out.vtype(i), if (i < lane) oldType else newType)
+          }
+          dut.clock.step()
+          packet()
+          expectType(dut.out.specvtype(0), newType)
+        }
+      }
+
+      for (lane <- 1 until width) {
+        seed(0x18)
+        packet(0 -> vsetivli(5, 1, 0x00), lane -> vsetivli(0, 0, 0x08))
+        expectType(dut.out.specvtype(lane), 0x00)
+        expectType(dut.out.vtype(lane), 0x08)
+        expectType(dut.out.vtype(width - 1), 0x08)
+        dut.clock.step()
+      }
+
+      seed(0x00)
+      packet(0 -> vsetivli(0, 0, 0x08))
+      dut.in.canUpdateVType.poke(false.B)
+      expectType(dut.out.vtype(0), 0x08)
+      dut.clock.step()
+      expectType(dut.out.specvtype(0), 0x00)
+      dut.in.canUpdateVType.poke(true.B)
+      dut.clock.step()
+      packet()
+      expectType(dut.out.specvtype(0), 0x08)
+
+      seed(0x00)
+      packet()
+      dut.in.insts(0).bits.poke(vsetivli(0, 0, 0x08).U(32.W))
+      expectType(dut.out.vtype(width - 1), 0x00)
+      dut.clock.step()
+      expectType(dut.out.specvtype(0), 0x00)
+
+      packet(0 -> vsetvli(0, 0, 0x09))
+      expectType(dut.out.vtype(0), 0x09)
+      dut.clock.step()
+      packet()
+      expectType(dut.out.specvtype(0), 0x09)
+
+      seed(0x18)
+      packet(0 -> vsetivli(5, 1, 0x00), 1 -> vsetvli(0, 0, 0x09))
+      expectType(dut.out.vtype(1), 0x09)
+      dut.clock.step()
+
+      seed(0x00)
+      packet(0 -> vsetvli(0, 0, 0x08))
+      dut.out.vtype(0).illegal.expect(true.B)
+
+      seed(0x00)
+      packet(0 -> vsetivli(0, 0, 0x100))
+      expectType(dut.out.vtype(0), 0x00, illegal = true)
+    }
+  }
+}


### PR DESCRIPTION
### Summary

`VTypeGen` incorrectly sets `vtype.vill` for `vsetivli x0, 0, ...` when the new configuration changes VLMAX.

This is a legal instruction. For `vsetivli`, AVL is a five-bit immediate, and an immediate value of zero sets `vl=0`. A destination of `x0` discards the integer return value; **it does not request preservation of the previous VL or prohibit changing VLMAX**.

### Root cause

The original keep-VL detection uses:

```scala
isVsetiVec(i) &&
instFieldVec(i).RD === 0.U &&
instFieldVec(i).RS1 === 0.U
```

`isVsetiVec` includes both `vsetvli` and `vsetivli`, although bits `[19:15]` have different meanings:

| Instruction | Bits `[19:15]` |
|---|---|
| `vsetvli` | Source register index |
| `vsetivli` | Five-bit AVL immediate |

Consequently, a zero immediate is mistaken for register `x0`, and the keep-VL VLMAX restriction is applied incorrectly.

The resulting vtype metadata is attached to instructions by IBuffer and propagates through VTypeBuffer into architectural state at retirement. This is therefore an architectural correctness issue rather than harmless speculative metadata.

### Minimal reproducer

With vector state enabled:

```asm
vsetivli t0,   1, e8,  m1, tu, mu
vsetivli zero, 0, e16, m1, tu, mu
csrr a0, vtype
csrr a1, vl
```

Expected:

```text
vtype = 0x0000000000000008
vl    = 0
```

Differential execution on the original RTL reports:

```text
Reference: vtype = 0x0000000000000008
DUT:       vtype = 0x8000000000000008
```

Changing only the second instruction's destination to a nonzero register makes the control case pass.

### Changes

Restrict keep-VL detection in this module to `vsetvli`:

```diff
- isVsetiVec(i) && instFieldVec(i).RD === 0.U && instFieldVec(i).RS1 === 0.U
+ isVsetvli(i)  && instFieldVec(i).RD === 0.U && instFieldVec(i).RS1 === 0.U
```

The cumulative VLMAX chain, register-form `vsetvl` execution path, other vector-configuration logic, and pipeline stages remain unchanged.

Files:

- `src/main/scala/xiangshan/backend/decode/VTypeGen.scala`: minimal RTL correction.
- `src/test/scala/xiangshan/backend/fu/VTypeGenSpec.scala`: directed ChiselSim regression targeting the current implementation.
- `src/test/resources/vsetivli-zero-avl.c`: bare-metal reproducer using the nexus-am cputest harness.
- 
### 问题概述

当执行 `vsetivli x0, 0, ...`，且新配置的 VLMAX 与前一配置不同时，`VTypeGen` 会错误设置 `vtype.vill`。

这是一条合法指令：`vsetivli` 的 AVL 来自 5 位立即数，立即数为 0 应设置 `vl=0`。目的寄存器为 `x0` 只表示丢弃通用寄存器的返回值，**不意味着保持旧 VL，也不禁止改变 VLMAX**。

### 根因

原先使用下面的条件识别保持旧 VL 的指令：

```scala
isVsetiVec(i) &&
instFieldVec(i).RD === 0.U &&
instFieldVec(i).RS1 === 0.U
```

其中 `isVsetiVec` 同时包含 `vsetvli` 和 `vsetivli`，但两种指令的 bits `[19:15]` 含义不同：

| 指令 | bits `[19:15]` 的含义 |
|---|---|
| `vsetvli` | 源寄存器编号 |
| `vsetivli` | 5 位 AVL 立即数 |

因此，`vsetivli` 的零立即数被误解释成寄存器 `x0`，继而套用了保持 VL 时的 VLMAX 检查。

这不是无影响的预测元数据错误：生成的 vtype 经 IBuffer 附着到指令，再经 VTypeBuffer 进入提交时的架构状态更新。

### 最小复现

前提：向量状态已启用。

```asm
vsetivli t0,   1, e8,  m1, tu, mu
vsetivli zero, 0, e16, m1, tu, mu
csrr a0, vtype
csrr a1, vl
```

预期：

```text
vtype = 0x0000000000000008
vl    = 0
```

原版 RTL 与 NEMU 差分结果：

```text
NEMU: vtype = 0x0000000000000008
RTL:  vtype = 0x8000000000000008
```

RTL 多置了 `vill`。将第二条指令的目的寄存器改为非零寄存器后，对照程序通过。

### 修改内容

仅将本处保持 VL 的识别范围收窄为 `vsetvli`：

```diff
- isVsetiVec(i) && instFieldVec(i).RD === 0.U && instFieldVec(i).RS1 === 0.U
+ isVsetvli(i)  && instFieldVec(i).RD === 0.U && instFieldVec(i).RS1 === 0.U
```

保留累计 VLMAX 链、寄存器形式 `vsetvl` 的执行路径和其他向量配置逻辑，不改变流水级。

涉及文件：

- `src/main/scala/xiangshan/backend/decode/VTypeGen.scala`：最小 RTL 修复。
- `src/test/scala/xiangshan/backend/fu/VTypeGenSpec.scala`：直接测试当前 `VTypeGen` 的 ChiselSim 回归。
- `src/test/resources/vsetivli-zero-avl.c`：使用 nexus-am cputest 的裸机复现程序。