### PR TITLE
fix(MemBlock): split VLS exception redirect by flush level

### DIFF
--- a/src/main/scala/xiangshan/mem/MemBlock.scala
+++ b/src/main/scala/xiangshan/mem/MemBlock.scala
@@ -398,9 +398,16 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
   dontTouch(io.inner_hc_perfEvents)
   dontTouch(io.outer_hc_perfEvents)
 
-  val redirectModifyLevel = WireInit(io.redirect)
-  redirectModifyLevel.bits.level := Mux(io.redirect.bits.isVlsException, RedirectLevel.flushAfter, io.redirect.bits.level)
-  val redirect = RegNextWithEnable(redirectModifyLevel)
+  // VLS exception redirect is flush in ROB. SQ recovery and StoreMisalignBuffer
+  // still need flushAfter so uncommitted vector-store side effects can drain.
+  // ExceptionBuffers and the rest of MemBlock must see the original flush, or
+  // the matching exception-address record survives and pollutes a later mtval.
+  val rawRedirect = RegNextWithEnable(io.redirect)
+  val flushAfterRedirect = WireInit(rawRedirect)
+  when (rawRedirect.bits.isVlsException) {
+    flushAfterRedirect.bits.level := RedirectLevel.flushAfter
+  }
+  val redirect = rawRedirect
 
   private val dcache = outer.dcache.module
   val uncache = outer.uncache.module
@@ -1199,7 +1206,7 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
 
   lsq.io.loadMisalignFull                       := loadMisalignBuffer.io.loadMisalignFull
 
-  storeMisalignBuffer.io.redirect               <> redirect
+  storeMisalignBuffer.io.redirect               <> flushAfterRedirect
   storeMisalignBuffer.io.rob.lcommit            := io.ooo_to_mem.lsqio.lcommit
   storeMisalignBuffer.io.rob.scommit            := io.ooo_to_mem.lsqio.scommit
   storeMisalignBuffer.io.rob.pendingMMIOld      := io.ooo_to_mem.lsqio.pendingMMIOld
@@ -1424,7 +1431,8 @@ class MemBlockInlinedImp(outer: MemBlockInlined) extends LazyModuleImp(outer)
 
   //  lsq.io.rob            <> io.lsqio.rob
   lsq.io.enq            <> io.ooo_to_mem.enqLsq
-  lsq.io.brqRedirect    <> redirect
+  lsq.io.brqRedirect         <> rawRedirect
+  lsq.io.flushAfterRedirect  <> flushAfterRedirect
 
   //  violation rollback
   def selectOldestRedirect(xs: Seq[Valid[Redirect]]): Vec[Bool] = {

--- a/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala
@@ -68,6 +68,7 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   val io = IO(new Bundle() {
     val hartId = Input(UInt(hartIdLen.W))
     val brqRedirect = Flipped(ValidIO(new Redirect))
+    val flushAfterRedirect = Flipped(ValidIO(new Redirect))
     val stvecFeedback = Vec(VecStorePipelineWidth, Flipped(ValidIO(new FeedbackToLsqIO)))
     val ldvecFeedback = Vec(VecLoadPipelineWidth, Flipped(ValidIO(new FeedbackToLsqIO)))
     val enq = new LsqEnqIO
@@ -184,7 +185,8 @@ class LsqWrapper(implicit p: Parameters) extends XSModule with HasDCacheParamete
   }
 
   // store queue wiring
-  storeQueue.io.brqRedirect <> io.brqRedirect
+  storeQueue.io.brqRedirect <> io.flushAfterRedirect
+  storeQueue.io.exceptionRedirect <> io.brqRedirect
   storeQueue.io.vecFeedback   <> io.stvecFeedback
   storeQueue.io.storeAddrIn <> io.sta.storeAddrIn // from store_s1
   storeQueue.io.storeAddrInRe <> io.sta.storeAddrInRe // from store_s2

--- a/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
+++ b/src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala
@@ -157,6 +157,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
     val hartId = Input(UInt(hartIdLen.W))
     val enq = new SqEnqIO
     val brqRedirect = Flipped(ValidIO(new Redirect))
+    val exceptionRedirect = Flipped(ValidIO(new Redirect))
     val vecFeedback = Vec(VecLoadPipelineWidth, Flipped(ValidIO(new FeedbackToLsqIO)))
     val storeAddrIn = Vec(StorePipelineWidth, Flipped(Valid(new LsPipelineBundle))) // store addr, data is not included
     val storeAddrInRe = Vec(StorePipelineWidth, Input(new LsPipelineBundle())) // store more mmio and exception
@@ -226,7 +227,7 @@ class StoreQueue(implicit p: Parameters) extends XSModule
   vaddrModule.io := DontCare
   val dataBuffer = Module(new DatamoduleResultBuffer(new DataBufferEntry))
   val exceptionBuffer = Module(new StoreExceptionBuffer)
-  exceptionBuffer.io.redirect := io.brqRedirect
+  exceptionBuffer.io.redirect := io.exceptionRedirect
   exceptionBuffer.io.exceptionAddr.isStore := DontCare
   // vlsu exception!
   for (i <- 0 until VecStorePipelineWidth) {


### PR DESCRIPTION
A VLS exception redirect interacts with two kinds of consumers that need different flush levels:

1. After the flush, residual vector-store entries of the faulting instruction may still sit in the StoreQueue waiting to be drained. Flushing them away with the same robIdx loses those store side effects, so the redirect level for SQ recovery (and StoreMisalignBuffer) must be relaxed to `flushAfter`.
2. The ExceptionBuffers, however, must not use `flushAfter`: their address record carries the same robIdx as the redirect, so without self-flush a stale entry survives and pollutes the `mtval`/`stval` of a later same-direction fault.

Fixes #6399, #6482, #6540