### PR TITLE
fix(VMove): NaN-box floating-point scalar move results

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/wrapper/VMove.scala
+++ b/src/main/scala/xiangshan/backend/fu/wrapper/VMove.scala
@@ -5,6 +5,7 @@ import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import utility.XSError
 import xiangshan.backend.fu.FuConfig
+import xiangshan.backend.fu.fpu.FPU
 import xiangshan.backend.fu.vector.Bundles.VLmul
 import xiangshan.backend.fu.vector.Utils.VecDataToMaskDataVec
 import xiangshan.backend.fu.vector.{Mgu, VecPipedFuncUnit}
@@ -34,8 +35,14 @@ class VMove(cfg: VecFuConfig)(implicit p: Parameters) extends VecFixLatFunc(cfg)
       mod.io.in.bits.mask := Fill(mod.io.in.bits.mask.getWidth, ex(0).bits.ctrl.vm.get) | ex(0).data.v0.get // Todo: use 16b mask instead
   }
 
+  // Floating scalar moves NaN-box instead of sign-extending the element.
+  private val fpResult = MuxLookup(VMoveOpcode.getElemWidth, vMove.io.out.bits.vd(63, 0))(Seq(
+    VSew.e16 -> FPU.box(vMove.io.out.bits.vd, FPU.f16),
+    VSew.e32 -> FPU.box(vMove.io.out.bits.vd, FPU.f32)
+  ))
+
   out.ex(0).data.int.foreach(_ := vMove.io.out.bits.vd)
-  out.ex(0).data.fp.foreach(_ := vMove.io.out.bits.vd)
+  out.ex(0).data.fp.foreach(_ := fpResult)
   out.ex(0).data.vec.foreach(_.normal := vMove.io.out.bits.vd)
   out.ex(0).data.vec.foreach(_.narrow := 0.U)
   out.ex(0).data.vec.foreach(_.maskE8 := 0.U)

--- a/src/test/resources/vfmv-f-s-boxing.c
+++ b/src/test/resources/vfmv-f-s-boxing.c
@@ -1,0 +1,31 @@
+#include "trap.h"
+
+#define CHECK_MOVE(SEW, VALUE, EXPECTED_FP, EXPECTED_INT) do { \
+  unsigned long fp, integer; \
+  __asm__ volatile( \
+      "vsetivli t0, 1, e" #SEW ", m1, tu, mu\n" \
+      "vmv.v.i v8, " #VALUE "\n" \
+      "vmv.x.s %1, v8\n" \
+      "vfmv.f.s ft0, v8\n" \
+      "fmv.x.d %0, ft0\n" \
+      : "=&r"(fp), "=&r"(integer) \
+      : \
+      : "t0", "ft0", "memory"); \
+  nemu_assert(fp == (EXPECTED_FP) && integer == (EXPECTED_INT)); \
+} while (0)
+
+int main(const char *args) {
+  __asm__ volatile("csrs mstatus, %0" : : "r"((1UL << 9) | (1UL << 13)) : "memory");
+  CHECK_MOVE(64, 1, 1UL, 1UL);
+  CHECK_MOVE(32, -1, ~0UL, ~0UL);
+  printf("Full-width and negative-value controls passed\n");
+  if (args[0] == 'c') return 0;
+
+  CHECK_MOVE(32, 1, 0xffffffff00000001UL, 1UL);
+  CHECK_MOVE(32, 0, 0xffffffff00000000UL, 0UL);
+  CHECK_MOVE(16, 1, 0xffffffffffff0001UL, 1UL);
+  CHECK_MOVE(16, 0, 0xffffffffffff0000UL, 0UL);
+  CHECK_MOVE(16, -1, ~0UL, ~0UL);
+  printf("Floating scalar move NaN-boxing regression passed\n");
+  return 0;
+}

