### PR TITLE
fix(decode): set CBO commitType to STORE and numWb to 2

### DIFF
--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeFields/SimpleDecodeChannel/CommitTypeField.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeFields/SimpleDecodeChannel/CommitTypeField.scala
@@ -17,6 +17,7 @@ object CommitTypeField extends DecodeField[InstPattern, UInt] {
       case intInst: IntInstPattern => intInst match {
         case _: IntRTypePattern => CommitType.NORMAL
         case iType: IntITypePattern => iType match {
+          case _: CboInstPattern => CommitType.STORE
           case IntLoadInstPattern() => CommitType.LOAD
           case HyperLoadInstPattern() => CommitType.LOAD
           case _ => CommitType.NORMAL

--- a/src/main/scala/xiangshan/backend/vector/Decoder/DecodeFields/SimpleDecodeChannel/NumWbField.scala
+++ b/src/main/scala/xiangshan/backend/vector/Decoder/DecodeFields/SimpleDecodeChannel/NumWbField.scala
@@ -21,6 +21,7 @@ object NumWbField extends DecodeField[InstPattern, UInt] {
     val numWb = instP match {
       case int: IntInstPattern =>
         int match {
+          case _: CboInstPattern => 2
           case s: IntSTypePattern => s match {
             // SB, SH, SW, SD,
             case IntStoreInstPattern() => 2


### PR DESCRIPTION
Before the new vector decoder was introduced, CBO instructions were decoded as stores with `numWB = 2`. The new decoder changed them to the default `NORMAL` commit type and `numWB = 1`.

Restore the original `STORE` commit type and writeback count so that CBO instructions with exceptions can be handled correctly.