### PR TITLE
fix(store): pass vector access size to TLB

### DIFF
--- a/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
+++ b/src/main/scala/xiangshan/mem/pipeline/StoreUnit.scala
@@ -218,7 +218,7 @@ class StoreUnit(implicit p: Parameters) extends XSModule
   io.tlb.req.bits.checkfullva        := s0_use_flow_rs || s0_use_flow_vec
   io.tlb.req.bits.cmd                := Mux(s0_isCbo_noZero, TlbCmd.read, TlbCmd.write)
   io.tlb.req.bits.isPrefetch         := s0_use_flow_prf
-  io.tlb.req.bits.size               := s0_size
+  io.tlb.req.bits.size               := Mux(s0_use_flow_vec, s0_vecstin.alignedType(2,0), s0_size)
   io.tlb.req.bits.kill               := false.B
   io.tlb.req.bits.memidx.is_ld       := false.B
   io.tlb.req.bits.memidx.is_st       := true.B


### PR DESCRIPTION
Use the vector request's alignedType when populating the StoreUnit TLB request size. The fuOpType low bits encode the vector operation and can report byte width zero for wider vector stores, preventing full virtual-address checks from covering the accessed bytes.