--- a/src/test/scala/xiangshan/backend/fu/VMoveSpec.scala
+++ b/src/test/scala/xiangshan/backend/fu/VMoveSpec.scala
@@ -1,0 +1,106 @@
+package xiangshan.backend.fu
+
+import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import org.chipsalliance.cde.config.Parameters
+import org.scalatest.flatspec.AnyFlatSpec
+import top.DefaultConfig
+import xiangshan.{XSCoreParamsKey, XSTileKey}
+import xiangshan.backend.fu.wrapper.VMove
+import xiangshan.backend.vector.fu.VecFuConfig
+import yunsuan.encoding.Opcode.Opcodes.VMoveOpcode
+
+class VMoveTestTop(implicit p: Parameters) extends Module {
+  val io = IO(new Bundle {
+    val valid = Input(Bool())
+    val opcode = Input(UInt(VMoveOpcode.getWidth.W))
+    val vs2 = Input(UInt(128.W))
+    val fpWen = Input(Bool())
+    val rfWen = Input(Bool())
+    val vecWen = Input(Bool())
+    val validOut = Output(Bool())
+    val fpWenOut = Output(Bool())
+    val rfWenOut = Output(Bool())
+    val fp = Output(UInt(64.W))
+    val int = Output(UInt(64.W))
+    val vec = Output(UInt(128.W))
+  })
+
+  private val dut = Module(new VMove(VecFuConfig.VmoveCfg))
+  dut.in := 0.U.asTypeOf(dut.in)
+  dut.in.ex(0).valid := io.valid
+  dut.in.ex(0).bits.ctrl.opcode := io.opcode
+  dut.in.ex(0).bits.ctrl.fpWen.get := io.fpWen
+  dut.in.ex(0).bits.ctrl.rfWen.get := io.rfWen
+  dut.in.ex(0).bits.ctrl.vecWen.get := io.vecWen
+  dut.in.ex(0).bits.ctrl.vm.get := true.B
+  dut.in.ex(0).bits.data.src(1) := io.vs2
+  io.validOut := dut.out.ex(0).valid
+  io.fpWenOut := dut.out.ex(0).bits.ctrl.fpWen.get
+  io.rfWenOut := dut.out.ex(0).bits.ctrl.rfWen.get
+  io.fp := dut.out.ex(0).bits.data.fp.get
+  io.int := dut.out.ex(0).bits.data.int.get
+  io.vec := dut.out.ex(0).bits.data.vec.get.normal
+}
+
+class VMoveSpec extends AnyFlatSpec with ChiselSim {
+  private val base = new DefaultConfig
+  private val config = base.alterPartial {
+    case XSCoreParamsKey => base(XSTileKey).head
+  }
+
+  behavior of "VMove"
+
+  it should "NaN-box floating scalar results without changing integer moves" in {
+    simulate(new VMoveTestTop()(config)) { dut =>
+      val mask64 = (BigInt(1) << 64) - 1
+      val poison = BigInt("a5a55a5a123456789abcdef0", 16)
+      val ops = Seq(
+        8 -> VMoveOpcode.vmv_vs2x_e8,
+        16 -> VMoveOpcode.vmv_vs2x_e16,
+        32 -> VMoveOpcode.vmv_vs2x_e32,
+        64 -> VMoveOpcode.vmv_vs2x_e64
+      )
+      val fpPatterns = Map(
+        16 -> Seq("3c00", "7c00", "fc00", "7e01", "7c01"),
+        32 -> Seq("3f800000", "7f800000", "ff800000", "7fc00001", "7f800001"),
+        64 -> Seq("3ff0000000000000", "7ff0000000000000", "fff0000000000000", "7ff8000000000001")
+      )
+      dut.io.valid.poke(true.B)
+      dut.io.vecWen.poke(false.B)
+      for ((sew, op) <- ops) {
+        val mask = (BigInt(1) << sew) - 1
+        val sign = BigInt(1) << (sew - 1)
+        val values = Seq(BigInt(0), BigInt(1), sign - 1, sign, sign + 1, mask) ++
+          fpPatterns.getOrElse(sew, Seq.empty).map(BigInt(_, 16))
+        dut.io.opcode.poke(op.encode.value)
+        for (value <- values; upper <- Seq(BigInt(0), poison)) {
+          val input = ((upper << sew) | value) & ((BigInt(1) << 128) - 1)
+          dut.io.vs2.poke(input.U(128.W))
+          dut.io.rfWen.poke(true.B)
+          dut.io.fpWen.poke(false.B)
+          dut.io.validOut.expect(true.B)
+          dut.io.rfWenOut.expect(true.B)
+          dut.io.fpWenOut.expect(false.B)
+          val signed = if ((value & sign) != 0) value | (mask64 ^ mask) else value
+          dut.io.int.expect(signed.U(64.W))
+          if (sew >= 16) {
+            dut.io.rfWen.poke(false.B)
+            dut.io.fpWen.poke(true.B)
+            dut.io.fpWenOut.expect(true.B)
+            dut.io.rfWenOut.expect(false.B)
+            dut.io.fp.expect((value | (mask64 ^ mask)).U(64.W))
+          }
+        }
+      }
+      dut.io.opcode.poke(VMoveOpcode.vmvnr.encode.value)
+      dut.io.vs2.poke(poison.U(128.W))
+      dut.io.rfWen.poke(false.B)
+      dut.io.fpWen.poke(false.B)
+      dut.io.vecWen.poke(true.B)
+      dut.io.vec.expect(poison.U(128.W))
+      dut.io.valid.poke(false.B)
+      dut.io.validOut.expect(false.B)
+    }
+  }
+}


### PR DESCRIPTION
### Summary

`VMove` currently connects the same underlying vector-move result to both integer and floating-point outputs.

For narrow elements, the underlying unit performs integer sign extension. This is appropriate for `vmv.x.s`, but not for `vfmv.f.s` when SEW is smaller than FLEN: all upper bits of the destination FP register must be set to ones through NaN-boxing.

NaN-boxing applies to all narrow floating-point bit patterns, **not only NaN values**.

### Examples

For FLEN=64:

| SEW | Element bits | Previous output | Required FP output |
|---|---|---|---|
| 16 | `0x0000` | `0x0000000000000000` | `0xffffffffffff0000` |
| 16 | `0x3c00` | `0x0000000000003c00` | `0xffffffffffff3c00` |
| 32 | `0x3f800000` | `0x000000003f800000` | `0xffffffff3f800000` |
| 64 | `0x3ff0000000000000` | Unchanged | Unchanged; no boxing required |

When the element's sign bit is set, sign extension happens to produce the required upper ones. Negative-only test cases can therefore conceal this defect.

### Root cause

The original implementation shares the result between both scalar output types:

```scala
out.ex(0).data.int.foreach(_ := vMove.io.out.bits.vd)
out.ex(0).data.fp.foreach(_ := vMove.io.out.bits.vd)
```

The result implements integer sign-extension semantics, but the FP output lacks the required NaN-boxing step.

This is the current `VMove` wrapper instantiated by `VecFuConfig.VmoveCfg`, not an unused legacy arithmetic implementation.

### Changes

Modify only the FP output:

- Use the existing `FPU.box(..., FPU.f16)` helper for SEW=16.
- Use `FPU.box(..., FPU.f32)` for SEW=32.
- Preserve the original low 64 bits for SEW=64.
- Preserve integer sign extension.
- Leave vector outputs, write enables and pipeline latency unchanged.
- Do not modify YunSuan or the top-level cross-region writeback connections.

Files:

- `src/main/scala/xiangshan/backend/fu/wrapper/VMove.scala`: FP output-format correction.
- `src/test/scala/xiangshan/backend/fu/VMoveSpec.scala`: directed ChiselSim regression instantiating the current wrapper.
- `src/test/resources/vfmv-f-s-boxing.c`: bare-metal architectural test.

### 问题概述

`VMove` 将底层向量移动单元的同一份结果直接连接到整数和浮点输出。

底层单元对较窄元素执行的是整数符号扩展。这符合 `vmv.x.s` 的需要，但不符合 `vfmv.f.s` 在 SEW 小于 FLEN 时的要求：浮点寄存器中元素以上的高位必须全部置 1，即 NaN-boxing。

NaN-boxing 适用于所有较窄浮点位型，**不只是 NaN 数值**。

### 错误示例

以 FLEN=64 为例：

| SEW | 元素位型 | 原输出 | 正确浮点输出 |
|---|---|---|---|
| 16 | `0x0000` | `0x0000000000000000` | `0xffffffffffff0000` |
| 16 | `0x3c00` | `0x0000000000003c00` | `0xffffffffffff3c00` |
| 32 | `0x3f800000` | `0x000000003f800000` | `0xffffffff3f800000` |
| 64 | `0x3ff0000000000000` | 原值 | 原值，不需要 boxing |

当元素最高位为 1 时，整数符号扩展恰好也会把高位补成 1，因此只测负值容易漏掉这个问题。

### 根因

原先两个输出共用同一结果：

```scala
out.ex(0).data.int.foreach(_ := vMove.io.out.bits.vd)
out.ex(0).data.fp.foreach(_ := vMove.io.out.bits.vd)
```

底层结果满足整数移动的符号扩展语义，但浮点输出缺少额外的 NaN-boxing 处理。

这是当前 `VecFuConfig.VmoveCfg` 实例化的 `VMove` 包装单元，而不是未使用的旧版算术实现。

### 修改内容

仅修改浮点输出：

- SEW=16：使用已有 `FPU.box(..., FPU.f16)`。
- SEW=32：使用已有 `FPU.box(..., FPU.f32)`。
- SEW=64：保留原始低 64 位结果。
- 整数输出继续使用原有符号扩展结果。
- 向量输出、写使能和流水延迟保持不变。
- 不修改 YunSuan 子模块或顶层跨区域写回接线。

```scala
private val fpResult = MuxLookup(
  VMoveOpcode.getElemWidth,
  vMove.io.out.bits.vd(63, 0)
)(Seq(
  VSew.e16 -> FPU.box(vMove.io.out.bits.vd, FPU.f16),
  VSew.e32 -> FPU.box(vMove.io.out.bits.vd, FPU.f32)
))

out.ex(0).data.int.foreach(_ := vMove.io.out.bits.vd)
out.ex(0).data.fp.foreach(_ := fpResult)
```

涉及文件：

- `src/main/scala/xiangshan/backend/fu/wrapper/VMove.scala`：浮点输出格式修复。
- `src/test/scala/xiangshan/backend/fu/VMoveSpec.scala`：直接实例化当前包装单元的 ChiselSim 回归。
- `src/test/resources/vfmv-f-s-boxing.c`：裸机架构测试程序。